### PR TITLE
fix(nous): separate background and pipeline panic counters

### DIFF
--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -12,7 +12,7 @@ use aletheia_mneme::store::SessionStore;
 
 use aletheia_hermeneus::provider::ProviderRegistry;
 
-use super::{MAX_SPAWNED_TASKS, NousActor};
+use super::{DEGRADED_WINDOW, MAX_SPAWNED_TASKS, NousActor};
 
 /// Drop guard that clears the distillation-in-progress flag on drop.
 /// Prevents the flag from being stuck if the background task panics.
@@ -34,20 +34,34 @@ impl NousActor {
                 Err(e) => {
                     if e.is_panic() {
                         // WHY: Background tasks run outside the main panic boundary.
-                        // Counting them ensures degraded mode triggers correctly if
-                        // background tasks are repeatedly panicking.
-                        self.record_panic();
-                        warn!(
-                            nous_id = %self.id,
-                            panic_count = self.runtime.panic_count,
-                            "background task panicked"
-                        );
+                        // They are logged but do NOT trigger degraded mode.
+                        self.record_background_panic();
                     } else {
                         warn!(nous_id = %self.id, error = %e, "background task failed");
                     }
                 }
             }
         }
+    }
+
+    /// Record a background task panic occurrence. Logs a warning but does NOT trigger degraded mode.
+    pub(super) fn record_background_panic(&mut self) {
+        self.runtime.background_panic_count += 1;
+        let now = std::time::Instant::now();
+        self.runtime.background_panic_timestamps.push(now);
+
+        // Clean up old timestamps outside the window (for accurate logging/monitoring)
+        let cutoff = std::time::Instant::now()
+            .checked_sub(DEGRADED_WINDOW)
+            .unwrap_or(self.runtime.started_at);
+        self.runtime.background_panic_timestamps.retain(|t| *t > cutoff);
+
+        warn!(
+            nous_id = %self.id,
+            background_panic_count = self.runtime.background_panic_count,
+            recent_background_panics = self.runtime.background_panic_timestamps.len(),
+            "background task panicked"
+        );
     }
 
     pub(super) fn maybe_spawn_extraction(&mut self, user_content: &str, assistant_content: &str) {

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -103,13 +103,17 @@ pub(crate) struct ActorRuntime {
     /// WHY: Background distillation is async; a second turn can finish while the
     /// first turn's distillation task is still running, triggering a duplicate.
     distillation_in_progress: Arc<AtomicBool>,
-    /// Number of panics caught by the panic boundary since start.
-    panic_count: u32,
-    /// Timestamps of recent panics for degraded-mode window calculation.
-    panic_timestamps: Vec<Instant>,
+    /// Number of pipeline panics caught by the panic boundary since start.
+    pipeline_panic_count: u32,
+    /// Timestamps of recent pipeline panics for degraded-mode window calculation.
+    pipeline_panic_timestamps: Vec<Instant>,
+    /// Number of background task panics since start.
+    background_panic_count: u32,
+    /// Timestamps of recent background task panics (for logging/monitoring only).
+    background_panic_timestamps: Vec<Instant>,
     /// When the actor started running.
     started_at: Instant,
-    /// Timestamp of the most recent panic, used for auto-recovery from degraded mode.
+    /// Timestamp of the most recent pipeline panic, used for auto-recovery from degraded mode.
     last_panic_at: Option<Instant>,
     /// Consecutive inbox recv timeouts without a successful message. (#2159)
     consecutive_timeouts: u32,
@@ -205,8 +209,10 @@ impl NousActor {
                 background_tasks: JoinSet::new(),
                 active_turn,
                 distillation_in_progress: Arc::new(AtomicBool::new(false)),
-                panic_count: 0,
-                panic_timestamps: Vec::new(),
+                pipeline_panic_count: 0,
+                pipeline_panic_timestamps: Vec::new(),
+                background_panic_count: 0,
+                background_panic_timestamps: Vec::new(),
                 started_at: Instant::now(),
                 last_panic_at: None,
                 consecutive_timeouts: 0,
@@ -283,7 +289,7 @@ impl NousActor {
                             if self.channel.status == NousLifecycle::Degraded {
                                 let _ = reply.send(Err(crate::error::ServiceDegradedSnafu {
                                     nous_id: self.id.clone(),
-                                    panic_count: self.runtime.panic_count,
+                                    panic_count: self.runtime.pipeline_panic_count,
                                 }.build()));
                             } else {
                                 self.handle_turn(session_key, session_id, content, span, reply).await;
@@ -300,7 +306,7 @@ impl NousActor {
                             if self.channel.status == NousLifecycle::Degraded {
                                 let _ = reply.send(Err(crate::error::ServiceDegradedSnafu {
                                     nous_id: self.id.clone(),
-                                    panic_count: self.runtime.panic_count,
+                                    panic_count: self.runtime.pipeline_panic_count,
                                 }.build()));
                                 drop(stream_tx);
                             } else {
@@ -357,7 +363,7 @@ impl NousActor {
 
         while self.runtime.background_tasks.join_next().await.is_some() {}
 
-        info!(lifecycle = %self.channel.status, panic_count = self.runtime.panic_count, "actor stopped");
+        info!(lifecycle = %self.channel.status, panic_count = self.runtime.pipeline_panic_count, "actor stopped");
     }
 
     /// # Cancel safety
@@ -390,7 +396,7 @@ impl NousActor {
             lifecycle: self.channel.status,
             session_count: self.sessions.len(),
             active_session: self.active_session.clone(),
-            panic_count: self.runtime.panic_count,
+            panic_count: self.runtime.pipeline_panic_count,
             uptime: self.runtime.started_at.elapsed(),
         };
         let _ = reply.send(status);
@@ -441,12 +447,12 @@ impl NousActor {
         if last_panic.elapsed() >= DEGRADED_WINDOW {
             info!(
                 nous_id = %self.id,
-                panic_count = self.runtime.panic_count,
+                panic_count = self.runtime.pipeline_panic_count,
                 elapsed_secs = last_panic.elapsed().as_secs(),
                 "auto-recovering from degraded mode: no panics in recovery window"
             );
-            self.runtime.panic_count = 0;
-            self.runtime.panic_timestamps.clear();
+            self.runtime.pipeline_panic_count = 0;
+            self.runtime.pipeline_panic_timestamps.clear();
             self.runtime.last_panic_at = None;
             self.channel.status = NousLifecycle::Idle;
         }
@@ -460,11 +466,11 @@ impl NousActor {
         }
         info!(
             nous_id = %self.id,
-            panic_count = self.runtime.panic_count,
+            panic_count = self.runtime.pipeline_panic_count,
             "manual recovery from degraded mode"
         );
-        self.runtime.panic_count = 0;
-        self.runtime.panic_timestamps.clear();
+        self.runtime.pipeline_panic_count = 0;
+        self.runtime.pipeline_panic_timestamps.clear();
         self.runtime.last_panic_at = None;
         self.channel.status = NousLifecycle::Idle;
         true

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -349,7 +349,7 @@ impl NousActor {
         match result {
             Ok(inner) => inner,
             Err(join_error) => {
-                self.record_panic();
+                self.record_pipeline_panic();
 
                 let panic_msg = if join_error.is_panic() {
                     let panic_payload = join_error.into_panic();
@@ -367,7 +367,7 @@ impl NousActor {
                 error!(
                     nous_id = %self.id,
                     session_key = %session_key,
-                    panic_count = self.runtime.panic_count,
+                    panic_count = self.runtime.pipeline_panic_count,
                     message = %panic_msg,
                     "pipeline panicked — actor continues"
                 );
@@ -381,27 +381,27 @@ impl NousActor {
         }
     }
 
-    /// Record a panic occurrence. Enters degraded mode if too many panics in the window.
-    pub(super) fn record_panic(&mut self) {
-        self.runtime.panic_count += 1;
+    /// Record a pipeline panic occurrence. Enters degraded mode if too many panics in the window.
+    pub(super) fn record_pipeline_panic(&mut self) {
+        self.runtime.pipeline_panic_count += 1;
         let now = std::time::Instant::now();
-        self.runtime.panic_timestamps.push(now);
+        self.runtime.pipeline_panic_timestamps.push(now);
         self.runtime.last_panic_at = Some(now);
 
         let cutoff = std::time::Instant::now()
             .checked_sub(DEGRADED_WINDOW)
             .unwrap_or(self.runtime.started_at);
-        self.runtime.panic_timestamps.retain(|t| *t > cutoff);
+        self.runtime.pipeline_panic_timestamps.retain(|t| *t > cutoff);
 
         #[expect(
             clippy::as_conversions,
             reason = "u32→usize: DEGRADED_PANIC_THRESHOLD is a small constant, fits in usize"
         )]
-        if self.runtime.panic_timestamps.len() >= DEGRADED_PANIC_THRESHOLD as usize {
+        if self.runtime.pipeline_panic_timestamps.len() >= DEGRADED_PANIC_THRESHOLD as usize {
             warn!(
                 nous_id = %self.id,
-                panic_count = self.runtime.panic_count,
-                recent_panics = self.runtime.panic_timestamps.len(),
+                panic_count = self.runtime.pipeline_panic_count,
+                recent_panics = self.runtime.pipeline_panic_timestamps.len(),
                 "entering degraded mode — too many panics in window"
             );
             self.channel.status = NousLifecycle::Degraded;


### PR DESCRIPTION
## Summary
- Split `panic_count`/`panic_timestamps` into pipeline and background variants
- `record_pipeline_panic()` triggers degraded mode (existing behavior, renamed)
- `record_background_panic()` logs warning only, does not degrade agent
- All references to `panic_count` in status, recovery, and degraded-mode logic updated

Replaces #2483 (had merge conflicts from as-cast restoration). Closes #2445.