### PR TITLE
feat(energeia): implement metron reporting capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "jiff",
  "serde",
@@ -172,12 +172,13 @@ dependencies = [
 
 [[package]]
 name = "aletheia-energeia"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
  "fjall",
  "jiff",
+ "prometheus",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -192,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -222,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -243,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -267,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -293,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "compact_str",
  "jiff",
@@ -314,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -358,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -377,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -392,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -421,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -446,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -473,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -507,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "argon2",
@@ -534,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -552,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6061,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6080,7 +6081,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.43"
+version = "0.13.44"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/energeia/Cargo.toml
+++ b/crates/energeia/Cargo.toml
@@ -18,6 +18,7 @@ storage-fjall = ["dep:fjall"]
 [dependencies]
 aletheia-koina = { path = "../koina" }
 aletheia-eidos = { path = "../eidos" }
+prometheus = { workspace = true }
 # WHY: hermeneus has pre-existing compilation errors on main (kanon lint pass
 # introduced unwrap_or_default on non-Default types). Add dependency once
 # hermeneus compiles again; implementations will need it for LLM evaluation.

--- a/crates/energeia/src/lib.rs
+++ b/crates/energeia/src/lib.rs
@@ -27,6 +27,8 @@ pub mod engine;
 pub mod error;
 /// HTTP/SSE dispatch engine: subprocess-based `DispatchEngine` and mock.
 pub mod http;
+/// Metrics and reporting: health signals, cost reports, status dashboard, Prometheus.
+pub mod metrics;
 /// Prompt loading from YAML frontmatter files.
 pub mod prompt;
 /// Quality assurance gate trait.

--- a/crates/energeia/src/metrics/cost.rs
+++ b/crates/energeia/src/metrics/cost.rs
@@ -1,0 +1,555 @@
+//! Cost and velocity reporting for energeia dispatch operations.
+//!
+//! Aggregates `DispatchRecord` and `SessionRecord` data into period reports
+//! with per-project and per-day breakdowns.
+
+#[cfg(feature = "storage-fjall")]
+use std::collections::HashMap;
+
+#[cfg(feature = "storage-fjall")]
+use crate::error::Result;
+#[cfg(feature = "storage-fjall")]
+use crate::store::records::{DispatchRecord, DispatchStatus, SessionRecord};
+#[cfg(feature = "storage-fjall")]
+use crate::store::{EnergeiaStore, SCAN_LIMIT_DISPATCHES, SCAN_LIMIT_SESSIONS};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Cost and velocity report for a time window.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct CostReport {
+    /// Start of the reporting window (inclusive).
+    pub period_start: jiff::Timestamp,
+    /// End of the reporting window (inclusive; the time the report was computed).
+    pub period_end: jiff::Timestamp,
+    /// Total cost across all dispatches in the window, in USD.
+    pub total_cost_usd: f64,
+    /// Total number of dispatches in the window.
+    pub total_dispatches: u64,
+    /// Total number of sessions across all dispatches in the window.
+    pub total_sessions: u64,
+    /// Average cost per dispatch (0.0 when `total_dispatches` is zero).
+    pub avg_cost_per_dispatch: f64,
+    /// Average cost per session (0.0 when `total_sessions` is zero).
+    pub avg_cost_per_session: f64,
+    /// Per-project cost breakdown, sorted by cost descending.
+    pub by_project: Vec<ProjectCost>,
+    /// Per-day velocity, sorted by date ascending.
+    pub daily_velocity: Vec<DailyVelocity>,
+}
+
+/// Cost summary for a single project.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ProjectCost {
+    /// Project identifier.
+    pub project: String,
+    /// Total cost in USD.
+    pub cost_usd: f64,
+    /// Number of dispatches.
+    pub dispatches: u64,
+    /// Total sessions across dispatches.
+    pub sessions: u64,
+    /// Fraction of completed dispatches (0.0–1.0).
+    pub success_rate: f64,
+}
+
+/// Dispatch velocity and cost for a single calendar day.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct DailyVelocity {
+    /// Calendar date (UTC).
+    pub date: jiff::civil::Date,
+    /// Number of dispatches created on this date.
+    pub dispatches: u64,
+    /// Total sessions across those dispatches.
+    pub sessions: u64,
+    /// Total cost in USD.
+    pub cost_usd: f64,
+    /// Fraction of dispatches that completed successfully (0.0–1.0).
+    pub success_rate: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "storage-fjall")]
+/// Compute a cost and velocity report for the given number of past days.
+///
+/// Pass `window_days = 0` to include all available history.
+/// Pass `window_days = 7` for the last week, `30` for the last month.
+///
+/// # Errors
+///
+/// Returns `Error::Store` if any underlying store read fails.
+pub fn compute_cost_report(store: &EnergeiaStore, window_days: u32) -> Result<CostReport> {
+    let now = jiff::Timestamp::now();
+
+    let cutoff_ms: Option<i64> = if window_days > 0 {
+        let span = jiff::SignedDuration::from_hours(i64::from(window_days) * 24);
+        #[expect(
+            clippy::expect_used,
+            reason = "bounded subtraction from now is infallible for realistic day counts"
+        )]
+        let cutoff = now
+            .checked_sub(span)
+            .expect("timestamp subtraction within realistic day range");
+        Some(cutoff.as_millisecond())
+    } else {
+        None
+    };
+
+    let period_start = cutoff_ms.map_or_else(
+        || jiff::Timestamp::UNIX_EPOCH,
+        |ms| {
+            #[expect(
+                clippy::expect_used,
+                reason = "ms from cutoff calculation is a valid timestamp"
+            )]
+            jiff::Timestamp::from_millisecond(ms).expect("valid cutoff timestamp")
+        },
+    );
+
+    let all_dispatches = store.list_dispatches(SCAN_LIMIT_DISPATCHES)?;
+    let all_sessions = store.list_all_sessions(SCAN_LIMIT_SESSIONS)?;
+
+    let dispatches: Vec<&DispatchRecord> = all_dispatches
+        .iter()
+        .filter(|d| cutoff_ms.map_or(true, |cutoff| d.created_at.as_millisecond() >= cutoff))
+        .collect();
+
+    let sessions: Vec<&SessionRecord> = all_sessions
+        .iter()
+        .filter(|s| cutoff_ms.map_or(true, |cutoff| s.created_at.as_millisecond() >= cutoff))
+        .collect();
+
+    // Count sessions per dispatch for aggregation.
+    let sessions_per_dispatch: HashMap<&str, Vec<&SessionRecord>> = {
+        let mut map: HashMap<&str, Vec<&SessionRecord>> = HashMap::new();
+        for s in &sessions {
+            map.entry(s.dispatch_id.as_str()).or_default().push(s);
+        }
+        map
+    };
+
+    let total_cost_usd: f64 = dispatches.iter().map(|d| d.total_cost_usd).sum();
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "dispatch/session counts are bounded by scan limits, fit u64"
+    )]
+    let total_dispatches = dispatches.len() as u64;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "dispatch/session counts are bounded by scan limits, fit u64"
+    )]
+    let total_sessions = sessions.len() as u64;
+
+    let avg_cost_per_dispatch = if total_dispatches > 0 {
+        #[expect(
+            clippy::cast_precision_loss,
+            clippy::as_conversions,
+            reason = "total_dispatches is bounded; precision loss unreachable"
+        )]
+        {
+            total_cost_usd / total_dispatches as f64
+        }
+    } else {
+        0.0
+    };
+
+    let avg_cost_per_session = if total_sessions > 0 {
+        #[expect(
+            clippy::cast_precision_loss,
+            clippy::as_conversions,
+            reason = "total_sessions is bounded; precision loss unreachable"
+        )]
+        {
+            total_cost_usd / total_sessions as f64
+        }
+    } else {
+        0.0
+    };
+
+    let by_project = build_project_costs(&dispatches, &sessions_per_dispatch);
+    let daily_velocity = build_daily_velocity(&dispatches, &sessions_per_dispatch);
+
+    Ok(CostReport {
+        period_start,
+        period_end: now,
+        total_cost_usd,
+        total_dispatches,
+        total_sessions,
+        avg_cost_per_dispatch,
+        avg_cost_per_session,
+        by_project,
+        daily_velocity,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "storage-fjall")]
+fn build_project_costs(
+    dispatches: &[&DispatchRecord],
+    sessions_per_dispatch: &HashMap<&str, Vec<&SessionRecord>>,
+) -> Vec<ProjectCost> {
+    #[derive(Default)]
+    struct Acc {
+        cost_usd: f64,
+        dispatches: u64,
+        sessions: u64,
+        completed: u64,
+    }
+
+    let mut by_project: HashMap<&str, Acc> = HashMap::new();
+
+    for d in dispatches {
+        let acc = by_project.entry(d.project.as_str()).or_default();
+        acc.cost_usd += d.total_cost_usd;
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::as_conversions,
+            reason = "dispatch count bounded, fits u64"
+        )]
+        {
+            acc.dispatches += 1;
+        }
+
+        let session_count = sessions_per_dispatch
+            .get(d.id.as_str())
+            .map_or(0, |v| v.len());
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::as_conversions,
+            reason = "session count bounded, fits u64"
+        )]
+        {
+            acc.sessions += session_count as u64;
+        }
+
+        if d.status == DispatchStatus::Completed {
+            acc.completed += 1;
+        }
+    }
+
+    let mut result: Vec<ProjectCost> = by_project
+        .into_iter()
+        .map(|(project, acc)| {
+            let success_rate = if acc.dispatches > 0 {
+                #[expect(
+                    clippy::cast_precision_loss,
+                    clippy::as_conversions,
+                    reason = "counts bounded; precision loss unreachable"
+                )]
+                {
+                    acc.completed as f64 / acc.dispatches as f64
+                }
+            } else {
+                0.0
+            };
+            ProjectCost {
+                project: project.to_owned(),
+                cost_usd: acc.cost_usd,
+                dispatches: acc.dispatches,
+                sessions: acc.sessions,
+                success_rate,
+            }
+        })
+        .collect();
+
+    // Sort by cost descending for easy reading.
+    result.sort_by(|a, b| {
+        b.cost_usd
+            .partial_cmp(&a.cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    result
+}
+
+#[cfg(feature = "storage-fjall")]
+fn build_daily_velocity(
+    dispatches: &[&DispatchRecord],
+    sessions_per_dispatch: &HashMap<&str, Vec<&SessionRecord>>,
+) -> Vec<DailyVelocity> {
+    #[derive(Default)]
+    struct DayAcc {
+        dispatches: u64,
+        sessions: u64,
+        cost_usd: f64,
+        completed: u64,
+    }
+
+    let mut by_day: HashMap<jiff::civil::Date, DayAcc> = HashMap::new();
+
+    for d in dispatches {
+        // Convert timestamp to UTC calendar date.
+        let date = jiff::Timestamp::from_millisecond(d.created_at.as_millisecond())
+            .unwrap_or(d.created_at)
+            .to_zoned(jiff::tz::TimeZone::UTC)
+            .date();
+
+        let acc = by_day.entry(date).or_default();
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::as_conversions,
+            reason = "dispatch count bounded, fits u64"
+        )]
+        {
+            acc.dispatches += 1;
+        }
+
+        let session_count = sessions_per_dispatch
+            .get(d.id.as_str())
+            .map_or(0, |v| v.len());
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::as_conversions,
+            reason = "session count bounded, fits u64"
+        )]
+        {
+            acc.sessions += session_count as u64;
+        }
+
+        acc.cost_usd += d.total_cost_usd;
+
+        if d.status == DispatchStatus::Completed {
+            acc.completed += 1;
+        }
+    }
+
+    let mut result: Vec<DailyVelocity> = by_day
+        .into_iter()
+        .map(|(date, acc)| {
+            let success_rate = if acc.dispatches > 0 {
+                #[expect(
+                    clippy::cast_precision_loss,
+                    clippy::as_conversions,
+                    reason = "counts bounded; precision loss unreachable"
+                )]
+                {
+                    acc.completed as f64 / acc.dispatches as f64
+                }
+            } else {
+                0.0
+            };
+            DailyVelocity {
+                date,
+                dispatches: acc.dispatches,
+                sessions: acc.sessions,
+                cost_usd: acc.cost_usd,
+                success_rate,
+            }
+        })
+        .collect();
+
+    // Sort by date ascending.
+    result.sort_by_key(|d| d.date);
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg(feature = "storage-fjall")]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::float_cmp, reason = "test assertions on exact float values")]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    use crate::store::EnergeiaStore;
+    use crate::store::records::SessionUpdate;
+    use crate::types::{DispatchSpec, SessionStatus};
+
+    fn setup() -> (TempDir, EnergeiaStore) {
+        let dir = TempDir::new().unwrap();
+        let db = fjall::Database::builder(dir.path()).open().unwrap();
+        (dir, EnergeiaStore::new(&db).unwrap())
+    }
+
+    fn spec() -> DispatchSpec {
+        DispatchSpec {
+            prompt_numbers: vec![1, 2],
+            project: "acme".to_owned(),
+            dag_ref: None,
+            max_parallel: Some(2),
+        }
+    }
+
+    #[test]
+    fn empty_store_returns_zero_report() {
+        let (_dir, store) = setup();
+        let report = compute_cost_report(&store, 30).unwrap();
+        assert_eq!(report.total_dispatches, 0);
+        assert_eq!(report.total_sessions, 0);
+        assert_eq!(report.total_cost_usd, 0.0);
+        assert!(report.by_project.is_empty());
+        assert!(report.daily_velocity.is_empty());
+    }
+
+    #[test]
+    fn aggregates_dispatch_cost() {
+        let (_dir, store) = setup();
+        let d1 = store.create_dispatch("acme", &spec()).unwrap();
+        let d2 = store.create_dispatch("acme", &spec()).unwrap();
+        let s1 = store.create_session(&d1, 1).unwrap();
+        let s2 = store.create_session(&d2, 1).unwrap();
+        store
+            .update_session(
+                &s1,
+                SessionUpdate {
+                    cost_usd: Some(1.0),
+                    status: Some(SessionStatus::Success),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .update_session(
+                &s2,
+                SessionUpdate {
+                    cost_usd: Some(2.0),
+                    status: Some(SessionStatus::Success),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .finish_dispatch(&d1, crate::store::records::DispatchStatus::Completed)
+            .unwrap();
+        store
+            .finish_dispatch(&d2, crate::store::records::DispatchStatus::Completed)
+            .unwrap();
+
+        let report = compute_cost_report(&store, 0).unwrap();
+        assert_eq!(report.total_dispatches, 2);
+        assert!((report.total_cost_usd - 3.0).abs() < 0.01);
+        assert_eq!(report.by_project.len(), 1);
+        assert_eq!(report.by_project[0].project, "acme");
+        assert!((report.by_project[0].cost_usd - 3.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn by_project_sorted_cost_descending() {
+        let (_dir, store) = setup();
+        let d1 = store
+            .create_dispatch(
+                "cheap",
+                &DispatchSpec {
+                    project: "cheap".to_owned(),
+                    prompt_numbers: vec![1],
+                    dag_ref: None,
+                    max_parallel: None,
+                },
+            )
+            .unwrap();
+        let d2 = store
+            .create_dispatch(
+                "expensive",
+                &DispatchSpec {
+                    project: "expensive".to_owned(),
+                    prompt_numbers: vec![1],
+                    dag_ref: None,
+                    max_parallel: None,
+                },
+            )
+            .unwrap();
+        let s1 = store.create_session(&d1, 1).unwrap();
+        let s2 = store.create_session(&d2, 1).unwrap();
+        store
+            .update_session(
+                &s1,
+                SessionUpdate {
+                    cost_usd: Some(0.5),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .update_session(
+                &s2,
+                SessionUpdate {
+                    cost_usd: Some(5.0),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .finish_dispatch(&d1, crate::store::records::DispatchStatus::Completed)
+            .unwrap();
+        store
+            .finish_dispatch(&d2, crate::store::records::DispatchStatus::Completed)
+            .unwrap();
+
+        let report = compute_cost_report(&store, 0).unwrap();
+        assert_eq!(report.by_project[0].project, "expensive");
+        assert_eq!(report.by_project[1].project, "cheap");
+    }
+
+    #[test]
+    fn avg_cost_per_dispatch_and_session() {
+        let (_dir, store) = setup();
+        let d = store.create_dispatch("acme", &spec()).unwrap();
+        let s1 = store.create_session(&d, 1).unwrap();
+        let s2 = store.create_session(&d, 2).unwrap();
+        store
+            .update_session(
+                &s1,
+                SessionUpdate {
+                    cost_usd: Some(1.0),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .update_session(
+                &s2,
+                SessionUpdate {
+                    cost_usd: Some(3.0),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .finish_dispatch(&d, crate::store::records::DispatchStatus::Completed)
+            .unwrap();
+
+        let report = compute_cost_report(&store, 0).unwrap();
+        // 1 dispatch with cost 4.0, 2 sessions
+        assert!((report.avg_cost_per_dispatch - 4.0).abs() < 0.01);
+        assert!((report.avg_cost_per_session - 2.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn daily_velocity_groups_by_date() {
+        let (_dir, store) = setup();
+        let d = store.create_dispatch("acme", &spec()).unwrap();
+        store
+            .finish_dispatch(&d, crate::store::records::DispatchStatus::Completed)
+            .unwrap();
+
+        let report = compute_cost_report(&store, 0).unwrap();
+        // Must have at least today's entry
+        assert!(!report.daily_velocity.is_empty());
+        let today = jiff::Timestamp::now()
+            .to_zoned(jiff::tz::TimeZone::UTC)
+            .date();
+        assert!(report.daily_velocity.iter().any(|dv| dv.date == today));
+    }
+}

--- a/crates/energeia/src/metrics/health.rs
+++ b/crates/energeia/src/metrics/health.rs
@@ -1,0 +1,864 @@
+//! Pipeline health metrics for energeia dispatch orchestration.
+//!
+//! Computes 7 health signals from historical dispatch and session data stored
+//! in `EnergeiaStore`. Each metric has a value, status (OK/WARN/CRIT), and
+//! threshold info.
+//!
+//! ## Metric proxies
+//!
+//! Several metrics require data that the store does not yet capture directly:
+//!
+//! | Metric | Proxy used | Missing data |
+//! |--------|-----------|-------------|
+//! | Corrective rate | Dispatches with Failed/Stuck sessions | QA PARTIAL/FAIL verdicts |
+//! | QA false positive | PR sessions with CI failures | QA verdict records |
+//! | Fix agent success | CI-validated sessions that succeeded | Fix agent marker |
+//! | Observation-to-issue | `Unavailable` | Issue tracker records |
+//!
+//! These will improve as the store schema is extended with QA verdict and issue
+//! tracking records.
+
+#[cfg(feature = "storage-fjall")]
+use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "storage-fjall")]
+use crate::error::Result;
+#[cfg(feature = "storage-fjall")]
+use crate::store::records::{
+    CiValidationRecord, CiValidationStatus, DispatchRecord, DispatchStatus, SessionRecord,
+};
+#[cfg(feature = "storage-fjall")]
+use crate::store::{
+    EnergeiaStore, SCAN_LIMIT_CI_VALIDATIONS, SCAN_LIMIT_DISPATCHES, SCAN_LIMIT_SESSIONS,
+};
+#[cfg(feature = "storage-fjall")]
+use crate::types::SessionStatus;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Status classification for a health metric.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HealthStatus {
+    /// Metric is within healthy bounds.
+    Ok,
+    /// Metric is degraded but not critical.
+    Warn,
+    /// Metric indicates a critical problem requiring attention.
+    Crit,
+    /// Insufficient data to compute the metric (sample size zero).
+    Unavailable,
+}
+
+impl std::fmt::Display for HealthStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ok => write!(f, "ok"),
+            Self::Warn => write!(f, "warn"),
+            Self::Crit => write!(f, "crit"),
+            Self::Unavailable => write!(f, "unavailable"),
+        }
+    }
+}
+
+/// A single pipeline health metric with value, status, and threshold info.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct HealthMetric {
+    /// Short `snake_case` identifier.
+    pub name: &'static str,
+    /// Human-readable description of what this metric measures.
+    pub description: &'static str,
+    /// Computed value: rate (0.0–1.0), hours, or count depending on metric.
+    pub value: f64,
+    /// Status classification of the current value.
+    pub status: HealthStatus,
+    /// Threshold at or beyond which the status is `Ok`.
+    pub ok_threshold: f64,
+    /// Threshold at or beyond which the status is `Warn` (between Ok and Crit).
+    pub warn_threshold: f64,
+    /// Number of records used to compute this metric (0 means unavailable).
+    pub sample_size: u64,
+    /// `true` if a higher value is healthier (e.g. success rate).
+    pub higher_is_better: bool,
+}
+
+/// Aggregate pipeline health report for a time window.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct HealthReport {
+    /// When this report was computed.
+    pub computed_at: jiff::Timestamp,
+    /// Days of history included (0 = all available data).
+    pub window_days: u32,
+    /// All 7 pipeline health metrics.
+    pub metrics: Vec<HealthMetric>,
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "storage-fjall")]
+/// Compute all 7 pipeline health metrics from stored dispatch and session data.
+///
+/// `window_days` controls how far back to look; pass `0` to include all
+/// available data. All queries are read-only.
+///
+/// # Errors
+///
+/// Returns `Error::Store` if any underlying store read fails.
+pub fn compute_health_report(store: &EnergeiaStore, window_days: u32) -> Result<HealthReport> {
+    let now = jiff::Timestamp::now();
+
+    let cutoff_ms: Option<i64> = if window_days > 0 {
+        let span = jiff::SignedDuration::from_hours(i64::from(window_days) * 24);
+        #[expect(
+            clippy::expect_used,
+            reason = "bounded subtraction from now is infallible for realistic day counts"
+        )]
+        let cutoff = now
+            .checked_sub(span)
+            .expect("timestamp subtraction within realistic day range");
+        Some(cutoff.as_millisecond())
+    } else {
+        None
+    };
+
+    // Load raw data — time filtering happens in-process after the scans.
+    let all_dispatches = store.list_dispatches(SCAN_LIMIT_DISPATCHES)?;
+    let all_sessions = store.list_all_sessions(SCAN_LIMIT_SESSIONS)?;
+    let all_ci_validations = store.list_all_ci_validations(SCAN_LIMIT_CI_VALIDATIONS)?;
+
+    let dispatches: Vec<&DispatchRecord> = all_dispatches
+        .iter()
+        .filter(|d| cutoff_ms.map_or(true, |cutoff| d.created_at.as_millisecond() >= cutoff))
+        .collect();
+
+    let sessions: Vec<&SessionRecord> = all_sessions
+        .iter()
+        .filter(|s| cutoff_ms.map_or(true, |cutoff| s.created_at.as_millisecond() >= cutoff))
+        .collect();
+
+    // Build session-id → CI validations map for O(1) per-session lookup.
+    let ci_by_session: HashMap<String, Vec<&CiValidationRecord>> = {
+        let mut map: HashMap<String, Vec<&CiValidationRecord>> = HashMap::new();
+        for v in &all_ci_validations {
+            map.entry(v.session_id.as_str().to_owned())
+                .or_default()
+                .push(v);
+        }
+        map
+    };
+
+    let metrics = vec![
+        corrective_rate(&dispatches, &sessions),
+        stuck_rate(&sessions),
+        qa_false_positive_rate(&sessions, &ci_by_session),
+        fix_agent_success_rate(&sessions, &ci_by_session),
+        cycle_time(&dispatches),
+        observation_to_issue_rate(),
+        batch_parallelism(&dispatches, &sessions),
+    ];
+
+    Ok(HealthReport {
+        computed_at: now,
+        window_days,
+        metrics,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Metric helpers
+// ---------------------------------------------------------------------------
+
+/// Classify a lower-is-better rate value into OK/WARN/CRIT.
+#[cfg(feature = "storage-fjall")]
+fn classify_lower_is_better(value: f64, ok_threshold: f64, warn_threshold: f64) -> HealthStatus {
+    if value <= ok_threshold {
+        HealthStatus::Ok
+    } else if value <= warn_threshold {
+        HealthStatus::Warn
+    } else {
+        HealthStatus::Crit
+    }
+}
+
+/// Classify a higher-is-better rate or count value into OK/WARN/CRIT.
+#[cfg(feature = "storage-fjall")]
+fn classify_higher_is_better(value: f64, ok_threshold: f64, warn_threshold: f64) -> HealthStatus {
+    if value >= ok_threshold {
+        HealthStatus::Ok
+    } else if value >= warn_threshold {
+        HealthStatus::Warn
+    } else {
+        HealthStatus::Crit
+    }
+}
+
+/// Build an `Unavailable` metric with zeroed sample size.
+#[cfg(feature = "storage-fjall")]
+fn unavailable(
+    name: &'static str,
+    description: &'static str,
+    ok_threshold: f64,
+    warn_threshold: f64,
+    higher_is_better: bool,
+) -> HealthMetric {
+    HealthMetric {
+        name,
+        description,
+        value: 0.0,
+        status: HealthStatus::Unavailable,
+        ok_threshold,
+        warn_threshold,
+        sample_size: 0,
+        higher_is_better,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The 7 metrics
+// ---------------------------------------------------------------------------
+
+/// 1. Corrective prompt rate.
+///
+/// **Threshold:** <10% OK, ≤20% WARN, >20% CRIT.
+///
+/// **Proxy:** dispatches that contain at least one Failed or Stuck session, as
+/// a fraction of all dispatches. True corrective rate requires QA PARTIAL/FAIL
+/// verdict records which are not yet stored.
+#[cfg(feature = "storage-fjall")]
+fn corrective_rate(dispatches: &[&DispatchRecord], sessions: &[&SessionRecord]) -> HealthMetric {
+    const NAME: &str = "corrective_rate";
+    const DESC: &str = "% of dispatches needing corrective prompts \
+        (proxy: dispatches with Failed/Stuck sessions; true rate needs QA verdicts)";
+
+    let total = dispatches.len();
+    if total == 0 {
+        return unavailable(NAME, DESC, 0.10, 0.20, false);
+    }
+
+    let corrective_dispatch_ids: HashSet<&str> = sessions
+        .iter()
+        .filter(|s| matches!(s.status, SessionStatus::Failed | SessionStatus::Stuck))
+        .map(|s| s.dispatch_id.as_str())
+        .collect();
+
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "dispatch counts are bounded; precision loss unreachable at practical scale"
+    )]
+    let rate = corrective_dispatch_ids.len() as f64 / total as f64;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "dispatch count is bounded by SCAN_LIMIT_DISPATCHES, fits u64"
+    )]
+    let sample_size = total as u64;
+
+    HealthMetric {
+        name: NAME,
+        description: DESC,
+        value: rate,
+        status: classify_lower_is_better(rate, 0.10, 0.20),
+        ok_threshold: 0.10,
+        warn_threshold: 0.20,
+        sample_size,
+        higher_is_better: false,
+    }
+}
+
+/// 2. Stuck rate.
+///
+/// **Threshold:** <5% OK, ≤15% WARN, >15% CRIT.
+#[cfg(feature = "storage-fjall")]
+fn stuck_rate(sessions: &[&SessionRecord]) -> HealthMetric {
+    const NAME: &str = "stuck_rate";
+    const DESC: &str = "% of sessions ending in Stuck status (health escalation exhausted)";
+
+    let total = sessions.len();
+    if total == 0 {
+        return unavailable(NAME, DESC, 0.05, 0.15, false);
+    }
+
+    let stuck = sessions
+        .iter()
+        .filter(|s| s.status == SessionStatus::Stuck)
+        .count();
+
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "session counts are bounded; precision loss unreachable at practical scale"
+    )]
+    let rate = stuck as f64 / total as f64;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "session count fits u64 within SCAN_LIMIT_SESSIONS"
+    )]
+    let sample_size = total as u64;
+
+    HealthMetric {
+        name: NAME,
+        description: DESC,
+        value: rate,
+        status: classify_lower_is_better(rate, 0.05, 0.15),
+        ok_threshold: 0.05,
+        warn_threshold: 0.15,
+        sample_size,
+        higher_is_better: false,
+    }
+}
+
+/// 3. QA false positive rate.
+///
+/// **Threshold:** <5% OK, ≤10% WARN, >10% CRIT.
+///
+/// **Proxy:** sessions with a PR URL (implying QA passed) where at least one
+/// CI validation record has Fail status. True rate needs stored QA verdicts.
+#[cfg(feature = "storage-fjall")]
+fn qa_false_positive_rate(
+    sessions: &[&SessionRecord],
+    ci_by_session: &HashMap<String, Vec<&CiValidationRecord>>,
+) -> HealthMetric {
+    const NAME: &str = "qa_false_positive_rate";
+    const DESC: &str = "% of sessions with a PR that later fail CI \
+        (proxy for QA passing work that CI rejects; true rate needs QA verdict records)";
+
+    let sessions_with_pr: Vec<&&SessionRecord> =
+        sessions.iter().filter(|s| s.pr_url.is_some()).collect();
+    let total = sessions_with_pr.len();
+
+    if total == 0 {
+        return unavailable(NAME, DESC, 0.05, 0.10, false);
+    }
+
+    let ci_fail_count = sessions_with_pr
+        .iter()
+        .filter(|s| {
+            ci_by_session
+                .get(s.id.as_str())
+                .map_or(false, |validations| {
+                    validations
+                        .iter()
+                        .any(|v| v.status == CiValidationStatus::Fail)
+                })
+        })
+        .count();
+
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "session counts are bounded; precision loss unreachable at practical scale"
+    )]
+    let rate = ci_fail_count as f64 / total as f64;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "session count fits u64 within SCAN_LIMIT_SESSIONS"
+    )]
+    let sample_size = total as u64;
+
+    HealthMetric {
+        name: NAME,
+        description: DESC,
+        value: rate,
+        status: classify_lower_is_better(rate, 0.05, 0.10),
+        ok_threshold: 0.05,
+        warn_threshold: 0.10,
+        sample_size,
+        higher_is_better: false,
+    }
+}
+
+/// 4. Fix agent success rate.
+///
+/// **Threshold:** >80% OK, ≥60% WARN, <60% CRIT.
+///
+/// **Proxy:** among sessions that have CI validation records (proxy for fix
+/// agent sessions), the fraction that reached `Success` status. True rate
+/// requires a fix-agent marker in the session record.
+#[cfg(feature = "storage-fjall")]
+fn fix_agent_success_rate(
+    sessions: &[&SessionRecord],
+    ci_by_session: &HashMap<String, Vec<&CiValidationRecord>>,
+) -> HealthMetric {
+    const NAME: &str = "fix_agent_success_rate";
+    const DESC: &str = "% of CI-validated sessions reaching Success \
+        (proxy for fix agent success; true rate needs fix-agent marker in session record)";
+
+    let sessions_with_ci: Vec<&&SessionRecord> = sessions
+        .iter()
+        .filter(|s| ci_by_session.contains_key(s.id.as_str()))
+        .collect();
+
+    let total = sessions_with_ci.len();
+    if total == 0 {
+        return unavailable(NAME, DESC, 0.80, 0.60, true);
+    }
+
+    let successes = sessions_with_ci
+        .iter()
+        .filter(|s| s.status == SessionStatus::Success)
+        .count();
+
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "session counts are bounded; precision loss unreachable at practical scale"
+    )]
+    let rate = successes as f64 / total as f64;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "session count fits u64 within SCAN_LIMIT_SESSIONS"
+    )]
+    let sample_size = total as u64;
+
+    HealthMetric {
+        name: NAME,
+        description: DESC,
+        value: rate,
+        status: classify_higher_is_better(rate, 0.80, 0.60),
+        ok_threshold: 0.80,
+        warn_threshold: 0.60,
+        sample_size,
+        higher_is_better: true,
+    }
+}
+
+/// 5. Cycle time — average hours from dispatch creation to completion.
+///
+/// **Threshold:** ≤4h OK, ≤8h WARN, >8h CRIT.
+#[cfg(feature = "storage-fjall")]
+fn cycle_time(dispatches: &[&DispatchRecord]) -> HealthMetric {
+    const NAME: &str = "cycle_time_hours";
+    const DESC: &str =
+        "Average hours from dispatch creation to completion (completed dispatches only)";
+
+    let completed: Vec<&&DispatchRecord> = dispatches
+        .iter()
+        .filter(|d| d.status == DispatchStatus::Completed && d.finished_at.is_some())
+        .collect();
+
+    let total = completed.len();
+    if total == 0 {
+        return unavailable(NAME, DESC, 4.0, 8.0, false);
+    }
+
+    let total_ms: i64 = completed
+        .iter()
+        .filter_map(|d| {
+            d.finished_at
+                .map(|finished| finished.as_millisecond() - d.created_at.as_millisecond())
+        })
+        .sum();
+
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "total_ms as f64: bounded by dispatch count × max session duration; precision loss unreachable"
+    )]
+    let avg_hours = (total_ms as f64 / total as f64) / 3_600_000.0;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "dispatch count fits u64 within SCAN_LIMIT_DISPATCHES"
+    )]
+    let sample_size = total as u64;
+
+    HealthMetric {
+        name: NAME,
+        description: DESC,
+        value: avg_hours,
+        status: classify_lower_is_better(avg_hours, 4.0, 8.0),
+        ok_threshold: 4.0,
+        warn_threshold: 8.0,
+        sample_size,
+        higher_is_better: false,
+    }
+}
+
+/// 6. Observation-to-issue rate.
+///
+/// **Threshold:** >50% OK, ≥25% WARN, <25% CRIT.
+///
+/// Currently returns `Unavailable` — the energeia store tracks observations
+/// but not issue-tracker records. This metric requires cross-system data
+/// (observation records × issue tracker entries) not yet integrated.
+#[cfg(feature = "storage-fjall")]
+fn observation_to_issue_rate() -> HealthMetric {
+    unavailable(
+        "observation_to_issue_rate",
+        "% of observations matched to tracked issues \
+            (unavailable: requires issue-tracker integration not yet implemented)",
+        0.50,
+        0.25,
+        true,
+    )
+}
+
+/// 7. Batch parallelism — average sessions per dispatch.
+///
+/// **Threshold:** >3 OK, ≥1.5 WARN, <1.5 CRIT.
+///
+/// Uses total sessions per dispatch as a proxy for concurrent group size.
+#[cfg(feature = "storage-fjall")]
+fn batch_parallelism(dispatches: &[&DispatchRecord], sessions: &[&SessionRecord]) -> HealthMetric {
+    const NAME: &str = "batch_parallelism";
+    const DESC: &str = "Average sessions per dispatch (proxy for concurrent group size)";
+
+    let total_dispatches = dispatches.len();
+    if total_dispatches == 0 {
+        return unavailable(NAME, DESC, 3.0, 1.5, true);
+    }
+
+    // Count sessions per dispatch.
+    let mut counts: HashMap<&str, u64> = HashMap::new();
+    for s in sessions {
+        *counts.entry(s.dispatch_id.as_str()).or_insert(0) += 1;
+    }
+
+    // Only include dispatches that have at least one session.
+    let dispatches_with_sessions: Vec<u64> = dispatches
+        .iter()
+        .filter_map(|d| counts.get(d.id.as_str()).copied())
+        .collect();
+
+    let n = dispatches_with_sessions.len();
+    if n == 0 {
+        return unavailable(NAME, DESC, 3.0, 1.5, true);
+    }
+
+    let total_sessions: u64 = dispatches_with_sessions.iter().sum();
+
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "total_sessions and n are bounded; precision loss unreachable at practical scale"
+    )]
+    let avg = total_sessions as f64 / n as f64;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "n fits u64 within SCAN_LIMIT_DISPATCHES"
+    )]
+    let sample_size = n as u64;
+
+    HealthMetric {
+        name: NAME,
+        description: DESC,
+        value: avg,
+        status: classify_higher_is_better(avg, 3.0, 1.5),
+        ok_threshold: 3.0,
+        warn_threshold: 1.5,
+        sample_size,
+        higher_is_better: true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- health status display (always compiled) ---
+
+    #[test]
+    fn health_status_display() {
+        assert_eq!(HealthStatus::Ok.to_string(), "ok");
+        assert_eq!(HealthStatus::Warn.to_string(), "warn");
+        assert_eq!(HealthStatus::Crit.to_string(), "crit");
+        assert_eq!(HealthStatus::Unavailable.to_string(), "unavailable");
+    }
+
+    // --- storage-dependent tests ---
+
+    #[cfg(feature = "storage-fjall")]
+    #[expect(clippy::float_cmp, reason = "test assertions on exact float values")]
+    mod storage_tests {
+        use super::*;
+        use crate::store::records::{
+            DispatchId, DispatchRecord, DispatchStatus, SessionId, SessionRecord,
+        };
+        use crate::types::SessionStatus;
+
+        fn make_dispatch(id: &str) -> DispatchRecord {
+            DispatchRecord {
+                id: DispatchId::new(id),
+                project: "acme".to_owned(),
+                spec: r#"{"prompt_numbers":[1],"project":"acme"}"#.to_owned(),
+                status: DispatchStatus::Completed,
+                created_at: jiff::Timestamp::now(),
+                finished_at: Some(jiff::Timestamp::now()),
+                total_cost_usd: 1.0,
+                total_sessions: 1,
+            }
+        }
+
+        fn make_session(dispatch_id: &str, status: SessionStatus) -> SessionRecord {
+            SessionRecord {
+                id: SessionId::new(ulid::Ulid::new().to_string()),
+                dispatch_id: DispatchId::new(dispatch_id),
+                prompt_number: 1,
+                status,
+                session_id: None,
+                cost_usd: 0.5,
+                num_turns: 10,
+                duration_ms: 60_000,
+                pr_url: None,
+                error: None,
+                created_at: jiff::Timestamp::now(),
+                updated_at: jiff::Timestamp::now(),
+            }
+        }
+
+        // --- classify helpers ---
+
+        #[test]
+        fn classify_lower_ok() {
+            assert_eq!(classify_lower_is_better(0.05, 0.10, 0.20), HealthStatus::Ok);
+        }
+
+        #[test]
+        fn classify_lower_warn() {
+            assert_eq!(
+                classify_lower_is_better(0.15, 0.10, 0.20),
+                HealthStatus::Warn
+            );
+        }
+
+        #[test]
+        fn classify_lower_crit() {
+            assert_eq!(
+                classify_lower_is_better(0.25, 0.10, 0.20),
+                HealthStatus::Crit
+            );
+        }
+
+        #[test]
+        fn classify_lower_ok_at_boundary() {
+            assert_eq!(classify_lower_is_better(0.10, 0.10, 0.20), HealthStatus::Ok);
+        }
+
+        #[test]
+        fn classify_higher_ok() {
+            assert_eq!(
+                classify_higher_is_better(0.90, 0.80, 0.60),
+                HealthStatus::Ok
+            );
+        }
+
+        #[test]
+        fn classify_higher_warn() {
+            assert_eq!(
+                classify_higher_is_better(0.70, 0.80, 0.60),
+                HealthStatus::Warn
+            );
+        }
+
+        #[test]
+        fn classify_higher_crit() {
+            assert_eq!(
+                classify_higher_is_better(0.50, 0.80, 0.60),
+                HealthStatus::Crit
+            );
+        }
+
+        #[test]
+        fn classify_higher_ok_at_boundary() {
+            assert_eq!(
+                classify_higher_is_better(0.80, 0.80, 0.60),
+                HealthStatus::Ok
+            );
+        }
+
+        // --- corrective rate ---
+
+        #[test]
+        fn corrective_rate_all_clean() {
+            let d = make_dispatch("D1");
+            let s = make_session("D1", SessionStatus::Success);
+            let metric = corrective_rate(&[&d], &[&s]);
+            assert_eq!(metric.status, HealthStatus::Ok);
+            assert_eq!(metric.value, 0.0);
+            assert_eq!(metric.sample_size, 1);
+        }
+
+        #[test]
+        fn corrective_rate_half_affected() {
+            let d1 = make_dispatch("D1");
+            let d2 = make_dispatch("D2");
+            let s1 = make_session("D1", SessionStatus::Success);
+            let s2 = make_session("D2", SessionStatus::Stuck);
+            let metric = corrective_rate(&[&d1, &d2], &[&s1, &s2]);
+            // 1 out of 2 dispatches has a Stuck session → rate = 0.5 → CRIT
+            assert_eq!(metric.status, HealthStatus::Crit);
+            assert!((metric.value - 0.5).abs() < 1e-10);
+        }
+
+        #[test]
+        fn corrective_rate_no_dispatches_unavailable() {
+            let metric = corrective_rate(&[], &[]);
+            assert_eq!(metric.status, HealthStatus::Unavailable);
+            assert_eq!(metric.sample_size, 0);
+        }
+
+        // --- stuck rate ---
+
+        #[test]
+        fn stuck_rate_zero() {
+            let s = make_session("D1", SessionStatus::Success);
+            let metric = stuck_rate(&[&s]);
+            assert_eq!(metric.status, HealthStatus::Ok);
+            assert_eq!(metric.value, 0.0);
+        }
+
+        #[test]
+        fn stuck_rate_all_stuck_crit() {
+            let s1 = make_session("D1", SessionStatus::Stuck);
+            let s2 = make_session("D1", SessionStatus::Stuck);
+            let metric = stuck_rate(&[&s1, &s2]);
+            assert_eq!(metric.status, HealthStatus::Crit);
+            assert_eq!(metric.value, 1.0);
+            assert_eq!(metric.sample_size, 2);
+        }
+
+        #[test]
+        fn stuck_rate_below_warn_threshold() {
+            // 4 sessions, 0 stuck → 0% < 5% → OK
+            let sessions: Vec<SessionRecord> = (0..4)
+                .map(|i| {
+                    let mut s = make_session("D1", SessionStatus::Success);
+                    s.prompt_number = i;
+                    s
+                })
+                .collect();
+            let refs: Vec<&SessionRecord> = sessions.iter().collect();
+            let metric = stuck_rate(&refs);
+            assert_eq!(metric.status, HealthStatus::Ok);
+        }
+
+        #[test]
+        fn stuck_rate_no_sessions_unavailable() {
+            let metric = stuck_rate(&[]);
+            assert_eq!(metric.status, HealthStatus::Unavailable);
+        }
+
+        // --- cycle time ---
+
+        #[test]
+        fn cycle_time_under_4h_ok() {
+            let span = jiff::SignedDuration::from_hours(2);
+            let now = jiff::Timestamp::now();
+            #[expect(clippy::expect_used, reason = "test setup")]
+            let start = now.checked_sub(span).expect("test timestamp");
+            let d = DispatchRecord {
+                id: DispatchId::new("D1"),
+                project: "acme".to_owned(),
+                spec: "{}".to_owned(),
+                status: DispatchStatus::Completed,
+                created_at: start,
+                finished_at: Some(now),
+                total_cost_usd: 0.0,
+                total_sessions: 1,
+            };
+            let metric = cycle_time(&[&d]);
+            assert_eq!(metric.status, HealthStatus::Ok);
+            assert!(metric.value > 1.9 && metric.value < 2.1);
+        }
+
+        #[test]
+        fn cycle_time_over_8h_crit() {
+            let span = jiff::SignedDuration::from_hours(10);
+            let now = jiff::Timestamp::now();
+            #[expect(clippy::expect_used, reason = "test setup")]
+            let start = now.checked_sub(span).expect("test timestamp");
+            let d = DispatchRecord {
+                id: DispatchId::new("D1"),
+                project: "acme".to_owned(),
+                spec: "{}".to_owned(),
+                status: DispatchStatus::Completed,
+                created_at: start,
+                finished_at: Some(now),
+                total_cost_usd: 0.0,
+                total_sessions: 1,
+            };
+            let metric = cycle_time(&[&d]);
+            assert_eq!(metric.status, HealthStatus::Crit);
+            assert!(metric.value > 9.9 && metric.value < 10.1);
+        }
+
+        #[test]
+        fn cycle_time_no_completed_unavailable() {
+            let d = DispatchRecord {
+                id: DispatchId::new("D1"),
+                project: "acme".to_owned(),
+                spec: "{}".to_owned(),
+                status: DispatchStatus::Running,
+                created_at: jiff::Timestamp::now(),
+                finished_at: None,
+                total_cost_usd: 0.0,
+                total_sessions: 0,
+            };
+            let metric = cycle_time(&[&d]);
+            assert_eq!(metric.status, HealthStatus::Unavailable);
+        }
+
+        // --- batch parallelism ---
+
+        #[test]
+        fn batch_parallelism_four_sessions_ok() {
+            let d = make_dispatch("D1");
+            let sessions: Vec<SessionRecord> = (1..=4)
+                .map(|i| {
+                    let mut s = make_session("D1", SessionStatus::Success);
+                    s.prompt_number = i;
+                    s
+                })
+                .collect();
+            let refs: Vec<&SessionRecord> = sessions.iter().collect();
+            let metric = batch_parallelism(&[&d], &refs);
+            assert_eq!(metric.status, HealthStatus::Ok);
+            assert_eq!(metric.value, 4.0);
+        }
+
+        #[test]
+        fn batch_parallelism_one_session_crit() {
+            let d = make_dispatch("D1");
+            let s = make_session("D1", SessionStatus::Success);
+            let metric = batch_parallelism(&[&d], &[&s]);
+            assert_eq!(metric.status, HealthStatus::Crit);
+            assert_eq!(metric.value, 1.0);
+        }
+
+        #[test]
+        fn batch_parallelism_no_dispatches_unavailable() {
+            let metric = batch_parallelism(&[], &[]);
+            assert_eq!(metric.status, HealthStatus::Unavailable);
+        }
+
+        // --- observation to issue rate ---
+
+        #[test]
+        fn observation_to_issue_rate_always_unavailable() {
+            let metric = observation_to_issue_rate();
+            assert_eq!(metric.status, HealthStatus::Unavailable);
+            assert_eq!(metric.name, "observation_to_issue_rate");
+        }
+    }
+}

