### PR TITLE
fix(theatron-desktop): visible server URL input (#2390)

### DIFF
--- a/crates/theatron/desktop/assets/styles/base.css
+++ b/crates/theatron/desktop/assets/styles/base.css
@@ -40,6 +40,34 @@ select {
   color: inherit;
 }
 
+/* WHY: Ensure text inputs are always visible against surface backgrounds.
+   Browser/WebView resets strip native borders, leaving invisible fields. */
+input[type="text"],
+input[type="password"],
+input[type="url"],
+input[type="email"],
+input[type="search"],
+input:not([type]),
+textarea {
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-md);
+  padding: 8px 12px;
+  color: var(--text-primary);
+  transition: border-color var(--transition-quick);
+}
+
+input[type="text"]:focus,
+input[type="password"]:focus,
+input[type="url"]:focus,
+input[type="email"]:focus,
+input[type="search"]:focus,
+input:not([type]):focus,
+textarea:focus {
+  border-color: var(--input-border-focus);
+}
+
+
 /* ===================================================================== */
 /* Body defaults                                                         */
 /* ===================================================================== */

--- a/crates/theatron/desktop/assets/styles/themes.css
+++ b/crates/theatron/desktop/assets/styles/themes.css
@@ -30,6 +30,11 @@
   --border-separator: #221f1c;
   --border-selected: #9A7B4F;
 
+  /* Inputs */
+  --input-bg: #1e1c19;
+  --input-border: #3d3832;
+  --input-border-focus: #9A7B4F;
+
   /* Status — muted earth tones */
   --status-success: #5C7A4A;
   --status-warning: #B8923B;
@@ -120,6 +125,11 @@
   --border-focused: #9A7B4F;
   --border-separator: #E0DBD3;
   --border-selected: #9A7B4F;
+
+  /* Inputs */
+  --input-bg: #FDFAF5;
+  --input-border: #B8B2A8;
+  --input-border-focus: #9A7B4F;
 
   /* Status — same palette, lighter values */
   --status-success: #4A6A3A;

--- a/crates/theatron/desktop/src/views/settings/wizard.rs
+++ b/crates/theatron/desktop/src/views/settings/wizard.rs
@@ -162,7 +162,7 @@ fn StepServer(wizard_data: Signal<WizardData>, on_next: EventHandler<()>) -> Ele
                     "Server URL"
                 }
                 input {
-                    style: "background: var(--bg-surface-dim); border: 1px solid var(--border); border-radius: 6px; \
+                    style: "background: var(--input-bg); border: 1px solid var(--input-border); border-radius: 6px; \
                             padding: 8px 12px; color: var(--text-primary); font-size: 13px; width: 100%; box-sizing: border-box;",
                     placeholder: "http://localhost:3000",
                     value: "{wizard_data.read().server_url}",


### PR DESCRIPTION
## Summary

- Add `--input-bg`, `--input-border`, and `--input-border-focus` CSS custom property tokens to both dark and light themes in `themes.css` with proper contrast against surface backgrounds
- Add base input styles in `base.css` so all text inputs get visible borders/backgrounds by default (prevents invisible inputs when browser/WebView resets strip native styling)
- Update wizard server URL input in `wizard.rs` to use the new tokens instead of `--bg-surface-dim`/`--border` which had insufficient contrast
- The connect view (`connect.rs`) already references `--input-bg`/`--input-border` tokens, which this PR now defines

Closes #2390.

## Test plan

- [ ] Launch desktop app in first-run state, verify server URL input is visible with clear border and background in dark theme
- [ ] Switch to light theme, verify input remains visible
- [ ] Verify focus state highlights the input border with accent color
- [ ] Check connect view inputs also render with proper contrast