### PR TITLE
refactor: replace ring with RustCrypto for direct crypto operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -85,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -106,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -121,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -145,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -164,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "jiff",
  "serde",
@@ -174,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-energeia"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -197,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -228,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -249,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -258,10 +293,10 @@ dependencies = [
  "rand 0.9.2",
  "regex",
  "reqwest 0.13.2",
- "ring",
  "rustls",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "snafu",
  "static_assertions",
  "tokio",
@@ -273,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -299,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "compact_str",
  "jiff",
@@ -320,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -364,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -383,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -398,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -427,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -452,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-energeia",
  "aletheia-hermeneus",
@@ -481,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -515,21 +550,23 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
+ "aes-gcm",
  "aletheia-koina",
  "argon2",
  "base64 0.22.1",
  "blake3",
+ "hmac",
  "keyring",
  "prometheus",
  "rand 0.9.2",
  "reqwest 0.13.2",
- "ring",
  "rusqlite",
  "rustix 1.1.4",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "snafu",
  "static_assertions",
  "tempfile",
@@ -542,14 +579,14 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
+ "chacha20poly1305",
  "figment",
  "proptest",
  "rand 0.9.2",
- "ring",
  "serde",
  "serde_json",
  "snafu",
@@ -560,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -1260,6 +1297,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -1267,6 +1315,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1281,6 +1342,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1659,6 +1731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1679,6 +1752,15 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -2644,6 +2726,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,6 +2859,15 @@ dependencies = [
  "thiserror 2.0.18",
  "ureq",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3165,6 +3266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -4035,6 +4145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,6 +4439,29 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4767,7 +4906,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -6095,7 +6234,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6114,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.53"
+version = "0.13.58"
 dependencies = [
  "aletheia-koina",
  "arboard",
@@ -6791,6 +6930,16 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,8 +155,14 @@ tokio-util = { version = "0.7", features = ["rt"] }
 flate2 = "1"
 
 # TLS / Security
-ring = "0.17"
+# ring remains as transitive via rustls; direct usage replaced by RustCrypto crates
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
+
+# Cryptography (RustCrypto)
+hmac = "0.12"
+sha2 = "0.10"
+aes-gcm = "0.10"
+chacha20poly1305 = "0.10"
 rcgen = "0.14"
 regex = "1"
 

--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -17,7 +17,7 @@ prometheus = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
-ring = { workspace = true }
+sha2 = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hermeneus/src/anthropic/cc_profile.rs
+++ b/crates/hermeneus/src/anthropic/cc_profile.rs
@@ -102,7 +102,7 @@ impl CcProfile {
 ///
 /// Public for unit testing.
 pub(crate) fn compute_fingerprint(first_message_text: &str, version: &str) -> String {
-    use ring::digest;
+    use sha2::{Digest, Sha256};
 
     let chars: Vec<char> = first_message_text.chars().collect();
     let indices = [4, 7, 20];
@@ -112,10 +112,10 @@ pub(crate) fn compute_fingerprint(first_message_text: &str, version: &str) -> St
         .collect();
 
     let input = format!("{FINGERPRINT_SALT}{extracted}{version}");
-    let hash = digest::digest(&digest::SHA256, input.as_bytes());
+    let hash = Sha256::digest(input.as_bytes());
     // First 3 hex chars: take 2 bytes (= 4 hex chars), then slice to 3.
     // All chars are ASCII hex digits so the byte slice is always valid UTF-8.
-    let hex: String = hash.as_ref().iter().take(2).flat_map(|b| {
+    let hex: String = hash.iter().take(2).flat_map(|b| {
         let hi = char::from_digit(u32::from(b >> 4), 16).unwrap_or('0');
         let lo = char::from_digit(u32::from(b & 0xf), 16).unwrap_or('0');
         [hi, lo]

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -24,7 +24,9 @@ base64 = { workspace = true }
 blake3 = "1"
 prometheus = { workspace = true }
 rand = { workspace = true }
-ring = { workspace = true }
+hmac = { workspace = true }
+sha2 = { workspace = true }
+aes-gcm = { workspace = true }
 reqwest = { workspace = true }
 rustix = { workspace = true }
 rusqlite = { workspace = true }

--- a/crates/symbolon/src/encrypt.rs
+++ b/crates/symbolon/src/encrypt.rs
@@ -12,39 +12,20 @@
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
+use aes_gcm::aead::generic_array::GenericArray;
+use aes_gcm::aead::{Aead, AeadCore, OsRng};
+use aes_gcm::{Aes256Gcm, KeyInit};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use ring::aead::{
-    AES_256_GCM, Aad, BoundKey, NONCE_LEN as RING_NONCE_LEN, Nonce, NonceSequence, SealingKey,
-    UnboundKey,
-};
 
 /// Magic prefix that marks an encrypted credential file.
 pub(crate) const ENCRYPTED_SENTINEL: &str = "ALETHEIA_ENC_V1:";
 
 /// AES-256-GCM nonce length (96 bits / 12 bytes per NIST recommendation).
 const NONCE_LEN: usize = 12;
-// Compile-time assertion: our constant must match ring's.
-const _: () = assert!(NONCE_LEN == RING_NONCE_LEN, "NONCE_LEN must match ring");
 
 /// AES-256-GCM key length (256 bits / 32 bytes).
 const KEY_LEN: usize = 32;
-
-/// A [`NonceSequence`] that yields a single nonce and then errors.
-///
-/// AES-GCM with a random nonce is IND-CPA secure when the nonce is never
-/// reused. This type encodes "use once" at the type level: advancing it a
-/// second time returns `Unspecified`, which causes `SealingKey::seal` to fail.
-struct OnceThenError(Option<[u8; RING_NONCE_LEN]>);
-
-impl NonceSequence for OnceThenError {
-    fn advance(&mut self) -> Result<Nonce, ring::error::Unspecified> {
-        self.0
-            .take()
-            .map(Nonce::assume_unique_for_key)
-            .ok_or(ring::error::Unspecified)
-    }
-}
 
 /// Derive the key-file path from the credential file path.
 ///
@@ -158,27 +139,19 @@ pub(crate) fn commit_key_file(credential_path: &Path, tmp: &Path) -> std::io::Re
 ///
 /// # Errors
 ///
-/// Returns an `io::Error` if the RNG or the AEAD primitive fails.
+/// Returns an `io::Error` if the AEAD primitive fails.
 pub(crate) fn encrypt(key: &[u8; KEY_LEN], plaintext: &[u8]) -> std::io::Result<String> {
-    let nonce_bytes: [u8; NONCE_LEN] = generate_nonce()?;
+    let cipher = Aes256Gcm::new(GenericArray::from_slice(key));
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
 
-    let unbound = UnboundKey::new(&AES_256_GCM, key)
-        .map_err(|_ignored| std::io::Error::other("AES-256-GCM: invalid key length"))?;
-
-    let mut sealing_key: SealingKey<OnceThenError> =
-        SealingKey::new(unbound, OnceThenError(Some(nonce_bytes)));
-
-    let mut in_out = plaintext.to_vec();
-    sealing_key
-        .seal_in_place_append_tag(Aad::empty(), &mut in_out)
-        .map_err(|_ignored| {
-            std::io::Error::other("AES-256-GCM: seal_in_place_append_tag failed")
-        })?;
+    let ciphertext_with_tag = cipher
+        .encrypt(&nonce, plaintext)
+        .map_err(|_ignored| std::io::Error::other("AES-256-GCM: encryption failed"))?;
 
     // Prepend nonce so the decryptor can recover it.
-    let mut combined = Vec::with_capacity(NONCE_LEN + in_out.len());
-    combined.extend_from_slice(&nonce_bytes);
-    combined.extend_from_slice(&in_out);
+    let mut combined = Vec::with_capacity(NONCE_LEN + ciphertext_with_tag.len());
+    combined.extend_from_slice(&nonce);
+    combined.extend_from_slice(&ciphertext_with_tag);
 
     Ok(BASE64.encode(&combined))
 }
@@ -189,8 +162,6 @@ pub(crate) fn encrypt(key: &[u8; KEY_LEN], plaintext: &[u8]) -> std::io::Result<
 ///
 /// Returns an `io::Error` if base64 decoding or AES-GCM authentication fails.
 pub(crate) fn decrypt(key: &[u8; KEY_LEN], encoded: &str) -> std::io::Result<Vec<u8>> {
-    use ring::aead::{LessSafeKey, Nonce as AeadNonce, UnboundKey as AeadUnbound};
-
     let combined = BASE64.decode(encoded).map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
@@ -206,21 +177,12 @@ pub(crate) fn decrypt(key: &[u8; KEY_LEN], encoded: &str) -> std::io::Result<Vec
     }
 
     let (nonce_bytes, ciphertext_with_tag) = combined.split_at(NONCE_LEN);
-    let nonce_arr: [u8; NONCE_LEN] = nonce_bytes.try_into().map_err(|_ignored| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "nonce slice has wrong length",
-        )
-    })?;
 
-    let unbound = AeadUnbound::new(&AES_256_GCM, key)
-        .map_err(|_ignored| std::io::Error::other("AES-256-GCM: invalid key length"))?;
-    let opening_key = LessSafeKey::new(unbound);
-    let nonce = AeadNonce::assume_unique_for_key(nonce_arr);
+    let cipher = Aes256Gcm::new(GenericArray::from_slice(key));
+    let nonce = GenericArray::from_slice(nonce_bytes);
 
-    let mut buf = ciphertext_with_tag.to_vec();
-    let plaintext = opening_key
-        .open_in_place(nonce, Aad::empty(), &mut buf)
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext_with_tag)
         .map_err(|_ignored| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -228,35 +190,14 @@ pub(crate) fn decrypt(key: &[u8; KEY_LEN], encoded: &str) -> std::io::Result<Vec
             )
         })?;
 
-    Ok(plaintext.to_vec())
+    Ok(plaintext)
 }
 
 /// Generate a fresh random 32-byte AES-256-GCM key using the system CSPRNG.
-///
-/// # Errors
-///
-/// Returns an `io::Error` if the system random source is unavailable.
 fn generate_key() -> std::io::Result<[u8; KEY_LEN]> {
-    let random = ring::rand::SystemRandom::new();
     let mut key = [0u8; KEY_LEN];
-    ring::rand::SecureRandom::fill(&random, &mut key).map_err(|_ignored| {
-        std::io::Error::other("system RNG unavailable (cannot generate encryption key)")
-    })?;
+    rand::fill(&mut key);
     Ok(key)
-}
-
-/// Generate a fresh 12-byte nonce using the system CSPRNG.
-///
-/// # Errors
-///
-/// Returns an `io::Error` if the system random source is unavailable.
-fn generate_nonce() -> std::io::Result<[u8; NONCE_LEN]> {
-    let random = ring::rand::SystemRandom::new();
-    let mut buf = [0u8; NONCE_LEN];
-    ring::rand::SecureRandom::fill(&random, &mut buf).map_err(|_ignored| {
-        std::io::Error::other("system RNG unavailable (cannot generate nonce)")
-    })?;
-    Ok(buf)
 }
 
 /// Write the encryption key to disk with restrictive permissions.

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -1,20 +1,23 @@
 //! HS256 JWT token issuance and validation.
 //!
-//! Owned implementation using `ring::hmac` for HMAC-SHA256 signing.
-//! Replaces the `jsonwebtoken` crate to eliminate its CVE-flagged transitive
-//! dependencies and `rand` version duplication.
+//! Owned implementation using `hmac` + `sha2` (RustCrypto) for HMAC-SHA256
+//! signing. Replaces the `jsonwebtoken` crate to eliminate its CVE-flagged
+//! transitive dependencies and `rand` version duplication.
 
 use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use ring::hmac;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 use tracing::instrument;
 
 use aletheia_koina::secret::SecretString;
 
 use crate::error::{self, Result};
 use crate::types::{Claims, Role, TokenKind, TokenPair};
+
+type HmacSha256 = Hmac<Sha256>;
 
 /// Base64url-encoded HS256 JWT header (constant, never changes).
 const HS256_HEADER_B64: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
@@ -91,7 +94,8 @@ impl JwtConfig {
 
 /// Manages JWT issuance and validation.
 pub struct JwtManager {
-    signing_key: hmac::Key,
+    /// Raw secret bytes for HMAC-SHA256 signing.
+    signing_key_bytes: Vec<u8>,
     config: JwtConfig,
 }
 
@@ -99,12 +103,9 @@ impl JwtManager {
     /// Create a new JWT manager from the given config.
     #[must_use]
     pub fn new(config: JwtConfig) -> Self {
-        let signing_key = hmac::Key::new(
-            hmac::HMAC_SHA256,
-            config.signing_key.expose_secret().as_bytes(),
-        );
+        let signing_key_bytes = config.signing_key.expose_secret().as_bytes().to_vec();
         Self {
-            signing_key,
+            signing_key_bytes,
             config,
         }
     }
@@ -156,7 +157,14 @@ impl JwtManager {
             .build()
         })?;
 
-        hmac::verify(&self.signing_key, header_payload.as_bytes(), &sig_bytes).map_err(|_err| {
+        let mut mac = HmacSha256::new_from_slice(&self.signing_key_bytes).map_err(|_err| {
+            error::TokenDecodeSnafu {
+                message: "HMAC key initialization failed".to_owned(),
+            }
+            .build()
+        })?;
+        mac.update(header_payload.as_bytes());
+        mac.verify_slice(&sig_bytes).map_err(|_err| {
             error::TokenDecodeSnafu {
                 message: "signature verification failed".to_owned(),
             }
@@ -252,8 +260,17 @@ impl JwtManager {
         })?;
         let payload_b64 = URL_SAFE_NO_PAD.encode(&payload_json);
         let signing_input = format!("{HS256_HEADER_B64}.{payload_b64}");
-        let tag = hmac::sign(&self.signing_key, signing_input.as_bytes());
-        let signature = URL_SAFE_NO_PAD.encode(tag.as_ref());
+        // WHY: new_from_slice only fails if the key length is incompatible with
+        // the hash block size, which cannot happen for HMAC-SHA256 (any length accepted).
+        let mut mac = HmacSha256::new_from_slice(&self.signing_key_bytes).map_err(|e| {
+            error::TokenEncodeSnafu {
+                message: format!("HMAC key initialization failed: {e}"),
+            }
+            .build()
+        })?;
+        mac.update(signing_input.as_bytes());
+        let tag = mac.finalize().into_bytes();
+        let signature = URL_SAFE_NO_PAD.encode(&tag);
 
         Ok(format!("{signing_input}.{signature}"))
     }

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -19,7 +19,7 @@ aletheia-koina = { path = "../koina" }
 base64 = { workspace = true }
 figment = { workspace = true }
 rand = { workspace = true }
-ring = { workspace = true }
+chacha20poly1305 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -9,8 +9,9 @@
 use std::path::{Path, PathBuf};
 
 use base64::Engine as _;
-use ring::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, NONCE_LEN, Nonce, UnboundKey};
-use ring::rand::{SecureRandom, SystemRandom};
+use chacha20poly1305::aead::generic_array::GenericArray;
+use chacha20poly1305::aead::{Aead, AeadCore, OsRng};
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit};
 use snafu::ResultExt;
 use tracing::warn;
 
@@ -21,6 +22,9 @@ pub(crate) const ENCRYPTED_PREFIX: &str = "enc:";
 
 /// Length of the ChaCha20-Poly1305 key in bytes.
 const KEY_LEN: usize = 32;
+
+/// ChaCha20-Poly1305 nonce length (96 bits / 12 bytes).
+const NONCE_LEN: usize = 12;
 
 /// Default path for the primary key file.
 fn default_key_path() -> Option<PathBuf> {
@@ -168,15 +172,8 @@ pub fn generate_primary_key(path: &Path) -> Result<()> {
         .build());
     }
 
-    let rng = SystemRandom::new();
     let mut key = [0u8; KEY_LEN];
-    // WHY: ring::error::Unspecified has no useful fields to propagate
-    rng.fill(&mut key).map_err(|_unspecified| {
-        error::EncryptSnafu {
-            reason: "failed to generate random key".to_owned(),
-        }
-        .build()
-    })?;
+    rand::fill(&mut key);
 
     let hex = to_hex(&key);
     aletheia_koina::fs::write_restricted(path, hex.as_bytes()).context(
@@ -211,26 +208,18 @@ pub(crate) fn is_encrypted(value: &str) -> bool {
     reason = "kanon lint requires explicit #[must_use] on pub fns returning Result"
 )]
 pub(crate) fn encrypt_value(plaintext: &str, primary_key: &[u8; KEY_LEN]) -> Result<String> {
-    // WHY: ring::error::Unspecified has no useful fields to propagate
-    let unbound = UnboundKey::new(&CHACHA20_POLY1305, primary_key)
-        .map_err(|_unspecified| build_encrypt_error())?;
-    let key = LessSafeKey::new(unbound);
+    let cipher =
+        ChaCha20Poly1305::new(GenericArray::from_slice(primary_key));
+    let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
 
-    let rng = SystemRandom::new();
-    let mut nonce_bytes = [0u8; NONCE_LEN];
-    rng.fill(&mut nonce_bytes)
-        .map_err(|_unspecified| build_encrypt_error())?;
-
-    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
-
-    let mut in_out = plaintext.as_bytes().to_vec();
-    key.seal_in_place_append_tag(nonce, Aad::empty(), &mut in_out)
-        .map_err(|_unspecified| build_encrypt_error())?;
+    let ciphertext_with_tag = cipher
+        .encrypt(&nonce, plaintext.as_bytes())
+        .map_err(|_aead_err| build_encrypt_error())?;
 
     // NOTE: nonce || ciphertext+tag
-    let mut payload = Vec::with_capacity(NONCE_LEN + in_out.len());
-    payload.extend_from_slice(&nonce_bytes);
-    payload.extend_from_slice(&in_out);
+    let mut payload = Vec::with_capacity(NONCE_LEN + ciphertext_with_tag.len());
+    payload.extend_from_slice(&nonce);
+    payload.extend_from_slice(&ciphertext_with_tag);
 
     let encoded = base64::engine::general_purpose::STANDARD.encode(&payload);
     Ok(format!("{ENCRYPTED_PREFIX}{encoded}"))
@@ -260,27 +249,25 @@ pub(crate) fn decrypt_value(encrypted: &str, primary_key: &[u8; KEY_LEN]) -> Res
         .decode(encoded)
         .map_err(|_decode_err| build_decrypt_error("invalid base64"))?;
 
-    if payload.len() < NONCE_LEN + CHACHA20_POLY1305.tag_len() {
+    // ChaCha20-Poly1305 tag is 16 bytes
+    const TAG_LEN: usize = 16;
+    if payload.len() < NONCE_LEN + TAG_LEN {
         return Err(build_decrypt_error("ciphertext too short"));
     }
 
     let (nonce_bytes, ciphertext) = payload.split_at(NONCE_LEN);
-    // WHY: ring::error::Unspecified has no useful fields to propagate
-    let nonce = Nonce::try_assume_unique_for_key(nonce_bytes)
-        .map_err(|_unspecified| build_decrypt_error("invalid nonce"))?;
 
-    let unbound = UnboundKey::new(&CHACHA20_POLY1305, primary_key)
-        .map_err(|_unspecified| build_decrypt_error("invalid key"))?;
-    let key = LessSafeKey::new(unbound);
+    let cipher =
+        ChaCha20Poly1305::new(GenericArray::from_slice(primary_key));
+    let nonce = GenericArray::from_slice(nonce_bytes);
 
-    let mut in_out = ciphertext.to_vec();
-    let plaintext = key
-        .open_in_place(nonce, Aad::empty(), &mut in_out)
-        .map_err(|_unspecified| {
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_aead_err| {
             build_decrypt_error("decryption failed (wrong key or corrupted data)")
         })?;
 
-    String::from_utf8(plaintext.to_vec())
+    String::from_utf8(plaintext)
         .map_err(|_utf8_err| build_decrypt_error("decrypted value is not valid UTF-8"))
 }
 


### PR DESCRIPTION
Closes #2288. Eliminates direct ring dependency from symbolon, taxis, hermeneus. ring remains as transitive via rustls. Wire format unchanged — existing encrypted credentials work without migration.

## Summary

- **symbolon/jwt.rs**: `ring::hmac` replaced with `hmac` + `sha2` (RustCrypto `HmacSha256`)
- **symbolon/encrypt.rs**: `ring::aead` AES-256-GCM replaced with `aes-gcm` crate; `ring::rand::SystemRandom` replaced with `rand::fill` and `aes_gcm::aead::OsRng`
- **taxis/encrypt.rs**: `ring::aead` ChaCha20-Poly1305 replaced with `chacha20poly1305` crate; `ring::rand::SystemRandom` replaced with `rand::fill` and `chacha20poly1305::aead::OsRng`
- **hermeneus/cc_profile.rs**: `ring::digest::SHA256` replaced with `sha2::Sha256`
- `OnceThenError` nonce wrapper removed (no longer needed — RustCrypto AEAD takes nonce directly)

## Test plan

- [x] `cargo test -p aletheia-symbolon` — 135 passed (HMAC JWT + AES-256-GCM round-trip, wrong-key, tampered-ciphertext)
- [x] `cargo test -p aletheia-taxis` — 174 passed (ChaCha20-Poly1305 round-trip, wrong-key, corrupted, hex key parsing)
- [x] `cargo test -p aletheia-hermeneus` — 254 passed (SHA256 fingerprint matches known CC output)
- [x] `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)