### PR TITLE
fix(nous): evict sessions by last-access time instead of creation time

### DIFF
--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -470,17 +470,17 @@ impl NousActor {
         true
     }
 
-    /// Evict the oldest session (by `turn_id`, which is a `ULID` encoding creation time)
-    /// when the session count reaches `MAX_SESSIONS`. Prevents unbounded memory growth.
+    /// Evict the oldest session (by `last_accessed`) when the session count reaches
+    /// `MAX_SESSIONS`. Prevents unbounded memory growth using LRU eviction.
     fn evict_oldest_session_if_needed(&mut self) {
         if self.sessions.len() < MAX_SESSIONS {
             return;
         }
-        // WHY: turn_id is a ULID (time-ordered); the smallest ULID is the oldest session.
+        // WHY: last_accessed tracks actual session activity; least recently used is evicted.
         let oldest_key = self
             .sessions
             .iter()
-            .min_by_key(|(_, state)| state.turn_id)
+            .min_by_key(|(_, state)| state.last_accessed)
             .map(|(key, _)| key.clone());
         if let Some(key) = oldest_key {
             warn!(

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -205,6 +205,9 @@ impl NousActor {
                 SessionState::new(id, session_key.to_owned(), &self.config)
             });
 
+        // Update last_accessed on every session access for LRU eviction
+        session.last_accessed = std::time::Instant::now();
+
         session.next_turn();
 
         // WHY(#2160): persist session to store BEFORE spawning the pipeline task.
@@ -397,7 +400,9 @@ impl NousActor {
             clippy::as_conversions,
             reason = "u32→usize: DEGRADED_PANIC_THRESHOLD is a small constant, fits in usize"
         )]
-        if self.runtime.panic_timestamps.len() >= usize::try_from(DEGRADED_PANIC_THRESHOLD).unwrap_or_default() {
+        if self.runtime.panic_timestamps.len()
+            >= usize::try_from(DEGRADED_PANIC_THRESHOLD).unwrap_or_default()
+        {
             warn!(
                 nous_id = %self.id,
                 panic_count = self.runtime.panic_count,
@@ -436,6 +441,9 @@ impl NousActor {
                 }
                 state
             });
+
+        // Update last_accessed on every session access for LRU eviction
+        session.last_accessed = std::time::Instant::now();
 
         session.next_turn();
 

--- a/crates/nous/src/session.rs
+++ b/crates/nous/src/session.rs
@@ -1,5 +1,7 @@
 //! Session manager: creates, finds, and manages agent sessions.
 
+use std::time::Instant;
+
 use tracing::{info, instrument};
 use ulid::Ulid;
 
@@ -28,6 +30,8 @@ pub struct SessionState {
     pub cumulative_tokens: u64,
     pub distillation_count: u32,
     pub bootstrap_hash: Option<String>,
+    /// Last time the session was accessed. Used for LRU eviction.
+    pub last_accessed: Instant,
 }
 
 impl SessionState {
@@ -47,6 +51,7 @@ impl SessionState {
             thinking_budget: config.generation.thinking_budget,
             bootstrap_hash: None,
             cumulative_tokens: 0,
+            last_accessed: Instant::now(),
         }
     }
 


### PR DESCRIPTION
Closes #2441