### PR TITLE
feat(energeia): implement DispatchEngine HTTP/SSE client shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/eidos/src/knowledge.rs
+++ b/crates/eidos/src/knowledge.rs
@@ -580,10 +580,6 @@ pub fn default_stability_hours(fact_type: &str) -> f64 {
 /// so existing data using `"9999-12-31"` must be treated equivalently (any year-9999
 /// timestamp means "no end date").
 #[must_use]
-#[expect(
-    clippy::expect_used,
-    reason = "date(9999, 1, 1) is a valid Gregorian date and UTC conversion is infallible"
-)]
 pub fn far_future() -> jiff::Timestamp {
     jiff::civil::date(9999, 1, 1)
         .to_zoned(jiff::tz::TimeZone::UTC)
@@ -618,10 +614,6 @@ pub(crate) fn is_far_future(ts: &jiff::Timestamp) -> bool {
 ///
 /// Returns `None` for empty or unparseable strings.
 #[must_use]
-#[expect(
-    clippy::expect_used,
-    reason = "UTC timezone conversion for a valid parsed date is infallible"
-)]
 pub fn parse_timestamp(s: &str) -> Option<jiff::Timestamp> {
     if s.is_empty() {
         return None;

--- a/crates/energeia/Cargo.toml
+++ b/crates/energeia/Cargo.toml
@@ -26,8 +26,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 snafu = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["process", "io-util"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["process", "io-util", "test-util"] }

--- a/crates/energeia/src/engine.rs
+++ b/crates/energeia/src/engine.rs
@@ -18,6 +18,10 @@ use crate::error::Result;
 ///
 /// Targets the Anthropic Agent SDK HTTP/SSE API. Production implementations
 /// use HTTP+SSE streaming; test implementations return canned responses.
+#[expect(
+    clippy::type_complexity,
+    reason = "async trait methods returning boxed trait objects require nested generics"
+)]
 pub trait DispatchEngine: Send + Sync {
     /// Spawn a new agent session for the given spec and options.
     fn spawn_session<'a>(

--- a/crates/energeia/src/http/client.rs
+++ b/crates/energeia/src/http/client.rs
@@ -1,0 +1,408 @@
+//! `HttpEngine`: subprocess-based implementation of [`DispatchEngine`].
+//!
+//! Named `HttpEngine` because the trait targets the Anthropic Agent SDK HTTP/SSE
+//! API. The current implementation uses the Claude CLI subprocess as a transport
+//! (matching phronesis's approach) because the Agent SDK HTTP endpoints are not
+//! yet publicly documented. The [`DispatchEngine`] trait boundary insulates
+//! callers from this implementation detail.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::process::Stdio;
+
+use tokio::process::Command;
+
+use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+use crate::error::{self, Result};
+use crate::http::session::ProcessSessionHandle;
+use crate::http::stream::EventStream;
+
+// ---------------------------------------------------------------------------
+// HttpEngine
+// ---------------------------------------------------------------------------
+
+/// Subprocess-based dispatch engine targeting the Claude CLI.
+///
+/// Spawns `claude --output-format stream-json` subprocesses and streams NDJSON
+/// events. Will be replaced by a direct HTTP/SSE client when the Anthropic
+/// Agent SDK HTTP endpoints are publicly available.
+pub struct HttpEngine {
+    /// Default model identifier (e.g., "claude-sonnet-4-20250514").
+    default_model: String,
+    /// Path to the claude CLI binary.
+    binary: String,
+}
+
+impl HttpEngine {
+    /// Create a new engine with the given default model.
+    #[must_use]
+    pub fn new(default_model: impl Into<String>) -> Self {
+        Self {
+            default_model: default_model.into(),
+            binary: "claude".to_owned(),
+        }
+    }
+
+    /// Override the CLI binary path (for testing with mock scripts).
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn binary(mut self, path: impl Into<String>) -> Self {
+        self.binary = path.into();
+        self
+    }
+
+    /// Build the CLI argument vector for a session.
+    fn build_args(&self, options: &AgentOptions) -> Vec<String> {
+        let mut args = Vec::new();
+
+        args.extend(["--output-format".to_owned(), "stream-json".to_owned()]);
+        args.push("--verbose".to_owned());
+
+        let model = options.model.as_deref().unwrap_or(&self.default_model);
+        args.extend(["--model".to_owned(), model.to_owned()]);
+
+        if let Some(ref mode) = options.permission_mode {
+            args.extend(["--permission-mode".to_owned(), mode.clone()]);
+        }
+
+        if let Some(ref prompt) = options.system_prompt {
+            args.extend(["--system-prompt".to_owned(), prompt.clone()]);
+        }
+
+        if let Some(turns) = options.max_turns {
+            args.extend(["--max-turns".to_owned(), turns.to_string()]);
+        }
+
+        args
+    }
+
+    /// Spawn a subprocess and return a session handle.
+    fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        // INVARIANT: kill_on_drop ensures cleanup if the handle is dropped
+        // without explicit wait/abort.
+        cmd.kill_on_drop(true);
+
+        let mut child = cmd.spawn().map_err(|e| {
+            error::EngineSnafu {
+                detail: format!("failed to spawn claude subprocess: {e}"),
+            }
+            .build()
+        })?;
+
+        let stdout = child.stdout.take().ok_or_else(|| {
+            error::EngineSnafu {
+                detail: "stdout not captured from subprocess",
+            }
+            .build()
+        })?;
+
+        let stream = EventStream::new(stdout);
+        Ok(ProcessSessionHandle::new(child, stream, String::new()))
+    }
+}
+
+impl DispatchEngine for HttpEngine {
+    fn spawn_session<'a>(
+        &'a self,
+        spec: &'a SessionSpec,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut cmd = Command::new(&self.binary);
+            cmd.args(["-p", &spec.prompt]);
+            cmd.args(self.build_args(options));
+
+            // WHY: cwd is set on the Command, not as a CLI flag.
+            let cwd = spec.cwd.as_ref().or(options.cwd.as_ref());
+            if let Some(dir) = cwd {
+                cmd.current_dir(dir);
+            }
+
+            if let Some(ref sys) = spec.system_prompt
+                && options.system_prompt.is_none()
+            {
+                cmd.args(["--system-prompt", sys]);
+            }
+
+            tracing::debug!(
+                prompt_len = spec.prompt.len(),
+                model = options.model.as_deref().unwrap_or(&self.default_model),
+                "spawning session"
+            );
+
+            let handle = Self::launch(cmd)?;
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+
+    fn resume_session<'a>(
+        &'a self,
+        session_id: &'a str,
+        prompt: &'a str,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut cmd = Command::new(&self.binary);
+            cmd.args(["--resume", session_id, "-p", prompt]);
+            cmd.args(self.build_args(options));
+
+            if let Some(ref dir) = options.cwd {
+                cmd.current_dir(dir);
+            }
+
+            tracing::debug!(session_id, prompt_len = prompt.len(), "resuming session");
+
+            let handle = Self::launch(cmd)?;
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test assertions and helpers"
+)]
+mod tests {
+    use std::fmt::Write;
+
+    use super::*;
+    use crate::engine::SessionEvent;
+
+    #[test]
+    fn build_args_default_model() {
+        let engine = HttpEngine::new("claude-sonnet-4-20250514");
+        let options = AgentOptions::new();
+        let args = engine.build_args(&options);
+
+        assert!(args.contains(&"--output-format".to_owned()));
+        assert!(args.contains(&"stream-json".to_owned()));
+        assert!(args.contains(&"--model".to_owned()));
+        assert!(args.contains(&"claude-sonnet-4-20250514".to_owned()));
+    }
+
+    #[test]
+    fn build_args_option_overrides() {
+        let engine = HttpEngine::new("default-model");
+        let options = AgentOptions::new()
+            .model("claude-opus-4-6")
+            .max_turns(50)
+            .permission_mode("bypassPermissions");
+        let args = engine.build_args(&options);
+
+        assert!(args.contains(&"claude-opus-4-6".to_owned()));
+        assert!(args.contains(&"--max-turns".to_owned()));
+        assert!(args.contains(&"50".to_owned()));
+        assert!(args.contains(&"--permission-mode".to_owned()));
+        assert!(args.contains(&"bypassPermissions".to_owned()));
+    }
+
+    #[test]
+    fn build_args_omits_unset_options() {
+        let engine = HttpEngine::new("m");
+        let options = AgentOptions::new();
+        let args = engine.build_args(&options);
+
+        assert!(!args.contains(&"--system-prompt".to_owned()));
+        assert!(!args.contains(&"--max-turns".to_owned()));
+        assert!(!args.contains(&"--permission-mode".to_owned()));
+    }
+
+    /// Helper: create a mock script that emits NDJSON lines and exits.
+    fn create_mock_script(
+        dir: &std::path::Path,
+        stdout_lines: &[&str],
+        exit_code: i32,
+    ) -> std::path::PathBuf {
+        let script_path = dir.join("claude");
+        let mut content = String::from("#!/bin/sh\n");
+        for line in stdout_lines {
+            let _ = writeln!(content, "echo '{line}'");
+        }
+        let _ = writeln!(content, "exit {exit_code}");
+        std::fs::write(&script_path, &content).expect("mock script should be writable");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+                .expect("mock script should be chmod-able");
+        }
+
+        script_path
+    }
+
+    fn mock_engine(dir: &std::path::Path) -> HttpEngine {
+        HttpEngine::new("test-model").binary(dir.join("claude").display().to_string())
+    }
+
+    fn test_spec(prompt: &str) -> SessionSpec {
+        SessionSpec {
+            prompt: prompt.to_owned(),
+            system_prompt: None,
+            cwd: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_session_successful() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lines = &[
+            r#"{"type":"system","subtype":"init","session_id":"sess-001"}"#,
+            r#"{"type":"assistant","content":[{"type":"text","text":"Hello"}]}"#,
+            r#"{"type":"result","session_id":"sess-001","subtype":"success","is_error":false,"total_cost_usd":0.10,"num_turns":3,"duration_ms":5000,"result":"Done"}"#,
+        ];
+        create_mock_script(tmp.path(), lines, 0);
+
+        let engine = mock_engine(tmp.path());
+        let handle = engine
+            .spawn_session(&test_spec("test prompt"), &AgentOptions::new())
+            .await
+            .unwrap();
+        let result = handle.wait().await.unwrap();
+
+        assert_eq!(result.session_id, "sess-001");
+        assert!(result.success);
+        assert_eq!(result.num_turns, 3);
+        assert!((result.cost_usd - 0.10).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn spawn_session_error_result() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lines = &[
+            r#"{"type":"system","subtype":"init","session_id":"sess-err"}"#,
+            r#"{"type":"result","session_id":"sess-err","subtype":"error_during_execution","is_error":true,"num_turns":1,"duration_ms":500}"#,
+        ];
+        create_mock_script(tmp.path(), lines, 1);
+
+        let engine = mock_engine(tmp.path());
+        let handle = engine
+            .spawn_session(&test_spec("bad prompt"), &AgentOptions::new())
+            .await
+            .unwrap();
+        let result = handle.wait().await.unwrap();
+
+        assert!(!result.success);
+    }
+
+    #[tokio::test]
+    async fn resume_session_works() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lines = &[
+            r#"{"type":"system","subtype":"init","session_id":"sess-resume"}"#,
+            r#"{"type":"result","session_id":"sess-resume","subtype":"success","is_error":false,"num_turns":5,"duration_ms":3000}"#,
+        ];
+        create_mock_script(tmp.path(), lines, 0);
+
+        let engine = mock_engine(tmp.path());
+        let handle = engine
+            .resume_session("sess-resume", "continue working", &AgentOptions::new())
+            .await
+            .unwrap();
+        let result = handle.wait().await.unwrap();
+
+        assert_eq!(result.session_id, "sess-resume");
+        assert!(result.success);
+    }
+
+    #[tokio::test]
+    async fn spawn_session_event_streaming() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lines = &[
+            r#"{"type":"system","subtype":"init","session_id":"sess-stream"}"#,
+            r#"{"type":"assistant","content":[{"type":"text","text":"step 1"}]}"#,
+            r#"{"type":"assistant","content":[{"type":"text","text":"step 2"}]}"#,
+            r#"{"type":"result","session_id":"sess-stream","subtype":"success","is_error":false,"num_turns":2,"duration_ms":1000}"#,
+        ];
+        create_mock_script(tmp.path(), lines, 0);
+
+        let engine = mock_engine(tmp.path());
+        let mut handle = engine
+            .spawn_session(&test_spec("test"), &AgentOptions::new())
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(event) = handle.next_event().await {
+            events.push(event);
+        }
+
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], SessionEvent::TextDelta { text } if text == "step 1"));
+        assert!(matches!(&events[1], SessionEvent::TextDelta { text } if text == "step 2"));
+    }
+
+    #[tokio::test]
+    async fn spawn_session_rate_limit_abort() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lines = &[
+            r#"{"type":"system","subtype":"init","session_id":"sess-rl"}"#,
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"throttled","utilization":0.99}}"#,
+        ];
+        create_mock_script(tmp.path(), lines, 0);
+
+        let engine = mock_engine(tmp.path());
+        let handle = engine
+            .spawn_session(&test_spec("test"), &AgentOptions::new())
+            .await
+            .unwrap();
+        let err = handle.wait().await.unwrap_err();
+
+        assert!(err.to_string().contains("budget exceeded"));
+        assert!(err.to_string().contains("rate limit"));
+    }
+
+    #[tokio::test]
+    async fn spawn_session_no_result_message() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lines = &[r#"{"type":"system","subtype":"init","session_id":"sess-no-result"}"#];
+        create_mock_script(tmp.path(), lines, 1);
+
+        let engine = mock_engine(tmp.path());
+        let handle = engine
+            .spawn_session(&test_spec("test"), &AgentOptions::new())
+            .await
+            .unwrap();
+        let err = handle.wait().await.unwrap_err();
+
+        assert!(err.to_string().contains("without emitting a result"));
+    }
+
+    #[tokio::test]
+    async fn abort_kills_subprocess() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let script_path = tmp.path().join("claude");
+        std::fs::write(&script_path, "#!/bin/sh\nsleep 30\n")
+            .expect("long-running mock should be writable");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+                .expect("mock script should be chmod-able");
+        }
+
+        let engine = HttpEngine::new("test-model").binary(script_path.display().to_string());
+        let mut handle = engine
+            .spawn_session(&test_spec("test"), &AgentOptions::new())
+            .await
+            .unwrap();
+        let result = handle.abort().await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn http_engine_is_send_sync() {
+        static_assertions::assert_impl_all!(HttpEngine: Send, Sync);
+    }
+}

