### PR TITLE
feat(aletheia): integrate LLM context access + Semantic Scholar as native recall sources

### DIFF
--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -1,4 +1,8 @@
 //! Adapter bridging `KnowledgeStore` + `EmbeddingProvider` to `KnowledgeSearchService`.
+//!
+//! WHY: Also integrates external recall sources (issue #2338) so that
+//! academic literature and LLM context results appear alongside mneme
+//! facts in the recall pipeline.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -15,14 +19,25 @@ use aletheia_organon::error::{
 };
 use aletheia_organon::types::{DatalogResult, FactSummary, KnowledgeSearchService, MemoryResult};
 
+use crate::recall_sources::RecallSourceRegistry;
+
 pub(crate) struct KnowledgeSearchAdapter {
     store: Arc<KnowledgeStore>,
     embedder: Arc<dyn EmbeddingProvider>,
+    recall_sources: Arc<RecallSourceRegistry>,
 }
 
 impl KnowledgeSearchAdapter {
-    pub(crate) fn new(store: Arc<KnowledgeStore>, embedder: Arc<dyn EmbeddingProvider>) -> Self {
-        Self { store, embedder }
+    pub(crate) fn new(
+        store: Arc<KnowledgeStore>,
+        embedder: Arc<dyn EmbeddingProvider>,
+        recall_sources: Arc<RecallSourceRegistry>,
+    ) -> Self {
+        Self {
+            store,
+            embedder,
+            recall_sources,
+        }
     }
 }
 
@@ -44,6 +59,7 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 .build()
             })?;
 
+            let query_for_external = query.clone();
             let hybrid_query = HybridQuery {
                 text: query,
                 embedding,
@@ -90,6 +106,37 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                     source_type: "fact".to_owned(),
                 });
             }
+
+            // WHY: External recall sources (issue #2338) are queried in
+            // parallel with the knowledge store. Results are appended with
+            // lower scores so mneme facts take priority, but external
+            // knowledge is still surfaced when relevant.
+            let external_limit = limit.saturating_sub(out.len()).max(2);
+            let external = self
+                .recall_sources
+                .query_all(&query_for_external, external_limit)
+                .await;
+            for (source_type, result) in external {
+                // NOTE: Scale external relevance to [0.0, 0.5] so knowledge
+                // store facts (which score 0.0-1.0 via RRF) naturally rank
+                // higher. External sources supplement rather than displace.
+                let scaled_score = result.relevance * 0.5;
+                out.push(MemoryResult {
+                    id: result.source_id,
+                    content: result.content,
+                    score: scaled_score,
+                    source_type,
+                });
+            }
+
+            // Sort by score descending, then truncate to requested limit.
+            out.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            out.truncate(limit);
+
             Ok(out)
         })
     }

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -13,6 +13,8 @@ mod knowledge_maintenance;
 #[cfg(feature = "migrate-qdrant")]
 mod migrate_memory;
 mod planning_adapter;
+#[cfg(feature = "recall")]
+mod recall_sources;
 mod runtime;
 mod status;
 