--- a/crates/energeia/src/metrics/mod.rs
+++ b/crates/energeia/src/metrics/mod.rs
@@ -1,0 +1,169 @@
+//! Metrics and reporting for energeia dispatch orchestration.
+//!
+//! # Modules
+//!
+//! - [`health`] — 7 pipeline health signals (corrective rate, stuck rate, etc.)
+//! - [`cost`] — cost and velocity reporting with per-project and per-day breakdown
+//! - [`status`] — real-time dashboard: active dispatches, queue depth, recent outcomes
+//! - [`prometheus`] — Prometheus metric registration and recording functions
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use std::sync::Arc;
+//! use aletheia_energeia::metrics::MetricsService;
+//! use aletheia_energeia::store::EnergeiaStore;
+//!
+//! let service = MetricsService::new(Arc::clone(&store));
+//!
+//! let health = service.health_report(30)?;   // last 30 days
+//! let cost   = service.cost_report(7)?;      // last 7 days
+//! let status = service.status_dashboard()?;  // current snapshot
+//!
+//! // Initialize prometheus metrics at startup:
+//! aletheia_energeia::metrics::prometheus::init();
+//! ```
+
+pub mod cost;
+pub mod health;
+pub mod prometheus;
+pub mod status;
+
+#[cfg(feature = "storage-fjall")]
+use std::sync::Arc;
+
+#[cfg(feature = "storage-fjall")]
+use crate::error::Result;
+#[cfg(feature = "storage-fjall")]
+use crate::store::EnergeiaStore;
+
+pub use cost::{CostReport, DailyVelocity, ProjectCost};
+pub use health::{HealthMetric, HealthReport, HealthStatus};
+pub use status::{ProjectSummary, RecentOutcome, StatusDashboard};
+
+// ---------------------------------------------------------------------------
+// MetricsService
+// ---------------------------------------------------------------------------
+
+/// Entry point for energeia metrics reporting.
+///
+/// Wraps an `Arc<EnergeiaStore>` and provides read-only access to health
+/// metrics, cost reports, and the status dashboard. Constructed once and
+/// shared across threads.
+///
+/// All methods are read-only and non-blocking beyond the underlying fjall
+/// prefix scans.
+#[cfg(feature = "storage-fjall")]
+pub struct MetricsService {
+    store: Arc<EnergeiaStore>,
+}
+
+#[cfg(feature = "storage-fjall")]
+impl MetricsService {
+    /// Create a new `MetricsService` backed by the given store.
+    #[must_use]
+    pub fn new(store: Arc<EnergeiaStore>) -> Self {
+        Self { store }
+    }
+
+    /// Compute the 7 pipeline health metrics.
+    ///
+    /// `window_days` controls the historical window. Pass `0` for all data,
+    /// `7` for the last week, `30` for the last month.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Store` if any store read fails.
+    pub fn health_report(&self, window_days: u32) -> Result<HealthReport> {
+        health::compute_health_report(&self.store, window_days)
+    }
+
+    /// Compute cost and velocity metrics.
+    ///
+    /// `window_days` controls the historical window. Pass `0` for all data.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Store` if any store read fails.
+    pub fn cost_report(&self, window_days: u32) -> Result<CostReport> {
+        cost::compute_cost_report(&self.store, window_days)
+    }
+
+    /// Build a real-time status dashboard snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Store` if any store read fails.
+    pub fn status_dashboard(&self) -> Result<StatusDashboard> {
+        status::compute_status_dashboard(&self.store)
+    }
+}
+
+#[cfg(feature = "storage-fjall")]
+impl std::fmt::Debug for MetricsService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetricsService").finish_non_exhaustive()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg(feature = "storage-fjall")]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup() -> (TempDir, MetricsService) {
+        let dir = TempDir::new().unwrap();
+        let db = fjall::Database::builder(dir.path()).open().unwrap();
+        let store = Arc::new(EnergeiaStore::new(&db).unwrap());
+        (dir, MetricsService::new(store))
+    }
+
+    #[test]
+    fn empty_store_health_report() {
+        let (_dir, svc) = setup();
+        let report = svc.health_report(30).unwrap();
+        assert_eq!(report.metrics.len(), 7);
+        // All metrics should be Unavailable with no data.
+        for m in &report.metrics {
+            assert_eq!(
+                m.status,
+                HealthStatus::Unavailable,
+                "{} should be Unavailable with empty store",
+                m.name
+            );
+        }
+    }
+
+    #[test]
+    fn empty_store_cost_report() {
+        let (_dir, svc) = setup();
+        let report = svc.cost_report(30).unwrap();
+        assert_eq!(report.total_dispatches, 0);
+        assert_eq!(report.total_cost_usd, 0.0);
+    }
+
+    #[test]
+    fn empty_store_status_dashboard() {
+        let (_dir, svc) = setup();
+        let dashboard = svc.status_dashboard().unwrap();
+        assert_eq!(dashboard.active_dispatches, 0);
+        assert_eq!(dashboard.queue_depth, 0);
+    }
+
+    #[test]
+    fn service_is_send_sync() {
+        static_assertions::assert_impl_all!(MetricsService: Send, Sync);
+    }
+
+    #[test]
+    fn debug_format_does_not_panic() {
+        let (_dir, svc) = setup();
+        let _ = format!("{svc:?}");
+    }
+}