--- a/crates/energeia/src/http/mock.rs
+++ b/crates/energeia/src/http/mock.rs
@@ -1,0 +1,320 @@
+//! Mock dispatch engine for tests.
+//!
+//! [`MockEngine`] implements [`DispatchEngine`] with configurable outcomes,
+//! enabling unit tests without real subprocess spawns or network calls.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Mutex;
+
+use crate::engine::{
+    AgentOptions, DispatchEngine, SessionEvent, SessionHandle, SessionResult, SessionSpec,
+};
+use crate::error::{self, Result};
+
+// ---------------------------------------------------------------------------
+// MockEngine
+// ---------------------------------------------------------------------------
+
+/// Test double for [`DispatchEngine`].
+///
+/// Returns pre-configured outcomes in FIFO order. Thread-safe for use in
+/// async test contexts.
+pub struct MockEngine {
+    outcomes: Mutex<VecDeque<MockOutcome>>,
+}
+
+/// Pre-configured outcome for a mock session.
+pub enum MockOutcome {
+    /// Session completes successfully with the given events and result.
+    Success {
+        /// Events yielded by `next_event()` before the stream ends.
+        events: Vec<SessionEvent>,
+        /// Final result returned by `wait()`.
+        result: SessionResult,
+    },
+    /// Session fails to spawn with the given error message.
+    SpawnFailure {
+        /// Error detail message.
+        detail: String,
+    },
+}
+
+impl MockEngine {
+    /// Create a mock engine that will return the given outcomes in order.
+    #[must_use]
+    pub fn new(outcomes: Vec<MockOutcome>) -> Self {
+        Self {
+            outcomes: Mutex::new(VecDeque::from(outcomes)),
+        }
+    }
+
+    /// Pop the next configured outcome.
+    fn next_outcome(&self) -> Result<MockOutcome> {
+        self.outcomes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pop_front()
+            .ok_or_else(|| {
+                error::EngineSnafu {
+                    detail: "MockEngine: no more configured outcomes",
+                }
+                .build()
+            })
+    }
+}
+
+impl DispatchEngine for MockEngine {
+    fn spawn_session<'a>(
+        &'a self,
+        _spec: &'a SessionSpec,
+        _options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let outcome = self.next_outcome()?;
+            match outcome {
+                MockOutcome::Success { events, result } => {
+                    let handle = MockSessionHandle::new(result.session_id.clone(), events, result);
+                    let boxed: Box<dyn SessionHandle> = Box::new(handle);
+                    Ok(boxed)
+                }
+                MockOutcome::SpawnFailure { detail } => Err(error::EngineSnafu { detail }.build()),
+            }
+        })
+    }
+
+    fn resume_session<'a>(
+        &'a self,
+        _session_id: &'a str,
+        _prompt: &'a str,
+        _options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        // WHY: Resume uses the same outcome queue as spawn. The mock doesn't
+        // distinguish between spawn and resume for simplicity.
+        Box::pin(async move {
+            let outcome = self.next_outcome()?;
+            match outcome {
+                MockOutcome::Success { events, result } => {
+                    let handle = MockSessionHandle::new(result.session_id.clone(), events, result);
+                    let boxed: Box<dyn SessionHandle> = Box::new(handle);
+                    Ok(boxed)
+                }
+                MockOutcome::SpawnFailure { detail } => Err(error::EngineSnafu { detail }.build()),
+            }
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MockSessionHandle
+// ---------------------------------------------------------------------------
+
+/// Test double for [`SessionHandle`].
+///
+/// Yields pre-configured events from a `VecDeque`, then returns `None`.
+/// `wait()` returns the pre-configured result.
+struct MockSessionHandle {
+    session_id: String,
+    events: VecDeque<SessionEvent>,
+    result: Option<SessionResult>,
+}
+
+impl MockSessionHandle {
+    fn new(session_id: String, events: Vec<SessionEvent>, result: SessionResult) -> Self {
+        Self {
+            session_id,
+            events: VecDeque::from(events),
+            result: Some(result),
+        }
+    }
+}
+
+impl SessionHandle for MockSessionHandle {
+    fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    fn next_event<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Option<SessionEvent>> + Send + 'a>> {
+        Box::pin(async move { self.events.pop_front() })
+    }
+
+    fn wait(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = Result<SessionResult>> + Send>> {
+        Box::pin(async move {
+            self.result.take().ok_or_else(|| {
+                error::EngineSnafu {
+                    detail: "MockSessionHandle: wait() called more than once",
+                }
+                .build()
+            })
+        })
+    }
+
+    fn abort<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            self.events.clear();
+            Ok(())
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn make_result(session_id: &str, success: bool) -> SessionResult {
+        SessionResult {
+            session_id: session_id.to_owned(),
+            cost_usd: 0.05,
+            num_turns: 3,
+            duration_ms: 1000,
+            success,
+            result_text: Some("done".to_owned()),
+        }
+    }
+
+    fn make_spec() -> SessionSpec {
+        SessionSpec {
+            prompt: "test".to_owned(),
+            system_prompt: None,
+            cwd: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_engine_success_with_events() {
+        let engine = MockEngine::new(vec![MockOutcome::Success {
+            events: vec![
+                SessionEvent::TextDelta {
+                    text: "hello".to_owned(),
+                },
+                SessionEvent::ToolUse {
+                    name: "bash".to_owned(),
+                    input: serde_json::json!({"cmd": "ls"}),
+                },
+            ],
+            result: make_result("sess-mock", true),
+        }]);
+
+        let mut handle = engine
+            .spawn_session(&make_spec(), &AgentOptions::new())
+            .await
+            .unwrap();
+
+        let e1 = handle.next_event().await;
+        assert!(matches!(e1, Some(SessionEvent::TextDelta { ref text }) if text == "hello"));
+
+        let e2 = handle.next_event().await;
+        assert!(matches!(e2, Some(SessionEvent::ToolUse { ref name, .. }) if name == "bash"));
+
+        let e3 = handle.next_event().await;
+        assert!(e3.is_none());
+
+        let result = handle.wait().await.unwrap();
+        assert_eq!(result.session_id, "sess-mock");
+        assert!(result.success);
+    }
+
+    #[tokio::test]
+    async fn mock_engine_spawn_failure() {
+        let engine = MockEngine::new(vec![MockOutcome::SpawnFailure {
+            detail: "auth failure".to_owned(),
+        }]);
+
+        let result = engine
+            .spawn_session(&make_spec(), &AgentOptions::new())
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.err().unwrap().to_string().contains("auth failure"));
+    }
+
+    #[tokio::test]
+    async fn mock_engine_multiple_sessions() {
+        let engine = MockEngine::new(vec![
+            MockOutcome::Success {
+                events: vec![],
+                result: make_result("sess-1", true),
+            },
+            MockOutcome::Success {
+                events: vec![],
+                result: make_result("sess-2", false),
+            },
+        ]);
+        let opts = AgentOptions::new();
+
+        let h1 = engine.spawn_session(&make_spec(), &opts).await.unwrap();
+        let r1 = h1.wait().await.unwrap();
+        assert_eq!(r1.session_id, "sess-1");
+
+        let h2 = engine.spawn_session(&make_spec(), &opts).await.unwrap();
+        let r2 = h2.wait().await.unwrap();
+        assert_eq!(r2.session_id, "sess-2");
+    }
+
+    #[tokio::test]
+    async fn mock_engine_exhausted_outcomes() {
+        let engine = MockEngine::new(vec![]);
+
+        let result = engine
+            .spawn_session(&make_spec(), &AgentOptions::new())
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("no more configured outcomes")
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_engine_resume() {
+        let engine = MockEngine::new(vec![MockOutcome::Success {
+            events: vec![],
+            result: make_result("sess-resumed", true),
+        }]);
+
+        let handle = engine
+            .resume_session("sess-resumed", "continue", &AgentOptions::new())
+            .await
+            .unwrap();
+
+        let result = handle.wait().await.unwrap();
+        assert_eq!(result.session_id, "sess-resumed");
+    }
+
+    #[tokio::test]
+    async fn mock_session_abort() {
+        let engine = MockEngine::new(vec![MockOutcome::Success {
+            events: vec![SessionEvent::TextDelta {
+                text: "hello".to_owned(),
+            }],
+            result: make_result("sess-abort", true),
+        }]);
+
+        let mut handle = engine
+            .spawn_session(&make_spec(), &AgentOptions::new())
+            .await
+            .unwrap();
+
+        handle.abort().await.unwrap();
+
+        let event = handle.next_event().await;
+        assert!(event.is_none(), "events should be cleared after abort");
+    }
+
+    #[test]
+    fn mock_engine_is_send_sync() {
+        static_assertions::assert_impl_all!(MockEngine: Send, Sync);
+    }
+}

--- a/crates/energeia/src/http/mod.rs
+++ b/crates/energeia/src/http/mod.rs
@@ -1,0 +1,22 @@
+//! HTTP/SSE dispatch engine module.
+//!
+//! Implements [`DispatchEngine`](crate::engine::DispatchEngine) targeting the
+//! Anthropic Agent SDK. The current transport is a subprocess wrapper around
+//! the Claude CLI (`claude --output-format stream-json`), parsing NDJSON from
+//! stdout. The trait boundary insulates callers from this detail; when the
+//! Agent SDK HTTP endpoints are publicly available, only this module changes.
+//!
+//! # Module layout
+//!
+//! - [`client`] — `HttpEngine` implementing `DispatchEngine`
+//! - [`session`] — `ProcessSessionHandle` implementing `SessionHandle`
+//! - [`stream`] — NDJSON wire types and event stream parser
+//! - [`mock`] — `MockEngine` for tests
+
+mod client;
+pub mod mock;
+pub(crate) mod session;
+pub(crate) mod stream;
+
+pub use client::HttpEngine;
+pub use mock::{MockEngine, MockOutcome};

--- a/crates/energeia/src/http/session.rs
+++ b/crates/energeia/src/http/session.rs
@@ -1,0 +1,147 @@
+//! Session handle for subprocess-based engine.
+//!
+//! [`ProcessSessionHandle`] implements [`SessionHandle`] by wrapping a Claude
+//! CLI subprocess. It owns the child process and ensures kill-on-drop safety:
+//! if the handle is dropped without calling [`SessionHandle::wait`], the
+//! subprocess is killed via `start_kill()`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Instant;
+
+use tokio::process::Child;
+
+use crate::engine::{SessionEvent, SessionHandle, SessionResult};
+use crate::error::{self, Result};
+use crate::http::stream::EventStream;
+
+/// Handle to a running Claude CLI subprocess session.
+///
+/// INVARIANT: The child process is killed on drop if `wait()` was not called.
+/// This prevents zombie processes when sessions are abandoned.
+pub struct ProcessSessionHandle {
+    session_id: String,
+    pub(crate) stream: EventStream,
+    child: Option<Child>,
+    start_time: Instant,
+}
+
+impl ProcessSessionHandle {
+    /// Create a new handle from a spawned subprocess.
+    pub(crate) fn new(child: Child, stream: EventStream, session_id: String) -> Self {
+        Self {
+            session_id,
+            stream,
+            child: Some(child),
+            start_time: Instant::now(),
+        }
+    }
+
+    /// Update the session ID from the stream's parsed system message.
+    pub(crate) fn sync_session_id(&mut self) {
+        if let Some(ref id) = self.stream.session_id {
+            self.session_id.clone_from(id);
+        }
+    }
+}
+
+impl SessionHandle for ProcessSessionHandle {
+    fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    fn next_event<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Option<SessionEvent>> + Send + 'a>> {
+        Box::pin(async move {
+            let event = self.stream.next_event().await;
+            // Keep session_id in sync with what the stream discovers.
+            self.sync_session_id();
+            event
+        })
+    }
+
+    fn wait(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = Result<SessionResult>> + Send>> {
+        Box::pin(async move {
+            // Drain remaining events to capture the result message.
+            while self.stream.next_event().await.is_some() {}
+            self.sync_session_id();
+
+            // Wait for the child process to avoid zombies.
+            if let Some(ref mut child) = self.child {
+                let _ = child.wait().await;
+            }
+            // Take child so Drop doesn't kill it again.
+            self.child.take();
+
+            if self.stream.rate_limit_exceeded {
+                return Err(error::BudgetExceededSnafu {
+                    reason: "rate limit utilization exceeded 98%",
+                }
+                .build());
+            }
+
+            if let Some(result) = self.stream.wire_result.take() {
+                #[expect(
+                    clippy::as_conversions,
+                    clippy::cast_possible_truncation,
+                    reason = "elapsed ms fits u64 for any realistic session duration"
+                )]
+                let duration_ms = if result.duration_ms > 0 {
+                    result.duration_ms
+                } else {
+                    self.start_time.elapsed().as_millis() as u64
+                };
+
+                Ok(SessionResult {
+                    session_id: self.session_id.clone(),
+                    cost_usd: result.total_cost_usd.unwrap_or(0.0),
+                    num_turns: result.num_turns,
+                    duration_ms,
+                    success: !result.is_error,
+                    result_text: result.result,
+                })
+            } else {
+                Err(error::EngineSnafu {
+                    detail: "subprocess exited without emitting a result message",
+                }
+                .build())
+            }
+        })
+    }
+
+    fn abort<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            if let Some(ref mut child) = self.child {
+                tracing::info!(session_id = %self.session_id, "aborting session subprocess");
+                child.kill().await.map_err(|e| {
+                    error::EngineSnafu {
+                        detail: format!("failed to kill subprocess: {e}"),
+                    }
+                    .build()
+                })?;
+            }
+            Ok(())
+        })
+    }
+}
+
+impl Drop for ProcessSessionHandle {
+    fn drop(&mut self) {
+        // SAFETY: start_kill() is non-async and sends SIGKILL to the child.
+        // This is the kill-on-drop safety net for sessions not explicitly waited.
+        if let Some(ref mut child) = self.child {
+            let _ = child.start_kill();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_session_handle_is_send() {
+        static_assertions::assert_impl_all!(ProcessSessionHandle: Send);
+    }
+}

--- a/crates/energeia/src/http/stream.rs
+++ b/crates/energeia/src/http/stream.rs
@@ -1,0 +1,612 @@
+//! NDJSON wire protocol types and event stream parser.
+//!
+//! Parses the `claude --output-format stream-json` NDJSON protocol into
+//! [`SessionEvent`] values. Wire types mirror the Claude CLI protocol from
+//! phronesis: System, Assistant (with content blocks), Result, and `RateLimit`.
+
+use std::collections::VecDeque;
+
+use serde::Deserialize;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::ChildStdout;
+
+use crate::engine::SessionEvent;
+
+// ---------------------------------------------------------------------------
+// Wire protocol types (NDJSON from claude CLI)
+// ---------------------------------------------------------------------------
+
+/// Top-level NDJSON message from `claude --output-format stream-json`.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+#[non_exhaustive]
+pub(crate) enum WireMessage {
+    /// Session initialization.
+    #[serde(rename = "system")]
+    System(SystemMessage),
+    /// Streamed assistant response with content blocks.
+    #[serde(rename = "assistant")]
+    Assistant(AssistantMessage),
+    /// Final session result.
+    #[serde(rename = "result")]
+    Result(ResultMessage),
+    /// Rate limit status update.
+    #[serde(rename = "rate_limit_event")]
+    RateLimit(RateLimitMessage),
+    /// User turn visible during session resume (deserialized, not consumed).
+    // WHY: serde needs somewhere to put "human" messages during session
+    // resume replay. We absorb unknown fields silently and discard.
+    #[serde(rename = "human")]
+    Human {},
+    /// Unrecognized message type, ignored.
+    // WHY: Claude CLI may emit types we don't handle. Without this catch-all,
+    // serde fails on unknown types and kills the session.
+    #[serde(other)]
+    Unknown,
+}
+
+/// System message at session start or compaction boundary.
+#[derive(Debug, Deserialize)]
+pub(crate) struct SystemMessage {
+    #[serde(default)]
+    pub(crate) session_id: Option<String>,
+}
+
+/// Streamed content from the assistant.
+#[derive(Debug, Deserialize)]
+pub(crate) struct AssistantMessage {
+    #[serde(default)]
+    pub(crate) content: Vec<ContentBlock>,
+}
+
+/// Individual content block within an assistant message.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+#[non_exhaustive]
+pub(crate) enum ContentBlock {
+    /// Plain text output.
+    #[serde(rename = "text")]
+    Text { text: String },
+    /// Extended thinking output (not surfaced as events).
+    #[serde(rename = "thinking")]
+    Thinking {},
+    /// Tool invocation requested by the assistant.
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        name: String,
+        input: serde_json::Value,
+    },
+    /// Result returned from a tool invocation (not surfaced as events).
+    // WHY: ToolResult blocks in the wire protocol represent tool outputs
+    // replayed during session resume. The SessionEvent::ToolResult expects
+    // a name+success pair which isn't available from the wire content block.
+    #[serde(rename = "tool_result")]
+    ToolResult {},
+}
+
+/// Rate limit status update.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RateLimitMessage {
+    #[serde(default)]
+    pub(crate) rate_limit_info: Option<RateLimitInfo>,
+}
+
+/// Inner rate limit details.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RateLimitInfo {
+    /// 0.0 to 1.0 -- fraction of rate limit consumed.
+    #[serde(default)]
+    pub(crate) utilization: Option<f64>,
+}
+
+/// Final message when session ends.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ResultMessage {
+    // WHY: Deserialized from wire protocol for test assertions and future use;
+    // the session handle uses its own tracked session_id from the System message.
+    #[expect(
+        dead_code,
+        reason = "deserialized from wire but read via EventStream.session_id"
+    )]
+    pub(crate) session_id: String,
+    #[serde(default)]
+    pub(crate) result: Option<String>,
+    #[serde(default)]
+    pub(crate) subtype: String,
+    #[serde(default)]
+    pub(crate) is_error: bool,
+    #[serde(default)]
+    pub(crate) total_cost_usd: Option<f64>,
+    #[serde(default)]
+    pub(crate) num_turns: u32,
+    #[serde(default)]
+    pub(crate) duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Event stream
+// ---------------------------------------------------------------------------
+
+/// Parsed NDJSON stream that yields [`SessionEvent`] values.
+///
+/// Reads line-delimited JSON from the claude CLI subprocess stdout, parses wire
+/// messages, and maps content blocks to individual `SessionEvent` values.
+/// Buffers multiple events from a single assistant message (which can contain
+/// multiple content blocks).
+pub(crate) struct EventStream {
+    reader: BufReader<ChildStdout>,
+    pending: VecDeque<SessionEvent>,
+    /// Session ID captured from the System init message.
+    pub(crate) session_id: Option<String>,
+    /// Stored result message for `wait()`.
+    pub(crate) wire_result: Option<ResultMessage>,
+    /// Set when rate limit utilization exceeds 98%.
+    pub(crate) rate_limit_exceeded: bool,
+}
+
+impl EventStream {
+    /// Create a new event stream from subprocess stdout.
+    pub(crate) fn new(stdout: ChildStdout) -> Self {
+        Self {
+            reader: BufReader::new(stdout),
+            pending: VecDeque::new(),
+            session_id: None,
+            wire_result: None,
+            rate_limit_exceeded: false,
+        }
+    }
+
+    /// Yield the next [`SessionEvent`].
+    ///
+    /// Returns `None` when the stream is exhausted (result received, rate limit
+    /// exceeded, or subprocess stdout closed).
+    pub(crate) async fn next_event(&mut self) -> Option<SessionEvent> {
+        // Drain buffered events from multi-block assistant messages first.
+        if let Some(event) = self.pending.pop_front() {
+            return Some(event);
+        }
+
+        loop {
+            let mut line = String::new();
+            match self.reader.read_line(&mut line).await {
+                Ok(0) => return None,
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, "I/O error reading NDJSON stream");
+                    return Some(SessionEvent::Error {
+                        message: format!("I/O error: {e}"),
+                    });
+                }
+            }
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let msg: WireMessage = match serde_json::from_str(trimmed) {
+                Ok(msg) => msg,
+                Err(e) => {
+                    tracing::warn!(
+                        line = %trimmed,
+                        error = %e,
+                        "skipping unparseable NDJSON line"
+                    );
+                    continue;
+                }
+            };
+
+            match msg {
+                WireMessage::System(sys) => {
+                    if let Some(id) = sys.session_id {
+                        self.session_id = Some(id);
+                    }
+                }
+                WireMessage::Assistant(asst) => {
+                    self.map_content_blocks(asst.content);
+                    if let Some(event) = self.pending.pop_front() {
+                        return Some(event);
+                    }
+                }
+                WireMessage::Result(result) => {
+                    if result.is_error {
+                        self.pending.push_back(SessionEvent::Error {
+                            message: result
+                                .result
+                                .clone()
+                                .unwrap_or_else(|| result.subtype.clone()),
+                        });
+                    }
+                    self.wire_result = Some(result);
+                    return self.pending.pop_front();
+                }
+                WireMessage::RateLimit(rl) => {
+                    let utilization = rl
+                        .rate_limit_info
+                        .and_then(|info| info.utilization)
+                        .unwrap_or(0.0);
+                    if utilization > 0.98 {
+                        tracing::warn!(
+                            utilization,
+                            "rate limit utilization >98%, aborting session"
+                        );
+                        self.rate_limit_exceeded = true;
+                        return None;
+                    }
+                }
+                WireMessage::Human { .. } | WireMessage::Unknown => {}
+            }
+        }
+    }
+
+    /// Map assistant content blocks to buffered `SessionEvent` values.
+    fn map_content_blocks(&mut self, blocks: Vec<ContentBlock>) {
+        for block in blocks {
+            match block {
+                ContentBlock::Text { text } => {
+                    self.pending.push_back(SessionEvent::TextDelta { text });
+                }
+                ContentBlock::ToolUse { name, input } => {
+                    self.pending
+                        .push_back(SessionEvent::ToolUse { name, input });
+                }
+                // WHY: Thinking and ToolResult blocks are not surfaced as events.
+                // Thinking is internal reasoning; ToolResult is replayed during
+                // session resume and lacks the name+success pair SessionEvent needs.
+                ContentBlock::Thinking { .. } | ContentBlock::ToolResult { .. } => {}
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test assertions and helpers"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_system_init() {
+        let json = r#"{"type":"system","subtype":"init","session_id":"sess-001"}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        assert!(
+            matches!(msg, WireMessage::System(sys) if sys.session_id.as_deref() == Some("sess-001"))
+        );
+    }
+
+    #[test]
+    fn deserialize_system_without_session_id() {
+        let json = r#"{"type":"system","subtype":"compact_boundary"}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg, WireMessage::System(sys) if sys.session_id.is_none()));
+    }
+
+    #[test]
+    fn deserialize_assistant_text() {
+        let json = r#"{"type":"assistant","content":[{"type":"text","text":"Hello"}]}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WireMessage::Assistant(asst) => {
+                assert_eq!(asst.content.len(), 1);
+                assert!(matches!(&asst.content[0], ContentBlock::Text { text } if text == "Hello"));
+            }
+            _ => panic!("expected Assistant"),
+        }
+    }
+
+    #[test]
+    fn deserialize_assistant_tool_use() {
+        let json = r#"{"type":"assistant","content":[{"type":"tool_use","id":"tu-1","name":"bash","input":{"cmd":"ls"}}]}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WireMessage::Assistant(asst) => match &asst.content[0] {
+                ContentBlock::ToolUse { name, input } => {
+                    assert_eq!(name, "bash");
+                    assert_eq!(input["cmd"], "ls");
+                }
+                _ => panic!("expected ToolUse"),
+            },
+            _ => panic!("expected Assistant"),
+        }
+    }
+
+    #[test]
+    fn deserialize_assistant_multi_blocks() {
+        let json = r#"{"type":"assistant","content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"answer"},{"type":"tool_use","id":"t1","name":"read","input":{}}]}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WireMessage::Assistant(asst) => {
+                assert_eq!(asst.content.len(), 3);
+                assert!(matches!(&asst.content[0], ContentBlock::Thinking { .. }));
+                assert!(matches!(&asst.content[1], ContentBlock::Text { .. }));
+                assert!(matches!(&asst.content[2], ContentBlock::ToolUse { .. }));
+            }
+            _ => panic!("expected Assistant"),
+        }
+    }
+
+    #[test]
+    fn deserialize_assistant_empty_content() {
+        let json = r#"{"type":"assistant"}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WireMessage::Assistant(asst) => assert!(asst.content.is_empty()),
+            _ => panic!("expected Assistant"),
+        }
+    }
+
+    #[test]
+    fn deserialize_result_success() {
+        let json = r#"{"type":"result","session_id":"sess-001","subtype":"success","is_error":false,"total_cost_usd":0.42,"num_turns":5,"duration_ms":12345,"result":"Done!"}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WireMessage::Result(res) => {
+                assert_eq!(res.subtype, "success");
+                assert!(!res.is_error);
+                assert!((res.total_cost_usd.unwrap() - 0.42).abs() < f64::EPSILON);
+                assert_eq!(res.num_turns, 5);
+                assert_eq!(res.duration_ms, 12345);
+                assert_eq!(res.result.as_deref(), Some("Done!"));
+            }
+            _ => panic!("expected Result"),
+        }
+    }
+
+    #[test]
+    fn deserialize_result_error() {
+        let json = r#"{"type":"result","session_id":"sess-err","subtype":"error_during_execution","is_error":true,"num_turns":1,"duration_ms":500}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WireMessage::Result(res) => {
+                assert!(res.is_error);
+                assert_eq!(res.subtype, "error_during_execution");
+                assert!(res.total_cost_usd.is_none());
+            }
+            _ => panic!("expected Result"),
+        }
+    }
+
+    #[test]
+    fn deserialize_result_minimal() {
+        let json = r#"{"type":"result","session_id":"sess-min","subtype":"success"}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WireMessage::Result(res) => {
+                assert!(!res.is_error);
+                assert_eq!(res.num_turns, 0);
+                assert_eq!(res.duration_ms, 0);
+                assert!(res.total_cost_usd.is_none());
+            }
+            _ => panic!("expected Result"),
+        }
+    }
+
+    #[test]
+    fn deserialize_rate_limit() {
+        let json = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","utilization":0.45}}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            WireMessage::RateLimit(rl) => {
+                let info = rl.rate_limit_info.unwrap();
+                assert!((info.utilization.unwrap() - 0.45).abs() < f64::EPSILON);
+            }
+            _ => panic!("expected RateLimit"),
+        }
+    }
+
+    #[test]
+    fn deserialize_human_message() {
+        let json = r#"{"type":"human","content":[{"type":"text","text":"fix it"}]}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg, WireMessage::Human { .. }));
+    }
+
+    #[test]
+    fn deserialize_unknown_type_ignored() {
+        let json = r#"{"type":"something_new","data":123}"#;
+        let msg: WireMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg, WireMessage::Unknown));
+    }
+
+    #[tokio::test]
+    async fn map_content_blocks_text_and_tool_use() {
+        let blocks = vec![
+            ContentBlock::Text {
+                text: "hello".to_owned(),
+            },
+            ContentBlock::ToolUse {
+                name: "bash".to_owned(),
+                input: serde_json::json!({"cmd": "ls"}),
+            },
+        ];
+
+        let stdout = make_empty_stdout();
+        let mut stream = EventStream::new(stdout);
+        stream.map_content_blocks(blocks);
+
+        assert_eq!(stream.pending.len(), 2);
+        assert!(matches!(&stream.pending[0], SessionEvent::TextDelta { text } if text == "hello"));
+        assert!(matches!(&stream.pending[1], SessionEvent::ToolUse { name, .. } if name == "bash"));
+    }
+
+    #[tokio::test]
+    async fn map_content_blocks_skips_thinking_and_tool_result() {
+        let blocks = vec![
+            ContentBlock::Thinking {},
+            ContentBlock::ToolResult {},
+            ContentBlock::Text {
+                text: "answer".to_owned(),
+            },
+        ];
+
+        let stdout = make_empty_stdout();
+        let mut stream = EventStream::new(stdout);
+        stream.map_content_blocks(blocks);
+
+        assert_eq!(stream.pending.len(), 1);
+        assert!(matches!(&stream.pending[0], SessionEvent::TextDelta { text } if text == "answer"));
+    }
+
+    #[tokio::test]
+    async fn event_stream_parses_full_session() {
+        let ndjson = [
+            r#"{"type":"system","subtype":"init","session_id":"sess-test"}"#,
+            r#"{"type":"assistant","content":[{"type":"text","text":"Hello"}]}"#,
+            r#"{"type":"assistant","content":[{"type":"tool_use","id":"t1","name":"bash","input":{"cmd":"ls"}}]}"#,
+            r#"{"type":"result","session_id":"sess-test","subtype":"success","is_error":false,"total_cost_usd":0.10,"num_turns":3,"duration_ms":5000,"result":"Done"}"#,
+        ]
+        .join("\n");
+
+        let mut stream = event_stream_from_bytes(ndjson.as_bytes());
+
+        let e1 = stream.next_event().await;
+        assert!(matches!(e1, Some(SessionEvent::TextDelta { ref text }) if text == "Hello"));
+
+        let e2 = stream.next_event().await;
+        assert!(matches!(e2, Some(SessionEvent::ToolUse { ref name, .. }) if name == "bash"));
+
+        let e3 = stream.next_event().await;
+        assert!(e3.is_none(), "result message ends the stream");
+
+        assert_eq!(stream.session_id.as_deref(), Some("sess-test"));
+        assert!(stream.wire_result.is_some());
+        assert_eq!(stream.wire_result.as_ref().unwrap().num_turns, 3);
+    }
+
+    #[tokio::test]
+    async fn event_stream_skips_malformed_lines() {
+        let ndjson = [
+            r#"{"type":"system","subtype":"init","session_id":"sess-bad"}"#,
+            "NOT JSON",
+            "",
+            r#"{"type":"assistant","content":[{"type":"text","text":"ok"}]}"#,
+            r#"{"type":"result","session_id":"sess-bad","subtype":"success","is_error":false,"num_turns":1,"duration_ms":100}"#,
+        ]
+        .join("\n");
+
+        let mut stream = event_stream_from_bytes(ndjson.as_bytes());
+
+        let e1 = stream.next_event().await;
+        assert!(matches!(e1, Some(SessionEvent::TextDelta { ref text }) if text == "ok"));
+
+        let e2 = stream.next_event().await;
+        assert!(e2.is_none());
+    }
+
+    #[tokio::test]
+    async fn event_stream_rate_limit_abort() {
+        let ndjson = [
+            r#"{"type":"system","subtype":"init","session_id":"sess-rl"}"#,
+            r#"{"type":"assistant","content":[{"type":"text","text":"working"}]}"#,
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"throttled","utilization":0.99}}"#,
+            r#"{"type":"assistant","content":[{"type":"text","text":"should not see"}]}"#,
+        ]
+        .join("\n");
+
+        let mut stream = event_stream_from_bytes(ndjson.as_bytes());
+
+        let e1 = stream.next_event().await;
+        assert!(matches!(e1, Some(SessionEvent::TextDelta { ref text }) if text == "working"));
+
+        let e2 = stream.next_event().await;
+        assert!(e2.is_none(), "stream should end on rate limit >98%");
+        assert!(stream.rate_limit_exceeded);
+    }
+
+    #[tokio::test]
+    async fn event_stream_rate_limit_below_threshold() {
+        let ndjson = [
+            r#"{"type":"system","subtype":"init","session_id":"sess-rl2"}"#,
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","utilization":0.75}}"#,
+            r#"{"type":"assistant","content":[{"type":"text","text":"still going"}]}"#,
+            r#"{"type":"result","session_id":"sess-rl2","subtype":"success","is_error":false,"num_turns":1,"duration_ms":100}"#,
+        ]
+        .join("\n");
+
+        let mut stream = event_stream_from_bytes(ndjson.as_bytes());
+
+        let e1 = stream.next_event().await;
+        assert!(matches!(e1, Some(SessionEvent::TextDelta { ref text }) if text == "still going"));
+
+        assert!(!stream.rate_limit_exceeded);
+    }
+
+    #[tokio::test]
+    async fn event_stream_error_result_emits_error_event() {
+        let ndjson = [
+            r#"{"type":"system","subtype":"init","session_id":"sess-err"}"#,
+            r#"{"type":"result","session_id":"sess-err","subtype":"error_during_execution","is_error":true,"num_turns":1,"duration_ms":500,"result":"something broke"}"#,
+        ]
+        .join("\n");
+
+        let mut stream = event_stream_from_bytes(ndjson.as_bytes());
+
+        let e1 = stream.next_event().await;
+        assert!(
+            matches!(e1, Some(SessionEvent::Error { ref message }) if message == "something broke")
+        );
+
+        let e2 = stream.next_event().await;
+        assert!(e2.is_none());
+    }
+
+    #[tokio::test]
+    async fn event_stream_multi_block_assistant() {
+        let ndjson = [
+            r#"{"type":"system","subtype":"init","session_id":"sess-mb"}"#,
+            r#"{"type":"assistant","content":[{"type":"text","text":"first"},{"type":"text","text":"second"}]}"#,
+            r#"{"type":"result","session_id":"sess-mb","subtype":"success","is_error":false,"num_turns":1,"duration_ms":100}"#,
+        ]
+        .join("\n");
+
+        let mut stream = event_stream_from_bytes(ndjson.as_bytes());
+
+        let e1 = stream.next_event().await;
+        assert!(matches!(e1, Some(SessionEvent::TextDelta { ref text }) if text == "first"));
+
+        let e2 = stream.next_event().await;
+        assert!(matches!(e2, Some(SessionEvent::TextDelta { ref text }) if text == "second"));
+
+        let e3 = stream.next_event().await;
+        assert!(e3.is_none());
+    }
+
+    // -- helpers --
+
+    /// Create an empty `ChildStdout` for synchronous tests that only exercise
+    /// `map_content_blocks` (never actually read from the stream).
+    fn make_empty_stdout() -> ChildStdout {
+        // WHY: Spawn a trivial process to get a ChildStdout handle. The process
+        // exits immediately so the stream will return EOF if read.
+        let mut child = tokio::process::Command::new("true")
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("'true' command should be available");
+        child.stdout.take().expect("stdout should be piped")
+    }
+
+    /// Create an `EventStream` backed by in-memory bytes instead of a real subprocess.
+    fn event_stream_from_bytes(data: &[u8]) -> EventStream {
+        // WHY: We need a ChildStdout for the type system but want to feed known
+        // data. Use a shell process that echoes our test data.
+        let escaped = String::from_utf8_lossy(data).replace('\'', "'\\''");
+        let mut child = tokio::process::Command::new("sh")
+            .args(["-c", &format!("printf '%s' '{escaped}'")])
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("sh command should be available");
+        let stdout = child.stdout.take().expect("stdout should be piped");
+        // WHY: Leak the child handle. It exits immediately after printf; the OS
+        // reaps it. We only need the stdout pipe.
+        std::mem::forget(child);
+        EventStream::new(stdout)
+    }
+}

