### PR TITLE
fix(diaporeia): add Bearer token authentication to MCP endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "jiff",
  "serde",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-energeia"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "compact_str",
  "jiff",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-energeia",
  "aletheia-hermeneus",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aes-gcm",
  "aletheia-koina",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -74,13 +74,23 @@ pub(crate) async fn run(args: Args) -> Result<()> {
 
     #[cfg(feature = "mcp")]
     let app = {
+        // WHY: auth_mode == "none" means no signing key; pass None so the
+        // middleware skips JWT validation and injects anonymous claims.
+        let mcp_jwt = if runtime.state.auth_mode == "none" {
+            None
+        } else {
+            Some(Arc::clone(&runtime.state.jwt_manager))
+        };
         let diaporeia_state = Arc::new(aletheia_diaporeia::state::DiaporeiaState {
             session_store: Arc::clone(&runtime.state.session_store),
             nous_manager: Arc::clone(&runtime.state.nous_manager),
             tool_registry: Arc::clone(&runtime.state.tool_registry),
             oikos: Arc::clone(&runtime.state.oikos),
+            jwt_manager: mcp_jwt,
             start_time: runtime.state.start_time,
             config: Arc::clone(&runtime.state.config),
+            auth_mode: runtime.state.auth_mode.clone(),
+            none_role: runtime.state.none_role.clone(),
             shutdown: runtime.shutdown_token.clone(),
         });
         let mcp_router = aletheia_diaporeia::transport::streamable_http_router(diaporeia_state);

--- a/crates/diaporeia/src/auth.rs
+++ b/crates/diaporeia/src/auth.rs
@@ -1,0 +1,115 @@
+//! Bearer token authentication middleware for MCP transport.
+//!
+//! Mirrors pylon's `Claims` extractor but operates as an Axum middleware layer
+//! so it can wrap the opaque `StreamableHttpService` (which does not use
+//! Axum extractors). When `auth_mode == "none"`, requests pass through without
+//! a token and receive anonymous claims via request extensions.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, Response, StatusCode};
+use axum::middleware::Next;
+use tracing::warn;
+
+use aletheia_koina::http::BEARER_PREFIX;
+use aletheia_symbolon::types::Role;
+
+use crate::state::DiaporeiaState;
+
+/// Validated identity attached to request extensions after successful auth.
+///
+/// Parallel to `pylon::extract::Claims` but decoupled: diaporeia does not
+/// depend on pylon, and the two may diverge as per-tool RBAC is added.
+#[derive(Debug, Clone)]
+pub struct McpClaims {
+    /// Subject identifier (user or service principal).
+    pub sub: String,
+    /// Authorization role governing API access.
+    pub role: Role,
+    /// Optional nous scope: when set, restricts access to a single agent.
+    pub nous_id: Option<String>,
+}
+
+/// Axum middleware that validates Bearer JWT tokens on MCP requests.
+///
+/// # Auth modes
+///
+/// - `"none"`: injects anonymous `McpClaims` with the configured `none_role`.
+/// - Any other value: requires a valid `Authorization: Bearer <token>` header;
+///   returns 401 Unauthorized on missing/invalid tokens.
+///
+/// Validated claims are inserted into request extensions so downstream handlers
+/// can access them via `req.extensions().get::<McpClaims>()`.
+pub async fn mcp_auth(
+    state: Arc<DiaporeiaState>,
+    mut req: Request<Body>,
+    next: Next,
+) -> Response<Body> {
+    if state.auth_mode == "none" {
+        let role = state.none_role.parse::<Role>().unwrap_or(Role::Readonly);
+        req.extensions_mut().insert(McpClaims {
+            sub: "anonymous".to_owned(),
+            role,
+            nous_id: None,
+        });
+        return next.run(req).await;
+    }
+
+    // Extract Bearer token from Authorization header.
+    let token = req
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix(BEARER_PREFIX));
+
+    let Some(token) = token else {
+        warn!("MCP request rejected: missing or malformed Authorization header");
+        return unauthorized();
+    };
+
+    // Validate via JwtManager. When auth_mode != "none" the jwt_manager is
+    // always Some (enforced at construction in server/mod.rs).
+    let Some(ref jwt) = state.jwt_manager else {
+        // Defensive: should never happen if construction is correct.
+        warn!("MCP request rejected: jwt_manager unavailable despite auth_mode != \"none\"");
+        return unauthorized();
+    };
+
+    match jwt.validate(token) {
+        Ok(claims) => {
+            req.extensions_mut().insert(McpClaims {
+                sub: claims.sub,
+                role: claims.role,
+                nous_id: claims.nous_id,
+            });
+            next.run(req).await
+        }
+        Err(_err) => {
+            warn!("MCP request rejected: invalid Bearer token");
+            unauthorized()
+        }
+    }
+}
+
+/// Build a 401 Unauthorized response with an empty body.
+#[expect(
+    clippy::expect_used,
+    reason = "static 401 response with empty body: infallible in practice"
+)]
+fn unauthorized() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::UNAUTHORIZED)
+        .body(Body::empty())
+        .expect("static 401 response must be valid")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mcp_claims_is_send_sync() {
+        static_assertions::assert_impl_all!(McpClaims: Send, Sync, Clone);
+    }
+}