--- a/crates/energeia/src/metrics/prometheus.rs
+++ b/crates/energeia/src/metrics/prometheus.rs
@@ -1,0 +1,199 @@
+//! Prometheus metric definitions for energeia dispatch orchestration.
+//!
+//! Call [`init`] once at startup to force-register all metrics with the global
+//! prometheus registry. The pylon `/metrics` endpoint will then expose them.
+//!
+//! Recording functions are called at dispatch/session/QA event boundaries.
+
+#![expect(
+    clippy::expect_used,
+    reason = "metric registration is infallible at startup"
+)]
+
+use std::sync::LazyLock;
+
+use prometheus::{
+    CounterVec, HistogramOpts, HistogramVec, IntCounterVec, Opts, register_counter_vec,
+    register_histogram_vec, register_int_counter_vec,
+};
+
+// ---------------------------------------------------------------------------
+// Metric statics
+// ---------------------------------------------------------------------------
+
+static DISPATCHES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new("energeia_dispatches_total", "Total dispatch runs completed"),
+        &["project", "status"]
+    )
+    .expect("metric registration")
+});
+
+static SESSIONS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new("energeia_sessions_total", "Total agent sessions dispatched"),
+        &["project", "status"]
+    )
+    .expect("metric registration")
+});
+
+/// Float counter: USD is not integer-valued.
+static COST_USD_TOTAL: LazyLock<CounterVec> = LazyLock::new(|| {
+    register_counter_vec!(
+        Opts::new(
+            "energeia_cost_usd_total",
+            "Cumulative LLM cost in USD by project and model"
+        ),
+        &["project", "model"]
+    )
+    .expect("metric registration")
+});
+
+static SESSION_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
+        HistogramOpts::new(
+            "energeia_session_duration_seconds",
+            "Agent session wall-clock duration in seconds"
+        )
+        // WHY: sessions range from <1 minute (infra failure) to several hours
+        // (complex implementation prompts). Buckets cover this full range.
+        .buckets(vec![
+            60.0, 300.0, 900.0, 1_800.0, 3_600.0, 7_200.0, 14_400.0, 28_800.0,
+        ]),
+        &["project"]
+    )
+    .expect("metric registration")
+});
+
+static QA_VERDICTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "energeia_qa_verdicts_total",
+            "Total QA evaluation verdicts by project and verdict"
+        ),
+        &["project", "verdict"]
+    )
+    .expect("metric registration")
+});
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+/// Force-initialize all energeia metric statics.
+///
+/// Must be called once at server startup so metrics appear in `/metrics` even
+/// before any dispatch events occur. Safe to call multiple times.
+pub fn init() {
+    LazyLock::force(&DISPATCHES_TOTAL);
+    LazyLock::force(&SESSIONS_TOTAL);
+    LazyLock::force(&COST_USD_TOTAL);
+    LazyLock::force(&SESSION_DURATION_SECONDS);
+    LazyLock::force(&QA_VERDICTS_TOTAL);
+}
+
+// ---------------------------------------------------------------------------
+// Recording functions
+// ---------------------------------------------------------------------------
+
+/// Record a completed dispatch run.
+///
+/// Call once per dispatch when it finishes (Completed or Failed).
+pub fn record_dispatch(project: &str, status: &str) {
+    DISPATCHES_TOTAL.with_label_values(&[project, status]).inc();
+}
+
+/// Record a completed agent session.
+///
+/// - `cost_usd` — session cost; silently skipped when zero.
+/// - `duration_ms` — wall-clock duration in milliseconds.
+pub fn record_session(project: &str, status: &str, cost_usd: f64, duration_ms: u64) {
+    SESSIONS_TOTAL.with_label_values(&[project, status]).inc();
+
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "duration_ms to f64: session durations are far below f64 precision threshold"
+    )]
+    let duration_secs = duration_ms as f64 / 1_000.0;
+    SESSION_DURATION_SECONDS
+        .with_label_values(&[project])
+        .observe(duration_secs);
+
+    if cost_usd > 0.0 {
+        // WHY: DispatchSpec carries no model field yet; use "unknown" until the
+        // store schema is extended to track per-session model selection.
+        COST_USD_TOTAL
+            .with_label_values(&[project, "unknown"])
+            .inc_by(cost_usd);
+    }
+}
+
+/// Record a QA evaluation verdict.
+///
+/// `verdict` should be one of `"pass"`, `"partial"`, or `"fail"`.
+pub fn record_qa_verdict(project: &str, verdict: &str) {
+    QA_VERDICTS_TOTAL
+        .with_label_values(&[project, verdict])
+        .inc();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_is_idempotent() {
+        init();
+        init(); // second call must not panic
+    }
+
+    #[test]
+    fn record_dispatch_increments_counter() {
+        init();
+        record_dispatch("acme", "completed");
+        record_dispatch("acme", "completed");
+        let count = DISPATCHES_TOTAL
+            .with_label_values(&["acme", "completed"])
+            .get();
+        assert!(count >= 2, "counter should be >= 2 after two increments");
+    }
+
+    #[test]
+    fn record_session_increments_counter_and_histogram() {
+        init();
+        record_session("acme", "success", 0.50, 30_000);
+        let count = SESSIONS_TOTAL.with_label_values(&["acme", "success"]).get();
+        assert!(count >= 1);
+    }
+
+    #[test]
+    fn record_session_zero_cost_skips_cost_counter() {
+        init();
+        // Capture cost before
+        let before = COST_USD_TOTAL
+            .with_label_values(&["nocost-project", "unknown"])
+            .get();
+        record_session("nocost-project", "failed", 0.0, 5_000);
+        let after = COST_USD_TOTAL
+            .with_label_values(&["nocost-project", "unknown"])
+            .get();
+        // Float comparison: should be unchanged
+        assert!(
+            (after - before).abs() < 1e-10,
+            "zero-cost session must not increment cost counter"
+        );
+    }
+
+    #[test]
+    fn record_qa_verdict_increments_counter() {
+        init();
+        record_qa_verdict("acme", "pass");
+        let count = QA_VERDICTS_TOTAL.with_label_values(&["acme", "pass"]).get();
+        assert!(count >= 1);
+    }
+}

