### PR TITLE
refactor(daemon,pylon): DRY cleanup — threshold checker, task registration, From impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "jiff",
  "serde",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "compact_str",
  "jiff",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6062,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.32"
+version = "0.13.34"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/aletheia/src/recall_sources/academic.rs
+++ b/crates/aletheia/src/recall_sources/academic.rs
@@ -85,7 +85,7 @@ impl RecallSource for AcademicSource {
                     // Semantic Scholar returns results in relevance ORDER.
                     let denominator = (clamped_limit.max(1)) as f64;
                     #[expect(clippy::cast_precision_loss, reason = "rank index is small enough that f64 precision is sufficient")]
-                    let relevance = 1.0 - (f64::try_from(rank).unwrap_or_default() / denominator);
+                    let relevance = 1.0 - (rank as f64 / denominator);
                     SourceResult {
                         content,
                         relevance,
@@ -130,7 +130,7 @@ fn format_paper(paper: &Paper) -> String {
         parts.push(format!("URL: {url}"));
     }
 
-    parts.JOIN("\n")
+    parts.join("\n")
 }
 
 // -- Semantic Scholar API response types ------------------------------------

--- a/crates/aletheia/src/recall_sources/llm_context.rs
+++ b/crates/aletheia/src/recall_sources/llm_context.rs
@@ -49,7 +49,7 @@ impl ModelCard {
             caps.push("extended thinking");
         }
         if !caps.is_empty() {
-            parts.push(format!("Capabilities: {}", caps.JOIN(", ")));
+            parts.push(format!("Capabilities: {}", caps.join(", ")));
         }
 
         match (self.input_cost_per_mtok, self.output_cost_per_mtok) {
@@ -61,7 +61,7 @@ impl ModelCard {
             _ => {}
         }
 
-        parts.JOIN("\n")
+        parts.join("\n")
     }
 
     /// Compute a relevance score against a query by checking keyword overlap.
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn from_known_models_applies_pricing() {
         let mut pricing = std::collections::HashMap::new();
-        pricing.INSERT(
+        pricing.insert(
             "claude-sonnet-4-20250514".to_owned(),
             aletheia_taxis::config::ModelPricing {
                 input_cost_per_mtok: 99.0,

--- a/crates/aletheia/src/runtime.rs
+++ b/crates/aletheia/src/runtime.rs
@@ -348,7 +348,7 @@ impl RuntimeBuilder {
             self.config.gateway.auth.signing_key.clone().or_else(|| {
                 std::env::var("ALETHEIA_JWT_SECRET")
                     .ok()
-                    .map(SecretString::FROM)
+                    .map(SecretString::from)
             });
         let jwt_config = match jwt_key {
             Some(k) => JwtConfig {
@@ -480,7 +480,7 @@ impl RuntimeBuilder {
                     Arc::clone(&tool_registry),
                     Arc::clone(&self.oikos),
                 )));
-            let planning_root = self.oikos.data().JOIN("planning");
+            let planning_root = self.oikos.data().join("planning");
             let planning: Option<Arc<dyn aletheia_organon::types::PlanningService>> =
                 Some(Arc::new(planning_adapter::FilesystemPlanningService::new(
                     planning_root,
@@ -639,7 +639,7 @@ impl RuntimeBuilder {
                     domains,
                     server_tools: Vec::new(),
                     cache_enabled: resolved.capabilities.cache_enabled,
-                    recall: resolved.recall.INTO(),
+                    recall: resolved.recall.into(),
                     tool_allowlist: None,
                     hooks: Default::default(),
                 };
@@ -798,14 +798,14 @@ fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) -> ProviderRe
             .collect();
 
     let cred_source = config.credential.source.as_str();
-    let cred_file = oikos.credentials().JOIN("anthropic.json");
+    let cred_file = oikos.credentials().join("anthropic.json");
     let mut chain: Vec<Box<dyn CredentialProvider>> = Vec::new();
 
     let claude_code_path = config
         .credential
         .claude_code_credentials
         .as_ref()
-        .map(std::path::PathBuf::FROM)
+        .map(std::path::PathBuf::from)
         .or_else(claude_code_default_path);
 
     if cred_source == "claude-code"
@@ -926,7 +926,7 @@ fn create_embedding_provider(settings: &EmbeddingSettings) -> Arc<dyn EmbeddingP
                 dim = settings.dimension,
                 "embedding provider created"
             );
-            Arc::FROM(p)
+            Arc::from(p)
         }
         Err(e) => {
             warn!(
@@ -1060,12 +1060,12 @@ mod tool_adapters {
     impl CrossNousService for CrossNousAdapter {
         fn send(
             &self,
-            FROM: &str,
+            from: &str,
             to: &str,
             session_key: &str,
             content: &str,
         ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
-            let msg = CrossNousMessage::new(FROM, to, content).with_target_session(session_key);
+            let msg = CrossNousMessage::new(from, to, content).with_target_session(session_key);
             let router = Arc::clone(&self.0);
             Box::pin(async move {
                 router
@@ -1078,13 +1078,13 @@ mod tool_adapters {
 
         fn ask(
             &self,
-            FROM: &str,
+            from: &str,
             to: &str,
             session_key: &str,
             content: &str,
             timeout_secs: u64,
         ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
-            let msg = CrossNousMessage::new(FROM, to, content)
+            let msg = CrossNousMessage::new(from, to, content)
                 .with_target_session(session_key)
                 .with_reply(Duration::from_secs(timeout_secs));
             let router = Arc::clone(&self.0);

--- a/crates/daemon/src/prosoche.rs
+++ b/crates/daemon/src/prosoche.rs
@@ -137,33 +137,47 @@ impl ProsocheCheck {
     }
 }
 
+/// Check a numeric value against two thresholds, returning an [`AttentionItem`] if either is exceeded.
+///
+/// `warn_threshold` maps to [`Urgency::High`], `critical_threshold` to [`Urgency::Critical`].
+/// `format_summary` receives the measured value and should return a human-readable description.
+fn check_threshold(
+    value: f64,
+    warn_threshold: f64,
+    critical_threshold: f64,
+    format_summary: impl FnOnce(f64) -> String,
+) -> Option<AttentionItem> {
+    let (urgency, summary) = if value >= critical_threshold {
+        (Urgency::Critical, format_summary(value))
+    } else if value >= warn_threshold {
+        (Urgency::High, format_summary(value))
+    } else {
+        return None;
+    };
+
+    Some(AttentionItem {
+        category: AttentionCategory::SystemHealth,
+        summary,
+        urgency,
+    })
+}
+
 /// Check disk space usage on the filesystem containing `path`.
 ///
 /// Uses `df` command output. WARN at 80% usage, CRITICAL at 95%.
 async fn check_disk_space(path: &Path) -> Vec<AttentionItem> {
-    let mut items = Vec::new();
-
     match disk_usage_percent(path).await {
         Ok(percent) => {
-            if percent >= 95.0 {
-                items.push(AttentionItem {
-                    category: AttentionCategory::SystemHealth,
-                    summary: format!(
-                        "Disk space critical: {percent:.1}% used on {}",
-                        path.display()
-                    ),
-                    urgency: Urgency::Critical,
-                });
-            } else if percent >= 80.0 {
-                items.push(AttentionItem {
-                    category: AttentionCategory::SystemHealth,
-                    summary: format!(
-                        "Disk space warning: {percent:.1}% used on {}",
-                        path.display()
-                    ),
-                    urgency: Urgency::High,
-                });
-            }
+            let label = if percent >= 95.0 {
+                "critical"
+            } else {
+                "warning"
+            };
+            check_threshold(percent, 80.0, 95.0, |p| {
+                format!("Disk space {label}: {p:.1}% used on {}", path.display())
+            })
+            .into_iter()
+            .collect()
         }
         Err(e) => {
             tracing::warn!(
@@ -171,10 +185,9 @@ async fn check_disk_space(path: &Path) -> Vec<AttentionItem> {
                 error = %e,
                 "failed to check disk space"
             );
+            Vec::new()
         }
     }
-
-    items
 }
 
 /// Get disk usage percentage for the filesystem containing `path` via `df`.
@@ -221,23 +234,16 @@ fn check_db_sizes(paths: &[PathBuf]) -> Vec<AttentionItem> {
     for path in paths {
         match std::fs::metadata(path) {
             Ok(meta) => {
-                let size = meta.len();
-                if size > ONE_GB {
-                    #[expect(
-                        clippy::cast_precision_loss,
-                        clippy::as_conversions,
-                        reason = "u64→f64: file sizes don't need exact precision for display"
-                    )]
-                    let size_gb = size as f64 / ONE_GB as f64;
-                    items.push(AttentionItem {
-                        category: AttentionCategory::SystemHealth,
-                        summary: format!(
-                            "Database file large: {} is {size_gb:.1} GB",
-                            path.display(),
-                        ),
-                        urgency: Urgency::High,
-                    });
-                }
+                #[expect(
+                    clippy::cast_precision_loss,
+                    clippy::as_conversions,
+                    reason = "u64→f64: file sizes don't need exact precision for display"
+                )]
+                let size_gb = meta.len() as f64 / ONE_GB as f64;
+                // NOTE: single threshold — any file over 1 GB is High urgency.
+                items.extend(check_threshold(size_gb, 1.0, f64::INFINITY, |gb| {
+                    format!("Database file large: {} is {gb:.1} GB", path.display())
+                }));
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // NOTE: File doesn't exist: not an error for health checks.
@@ -262,23 +268,21 @@ fn check_memory() -> Vec<AttentionItem> {
     match read_process_rss_kb() {
         Ok(resident_kb) => {
             let rss_mb = resident_kb / 1024;
-            let mut items = Vec::new();
-
-            if rss_mb >= 2048 {
-                items.push(AttentionItem {
-                    category: AttentionCategory::SystemHealth,
-                    summary: format!("Process memory critical: {rss_mb} MB RSS"),
-                    urgency: Urgency::Critical,
-                });
-            } else if rss_mb >= 1024 {
-                items.push(AttentionItem {
-                    category: AttentionCategory::SystemHealth,
-                    summary: format!("Process memory high: {rss_mb} MB RSS"),
-                    urgency: Urgency::High,
-                });
-            }
-
-            items
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "u64→f64: MB values are small enough for exact representation"
+            )]
+            let rss_f64 = rss_mb as f64;
+            let label = if rss_mb >= 2048 {
+                "critical"
+            } else {
+                "high"
+            };
+            check_threshold(rss_f64, 1024.0, 2048.0, |mb| {
+                format!("Process memory {label}: {mb:.0} MB RSS")
+            })
+            .into_iter()
+            .collect()
         }
         Err(e) => {
             tracing::debug!(error = %e, "failed to read process RSS — skipping memory check");

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -55,8 +55,8 @@ pub(crate) fn truncate_output(output: &str) -> String {
 
     format!(
         "{}\n... ({omitted} lines omitted)\n{}",
-        head.JOIN("\n"),
-        tail.JOIN("\n")
+        head.join("\n"),
+        tail.join("\n")
     )
 }
 
@@ -122,7 +122,7 @@ impl TaskRunner {
     /// Create a runner for the given nous, listening for shutdown on the cancellation token.
     pub fn new(nous_id: impl Into<String>, shutdown: CancellationToken) -> Self {
         Self {
-            nous_id: nous_id.INTO(),
+            nous_id: nous_id.into(),
             tasks: Vec::new(),
             shutdown,
             bridge: None,
@@ -142,7 +142,7 @@ impl TaskRunner {
         bridge: Arc<dyn DaemonBridge>,
     ) -> Self {
         Self {
-            nous_id: nous_id.INTO(),
+            nous_id: nous_id.into(),
             tasks: Vec::new(),
             shutdown,
             bridge: Some(bridge),
@@ -197,6 +197,27 @@ impl TaskRunner {
         self
     }
 
+    /// Register a builtin task with standard defaults, binding it to this runner's `nous_id`.
+    fn register_builtin(
+        &mut self,
+        id: &str,
+        name: &str,
+        schedule: Schedule,
+        task: BuiltinTask,
+        catch_up: bool,
+    ) {
+        self.register(TaskDef {
+            id: id.to_owned(),
+            name: name.to_owned(),
+            nous_id: self.nous_id.clone(),
+            schedule,
+            action: TaskAction::Builtin(task),
+            enabled: true,
+            catch_up,
+            ..TaskDef::default()
+        });
+    }
+
     /// Register default maintenance tasks based on configuration.
     ///
     /// Skips disabled tasks and retention when no executor is provided.
@@ -207,55 +228,43 @@ impl TaskRunner {
         let has_executor = self.retention_executor.is_some();
 
         if config.trace_rotation.enabled {
-            self.register(TaskDef {
-                id: "trace-rotation".to_owned(),
-                name: "Trace rotation".to_owned(),
-                nous_id: self.nous_id.clone(),
-                schedule: Schedule::Cron("0 0 3 * * *".to_owned()),
-                action: TaskAction::Builtin(BuiltinTask::TraceRotation),
-                enabled: true,
-                catch_up: true,
-                ..TaskDef::default()
-            });
+            self.register_builtin(
+                "trace-rotation",
+                "Trace rotation",
+                Schedule::Cron("0 0 3 * * *".to_owned()),
+                BuiltinTask::TraceRotation,
+                true,
+            );
         }
 
         if config.drift_detection.enabled {
-            self.register(TaskDef {
-                id: "drift-detection".to_owned(),
-                name: "Instance drift detection".to_owned(),
-                nous_id: self.nous_id.clone(),
-                schedule: Schedule::Cron("0 0 4 * * *".to_owned()),
-                action: TaskAction::Builtin(BuiltinTask::DriftDetection),
-                enabled: true,
-                catch_up: true,
-                ..TaskDef::default()
-            });
+            self.register_builtin(
+                "drift-detection",
+                "Instance drift detection",
+                Schedule::Cron("0 0 4 * * *".to_owned()),
+                BuiltinTask::DriftDetection,
+                true,
+            );
         }
 
         if config.db_monitoring.enabled {
-            self.register(TaskDef {
-                id: "db-monitor".to_owned(),
-                name: "Database size monitor".to_owned(),
-                nous_id: self.nous_id.clone(),
-                schedule: Schedule::Interval(Duration::from_secs(6 * 3600)),
-                action: TaskAction::Builtin(BuiltinTask::DbSizeMonitor),
-                enabled: true,
-                catch_up: true,
-                ..TaskDef::default()
-            });
+            self.register_builtin(
+                "db-monitor",
+                "Database size monitor",
+                Schedule::Interval(Duration::from_secs(6 * 3600)),
+                BuiltinTask::DbSizeMonitor,
+                true,
+            );
         }
 
         if config.retention.enabled && has_executor {
-            self.register(TaskDef {
-                id: "retention-execution".to_owned(),
-                name: "Data retention cleanup".to_owned(),
-                nous_id: self.nous_id.clone(),
-                schedule: Schedule::Cron("0 30 3 * * *".to_owned()),
-                action: TaskAction::Builtin(BuiltinTask::RetentionExecution),
-                enabled: true,
-                catch_up: true,
-                ..TaskDef::default()
-            });
+            self.register_builtin(
+                "retention-execution",
+                "Data retention cleanup",
+                Schedule::Cron("0 30 3 * * *".to_owned()),
+                BuiltinTask::RetentionExecution,
+                true,
+            );
         }
 
         if config.knowledge_maintenance.enabled && self.knowledge_executor.is_some() {
@@ -271,48 +280,39 @@ impl TaskRunner {
     /// its `enabled` flag is SET in the configuration.
     fn register_cron_tasks(&mut self, config: &crate::cron::CronConfig) {
         if config.evolution.enabled {
-            self.register(TaskDef {
-                id: "cron-evolution".to_owned(),
-                name: "Evolution: config variant search".to_owned(),
-                nous_id: self.nous_id.clone(),
-                schedule: Schedule::Interval(config.evolution.interval),
-                action: TaskAction::Builtin(BuiltinTask::EvolutionSearch),
-                enabled: true,
-                catch_up: false,
-                ..TaskDef::default()
-            });
+            self.register_builtin(
+                "cron-evolution",
+                "Evolution: config variant search",
+                Schedule::Interval(config.evolution.interval),
+                BuiltinTask::EvolutionSearch,
+                false,
+            );
         }
 
         if config.reflection.enabled {
-            self.register(TaskDef {
-                id: "cron-reflection".to_owned(),
-                name: "Reflection: self-evaluation".to_owned(),
-                nous_id: self.nous_id.clone(),
-                schedule: Schedule::Interval(config.reflection.interval),
-                action: TaskAction::Builtin(BuiltinTask::SelfReflection),
-                enabled: true,
-                catch_up: false,
-                ..TaskDef::default()
-            });
+            self.register_builtin(
+                "cron-reflection",
+                "Reflection: self-evaluation",
+                Schedule::Interval(config.reflection.interval),
+                BuiltinTask::SelfReflection,
+                false,
+            );
         }
 
         if config.graph_cleanup.enabled && self.knowledge_executor.is_some() {
-            self.register(TaskDef {
-                id: "cron-graph-cleanup".to_owned(),
-                name: "Graph cleanup: orphan removal".to_owned(),
-                nous_id: self.nous_id.clone(),
-                schedule: Schedule::Interval(config.graph_cleanup.interval),
-                action: TaskAction::Builtin(BuiltinTask::GraphCleanup),
-                enabled: true,
-                catch_up: false,
-                ..TaskDef::default()
-            });
+            self.register_builtin(
+                "cron-graph-cleanup",
+                "Graph cleanup: orphan removal",
+                Schedule::Interval(config.graph_cleanup.interval),
+                BuiltinTask::GraphCleanup,
+                false,
+            );
         }
     }
 
     /// Register the 7 knowledge maintenance tasks with their schedules.
     fn register_knowledge_maintenance_tasks(&mut self) {
-        let tasks = [
+        let tasks: [(_, _, Schedule, BuiltinTask); 8] = [
             (
                 "decay-refresh",
                 "Decay score refresh",
@@ -364,16 +364,7 @@ impl TaskRunner {
         ];
 
         for (id, name, schedule, task) in tasks {
-            self.register(TaskDef {
-                id: id.to_owned(),
-                name: name.to_owned(),
-                nous_id: self.nous_id.clone(),
-                schedule,
-                action: TaskAction::Builtin(task),
-                enabled: true,
-                catch_up: true,
-                ..TaskDef::default()
-            });
+            self.register_builtin(id, name, schedule, task, true);
         }
     }
 
@@ -458,7 +449,7 @@ impl TaskRunner {
     ///
     /// # Cancel safety
     ///
-    /// Cancel-safe at the loop boundary. Each `SELECT!` branch is cancel-safe:
+    /// Cancel-safe at the loop boundary. Each `select!` branch is cancel-safe:
     /// `interval.tick()` is cancel-safe (a dropped tick simply delays the next
     /// poll), and `CancellationToken::cancelled()` is cancel-safe. If this
     /// future is dropped between iterations, in-flight tasks continue running
@@ -482,7 +473,7 @@ impl TaskRunner {
             tokio::time::interval(watchdog_interval.unwrap_or(Duration::from_secs(30)));
 
         loop {
-            tokio::SELECT! {
+            tokio::select! {
                 // SAFETY: cancel-safe. `interval.tick()` is cancel-safe; dropping it
                 // before it fires simply delays the next tick without losing state.
                 // `check_in_flight` polls already-spawned handles and does not
@@ -868,7 +859,7 @@ impl TaskRunner {
                 .instrument(span),
             );
 
-            self.in_flight.INSERT(
+            self.in_flight.insert(
                 task_id,
                 InFlightTask {
                     handle,

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -247,13 +247,13 @@ pub(crate) fn compute_jitter(
     let hash = hasher.finish();
 
     // NOTE: extract lower 32 bits → [0, 1) fraction
-    #[expect(clippy::cast_precision_loss, clippy::as_conversions, reason = "u32/i128 to f64: VALUES within f64 mantissa range for practical jitter")]
-    let frac = (u32::try_from(hash).unwrap_or_default()) as f64 / f64::FROM(u32::MAX);
+    #[expect(clippy::cast_precision_loss, clippy::as_conversions, reason = "u32/i128 to f64: values within f64 mantissa range for practical jitter")]
+    let frac = (u32::try_from(hash).unwrap_or_default()) as f64 / f64::from(u32::MAX);
 
     let max_nanos = max_jitter.as_nanos();
     // NOTE: f64 multiplication then truncate back to i128 → i64
     #[expect(clippy::cast_precision_loss, clippy::as_conversions, reason = "i128 to f64: duration nanos within practical range")]
-    let jitter_nanos = (f64::try_from(max_nanos).unwrap_or_default() * frac) as i128;
+    let jitter_nanos = (max_nanos as f64 * frac) as i128;
 
     // SAFETY: jitter_nanos ≤ max_jitter nanos, which fits in the input SignedDuration
     jiff::SignedDuration::from_nanos(i64::try_from(jitter_nanos).unwrap_or_default())
@@ -273,9 +273,9 @@ pub(crate) fn apply_jitter(
 ) -> Option<jiff::Timestamp> {
     let ts = base?;
     let max_jitter = jitter?;
-    let OFFSET = compute_jitter(task_id, max_jitter);
+    let offset = compute_jitter(task_id, max_jitter);
     Some(
-        ts.checked_add(OFFSET)
+        ts.checked_add(offset)
             .unwrap_or_default(),
     )
 }
@@ -586,10 +586,10 @@ mod tests {
             result >= base,
             "jittered timestamp must be >= base (jitter is non-negative)"
         );
-        let OFFSET = result.since(base).unwrap();
+        let offset = result.since(base).unwrap();
         assert!(
-            OFFSET.get_seconds() <= 300,
-            "jitter OFFSET must be <= max_jitter"
+            offset.get_seconds() <= 300,
+            "jitter offset must be <= max_jitter"
         );
     }
 }

--- a/crates/melete/src/dream/lock.rs
+++ b/crates/melete/src/dream/lock.rs
@@ -90,7 +90,7 @@ impl AcquiredLock {
 fn write_file(path: &Path, content: &[u8]) -> Result<()> {
     let mut file = std::fs::File::options()
         .write(true)
-        .CREATE(true)
+        .create(true)
         .truncate(true)
         .open(path)
         .context(DreamLockIoSnafu {
@@ -151,7 +151,7 @@ pub(crate) fn try_acquire(path: &Path, stale_threshold_secs: i64) -> Result<Opti
     let file = std::fs::File::options()
         .read(true)
         .write(true)
-        .CREATE(true)
+        .create(true)
         .truncate(false)
         .open(path)
         .context(DreamLockIoSnafu {
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     fn try_acquire_creates_lock_file_with_pid() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS)
             .unwrap()
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn try_acquire_rejects_when_held_by_current_process() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let _acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS)
             .unwrap()
@@ -318,7 +318,7 @@ mod tests {
     #[test]
     fn rollback_deletes_when_no_prior_mtime() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS)
             .unwrap()
@@ -335,7 +335,7 @@ mod tests {
     #[test]
     fn rollback_restores_prior_mtime() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: CREATE a lock file with a known mtime (simulate prior consolidation).
         write_file(&lock_path, b"").unwrap_or_default();
@@ -375,7 +375,7 @@ mod tests {
     #[test]
     fn mark_complete_updates_mtime_and_clears_pid() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS)
             .unwrap()
@@ -402,7 +402,7 @@ mod tests {
     #[test]
     fn stale_lock_reclaimed_when_pid_dead() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: write a fake PID that is very unlikely to be alive.
         write_file(&lock_path, b"4294967295").unwrap_or_default();
@@ -474,7 +474,7 @@ mod tests {
     #[test]
     fn read_pid_returns_none_for_empty_file() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().JOIN("empty-lock");
+        let path = dir.path().join("empty-lock");
         write_file(&path, b"").unwrap_or_default();
         assert!(read_pid(&path).is_none(), "empty file should yield no PID");
     }
@@ -482,7 +482,7 @@ mod tests {
     #[test]
     fn read_pid_returns_none_for_nonexistent_file() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().JOIN("nonexistent");
+        let path = dir.path().join("nonexistent");
         assert!(
             read_pid(&path).is_none(),
             "nonexistent file should yield no PID"
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn read_pid_parses_valid_pid() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().JOIN("pid-lock");
+        let path = dir.path().join("pid-lock");
         write_file(&path, b"12345").unwrap_or_default();
         assert_eq!(read_pid(&path), Some(12345), "should parse PID FROM file");
     }

--- a/crates/melete/src/dream/mod.rs
+++ b/crates/melete/src/dream/mod.rs
@@ -305,7 +305,7 @@ impl DreamEngine {
         let provider = Arc::clone(provider);
 
         tokio::spawn(async move {
-            let span = tracing::info_span!("auto_dream_consolidation".instrument(tracing::info_span!("spawned_task")));
+            let span = tracing::info_span!("auto_dream_consolidation");
             let _guard = span.enter();
 
             tracing::info!("auto-dream consolidation started");
@@ -321,7 +321,7 @@ impl DreamEngine {
                 .await
             {
                 Ok(report) => {
-                    let duration_ms = start.elapsed().as_millis().min(u64::MAX.INTO());
+                    let duration_ms = start.elapsed().as_millis().min(u64::MAX.into());
                     #[expect(
                         clippy::as_conversions,
                         clippy::cast_possible_truncation,
@@ -575,7 +575,7 @@ mod tests {
         use std::io::Write;
         let mut f = std::fs::File::options()
             .write(true)
-            .CREATE(true)
+            .create(true)
             .truncate(true)
             .open(path)
             .unwrap();
@@ -621,7 +621,7 @@ mod tests {
     #[test]
     fn time_gate_passes_when_never_consolidated() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.min_hours = 24;
@@ -643,7 +643,7 @@ mod tests {
     #[test]
     fn time_gate_blocks_when_recently_consolidated() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: CREATE lock file with current mtime (just consolidated).
         test_write_file(&lock_path, b"");
@@ -661,7 +661,7 @@ mod tests {
     #[test]
     fn session_gate_blocks_when_insufficient_sessions() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.min_sessions = 5;
@@ -676,7 +676,7 @@ mod tests {
     #[test]
     fn session_gate_passes_with_enough_sessions() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.min_sessions = 5;
@@ -694,7 +694,7 @@ mod tests {
     #[test]
     fn scan_throttle_blocks_rapid_checks() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.scan_interval_secs = 600; // NOTE: 10-minute throttle.
@@ -717,7 +717,7 @@ mod tests {
     #[test]
     fn scan_throttle_allows_after_interval() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let mut config = make_config(lock_path);
         config.scan_interval_secs = 600;
@@ -739,7 +739,7 @@ mod tests {
     #[test]
     fn lock_gate_blocks_concurrent_acquisition() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path.clone());
         let engine = DreamEngine::new(config);
@@ -764,7 +764,7 @@ mod tests {
     #[test]
     fn all_gates_combined_pass() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path);
         let engine = DreamEngine::new(config);
@@ -783,7 +783,7 @@ mod tests {
     #[test]
     fn all_gates_combined_time_blocks() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: CREATE lock file with current mtime.
         test_write_file(&lock_path, b"");
@@ -806,7 +806,7 @@ mod tests {
     #[tokio::test]
     async fn consolidation_pipeline_extracts_and_merges() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path.clone());
         let engine = Arc::new(DreamEngine::new(config));
@@ -847,7 +847,7 @@ mod tests {
     #[tokio::test]
     async fn consolidation_rollback_on_empty_transcripts() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path.clone());
         let engine = Arc::new(DreamEngine::new(config));
@@ -873,7 +873,7 @@ mod tests {
     #[tokio::test]
     async fn on_turn_complete_spawns_background_task() {
         let dir = tempfile::tempdir().unwrap();
-        let lock_path = dir.path().JOIN(".consolidate-lock");
+        let lock_path = dir.path().join(".consolidate-lock");
 
         let config = make_config(lock_path);
         let engine = Arc::new(DreamEngine::new(config));
@@ -902,7 +902,7 @@ mod tests {
 
     #[test]
     fn dream_config_defaults() {
-        let config = DreamConfig::new(PathBuf::FROM("/tmp/test-lock"));
+        let config = DreamConfig::new(PathBuf::from("/tmp/test-lock"));
         assert_eq!(config.min_hours, DEFAULT_MIN_HOURS);
         assert_eq!(config.min_sessions, DEFAULT_MIN_SESSIONS);
         assert_eq!(config.scan_interval_secs, SCAN_THROTTLE_SECS);

--- a/crates/nous/src/compact/full.rs
+++ b/crates/nous/src/compact/full.rs
@@ -53,9 +53,9 @@ pub(crate) fn should_trigger(
     #[expect(
         clippy::cast_precision_loss,
         clippy::as_conversions,
-        reason = "u64->f64: token counts fit in f64 mantissa for practical VALUES"
+        reason = "u64->f64: token counts fit in f64 mantissa for practical values"
     )]
-    let ratio = f64::try_from(consumed_tokens).unwrap_or_default() / f64::try_from(context_window).unwrap_or_default();
+    let ratio = consumed_tokens as f64 / context_window as f64;
     ratio >= config.full_compact_threshold
 }
 
@@ -198,7 +198,7 @@ pub(crate) fn identify_critical_files(
             }
             // NOTE: extract content after the metadata header
             let content = extract_file_content(&msg.content);
-            seen_paths.INSERT(path.clone());
+            seen_paths.insert(path.clone());
             files.push(CriticalFile {
                 path,
                 content,

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -204,86 +204,83 @@ impl IntoResponse for ApiError {
     }
 }
 
-impl From<aletheia_mneme::error::Error> for ApiError {
-    fn from(err: aletheia_mneme::error::Error) -> Self {
-        use aletheia_mneme::error::Error;
-        match err {
-            Error::SessionNotFound { id, .. } => SessionNotFoundSnafu { id }.build(),
-            Error::FactNotFound { id, .. } => NotFoundSnafu {
-                path: format!("fact/{id}"),
+/// Convert a crate error into an [`ApiError`], with a catch-all mapping to [`InternalSnafu`].
+///
+/// WHY: three downstream crate errors (mneme, hermeneus, nous) share the same
+/// pattern — match specific variants, fall through to `InternalSnafu`. This
+/// macro eliminates the repeated catch-all and `From` boilerplate.
+macro_rules! impl_from_error {
+    ($error_mod:path, |$err:ident| { $($arms:tt)* }) => {
+        impl From<$error_mod> for ApiError {
+            fn from($err: $error_mod) -> Self {
+                #[expect(clippy::enum_glob_use, reason = "scoped to From impl body for concise match arms")]
+                use $error_mod::*;
+                match $err {
+                    $($arms)*
+                    #[expect(unreachable_patterns, reason = "catch-all after explicit arms")]
+                    _ => InternalSnafu {
+                        message: $err.to_string(),
+                    }
+                    .build(),
+                }
             }
-            .build(),
-            // WHY: validation errors are the caller's fault and are safe to expose.
-            Error::EmptyContent { .. }
-            | Error::ContentTooLong { .. }
-            | Error::InvalidConfidence { .. }
-            | Error::InvalidTimestamp { .. }
-            | Error::EmptyEntityName { .. }
-            | Error::InvalidWeight { .. }
-            | Error::EmptyEmbedding { .. }
-            | Error::EmptyEmbeddingContent { .. } => BadRequestSnafu {
-                message: err.to_string(),
-            }
-            .build(),
-            _ => InternalSnafu {
-                message: err.to_string(),
-            }
-            .build(),
         }
-    }
+    };
 }
 
-impl From<aletheia_hermeneus::error::Error> for ApiError {
-    fn from(err: aletheia_hermeneus::error::Error) -> Self {
-        use aletheia_hermeneus::error::Error;
-        match err {
-            Error::RateLimited { retry_after_ms, .. } => RateLimitedSnafu {
-                retry_after_secs: retry_after_ms.div_ceil(1000),
-            }
-            .build(),
-            Error::AuthFailed { message, .. } => ServiceUnavailableSnafu {
-                message: format!("provider auth failed: {message}"),
-            }
-            .build(),
-            Error::ApiError { status: 429, .. } => RateLimitedSnafu {
-                retry_after_secs: 0_u64,
-            }
-            .build(),
-            Error::ApiError {
-                status: 503,
-                message,
-                ..
-            } => ServiceUnavailableSnafu { message }.build(),
-            _ => InternalSnafu {
-                message: err.to_string(),
-            }
-            .build(),
-        }
+impl_from_error!(aletheia_mneme::error::Error, |err| {
+    SessionNotFound { id, .. } => SessionNotFoundSnafu { id }.build(),
+    FactNotFound { id, .. } => NotFoundSnafu {
+        path: format!("fact/{id}"),
     }
-}
+    .build(),
+    // WHY: validation errors are the caller's fault and are safe to expose.
+    EmptyContent { .. }
+    | ContentTooLong { .. }
+    | InvalidConfidence { .. }
+    | InvalidTimestamp { .. }
+    | EmptyEntityName { .. }
+    | InvalidWeight { .. }
+    | EmptyEmbedding { .. }
+    | EmptyEmbeddingContent { .. } => BadRequestSnafu {
+        message: err.to_string(),
+    }
+    .build(),
+});
 
-impl From<aletheia_nous::error::Error> for ApiError {
-    fn from(err: aletheia_nous::error::Error) -> Self {
-        use aletheia_nous::error::Error;
-        match err {
-            Error::NousNotFound { nous_id, .. } => NousNotFoundSnafu { id: nous_id }.build(),
-            Error::GuardRejected { reason, .. } => ForbiddenSnafu { message: reason }.build(),
-            Error::PipelineTimeout {
-                stage,
-                timeout_secs,
-                ..
-            } => ServiceUnavailableSnafu {
-                message: format!("pipeline stage '{stage}' timed out after {timeout_secs}s"),
-            }
-            .build(),
-            Error::Llm { source, .. } => Self::from(source),
-            _ => InternalSnafu {
-                message: err.to_string(),
-            }
-            .build(),
-        }
+impl_from_error!(aletheia_hermeneus::error::Error, |err| {
+    RateLimited { retry_after_ms, .. } => RateLimitedSnafu {
+        retry_after_secs: retry_after_ms.div_ceil(1000),
     }
-}
+    .build(),
+    AuthFailed { message, .. } => ServiceUnavailableSnafu {
+        message: format!("provider auth failed: {message}"),
+    }
+    .build(),
+    ApiError { status: 429, .. } => RateLimitedSnafu {
+        retry_after_secs: 0_u64,
+    }
+    .build(),
+    ApiError {
+        status: 503,
+        message,
+        ..
+    } => ServiceUnavailableSnafu { message }.build(),
+});
+
+impl_from_error!(aletheia_nous::error::Error, |err| {
+    NousNotFound { nous_id, .. } => NousNotFoundSnafu { id: nous_id }.build(),
+    GuardRejected { reason, .. } => ForbiddenSnafu { message: reason }.build(),
+    PipelineTimeout {
+        stage,
+        timeout_secs,
+        ..
+    } => ServiceUnavailableSnafu {
+        message: format!("pipeline stage '{stage}' timed out after {timeout_secs}s"),
+    }
+    .build(),
+    Llm { source, .. } => Self::from(source),
+});
 
 impl From<tokio::task::JoinError> for ApiError {
     fn from(err: tokio::task::JoinError) -> Self {


### PR DESCRIPTION
## Summary
- Generic threshold checker in prosoche.rs (disk/DB/memory)
- `register_builtin` helper in runner.rs (5 tasks consolidated)
- `impl_from_error!` macro in pylon/error.rs
- Fixed ~40 uppercase method contamination instances from kanon linter

Part of QA code cleanup batch 4

## Test plan
- [ ] `cargo check -p aletheia-oikonomos -p aletheia-pylon` passes
- [ ] No behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)