### PR TITLE
fix(theatron-desktop): remove color scheme preview label (#2392)

### DIFF
--- a/crates/theatron/desktop/src/state/settings.rs
+++ b/crates/theatron/desktop/src/state/settings.rs
@@ -358,6 +358,7 @@ pub(crate) struct WizardData {
     pub(crate) auth_token: String,
     pub(crate) selected_theme: String,
     pub(crate) selected_density: UiDensity,
+    pub(crate) selected_accent: String,
 }
 
 /// Preset accent color swatches: (label, hex).

--- a/crates/theatron/desktop/src/views/settings/wizard.rs
+++ b/crates/theatron/desktop/src/views/settings/wizard.rs
@@ -83,6 +83,7 @@ pub(crate) fn SetupWizard() -> Element {
                                     drop(server_id);
 
                                     let selected_theme = data.selected_theme.clone();
+                                    let selected_accent = data.selected_accent.clone();
                                     let density = data.selected_density;
                                     drop(data);
 
@@ -96,6 +97,9 @@ pub(crate) fn SetupWizard() -> Element {
                                         let mut app = appearance.write();
                                         app.theme = selected_theme;
                                         app.density = density;
+                                        if !selected_accent.is_empty() {
+                                            app.accent_color = selected_accent;
+                                        }
                                     }
 
                                     // Persist.
@@ -270,22 +274,27 @@ fn StepAppearance(
                 style: "display: flex; flex-direction: column; gap: 8px;",
                 div {
                     style: "font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px;",
-                    "Accent Color (preview)"
+                    "Accent Color"
                 }
                 div {
                     style: "display: flex; gap: 10px; flex-wrap: wrap;",
                     for (label, hex) in ACCENT_PRESETS.iter() {
                         {
                             let hex_owned = hex.to_string();
+                            let is_active = wizard_data.read().selected_accent == *hex;
+                            let border = if is_active { "3px solid #fff" } else { "2px solid var(--border)" };
                             let style = format!(
                                 "width: 28px; height: 28px; border-radius: 50%; background: {hex_owned}; \
-                                 border: 2px solid var(--border); cursor: pointer; outline: none;"
+                                 border: {border}; cursor: pointer; outline: none;"
                             );
                             rsx! {
                                 button {
                                     key: "{label}",
                                     title: "{label}",
                                     style: "{style}",
+                                    onclick: move |_| {
+                                        wizard_data.write().selected_accent = hex_owned.clone();
+                                    },
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

- Removed confusing "(preview)" label from the accent color section in the setup wizard
- Wired up onclick handlers on accent color swatches so the selection is interactive
- Added `selected_accent` to `WizardData` so the choice propagates to `AppearanceSettings` on wizard finish
- Added visual feedback (white border) on the selected swatch

Closes #2392.

## Test plan

- [ ] Run setup wizard, verify "Accent Color" label has no "(preview)" suffix
- [ ] Click accent swatches in wizard, verify white border appears on selected swatch
- [ ] Complete wizard with a non-default accent, verify it persists in Settings > Appearance