--- a/crates/energeia/src/metrics/status.rs
+++ b/crates/energeia/src/metrics/status.rs
@@ -1,0 +1,368 @@
+//! Real-time status dashboard for energeia dispatch operations.
+//!
+//! Provides a point-in-time snapshot of:
+//! - Active (running) dispatches and their session counts
+//! - Queue depth (number of running dispatches)
+//! - Recent dispatch outcomes (last N dispatches, newest first)
+//! - Per-project summary of active and recent activity
+
+#[cfg(feature = "storage-fjall")]
+use std::collections::HashMap;
+
+#[cfg(feature = "storage-fjall")]
+use crate::error::Result;
+#[cfg(feature = "storage-fjall")]
+use crate::store::records::{DispatchRecord, DispatchStatus, SessionRecord};
+#[cfg(feature = "storage-fjall")]
+use crate::store::{EnergeiaStore, SCAN_LIMIT_DISPATCHES, SCAN_LIMIT_SESSIONS};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Point-in-time status dashboard.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct StatusDashboard {
+    /// When this snapshot was taken.
+    pub computed_at: jiff::Timestamp,
+    /// Number of dispatches currently in `Running` state.
+    pub active_dispatches: u64,
+    /// Alias for `active_dispatches`; number of prompts awaiting completion.
+    pub queue_depth: u64,
+    /// Recent dispatch outcomes (newest first), up to `RECENT_LIMIT`.
+    pub recent_outcomes: Vec<RecentOutcome>,
+    /// Per-project summary aggregated from active and recent dispatches.
+    pub by_project: Vec<ProjectSummary>,
+}
+
+/// Summary of a single dispatch run for the recent history list.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct RecentOutcome {
+    /// Dispatch identifier.
+    pub dispatch_id: String,
+    /// Project this dispatch belongs to.
+    pub project: String,
+    /// Current lifecycle status.
+    pub status: String,
+    /// When the dispatch was created.
+    pub started_at: jiff::Timestamp,
+    /// When the dispatch finished (`None` if still running).
+    pub finished_at: Option<jiff::Timestamp>,
+    /// Number of sessions in this dispatch.
+    pub total_sessions: u32,
+    /// Total cost in USD across all sessions.
+    pub total_cost_usd: f64,
+}
+
+/// Per-project status summary.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ProjectSummary {
+    /// Project identifier.
+    pub project: String,
+    /// Number of currently running dispatches.
+    pub active_dispatches: u64,
+    /// Total sessions across all dispatches in the recent window.
+    pub total_sessions: u64,
+    /// Total cost in USD across the recent window.
+    pub total_cost_usd: f64,
+    /// Fraction of completed dispatches in the recent window (0.0–1.0).
+    pub success_rate: f64,
+}
+
+/// How many recent dispatches to include in [`StatusDashboard::recent_outcomes`].
+#[cfg(feature = "storage-fjall")]
+const RECENT_LIMIT: usize = 50;
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "storage-fjall")]
+/// Build a real-time status dashboard snapshot.
+///
+/// Scans all dispatches and sessions. The `recent_outcomes` list contains the
+/// most recent `50` dispatches sorted newest-first.
+///
+/// # Errors
+///
+/// Returns `Error::Store` if any underlying store read fails.
+pub fn compute_status_dashboard(store: &EnergeiaStore) -> Result<StatusDashboard> {
+    let now = jiff::Timestamp::now();
+
+    let all_dispatches = store.list_dispatches(SCAN_LIMIT_DISPATCHES)?;
+    let all_sessions = store.list_all_sessions(SCAN_LIMIT_SESSIONS)?;
+
+    // Count sessions per dispatch for summary aggregation.
+    let mut sessions_by_dispatch: HashMap<&str, Vec<&SessionRecord>> = HashMap::new();
+    for s in &all_sessions {
+        sessions_by_dispatch
+            .entry(s.dispatch_id.as_str())
+            .or_default()
+            .push(s);
+    }
+
+    // -----------------------------------------------------------------------
+    // Active dispatches / queue depth
+    // -----------------------------------------------------------------------
+
+    let active_dispatch_records: Vec<&DispatchRecord> = all_dispatches
+        .iter()
+        .filter(|d| d.status == DispatchStatus::Running)
+        .collect();
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "active dispatch count bounded by SCAN_LIMIT_DISPATCHES, fits u64"
+    )]
+    let active_dispatches = active_dispatch_records.len() as u64;
+    let queue_depth = active_dispatches;
+
+    // -----------------------------------------------------------------------
+    // Recent outcomes — last RECENT_LIMIT dispatches, newest first
+    // -----------------------------------------------------------------------
+
+    // Dispatches from the scan come out oldest-first (ULID order). Reverse to
+    // get newest first, then take up to RECENT_LIMIT.
+    let recent_outcomes: Vec<RecentOutcome> = all_dispatches
+        .iter()
+        .rev()
+        .take(RECENT_LIMIT)
+        .map(|d| RecentOutcome {
+            dispatch_id: d.id.as_str().to_owned(),
+            project: d.project.clone(),
+            status: d.status.to_string(),
+            started_at: d.created_at,
+            finished_at: d.finished_at,
+            total_sessions: d.total_sessions,
+            total_cost_usd: d.total_cost_usd,
+        })
+        .collect();
+
+    // -----------------------------------------------------------------------
+    // Per-project summary
+    // -----------------------------------------------------------------------
+
+    let by_project = build_project_summaries(&all_dispatches, &sessions_by_dispatch);
+
+    Ok(StatusDashboard {
+        computed_at: now,
+        active_dispatches,
+        queue_depth,
+        recent_outcomes,
+        by_project,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "storage-fjall")]
+fn build_project_summaries(
+    dispatches: &[DispatchRecord],
+    sessions_by_dispatch: &HashMap<&str, Vec<&SessionRecord>>,
+) -> Vec<ProjectSummary> {
+    #[derive(Default)]
+    struct Acc {
+        active: u64,
+        sessions: u64,
+        cost_usd: f64,
+        total: u64,
+        completed: u64,
+    }
+
+    let mut by_project: HashMap<&str, Acc> = HashMap::new();
+
+    for d in dispatches {
+        let acc = by_project.entry(d.project.as_str()).or_default();
+        acc.total += 1;
+        acc.cost_usd += d.total_cost_usd;
+
+        if d.status == DispatchStatus::Running {
+            acc.active += 1;
+        }
+        if d.status == DispatchStatus::Completed {
+            acc.completed += 1;
+        }
+
+        let session_count = sessions_by_dispatch
+            .get(d.id.as_str())
+            .map_or(0, |v| v.len());
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::as_conversions,
+            reason = "session count bounded, fits u64"
+        )]
+        {
+            acc.sessions += session_count as u64;
+        }
+    }
+
+    let mut result: Vec<ProjectSummary> = by_project
+        .into_iter()
+        .map(|(project, acc)| {
+            let success_rate = if acc.total > 0 {
+                #[expect(
+                    clippy::cast_precision_loss,
+                    clippy::as_conversions,
+                    reason = "counts bounded; precision loss unreachable"
+                )]
+                {
+                    acc.completed as f64 / acc.total as f64
+                }
+            } else {
+                0.0
+            };
+            ProjectSummary {
+                project: project.to_owned(),
+                active_dispatches: acc.active,
+                total_sessions: acc.sessions,
+                total_cost_usd: acc.cost_usd,
+                success_rate,
+            }
+        })
+        .collect();
+
+    // Sort alphabetically by project name for stable output.
+    result.sort_by(|a, b| a.project.cmp(&b.project));
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg(feature = "storage-fjall")]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::float_cmp, reason = "test assertions on exact float values")]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    use crate::store::EnergeiaStore;
+    use crate::store::records::SessionUpdate;
+    use crate::types::{DispatchSpec, SessionStatus};
+
+    fn setup() -> (TempDir, EnergeiaStore) {
+        let dir = TempDir::new().unwrap();
+        let db = fjall::Database::builder(dir.path()).open().unwrap();
+        (dir, EnergeiaStore::new(&db).unwrap())
+    }
+
+    fn spec(project: &str) -> DispatchSpec {
+        DispatchSpec {
+            prompt_numbers: vec![1],
+            project: project.to_owned(),
+            dag_ref: None,
+            max_parallel: None,
+        }
+    }
+
+    #[test]
+    fn empty_store_zero_active() {
+        let (_dir, store) = setup();
+        let dashboard = compute_status_dashboard(&store).unwrap();
+        assert_eq!(dashboard.active_dispatches, 0);
+        assert_eq!(dashboard.queue_depth, 0);
+        assert!(dashboard.recent_outcomes.is_empty());
+        assert!(dashboard.by_project.is_empty());
+    }
+
+    #[test]
+    fn running_dispatch_counted_as_active() {
+        let (_dir, store) = setup();
+        let _d = store.create_dispatch("acme", &spec("acme")).unwrap();
+        let dashboard = compute_status_dashboard(&store).unwrap();
+        assert_eq!(dashboard.active_dispatches, 1);
+        assert_eq!(dashboard.queue_depth, 1);
+    }
+
+    #[test]
+    fn completed_dispatch_not_active() {
+        let (_dir, store) = setup();
+        let d = store.create_dispatch("acme", &spec("acme")).unwrap();
+        store
+            .finish_dispatch(&d, crate::store::records::DispatchStatus::Completed)
+            .unwrap();
+        let dashboard = compute_status_dashboard(&store).unwrap();
+        assert_eq!(dashboard.active_dispatches, 0);
+    }
+
+    #[test]
+    fn recent_outcomes_contains_both_dispatches() {
+        let (_dir, store) = setup();
+        let d1 = store.create_dispatch("acme", &spec("acme")).unwrap();
+        let d2 = store.create_dispatch("acme", &spec("acme")).unwrap();
+        let dashboard = compute_status_dashboard(&store).unwrap();
+        assert_eq!(dashboard.recent_outcomes.len(), 2);
+        // Both dispatches appear; ULID ordering within the same millisecond is
+        // non-deterministic, so we check presence rather than position.
+        let ids: Vec<&str> = dashboard
+            .recent_outcomes
+            .iter()
+            .map(|o| o.dispatch_id.as_str())
+            .collect();
+        assert!(ids.contains(&d1.as_str()));
+        assert!(ids.contains(&d2.as_str()));
+    }
+
+    #[test]
+    fn by_project_summary_aggregates_correctly() {
+        let (_dir, store) = setup();
+        let d1 = store.create_dispatch("acme", &spec("acme")).unwrap();
+        let d2 = store.create_dispatch("other", &spec("other")).unwrap();
+        let s1 = store.create_session(&d1, 1).unwrap();
+        store
+            .update_session(
+                &s1,
+                SessionUpdate {
+                    cost_usd: Some(2.0),
+                    status: Some(SessionStatus::Success),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+            .finish_dispatch(&d1, crate::store::records::DispatchStatus::Completed)
+            .unwrap();
+        store
+            .finish_dispatch(&d2, crate::store::records::DispatchStatus::Failed)
+            .unwrap();
+
+        let dashboard = compute_status_dashboard(&store).unwrap();
+        let acme = dashboard
+            .by_project
+            .iter()
+            .find(|p| p.project == "acme")
+            .unwrap();
+        let other = dashboard
+            .by_project
+            .iter()
+            .find(|p| p.project == "other")
+            .unwrap();
+
+        assert_eq!(acme.success_rate, 1.0);
+        assert_eq!(other.success_rate, 0.0);
+        assert_eq!(acme.total_sessions, 1);
+        assert_eq!(acme.active_dispatches, 0);
+    }
+
+    #[test]
+    fn active_dispatch_shows_in_project_summary() {
+        let (_dir, store) = setup();
+        let _d = store.create_dispatch("acme", &spec("acme")).unwrap();
+        let dashboard = compute_status_dashboard(&store).unwrap();
+        let acme = dashboard
+            .by_project
+            .iter()
+            .find(|p| p.project == "acme")
+            .unwrap();
+        assert_eq!(acme.active_dispatches, 1);
+    }
+}

--- a/crates/energeia/src/store/fjall_store.rs
+++ b/crates/energeia/src/store/fjall_store.rs
@@ -14,6 +14,11 @@ use crate::store::records::{
     LessonRecord, NewLesson, NewObservation, ObservationRecord, SessionId, SessionOutcomeData,
     SessionRecord, SessionUpdate,
 };
+
+/// Maximum records returned by bulk-scan methods to prevent unbounded memory use.
+pub(crate) const SCAN_LIMIT_DISPATCHES: usize = 10_000;
+pub(crate) const SCAN_LIMIT_SESSIONS: usize = 100_000;
+pub(crate) const SCAN_LIMIT_CI_VALIDATIONS: usize = 200_000;
 use crate::store::schema;
 use crate::types::{DispatchSpec, SessionOutcome, SessionStatus};
 
@@ -469,6 +474,59 @@ impl EnergeiaStore {
         };
 
         Ok(fact)
+    }
+
+    // -----------------------------------------------------------------------
+    // Bulk scan (metrics / reporting)
+    // -----------------------------------------------------------------------
+
+    /// List all dispatch records ordered by ULID (time-ascending), up to `limit`.
+    ///
+    /// Intended for metrics computation. Use [`SCAN_LIMIT_DISPATCHES`] as a
+    /// sensible default to prevent unbounded memory use.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Store` on read failure.
+    pub fn list_dispatches(&self, limit: usize) -> Result<Vec<DispatchRecord>> {
+        queries::list_dispatches(&self.keyspace, limit)
+    }
+
+    /// List all session records across all dispatches, up to `limit`.
+    ///
+    /// Ordered approximately by time (dispatch ULID, then prompt number).
+    /// Intended for metrics computation. Use [`SCAN_LIMIT_SESSIONS`] as a
+    /// sensible default.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Store` on read failure.
+    pub fn list_all_sessions(&self, limit: usize) -> Result<Vec<SessionRecord>> {
+        queries::list_all_sessions(&self.keyspace, limit)
+    }
+
+    /// List all CI validation records across all sessions, up to `limit`.
+    ///
+    /// Intended for metrics computation. Use [`SCAN_LIMIT_CI_VALIDATIONS`] as a
+    /// sensible default.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Store` on read failure.
+    pub fn list_all_ci_validations(&self, limit: usize) -> Result<Vec<CiValidationRecord>> {
+        queries::list_all_ci_validations(&self.keyspace, limit)
+    }
+
+    /// List CI validation records for a specific session.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Store` on read failure.
+    pub fn list_ci_validations_for_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Vec<CiValidationRecord>> {
+        queries::list_ci_validations_for_session(&self.keyspace, session_id)
     }
 
     // -----------------------------------------------------------------------

