### PR TITLE
refactor: deduplicate install_crypto_provider test helper

### DIFF
--- a/crates/agora/Cargo.toml
+++ b/crates/agora/Cargo.toml
@@ -29,7 +29,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-rustls = { workspace = true }
+aletheia-organon = { path = "../organon", features = ["test-support"] }
 static_assertions = { workspace = true }
 tokio = { workspace = true }
 wiremock = { workspace = true }

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -302,11 +302,9 @@ fn normalize_url(url: &str) -> String {
     reason = "test: JSON key indexing on known-present keys"
 )]
 mod tests {
-    use super::*;
+    use aletheia_organon::testing::install_crypto_provider;
 
-    fn install_crypto_provider() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    }
+    use super::*;
 
     #[test]
     fn url_normalization() {

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -501,13 +501,10 @@ async fn poll_loop(
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
+    use aletheia_organon::testing::install_crypto_provider;
     use tracing::Instrument;
 
     use super::*;
-
-    fn install_crypto_provider() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    }
 
     #[test]
     fn parse_target_phone() {

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -28,6 +28,6 @@ owo-colors = "4"
 supports-color = "3"
 
 [dev-dependencies]
-rustls = { workspace = true }
+aletheia-organon = { path = "../organon", features = ["test-support"] }
 wiremock = { workspace = true }
 static_assertions = { workspace = true }

--- a/crates/eval/src/client.rs
+++ b/crates/eval/src/client.rs
@@ -415,11 +415,9 @@ pub struct KnowledgeFact {
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
-    use super::*;
+    use aletheia_organon::testing::install_crypto_provider;
 
-    fn install_crypto_provider() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    }
+    use super::*;
 
     #[test]
     fn url_construction_trims_trailing_slash() {

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -33,7 +33,6 @@ aletheia-symbolon = { path = "../symbolon" }
 jiff = { workspace = true }
 axum = { workspace = true }
 reqwest = { workspace = true }
-rustls = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -19,15 +19,12 @@ use aletheia_mneme::store::SessionStore;
 use aletheia_nous::config::{NousConfig, PipelineConfig};
 use aletheia_nous::manager::NousManager;
 use aletheia_organon::registry::ToolRegistry;
+use aletheia_organon::testing::install_crypto_provider;
 use aletheia_pylon::router::build_router;
 use aletheia_pylon::state::AppState;
 use aletheia_symbolon::jwt::{JwtConfig, JwtManager};
 use aletheia_symbolon::types::Role;
 use aletheia_taxis::oikos::Oikos;
-
-fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
 
 async fn start_test_server() -> (String, String, tempfile::TempDir) {
     install_crypto_provider();

--- a/crates/integration-tests/tests/organon_mneme_tools.rs
+++ b/crates/integration-tests/tests/organon_mneme_tools.rs
@@ -32,14 +32,11 @@ use aletheia_nous::adapters::{SessionBlackboardAdapter, SessionNoteAdapter};
 use aletheia_organon::builtins;
 use aletheia_organon::error::KnowledgeAdapterError;
 use aletheia_organon::registry::ToolRegistry;
+use aletheia_organon::testing::install_crypto_provider;
 use aletheia_organon::types::{
     FactSummary, KnowledgeSearchService, MemoryResult, ServerToolConfig, ToolContext, ToolInput,
     ToolServices,
 };
-
-fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -18,7 +18,7 @@ computer-use = []
 # mathesis, prographe, schedion, metron). Wires to real energeia subsystem.
 energeia = ["dep:aletheia-energeia"]
 # Gates MockToolExecutor, ToolExecutorSpec, and other test helpers. No test code in release binaries.
-test-support = ["aletheia-hermeneus/test-support"]
+test-support = ["aletheia-hermeneus/test-support", "dep:rustls"]
 test-core = []
 test-full = []
 
@@ -43,6 +43,10 @@ tracing = { workspace = true }
 landlock = "0.4"
 rustix = { workspace = true, features = ["process", "thread"] }
 seccompiler = "0.5"
+
+[dependencies.rustls]
+workspace = true
+optional = true
 
 [dev-dependencies]
 aletheia-energeia = { path = "../energeia", features = ["storage-fjall"] }

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -297,14 +297,11 @@ mod tests {
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
     use crate::registry::ToolRegistry;
+    use crate::testing::install_crypto_provider;
     use crate::types::{
         ServerToolConfig, SpawnRequest, SpawnResult, SpawnService, ToolContext, ToolInput,
         ToolServices,
     };
-
-    fn install_crypto_provider() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    }
 
     fn mock_ctx() -> ToolContext {
         ToolContext {

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -309,13 +309,10 @@ mod tests {
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
     use crate::registry::ToolRegistry;
+    use crate::testing::install_crypto_provider;
     use crate::types::{
         CrossNousService, MessageService, ServerToolConfig, ToolContext, ToolInput, ToolServices,
     };
-
-    fn install_crypto_provider() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    }
 
     fn mock_ctx() -> ToolContext {
         ToolContext {

--- a/crates/organon/src/builtins/enable_tool.rs
+++ b/crates/organon/src/builtins/enable_tool.rs
@@ -117,13 +117,10 @@ mod tests {
 
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
+    use crate::testing::install_crypto_provider;
     use crate::types::{ServerToolConfig, ToolContext, ToolInput, ToolServices};
 
     use super::*;
-
-    fn install_crypto_provider() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    }
 
     fn mock_ctx_with_catalog(catalog: Vec<(ToolName, String)>) -> ToolContext {
         install_crypto_provider();

--- a/crates/organon/src/builtins/memory/tests.rs
+++ b/crates/organon/src/builtins/memory/tests.rs
@@ -16,10 +16,7 @@ use crate::types::{
 };
 
 use crate::error::StoreError;
-
-fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
+use crate::testing::install_crypto_provider;
 
 struct MockNoteStore {
     notes: Mutex<Vec<NoteEntry>>,

--- a/crates/organon/src/builtins/planning_tests_mock.rs
+++ b/crates/organon/src/builtins/planning_tests_mock.rs
@@ -8,11 +8,8 @@ use std::sync::{Arc, Mutex, RwLock};
 use aletheia_koina::id::{NousId, SessionId};
 
 use crate::error::PlanningAdapterError;
+use crate::testing::install_crypto_provider;
 use crate::types::{PlanningService, ServerToolConfig, ToolContext, ToolServices};
-
-pub(super) fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
 
 pub(super) fn test_ctx() -> ToolContext {
     ToolContext {

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -374,13 +374,10 @@ mod tests {
 
     use aletheia_koina::id::{NousId, SessionId, ToolName};
 
+    use crate::testing::install_crypto_provider;
     use crate::types::{ServerToolConfig, ToolContext, ToolInput, ToolServices};
 
     use super::*;
-
-    fn install_crypto_provider() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    }
 
     fn mock_ctx() -> ToolContext {
         install_crypto_provider();

--- a/crates/organon/src/builtins/triage/triage_tests.rs
+++ b/crates/organon/src/builtins/triage/triage_tests.rs
@@ -8,10 +8,11 @@ use std::sync::{Arc, RwLock};
 use aletheia_koina::id::{NousId, SessionId, ToolName};
 
 use super::*;
+use crate::testing::install_crypto_provider;
 use crate::types::{ServerToolConfig, ToolContext, ToolInput, ToolServices};
 
 fn test_ctx() -> ToolContext {
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    install_crypto_provider();
     ToolContext {
         nous_id: NousId::new("test-agent").expect("valid"),
         session_id: SessionId::new(),

--- a/crates/organon/src/testing.rs
+++ b/crates/organon/src/testing.rs
@@ -26,6 +26,28 @@ use crate::error::Result;
 use crate::registry::ToolExecutor;
 use crate::types::{ToolContext, ToolInput, ToolResult};
 
+// ── Crypto provider helper ───────────────────────────────────────────────────
+
+/// Install the default rustls crypto provider for tests.
+///
+/// Safe to call multiple times (uses `try_install_default`). This helper prevents
+/// the "no crypto provider installed" panic when tests use TLS connections.
+///
+/// # Example
+///
+/// ```ignore
+/// use aletheia_organon::testing::install_crypto_provider;
+///
+/// #[test]
+/// fn test_with_tls() {
+///     install_crypto_provider();
+///     // ... test code that uses TLS
+/// }
+/// ```
+pub fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 // ── Mock executor ────────────────────────────────────────────────────────────
 
 /// Configurable mock [`ToolExecutor`] for use in tests.


### PR DESCRIPTION
## Summary
- Consolidate 8 duplicate `install_crypto_provider()` into `organon::testing`
- Gate behind `test-support` feature to keep test code out of release binaries
- Update agora, eval, integration-tests to import from shared location

Partial fix for #2420 — crypto provider dedup done. mock_ctx consolidation can follow.