### PR TITLE
fix(lint): resolve 40 mechanical lint violations across 19 files

### DIFF
--- a/crates/aletheia/src/recall_sources/llm_context.rs
+++ b/crates/aletheia/src/recall_sources/llm_context.rs
@@ -266,7 +266,7 @@ fn anthropic_model_cards() -> Vec<ModelCard> {
 mod tests {
     use super::*;
 
-    fn test_models() -> Vec<ModelCard> {
+    fn sample_model_cards() -> Vec<ModelCard> {
         vec![
             ModelCard {
                 id: "model-a".to_owned(),
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn model_card_content_formatting() {
-        let card = &test_models()[0];
+        let card = &sample_model_cards()[0];
         let content = card.to_content();
         assert!(content.contains("Model Alpha (TestCorp)"));
         assert!(content.contains("128K tokens"));
@@ -308,14 +308,14 @@ mod tests {
 
     #[test]
     fn relevance_name_match() {
-        let card = &test_models()[0];
+        let card = &sample_model_cards()[0];
         let score = card.relevance("tell me about model alpha");
         assert!(score > 0.5, "name match should score high: {score}");
     }
 
     #[test]
     fn relevance_capability_match() {
-        let cards = test_models();
+        let cards = sample_model_cards();
         let vision_score_a = cards.get(0).copied().unwrap_or_default().relevance("which model supports vision");
         let vision_score_b = cards.get(1).copied().unwrap_or_default().relevance("which model supports vision");
         assert!(
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn relevance_context_window_query() {
-        let cards = test_models();
+        let cards = sample_model_cards();
         let score_a = cards.get(0).copied().unwrap_or_default().relevance("model with 256k context");
         let score_b = cards.get(1).copied().unwrap_or_default().relevance("model with 256k context");
         assert!(
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn relevance_no_match() {
-        let card = &test_models()[0];
+        let card = &sample_model_cards()[0];
         let score = card.relevance("unrelated query about cooking");
         assert!(
             score < f64::EPSILON,
@@ -355,7 +355,7 @@ mod tests {
 
     #[tokio::test]
     async fn llm_context_source_query() {
-        let source = LlmContextSource::new(test_models());
+        let source = LlmContextSource::new(sample_model_cards());
         let results = source
             .query("model with vision support", 10)
             .await
@@ -367,7 +367,7 @@ mod tests {
 
     #[tokio::test]
     async fn llm_context_source_empty_on_no_match() {
-        let source = LlmContextSource::new(test_models());
+        let source = LlmContextSource::new(sample_model_cards());
         let results = source
             .query("quantum entanglement recipes", 10)
             .await

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -20,6 +20,7 @@ use crate::schedule::{
 ///
 /// WHY: daemon logs should be scannable; full model responses and tool results
 /// flood the log when running in production.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DaemonOutputMode {
     /// Full output  -  all tool results and model responses logged verbatim.

--- a/crates/energeia/src/http/client.rs
+++ b/crates/energeia/src/http/client.rs
@@ -246,7 +246,7 @@ mod tests {
         HttpEngine::new("test-model").binary(dir.join("claude").display().to_string())
     }
 
-    fn test_spec(prompt: &str) -> SessionSpec {
+    fn sample_session_spec(prompt: &str) -> SessionSpec {
         SessionSpec {
             prompt: prompt.to_owned(),
             system_prompt: None,
@@ -266,7 +266,7 @@ mod tests {
 
         let engine = mock_engine(tmp.path());
         let handle = engine
-            .spawn_session(&test_spec("test prompt"), &AgentOptions::new())
+            .spawn_session(&sample_session_spec("test prompt"), &AgentOptions::new())
             .await
             .unwrap();
         let result = handle.wait().await.unwrap();
@@ -288,7 +288,7 @@ mod tests {
 
         let engine = mock_engine(tmp.path());
         let handle = engine
-            .spawn_session(&test_spec("bad prompt"), &AgentOptions::new())
+            .spawn_session(&sample_session_spec("bad prompt"), &AgentOptions::new())
             .await
             .unwrap();
         let result = handle.wait().await.unwrap();
@@ -329,7 +329,7 @@ mod tests {
 
         let engine = mock_engine(tmp.path());
         let mut handle = engine
-            .spawn_session(&test_spec("test"), &AgentOptions::new())
+            .spawn_session(&sample_session_spec("test"), &AgentOptions::new())
             .await
             .unwrap();
 
@@ -354,7 +354,7 @@ mod tests {
 
         let engine = mock_engine(tmp.path());
         let handle = engine
-            .spawn_session(&test_spec("test"), &AgentOptions::new())
+            .spawn_session(&sample_session_spec("test"), &AgentOptions::new())
             .await
             .unwrap();
         let err = handle.wait().await.unwrap_err();
@@ -371,7 +371,7 @@ mod tests {
 
         let engine = mock_engine(tmp.path());
         let handle = engine
-            .spawn_session(&test_spec("test"), &AgentOptions::new())
+            .spawn_session(&sample_session_spec("test"), &AgentOptions::new())
             .await
             .unwrap();
         let err = handle.wait().await.unwrap_err();
@@ -394,7 +394,7 @@ mod tests {
 
         let engine = HttpEngine::new("test-model").binary(script_path.display().to_string());
         let mut handle = engine
-            .spawn_session(&test_spec("test"), &AgentOptions::new())
+            .spawn_session(&sample_session_spec("test"), &AgentOptions::new())
             .await
             .unwrap();
         let result = handle.abort().await;

--- a/crates/energeia/src/http/mock.rs
+++ b/crates/energeia/src/http/mock.rs
@@ -26,6 +26,7 @@ pub struct MockEngine {
 }
 
 /// Pre-configured outcome for a mock session.
+#[non_exhaustive]
 pub enum MockOutcome {
     /// Session completes successfully with the given events and result.
     Success {

--- a/crates/energeia/src/orchestrator/group.rs
+++ b/crates/energeia/src/orchestrator/group.rs
@@ -167,7 +167,7 @@ mod tests {
 
     use super::execute_group;
 
-    fn test_prompt(number: u32) -> PromptSpec {
+    fn sample_prompt_spec(number: u32) -> PromptSpec {
         PromptSpec {
             number,
             description: format!("test prompt {number}"),
@@ -206,7 +206,7 @@ mod tests {
         let budget = Arc::new(Budget::new(Some(10.0), Some(500), None));
         let cancel = CancellationToken::new();
 
-        let prompts = vec![test_prompt(1), test_prompt(2), test_prompt(3)];
+        let prompts = vec![sample_prompt_spec(1), sample_prompt_spec(2), sample_prompt_spec(3)];
 
         let outcomes = execute_group(
             &prompts,
@@ -239,7 +239,7 @@ mod tests {
         let budget = Arc::new(Budget::new(None, None, None));
         let cancel = CancellationToken::new();
 
-        let prompts = vec![test_prompt(1), test_prompt(2), test_prompt(3)];
+        let prompts = vec![sample_prompt_spec(1), sample_prompt_spec(2), sample_prompt_spec(3)];
 
         let outcomes = execute_group(
             &prompts,
@@ -265,7 +265,7 @@ mod tests {
         let cancel = CancellationToken::new();
         cancel.cancel();
 
-        let prompts = vec![test_prompt(1), test_prompt(2)];
+        let prompts = vec![sample_prompt_spec(1), sample_prompt_spec(2)];
 
         let outcomes = execute_group(
             &prompts,
@@ -290,7 +290,7 @@ mod tests {
         let budget = Arc::new(Budget::new(Some(0.05), None, None));
         let cancel = CancellationToken::new();
 
-        let prompts = vec![test_prompt(1), test_prompt(2)];
+        let prompts = vec![sample_prompt_spec(1), sample_prompt_spec(2)];
 
         let outcomes = execute_group(
             &prompts,
@@ -319,7 +319,7 @@ mod tests {
         let budget = Arc::new(Budget::new(None, None, None));
         let cancel = CancellationToken::new();
 
-        let prompts = vec![test_prompt(1), test_prompt(2)];
+        let prompts = vec![sample_prompt_spec(1), sample_prompt_spec(2)];
 
         let outcomes = execute_group(
             &prompts,

--- a/crates/energeia/src/orchestrator/mod.rs
+++ b/crates/energeia/src/orchestrator/mod.rs
@@ -661,7 +661,7 @@ mod tests {
     // Test helpers
     // -----------------------------------------------------------------------
 
-    fn test_prompt(number: u32, depends_on: Vec<u32>) -> PromptSpec {
+    fn sample_prompt_spec(number: u32, depends_on: Vec<u32>) -> PromptSpec {
         PromptSpec {
             number,
             description: format!("test prompt {number}"),
@@ -700,7 +700,7 @@ mod tests {
         }
     }
 
-    fn test_spec(prompt_numbers: Vec<u32>) -> DispatchSpec {
+    fn sample_dispatch_spec(prompt_numbers: Vec<u32>) -> DispatchSpec {
         DispatchSpec {
             prompt_numbers,
             project: "acme".to_owned(),
@@ -720,8 +720,8 @@ mod tests {
         let config = OrchestratorConfig::new().max_concurrent(4);
 
         let orchestrator = Orchestrator::new(engine, qa, config);
-        let prompts = vec![test_prompt(1, vec![])];
-        let spec = test_spec(vec![1]);
+        let prompts = vec![sample_prompt_spec(1, vec![])];
+        let spec = sample_dispatch_spec(vec![1]);
 
         let result = orchestrator.dispatch(spec, &prompts).await.unwrap();
 
@@ -746,12 +746,12 @@ mod tests {
 
         let orchestrator = Orchestrator::new(engine, qa, config);
         let prompts = vec![
-            test_prompt(1, vec![]),
-            test_prompt(2, vec![1]),
-            test_prompt(3, vec![1]),
-            test_prompt(4, vec![2, 3]),
+            sample_prompt_spec(1, vec![]),
+            sample_prompt_spec(2, vec![1]),
+            sample_prompt_spec(3, vec![1]),
+            sample_prompt_spec(4, vec![2, 3]),
         ];
-        let spec = test_spec(vec![1, 2, 3, 4]);
+        let spec = sample_dispatch_spec(vec![1, 2, 3, 4]);
 
         let result = orchestrator.dispatch(spec, &prompts).await.unwrap();
 
@@ -782,11 +782,11 @@ mod tests {
 
         let orchestrator = Orchestrator::new(engine, qa, config);
         let prompts = vec![
-            test_prompt(1, vec![]),
-            test_prompt(2, vec![1]),
-            test_prompt(3, vec![2]),
+            sample_prompt_spec(1, vec![]),
+            sample_prompt_spec(2, vec![1]),
+            sample_prompt_spec(3, vec![2]),
         ];
-        let spec = test_spec(vec![1, 2, 3]);
+        let spec = sample_dispatch_spec(vec![1, 2, 3]);
 
         let result = orchestrator.dispatch(spec, &prompts).await.unwrap();
 
@@ -827,8 +827,8 @@ mod tests {
             .default_budget_usd(0.15);
 
         let orchestrator = Orchestrator::new(engine, qa, config);
-        let prompts = vec![test_prompt(1, vec![]), test_prompt(2, vec![1])];
-        let spec = test_spec(vec![1, 2]);
+        let prompts = vec![sample_prompt_spec(1, vec![]), sample_prompt_spec(2, vec![1])];
+        let spec = sample_dispatch_spec(vec![1, 2]);
 
         let result = orchestrator.dispatch(spec, &prompts).await.unwrap();
 
@@ -848,7 +848,7 @@ mod tests {
         let config = OrchestratorConfig::default();
 
         let orchestrator = Orchestrator::new(engine, qa, config);
-        let result = orchestrator.dispatch(test_spec(vec![]), &[]).await;
+        let result = orchestrator.dispatch(sample_dispatch_spec(vec![]), &[]).await;
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("no prompts"));
@@ -867,11 +867,11 @@ mod tests {
 
         let orchestrator = Orchestrator::new(engine, qa, config);
         let prompts = vec![
-            test_prompt(1, vec![]),
-            test_prompt(2, vec![]),
-            test_prompt(3, vec![]),
+            sample_prompt_spec(1, vec![]),
+            sample_prompt_spec(2, vec![]),
+            sample_prompt_spec(3, vec![]),
         ];
-        let spec = test_spec(vec![1, 2, 3]);
+        let spec = sample_dispatch_spec(vec![1, 2, 3]);
 
         let result = orchestrator.dispatch(spec, &prompts).await.unwrap();
 
@@ -899,10 +899,10 @@ mod tests {
 
         let orchestrator = Orchestrator::new(engine, qa, config);
         let prompts = vec![
-            test_prompt(1, vec![]),
-            test_prompt(2, vec![1]),
-            test_prompt(3, vec![1]),
-            test_prompt(4, vec![2, 3]),
+            sample_prompt_spec(1, vec![]),
+            sample_prompt_spec(2, vec![1]),
+            sample_prompt_spec(3, vec![1]),
+            sample_prompt_spec(4, vec![2, 3]),
         ];
 
         let plan = orchestrator.dry_run(&prompts).unwrap();
@@ -944,7 +944,7 @@ mod tests {
         let config = OrchestratorConfig::default();
 
         let orchestrator = Orchestrator::new(engine, qa, config);
-        let prompts = vec![test_prompt(1, vec![]), test_prompt(2, vec![1])];
+        let prompts = vec![sample_prompt_spec(1, vec![]), sample_prompt_spec(2, vec![1])];
 
         let plan = orchestrator.dry_run(&prompts).unwrap();
         let json = serde_json::to_string(&plan).unwrap();

--- a/crates/energeia/src/resume.rs
+++ b/crates/energeia/src/resume.rs
@@ -63,11 +63,11 @@ impl ResumePolicy {
     /// # Example
     /// ```ignore
     /// let policy = ResumePolicy::default();
-    /// assert!(policy.next_stage(0).is_some());    // stage 0
-    /// assert!(policy.next_stage(79).is_some());   // still stage 0
-    /// assert!(policy.next_stage(80).is_some());   // stage 1
-    /// assert!(policy.next_stage(229).is_some());  // stage 2 (80+100+49)
-    /// assert!(policy.next_stage(230).is_none());  // exhausted
+    /// assert!(policy.next_stage(0).is_some(), "stage 0 should exist for turn 0");    // stage 0
+    /// assert!(policy.next_stage(79).is_some(), "stage 0 should still exist at turn 79");   // still stage 0
+    /// assert!(policy.next_stage(80).is_some(), "stage 1 should exist at turn 80");   // stage 1
+    /// assert!(policy.next_stage(229).is_some(), "stage 2 should exist at turn 229");  // stage 2 (80+100+49)
+    /// assert!(policy.next_stage(230).is_none(), "all stages should be exhausted at turn 230");  // exhausted
     /// ```
     #[must_use]
     pub fn next_stage(&self, current_turns: u32) -> Option<&ResumeStage> {

--- a/crates/energeia/src/session/events.rs
+++ b/crates/energeia/src/session/events.rs
@@ -177,7 +177,7 @@ pub(crate) fn extract_pr_url(text: &str) -> Option<&str> {
 /// rate-limit variant (pending Agent SDK integration).
 // NOTE: Will be consumed by the session manager once `SessionEvent` gains a
 // rate-limit variant (pending Agent SDK integration). Used in tests only for now.
-#[allow(
+#[expect(
     dead_code,
     reason = "constant defined for use once SessionEvent gains rate-limit events"
 )]

--- a/crates/energeia/src/session/manager.rs
+++ b/crates/energeia/src/session/manager.rs
@@ -439,7 +439,7 @@ mod tests {
     use crate::http::mock::{MockEngine, MockOutcome};
     use crate::resume::ResumeStage;
 
-    fn test_prompt(number: u32) -> PromptSpec {
+    fn sample_prompt_spec(number: u32) -> PromptSpec {
         PromptSpec {
             number,
             description: format!("test prompt {number}"),
@@ -531,7 +531,7 @@ mod tests {
         let mgr = SessionManager::new(engine, budget.clone(), ResumePolicy::default());
 
         let outcome = mgr
-            .execute(&test_prompt(1), &default_config())
+            .execute(&sample_prompt_spec(1), &default_config())
             .await
             .unwrap();
 
@@ -558,7 +558,7 @@ mod tests {
         let mgr = SessionManager::new(engine, budget, ResumePolicy::default());
 
         let outcome = mgr
-            .execute(&test_prompt(1), &default_config())
+            .execute(&sample_prompt_spec(1), &default_config())
             .await
             .unwrap();
 
@@ -584,7 +584,7 @@ mod tests {
         let mgr = SessionManager::new(engine, budget.clone(), two_stage_policy());
 
         let outcome = mgr
-            .execute(&test_prompt(1), &default_config())
+            .execute(&sample_prompt_spec(1), &default_config())
             .await
             .unwrap();
 
@@ -611,7 +611,7 @@ mod tests {
         let mgr = SessionManager::new(engine, budget, two_stage_policy());
 
         let outcome = mgr
-            .execute(&test_prompt(1), &default_config())
+            .execute(&sample_prompt_spec(1), &default_config())
             .await
             .unwrap();
 
@@ -630,7 +630,7 @@ mod tests {
         let mgr = SessionManager::new(engine, budget, two_stage_policy());
 
         let outcome = mgr
-            .execute(&test_prompt(1), &default_config())
+            .execute(&sample_prompt_spec(1), &default_config())
             .await
             .unwrap();
 
@@ -651,7 +651,7 @@ mod tests {
         let mgr = SessionManager::new(engine, budget, two_stage_policy());
 
         let outcome = mgr
-            .execute(&test_prompt(1), &default_config())
+            .execute(&sample_prompt_spec(1), &default_config())
             .await
             .unwrap();
 
@@ -670,7 +670,7 @@ mod tests {
 
         let mgr = SessionManager::new(engine, budget, ResumePolicy::default());
 
-        let result = mgr.execute(&test_prompt(1), &default_config()).await;
+        let result = mgr.execute(&sample_prompt_spec(1), &default_config()).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("auth expired"));
@@ -701,7 +701,7 @@ mod tests {
         let mgr = SessionManager::new(engine, budget, two_stage_policy());
 
         let outcome = mgr
-            .execute(&test_prompt(1), &default_config())
+            .execute(&sample_prompt_spec(1), &default_config())
             .await
             .unwrap();
         assert_eq!(outcome.status, SessionStatus::Success);
@@ -722,7 +722,7 @@ mod tests {
         let mgr = SessionManager::new(engine, budget, two_stage_policy());
 
         let outcome = mgr
-            .execute(&test_prompt(1), &default_config())
+            .execute(&sample_prompt_spec(1), &default_config())
             .await
             .unwrap();
         assert_eq!(outcome.status, SessionStatus::BudgetExceeded);

--- a/crates/energeia/src/store/fjall_store.rs
+++ b/crates/energeia/src/store/fjall_store.rs
@@ -579,7 +579,7 @@ mod tests {
         (temp_dir, store)
     }
 
-    fn test_dispatch_spec() -> DispatchSpec {
+    fn sample_dispatch_spec() -> DispatchSpec {
         DispatchSpec {
             prompt_numbers: vec![1, 2, 3],
             project: "acme".to_owned(),
@@ -595,7 +595,7 @@ mod tests {
     #[test]
     fn create_and_get_dispatch() {
         let (_dir, store) = setup_test_store();
-        let spec = test_dispatch_spec();
+        let spec = sample_dispatch_spec();
 
         let id = store.create_dispatch("acme", &spec).unwrap();
         let record = store.get_dispatch(&id).unwrap().unwrap();
@@ -616,7 +616,7 @@ mod tests {
     #[test]
     fn finish_dispatch_aggregates_sessions() {
         let (_dir, store) = setup_test_store();
-        let spec = test_dispatch_spec();
+        let spec = sample_dispatch_spec();
         let dispatch_id = store.create_dispatch("acme", &spec).unwrap();
 
         let sess1 = store.create_session(&dispatch_id, 1).unwrap();
@@ -671,7 +671,7 @@ mod tests {
     #[test]
     fn create_and_list_sessions() {
         let (_dir, store) = setup_test_store();
-        let spec = test_dispatch_spec();
+        let spec = sample_dispatch_spec();
         let dispatch_id = store.create_dispatch("acme", &spec).unwrap();
 
         store.create_session(&dispatch_id, 1).unwrap();
@@ -688,7 +688,7 @@ mod tests {
     #[test]
     fn sessions_isolated_between_dispatches() {
         let (_dir, store) = setup_test_store();
-        let spec = test_dispatch_spec();
+        let spec = sample_dispatch_spec();
 
         let d1 = store.create_dispatch("project-a", &spec).unwrap();
         let d2 = store.create_dispatch("project-b", &spec).unwrap();
@@ -704,7 +704,7 @@ mod tests {
     #[test]
     fn update_session_partial() {
         let (_dir, store) = setup_test_store();
-        let spec = test_dispatch_spec();
+        let spec = sample_dispatch_spec();
         let dispatch_id = store.create_dispatch("acme", &spec).unwrap();
         let session_id = store.create_session(&dispatch_id, 1).unwrap();
 
@@ -865,7 +865,7 @@ mod tests {
     #[test]
     fn add_and_list_ci_validations() {
         let (_dir, store) = setup_test_store();
-        let spec = test_dispatch_spec();
+        let spec = sample_dispatch_spec();
         let dispatch_id = store.create_dispatch("acme", &spec).unwrap();
         let session_id = store.create_session(&dispatch_id, 1).unwrap();
 
@@ -895,7 +895,7 @@ mod tests {
     #[test]
     fn record_training_data_produces_fact() {
         let (_dir, store) = setup_test_store();
-        let spec = test_dispatch_spec();
+        let spec = sample_dispatch_spec();
         let dispatch_id = store.create_dispatch("acme", &spec).unwrap();
         let session_id = store.create_session(&dispatch_id, 1).unwrap();
 
@@ -943,7 +943,7 @@ mod tests {
             .unwrap();
         let store = EnergeiaStore::from_keyspace(Arc::new(ks));
 
-        let spec = test_dispatch_spec();
+        let spec = sample_dispatch_spec();
         let id = store.create_dispatch("acme", &spec).unwrap();
         assert!(store.get_dispatch(&id).unwrap().is_some());
     }

--- a/crates/episteme/src/recall_tests/side_query.rs
+++ b/crates/episteme/src/recall_tests/side_query.rs
@@ -182,7 +182,11 @@ fn select_calls_ranker_and_returns_results() {
     let result = selector
         .select("what is alpha?", &manifest, &ranker)
         .unwrap_or_else(|_| unreachable!());
-    assert_eq!(result.selected_ids, vec!["a", "c"]);
+    assert_eq!(
+        result.selected_ids,
+        vec!["a", "c"],
+        "selector should return IDs ranked by the ranker"
+    );
     assert!(!result.from_cache, "first call should not be cached");
 }
 
@@ -239,7 +243,11 @@ fn mark_surfaced_prevents_reselection() {
         "surfaced entry 'a' should not appear in manifest sent to ranker"
     );
 
-    assert_eq!(result.selected_ids, vec!["b"]);
+    assert_eq!(
+        result.selected_ids,
+        vec!["b"],
+        "only non-surfaced entry 'b' should be selected"
+    );
 }
 
 #[test]
@@ -390,7 +398,11 @@ fn pre_filter_removes_unselected_candidates() {
 
     let filtered = pre_filter_by_side_query(candidates, &selected);
     assert_eq!(filtered.len(), 1, "only 'a' should remain");
-    assert_eq!(filtered.first().map(|r| r.source_id.as_str()), Some("a"));
+    assert_eq!(
+        filtered.first().map(|r| r.source_id.as_str()),
+        Some("a"),
+        "pre-filter should keep only selected source 'a'"
+    );
 }
 
 #[test]

--- a/crates/koina/src/redact.rs
+++ b/crates/koina/src/redact.rs
@@ -13,7 +13,7 @@ use regex::Regex;
 // through macro expansion on static items.
 macro_rules! static_regex {
     ($name:ident, $pattern:expr) => {
-        #[allow(clippy::expect_used)]
+        #[expect(clippy::expect_used, reason = "macro-generated static regex requires expect() for compilation failure")]
         static $name: LazyLock<Regex> = LazyLock::new(||
             Regex::new($pattern).expect("static regex must compile")
         );

--- a/crates/koina/src/retry.rs
+++ b/crates/koina/src/retry.rs
@@ -202,11 +202,11 @@ impl RetryConfig {
 /// ```
 /// use aletheia_koina::retry::exponential_steps;
 ///
-/// assert_eq!(exponential_steps(0, 2, 8), 1); // 2^0 = 1
-/// assert_eq!(exponential_steps(1, 2, 8), 2); // 2^1 = 2
-/// assert_eq!(exponential_steps(2, 2, 8), 4); // 2^2 = 4
-/// assert_eq!(exponential_steps(3, 2, 8), 8); // 2^3 = 8
-/// assert_eq!(exponential_steps(4, 2, 8), 8); // capped
+/// assert_eq!(exponential_steps(0, 2, 8), 1, "exponential step at attempt 0 should be factor^0 = 1"); // 2^0 = 1
+/// assert_eq!(exponential_steps(1, 2, 8), 2, "exponential step at attempt 1 should be factor^1 = 2"); // 2^1 = 2
+/// assert_eq!(exponential_steps(2, 2, 8), 4, "exponential step at attempt 2 should be factor^2 = 4"); // 2^2 = 4
+/// assert_eq!(exponential_steps(3, 2, 8), 8, "exponential step at attempt 3 should be factor^3 = 8"); // 2^3 = 8
+/// assert_eq!(exponential_steps(4, 2, 8), 8, "exponential step should be capped at maximum value"); // capped
 /// ```
 #[must_use]
 pub fn exponential_steps(attempt: u32, factor: u32, cap: u32) -> u32 {

--- a/crates/melete/src/dream/mod.rs
+++ b/crates/melete/src/dream/mod.rs
@@ -571,7 +571,7 @@ mod tests {
     /// Write bytes to a file (test helper).
     ///
     /// WHY: `std::fs::write` is disallowed by melete's clippy.toml.
-    fn test_write_file(path: &std::path::Path, content: &[u8]) {
+    fn write_test_file(path: &std::path::Path, content: &[u8]) {
         use std::io::Write;
         let mut f = std::fs::File::options()
             .write(true)
@@ -646,7 +646,7 @@ mod tests {
         let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: CREATE lock file with current mtime (just consolidated).
-        test_write_file(&lock_path, b"");
+        write_test_file(&lock_path, b"");
 
         let mut config = make_config(lock_path);
         config.min_hours = 24;
@@ -786,7 +786,7 @@ mod tests {
         let lock_path = dir.path().join(".consolidate-lock");
 
         // NOTE: CREATE lock file with current mtime.
-        test_write_file(&lock_path, b"");
+        write_test_file(&lock_path, b"");
 
         let mut config = make_config(lock_path);
         config.min_hours = 24;

--- a/crates/nous/src/tasks/output.rs
+++ b/crates/nous/src/tasks/output.rs
@@ -20,6 +20,7 @@ use tokio::io::{AsyncRead, AsyncWriteExt as _, ReadBuf};
     missing_docs,
     reason = "snafu error variant fields (source, location, path) are self-documenting via display format"
 )]
+#[non_exhaustive]
 pub enum OutputError {
     /// Failed to create the output temp file.
     #[snafu(display("failed to CREATE output file: {source}"))]

--- a/crates/nous/src/tasks/registry.rs
+++ b/crates/nous/src/tasks/registry.rs
@@ -17,6 +17,7 @@ use super::types::{ProgressEvent, TaskEntry, TaskId, TaskStatus, TaskType, ToolC
     missing_docs,
     reason = "snafu error variant fields (task_id, FROM, to, source, location) are self-documenting via display format"
 )]
+#[non_exhaustive]
 pub enum RegistryError {
     /// Task not found in the registry.
     #[snafu(display("task {task_id} not found"))]

--- a/crates/nous/src/tasks/types.rs
+++ b/crates/nous/src/tasks/types.rs
@@ -57,6 +57,7 @@ impl fmt::Display for TaskId {
 /// WHY: Task display and lifecycle differ by type. Shell tasks carry a command
 /// string, agent tasks carry an agent ID and prompt, etc. Discriminating at the
 /// type level lets callers match exhaustively.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TaskType {
     /// A shell command execution.
@@ -113,6 +114,7 @@ impl fmt::Display for TaskType {
 ///                    -> Failed
 ///                    -> Killed
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TaskStatus {
     /// Registered but not yet started.
@@ -167,6 +169,7 @@ pub struct ToolCallSummary {
 ///
 /// WHY: Subscribers (UI, logging, parent agents) need typed events to decide
 /// what to display. A single enum keeps the channel monomorphic.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum ProgressEvent {
     /// Task transitioned between statuses.

--- a/crates/nous/src/working_state.rs
+++ b/crates/nous/src/working_state.rs
@@ -610,7 +610,7 @@ mod tests {
 
     // -- Forked agent cache coherence tests --
 
-    fn test_tool(name: &str) -> ToolDefinition {
+    fn sample_tool_definition(name: &str) -> ToolDefinition {
         ToolDefinition {
             name: name.to_owned(),
             description: format!("Test tool {name}"),
@@ -619,19 +619,19 @@ mod tests {
         }
     }
 
-    fn test_message(text: &str) -> Message {
+    fn sample_message(text: &str) -> Message {
         Message {
             role: aletheia_hermeneus::types::Role::User,
             content: aletheia_hermeneus::types::Content::Text(text.to_owned()),
         }
     }
 
-    fn test_cache_params() -> Arc<CacheSafeParams> {
+    fn sample_cache_params() -> Arc<CacheSafeParams> {
         let messages: Arc<[Message]> =
-            Arc::from(vec![test_message("hello"), test_message("world")]);
+            Arc::from(vec![sample_message("hello"), sample_message("world")]);
         Arc::new(CacheSafeParams::new(
             "You are a test agent.",
-            vec![test_tool("zeta_tool"), test_tool("alpha_tool")],
+            vec![sample_tool_definition("zeta_tool"), sample_tool_definition("alpha_tool")],
             "claude-opus-4-20250514",
             messages,
             Some(ThinkingConfig {
@@ -643,7 +643,7 @@ mod tests {
 
     #[test]
     fn cache_safe_params_preserves_all_fields() {
-        let params = test_cache_params();
+        let params = sample_cache_params();
         assert_eq!(params.model, "claude-opus-4-20250514");
         assert_eq!(params.system_prompt.as_ref(), "You are a test agent.");
         assert_eq!(params.tools.len(), 2);
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn cache_safe_params_sorts_tools_deterministically() {
-        let params = test_cache_params();
+        let params = sample_cache_params();
         // WHY: tools were provided as [zeta, alpha] but must be sorted [alpha, zeta]
         assert_eq!(params.tools.get(0).copied().unwrap_or_default().name, "alpha_tool");
         assert_eq!(params.tools.get(1).copied().unwrap_or_default().name, "zeta_tool");
@@ -664,7 +664,7 @@ mod tests {
     #[test]
     fn clone_for_fork_shares_cache_params_via_arc() {
         let mut parent = WorkingState::new();
-        let params = test_cache_params();
+        let params = sample_cache_params();
         parent.set_cache_params(Arc::clone(&params));
         parent.push_task("parent work");
 
@@ -690,7 +690,7 @@ mod tests {
     #[test]
     fn clone_for_fork_deep_clones_mutable_state() {
         let mut parent = WorkingState::new();
-        parent.set_cache_params(test_cache_params());
+        parent.set_cache_params(sample_cache_params());
         parent.push_task("shared context");
         parent.set_focus(Some("src/lib.rs".to_owned()), None, None);
 
@@ -765,14 +765,14 @@ mod tests {
     #[test]
     fn shared_prefix_immutability() {
         let messages: Arc<[Message]> = Arc::from(vec![
-            test_message("context message 1"),
-            test_message("context message 2"),
+            sample_message("context message 1"),
+            sample_message("context message 2"),
         ]);
         let prefix_clone = Arc::clone(&messages);
 
         let params = Arc::new(CacheSafeParams::new(
             "system prompt",
-            vec![test_tool("tool_a")],
+            vec![sample_tool_definition("tool_a")],
             "model-v1",
             messages,
             None,
@@ -788,7 +788,7 @@ mod tests {
     fn cache_params_serde_roundtrip_skips_field() {
         let mut state = WorkingState::new();
         state.push_task("test task");
-        state.set_cache_params(test_cache_params());
+        state.set_cache_params(sample_cache_params());
 
         let json = state.to_json().unwrap();
         let restored = WorkingState::from_json(&json).unwrap();

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,15 +11,15 @@ set -euo pipefail
 #   No flags:    build + copy + restart (full deploy)
 #
 # Path discovery (first match wins):
-#   Instance root:  $ALETHEIA_ROOT > ~/ergon/instance > ~/aletheia/instance
-#   Binary dest:    $ALETHEIA_BINARY > ~/ergon/bin/aletheia > ~/.local/bin/aletheia
+#   Instance root:  "$ALETHEIA_ROOT" > ~/ergon/instance > ~/aletheia/instance
+#   Binary dest:    "$ALETHEIA_BINARY" > ~/ergon/bin/aletheia > ~/.local/bin/aletheia
 #
 # Prerequisites: cargo, curl, jq, systemctl
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Instance root: env var, then common locations, then fail
-if [ -n "${ALETHEIA_ROOT:-}" ]; then
+if [[ -n "${ALETHEIA_ROOT:-}" ]]; then
     INSTANCE_ROOT="$ALETHEIA_ROOT"
 elif [ -d "$HOME/ergon/instance" ]; then
     INSTANCE_ROOT="$HOME/ergon/instance"
@@ -33,7 +33,7 @@ fi
 BINARY_SRC="$REPO_ROOT/target/release/aletheia"
 
 # Binary destination: env var, then common locations
-if [ -n "${ALETHEIA_BINARY:-}" ]; then
+if [[ -n "${ALETHEIA_BINARY:-}" ]]; then
     BINARY_DST="$ALETHEIA_BINARY"
 elif [ -d "$HOME/ergon/bin" ]; then
     BINARY_DST="$HOME/ergon/bin/aletheia"


### PR DESCRIPTION
## Summary
- Shell: quoted variables, [[ ]] in deploy.sh (4 fixes)
- Rust: bare assert messages in energeia, episteme, koina (14 fixes)
- Rust: #[allow] to #[expect] with reasons (2 fixes)
- Rust: #[non_exhaustive] on pub enums (7 fixes)
- Testing: behavior-driven test names (11 fixes)

Verified with cargo check on energeia + koina. Pre-existing graphe errors unrelated.

🤖 Generated with Claude Code + Kimi CLI