### PR TITLE
fix(theatron-desktop): wire appearance buttons (#2391)

### DIFF
--- a/crates/theatron/desktop/src/views/settings/appearance.rs
+++ b/crates/theatron/desktop/src/views/settings/appearance.rs
@@ -1,13 +1,30 @@
 //! Appearance settings panel.
 //!
 //! Controls theme (Dark/Light/System), font size slider, UI density, and
-//! accent color swatches.
+//! accent color swatches. All styling uses CSS variables from the design
+//! system so changes are visible under both themes.
 
 use dioxus::prelude::*;
 
 use crate::services::settings_config;
 use crate::state::settings::{ACCENT_PRESETS, AppearanceSettings, UiDensity};
 use crate::theme::ThemeMode;
+
+// WHY: Section card styling uses theme tokens so appearance settings are
+// visually consistent with the rest of the app and respond to theme changes.
+const SECTION_STYLE: &str = "\
+    background: var(--bg-surface); \
+    border: 1px solid var(--border); \
+    border-radius: 8px; \
+    padding: 16px 20px;";
+
+const SECTION_LABEL_STYLE: &str = "\
+    font-size: 11px; \
+    font-weight: bold; \
+    color: var(--text-muted); \
+    text-transform: uppercase; \
+    letter-spacing: 0.6px; \
+    margin-bottom: 14px;";
 
 /// Appearance settings panel.
 #[component]
@@ -25,23 +42,21 @@ pub(crate) fn AppearancePanel() -> Element {
 
             // Theme
             section {
-                style: "background: #1a1a2e; border: 1px solid #333; border-radius: 8px; padding: 16px 20px;",
-                div {
-                    style: "font-size: 11px; font-weight: bold; color: #666; text-transform: uppercase; \
-                            letter-spacing: 0.6px; margin-bottom: 14px;",
-                    "Theme"
-                }
+                style: SECTION_STYLE,
+                div { style: SECTION_LABEL_STYLE, "Theme" }
                 div {
                     style: "display: flex; gap: 8px;",
                     for mode in [ThemeMode::Dark, ThemeMode::Light, ThemeMode::System] {
                         {
                             let is_active = current.theme == mode_str(mode);
-                            let bg = if is_active { "#5b6af0" } else { "#2a2a4a" };
-                            let border = if is_active { "1px solid #5b6af0" } else { "1px solid #444" };
-                            let color = if is_active { "#fff" } else { "#aaa" };
+                            let bg = if is_active { "var(--accent)" } else { "var(--bg-surface-bright)" };
+                            let border = if is_active { "1px solid var(--accent)" } else { "1px solid var(--border)" };
+                            let color = if is_active { "var(--text-inverse)" } else { "var(--text-secondary)" };
                             let style = format!(
                                 "padding: 8px 18px; background: {bg}; border: {border}; \
-                                 border-radius: 6px; color: {color}; font-size: 13px; cursor: pointer;"
+                                 border-radius: 6px; color: {color}; font-size: 13px; cursor: pointer; \
+                                 transition: background var(--transition-quick), \
+                                 color var(--transition-quick), border-color var(--transition-quick);"
                             );
                             rsx! {
                                 button {
@@ -65,16 +80,12 @@ pub(crate) fn AppearancePanel() -> Element {
 
             // Font size
             section {
-                style: "background: #1a1a2e; border: 1px solid #333; border-radius: 8px; padding: 16px 20px;",
-                div {
-                    style: "font-size: 11px; font-weight: bold; color: #666; text-transform: uppercase; \
-                            letter-spacing: 0.6px; margin-bottom: 14px;",
-                    "Font Size"
-                }
+                style: SECTION_STYLE,
+                div { style: SECTION_LABEL_STYLE, "Font Size" }
                 div {
                     style: "display: flex; align-items: center; gap: 14px;",
                     span {
-                        style: "font-size: 11px; color: #666; width: 22px;",
+                        style: "font-size: 11px; color: var(--text-muted); width: 22px;",
                         "12"
                     }
                     input {
@@ -83,7 +94,7 @@ pub(crate) fn AppearancePanel() -> Element {
                         max: "20",
                         step: "1",
                         value: "{current.font_size}",
-                        style: "flex: 1; accent-color: #5b6af0;",
+                        style: "flex: 1; accent-color: var(--accent);",
                         oninput: move |e| {
                             if let Ok(v) = e.value().parse::<u8>() {
                                 appearance.write().set_font_size(v);
@@ -95,11 +106,11 @@ pub(crate) fn AppearancePanel() -> Element {
                         },
                     }
                     span {
-                        style: "font-size: 11px; color: #666; width: 22px;",
+                        style: "font-size: 11px; color: var(--text-muted); width: 22px;",
                         "20"
                     }
                     span {
-                        style: "font-size: 13px; color: #e0e0e0; width: 36px; text-align: right;",
+                        style: "font-size: 13px; color: var(--text-primary); width: 36px; text-align: right;",
                         "{current.font_size}px"
                     }
                 }
@@ -107,23 +118,21 @@ pub(crate) fn AppearancePanel() -> Element {
 
             // Density
             section {
-                style: "background: #1a1a2e; border: 1px solid #333; border-radius: 8px; padding: 16px 20px;",
-                div {
-                    style: "font-size: 11px; font-weight: bold; color: #666; text-transform: uppercase; \
-                            letter-spacing: 0.6px; margin-bottom: 14px;",
-                    "UI Density"
-                }
+                style: SECTION_STYLE,
+                div { style: SECTION_LABEL_STYLE, "UI Density" }
                 div {
                     style: "display: flex; gap: 8px;",
                     for density in [UiDensity::Compact, UiDensity::Comfortable, UiDensity::Spacious] {
                         {
                             let is_active = current.density == density;
-                            let bg = if is_active { "#5b6af0" } else { "#2a2a4a" };
-                            let border = if is_active { "1px solid #5b6af0" } else { "1px solid #444" };
-                            let color = if is_active { "#fff" } else { "#aaa" };
+                            let bg = if is_active { "var(--accent)" } else { "var(--bg-surface-bright)" };
+                            let border = if is_active { "1px solid var(--accent)" } else { "1px solid var(--border)" };
+                            let color = if is_active { "var(--text-inverse)" } else { "var(--text-secondary)" };
                             let style = format!(
                                 "flex: 1; padding: 8px; background: {bg}; border: {border}; \
-                                 border-radius: 6px; color: {color}; font-size: 13px; cursor: pointer; text-align: center;"
+                                 border-radius: 6px; color: {color}; font-size: 13px; cursor: pointer; \
+                                 text-align: center; transition: background var(--transition-quick), \
+                                 color var(--transition-quick), border-color var(--transition-quick);"
                             );
                             rsx! {
                                 button {
@@ -146,22 +155,23 @@ pub(crate) fn AppearancePanel() -> Element {
 
             // Accent color
             section {
-                style: "background: #1a1a2e; border: 1px solid #333; border-radius: 8px; padding: 16px 20px;",
-                div {
-                    style: "font-size: 11px; font-weight: bold; color: #666; text-transform: uppercase; \
-                            letter-spacing: 0.6px; margin-bottom: 14px;",
-                    "Accent Color"
-                }
+                style: SECTION_STYLE,
+                div { style: SECTION_LABEL_STYLE, "Accent Color" }
                 div {
                     style: "display: flex; gap: 10px; flex-wrap: wrap;",
                     for (label, hex) in ACCENT_PRESETS.iter() {
                         {
                             let is_active = current.accent_color == *hex;
-                            let border = if is_active { "3px solid #fff" } else { "3px solid transparent" };
+                            let border = if is_active {
+                                "3px solid var(--text-primary)"
+                            } else {
+                                "3px solid transparent"
+                            };
                             let hex_owned = hex.to_string();
                             let style = format!(
                                 "width: 30px; height: 30px; border-radius: 50%; background: {hex_owned}; \
-                                 border: {border}; cursor: pointer; outline: none;"
+                                 border: {border}; cursor: pointer; outline: none; \
+                                 transition: border-color var(--transition-quick);"
                             );
                             rsx! {
                                 button {


### PR DESCRIPTION
Closes #2391.

## Problem

Appearance settings panel used hardcoded hex colors (`#1a1a2e`, `#5b6af0`, `#2a2a4a`, etc.) instead of CSS variables from the design system. Clicking theme/density/accent buttons updated internal state and persisted to disk, but produced no visible change because the inline styles were static hex values that ignored the `[data-theme]` attribute.

## Changes

- Replace all hardcoded hex colors with CSS variable references (`var(--bg-surface)`, `var(--accent)`, `var(--border)`, `var(--text-inverse)`, `var(--text-secondary)`, `var(--text-muted)`, `var(--text-primary)`)
- Extract repeated section card and label styling into `SECTION_STYLE` / `SECTION_LABEL_STYLE` constants
- Add CSS `transition` properties for smooth visual feedback on button state changes
- Accent color swatch active border now uses `var(--text-primary)` instead of hardcoded `#fff` so it adapts to light/dark theme

## Test plan

- [ ] Click each theme button (Dark/Light/System) -- active button highlights, `data-theme` attribute updates, app re-renders with correct palette
- [ ] Drag font size slider -- value label updates, persists across restart
- [ ] Click each density button -- active button highlights, persists
- [ ] Click each accent color swatch -- active swatch shows border ring, persists
- [ ] Switch theme to Light, verify all section cards and labels render correctly against the light background