--- a/crates/aletheia/src/recall_sources/academic.rs
+++ b/crates/aletheia/src/recall_sources/academic.rs
@@ -1,0 +1,210 @@
+//! Semantic Scholar recall source.
+//!
+//! WHY: Wraps the Semantic Scholar Academic Graph API so agents can query
+//! academic literature as part of the recall pipeline, not just via ad-hoc
+//! MCP tools in CC sessions.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use snafu::ResultExt;
+use tracing::debug;
+
+use super::error::{HttpRequestSnafu, ParseResponseSnafu, RecallSourceError};
+use super::{RecallSource, SourceResult};
+
+const API_BASE: &str = "https://api.semanticscholar.org/graph/v1";
+
+/// Fields requested from the Semantic Scholar paper search endpoint.
+const PAPER_FIELDS: &str = "paperId,title,abstract,year,citationCount,url";
+
+/// Recall source backed by the Semantic Scholar Academic Graph API.
+///
+/// Queries the paper search endpoint and returns results formatted as
+/// recall-compatible content strings. An optional API key raises the
+/// per-second rate limit.
+pub(crate) struct AcademicSource {
+    client: Arc<reqwest::Client>,
+    api_key: Option<String>,
+}
+
+impl AcademicSource {
+    pub(crate) fn new(client: Arc<reqwest::Client>, api_key: Option<String>) -> Self {
+        Self { client, api_key }
+    }
+}
+
+impl RecallSource for AcademicSource {
+    fn query<'a>(
+        &'a self,
+        query: &'a str,
+        limit: usize,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<SourceResult>, RecallSourceError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            let endpoint = format!("{API_BASE}/paper/search");
+            let clamped_limit = limit.min(100);
+
+            let mut req = self
+                .client
+                .get(&endpoint)
+                .query(&[("query", query), ("fields", PAPER_FIELDS)])
+                .query(&[("limit", clamped_limit)]);
+
+            if let Some(ref key) = self.api_key {
+                req = req.header("x-api-key", key);
+            }
+
+            let response = req.send().await.context(HttpRequestSnafu {
+                endpoint: &endpoint,
+            })?;
+
+            let body = response.text().await.context(HttpRequestSnafu {
+                endpoint: &endpoint,
+            })?;
+
+            let parsed: SearchResponse =
+                serde_json::from_str(&body).context(ParseResponseSnafu {
+                    endpoint: &endpoint,
+                })?;
+
+            debug!(
+                total = parsed.total,
+                returned = parsed.data.len(),
+                "semantic scholar search complete"
+            );
+
+            let results = parsed
+                .data
+                .into_iter()
+                .enumerate()
+                .map(|(rank, paper)| {
+                    let content = format_paper(&paper);
+                    // NOTE: Position-based relevance: rank 0 = 1.0, declining linearly.
+                    // Semantic Scholar returns results in relevance order.
+                    let denominator = (clamped_limit.max(1)) as f64;
+                    let relevance = 1.0 - (rank as f64 / denominator);
+                    SourceResult {
+                        content,
+                        relevance,
+                        source_id: paper.paper_id,
+                    }
+                })
+                .collect();
+
+            Ok(results)
+        })
+    }
+
+    fn source_type(&self) -> &str {
+        "academic"
+    }
+
+    fn available(&self) -> bool {
+        true
+    }
+}
+
+fn format_paper(paper: &Paper) -> String {
+    let mut parts = Vec::with_capacity(4);
+
+    if let Some(year) = paper.year {
+        parts.push(format!("{} ({})", paper.title, year));
+    } else {
+        parts.push(paper.title.clone());
+    }
+
+    if let Some(ref abs) = paper.r#abstract {
+        if !abs.is_empty() {
+            parts.push(abs.clone());
+        }
+    }
+
+    if let Some(citations) = paper.citation_count {
+        parts.push(format!("Citations: {citations}"));
+    }
+
+    if let Some(ref url) = paper.url {
+        parts.push(format!("URL: {url}"));
+    }
+
+    parts.join("\n")
+}
+
+// -- Semantic Scholar API response types ------------------------------------
+
+#[derive(Debug, serde::Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    total: u64,
+    data: Vec<Paper>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Paper {
+    paper_id: String,
+    title: String,
+    r#abstract: Option<String>,
+    year: Option<u32>,
+    citation_count: Option<u64>,
+    url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_paper_full() {
+        let paper = Paper {
+            paper_id: "abc123".to_owned(),
+            title: "Attention Is All You Need".to_owned(),
+            r#abstract: Some("We propose a new architecture.".to_owned()),
+            year: Some(2017),
+            citation_count: Some(100_000),
+            url: Some("https://arxiv.org/abs/1706.03762".to_owned()),
+        };
+        let formatted = format_paper(&paper);
+        assert!(formatted.contains("Attention Is All You Need (2017)"));
+        assert!(formatted.contains("We propose a new architecture."));
+        assert!(formatted.contains("Citations: 100000"));
+        assert!(formatted.contains("https://arxiv.org/abs/1706.03762"));
+    }
+
+    #[test]
+    fn format_paper_minimal() {
+        let paper = Paper {
+            paper_id: "xyz".to_owned(),
+            title: "Some Paper".to_owned(),
+            r#abstract: None,
+            year: None,
+            citation_count: None,
+            url: None,
+        };
+        let formatted = format_paper(&paper);
+        assert_eq!(formatted, "Some Paper");
+    }
+
+    #[test]
+    fn parse_search_response() {
+        let json = r#"{
+            "total": 1,
+            "offset": 0,
+            "data": [{
+                "paperId": "p1",
+                "title": "Test Paper",
+                "abstract": "An abstract.",
+                "year": 2024,
+                "citationCount": 5,
+                "url": "https://example.com/p1"
+            }]
+        }"#;
+        let resp: SearchResponse = serde_json::from_str(json).expect("valid json");
+        assert_eq!(resp.total, 1);
+        assert_eq!(resp.data.len(), 1);
+        assert_eq!(resp.data[0].title, "Test Paper");
+        assert_eq!(resp.data[0].year, Some(2024));
+    }
+}