--- a/crates/energeia/src/lib.rs
+++ b/crates/energeia/src/lib.rs
@@ -8,6 +8,7 @@
 //! # Architecture
 //!
 //! - [`engine::DispatchEngine`] — session execution backend (Agent SDK HTTP/SSE)
+//! - [`http`] — subprocess-based `DispatchEngine` implementation and mock engine
 //! - [`qa::QaGate`] — quality assurance evaluation (mechanical + LLM)
 //! - [`budget`] — atomic cost/turn/duration tracking for concurrent sessions
 //! - [`resume`] — multi-stage escalation policy for stuck sessions
@@ -24,6 +25,8 @@ pub mod dag;
 pub mod engine;
 /// Error types for energeia operations.
 pub mod error;
+/// HTTP/SSE dispatch engine: subprocess-based `DispatchEngine` and mock.
+pub mod http;
 /// Prompt loading from YAML frontmatter files.
 pub mod prompt;
 /// Quality assurance gate trait.


### PR DESCRIPTION
## Summary

- Implement `HttpEngine` subprocess-based `DispatchEngine` targeting `claude --output-format stream-json` with NDJSON wire protocol parser
- Add `ProcessSessionHandle` with kill-on-drop safety, `EventStream` line parser mapping wire types to `SessionEvent`, and rate-limit abort at >98% utilization
- Add `MockEngine` test double with configurable FIFO outcomes for unit tests
- Fix pre-existing lint violations in `eidos::knowledge` (stale `#[expect]`) and `energeia::types` (broken `TryFrom` casts, missing `finish_non_exhaustive`)

Ref: kanon#191

## Test plan

- [x] `cargo fmt -p aletheia-energeia` — clean
- [x] `cargo clippy -p aletheia-energeia -p aletheia-eidos --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test -p aletheia-energeia -p aletheia-eidos` — 73 tests pass, 0 failures
- [ ] Full workspace validation blocked by pre-existing `krites` compilation errors from `kanon lint --fix` (commit `7342f6c6c` on main)

## Observations

- `krites` crate has 212+ compilation errors on main from automated `kanon lint --fix` pass that converted valid `as` casts to non-existent `TryFrom` impls and `.copied()` on non-Copy types. Same class of breakage found and fixed in `energeia::types` and `eidos::knowledge` in this PR.
- Agent SDK HTTP endpoints remain undocumented; `HttpEngine` uses subprocess transport as specified. `DispatchEngine` trait boundary insulates callers for future swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)