--- a/crates/energeia/src/store/mod.rs
+++ b/crates/energeia/src/store/mod.rs
@@ -21,3 +21,7 @@ mod fjall_store;
 
 #[cfg(feature = "storage-fjall")]
 pub use fjall_store::EnergeiaStore;
+#[cfg(feature = "storage-fjall")]
+pub(crate) use fjall_store::{
+    SCAN_LIMIT_CI_VALIDATIONS, SCAN_LIMIT_DISPATCHES, SCAN_LIMIT_SESSIONS,
+};

--- a/crates/energeia/src/store/queries.rs
+++ b/crates/energeia/src/store/queries.rs
@@ -6,7 +6,9 @@
 #[cfg(feature = "storage-fjall")]
 use crate::error::{self, Result};
 #[cfg(feature = "storage-fjall")]
-use crate::store::records::{CiValidationRecord, LessonRecord, ObservationRecord, SessionRecord};
+use crate::store::records::{
+    CiValidationRecord, DispatchRecord, LessonRecord, ObservationRecord, SessionRecord,
+};
 #[cfg(feature = "storage-fjall")]
 use crate::store::schema;
 
@@ -137,15 +139,85 @@ pub(crate) fn query_observations(
     Ok(results)
 }
 
+/// Collect all dispatch records via prefix scan.
+///
+/// Results are ordered by ULID (time-ascending). Use `limit` to cap memory
+/// usage; pass `usize::MAX` for no limit.
+#[cfg(feature = "storage-fjall")]
+pub(crate) fn list_dispatches(
+    keyspace: &fjall::Keyspace,
+    limit: usize,
+) -> Result<Vec<crate::store::records::DispatchRecord>> {
+    let prefix_bytes = schema::dispatch_prefix().as_bytes();
+    let mut results = Vec::new();
+    for guard in keyspace.prefix(prefix_bytes) {
+        if results.len() >= limit {
+            break;
+        }
+        let (_key, value) = guard.into_inner().map_err(|e| {
+            error::StoreSnafu {
+                message: format!("dispatch prefix scan: {e}"),
+            }
+            .build()
+        })?;
+        results.push(deserialize_value::<DispatchRecord>(&value)?);
+    }
+    Ok(results)
+}
+
+/// Collect all session records across all dispatches via prefix scan.
+///
+/// Results are ordered by `(dispatch_ulid, prompt_number)` (time-approximate
+/// ascending). Use `limit` to cap memory usage.
+#[cfg(feature = "storage-fjall")]
+pub(crate) fn list_all_sessions(
+    keyspace: &fjall::Keyspace,
+    limit: usize,
+) -> Result<Vec<SessionRecord>> {
+    let prefix_bytes = schema::session_prefix().as_bytes();
+    let mut results = Vec::new();
+    for guard in keyspace.prefix(prefix_bytes) {
+        if results.len() >= limit {
+            break;
+        }
+        let (_key, value) = guard.into_inner().map_err(|e| {
+            error::StoreSnafu {
+                message: format!("session prefix scan: {e}"),
+            }
+            .build()
+        })?;
+        results.push(deserialize_value::<SessionRecord>(&value)?);
+    }
+    Ok(results)
+}
+
+/// Collect all CI validation records across all sessions via prefix scan.
+///
+/// Use `limit` to cap memory usage.
+#[cfg(feature = "storage-fjall")]
+pub(crate) fn list_all_ci_validations(
+    keyspace: &fjall::Keyspace,
+    limit: usize,
+) -> Result<Vec<CiValidationRecord>> {
+    let prefix_bytes = schema::ci_validation_prefix().as_bytes();
+    let mut results = Vec::new();
+    for guard in keyspace.prefix(prefix_bytes) {
+        if results.len() >= limit {
+            break;
+        }
+        let (_key, value) = guard.into_inner().map_err(|e| {
+            error::StoreSnafu {
+                message: format!("ci_validation prefix scan: {e}"),
+            }
+            .build()
+        })?;
+        results.push(deserialize_value::<CiValidationRecord>(&value)?);
+    }
+    Ok(results)
+}
+
 /// Collect CI validations for a given session via prefix scan.
 #[cfg(feature = "storage-fjall")]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "will be called from store API as CI validation listing lands"
