### PR TITLE
feat(energeia): create crate shell with core types and trait boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,12 +33,13 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
  "aletheia-diaporeia",
  "aletheia-dokimion",
+ "aletheia-energeia",
  "aletheia-hermeneus",
  "aletheia-koina",
  "aletheia-mneme",
@@ -84,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -105,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -120,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -142,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -161,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "jiff",
  "serde",
@@ -170,8 +171,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-energeia"
+version = "0.13.38"
+dependencies = [
+ "aletheia-eidos",
+ "aletheia-koina",
+ "jiff",
+ "serde",
+ "serde_json",
+ "snafu",
+ "static_assertions",
+ "tokio",
+]
+
+[[package]]
 name = "aletheia-episteme"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -201,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -222,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -246,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -272,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "compact_str",
  "jiff",
@@ -293,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -337,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -356,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -371,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -400,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -425,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -452,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -486,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -513,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -531,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6044,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6063,7 +6078,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.34"
+version = "0.13.38"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/diaporeia",
     "crates/dianoia",
     "crates/eidos",
+    "crates/energeia",
     "crates/episteme",
     "crates/agora",
     "crates/daemon",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -30,6 +30,8 @@ migrate-qdrant = ["dep:qdrant-client", "aletheia-mneme/mneme-engine", "aletheia-
 tls = ["aletheia-pylon/tls"]
 keyring = ["aletheia-symbolon/keyring"]
 tui = ["dep:theatron-tui"]
+# Dispatch orchestration (kanon phronesis port). Default off for incremental development.
+energeia = ["dep:aletheia-energeia"]
 # Test tiers (see docs/test-tiers.md)
 test-core = ["aletheia-mneme/test-core", "aletheia-nous/test-core", "aletheia-pylon/test-core"]
 test-full = ["test-core", "aletheia-mneme/test-full"]
@@ -37,6 +39,7 @@ test-full = ["test-core", "aletheia-mneme/test-full"]
 [dependencies]
 aletheia-diaporeia = { path = "../diaporeia", optional = true }
 aletheia-dianoia = { path = "../dianoia" }
+aletheia-energeia = { path = "../energeia", optional = true }
 aletheia-oikonomos = { path = "../daemon" }
 aletheia-koina = { path = "../koina" }
 aletheia-taxis = { path = "../taxis" }

--- a/crates/energeia/CLAUDE.md
+++ b/crates/energeia/CLAUDE.md
@@ -1,0 +1,48 @@
+# energeia
+
+Dispatch orchestration: actualization of plans into execution. Absorbs kanon's phronesis dispatch system into aletheia.
+
+## Read first
+
+1. `src/types.rs`: DispatchSpec, DispatchResult, SessionOutcome, Budget, ResumePolicy, QA types
+2. `src/engine.rs`: DispatchEngine trait, SessionHandle trait, SessionSpec, AgentOptions
+3. `src/qa.rs`: QaGate trait, PromptSpec
+4. `src/error.rs`: snafu error enum
+
+## Key types
+
+| Type | Path | Purpose |
+|------|------|---------|
+| `DispatchSpec` | `types.rs` | What to dispatch: prompt numbers, DAG reference, project |
+| `DispatchResult` | `types.rs` | Aggregate outcome: dispatch_id, outcomes, cost, duration |
+| `SessionOutcome` | `types.rs` | Per-prompt result: status, cost, turns, duration, PR URL |
+| `SessionStatus` | `types.rs` | Terminal state: Success, Failed, Stuck, Aborted, BudgetExceeded |
+| `Budget` | `types.rs` | Cost/turn/duration limits with record + check |
+| `BudgetStatus` | `types.rs` | Ok, Warning, Exceeded |
+| `ResumePolicy` | `types.rs` | Multi-stage escalation with turn budgets |
+| `QaResult` | `types.rs` | QA evaluation outcome: verdict, criteria, mechanical issues |
+| `QaVerdict` | `types.rs` | Pass, Partial, Fail |
+| `DispatchEngine` | `engine.rs` | Trait: spawn/resume sessions against Agent SDK |
+| `SessionHandle` | `engine.rs` | Trait: event stream, wait, abort for a running session |
+| `QaGate` | `qa.rs` | Trait: evaluate PR quality, mechanical checks |
+
+## Patterns
+
+- **Atomic budget tracking**: Budget uses atomic operations for thread-safe concurrent recording
+- **Health-driven escalation**: ResumePolicy defines stages with escalating urgency
+- **Mechanical pre-screening**: QaGate separates fast structural checks from LLM evaluation
+- **Agent SDK target**: DispatchEngine targets Anthropic Agent SDK HTTP/SSE API
+
+## Common tasks
+
+| Task | Where |
+|------|-------|
+| Add dispatch type | `src/types.rs` |
+| Add error variant | `src/error.rs` |
+| Add engine capability | `src/engine.rs` (DispatchEngine or SessionHandle trait) |
+| Add QA check | `src/qa.rs` (QaGate trait or MechanicalIssueKind) |
+
+## Dependencies
+
+Uses: koina, eidos, jiff, serde, snafu, tokio (hermeneus pending compilation fix)
+Used by: aletheia (binary, behind `energeia` feature flag)

--- a/crates/energeia/Cargo.toml
+++ b/crates/energeia/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "aletheia-energeia"
+version.workspace = true
+description = "Dispatch orchestration — actualization of plans into execution"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+test-core = []
+test-full = []
+
+[dependencies]
+aletheia-koina = { path = "../koina" }
+aletheia-eidos = { path = "../eidos" }
+# WHY: hermeneus has pre-existing compilation errors on main (kanon lint pass
+# introduced unwrap_or_default on non-Default types). Add dependency once
+# hermeneus compiles again; implementations will need it for LLM evaluation.
+# aletheia-hermeneus = { path = "../hermeneus" }
+jiff = { workspace = true, features = ["serde"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+static_assertions = { workspace = true }

--- a/crates/energeia/src/engine.rs
+++ b/crates/energeia/src/engine.rs
@@ -1,0 +1,270 @@
+//! Dispatch engine trait: abstraction over session execution backends.
+//!
+//! The [`DispatchEngine`] trait targets the Anthropic Agent SDK HTTP/SSE API.
+//! Implementations: `HttpEngine` (production), `MockEngine` (tests).
+
+use std::future::Future;
+use std::pin::Pin;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+// ---------------------------------------------------------------------------
+// DispatchEngine trait
+// ---------------------------------------------------------------------------
+
+/// Core abstraction over session execution backends.
+///
+/// Targets the Anthropic Agent SDK HTTP/SSE API. Production implementations
+/// use HTTP+SSE streaming; test implementations return canned responses.
+pub trait DispatchEngine: Send + Sync {
+    /// Spawn a new agent session for the given spec and options.
+    fn spawn_session<'a>(
+        &'a self,
+        spec: &'a SessionSpec,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>>;
+
+    /// Resume an existing session with a new prompt.
+    fn resume_session<'a>(
+        &'a self,
+        session_id: &'a str,
+        prompt: &'a str,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>>;
+}
+
+// ---------------------------------------------------------------------------
+// SessionHandle trait
+// ---------------------------------------------------------------------------
+
+/// Handle to a running or completed agent session.
+///
+/// Provides an event stream for observing session progress, plus control
+/// methods for waiting on completion or aborting.
+pub trait SessionHandle: Send {
+    /// The Agent SDK session identifier.
+    fn session_id(&self) -> &str;
+
+    /// Receive the next event from the session's SSE stream.
+    ///
+    /// Returns `None` when the stream is exhausted (session complete or errored).
+    fn next_event<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Option<SessionEvent>> + Send + 'a>>;
+
+    /// Wait for the session to complete and return the final result.
+    fn wait(self: Box<Self>) -> Pin<Box<dyn Future<Output = Result<SessionResult>> + Send>>;
+
+    /// Request the session to abort.
+    fn abort<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+}
+
+// ---------------------------------------------------------------------------
+// Session types
+// ---------------------------------------------------------------------------
+
+/// Specification for spawning a new agent session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SessionSpec {
+    /// The prompt or task description to send to the agent.
+    pub prompt: String,
+    /// System prompt to prepend to the session.
+    pub system_prompt: Option<String>,
+    /// Working directory for the agent session.
+    pub cwd: Option<String>,
+}
+
+/// Configuration options for an agent session.
+///
+/// Built incrementally via the builder methods.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AgentOptions {
+    /// LLM model identifier (e.g., "claude-sonnet-4-20250514").
+    pub model: Option<String>,
+    /// System prompt override.
+    pub system_prompt: Option<String>,
+    /// Working directory for the agent.
+    pub cwd: Option<String>,
+    /// Maximum LLM turns before the session is stopped.
+    pub max_turns: Option<u32>,
+    /// Permission mode for tool execution (e.g., "plan", "auto").
+    pub permission_mode: Option<String>,
+}
+
+impl AgentOptions {
+    /// Create empty options with all fields unset.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            model: None,
+            system_prompt: None,
+            cwd: None,
+            max_turns: None,
+            permission_mode: None,
+        }
+    }
+
+    /// Set the model identifier.
+    #[must_use]
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the system prompt.
+    #[must_use]
+    pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(prompt.into());
+        self
+    }
+
+    /// Set the working directory.
+    #[must_use]
+    pub fn cwd(mut self, cwd: impl Into<String>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    /// Set the maximum turn count.
+    #[must_use]
+    pub fn max_turns(mut self, turns: u32) -> Self {
+        self.max_turns = Some(turns);
+        self
+    }
+
+    /// Set the permission mode.
+    #[must_use]
+    pub fn permission_mode(mut self, mode: impl Into<String>) -> Self {
+        self.permission_mode = Some(mode.into());
+        self
+    }
+}
+
+impl Default for AgentOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// An event from a running agent session's SSE stream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum SessionEvent {
+    /// Agent produced a text output chunk.
+    TextDelta {
+        /// The text content.
+        text: String,
+    },
+    /// Agent invoked a tool.
+    ToolUse {
+        /// Tool name.
+        name: String,
+        /// Tool input as JSON.
+        input: serde_json::Value,
+    },
+    /// Tool execution completed.
+    ToolResult {
+        /// Tool name.
+        name: String,
+        /// Whether the tool succeeded.
+        success: bool,
+    },
+    /// Session turn completed.
+    TurnComplete {
+        /// Turn number within the session.
+        turn: u32,
+    },
+    /// Session encountered an error.
+    Error {
+        /// Error description.
+        message: String,
+    },
+}
+
+/// Final result of a completed session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SessionResult {
+    /// The Agent SDK session identifier.
+    pub session_id: String,
+    /// Total cost in USD.
+    pub cost_usd: f64,
+    /// Total turns consumed.
+    pub num_turns: u32,
+    /// Wall-clock duration in milliseconds.
+    pub duration_ms: u64,
+    /// Whether the session completed successfully.
+    pub success: bool,
+    /// Final text output from the agent, if any.
+    pub result_text: Option<String>,
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_options_builder() {
+        let opts = AgentOptions::new()
+            .model("claude-sonnet-4-20250514")
+            .cwd("/tmp/work")
+            .max_turns(50)
+            .permission_mode("plan");
+
+        assert_eq!(opts.model.as_deref(), Some("claude-sonnet-4-20250514"));
+        assert_eq!(opts.cwd.as_deref(), Some("/tmp/work"));
+        assert_eq!(opts.max_turns, Some(50));
+        assert_eq!(opts.permission_mode.as_deref(), Some("plan"));
+    }
+
+    #[test]
+    fn agent_options_default() {
+        let opts = AgentOptions::default();
+        assert!(opts.model.is_none());
+        assert!(opts.max_turns.is_none());
+    }
+
+    #[test]
+    fn session_spec_roundtrip() {
+        let spec = SessionSpec {
+            prompt: "implement feature X".to_owned(),
+            system_prompt: Some("you are a coding agent".to_owned()),
+            cwd: Some("/home/user/project".to_owned()),
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let deserialized: SessionSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.prompt, "implement feature X");
+    }
+
+    #[test]
+    fn session_event_roundtrip() {
+        let event = SessionEvent::ToolUse {
+            name: "read_file".to_owned(),
+            input: serde_json::json!({"path": "/tmp/test.rs"}),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: SessionEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized, SessionEvent::ToolUse { name, .. } if name == "read_file"));
+    }
+
+    #[test]
+    fn session_result_roundtrip() {
+        let result = SessionResult {
+            session_id: "sess-abc".to_owned(),
+            cost_usd: 0.42,
+            num_turns: 15,
+            duration_ms: 30_000,
+            success: true,
+            result_text: Some("done".to_owned()),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let deserialized: SessionResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.session_id, "sess-abc");
+        assert!(deserialized.success);
+    }
+}