--- a/crates/diaporeia/src/lib.rs
+++ b/crates/diaporeia/src/lib.rs
@@ -15,6 +15,8 @@
 //! - **Streamable HTTP**: Mounted into pylon's Axum router at `/mcp`.
 //! - **stdio**: For `aletheia mcp` subcommand (Claude Code / local agent).
 
+/// Bearer token authentication middleware for MCP transport.
+pub mod auth;
 /// Diaporeia-specific error types and result alias.
 pub mod error;
 pub(crate) mod rate_limit;

--- a/crates/diaporeia/src/state.rs
+++ b/crates/diaporeia/src/state.rs
@@ -12,6 +12,7 @@ use tokio_util::sync::CancellationToken;
 use aletheia_mneme::store::SessionStore;
 use aletheia_nous::manager::NousManager;
 use aletheia_organon::registry::ToolRegistry;
+use aletheia_symbolon::jwt::JwtManager;
 use aletheia_taxis::config::AletheiaConfig;
 use aletheia_taxis::oikos::Oikos;
 
@@ -28,10 +29,18 @@ pub struct DiaporeiaState {
     pub tool_registry: Arc<ToolRegistry>,
     /// Instance directory layout for file resolution.
     pub oikos: Arc<Oikos>,
+    /// JWT token validation (shared with pylon).
+    ///
+    /// `None` when `auth_mode == "none"` (no signing key available).
+    pub jwt_manager: Option<Arc<JwtManager>>,
     /// Server start instant for uptime calculation.
     pub start_time: Instant,
     /// Runtime configuration, updatable via config API.
     pub config: Arc<tokio::sync::RwLock<AletheiaConfig>>,
+    /// Auth mode from gateway config (`"token"`, `"none"`, etc.).
+    pub auth_mode: String,
+    /// Role assigned to anonymous requests when auth mode is `"none"`.
+    pub none_role: String,
     /// Root shutdown token.
     pub shutdown: CancellationToken,
 }

--- a/crates/diaporeia/src/transport.rs
+++ b/crates/diaporeia/src/transport.rs
@@ -2,10 +2,12 @@
 
 use std::sync::Arc;
 
+use axum::middleware;
 use rmcp::ServiceExt;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::streamable_http_server::tower::StreamableHttpService;
 
+use crate::auth;
 use crate::error::{self, Result};
 use crate::server::DiaporeiaServer;
 use crate::state::DiaporeiaState;
@@ -13,14 +15,21 @@ use crate::state::DiaporeiaState;
 /// Build an Axum Router that serves MCP over streamable HTTP.
 ///
 /// Mount this into the main application router to expose MCP at `/mcp`.
+/// The auth middleware validates Bearer JWT tokens (or passes through
+/// anonymous claims when `auth_mode == "none"`).
 pub fn streamable_http_router(state: Arc<DiaporeiaState>) -> axum::Router {
+    let auth_state = Arc::clone(&state);
     let service = StreamableHttpService::new(
         move || Ok(DiaporeiaServer::with_state(Arc::clone(&state))),
         LocalSessionManager::default().into(),
         rmcp::transport::streamable_http_server::StreamableHttpServerConfig::default(),
     );
 
-    axum::Router::new().nest_service("/mcp", service)
+    axum::Router::new()
+        .nest_service("/mcp", service)
+        .layer(middleware::from_fn(move |req, next| {
+            auth::mcp_auth(Arc::clone(&auth_state), req, next)
+        }))
 }
 
 /// Run MCP over stdio (blocking: intended for `aletheia mcp` subcommand).


### PR DESCRIPTION
## Summary

- Add `jwt_manager`, `auth_mode`, and `none_role` fields to `DiaporeiaState`
- Create `auth.rs` middleware that validates Bearer JWT on every `/mcp` request
- When `auth_mode == "none"`: pass through with anonymous claims (matching pylon)
- When auth is enabled: require valid Bearer token, return 401 otherwise
- Wire middleware as Axum layer wrapping the `StreamableHttpService`

Closes #2434

## Test plan

- [ ] `cargo check -p aletheia-diaporeia -p aletheia-pylon -p aletheia` passes
- [ ] `cargo test -p aletheia-diaporeia --lib auth` passes
- [ ] Start server with `auth.mode = "none"`, verify MCP requests work without token
- [ ] Start server with `auth.mode = "token"`, verify MCP requests without token return 401
- [ ] Start server with `auth.mode = "token"`, verify MCP requests with valid Bearer token succeed
- [ ] Per-tool RBAC is a follow-up (claims stored in extensions for downstream use)