### PR TITLE
feat(energeia): implement session management layer

### DIFF
--- a/crates/energeia/src/lib.rs
+++ b/crates/energeia/src/lib.rs
@@ -9,6 +9,7 @@
 //!
 //! - [`engine::DispatchEngine`] — session execution backend (Agent SDK HTTP/SSE)
 //! - [`http`] — subprocess-based `DispatchEngine` implementation and mock engine
+//! - [`session`] — per-prompt session management: spawn, monitor, resume, budget enforce
 //! - [`qa::QaGate`] — quality assurance evaluation (mechanical + LLM)
 //! - [`budget`] — atomic cost/turn/duration tracking for concurrent sessions
 //! - [`resume`] — multi-stage escalation policy for stuck sessions
@@ -33,6 +34,8 @@ pub mod prompt;
 pub mod qa;
 /// Multi-stage resume escalation policy.
 pub mod resume;
+/// Per-prompt session management: spawn, monitor, resume, budget enforce.
+pub mod session;
 /// State persistence layer (fjall key-value store).
 pub mod store;
 /// Core dispatch types: specs, outcomes, QA results.

--- a/crates/energeia/src/session/events.rs
+++ b/crates/energeia/src/session/events.rs
@@ -1,0 +1,374 @@
+// WHY: Processes the SessionEvent stream from a SessionHandle, accumulating
+// cost and turn metrics while detecting timeouts and PR URLs.
+// Separated from the manager so event logic is testable without the full
+// resume loop.
+
+use std::time::{Duration, Instant};
+
+use crate::engine::{SessionEvent, SessionHandle};
+
+// ---------------------------------------------------------------------------
+// EventAccumulator
+// ---------------------------------------------------------------------------
+
+/// Accumulated metrics from processing a session's event stream.
+#[derive(Debug, Clone)]
+pub(crate) struct EventAccumulator {
+    /// Total cost in USD observed during this stream.
+    pub cost_usd: f64,
+    /// Number of turns completed.
+    pub num_turns: u32,
+    /// Collected text fragments from assistant output.
+    pub text_fragments: Vec<String>,
+}
+
+impl EventAccumulator {
+    pub(crate) fn new() -> Self {
+        Self {
+            cost_usd: 0.0,
+            num_turns: 0,
+            text_fragments: Vec::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StreamOutcome — how the event stream terminated
+// ---------------------------------------------------------------------------
+
+/// How the session's event stream terminated.
+#[derive(Debug)]
+pub(crate) enum StreamOutcome {
+    /// Stream ended normally (all events consumed).
+    Complete(EventAccumulator),
+    /// No events received within the configured timeout.
+    Timeout {
+        accumulator: EventAccumulator,
+        elapsed: Duration,
+    },
+    /// An error event was received from the session.
+    Error {
+        accumulator: EventAccumulator,
+        message: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// process_events
+// ---------------------------------------------------------------------------
+
+/// Drain the event stream from a session handle, accumulating metrics.
+///
+/// Stops early on timeout or error events. Returns a [`StreamOutcome`]
+/// describing how the stream terminated.
+///
+/// `idle_timeout` controls how long we wait for the next event before treating
+/// the session as stalled. Pass `None` to disable timeout detection.
+pub(crate) async fn process_events(
+    handle: &mut Box<dyn SessionHandle>,
+    idle_timeout: Option<Duration>,
+) -> StreamOutcome {
+    let mut acc = EventAccumulator::new();
+    let mut last_event_time = Instant::now();
+
+    loop {
+        // WHY: Check idle timeout before awaiting the next event. If we've
+        // already exceeded the timeout, don't wait for another event.
+        if let Some(timeout) = idle_timeout {
+            let elapsed = last_event_time.elapsed();
+            if elapsed >= timeout {
+                return StreamOutcome::Timeout {
+                    accumulator: acc,
+                    elapsed,
+                };
+            }
+        }
+
+        let event = if let Some(timeout) = idle_timeout {
+            let remaining = timeout.saturating_sub(last_event_time.elapsed());
+            match tokio::time::timeout(remaining, handle.next_event()).await {
+                Ok(event) => event,
+                Err(_) => {
+                    return StreamOutcome::Timeout {
+                        accumulator: acc,
+                        elapsed: last_event_time.elapsed(),
+                    };
+                }
+            }
+        } else {
+            handle.next_event().await
+        };
+
+        let Some(event) = event else {
+            // Stream exhausted — session complete.
+            return StreamOutcome::Complete(acc);
+        };
+
+        last_event_time = Instant::now();
+
+        match event {
+            SessionEvent::TextDelta { text } => {
+                acc.text_fragments.push(text);
+            }
+            SessionEvent::ToolUse { .. } | SessionEvent::ToolResult { .. } => {
+                // NOTE: Tool events are observed but don't carry cost data in
+                // the current `SessionEvent` model. Cost comes from `SessionResult`.
+            }
+            SessionEvent::TurnComplete { turn } => {
+                acc.num_turns = turn;
+            }
+            SessionEvent::Error { message } => {
+                return StreamOutcome::Error {
+                    accumulator: acc,
+                    message,
+                };
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PR URL extraction
+// ---------------------------------------------------------------------------
+
+/// Extract a GitHub pull request URL from text.
+///
+/// Matches `https://github.com/{owner}/{repo}/pull/{number}` patterns.
+/// Returns the first match found.
+pub(crate) fn extract_pr_url(text: &str) -> Option<&str> {
+    // WHY: Simple substring search avoids a regex dependency. PR URLs have a
+    // predictable structure and we only need the first match.
+    const PREFIX: &str = "https://github.com/";
+
+    let mut search_from = 0;
+
+    while let Some(start) = text.get(search_from..)?.find(PREFIX) {
+        let abs_start = search_from + start;
+        let rest = text.get(abs_start..)?;
+
+        // NOTE: Find the end of the URL (whitespace, quote, paren, or end of string).
+        let end = rest
+            .find(|c: char| c.is_whitespace() || matches!(c, '"' | '\'' | ')' | '>' | ']'))
+            .unwrap_or(rest.len());
+
+        let candidate = rest.get(..end)?;
+
+        // NOTE: Validate it contains /pull/ followed by digits.
+        if let Some(pull_pos) = candidate.find("/pull/") {
+            let after_pull = candidate.get(pull_pos + "/pull/".len()..)?;
+            if !after_pull.is_empty() && after_pull.chars().all(|c| c.is_ascii_digit()) {
+                return Some(candidate);
+            }
+        }
+
+        // WHY: Advance past "github.com/" to avoid re-matching the same prefix.
+        search_from = abs_start + "github.com/".len();
+    }
+
+    None
+}
+
+/// The utilization threshold above which sessions should be aborted.
+///
+/// WHY: At >98% utilization the API will start rejecting requests imminently.
+/// Aborting early avoids wasting turns on requests that will fail.
+///
+/// NOTE: Will be consumed by the session manager once `SessionEvent` gains a
+/// rate-limit variant (pending Agent SDK integration).
+// NOTE: Will be consumed by the session manager once `SessionEvent` gains a
+// rate-limit variant (pending Agent SDK integration). Used in tests only for now.
+#[allow(
+    dead_code,
+    reason = "constant defined for use once SessionEvent gains rate-limit events"
+)]
+pub(crate) const RATE_LIMIT_ABORT_THRESHOLD: f64 = 0.98;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::engine::DispatchEngine;
+    use crate::engine::{AgentOptions, SessionResult, SessionSpec};
+    use crate::http::mock::{MockEngine, MockOutcome};
+
+    // ---- PR URL extraction ----
+
+    #[test]
+    fn extract_pr_url_from_text() {
+        let text = "Created PR: https://github.com/acme/repo/pull/42 for review";
+        assert_eq!(
+            extract_pr_url(text),
+            Some("https://github.com/acme/repo/pull/42")
+        );
+    }
+
+    #[test]
+    fn extract_pr_url_at_end_of_string() {
+        let text = "PR: https://github.com/acme/repo/pull/123";
+        assert_eq!(
+            extract_pr_url(text),
+            Some("https://github.com/acme/repo/pull/123")
+        );
+    }
+
+    #[test]
+    fn extract_pr_url_with_org_slash() {
+        let text = "https://github.com/my-org/my-repo/pull/999";
+        assert_eq!(
+            extract_pr_url(text),
+            Some("https://github.com/my-org/my-repo/pull/999")
+        );
+    }
+
+    #[test]
+    fn extract_pr_url_ignores_non_pull_github_urls() {
+        let text = "See https://github.com/acme/repo/issues/42";
+        assert!(extract_pr_url(text).is_none());
+    }
+
+    #[test]
+    fn extract_pr_url_ignores_pull_without_number() {
+        let text = "https://github.com/acme/repo/pull/";
+        assert!(extract_pr_url(text).is_none());
+    }
+
+    #[test]
+    fn extract_pr_url_returns_none_for_no_url() {
+        assert!(extract_pr_url("no urls here").is_none());
+    }
+
+    #[test]
+    fn extract_pr_url_in_markdown_link() {
+        let text = "[PR](https://github.com/acme/repo/pull/7)";
+        assert_eq!(
+            extract_pr_url(text),
+            Some("https://github.com/acme/repo/pull/7")
+        );
+    }
+
+    #[test]
+    fn extract_pr_url_in_quotes() {
+        let text = r#"url: "https://github.com/acme/repo/pull/55""#;
+        assert_eq!(
+            extract_pr_url(text),
+            Some("https://github.com/acme/repo/pull/55")
+        );
+    }
+
+    // ---- Rate limit threshold ----
+
+    #[test]
+    fn rate_limit_threshold_value() {
+        assert!((RATE_LIMIT_ABORT_THRESHOLD - 0.98).abs() < f64::EPSILON);
+    }
+
+    // ---- Event processing ----
+
+    fn make_result(session_id: &str, success: bool) -> SessionResult {
+        SessionResult {
+            session_id: session_id.to_owned(),
+            cost_usd: 0.10,
+            num_turns: 5,
+            duration_ms: 2000,
+            success,
+            result_text: Some("done".to_owned()),
+        }
+    }
+
+    fn make_spec() -> SessionSpec {
+        SessionSpec {
+            prompt: "test".to_owned(),
+            system_prompt: None,
+            cwd: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn process_events_collects_text_and_turns() {
+        let engine = MockEngine::new(vec![MockOutcome::Success {
+            events: vec![
+                SessionEvent::TextDelta {
+                    text: "hello ".to_owned(),
+                },
+                SessionEvent::TurnComplete { turn: 1 },
+                SessionEvent::TextDelta {
+                    text: "world".to_owned(),
+                },
+                SessionEvent::TurnComplete { turn: 2 },
+            ],
+            result: make_result("sess-1", true),
+        }]);
+
+        let mut handle = engine
+            .spawn_session(&make_spec(), &AgentOptions::new())
+            .await
+            .unwrap();
+
+        let outcome = process_events(&mut handle, None).await;
+        match outcome {
+            StreamOutcome::Complete(acc) => {
+                assert_eq!(acc.num_turns, 2);
+                assert_eq!(acc.text_fragments.len(), 2);
+                assert_eq!(
+                    acc.text_fragments.first().map(String::as_str),
+                    Some("hello ")
+                );
+                assert_eq!(acc.text_fragments.get(1).map(String::as_str), Some("world"));
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn process_events_returns_error_on_error_event() {
+        let engine = MockEngine::new(vec![MockOutcome::Success {
+            events: vec![
+                SessionEvent::TurnComplete { turn: 1 },
+                SessionEvent::Error {
+                    message: "something broke".to_owned(),
+                },
+            ],
+            result: make_result("sess-err", false),
+        }]);
+
+        let mut handle = engine
+            .spawn_session(&make_spec(), &AgentOptions::new())
+            .await
+            .unwrap();
+
+        let outcome = process_events(&mut handle, None).await;
+        match outcome {
+            StreamOutcome::Error {
+                message,
+                accumulator,
+            } => {
+                assert_eq!(message, "something broke");
+                assert_eq!(accumulator.num_turns, 1);
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn process_events_completes_on_empty_stream() {
+        let engine = MockEngine::new(vec![MockOutcome::Success {
+            events: vec![],
+            result: make_result("sess-timeout", true),
+        }]);
+
+        let mut handle = engine
+            .spawn_session(&make_spec(), &AgentOptions::new())
+            .await
+            .unwrap();
+
+        // NOTE: With an empty event stream, the mock returns None immediately,
+        // so we get Complete rather than Timeout. This is correct behavior —
+        // timeout only fires when events stop arriving mid-stream.
+        let outcome = process_events(&mut handle, Some(Duration::from_millis(10))).await;
+        assert!(matches!(outcome, StreamOutcome::Complete(_)));
+    }
+}

--- a/crates/energeia/src/session/manager.rs
+++ b/crates/energeia/src/session/manager.rs
@@ -1,0 +1,731 @@
+// WHY: Per-prompt executor that spawns a session, monitors events, enforces
+// budget limits, and handles multi-stage resume escalation. Produces a
+// SessionOutcome that records cost, turns, duration, and terminal status.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::budget::BudgetStatus;
+use crate::engine::{DispatchEngine, SessionSpec};
+use crate::error::{self, Result};
+use crate::prompt::PromptSpec;
+use crate::resume::ResumePolicy;
+use crate::types::{Budget, SessionOutcome, SessionStatus};
+
+use super::events::{self, StreamOutcome, extract_pr_url};
+use super::options::EngineConfig;
+
+// ---------------------------------------------------------------------------
+// SessionManager
+// ---------------------------------------------------------------------------
+
+/// Per-prompt session executor with budget enforcement and resume escalation.
+///
+/// Owns a [`DispatchEngine`], shared [`Budget`], and [`ResumePolicy`] to
+/// manage a single prompt through initial execution and graduated resume
+/// stages when the session fails or exhausts its turn budget.
+pub struct SessionManager {
+    engine: Arc<dyn DispatchEngine>,
+    budget: Arc<Budget>,
+    resume_policy: ResumePolicy,
+}
+
+impl SessionManager {
+    /// Create a new session manager.
+    #[must_use]
+    pub fn new(
+        engine: Arc<dyn DispatchEngine>,
+        budget: Arc<Budget>,
+        resume_policy: ResumePolicy,
+    ) -> Self {
+        Self {
+            engine,
+            budget,
+            resume_policy,
+        }
+    }
+
+    /// Execute a prompt through initial session and resume stages.
+    ///
+    /// 1. Spawns a session via the engine
+    /// 2. Monitors events from the session handle
+    /// 3. Tracks cost/turns against the shared budget
+    /// 4. On budget warning: logs, continues
+    /// 5. On budget exceeded: aborts session, returns `BudgetExceeded`
+    /// 6. On session failure: checks resume policy for next stage
+    /// 7. Resumes with escalating urgency message
+    /// 8. On resume exhaustion: returns `Stuck`
+    /// 9. On success: returns `Success` with PR URL if found
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::SpawnFailed`](crate::error::Error::SpawnFailed) if the
+    /// initial session cannot be created.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "session lifecycle is inherently sequential with many branches"
+    )]
+    pub async fn execute(
+        &self,
+        prompt: &PromptSpec,
+        options: &EngineConfig,
+    ) -> Result<SessionOutcome> {
+        let start = Instant::now();
+        let mut total_cost = 0.0_f64;
+        let mut total_turns = 0_u32;
+        let mut resume_count = 0_u32;
+        let mut pr_url: Option<String> = None;
+
+        // --- Initial session ---
+
+        let spec = SessionSpec {
+            prompt: prompt.body.clone(),
+            system_prompt: options.options.system_prompt.clone(),
+            cwd: options.options.cwd.clone(),
+        };
+
+        let initial_opts = options.to_agent_options();
+
+        let mut handle = self
+            .engine
+            .spawn_session(&spec, &initial_opts)
+            .await
+            .map_err(|e| {
+                error::SpawnFailedSnafu {
+                    prompt_number: prompt.number,
+                    detail: e.to_string(),
+                }
+                .build()
+            })?;
+
+        let mut session_id = Some(handle.session_id().to_owned());
+
+        let stream_result = events::process_events(&mut handle, options.idle_timeout).await;
+
+        // NOTE: Wait for the session to produce its final result.
+        let session_result = handle.wait().await;
+
+        let (run_cost, run_turns, run_success, result_text) =
+            extract_run_metrics(session_result, &stream_result);
+
+        total_cost += run_cost;
+        total_turns += run_turns;
+        self.budget.record(run_cost, run_turns);
+
+        // NOTE: Extract PR URL from all text fragments and result text.
+        let all_text = collect_text(&stream_result, result_text.as_deref());
+        if let Some(url) = extract_pr_url(&all_text) {
+            pr_url = Some(url.to_owned());
+        }
+
+        // --- Check stream outcome for early exit ---
+
+        if let StreamOutcome::Timeout { elapsed, .. } = &stream_result {
+            tracing::warn!(
+                prompt_number = prompt.number,
+                elapsed_secs = elapsed.as_secs(),
+                "session stalled (no events within timeout)"
+            );
+            return Ok(build_outcome(
+                prompt.number,
+                SessionStatus::Stuck,
+                session_id,
+                total_cost,
+                total_turns,
+                start,
+                resume_count,
+                None,
+                Some(format!("timeout: no events for {}s", elapsed.as_secs())),
+            ));
+        }
+
+        if let StreamOutcome::Error { message, .. } = &stream_result
+            && !run_success
+        {
+            // NOTE: Error during initial run with failed result — try resume.
+            tracing::warn!(
+                prompt_number = prompt.number,
+                error = %message,
+                "initial session error, checking resume policy"
+            );
+        }
+
+        // --- Check if initial run succeeded ---
+
+        if run_success {
+            return Ok(build_outcome(
+                prompt.number,
+                SessionStatus::Success,
+                session_id,
+                total_cost,
+                total_turns,
+                start,
+                resume_count,
+                pr_url,
+                None,
+            ));
+        }
+
+        // --- Budget check before entering resume loop ---
+
+        if let BudgetStatus::Exceeded(reason) = self.budget.check() {
+            tracing::warn!(
+                prompt_number = prompt.number,
+                reason = %reason,
+                "budget exceeded after initial run"
+            );
+            return Ok(build_outcome(
+                prompt.number,
+                SessionStatus::BudgetExceeded,
+                session_id,
+                total_cost,
+                total_turns,
+                start,
+                resume_count,
+                None,
+                Some(reason),
+            ));
+        }
+
+        if let BudgetStatus::Warning(msg) = self.budget.check() {
+            tracing::info!(
+                prompt_number = prompt.number,
+                warning = %msg,
+                "budget warning after initial run, continuing"
+            );
+        }
+
+        // --- Resume loop ---
+
+        loop {
+            let Some(stage) = self.resume_policy.next_stage(total_turns) else {
+                // NOTE: All resume stages exhausted — mark as Stuck.
+                tracing::warn!(
+                    prompt_number = prompt.number,
+                    total_turns,
+                    resume_count,
+                    "all resume stages exhausted, marking as Stuck"
+                );
+                return Ok(build_outcome(
+                    prompt.number,
+                    SessionStatus::Stuck,
+                    session_id,
+                    total_cost,
+                    total_turns,
+                    start,
+                    resume_count,
+                    None,
+                    Some("resume policy exhausted".to_owned()),
+                ));
+            };
+
+            resume_count += 1;
+
+            tracing::info!(
+                prompt_number = prompt.number,
+                resume_count,
+                stage_max_turns = stage.max_turns,
+                total_turns,
+                "resuming session with escalation"
+            );
+
+            // NOTE: Resume the existing session with the stage's escalation message.
+            let sid = session_id.as_deref().unwrap_or("unknown");
+            let resume_opts = options.options_with_turns(stage.max_turns);
+
+            let mut handle = match self
+                .engine
+                .resume_session(sid, &stage.message, &resume_opts)
+                .await
+            {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::warn!(
+                        prompt_number = prompt.number,
+                        error = %e,
+                        "resume failed"
+                    );
+                    return Ok(build_outcome(
+                        prompt.number,
+                        SessionStatus::Failed,
+                        session_id,
+                        total_cost,
+                        total_turns,
+                        start,
+                        resume_count,
+                        None,
+                        Some(format!("resume failed: {e}")),
+                    ));
+                }
+            };
+
+            session_id = Some(handle.session_id().to_owned());
+
+            let stream_result = events::process_events(&mut handle, options.idle_timeout).await;
+
+            let session_result = handle.wait().await;
+
+            let (run_cost, run_turns, run_success, result_text) =
+                extract_run_metrics(session_result, &stream_result);
+
+            total_cost += run_cost;
+            total_turns += run_turns;
+            self.budget.record(run_cost, run_turns);
+
+            // NOTE: Check for PR URL in resume output.
+            let all_text = collect_text(&stream_result, result_text.as_deref());
+            if let Some(url) = extract_pr_url(&all_text) {
+                pr_url = Some(url.to_owned());
+            }
+
+            // --- Timeout in resume ---
+
+            if let StreamOutcome::Timeout { elapsed, .. } = &stream_result {
+                tracing::warn!(
+                    prompt_number = prompt.number,
+                    elapsed_secs = elapsed.as_secs(),
+                    "session stalled during resume"
+                );
+                return Ok(build_outcome(
+                    prompt.number,
+                    SessionStatus::Stuck,
+                    session_id,
+                    total_cost,
+                    total_turns,
+                    start,
+                    resume_count,
+                    None,
+                    Some(format!(
+                        "timeout during resume: no events for {}s",
+                        elapsed.as_secs()
+                    )),
+                ));
+            }
+
+            // --- Success check ---
+
+            if run_success {
+                return Ok(build_outcome(
+                    prompt.number,
+                    SessionStatus::Success,
+                    session_id,
+                    total_cost,
+                    total_turns,
+                    start,
+                    resume_count,
+                    pr_url,
+                    None,
+                ));
+            }
+
+            // --- Budget check before next resume ---
+
+            match self.budget.check() {
+                BudgetStatus::Exceeded(reason) => {
+                    tracing::warn!(
+                        prompt_number = prompt.number,
+                        reason = %reason,
+                        "budget exceeded during resume loop"
+                    );
+                    return Ok(build_outcome(
+                        prompt.number,
+                        SessionStatus::BudgetExceeded,
+                        session_id,
+                        total_cost,
+                        total_turns,
+                        start,
+                        resume_count,
+                        None,
+                        Some(reason),
+                    ));
+                }
+                BudgetStatus::Warning(msg) => {
+                    tracing::info!(
+                        prompt_number = prompt.number,
+                        warning = %msg,
+                        resume_count,
+                        "budget warning, continuing resume"
+                    );
+                }
+                BudgetStatus::Ok => {}
+            }
+
+            // NOTE: Loop continues to the next resume stage.
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract run metrics from a session result, falling back to the stream
+/// accumulator if the result is unavailable.
+fn extract_run_metrics(
+    session_result: Result<crate::engine::SessionResult>,
+    stream_result: &StreamOutcome,
+) -> (f64, u32, bool, Option<String>) {
+    if let Ok(result) = session_result {
+        (
+            result.cost_usd,
+            result.num_turns,
+            result.success,
+            result.result_text,
+        )
+    } else {
+        let acc = accumulator_from(stream_result);
+        (acc.cost_usd, acc.num_turns, false, None)
+    }
+}
+
+/// Extract the accumulator from any `StreamOutcome` variant.
+fn accumulator_from(outcome: &StreamOutcome) -> &super::events::EventAccumulator {
+    match outcome {
+        StreamOutcome::Complete(acc)
+        | StreamOutcome::Timeout {
+            accumulator: acc, ..
+        }
+        | StreamOutcome::Error {
+            accumulator: acc, ..
+        } => acc,
+    }
+}
+
+/// Collect all text from a stream outcome and optional result text.
+fn collect_text(outcome: &StreamOutcome, result_text: Option<&str>) -> String {
+    let fragments = &accumulator_from(outcome).text_fragments;
+    let mut text = fragments.join("");
+    if let Some(rt) = result_text {
+        text.push(' ');
+        text.push_str(rt);
+    }
+    text
+}
+
+/// Build a [`SessionOutcome`] from the accumulated session state.
+fn build_outcome(
+    prompt_number: u32,
+    status: SessionStatus,
+    session_id: Option<String>,
+    cost_usd: f64,
+    num_turns: u32,
+    start: Instant,
+    resume_count: u32,
+    pr_url: Option<String>,
+    error: Option<String>,
+) -> SessionOutcome {
+    SessionOutcome {
+        prompt_number,
+        status,
+        session_id,
+        cost_usd,
+        num_turns,
+        duration_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+        resume_count,
+        pr_url,
+        error,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::engine::{AgentOptions, SessionEvent, SessionResult};
+    use crate::http::mock::{MockEngine, MockOutcome};
+    use crate::resume::ResumeStage;
+
+    fn test_prompt(number: u32) -> PromptSpec {
+        PromptSpec {
+            number,
+            description: format!("test prompt {number}"),
+            depends_on: vec![],
+            acceptance_criteria: vec![],
+            blast_radius: vec![],
+            body: format!("implement task {number}"),
+        }
+    }
+
+    fn success_outcome(session_id: &str, cost: f64, turns: u32) -> MockOutcome {
+        MockOutcome::Success {
+            events: vec![
+                SessionEvent::TextDelta {
+                    text: "working on it".to_owned(),
+                },
+                SessionEvent::TurnComplete { turn: turns },
+            ],
+            result: SessionResult {
+                session_id: session_id.to_owned(),
+                cost_usd: cost,
+                num_turns: turns,
+                duration_ms: 1000,
+                success: true,
+                result_text: Some("task complete".to_owned()),
+            },
+        }
+    }
+
+    fn failure_outcome(session_id: &str, cost: f64, turns: u32) -> MockOutcome {
+        MockOutcome::Success {
+            events: vec![SessionEvent::TurnComplete { turn: turns }],
+            result: SessionResult {
+                session_id: session_id.to_owned(),
+                cost_usd: cost,
+                num_turns: turns,
+                duration_ms: 1000,
+                success: false,
+                result_text: Some("stuck".to_owned()),
+            },
+        }
+    }
+
+    fn success_with_pr(session_id: &str, cost: f64, turns: u32) -> MockOutcome {
+        MockOutcome::Success {
+            events: vec![
+                SessionEvent::TextDelta {
+                    text: "Created https://github.com/acme/repo/pull/42".to_owned(),
+                },
+                SessionEvent::TurnComplete { turn: turns },
+            ],
+            result: SessionResult {
+                session_id: session_id.to_owned(),
+                cost_usd: cost,
+                num_turns: turns,
+                duration_ms: 1000,
+                success: true,
+                result_text: Some("PR: https://github.com/acme/repo/pull/42".to_owned()),
+            },
+        }
+    }
+
+    fn two_stage_policy() -> ResumePolicy {
+        ResumePolicy {
+            stages: vec![
+                ResumeStage {
+                    max_turns: 10,
+                    message: "Continue the task.".to_owned(),
+                },
+                ResumeStage {
+                    max_turns: 5,
+                    message: "Final attempt. Commit and push.".to_owned(),
+                },
+            ],
+        }
+    }
+
+    fn default_config() -> EngineConfig {
+        EngineConfig::new(AgentOptions::new())
+    }
+
+    // ---- Success on first run ----
+
+    #[tokio::test]
+    async fn execute_success_first_run() {
+        let engine = Arc::new(MockEngine::new(vec![success_outcome("sess-1", 0.50, 10)]));
+        let budget = Arc::new(Budget::new(Some(10.0), Some(100), None));
+
+        let mgr = SessionManager::new(engine, budget.clone(), ResumePolicy::default());
+
+        let outcome = mgr
+            .execute(&test_prompt(1), &default_config())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, SessionStatus::Success);
+        assert_eq!(outcome.prompt_number, 1);
+        assert_eq!(outcome.session_id.as_deref(), Some("sess-1"));
+        assert!((outcome.cost_usd - 0.50).abs() < 0.01);
+        assert_eq!(outcome.num_turns, 10);
+        assert_eq!(outcome.resume_count, 0);
+        assert!(outcome.error.is_none());
+
+        // Budget should be recorded.
+        assert!((budget.current_cost_usd() - 0.50).abs() < 0.01);
+        assert_eq!(budget.current_turns(), 10);
+    }
+
+    // ---- PR URL extraction ----
+
+    #[tokio::test]
+    async fn execute_extracts_pr_url() {
+        let engine = Arc::new(MockEngine::new(vec![success_with_pr("sess-pr", 0.30, 5)]));
+        let budget = Arc::new(Budget::new(None, None, None));
+
+        let mgr = SessionManager::new(engine, budget, ResumePolicy::default());
+
+        let outcome = mgr
+            .execute(&test_prompt(1), &default_config())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, SessionStatus::Success);
+        assert_eq!(
+            outcome.pr_url.as_deref(),
+            Some("https://github.com/acme/repo/pull/42")
+        );
+    }
+
+    // ---- Resume on failure then success ----
+
+    #[tokio::test]
+    async fn execute_resumes_on_failure_then_succeeds() {
+        let engine = Arc::new(MockEngine::new(vec![
+            // Initial run: fails.
+            failure_outcome("sess-1", 0.20, 5),
+            // Resume stage 1: succeeds.
+            success_outcome("sess-1-r1", 0.30, 8),
+        ]));
+        let budget = Arc::new(Budget::new(Some(10.0), Some(100), None));
+
+        let mgr = SessionManager::new(engine, budget.clone(), two_stage_policy());
+
+        let outcome = mgr
+            .execute(&test_prompt(1), &default_config())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, SessionStatus::Success);
+        assert_eq!(outcome.resume_count, 1);
+        assert!((outcome.cost_usd - 0.50).abs() < 0.01);
+        assert_eq!(outcome.num_turns, 13); // 5 + 8
+    }
+
+    // ---- Resume exhaustion -> Stuck ----
+
+    #[tokio::test]
+    async fn execute_stuck_when_resume_exhausted() {
+        let engine = Arc::new(MockEngine::new(vec![
+            // Initial run: fails (5 turns).
+            failure_outcome("sess-1", 0.10, 5),
+            // Resume stage 1: fails (10 turns -> cumulative 15 > stage threshold).
+            failure_outcome("sess-1-r1", 0.10, 10),
+            // NOTE: Two-stage policy has thresholds at 10 and 15 cumulative turns.
+            // After 15 turns, next_stage(15) returns None -> Stuck.
+        ]));
+        let budget = Arc::new(Budget::new(Some(50.0), Some(500), None));
+
+        let mgr = SessionManager::new(engine, budget, two_stage_policy());
+
+        let outcome = mgr
+            .execute(&test_prompt(1), &default_config())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, SessionStatus::Stuck);
+        assert!(outcome.error.as_deref().unwrap().contains("exhausted"));
+    }
+
+    // ---- Budget exceeded ----
+
+    #[tokio::test]
+    async fn execute_budget_exceeded() {
+        // Budget of $0.50, session costs $0.60.
+        let engine = Arc::new(MockEngine::new(vec![failure_outcome("sess-1", 0.60, 20)]));
+        let budget = Arc::new(Budget::new(Some(0.50), None, None));
+
+        let mgr = SessionManager::new(engine, budget, two_stage_policy());
+
+        let outcome = mgr
+            .execute(&test_prompt(1), &default_config())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, SessionStatus::BudgetExceeded);
+    }
+
+    // ---- Budget warning then continue ----
+
+    #[tokio::test]
+    async fn execute_budget_warning_continues() {
+        // Budget of $1.00. First run costs $0.85 (warning at 80%), resume succeeds.
+        let engine = Arc::new(MockEngine::new(vec![
+            failure_outcome("sess-1", 0.85, 5),
+            success_outcome("sess-1-r1", 0.10, 3),
+        ]));
+        let budget = Arc::new(Budget::new(Some(1.00), Some(100), None));
+
+        let mgr = SessionManager::new(engine, budget, two_stage_policy());
+
+        let outcome = mgr
+            .execute(&test_prompt(1), &default_config())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, SessionStatus::Success);
+        assert_eq!(outcome.resume_count, 1);
+    }
+
+    // ---- Spawn failure ----
+
+    #[tokio::test]
+    async fn execute_spawn_failure() {
+        let engine = Arc::new(MockEngine::new(vec![MockOutcome::SpawnFailure {
+            detail: "auth expired".to_owned(),
+        }]));
+        let budget = Arc::new(Budget::new(None, None, None));
+
+        let mgr = SessionManager::new(engine, budget, ResumePolicy::default());
+
+        let result = mgr.execute(&test_prompt(1), &default_config()).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("auth expired"));
+    }
+
+    // ---- Error event during initial session ----
+
+    #[tokio::test]
+    async fn execute_error_event_triggers_resume() {
+        let engine = Arc::new(MockEngine::new(vec![
+            MockOutcome::Success {
+                events: vec![SessionEvent::Error {
+                    message: "tool failed".to_owned(),
+                }],
+                result: SessionResult {
+                    session_id: "sess-err".to_owned(),
+                    cost_usd: 0.05,
+                    num_turns: 2,
+                    duration_ms: 500,
+                    success: false,
+                    result_text: None,
+                },
+            },
+            success_outcome("sess-err-r1", 0.10, 5),
+        ]));
+        let budget = Arc::new(Budget::new(Some(10.0), Some(100), None));
+
+        let mgr = SessionManager::new(engine, budget, two_stage_policy());
+
+        let outcome = mgr
+            .execute(&test_prompt(1), &default_config())
+            .await
+            .unwrap();
+        assert_eq!(outcome.status, SessionStatus::Success);
+        assert_eq!(outcome.resume_count, 1);
+    }
+
+    // ---- Budget exceeded during resume loop ----
+
+    #[tokio::test]
+    async fn execute_budget_exceeded_during_resume() {
+        // Budget of $0.50. First run $0.20, resume costs $0.40 -> total $0.60 > $0.50.
+        let engine = Arc::new(MockEngine::new(vec![
+            failure_outcome("sess-1", 0.20, 3),
+            failure_outcome("sess-1-r1", 0.40, 5),
+        ]));
+        let budget = Arc::new(Budget::new(Some(0.50), None, None));
+
+        let mgr = SessionManager::new(engine, budget, two_stage_policy());
+
+        let outcome = mgr
+            .execute(&test_prompt(1), &default_config())
+            .await
+            .unwrap();
+        assert_eq!(outcome.status, SessionStatus::BudgetExceeded);
+        assert_eq!(outcome.resume_count, 1);
+    }
+}

--- a/crates/energeia/src/session/mod.rs
+++ b/crates/energeia/src/session/mod.rs
@@ -1,0 +1,19 @@
+//! Session management: spawn, monitor, resume, and budget-enforce dispatch sessions.
+//!
+//! The [`SessionManager`] is the per-prompt executor that drives a single
+//! prompt through initial execution and graduated resume stages, producing a
+//! [`SessionOutcome`](crate::types::SessionOutcome) with cost, turn, and
+//! status data.
+//!
+//! # Module structure
+//!
+//! - [`manager`] — `SessionManager::execute()` and resume loop
+//! - [`events`] — event stream processing, PR URL extraction, rate limit detection
+//! - [`options`] — `EngineConfig` builder for session-level configuration
+
+pub(crate) mod events;
+pub mod manager;
+pub mod options;
+
+pub use manager::SessionManager;
+pub use options::EngineConfig;

--- a/crates/energeia/src/session/options.rs
+++ b/crates/energeia/src/session/options.rs
@@ -1,0 +1,183 @@
+// WHY: Wraps AgentOptions into session-level configuration with additional
+// fields needed by the session manager (idle timeout, additional directories).
+// Separates session config concerns from the raw engine options.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::engine::AgentOptions;
+
+// ---------------------------------------------------------------------------
+// EngineConfig
+// ---------------------------------------------------------------------------
+
+/// Session-level configuration that wraps [`AgentOptions`] with additional
+/// parameters the session manager needs beyond what the engine consumes.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct EngineConfig {
+    /// Base options passed to the [`DispatchEngine`](crate::engine::DispatchEngine).
+    pub options: AgentOptions,
+    /// Additional directories the agent can access.
+    pub additional_dirs: Vec<PathBuf>,
+    /// How long to wait for session events before declaring a timeout.
+    /// `None` disables timeout detection.
+    pub idle_timeout: Option<Duration>,
+}
+
+impl EngineConfig {
+    /// Start building an `EngineConfig` from base options.
+    #[must_use]
+    pub fn new(options: AgentOptions) -> Self {
+        Self {
+            options,
+            additional_dirs: Vec::new(),
+            idle_timeout: None,
+        }
+    }
+
+    /// Set the LLM model identifier.
+    #[must_use]
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.options.model = Some(model.into());
+        self
+    }
+
+    /// Set the system prompt.
+    #[must_use]
+    pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.options.system_prompt = Some(prompt.into());
+        self
+    }
+
+    /// Set the working directory.
+    #[must_use]
+    pub fn cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        let path: PathBuf = cwd.into();
+        self.options.cwd = Some(path.to_string_lossy().into_owned());
+        self
+    }
+
+    /// Set the maximum turn count for a single session stage.
+    #[must_use]
+    pub fn max_turns(mut self, turns: u32) -> Self {
+        self.options.max_turns = Some(turns);
+        self
+    }
+
+    /// Set the permission mode (e.g., "plan", "auto", "bypass").
+    #[must_use]
+    pub fn permission_mode(mut self, mode: impl Into<String>) -> Self {
+        self.options.permission_mode = Some(mode.into());
+        self
+    }
+
+    /// Add an additional directory the agent should have access to.
+    #[must_use]
+    pub fn add_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.additional_dirs.push(dir.into());
+        self
+    }
+
+    /// Set the idle timeout for event stream monitoring.
+    #[must_use]
+    pub fn idle_timeout(mut self, timeout: Duration) -> Self {
+        self.idle_timeout = Some(timeout);
+        self
+    }
+
+    /// Extract the inner [`AgentOptions`] for passing to the engine.
+    #[must_use]
+    pub fn to_agent_options(&self) -> AgentOptions {
+        self.options.clone()
+    }
+
+    /// Create a copy of the inner options with a different `max_turns` value.
+    #[must_use]
+    pub(crate) fn options_with_turns(&self, turns: u32) -> AgentOptions {
+        let mut opts = self.options.clone();
+        opts.max_turns = Some(turns);
+        opts
+    }
+}
+
+impl Default for EngineConfig {
+    fn default() -> Self {
+        Self::new(AgentOptions::default())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_config_builder() {
+        let config = EngineConfig::default()
+            .model("claude-sonnet-4-20250514")
+            .cwd("/tmp/work")
+            .max_turns(50)
+            .permission_mode("plan")
+            .add_dir("/tmp/shared")
+            .idle_timeout(Duration::from_secs(300));
+
+        assert_eq!(
+            config.options.model.as_deref(),
+            Some("claude-sonnet-4-20250514")
+        );
+        assert_eq!(config.options.cwd.as_deref(), Some("/tmp/work"));
+        assert_eq!(config.options.max_turns, Some(50));
+        assert_eq!(config.options.permission_mode.as_deref(), Some("plan"));
+        assert_eq!(config.additional_dirs.len(), 1);
+        assert_eq!(
+            config.additional_dirs.first(),
+            Some(&PathBuf::from("/tmp/shared"))
+        );
+        assert_eq!(config.idle_timeout, Some(Duration::from_secs(300)));
+    }
+
+    #[test]
+    fn engine_config_default() {
+        let config = EngineConfig::default();
+        assert!(config.options.model.is_none());
+        assert!(config.additional_dirs.is_empty());
+        assert!(config.idle_timeout.is_none());
+    }
+
+    #[test]
+    fn to_agent_options_clones_inner() {
+        let config = EngineConfig::default().model("test-model").max_turns(10);
+        let opts = config.to_agent_options();
+        assert_eq!(opts.model.as_deref(), Some("test-model"));
+        assert_eq!(opts.max_turns, Some(10));
+    }
+
+    #[test]
+    fn options_with_turns_overrides_max_turns() {
+        let config = EngineConfig::default().max_turns(100);
+        let opts = config.options_with_turns(25);
+        assert_eq!(opts.max_turns, Some(25));
+    }
+
+    #[test]
+    fn multiple_add_dir() {
+        let config = EngineConfig::default()
+            .add_dir("/a")
+            .add_dir("/b")
+            .add_dir("/c");
+        assert_eq!(config.additional_dirs.len(), 3);
+    }
+
+    #[test]
+    fn system_prompt_builder() {
+        let config = EngineConfig::default().system_prompt("you are a coding agent");
+        assert_eq!(
+            config.options.system_prompt.as_deref(),
+            Some("you are a coding agent")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SessionManager` that uses `DispatchEngine`, `Budget`, and `ResumePolicy` to manage per-prompt dispatch sessions through initial execution and graduated resume escalation stages
- Event processing module drains `SessionHandle` event streams with idle timeout detection and PR URL extraction from assistant output
- `EngineConfig` builder composes `AgentOptions` with session-level config (idle timeout, additional directories)
- 8 unit tests cover success, resume, budget exceeded, spawn failure, error recovery, and resume exhaustion using `MockEngine`

Refs: kanon#191

## Test plan

- [x] `cargo fmt -p aletheia-energeia -- --check` passes
- [x] `cargo clippy -p aletheia-energeia --all-targets` — zero warnings from session module
- [x] `cargo test -p aletheia-energeia` — 175 tests pass (0 failures)
- [ ] `cargo test --workspace` — pre-existing compilation failures in `koina` and `graphe` (unrelated to this PR)

## Observations

- `cargo test --workspace` fails due to pre-existing `unwrap_or_default()` on non-`Default` types in `koina::cleanup` (test code) and `graphe::metrics` (lib code). These are Rust 2024 edition regressions from the `MutexGuard` and `MetricVec` types losing their `Default` impls.
- The `SessionEvent` enum does not include a rate-limit event variant. The rate limit abort threshold constant (`RATE_LIMIT_ABORT_THRESHOLD = 0.98`) is defined but will become active once `SessionEvent` gains a rate-limit variant from Agent SDK integration. The reference implementation in kanon handles rate limits via a dedicated `Message::RateLimit` wire protocol message.
- `SessionManager` takes `EngineConfig` as a parameter to `execute()` rather than storing it, allowing different configs per prompt without reconstructing the manager. This diverges from the reference implementation where config is stored on the struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)