--- a/crates/energeia/src/error.rs
+++ b/crates/energeia/src/error.rs
@@ -1,0 +1,195 @@
+//! Energeia-specific errors.
+
+use snafu::Snafu;
+
+/// Errors from dispatch orchestration operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+#[expect(
+    missing_docs,
+    reason = "snafu error variant fields are self-documenting via display format"
+)]
+pub enum Error {
+    /// Dispatch was aborted via cancellation.
+    #[snafu(display("dispatch aborted"))]
+    Aborted {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Budget limit exceeded during dispatch.
+    #[snafu(display("budget exceeded: {reason}"))]
+    BudgetExceeded {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Session spawn failed for a specific prompt.
+    #[snafu(display("spawn failed for prompt {prompt_number}: {detail}"))]
+    SpawnFailed {
+        prompt_number: u32,
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Session resume failed.
+    #[snafu(display("resume failed for session '{session_id}': {detail}"))]
+    ResumeFailed {
+        session_id: String,
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// QA evaluation failed.
+    #[snafu(display("QA evaluation failed: {detail}"))]
+    QaFailed {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// LLM provider error during dispatch operations.
+    // NOTE: will wrap aletheia_hermeneus::error::Error as `source` once
+    // hermeneus compiles on main. For now, carries the error as a string.
+    #[snafu(display("LLM error: {detail}"))]
+    Llm {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Preflight validation failed before dispatch could start.
+    #[snafu(display("preflight failed: {reason}"))]
+    Preflight {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Blast radius overlap detected between concurrent sessions.
+    #[snafu(display("blast radius overlap: {detail}"))]
+    BlastRadiusOverlap {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Task join error from a spawned session task.
+    #[snafu(display("task join failed: {detail}"))]
+    TaskJoin {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Engine-level transport or protocol error.
+    #[snafu(display("engine error: {detail}"))]
+    Engine {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Convenience alias for results with [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_aborted() {
+        let err = AbortedSnafu.build();
+        assert!(err.to_string().contains("aborted"));
+    }
+
+    #[test]
+    fn error_display_budget_exceeded() {
+        let err = BudgetExceededSnafu {
+            reason: "cost limit $5.00",
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("budget exceeded"));
+        assert!(msg.contains("$5.00"));
+    }
+
+    #[test]
+    fn error_display_spawn_failed() {
+        let err = SpawnFailedSnafu {
+            prompt_number: 3u32,
+            detail: "auth failure",
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("prompt 3"));
+        assert!(msg.contains("auth failure"));
+    }
+
+    #[test]
+    fn error_display_resume_failed() {
+        let err = ResumeFailedSnafu {
+            session_id: "sess-abc",
+            detail: "session expired",
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("sess-abc"));
+        assert!(msg.contains("session expired"));
+    }
+
+    #[test]
+    fn error_display_qa_failed() {
+        let err = QaFailedSnafu {
+            detail: "diff too large",
+        }
+        .build();
+        assert!(err.to_string().contains("diff too large"));
+    }
+
+    #[test]
+    fn error_display_preflight() {
+        let err = PreflightSnafu {
+            reason: "missing project config",
+        }
+        .build();
+        assert!(err.to_string().contains("missing project config"));
+    }
+
+    #[test]
+    fn error_display_blast_radius_overlap() {
+        let err = BlastRadiusOverlapSnafu {
+            detail: "prompts 1 and 3 share src/lib.rs",
+        }
+        .build();
+        assert!(err.to_string().contains("src/lib.rs"));
+    }
+
+    #[test]
+    fn error_display_task_join() {
+        let err = TaskJoinSnafu {
+            detail: "task panicked",
+        }
+        .build();
+        assert!(err.to_string().contains("task panicked"));
+    }
+
+    #[test]
+    fn error_display_engine() {
+        let err = EngineSnafu {
+            detail: "connection refused",
+        }
+        .build();
+        assert!(err.to_string().contains("connection refused"));
+    }
+
+    #[test]
+    fn error_is_send_sync() {
+        static_assertions::assert_impl_all!(Error: Send, Sync);
+    }
+}

--- a/crates/energeia/src/lib.rs
+++ b/crates/energeia/src/lib.rs
@@ -1,0 +1,22 @@
+//! aletheia-energeia: dispatch orchestration for the Aletheia agent runtime.
+//!
+//! Energeia (ἐνέργεια): "actualization" — the process of bringing potential
+//! into reality. This crate orchestrates the dispatch of coding tasks to agent
+//! sessions, tracks budgets and health, evaluates quality, and manages the
+//! lifecycle from prompt to merged PR.
+//!
+//! # Architecture
+//!
+//! - [`engine::DispatchEngine`] — session execution backend (Agent SDK HTTP/SSE)
+//! - [`qa::QaGate`] — quality assurance evaluation (mechanical + LLM)
+//! - [`types`] — dispatch specs, outcomes, budgets, resume policies, QA results
+//! - [`error`] — snafu error types with location tracking
+
+/// Dispatch engine trait and session types.
+pub mod engine;
+/// Error types for energeia operations.
+pub mod error;
+/// Quality assurance gate trait.
+pub mod qa;
+/// Core dispatch types: specs, outcomes, budgets, resume policies, QA results.
+pub mod types;

--- a/crates/energeia/src/qa.rs
+++ b/crates/energeia/src/qa.rs
@@ -1,0 +1,84 @@
+//! Quality assurance gate: trait for evaluating dispatch output.
+//!
+//! The [`QaGate`] trait separates mechanical pre-screening (fast, no LLM cost)
+//! from semantic evaluation (uses hermeneus for LLM-based assessment).
+
+use std::future::Future;
+use std::pin::Pin;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::types::{MechanicalIssue, QaResult};
+
+// ---------------------------------------------------------------------------
+// QaGate trait
+// ---------------------------------------------------------------------------
+
+/// Abstraction over quality assurance evaluation.
+///
+/// Implementations use hermeneus for LLM-based semantic evaluation and
+/// perform mechanical checks (blast radius, lint, format) without LLM calls.
+pub trait QaGate: Send + Sync {
+    /// Evaluate a pull request against the prompt's acceptance criteria.
+    ///
+    /// Combines mechanical pre-screening with LLM-based semantic evaluation.
+    /// Returns a [`QaResult`] with per-criterion results and overall verdict.
+    fn evaluate<'a>(
+        &'a self,
+        prompt: &'a PromptSpec,
+        pr_number: u64,
+        diff: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<QaResult>> + Send + 'a>>;
+
+    /// Run mechanical checks only (no LLM cost).
+    ///
+    /// Returns issues detectable by static analysis: blast radius violations,
+    /// anti-patterns, lint failures, format violations.
+    fn mechanical_check(&self, diff: &str, prompt: &PromptSpec) -> Vec<MechanicalIssue>;
+}
+
+// ---------------------------------------------------------------------------
+// Supporting types
+// ---------------------------------------------------------------------------
+
+/// Specification of a prompt for QA evaluation.
+///
+/// Contains the acceptance criteria and blast radius constraints that the
+/// QA gate evaluates against.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PromptSpec {
+    /// Prompt number within the dispatch.
+    pub prompt_number: u32,
+    /// Human-readable task description.
+    pub description: String,
+    /// Acceptance criteria that the PR must satisfy.
+    pub acceptance_criteria: Vec<String>,
+    /// Files that the prompt is allowed to modify.
+    pub blast_radius: Vec<String>,
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_spec_roundtrip() {
+        let spec = PromptSpec {
+            prompt_number: 1,
+            description: "add health endpoint".to_owned(),
+            acceptance_criteria: vec![
+                "GET /health returns 200".to_owned(),
+                "response includes version".to_owned(),
+            ],
+            blast_radius: vec!["src/handlers/health.rs".to_owned()],
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let deserialized: PromptSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.prompt_number, 1);
+        assert_eq!(deserialized.acceptance_criteria.len(), 2);
+        assert_eq!(deserialized.blast_radius.len(), 1);
+    }
+}

--- a/crates/energeia/src/types.rs
+++ b/crates/energeia/src/types.rs
@@ -1,0 +1,611 @@
+//! Core dispatch types ported from kanon's phronesis crate.
+//!
+//! These types define the vocabulary for dispatch orchestration: what to
+//! dispatch, how sessions terminate, budget tracking, resume policies, and
+//! quality assurance results.
+
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::time::Instant;
+
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Dispatch specification and results
+// ---------------------------------------------------------------------------
+
+/// What to dispatch: a set of prompt numbers with optional DAG constraints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DispatchSpec {
+    /// Prompt numbers to execute (may be a subset of the full DAG).
+    pub prompt_numbers: Vec<u32>,
+    /// Project identifier this dispatch belongs to.
+    pub project: String,
+    /// Optional reference to a prompt DAG for dependency ordering.
+    pub dag_ref: Option<String>,
+    /// Maximum parallelism (simultaneous sessions). `None` means unlimited.
+    pub max_parallel: Option<u32>,
+}
+
+/// Aggregate result of a dispatch run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DispatchResult {
+    /// Unique identifier for this dispatch run.
+    pub dispatch_id: String,
+    /// Per-prompt outcomes in execution order.
+    pub outcomes: Vec<SessionOutcome>,
+    /// Total cost across all sessions in USD.
+    pub total_cost_usd: f64,
+    /// Wall-clock duration of the entire dispatch.
+    pub duration_ms: u64,
+    /// Whether the dispatch was aborted before completing all prompts.
+    pub aborted: bool,
+    /// Timestamp when the dispatch completed.
+    pub completed_at: Timestamp,
+}
+
+// ---------------------------------------------------------------------------
+// Session outcome
+// ---------------------------------------------------------------------------
+
+/// Result of executing a single prompt in a dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SessionOutcome {
+    /// The prompt number that was executed.
+    pub prompt_number: u32,
+    /// Terminal status of the session.
+    pub status: SessionStatus,
+    /// Agent SDK session identifier, if one was created.
+    pub session_id: Option<String>,
+    /// Total cost in USD for this session (including resumes).
+    pub cost_usd: f64,
+    /// Total LLM turns consumed.
+    pub num_turns: u32,
+    /// Wall-clock duration in milliseconds.
+    pub duration_ms: u64,
+    /// Number of times the session was resumed via health checks.
+    pub resume_count: u32,
+    /// Pull request URL if the session produced one.
+    pub pr_url: Option<String>,
+    /// Error message if the session failed.
+    pub error: Option<String>,
+}
+
+/// Terminal status of a dispatched session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum SessionStatus {
+    /// Session completed its task successfully.
+    Success,
+    /// Session failed to complete its task.
+    Failed,
+    /// Session became stuck (health escalation reached terminal level).
+    Stuck,
+    /// Session was aborted via cancellation token.
+    Aborted,
+    /// Session exceeded its budget allocation.
+    BudgetExceeded,
+    /// Session was skipped (dependency failed or dispatch aborted).
+    Skipped,
+    /// Infrastructure failure (zero turns, short duration — auth/network issues).
+    InfraFailure,
+}
+
+impl std::fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Success => write!(f, "success"),
+            Self::Failed => write!(f, "failed"),
+            Self::Stuck => write!(f, "stuck"),
+            Self::Aborted => write!(f, "aborted"),
+            Self::BudgetExceeded => write!(f, "budget_exceeded"),
+            Self::Skipped => write!(f, "skipped"),
+            Self::InfraFailure => write!(f, "infra_failure"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Budget tracking
+// ---------------------------------------------------------------------------
+
+/// Cost, turn, and duration limits for a dispatch run.
+///
+/// Uses atomic operations for thread-safe concurrent recording from multiple
+/// sessions. Cost is stored as hundredths of a cent (10,000 per USD) to avoid
+/// floating-point accumulation drift.
+pub struct Budget {
+    /// Maximum cost in USD. `None` means unlimited.
+    pub max_cost_usd: Option<f64>,
+    /// Maximum total LLM turns. `None` means unlimited.
+    pub max_turns: Option<u32>,
+    /// Maximum wall-clock duration in milliseconds. `None` means unlimited.
+    pub max_duration_ms: Option<u64>,
+    // WHY: atomic operations allow lock-free recording from concurrent sessions
+    // without requiring a mutex around budget updates.
+    current_cost_hundredths: AtomicU64,
+    current_turns: AtomicU32,
+    start_time: Instant,
+}
+
+impl Budget {
+    /// Create a new budget with the given limits.
+    #[must_use]
+    pub fn new(
+        max_cost_usd: Option<f64>,
+        max_turns: Option<u32>,
+        max_duration_ms: Option<u64>,
+    ) -> Self {
+        Self {
+            max_cost_usd,
+            max_turns,
+            max_duration_ms,
+            current_cost_hundredths: AtomicU64::new(0),
+            current_turns: AtomicU32::new(0),
+            start_time: Instant::now(),
+        }
+    }
+
+    /// Record cost and turns consumed by a session. Thread-safe.
+    pub fn record(&self, cost_usd: f64, turns: u32) {
+        // WHY: 10,000 hundredths per USD gives 0.01-cent precision without
+        // floating-point accumulation drift across many sessions.
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "cost values are small positive numbers; truncation at u64 max is unreachable"
+        )]
+        let hundredths = (cost_usd * 10_000.0) as u64;
+        self.current_cost_hundredths
+            .fetch_add(hundredths, Ordering::Relaxed);
+        self.current_turns.fetch_add(turns, Ordering::Relaxed);
+    }
+
+    /// Check whether any budget limit has been exceeded.
+    #[must_use]
+    pub fn check(&self) -> BudgetStatus {
+        if let Some(max_cost) = self.max_cost_usd {
+            let current = self.current_cost_usd();
+            if current >= max_cost {
+                return BudgetStatus::Exceeded(format!(
+                    "cost ${current:.2} >= limit ${max_cost:.2}"
+                ));
+            }
+            if current >= max_cost * 0.8 {
+                return BudgetStatus::Warning(format!(
+                    "cost ${current:.2} approaching limit ${max_cost:.2}"
+                ));
+            }
+        }
+
+        if let Some(max_turns) = self.max_turns {
+            let current = self.current_turns();
+            if current >= max_turns {
+                return BudgetStatus::Exceeded(format!("turns {current} >= limit {max_turns}"));
+            }
+            if current >= max_turns * 4 / 5 {
+                return BudgetStatus::Warning(format!(
+                    "turns {current} approaching limit {max_turns}"
+                ));
+            }
+        }
+
+        if let Some(max_ms) = self.max_duration_ms {
+            let elapsed = self.elapsed_ms();
+            if elapsed >= max_ms {
+                return BudgetStatus::Exceeded(format!("duration {elapsed}ms >= limit {max_ms}ms"));
+            }
+        }
+
+        BudgetStatus::Ok
+    }
+
+    /// Current total cost in USD.
+    #[must_use]
+    pub fn current_cost_usd(&self) -> f64 {
+        let hundredths = self.current_cost_hundredths.load(Ordering::Relaxed);
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "hundredths values are small enough that f64 precision is sufficient"
+        )]
+        let cost = hundredths as f64 / 10_000.0;
+        cost
+    }
+
+    /// Current total turns consumed.
+    #[must_use]
+    pub fn current_turns(&self) -> u32 {
+        self.current_turns.load(Ordering::Relaxed)
+    }
+
+    /// Elapsed wall-clock time in milliseconds since budget creation.
+    #[must_use]
+    pub fn elapsed_ms(&self) -> u64 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "elapsed time in ms fits u64 for any realistic dispatch duration"
+        )]
+        let ms = self.start_time.elapsed().as_millis() as u64;
+        ms
+    }
+
+    /// Fraction of cost budget consumed (0.0 to 1.0+). Returns 0.0 if no cost limit.
+    #[must_use]
+    pub fn cost_fraction(&self) -> f64 {
+        self.max_cost_usd
+            .map_or(0.0, |max| self.current_cost_usd() / max)
+    }
+
+    /// Fraction of turn budget consumed (0.0 to 1.0+). Returns 0.0 if no turn limit.
+    #[must_use]
+    pub fn turn_fraction(&self) -> f64 {
+        self.max_turns.map_or(0.0, |max| {
+            #[expect(
+                clippy::cast_lossless,
+                reason = "u32 -> f64 is always lossless but clippy wants the annotation"
+            )]
+            let fraction = f64::from(self.current_turns()) / f64::from(max);
+            fraction
+        })
+    }
+}
+
+impl std::fmt::Debug for Budget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Budget")
+            .field("max_cost_usd", &self.max_cost_usd)
+            .field("max_turns", &self.max_turns)
+            .field("max_duration_ms", &self.max_duration_ms)
+            .field("current_cost_usd", &self.current_cost_usd())
+            .field("current_turns", &self.current_turns())
+            .field("elapsed_ms", &self.elapsed_ms())
+            .finish()
+    }
+}
+
+/// Result of a budget check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BudgetStatus {
+    /// All limits within acceptable range.
+    Ok,
+    /// Approaching a limit (80%+ consumed).
+    Warning(String),
+    /// A limit has been exceeded.
+    Exceeded(String),
+}
+
+// ---------------------------------------------------------------------------
+// Resume policy
+// ---------------------------------------------------------------------------
+
+/// Multi-stage resume policy for stuck or stalled sessions.
+///
+/// Each stage has a turn budget and an escalating urgency message injected
+/// into the session to redirect the agent's behavior.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ResumePolicy {
+    /// Ordered stages of escalating intervention.
+    pub stages: Vec<ResumeStage>,
+}
+
+/// A single stage in a resume escalation sequence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ResumeStage {
+    /// Maximum turns allowed in this stage before escalating.
+    pub turn_budget: u32,
+    /// Message injected into the session at this escalation level.
+    pub message: String,
+}
+
+impl Default for ResumePolicy {
+    fn default() -> Self {
+        Self {
+            stages: vec![
+                ResumeStage {
+                    turn_budget: 5,
+                    message: "You seem stuck. Try a different approach.".to_owned(),
+                },
+                ResumeStage {
+                    turn_budget: 3,
+                    message: "Focus on the core requirement only. Skip anything non-essential."
+                        .to_owned(),
+                },
+                ResumeStage {
+                    turn_budget: 2,
+                    message: "Final attempt. Commit what you have and report status.".to_owned(),
+                },
+            ],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QA types
+// ---------------------------------------------------------------------------
+
+/// Result of a QA evaluation against a pull request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct QaResult {
+    /// The prompt number that produced the PR.
+    pub prompt_number: u32,
+    /// Pull request number evaluated.
+    pub pr_number: u64,
+    /// Overall verdict.
+    pub verdict: QaVerdict,
+    /// Per-criterion evaluation results.
+    pub criteria_results: Vec<CriterionResult>,
+    /// Mechanical issues found in the diff.
+    pub mechanical_issues: Vec<MechanicalIssue>,
+    /// Cost in USD for the LLM evaluation.
+    pub cost_usd: f64,
+    /// Timestamp when the evaluation completed.
+    pub evaluated_at: Timestamp,
+}
+
+/// Overall quality verdict for a PR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum QaVerdict {
+    /// All criteria pass, no blocking mechanical issues.
+    Pass,
+    /// Some criteria fail but the PR is partially acceptable.
+    Partial,
+    /// Critical criteria fail or blocking mechanical issues found.
+    Fail,
+}
+
+impl std::fmt::Display for QaVerdict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pass => write!(f, "pass"),
+            Self::Partial => write!(f, "partial"),
+            Self::Fail => write!(f, "fail"),
+        }
+    }
+}
+
+/// Evaluation result for a single acceptance criterion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CriterionResult {
+    /// The acceptance criterion text.
+    pub criterion: String,
+    /// Whether this criterion was mechanically or semantically evaluated.
+    pub classification: CriterionType,
+    /// Whether the criterion passed.
+    pub passed: bool,
+    /// Supporting evidence from the diff or evaluation.
+    pub evidence: String,
+}
+
+/// How a criterion was evaluated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum CriterionType {
+    /// Checkable by static analysis (lint, format, blast radius).
+    Mechanical,
+    /// Requires LLM evaluation of intent and correctness.
+    Semantic,
+}
+
+/// A mechanical issue found in a diff.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct MechanicalIssue {
+    /// Category of the issue.
+    pub kind: MechanicalIssueKind,
+    /// Human-readable description.
+    pub message: String,
+    /// Optional additional details (file paths, line numbers, etc.).
+    pub details: Option<String>,
+}
+
+/// Categories of mechanical issues detectable without LLM evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum MechanicalIssueKind {
+    /// Changes touch files outside the declared blast radius.
+    BlastRadiusViolation,
+    /// Known anti-pattern detected in the diff.
+    AntiPattern,
+    /// Lint check failure.
+    LintViolation,
+    /// Code formatting violation.
+    FormatViolation,
+}
+
+impl std::fmt::Display for MechanicalIssueKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BlastRadiusViolation => write!(f, "blast_radius_violation"),
+            Self::AntiPattern => write!(f, "anti_pattern"),
+            Self::LintViolation => write!(f, "lint_violation"),
+            Self::FormatViolation => write!(f, "format_violation"),
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_status_display() {
+        assert_eq!(SessionStatus::Success.to_string(), "success");
+        assert_eq!(SessionStatus::Failed.to_string(), "failed");
+        assert_eq!(SessionStatus::Stuck.to_string(), "stuck");
+        assert_eq!(SessionStatus::Aborted.to_string(), "aborted");
+        assert_eq!(SessionStatus::BudgetExceeded.to_string(), "budget_exceeded");
+        assert_eq!(SessionStatus::Skipped.to_string(), "skipped");
+        assert_eq!(SessionStatus::InfraFailure.to_string(), "infra_failure");
+    }
+
+    #[test]
+    fn qa_verdict_display() {
+        assert_eq!(QaVerdict::Pass.to_string(), "pass");
+        assert_eq!(QaVerdict::Partial.to_string(), "partial");
+        assert_eq!(QaVerdict::Fail.to_string(), "fail");
+    }
+
+    #[test]
+    fn mechanical_issue_kind_display() {
+        assert_eq!(
+            MechanicalIssueKind::BlastRadiusViolation.to_string(),
+            "blast_radius_violation"
+        );
+        assert_eq!(MechanicalIssueKind::AntiPattern.to_string(), "anti_pattern");
+    }
+
+    #[test]
+    fn budget_new_no_limits() {
+        let budget = Budget::new(None, None, None);
+        assert_eq!(budget.current_cost_usd(), 0.0);
+        assert_eq!(budget.current_turns(), 0);
+        assert_eq!(budget.check(), BudgetStatus::Ok);
+    }
+
+    #[test]
+    fn budget_record_and_check() {
+        let budget = Budget::new(Some(1.0), Some(10), None);
+        budget.record(0.5, 3);
+        assert!((budget.current_cost_usd() - 0.5).abs() < 0.001);
+        assert_eq!(budget.current_turns(), 3);
+        assert_eq!(budget.check(), BudgetStatus::Ok);
+    }
+
+    #[test]
+    fn budget_warning_at_80_percent() {
+        let budget = Budget::new(Some(1.0), None, None);
+        budget.record(0.85, 0);
+        assert!(matches!(budget.check(), BudgetStatus::Warning(_)));
+    }
+
+    #[test]
+    fn budget_exceeded() {
+        let budget = Budget::new(Some(1.0), None, None);
+        budget.record(1.5, 0);
+        assert!(matches!(budget.check(), BudgetStatus::Exceeded(_)));
+    }
+
+    #[test]
+    fn budget_turn_exceeded() {
+        let budget = Budget::new(None, Some(5), None);
+        budget.record(0.0, 6);
+        assert!(matches!(budget.check(), BudgetStatus::Exceeded(_)));
+    }
+
+    #[test]
+    fn budget_cost_fraction() {
+        let budget = Budget::new(Some(10.0), None, None);
+        budget.record(3.0, 0);
+        assert!((budget.cost_fraction() - 0.3).abs() < 0.01);
+    }
+
+    #[test]
+    fn budget_turn_fraction() {
+        let budget = Budget::new(None, Some(20), None);
+        budget.record(0.0, 5);
+        assert!((budget.turn_fraction() - 0.25).abs() < 0.01);
+    }
+
+    #[test]
+    fn budget_fractions_zero_without_limits() {
+        let budget = Budget::new(None, None, None);
+        assert_eq!(budget.cost_fraction(), 0.0);
+        assert_eq!(budget.turn_fraction(), 0.0);
+    }
+
+    #[test]
+    fn budget_concurrent_recording() {
+        let budget = Budget::new(Some(100.0), Some(1000), None);
+        budget.record(1.0, 10);
+        budget.record(2.0, 20);
+        budget.record(0.5, 5);
+        assert!((budget.current_cost_usd() - 3.5).abs() < 0.001);
+        assert_eq!(budget.current_turns(), 35);
+    }
+
+    #[test]
+    fn budget_debug_format() {
+        let budget = Budget::new(Some(5.0), Some(100), None);
+        let debug = format!("{budget:?}");
+        assert!(debug.contains("Budget"));
+        assert!(debug.contains("max_cost_usd"));
+    }
+
+    #[test]
+    fn resume_policy_default_has_three_stages() {
+        let policy = ResumePolicy::default();
+        assert_eq!(policy.stages.len(), 3);
+        assert!(policy.stages[0].turn_budget > policy.stages[2].turn_budget);
+    }
+
+    #[test]
+    fn dispatch_spec_roundtrip() {
+        let spec = DispatchSpec {
+            prompt_numbers: vec![1, 2, 3],
+            project: "test-project".to_owned(),
+            dag_ref: None,
+            max_parallel: Some(2),
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let deserialized: DispatchSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.prompt_numbers, vec![1, 2, 3]);
+        assert_eq!(deserialized.max_parallel, Some(2));
+    }
+
+    #[test]
+    fn session_outcome_roundtrip() {
+        let outcome = SessionOutcome {
+            prompt_number: 1,
+            status: SessionStatus::Success,
+            session_id: Some("sess-123".to_owned()),
+            cost_usd: 0.42,
+            num_turns: 15,
+            duration_ms: 30_000,
+            resume_count: 0,
+            pr_url: Some("https://github.com/acme/repo/pull/42".to_owned()),
+            error: None,
+        };
+        let json = serde_json::to_string(&outcome).unwrap();
+        let deserialized: SessionOutcome = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.prompt_number, 1);
+        assert_eq!(deserialized.status, SessionStatus::Success);
+    }
+
+    #[test]
+    fn qa_result_roundtrip() {
+        let result = QaResult {
+            prompt_number: 1,
+            pr_number: 42,
+            verdict: QaVerdict::Pass,
+            criteria_results: vec![CriterionResult {
+                criterion: "tests pass".to_owned(),
+                classification: CriterionType::Mechanical,
+                passed: true,
+                evidence: "CI green".to_owned(),
+            }],
+            mechanical_issues: vec![],
+            cost_usd: 0.03,
+            evaluated_at: Timestamp::now(),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let deserialized: QaResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.verdict, QaVerdict::Pass);
+        assert_eq!(deserialized.criteria_results.len(), 1);
+    }
+
+    #[test]
+    fn session_status_equality() {
+        assert_eq!(SessionStatus::Success, SessionStatus::Success);
+        assert_ne!(SessionStatus::Success, SessionStatus::Failed);
+    }
+}


### PR DESCRIPTION
## Summary

Creates the `energeia` crate in the aletheia workspace with core types and trait boundaries for the dispatch system migration from kanon (kanon#191).

- energeia crate skeleton with Cargo.toml, workspace registration
- Core types ported from phronesis: DispatchSpec, SessionOutcome, SessionStatus, QaVerdict, Budget, ResumePolicy
- DispatchEngine and QaGate traits defined
- Feature flag `energeia` on binary crate (default off)

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo test --workspace --features energeia` passes
- [ ] Feature flag gates the crate correctly

Dispatch prompt: K-2050 (kanon#191)

🤖 Generated with [Claude Code](https://claude.com/claude-code)