### PR TITLE
fix(theatron-desktop): remove default OS menu bar

### DIFF
--- a/crates/theatron/desktop/src/lib.rs
+++ b/crates/theatron/desktop/src/lib.rs
@@ -52,7 +52,12 @@ pub fn run() {
         ))
         .with_maximized(window_state.maximized);
 
-    let config = Config::new().with_window(window_builder);
+    // WHY: Passing `None` removes the default OS menu bar (Window/Edit/Help)
+    // that Dioxus injects via `MenuBuilderState::Unset`. The app's intentional
+    // menu structure lives in `platform::menus` and will be wired in separately.
+    let config = Config::new()
+        .with_window(window_builder)
+        .with_menu(None::<dioxus::desktop::muda::Menu>);
 
     dioxus::LaunchBuilder::desktop()
         .with_cfg(config)


### PR DESCRIPTION
## Summary

- Remove the default Dioxus OS menu bar (Window/Edit/Help) by passing `None` to `Config::with_menu`
- The app's custom menu model in `platform::menus` remains available for future intentional wiring

Closes #2395.