--- a/crates/aletheia/src/recall_sources/error.rs
+++ b/crates/aletheia/src/recall_sources/error.rs
@@ -1,0 +1,31 @@
+//! Recall source error types.
+
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub(crate) enum RecallSourceError {
+    #[snafu(display("HTTP request to {endpoint} failed"))]
+    HttpRequest {
+        endpoint: String,
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("failed to parse response from {endpoint}"))]
+    ParseResponse {
+        endpoint: String,
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{message}"))]
+    SourceUnavailable {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/aletheia/src/recall_sources/llm_context.rs
+++ b/crates/aletheia/src/recall_sources/llm_context.rs
@@ -1,0 +1,397 @@
+//! LLM context recall source.
+//!
+//! WHY: Provides structured knowledge about available LLM models (context
+//! windows, capabilities, pricing) as a queryable recall source, so agents
+//! can answer questions like "which model supports 256K context?" from
+//! recall rather than hardcoded logic.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use super::error::RecallSourceError;
+use super::{RecallSource, SourceResult};
+
+/// A single model card describing an LLM's capabilities.
+#[derive(Debug, Clone)]
+pub(crate) struct ModelCard {
+    pub id: String,
+    pub name: String,
+    pub provider: String,
+    pub context_window: u64,
+    pub max_output_tokens: u64,
+    pub supports_tools: bool,
+    pub supports_vision: bool,
+    pub supports_thinking: bool,
+    pub input_cost_per_mtok: Option<f64>,
+    pub output_cost_per_mtok: Option<f64>,
+}
+
+impl ModelCard {
+    /// Format as a human-readable content string for recall results.
+    fn to_content(&self) -> String {
+        let mut parts = Vec::with_capacity(6);
+
+        parts.push(format!("Model: {} ({})", self.name, self.provider));
+        parts.push(format!(
+            "Context: {}K tokens, Max output: {}K tokens",
+            self.context_window / 1000,
+            self.max_output_tokens / 1000
+        ));
+
+        let mut caps = Vec::new();
+        if self.supports_tools {
+            caps.push("tool use");
+        }
+        if self.supports_vision {
+            caps.push("vision");
+        }
+        if self.supports_thinking {
+            caps.push("extended thinking");
+        }
+        if !caps.is_empty() {
+            parts.push(format!("Capabilities: {}", caps.join(", ")));
+        }
+
+        match (self.input_cost_per_mtok, self.output_cost_per_mtok) {
+            (Some(input), Some(output)) => {
+                parts.push(format!(
+                    "Pricing: ${input:.2}/MTok input, ${output:.2}/MTok output"
+                ));
+            }
+            _ => {}
+        }
+
+        parts.join("\n")
+    }
+
+    /// Compute a relevance score against a query by checking keyword overlap.
+    fn relevance(&self, query_lower: &str) -> f64 {
+        let mut score = 0.0_f64;
+        let name_lower = self.name.to_lowercase();
+        let id_lower = self.id.to_lowercase();
+        let provider_lower = self.provider.to_lowercase();
+
+        // Direct name match is highest signal.
+        if query_lower.contains(&name_lower) || query_lower.contains(&id_lower) {
+            score += 0.6;
+        }
+
+        if query_lower.contains(&provider_lower) {
+            score += 0.2;
+        }
+
+        // Capability keyword matching.
+        if query_lower.contains("tool") && self.supports_tools {
+            score += 0.3;
+        }
+        if query_lower.contains("vision") && self.supports_vision {
+            score += 0.3;
+        }
+        if query_lower.contains("thinking") && self.supports_thinking {
+            score += 0.3;
+        }
+
+        // Context window queries.
+        if query_lower.contains("context") || query_lower.contains("window") {
+            score += 0.2;
+        }
+        // WHY: Specific context size queries (e.g., "256k context") match
+        // models whose window is at or above the requested size.
+        if let Some(requested_k) = extract_context_size_k(query_lower) {
+            if self.context_window >= requested_k * 1000 {
+                score += 0.4;
+            }
+        }
+
+        if query_lower.contains("cost")
+            || query_lower.contains("price")
+            || query_lower.contains("pricing")
+        {
+            if self.input_cost_per_mtok.is_some() {
+                score += 0.2;
+            }
+        }
+
+        score.min(1.0)
+    }
+}
+
+/// Extract a context size in thousands from a query like "256k context".
+fn extract_context_size_k(query: &str) -> Option<u64> {
+    let bytes = query.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            // WHY: Check for 'k' suffix immediately after digits.
+            if i < bytes.len() && (bytes[i] == b'k' || bytes[i] == b'K') {
+                if let Ok(n) = query[start..i].parse::<u64>() {
+                    return Some(n);
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Recall source providing structured knowledge about available LLM models.
+///
+/// Model cards are loaded at construction time from the configured providers
+/// and pricing data. The source is always available (returns empty results
+/// if no models are registered).
+pub(crate) struct LlmContextSource {
+    models: Vec<ModelCard>,
+}
+
+impl LlmContextSource {
+    #[cfg(test)]
+    pub(crate) fn new(models: Vec<ModelCard>) -> Self {
+        Self { models }
+    }
+
+    /// Build model cards from the known Anthropic model catalog and any
+    /// pricing overrides from config.
+    pub(crate) fn from_known_models(
+        pricing: &std::collections::HashMap<String, aletheia_taxis::config::ModelPricing>,
+    ) -> Self {
+        let mut models = anthropic_model_cards();
+
+        // NOTE: Overlay pricing from config onto matching model cards.
+        for card in &mut models {
+            if let Some(p) = pricing.get(&card.id) {
+                card.input_cost_per_mtok = Some(p.input_cost_per_mtok);
+                card.output_cost_per_mtok = Some(p.output_cost_per_mtok);
+            }
+        }
+
+        Self { models }
+    }
+}
+
+impl RecallSource for LlmContextSource {
+    fn query<'a>(
+        &'a self,
+        query: &'a str,
+        limit: usize,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<SourceResult>, RecallSourceError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            let query_lower = query.to_lowercase();
+
+            let mut scored: Vec<(f64, &ModelCard)> = self
+                .models
+                .iter()
+                .map(|card| (card.relevance(&query_lower), card))
+                .filter(|(score, _)| *score > 0.0)
+                .collect();
+
+            // Sort by relevance descending.
+            scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+            scored.truncate(limit);
+
+            let results = scored
+                .into_iter()
+                .map(|(relevance, card)| SourceResult {
+                    content: card.to_content(),
+                    relevance,
+                    source_id: card.id.clone(),
+                })
+                .collect();
+
+            Ok(results)
+        })
+    }
+
+    fn source_type(&self) -> &str {
+        "llm_context"
+    }
+
+    fn available(&self) -> bool {
+        !self.models.is_empty()
+    }
+}
+
+/// Known Anthropic model catalog.
+///
+/// NOTE: This is intentionally static data. The issue specifies that model
+/// cards should be "updated automatically when new providers are configured,"
+/// which is handled by overlaying pricing config. Adding entirely new models
+/// requires a code update (or future config-driven model registry).
+fn anthropic_model_cards() -> Vec<ModelCard> {
+    vec![
+        ModelCard {
+            id: "claude-sonnet-4-20250514".to_owned(),
+            name: "Claude Sonnet 4".to_owned(),
+            provider: "Anthropic".to_owned(),
+            context_window: 200_000,
+            max_output_tokens: 16_000,
+            supports_tools: true,
+            supports_vision: true,
+            supports_thinking: true,
+            input_cost_per_mtok: Some(3.0),
+            output_cost_per_mtok: Some(15.0),
+        },
+        ModelCard {
+            id: "claude-opus-4-20250514".to_owned(),
+            name: "Claude Opus 4".to_owned(),
+            provider: "Anthropic".to_owned(),
+            context_window: 200_000,
+            max_output_tokens: 32_000,
+            supports_tools: true,
+            supports_vision: true,
+            supports_thinking: true,
+            input_cost_per_mtok: Some(15.0),
+            output_cost_per_mtok: Some(75.0),
+        },
+        ModelCard {
+            id: "claude-3-5-haiku-20241022".to_owned(),
+            name: "Claude 3.5 Haiku".to_owned(),
+            provider: "Anthropic".to_owned(),
+            context_window: 200_000,
+            max_output_tokens: 8_192,
+            supports_tools: true,
+            supports_vision: true,
+            supports_thinking: false,
+            input_cost_per_mtok: Some(0.8),
+            output_cost_per_mtok: Some(4.0),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_models() -> Vec<ModelCard> {
+        vec![
+            ModelCard {
+                id: "model-a".to_owned(),
+                name: "Model Alpha".to_owned(),
+                provider: "TestCorp".to_owned(),
+                context_window: 128_000,
+                max_output_tokens: 8_000,
+                supports_tools: true,
+                supports_vision: false,
+                supports_thinking: false,
+                input_cost_per_mtok: Some(1.0),
+                output_cost_per_mtok: Some(5.0),
+            },
+            ModelCard {
+                id: "model-b".to_owned(),
+                name: "Model Beta".to_owned(),
+                provider: "TestCorp".to_owned(),
+                context_window: 256_000,
+                max_output_tokens: 32_000,
+                supports_tools: true,
+                supports_vision: true,
+                supports_thinking: true,
+                input_cost_per_mtok: Some(10.0),
+                output_cost_per_mtok: Some(50.0),
+            },
+        ]
+    }
+
+    #[test]
+    fn model_card_content_formatting() {
+        let card = &test_models()[0];
+        let content = card.to_content();
+        assert!(content.contains("Model Alpha (TestCorp)"));
+        assert!(content.contains("128K tokens"));
+        assert!(content.contains("tool use"));
+        assert!(!content.contains("vision"));
+        assert!(content.contains("$1.00/MTok input"));
+    }
+
+    #[test]
+    fn relevance_name_match() {
+        let card = &test_models()[0];
+        let score = card.relevance("tell me about model alpha");
+        assert!(score > 0.5, "name match should score high: {score}");
+    }
+
+    #[test]
+    fn relevance_capability_match() {
+        let cards = test_models();
+        let vision_score_a = cards[0].relevance("which model supports vision");
+        let vision_score_b = cards[1].relevance("which model supports vision");
+        assert!(
+            vision_score_b > vision_score_a,
+            "model with vision should score higher: a={vision_score_a}, b={vision_score_b}"
+        );
+    }
+
+    #[test]
+    fn relevance_context_window_query() {
+        let cards = test_models();
+        let score_a = cards[0].relevance("model with 256k context");
+        let score_b = cards[1].relevance("model with 256k context");
+        assert!(
+            score_b > score_a,
+            "256K model should rank higher for 256K query: a={score_a}, b={score_b}"
+        );
+    }
+
+    #[test]
+    fn extract_context_size_k_works() {
+        assert_eq!(extract_context_size_k("256k context"), Some(256));
+        assert_eq!(extract_context_size_k("128K window"), Some(128));
+        assert_eq!(extract_context_size_k("no number here"), None);
+        assert_eq!(extract_context_size_k("100 tokens"), None);
+    }
+
+    #[test]
+    fn relevance_no_match() {
+        let card = &test_models()[0];
+        let score = card.relevance("unrelated query about cooking");
+        assert!(
+            score < f64::EPSILON,
+            "unrelated query should score zero: {score}"
+        );
+    }
+
+    #[tokio::test]
+    async fn llm_context_source_query() {
+        let source = LlmContextSource::new(test_models());
+        let results = source
+            .query("model with vision support", 10)
+            .await
+            .expect("query");
+        assert!(!results.is_empty());
+        // Model Beta supports vision, should appear first.
+        assert_eq!(results[0].source_id, "model-b");
+    }
+
+    #[tokio::test]
+    async fn llm_context_source_empty_on_no_match() {
+        let source = LlmContextSource::new(test_models());
+        let results = source
+            .query("quantum entanglement recipes", 10)
+            .await
+            .expect("query");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn from_known_models_applies_pricing() {
+        let mut pricing = std::collections::HashMap::new();
+        pricing.insert(
+            "claude-sonnet-4-20250514".to_owned(),
+            aletheia_taxis::config::ModelPricing {
+                input_cost_per_mtok: 99.0,
+                output_cost_per_mtok: 199.0,
+            },
+        );
+        let source = LlmContextSource::from_known_models(&pricing);
+        let sonnet = source
+            .models
+            .iter()
+            .find(|m| m.id == "claude-sonnet-4-20250514")
+            .expect("sonnet should exist");
+        assert!((sonnet.input_cost_per_mtok.unwrap() - 99.0).abs() < f64::EPSILON);
+        assert!((sonnet.output_cost_per_mtok.unwrap() - 199.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/aletheia/src/recall_sources/mod.rs
+++ b/crates/aletheia/src/recall_sources/mod.rs
@@ -1,0 +1,233 @@
+//! External recall sources for the knowledge pipeline.
+//!
+//! WHY: Issue #2338 -- academic literature and LLM context need to be
+//! queryable through the recall pipeline, not just via ad-hoc MCP tools.
+//! This module defines the `RecallSource` trait and a registry that queries
+//! all configured sources, merging results into the standard recall flow.
+
+pub(crate) mod academic;
+pub(crate) mod error;
+pub(crate) mod llm_context;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tracing::{debug, warn};
+
+use error::RecallSourceError;
+
+/// A single result from an external recall source.
+#[derive(Debug, Clone)]
+pub(crate) struct SourceResult {
+    /// Human-readable content returned to the recall pipeline.
+    pub content: String,
+    /// Relevance score in `[0.0, 1.0]` (higher = more relevant).
+    pub relevance: f64,
+    /// Source-specific identifier (paper ID, model ID, etc.).
+    pub source_id: String,
+}
+
+/// External recall source that can be queried as part of the recall pipeline.
+///
+/// Implementations wrap external APIs or structured datasets. Each source is
+/// configuration-driven: add it to the registry and it participates in recall;
+/// remove it and the pipeline continues without it.
+pub(crate) trait RecallSource: Send + Sync {
+    /// Query the source for results relevant to `query`, returning at most
+    /// `limit` results ordered by relevance.
+    fn query<'a>(
+        &'a self,
+        query: &'a str,
+        limit: usize,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<SourceResult>, RecallSourceError>> + Send + 'a>>;
+
+    /// Identifier for this source type (e.g., `"academic"`, `"llm_context"`).
+    fn source_type(&self) -> &str;
+
+    /// Whether the source is currently available for queries.
+    fn available(&self) -> bool;
+}
+
+/// Registry of external recall sources queried alongside the knowledge store.
+pub(crate) struct RecallSourceRegistry {
+    sources: Vec<Arc<dyn RecallSource>>,
+}
+
+impl RecallSourceRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            sources: Vec::new(),
+        }
+    }
+
+    pub(crate) fn register(&mut self, source: Arc<dyn RecallSource>) {
+        debug!(
+            source_type = source.source_type(),
+            "registered recall source"
+        );
+        self.sources.push(source);
+    }
+
+    /// Query all available sources concurrently, returning merged results.
+    ///
+    /// Each source is queried independently. Sources that fail or are
+    /// unavailable are skipped with a warning -- the pipeline degrades
+    /// gracefully rather than failing entirely.
+    pub(crate) async fn query_all(
+        &self,
+        query: &str,
+        limit_per_source: usize,
+    ) -> Vec<(String, SourceResult)> {
+        let mut handles = Vec::with_capacity(self.sources.len());
+
+        for source in &self.sources {
+            if !source.available() {
+                debug!(
+                    source_type = source.source_type(),
+                    "skipping unavailable recall source"
+                );
+                continue;
+            }
+
+            let source = Arc::clone(source);
+            let query = query.to_owned();
+            handles.push(tokio::spawn(async move {
+                let source_type = source.source_type().to_owned();
+                match source.query(&query, limit_per_source).await {
+                    Ok(results) => {
+                        debug!(
+                            source_type = %source_type,
+                            count = results.len(),
+                            "recall source returned results"
+                        );
+                        results
+                            .into_iter()
+                            .map(|r| (source_type.clone(), r))
+                            .collect::<Vec<_>>()
+                    }
+                    Err(e) => {
+                        warn!(
+                            source_type = %source_type,
+                            error = %e,
+                            "recall source query failed, skipping"
+                        );
+                        Vec::new()
+                    }
+                }
+            }));
+        }
+
+        let mut all_results = Vec::new();
+        for handle in handles {
+            match handle.await {
+                Ok(results) => all_results.extend(results),
+                Err(e) => {
+                    warn!(error = %e, "recall source task panicked");
+                }
+            }
+        }
+
+        all_results
+    }
+
+    pub(crate) fn source_count(&self) -> usize {
+        self.sources.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic test source that returns canned results.
+    struct TestSource {
+        type_name: &'static str,
+        results: Vec<SourceResult>,
+        is_available: bool,
+    }
+
+    impl RecallSource for TestSource {
+        fn query<'a>(
+            &'a self,
+            _query: &'a str,
+            limit: usize,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<SourceResult>, RecallSourceError>> + Send + 'a>>
+        {
+            let results: Vec<SourceResult> = self.results.iter().take(limit).cloned().collect();
+            Box::pin(async move { Ok(results) })
+        }
+
+        fn source_type(&self) -> &str {
+            self.type_name
+        }
+
+        fn available(&self) -> bool {
+            self.is_available
+        }
+    }
+
+    #[tokio::test]
+    async fn registry_queries_all_sources() {
+        let mut registry = RecallSourceRegistry::new();
+        registry.register(Arc::new(TestSource {
+            type_name: "test_a",
+            results: vec![SourceResult {
+                content: "result A".to_owned(),
+                relevance: 0.9,
+                source_id: "a1".to_owned(),
+            }],
+            is_available: true,
+        }));
+        registry.register(Arc::new(TestSource {
+            type_name: "test_b",
+            results: vec![SourceResult {
+                content: "result B".to_owned(),
+                relevance: 0.8,
+                source_id: "b1".to_owned(),
+            }],
+            is_available: true,
+        }));
+
+        let results = registry.query_all("test query", 5).await;
+        assert_eq!(results.len(), 2);
+
+        let types: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
+        assert!(types.contains(&"test_a"));
+        assert!(types.contains(&"test_b"));
+    }
+
+    #[tokio::test]
+    async fn registry_skips_unavailable_sources() {
+        let mut registry = RecallSourceRegistry::new();
+        registry.register(Arc::new(TestSource {
+            type_name: "available",
+            results: vec![SourceResult {
+                content: "available result".to_owned(),
+                relevance: 0.9,
+                source_id: "a1".to_owned(),
+            }],
+            is_available: true,
+        }));
+        registry.register(Arc::new(TestSource {
+            type_name: "unavailable",
+            results: vec![SourceResult {
+                content: "should not appear".to_owned(),
+                relevance: 0.9,
+                source_id: "u1".to_owned(),
+            }],
+            is_available: false,
+        }));
+
+        let results = registry.query_all("test", 5).await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "available");
+    }
+
+    #[tokio::test]
+    async fn registry_empty_returns_empty() {
+        let registry = RecallSourceRegistry::new();
+        let results = registry.query_all("test", 5).await;
+        assert!(results.is_empty());
+    }
+}

--- a/crates/aletheia/src/runtime.rs
+++ b/crates/aletheia/src/runtime.rs
@@ -520,6 +520,35 @@ impl RuntimeBuilder {
         #[cfg(not(feature = "recall"))]
         let vector_search: Option<Arc<dyn aletheia_nous::recall::VectorSearch>> = None;
 
+        // External recall sources (issue #2338)
+        #[cfg(feature = "recall")]
+        let recall_source_registry = {
+            let mut registry = crate::recall_sources::RecallSourceRegistry::new();
+            let http_client = Arc::new(reqwest::Client::new());
+
+            // Academic source (Semantic Scholar)
+            let api_key = std::env::var("SEMANTIC_SCHOLAR_API_KEY").ok();
+            registry.register(Arc::new(
+                crate::recall_sources::academic::AcademicSource::new(
+                    Arc::clone(&http_client),
+                    api_key,
+                ),
+            ));
+
+            // LLM context source (model cards + pricing)
+            registry.register(Arc::new(
+                crate::recall_sources::llm_context::LlmContextSource::from_known_models(
+                    &self.config.pricing,
+                ),
+            ));
+
+            info!(
+                count = registry.source_count(),
+                "external recall sources registered"
+            );
+            Arc::new(registry)
+        };
+
         // Knowledge search adapter for tool layer
         #[cfg(feature = "recall")]
         #[expect(
@@ -532,6 +561,7 @@ impl RuntimeBuilder {
             Arc::new(crate::knowledge_adapter::KnowledgeSearchAdapter::new(
                 Arc::clone(ks),
                 Arc::clone(&embedding_provider),
+                Arc::clone(&recall_source_registry),
             )) as Arc<dyn aletheia_organon::types::KnowledgeSearchService>
         });
         #[cfg(not(feature = "recall"))]


### PR DESCRIPTION
## Summary

- Add `RecallSource` trait and `RecallSourceRegistry` for configuration-driven external recall sources (#2338)
- Implement `AcademicSource` wrapping the Semantic Scholar Academic Graph API (paper search with optional API key)
- Implement `LlmContextSource` providing structured model cards (context windows, capabilities, pricing) from the known Anthropic catalog with config pricing overlays
- Wire both sources into `KnowledgeSearchAdapter.search()` so external results appear alongside mneme facts, scored at [0.0, 0.5] to let knowledge store facts take priority

## Test plan

- [x] 15 unit tests across all modules (registry, academic, llm_context)
- [x] `cargo test -p aletheia` passes (51 tests)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p aletheia --all-targets` clean (pre-existing krites/oikonomos warnings excluded)
- [x] Pre-existing pylon flaky test failures confirmed on main

## Observations

- `RecallSource` trait is defined in the binary crate (`crates/aletheia/`) per blast radius. Future extraction to `episteme` would allow other consumers to define recall sources without depending on the binary crate.
- `[recall.sources]` config section in `aletheia.toml` not implemented (requires taxis changes, out of blast radius). Currently uses `SEMANTIC_SCHOLAR_API_KEY` env var and pricing config overlay. Taxis integration is follow-up work.
- LLM model catalog is static data for known Anthropic models. A config-driven model registry would allow adding models without code changes.
- The `query_all` concurrency approach (tokio::spawn per source) works well for 2-3 sources but may need backpressure if many sources are registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)