-    )
-)]
 pub(crate) fn list_ci_validations_for_session(
     keyspace: &fjall::Keyspace,
     session_id: &crate::store::records::SessionId,

--- a/crates/energeia/src/store/schema.rs
+++ b/crates/energeia/src/store/schema.rs
@@ -145,6 +145,12 @@ pub(crate) fn ci_validation_key(session_id: &SessionId, check_name: &str) -> Str
     format!("{PREFIX_CI_VALIDATION}{}:{check_name}", session_id.as_str())
 }
 
+/// Prefix for scanning all CI validation records.
+#[must_use]
+pub(crate) fn ci_validation_prefix() -> &'static str {
+    PREFIX_CI_VALIDATION
+}
+
 /// Prefix for scanning CI validations for a session.
 #[must_use]
 pub(crate) fn ci_validation_prefix_for_session(session_id: &SessionId) -> String {


### PR DESCRIPTION
## Summary

- Add `MetricsService` with 7 pipeline health metrics, cost/velocity reporting, real-time status dashboard, and Prometheus metric integration
- Extend `EnergeiaStore` with three bulk scan methods (`list_dispatches`, `list_all_sessions`, `list_all_ci_validations`) and re-export scan limit constants
- All computation functions gated behind `storage-fjall` feature; public types always compiled for API accessibility
- 44 new tests; all pass

## Modules added

| Module | What it provides |
|--------|-----------------|
| `metrics/health.rs` | 7 pipeline health signals with OK/WARN/CRIT thresholds; proxy notes for metrics needing future store schema extensions |
| `metrics/cost.rs` | `CostReport` with per-project breakdown and per-day velocity |
| `metrics/status.rs` | `StatusDashboard` — active dispatches, queue depth, recent outcomes (last 50), per-project summary |
| `metrics/prometheus.rs` | 5 Prometheus statics; `init()` + 3 recording functions |
| `metrics/mod.rs` | `MetricsService` entry point wrapping `Arc<EnergeiaStore>` |

## Observations

- Two health metrics (`observation_to_issue_rate`, and partially `qa_false_positive_rate`) return proxy values or `Unavailable` because the store doesn't yet capture QA verdict records or issue-tracker data. Both have inline comments identifying what store schema extensions would unlock accurate computation.
- `SCAN_LIMIT_*` constants were added as `pub(crate)` to `fjall_store.rs` and re-exported from `store/mod.rs` to keep the private module boundary intact.
- The `http::client` tests are flaky under parallel execution (OS-level race on temp executables) — pre-existing, not introduced here; passes with `--test-threads=1`.

Closes kanon#191

🤖 Generated with [Claude Code](https://claude.com/claude-code)