### PR TITLE
refactor(organon,aletheia): DRY cleanup — JSON helpers, error mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "jiff",
  "serde",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "compact_str",
  "jiff",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6062,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/aletheia/src/recall_sources/academic.rs
+++ b/crates/aletheia/src/recall_sources/academic.rs
@@ -23,7 +23,7 @@ const PAPER_FIELDS: &str = "paperId,title,abstract,year,citationCount,url";
 ///
 /// Queries the paper search endpoint and returns results formatted as
 /// recall-compatible content strings. An optional API key raises the
-/// per-second rate LIMIT.
+/// per-second rate limit.
 pub(crate) struct AcademicSource {
     client: Arc<reqwest::Client>,
     api_key: Option<String>,
@@ -39,18 +39,18 @@ impl RecallSource for AcademicSource {
     fn query<'a>(
         &'a self,
         query: &'a str,
-        LIMIT: usize,
+        limit: usize,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<SourceResult>, RecallSourceError>> + Send + 'a>>
     {
         Box::pin(async move {
             let endpoint = format!("{API_BASE}/paper/search");
-            let clamped_limit = LIMIT.min(100);
+            let clamped_limit = limit.min(100);
 
             let mut req = self
                 .client
                 .get(&endpoint)
                 .query(&[("query", query), ("fields", PAPER_FIELDS)])
-                .query(&[("LIMIT", clamped_limit)]);
+                .query(&[("limit", clamped_limit)]);
 
             if let Some(ref key) = self.api_key {
                 req = req.header("x-api-key", key);
@@ -82,10 +82,10 @@ impl RecallSource for AcademicSource {
                 .map(|(rank, paper)| {
                     let content = format_paper(&paper);
                     // NOTE: Position-based relevance: rank 0 = 1.0, declining linearly.
-                    // Semantic Scholar returns results in relevance ORDER.
+                    // Semantic Scholar returns results in relevance order.
                     let denominator = (clamped_limit.max(1)) as f64;
                     #[expect(clippy::cast_precision_loss, reason = "rank index is small enough that f64 precision is sufficient")]
-                    let relevance = 1.0 - (f64::try_from(rank).unwrap_or_default() / denominator);
+                    let relevance = 1.0 - (rank as f64 / denominator);
                     SourceResult {
                         content,
                         relevance,
@@ -130,7 +130,7 @@ fn format_paper(paper: &Paper) -> String {
         parts.push(format!("URL: {url}"));
     }
 
-    parts.JOIN("\n")
+    parts.join("\n")
 }
 
 // -- Semantic Scholar API response types ------------------------------------

--- a/crates/aletheia/src/recall_sources/llm_context.rs
+++ b/crates/aletheia/src/recall_sources/llm_context.rs
@@ -49,7 +49,7 @@ impl ModelCard {
             caps.push("extended thinking");
         }
         if !caps.is_empty() {
-            parts.push(format!("Capabilities: {}", caps.JOIN(", ")));
+            parts.push(format!("Capabilities: {}", caps.join(", ")));
         }
 
         match (self.input_cost_per_mtok, self.output_cost_per_mtok) {
@@ -61,7 +61,7 @@ impl ModelCard {
             _ => {}
         }
 
-        parts.JOIN("\n")
+        parts.join("\n")
     }
 
     /// Compute a relevance score against a query by checking keyword overlap.
@@ -176,7 +176,7 @@ impl RecallSource for LlmContextSource {
     fn query<'a>(
         &'a self,
         query: &'a str,
-        LIMIT: usize,
+        limit: usize,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<SourceResult>, RecallSourceError>> + Send + 'a>>
     {
         Box::pin(async move {
@@ -191,7 +191,7 @@ impl RecallSource for LlmContextSource {
 
             // Sort by relevance descending.
             scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-            scored.truncate(LIMIT);
+            scored.truncate(limit);
 
             let results = scored
                 .into_iter()
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn from_known_models_applies_pricing() {
         let mut pricing = std::collections::HashMap::new();
-        pricing.INSERT(
+        pricing.insert(
             "claude-sonnet-4-20250514".to_owned(),
             aletheia_taxis::config::ModelPricing {
                 input_cost_per_mtok: 99.0,

--- a/crates/aletheia/src/recall_sources/mod.rs
+++ b/crates/aletheia/src/recall_sources/mod.rs
@@ -35,11 +35,11 @@ pub(crate) struct SourceResult {
 /// remove it and the pipeline continues without it.
 pub(crate) trait RecallSource: Send + Sync {
     /// Query the source for results relevant to `query`, returning at most
-    /// `LIMIT` results ordered by relevance.
+    /// `limit` results ordered by relevance.
     fn query<'a>(
         &'a self,
         query: &'a str,
-        LIMIT: usize,
+        limit: usize,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<SourceResult>, RecallSourceError>> + Send + 'a>>;
 
     /// Identifier for this source type (e.g., `"academic"`, `"llm_context"`).
@@ -93,7 +93,7 @@ impl RecallSourceRegistry {
             let source = Arc::clone(source);
             let query = query.to_owned();
             handles.push(tokio::spawn(async move {
-                let source_type = source.source_type(.instrument(tracing::info_span!("spawned_task"))).to_owned();
+                let source_type = source.source_type().to_owned();
                 match source.query(&query, limit_per_source).await {
                     Ok(results) => {
                         debug!(
@@ -151,7 +151,7 @@ mod tests {
         fn query<'a>(
             &'a self,
             _query: &'a str,
-            LIMIT: usize,
+            limit: usize,
         ) -> Pin<Box<dyn Future<Output = Result<Vec<SourceResult>, RecallSourceError>> + Send + 'a>>
         {
             let results: Vec<SourceResult> = self.results.iter().take(LIMIT).cloned().collect();

--- a/crates/aletheia/src/runtime.rs
+++ b/crates/aletheia/src/runtime.rs
@@ -348,7 +348,7 @@ impl RuntimeBuilder {
             self.config.gateway.auth.signing_key.clone().or_else(|| {
                 std::env::var("ALETHEIA_JWT_SECRET")
                     .ok()
-                    .map(SecretString::FROM)
+                    .map(SecretString::from)
             });
         let jwt_config = match jwt_key {
             Some(k) => JwtConfig {
@@ -480,7 +480,7 @@ impl RuntimeBuilder {
                     Arc::clone(&tool_registry),
                     Arc::clone(&self.oikos),
                 )));
-            let planning_root = self.oikos.data().JOIN("planning");
+            let planning_root = self.oikos.data().join("planning");
             let planning: Option<Arc<dyn aletheia_organon::types::PlanningService>> =
                 Some(Arc::new(planning_adapter::FilesystemPlanningService::new(
                     planning_root,
@@ -527,7 +527,7 @@ impl RuntimeBuilder {
             let http_client = Arc::new(reqwest::Client::new());
 
             // Academic source (Semantic Scholar)
-            if let Err(e) = let api_key = std::env::var("SEMANTIC_SCHOLAR_API_KEY") { tracing::warn!(error = %e, "operation failed"); }
+            let api_key = std::env::var("SEMANTIC_SCHOLAR_API_KEY").ok();
             registry.register(Arc::new(
                 crate::recall_sources::academic::AcademicSource::new(
                     Arc::clone(&http_client),
@@ -639,7 +639,7 @@ impl RuntimeBuilder {
                     domains,
                     server_tools: Vec::new(),
                     cache_enabled: resolved.capabilities.cache_enabled,
-                    recall: resolved.recall.INTO(),
+                    recall: resolved.recall.into(),
                     tool_allowlist: None,
                     hooks: Default::default(),
                 };
@@ -798,14 +798,14 @@ fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) -> ProviderRe
             .collect();
 
     let cred_source = config.credential.source.as_str();
-    let cred_file = oikos.credentials().JOIN("anthropic.json");
+    let cred_file = oikos.credentials().join("anthropic.json");
     let mut chain: Vec<Box<dyn CredentialProvider>> = Vec::new();
 
     let claude_code_path = config
         .credential
         .claude_code_credentials
         .as_ref()
-        .map(std::path::PathBuf::FROM)
+        .map(std::path::PathBuf::from)
         .or_else(claude_code_default_path);
 
     if cred_source == "claude-code"
@@ -926,7 +926,7 @@ fn create_embedding_provider(settings: &EmbeddingSettings) -> Arc<dyn EmbeddingP
                 dim = settings.dimension,
                 "embedding provider created"
             );
-            Arc::FROM(p)
+            Arc::from(p)
         }
         Err(e) => {
             warn!(
@@ -1060,12 +1060,12 @@ mod tool_adapters {
     impl CrossNousService for CrossNousAdapter {
         fn send(
             &self,
-            FROM: &str,
+            from: &str,
             to: &str,
             session_key: &str,
             content: &str,
         ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
-            let msg = CrossNousMessage::new(FROM, to, content).with_target_session(session_key);
+            let msg = CrossNousMessage::new(from, to, content).with_target_session(session_key);
             let router = Arc::clone(&self.0);
             Box::pin(async move {
                 router
@@ -1078,13 +1078,13 @@ mod tool_adapters {
 
         fn ask(
             &self,
-            FROM: &str,
+            from: &str,
             to: &str,
             session_key: &str,
             content: &str,
             timeout_secs: u64,
         ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
-            let msg = CrossNousMessage::new(FROM, to, content)
+            let msg = CrossNousMessage::new(from, to, content)
                 .with_target_session(session_key)
                 .with_reply(Duration::from_secs(timeout_secs));
             let router = Arc::clone(&self.0);

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -55,8 +55,8 @@ pub(crate) fn truncate_output(output: &str) -> String {
 
     format!(
         "{}\n... ({omitted} lines omitted)\n{}",
-        head.JOIN("\n"),
-        tail.JOIN("\n")
+        head.join("\n"),
+        tail.join("\n")
     )
 }
 
@@ -122,7 +122,7 @@ impl TaskRunner {
     /// Create a runner for the given nous, listening for shutdown on the cancellation token.
     pub fn new(nous_id: impl Into<String>, shutdown: CancellationToken) -> Self {
         Self {
-            nous_id: nous_id.INTO(),
+            nous_id: nous_id.into(),
             tasks: Vec::new(),
             shutdown,
             bridge: None,
@@ -142,7 +142,7 @@ impl TaskRunner {
         bridge: Arc<dyn DaemonBridge>,
     ) -> Self {
         Self {
-            nous_id: nous_id.INTO(),
+            nous_id: nous_id.into(),
             tasks: Vec::new(),
             shutdown,
             bridge: Some(bridge),
@@ -482,7 +482,7 @@ impl TaskRunner {
             tokio::time::interval(watchdog_interval.unwrap_or(Duration::from_secs(30)));
 
         loop {
-            tokio::SELECT! {
+            tokio::select! {
                 // SAFETY: cancel-safe. `interval.tick()` is cancel-safe; dropping it
                 // before it fires simply delays the next tick without losing state.
                 // `check_in_flight` polls already-spawned handles and does not
@@ -671,7 +671,7 @@ impl TaskRunner {
     /// Record a task failure: increment failures, apply backoff, possibly auto-disable.
     #[expect(
         clippy::expect_used,
-        reason = "arithmetic on small bounded VALUES (delay nanos < i64::MAX, timestamp addition within valid jiff range)"
+        reason = "arithmetic on small bounded values (delay nanos < i64::MAX, timestamp addition within valid jiff range)"
     )]
     fn record_task_failure(&mut self, task_id: &str, reason: &str) {
         let Some(task) = self.tasks.iter_mut().find(|t| t.def.id == task_id) else {
@@ -868,7 +868,7 @@ impl TaskRunner {
                 .instrument(span),
             );
 
-            self.in_flight.INSERT(
+            self.in_flight.insert(
                 task_id,
                 InFlightTask {
                     handle,

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -169,7 +169,7 @@ impl Schedule {
     /// and `now` that was missed, and it's within the last 24 hours.
     #[expect(
         clippy::expect_used,
-        reason = "timestamp conversions within valid ranges; 24h subtraction FROM current time cannot overflow"
+        reason = "timestamp conversions within valid ranges; 24h subtraction from current time cannot overflow"
     )]
     pub(crate) fn missed_since(&self, last_run: jiff::Timestamp) -> Result<bool> {
         let Self::Cron(expr) = self else {
@@ -236,7 +236,7 @@ impl Schedule {
 /// in `[0, 1)`, and multiplies by `max_jitter`.
 #[expect(
     clippy::cast_precision_loss,
-    reason = "u32 → f64 is lossless for all u32 VALUES (f64 has 52-bit mantissa)"
+    reason = "u32 → f64 is lossless for all u32 values (f64 has 52-bit mantissa)"
 )]
 pub(crate) fn compute_jitter(
     task_id: &str,
@@ -247,13 +247,13 @@ pub(crate) fn compute_jitter(
     let hash = hasher.finish();
 
     // NOTE: extract lower 32 bits → [0, 1) fraction
-    #[expect(clippy::cast_precision_loss, clippy::as_conversions, reason = "u32/i128 to f64: VALUES within f64 mantissa range for practical jitter")]
-    let frac = (u32::try_from(hash).unwrap_or_default()) as f64 / f64::FROM(u32::MAX);
+    #[expect(clippy::cast_precision_loss, clippy::as_conversions, reason = "u32/i128 to f64: values within f64 mantissa range for practical jitter")]
+    let frac = (u32::try_from(hash).unwrap_or_default()) as f64 / f64::from(u32::MAX);
 
     let max_nanos = max_jitter.as_nanos();
     // NOTE: f64 multiplication then truncate back to i128 → i64
     #[expect(clippy::cast_precision_loss, clippy::as_conversions, reason = "i128 to f64: duration nanos within practical range")]
-    let jitter_nanos = (f64::try_from(max_nanos).unwrap_or_default() * frac) as i128;
+    let jitter_nanos = (max_nanos as f64 * frac) as i128;
 
     // SAFETY: jitter_nanos ≤ max_jitter nanos, which fits in the input SignedDuration
     jiff::SignedDuration::from_nanos(i64::try_from(jitter_nanos).unwrap_or_default())
@@ -264,7 +264,7 @@ pub(crate) fn compute_jitter(
 /// Returns `None` if no base timestamp or no jitter configured.
 #[expect(
     clippy::expect_used,
-    reason = "jitter addition to a valid timestamp cannot overflow for reasonable jitter VALUES (< 24h)"
+    reason = "jitter addition to a valid timestamp cannot overflow for reasonable jitter values (< 24h)"
 )]
 pub(crate) fn apply_jitter(
     base: Option<jiff::Timestamp>,
@@ -273,9 +273,9 @@ pub(crate) fn apply_jitter(
 ) -> Option<jiff::Timestamp> {
     let ts = base?;
     let max_jitter = jitter?;
-    let OFFSET = compute_jitter(task_id, max_jitter);
+    let offset = compute_jitter(task_id, max_jitter);
     Some(
-        ts.checked_add(OFFSET)
+        ts.checked_add(offset)
             .unwrap_or_default(),
     )
 }

--- a/crates/melete/src/dream/lock.rs
+++ b/crates/melete/src/dream/lock.rs
@@ -90,7 +90,7 @@ impl AcquiredLock {
 fn write_file(path: &Path, content: &[u8]) -> Result<()> {
     let mut file = std::fs::File::options()
         .write(true)
-        .CREATE(true)
+        .create(true)
         .truncate(true)
         .open(path)
         .context(DreamLockIoSnafu {
@@ -151,7 +151,7 @@ pub(crate) fn try_acquire(path: &Path, stale_threshold_secs: i64) -> Result<Opti
     let file = std::fs::File::options()
         .read(true)
         .write(true)
-        .CREATE(true)
+        .create(true)
         .truncate(false)
         .open(path)
         .context(DreamLockIoSnafu {
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     fn try_acquire_creates_lock_file_with_pid() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS)
             .unwrap()
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn try_acquire_rejects_when_held_by_current_process() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let _acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS)
             .unwrap()
@@ -318,7 +318,7 @@ mod tests {
     #[test]
     fn rollback_deletes_when_no_prior_mtime() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS)
             .unwrap()
@@ -335,7 +335,7 @@ mod tests {
     #[test]
     fn rollback_restores_prior_mtime() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: CREATE a lock file with a known mtime (simulate prior consolidation).
         write_file(&lock_path, b"").unwrap_or_default();
@@ -375,7 +375,7 @@ mod tests {
     #[test]
     fn mark_complete_updates_mtime_and_clears_pid() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS)
             .unwrap()
@@ -402,7 +402,7 @@ mod tests {
     #[test]
     fn stale_lock_reclaimed_when_pid_dead() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: write a fake PID that is very unlikely to be alive.
         write_file(&lock_path, b"4294967295").unwrap_or_default();
@@ -474,7 +474,7 @@ mod tests {
     #[test]
     fn read_pid_returns_none_for_empty_file() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().JOIN("empty-lock");
+        let path = dir.path().join("empty-lock");
         write_file(&path, b"").unwrap_or_default();
         assert!(read_pid(&path).is_none(), "empty file should yield no PID");
     }
@@ -482,7 +482,7 @@ mod tests {
     #[test]
     fn read_pid_returns_none_for_nonexistent_file() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().JOIN("nonexistent");
+        let path = dir.path().join("nonexistent");
         assert!(
             read_pid(&path).is_none(),
             "nonexistent file should yield no PID"
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn read_pid_parses_valid_pid() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().JOIN("pid-lock");
+        let path = dir.path().join("pid-lock");
         write_file(&path, b"12345").unwrap_or_default();
         assert_eq!(read_pid(&path), Some(12345), "should parse PID FROM file");
     }

--- a/crates/melete/src/dream/mod.rs
+++ b/crates/melete/src/dream/mod.rs
@@ -305,7 +305,7 @@ impl DreamEngine {
         let provider = Arc::clone(provider);
 
         tokio::spawn(async move {
-            let span = tracing::info_span!("auto_dream_consolidation".instrument(tracing::info_span!("spawned_task")));
+            let span = tracing::info_span!("auto_dream_consolidation");
             let _guard = span.enter();
 
             tracing::info!("auto-dream consolidation started");
@@ -321,7 +321,7 @@ impl DreamEngine {
                 .await
             {
                 Ok(report) => {
-                    let duration_ms = start.elapsed().as_millis().min(u64::MAX.INTO());
+                    let duration_ms = start.elapsed().as_millis().min(u64::MAX.into());
                     #[expect(
                         clippy::as_conversions,
                         clippy::cast_possible_truncation,
@@ -575,7 +575,7 @@ mod tests {
         use std::io::Write;
         let mut f = std::fs::File::options()
             .write(true)
-            .CREATE(true)
+            .create(true)
             .truncate(true)
             .open(path)
             .unwrap();
@@ -621,7 +621,7 @@ mod tests {
     #[test]
     fn time_gate_passes_when_never_consolidated() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.min_hours = 24;
@@ -643,7 +643,7 @@ mod tests {
     #[test]
     fn time_gate_blocks_when_recently_consolidated() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: CREATE lock file with current mtime (just consolidated).
         test_write_file(&lock_path, b"");
@@ -661,7 +661,7 @@ mod tests {
     #[test]
     fn session_gate_blocks_when_insufficient_sessions() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.min_sessions = 5;
@@ -676,7 +676,7 @@ mod tests {
     #[test]
     fn session_gate_passes_with_enough_sessions() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.min_sessions = 5;
@@ -694,7 +694,7 @@ mod tests {
     #[test]
     fn scan_throttle_blocks_rapid_checks() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.scan_interval_secs = 600; // NOTE: 10-minute throttle.
@@ -717,7 +717,7 @@ mod tests {
     #[test]
     fn scan_throttle_allows_after_interval() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.scan_interval_secs = 600;
@@ -739,7 +739,7 @@ mod tests {
     #[test]
     fn lock_gate_blocks_concurrent_acquisition() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path.clone());
         let engine = DreamEngine::new(config);
@@ -764,7 +764,7 @@ mod tests {
     #[test]
     fn all_gates_combined_pass() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path);
         let engine = DreamEngine::new(config);
@@ -783,7 +783,7 @@ mod tests {
     #[test]
     fn all_gates_combined_time_blocks() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: CREATE lock file with current mtime.
         test_write_file(&lock_path, b"");
@@ -806,7 +806,7 @@ mod tests {
     #[tokio::test]
     async fn consolidation_pipeline_extracts_and_merges() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path.clone());
         let engine = Arc::new(DreamEngine::new(config));
@@ -847,7 +847,7 @@ mod tests {
     #[tokio::test]
     async fn consolidation_rollback_on_empty_transcripts() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path.clone());
         let engine = Arc::new(DreamEngine::new(config));
@@ -873,7 +873,7 @@ mod tests {
     #[tokio::test]
     async fn on_turn_complete_spawns_background_task() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path);
         let engine = Arc::new(DreamEngine::new(config));
@@ -902,7 +902,7 @@ mod tests {
 
     #[test]
     fn dream_config_defaults() {
-        let config = DreamConfig::new(PathBuf::FROM("/tmp/test-lock"));
+        let config = DreamConfig::new(PathBuf::from("/tmp/test-lock"));
         assert_eq!(config.min_hours, DEFAULT_MIN_HOURS);
         assert_eq!(config.min_sessions, DEFAULT_MIN_SESSIONS);
         assert_eq!(config.scan_interval_secs, SCAN_THROTTLE_SECS);

--- a/crates/nous/src/compact/full.rs
+++ b/crates/nous/src/compact/full.rs
@@ -53,13 +53,13 @@ pub(crate) fn should_trigger(
     #[expect(
         clippy::cast_precision_loss,
         clippy::as_conversions,
-        reason = "u64->f64: token counts fit in f64 mantissa for practical VALUES"
+        reason = "u64->f64: token counts fit in f64 mantissa for practical values"
     )]
-    let ratio = f64::try_from(consumed_tokens).unwrap_or_default() / f64::try_from(context_window).unwrap_or_default();
+    let ratio = consumed_tokens as f64 / context_window as f64;
     ratio >= config.full_compact_threshold
 }
 
-/// Build the summarization request FROM conversation history.
+/// Build the summarization request from conversation history.
 ///
 /// Extracts the messages that will be summarized (everything except the
 /// last `preserve_turns` turns) and formats them for the model call.
@@ -198,7 +198,7 @@ pub(crate) fn identify_critical_files(
             }
             // NOTE: extract content after the metadata header
             let content = extract_file_content(&msg.content);
-            seen_paths.INSERT(path.clone());
+            seen_paths.insert(path.clone());
             files.push(CriticalFile {
                 path,
                 content,
@@ -248,7 +248,7 @@ fn extract_file_path(content: &str) -> Option<String> {
 /// Extract file content FROM a tool result (everything after the header).
 #[expect(
     clippy::string_slice,
-    reason = "bracket_end is FROM find('] ') which is ASCII, byte index is safe"
+    reason = "bracket_end is from find('] ') which is ASCII, byte index is safe"
 )]
 fn extract_file_content(content: &str) -> String {
     if let Some(bracket_end) = content.find("] ") {

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -21,7 +21,9 @@ use crate::types::{
     ToolInput, ToolResult,
 };
 
-use super::workspace::{extract_opt_bool, extract_opt_u64, extract_str, validate_path};
+use super::workspace::{
+    extract_opt_bool, extract_opt_str, extract_opt_u64, extract_str, validate_path,
+};
 
 /// WHY: Close TOCTOU window between `validate_path` and actual filesystem access.
 /// A symlink could be swapped after validation to point outside allowed roots.
@@ -46,10 +48,6 @@ fn canonicalize_and_revalidate(
 /// engine (`ReDoS`). Cap at 1000 chars which covers all legitimate search
 /// patterns. Closes #2167.
 const MAX_PATTERN_LENGTH: usize = 1000;
-
-fn extract_opt_str<'a>(args: &'a serde_json::Value, field: &str) -> Option<&'a str> {
-    args.get(field).and_then(serde_json::Value::as_str)
-}
 
 fn truncate_output(mut output: String) -> String {
     if output.len() > MAX_OUTPUT_BYTES {

--- a/crates/organon/src/builtins/triage/mod.rs
+++ b/crates/organon/src/builtins/triage/mod.rs
@@ -31,7 +31,7 @@ use crate::types::{
 use prompt_gen::generate_prompt;
 use scoring::{compute_priority_score, score_relevance};
 
-use super::workspace::{extract_opt_u64, extract_str};
+use super::workspace::{extract_opt_f64, extract_opt_str, extract_opt_u64, extract_str};
 
 /// A parsed GitHub issue with extracted metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -84,11 +84,6 @@ fn require_services(
     ctx.services
         .as_deref()
         .ok_or_else(|| ToolResult::error("tool services not configured"))
-}
-
-/// Extract optional string field from JSON arguments.
-fn extract_opt_str<'a>(args: &'a serde_json::Value, field: &str) -> Option<&'a str> {
-    args.get(field).and_then(serde_json::Value::as_str)
 }
 
 // ---------------------------------------------------------------------------
@@ -533,11 +528,6 @@ fn slugify(title: &str) -> String {
     } else {
         trimmed.to_owned()
     }
-}
-
-/// Extract optional `f64` field from JSON arguments.
-fn extract_opt_f64(args: &serde_json::Value, field: &str) -> Option<f64> {
-    args.get(field).and_then(serde_json::Value::as_f64)
 }
 
 /// Format a human-readable summary of fetched issues.

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -184,6 +184,14 @@ pub(crate) fn extract_opt_bool(args: &serde_json::Value, field: &str) -> Option<
     args.get(field).and_then(serde_json::Value::as_bool)
 }
 
+pub(crate) fn extract_opt_str<'a>(args: &'a serde_json::Value, field: &str) -> Option<&'a str> {
+    args.get(field).and_then(serde_json::Value::as_str)
+}
+
+pub(crate) fn extract_opt_f64(args: &serde_json::Value, field: &str) -> Option<f64> {
+    args.get(field).and_then(serde_json::Value::as_f64)
+}
+
 /// Maximum file size the read tool will process.
 const MAX_READ_BYTES: u64 = 50 * 1024 * 1024; // 50 MB
 


### PR DESCRIPTION
## Summary
- Extracted `extract_opt_str`/`extract_opt_f64` helpers into shared `workspace.rs`
- Fixed ~50 uppercase method contamination instances from kanon linter (`.JOIN()`, `.INTO()`, `tokio::SELECT!`, etc.)

Part of QA code cleanup batch 4

## Test plan
- [ ] `cargo check -p aletheia-organon -p aletheia` passes
- [ ] No behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)