### PR TITLE
refactor(graphe): DRY cleanup — SQL builder, validate merge, serde export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "jiff",
  "serde",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "compact_str",
  "jiff",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6062,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/graphe/src/backup.rs
+++ b/crates/graphe/src/backup.rs
@@ -10,11 +10,13 @@ use aletheia_koina::disk_space::DiskSpaceMonitor;
 
 use crate::error::{self, Result};
 
-/// Validate a backup path contains only safe characters for SQL interpolation.
+/// Validate a backup path for safe SQL interpolation and optional directory containment.
 ///
-/// `SQLite` `VACUUM INTO` doesn't support parameter binding, so this is the
-/// only defense against path injection.
-fn validate_backup_path(path: &Path) -> Result<()> {
+/// `SQLite` `VACUUM INTO` doesn't support parameter binding, so character
+/// validation is the sole defense against path injection. When `backup_dir`
+/// is provided, also verifies the resolved path stays within that directory
+/// (canonicalizing the parent to handle paths that don't yet exist on disk).
+fn validate_backup_path(path: &Path, backup_dir: Option<&Path>) -> Result<()> {
     let path_str = path.to_str().ok_or_else(|| {
         error::InvalidBackupPathSnafu {
             path: path.to_path_buf(),
@@ -35,36 +37,28 @@ fn validate_backup_path(path: &Path) -> Result<()> {
         }
     );
 
-    Ok(())
-}
+    if let Some(backup_dir) = backup_dir {
+        let canonical_dir = std::fs::canonicalize(backup_dir).context(error::IoSnafu {
+            path: backup_dir.to_path_buf(),
+        })?;
 
-/// Verify the resolved backup path stays within the expected backup directory.
-///
-/// Canonicalizes the backup directory (which must exist), then resolves the
-/// backup path's parent to check containment. Works for paths that do not
-/// yet exist on disk by canonicalizing the parent directory and re-appending
-/// the filename.
-fn validate_backup_path_traversal(path: &Path, backup_dir: &Path) -> Result<()> {
-    let canonical_dir = std::fs::canonicalize(backup_dir).context(error::IoSnafu {
-        path: backup_dir.to_path_buf(),
-    })?;
+        let parent = path.parent().unwrap_or(path);
+        let canonical_parent = std::fs::canonicalize(parent).context(error::IoSnafu {
+            path: parent.to_path_buf(),
+        })?;
+        let canonical_path = match path.file_name() {
+            Some(name) => canonical_parent.join(name),
+            None => canonical_parent.clone(),
+        };
 
-    let parent = path.parent().unwrap_or(path);
-    let canonical_parent = std::fs::canonicalize(parent).context(error::IoSnafu {
-        path: parent.to_path_buf(),
-    })?;
-    let canonical_path = match path.file_name() {
-        Some(name) => canonical_parent.join(name),
-        None => canonical_parent.clone(),
-    };
-
-    snafu::ensure!(
-        canonical_path.starts_with(&canonical_dir),
-        error::BackupPathTraversalSnafu {
-            path: canonical_path,
-            allowed_dir: canonical_dir,
-        }
-    );
+        snafu::ensure!(
+            canonical_path.starts_with(&canonical_dir),
+            error::BackupPathTraversalSnafu {
+                path: canonical_path,
+                allowed_dir: canonical_dir,
+            }
+        );
+    }
 
     Ok(())
 }
@@ -163,8 +157,7 @@ impl<'a> BackupManager<'a> {
         let timestamp = jiff::Timestamp::now().strftime("%Y%m%dT%H%M%S").to_string();
         let filename = format!("sessions_{timestamp}.db");
         let backup_path = self.backup_dir.join(&filename);
-        validate_backup_path(&backup_path)?;
-        validate_backup_path_traversal(&backup_path, &self.backup_dir)?;
+        validate_backup_path(&backup_path, Some(&self.backup_dir))?;
 
         self.conn
             .execute(&format!("VACUUM INTO '{}'", backup_path.display()), [])
@@ -316,26 +309,59 @@ impl<'a> BackupManager<'a> {
     }
 }
 
+/// Serializable snapshot of a session for JSON export.
+#[derive(serde::Serialize)]
+struct SessionExport {
+    id: String,
+    nous_id: String,
+    session_key: String,
+    status: String,
+    model: Option<String>,
+    session_type: String,
+    token_count_estimate: i64,
+    message_count: i64,
+    created_at: String,
+    updated_at: String,
+}
+
+/// Serializable snapshot of a message for JSON export.
+#[derive(serde::Serialize)]
+struct MessageExport {
+    seq: i64,
+    role: String,
+    content: String,
+    token_estimate: i64,
+    created_at: String,
+}
+
+/// Top-level JSON export archive.
+#[derive(serde::Serialize)]
+struct SessionArchive {
+    session: SessionExport,
+    messages: Vec<MessageExport>,
+    exported_at: String,
+}
+
 fn build_session_json(conn: &Connection, session_id: &str) -> Result<String> {
-    let session: serde_json::Value = conn
+    let session = conn
         .query_row(
             "SELECT id, nous_id, session_key, status, model, session_type,
                     token_count_estimate, message_count, created_at, updated_at
              FROM sessions WHERE id = ?1",
             [session_id],
             |row| {
-                Ok(serde_json::json!({
-                    "id": row.get::<_, String>(0)?,
-                    "nous_id": row.get::<_, String>(1)?,
-                    "session_key": row.get::<_, String>(2)?,
-                    "status": row.get::<_, String>(3)?,
-                    "model": row.get::<_, Option<String>>(4)?,
-                    "session_type": row.get::<_, String>(5)?,
-                    "token_count_estimate": row.get::<_, i64>(6)?,
-                    "message_count": row.get::<_, i64>(7)?,
-                    "created_at": row.get::<_, String>(8)?,
-                    "updated_at": row.get::<_, String>(9)?,
-                }))
+                Ok(SessionExport {
+                    id: row.get(0)?,
+                    nous_id: row.get(1)?,
+                    session_key: row.get(2)?,
+                    status: row.get(3)?,
+                    model: row.get(4)?,
+                    session_type: row.get(5)?,
+                    token_count_estimate: row.get(6)?,
+                    message_count: row.get(7)?,
+                    created_at: row.get(8)?,
+                    updated_at: row.get(9)?,
+                })
             },
         )
         .context(error::DatabaseSnafu)?;
@@ -347,25 +373,25 @@ fn build_session_json(conn: &Connection, session_id: &str) -> Result<String> {
         )
         .context(error::DatabaseSnafu)?;
 
-    let messages: Vec<serde_json::Value> = msg_stmt
+    let messages: Vec<MessageExport> = msg_stmt
         .query_map([session_id], |row| {
-            Ok(serde_json::json!({
-                "seq": row.get::<_, i64>(0)?,
-                "role": row.get::<_, String>(1)?,
-                "content": row.get::<_, String>(2)?,
-                "token_estimate": row.get::<_, i64>(3)?,
-                "created_at": row.get::<_, String>(4)?,
-            }))
+            Ok(MessageExport {
+                seq: row.get(0)?,
+                role: row.get(1)?,
+                content: row.get(2)?,
+                token_estimate: row.get(3)?,
+                created_at: row.get(4)?,
+            })
         })
         .context(error::DatabaseSnafu)?
         .collect::<std::result::Result<Vec<_>, _>>()
         .context(error::DatabaseSnafu)?;
 
-    let archive = serde_json::json!({
-        "session": session,
-        "messages": messages,
-        "exported_at": jiff::Timestamp::now().to_string(),
-    });
+    let archive = SessionArchive {
+        session,
+        messages,
+        exported_at: jiff::Timestamp::now().to_string(),
+    };
 
     serde_json::to_string_pretty(&archive).context(error::StoredJsonSnafu)
 }

--- a/crates/graphe/src/backup_tests.rs
+++ b/crates/graphe/src/backup_tests.rs
@@ -150,43 +150,43 @@ fn list_backups_empty_when_no_dir() {
 #[test]
 fn validate_rejects_single_quote() {
     let path = Path::new("/tmp/it's-a-trap.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_semicolon() {
     let path = Path::new("/tmp/backup;DROP TABLE sessions.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_backtick() {
     let path = Path::new("/tmp/backup`cmd`.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_double_dash() {
     let path = Path::new("/tmp/backup--comment.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_accepts_normal_path() {
     let path = Path::new("/tmp/backup-2026-01-01.db");
-    assert!(validate_backup_path(path).is_ok());
+    assert!(validate_backup_path(path, None).is_ok());
 }
 
 #[test]
 fn validate_accepts_path_with_spaces() {
     let path = Path::new("/tmp/my backup.db");
-    assert!(validate_backup_path(path).is_ok());
+    assert!(validate_backup_path(path, None).is_ok());
 }
 
 #[test]
 fn validate_accepts_dotted_path() {
     let path = Path::new("/home/user/.config/backup.db");
-    assert!(validate_backup_path(path).is_ok());
+    assert!(validate_backup_path(path, None).is_ok());
 }
 
 #[test]
@@ -258,7 +258,7 @@ fn backup_path_validation_rejects_injection() {
     for bad in &bad_paths {
         let path = Path::new(bad);
         assert!(
-            validate_backup_path(path).is_err(),
+            validate_backup_path(path, None).is_err(),
             "path should be rejected: {bad}"
         );
     }
@@ -272,7 +272,7 @@ fn backup_path_validation_rejects_injection() {
 fn path_traversal_not_caught_by_sql_validation() {
     let traversal = Path::new("../../../etc/passwd");
     assert!(
-        validate_backup_path(traversal).is_ok(),
+        validate_backup_path(traversal, None).is_ok(),
         "traversal passes SQL-injection validation (known gap)"
     );
 }
@@ -280,79 +280,79 @@ fn path_traversal_not_caught_by_sql_validation() {
 #[test]
 fn validate_rejects_null_byte() {
     let path = Path::new("/tmp/backup\x00.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_parentheses() {
     let path = Path::new("/tmp/backup(1).db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_dollar_sign() {
     let path = Path::new("/tmp/$HOME/backup.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_pipe() {
     let path = Path::new("/tmp/backup|evil.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_angle_brackets() {
     let path = Path::new("/tmp/backup<script>.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_curly_braces() {
     let path = Path::new("/tmp/backup{0}.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_at_sign() {
     let path = Path::new("/tmp/backup@host.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_exclamation() {
     let path = Path::new("/tmp/backup!.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_hash() {
     let path = Path::new("/tmp/backup#1.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_percent() {
     let path = Path::new("/tmp/backup%20.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_double_quote() {
     let path = Path::new("/tmp/backup\"quoted\".db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_ampersand() {
     let path = Path::new("/tmp/backup&cmd.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
 fn validate_rejects_asterisk() {
     let path = Path::new("/tmp/backup*.db");
-    assert!(validate_backup_path(path).is_err());
+    assert!(validate_backup_path(path, None).is_err());
 }
 
 #[test]
@@ -378,7 +378,7 @@ fn validate_rejects_all_sqlite_metacharacters() {
     for bad in &metachar_paths {
         let path = Path::new(bad);
         assert!(
-            validate_backup_path(path).is_err(),
+            validate_backup_path(path, None).is_err(),
             "path should be rejected: {bad}"
         );
     }
@@ -395,7 +395,7 @@ fn validate_rejects_unicode_control_chars() {
     for bad in &paths_with_unicode {
         let path = Path::new(bad);
         assert!(
-            validate_backup_path(path).is_err(),
+            validate_backup_path(path, None).is_err(),
             "path with unicode control char should be rejected: {bad:?}"
         );
     }
@@ -405,7 +405,7 @@ fn validate_rejects_unicode_control_chars() {
 fn validate_accepts_unicode_alphanumeric() {
     let path = Path::new("/tmp/backup-données.db");
     assert!(
-        validate_backup_path(path).is_ok(),
+        validate_backup_path(path, None).is_ok(),
         "unicode alphanumeric chars should be accepted"
     );
 }
@@ -420,7 +420,7 @@ fn backup_path_validation_accepts_safe_paths() {
     for good in &good_paths {
         let path = Path::new(good);
         assert!(
-            validate_backup_path(path).is_ok(),
+            validate_backup_path(path, None).is_ok(),
             "path should be accepted: {good}"
         );
     }
@@ -506,7 +506,7 @@ fn backup_empty_store() {
 fn backup_path_with_spaces() {
     let path = Path::new("/home/my user/backup dir/sessions 2026.db");
     assert!(
-        validate_backup_path(path).is_ok(),
+        validate_backup_path(path, None).is_ok(),
         "paths with spaces should be accepted"
     );
 }
@@ -515,13 +515,13 @@ fn backup_path_with_spaces() {
 fn backup_path_with_dots() {
     let traversal = Path::new("../../etc/shadow.db");
     assert!(
-        validate_backup_path(traversal).is_ok(),
+        validate_backup_path(traversal, None).is_ok(),
         ".. components pass SQL-injection validation (path traversal is a separate concern)"
     );
 
     let dotted = Path::new("/home/user/.local/share/aletheia/backup.2026.01.01.db");
     assert!(
-        validate_backup_path(dotted).is_ok(),
+        validate_backup_path(dotted, None).is_ok(),
         "dotted paths are safe for SQL"
     );
 }
@@ -533,7 +533,7 @@ fn backup_path_empty_string() {
     // This documents current behavior: empty paths would fail at the filesystem
     // level during VACUUM INTO, not at validation time.
     assert!(
-        validate_backup_path(path).is_ok(),
+        validate_backup_path(path, None).is_ok(),
         "empty path passes SQL validation (filesystem rejects it later)"
     );
 }
@@ -628,7 +628,7 @@ fn restore_from_corrupt_file_errors() {
 fn validate_path_rejects_semicolons_in_filename() {
     let path = Path::new("/backups/data;rm -rf.db");
     assert!(
-        validate_backup_path(path).is_err(),
+        validate_backup_path(path, None).is_err(),
         "semicolon in filename must be rejected"
     );
 }
@@ -637,7 +637,7 @@ fn validate_path_rejects_semicolons_in_filename() {
 fn validate_path_rejects_backticks_in_filename() {
     let path = Path::new("/backups/`whoami`.db");
     assert!(
-        validate_backup_path(path).is_err(),
+        validate_backup_path(path, None).is_err(),
         "backticks in filename must be rejected"
     );
 }
@@ -646,7 +646,7 @@ fn validate_path_rejects_backticks_in_filename() {
 fn validate_path_rejects_single_quotes_in_dir() {
     let path = Path::new("/tmp/bob's dir/backup.db");
     assert!(
-        validate_backup_path(path).is_err(),
+        validate_backup_path(path, None).is_err(),
         "single quotes in directory must be rejected"
     );
 }
@@ -655,7 +655,7 @@ fn validate_path_rejects_single_quotes_in_dir() {
 fn validate_path_accepts_normal_nested() {
     let path = Path::new("/var/lib/aletheia/backups/sessions_20260309T120000.db");
     assert!(
-        validate_backup_path(path).is_ok(),
+        validate_backup_path(path, None).is_ok(),
         "normal nested path with underscores and digits must be accepted"
     );
 }

--- a/crates/graphe/src/store/message.rs
+++ b/crates/graphe/src/store/message.rs
@@ -72,79 +72,42 @@ impl SessionStore {
         limit: Option<i64>,
         before_seq: Option<i64>,
     ) -> Result<Vec<Message>> {
-        let mut messages = Vec::new();
+        // WHY: Dynamic SQL builder replaces a 4-branch match that duplicated
+        // the query/collect pattern. The parameter index (`idx`) advances as
+        // optional clauses are appended, keeping bind positions correct.
+        let mut where_clause = String::from("session_id = ?1 AND is_distilled = 0");
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> =
+            vec![Box::new(session_id.to_owned())];
+        let mut idx = 2u32;
 
-        match (limit, before_seq) {
-            (Some(limit), Some(before)) => {
-                let mut stmt = self
-                    .conn
-                    .prepare_cached(
-                        "SELECT * FROM (\
-                           SELECT * FROM messages \
-                           WHERE session_id = ?1 AND is_distilled = 0 AND seq < ?3 \
-                           ORDER BY seq DESC LIMIT ?2\
-                         ) ORDER BY seq ASC",
-                    )
-                    .context(error::DatabaseSnafu)?;
-                let rows = stmt
-                    .query_map(rusqlite::params![session_id, limit, before], map_message)
-                    .context(error::DatabaseSnafu)?;
-                for row in rows {
-                    messages.push(row.context(error::DatabaseSnafu)?);
-                }
-            }
-            (Some(limit), None) => {
-                let mut stmt = self
-                    .conn
-                    .prepare_cached(
-                        "SELECT * FROM (\
-                           SELECT * FROM messages \
-                           WHERE session_id = ?1 AND is_distilled = 0 \
-                           ORDER BY seq DESC LIMIT ?2\
-                         ) ORDER BY seq ASC",
-                    )
-                    .context(error::DatabaseSnafu)?;
-                let rows = stmt
-                    .query_map(rusqlite::params![session_id, limit], map_message)
-                    .context(error::DatabaseSnafu)?;
-                for row in rows {
-                    messages.push(row.context(error::DatabaseSnafu)?);
-                }
-            }
-            (None, Some(before)) => {
-                let mut stmt = self
-                    .conn
-                    .prepare_cached(
-                        "SELECT * FROM messages \
-                         WHERE session_id = ?1 AND is_distilled = 0 AND seq < ?2 \
-                         ORDER BY seq ASC",
-                    )
-                    .context(error::DatabaseSnafu)?;
-                let rows = stmt
-                    .query_map(rusqlite::params![session_id, before], map_message)
-                    .context(error::DatabaseSnafu)?;
-                for row in rows {
-                    messages.push(row.context(error::DatabaseSnafu)?);
-                }
-            }
-            (None, None) => {
-                let mut stmt = self
-                    .conn
-                    .prepare_cached(
-                        "SELECT * FROM messages \
-                         WHERE session_id = ?1 AND is_distilled = 0 \
-                         ORDER BY seq ASC",
-                    )
-                    .context(error::DatabaseSnafu)?;
-                let rows = stmt
-                    .query_map([session_id], map_message)
-                    .context(error::DatabaseSnafu)?;
-                for row in rows {
-                    messages.push(row.context(error::DatabaseSnafu)?);
-                }
-            }
+        if let Some(before) = before_seq {
+            where_clause.push_str(&format!(" AND seq < ?{idx}"));
+            params.push(Box::new(before));
+            idx += 1;
         }
 
+        let sql = if let Some(lim) = limit {
+            params.push(Box::new(lim));
+            format!(
+                "SELECT * FROM (\
+                   SELECT * FROM messages WHERE {where_clause} \
+                   ORDER BY seq DESC LIMIT ?{idx}\
+                 ) ORDER BY seq ASC"
+            )
+        } else {
+            format!("SELECT * FROM messages WHERE {where_clause} ORDER BY seq ASC")
+        };
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| &**p).collect();
+        let mut stmt = self.conn.prepare_cached(&sql).context(error::DatabaseSnafu)?;
+        let rows = stmt
+            .query_map(&*param_refs, map_message)
+            .context(error::DatabaseSnafu)?;
+
+        let mut messages = Vec::new();
+        for row in rows {
+            messages.push(row.context(error::DatabaseSnafu)?);
+        }
         Ok(messages)
     }
 


### PR DESCRIPTION
## Summary
- Dynamic SQL builder in `get_history_filtered` replacing 4-branch match
- Merged `validate_backup_path` + `validate_backup_path_traversal`
- Serde struct for session JSON export field mapping

Part of QA code cleanup batch 4 (~75 LOC reduction)

## Test plan
- [ ] `cargo check -p aletheia-graphe` passes
- [ ] `cargo test -p aletheia-graphe` passes
- [ ] Backup/restore behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)