### PR TITLE
docs: refresh overview, daemon spec, ergon status, Wayland limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ One binary. No containers. No external databases. No cloud dependencies beyond y
 Download the tarball from [releases](https://github.com/forkwright/aletheia/releases), extract, and run `init`:
 
 ```bash
-VERSION=v0.13.13
+VERSION=v0.13.59
 curl -L "https://github.com/forkwright/aletheia/releases/download/${VERSION}/aletheia-linux-x86_64-${VERSION}.tar.gz" \
   -o aletheia.tar.gz
 tar xzf aletheia.tar.gz
@@ -32,7 +32,7 @@ The tarball contains `instance.example/` with the reference config layout. See [
 
 - **Persistent memory.** Conversations carry forward. The agent builds a knowledge graph of facts, entities, and relationships that persists across sessions and grows over time.
 - **Multiple agents.** Each agent has its own character (SOUL.md), goals, memory, and workspace. They can coordinate, delegate, and specialize.
-- **Tools.** 38 built-in tools: file I/O, shell execution, web search, memory search, planning, agent coordination. Extend with domain packs or custom tools.
+- **Tools.** 40+ built-in tools: file I/O, shell execution, web search, memory search, planning, agent coordination. Extend with domain packs or custom tools.
 - **Terminal dashboard.** Rich TUI with markdown rendering, session management, and real-time streaming.
 - **Signal messaging.** Talk to your agents over Signal with 15 built-in commands.
 - **Privacy.** No telemetry, no analytics, no phone-home. Only outbound connections are to services you configure.
@@ -41,7 +41,7 @@ The tarball contains `instance.example/` with the reference config layout. See [
 
 ## Architecture
 
-Rust workspace with 24 crates (23 in default workspace build, theatron-desktop excluded). Single binary deployment. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and trait boundaries.
+23 Rust crates, ~348K lines, 6,200+ tests. Single binary deployment. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and trait boundaries.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -229,7 +229,7 @@ strip = "symbols"
 ## Structural properties
 
 - **koina, eidos, and dianoia are true leaf nodes.** No workspace deps in Rust.
-- **symbolon depends only on koina** (plus external crates: reqwest, rusqlite, ring, argon2).
+- **symbolon depends only on koina** (plus external crates: reqwest, rusqlite, hmac/sha2/aes-gcm, argon2).
 - **mneme is a thin facade.** It re-exports from eidos (types), graphe (session store), episteme (knowledge pipeline), and krites (Datalog engine). No logic of its own.
 - **krites contains the Datalog+HNSW engine**, gated behind the `mneme-engine` feature.
 - **EmbeddingProvider lives in episteme**, not mneme.
@@ -238,3 +238,7 @@ strip = "symbols"
 - **dianoia has no workspace dependencies** - planning context fully decoupled from the agent pipeline. No other application crate imports it.
 - **thesauros loads domain packs** - knowledge, tools, config overlays bundled as portable extensions. Depends on koina + organon.
 - **nous requires a multi-thread Tokio runtime** (`rt-multi-thread`). The actor model and spawn-based timeout machinery depend on multiple OS threads. Single-thread runtime will deadlock.
+
+## Ergon
+
+Ergon is a strategic fork of aletheia maintained in a separate repository. It tracks aletheia's main branch with zero divergence — no custom code, no feature additions. It exists as a client-deliverable identity: same runtime, different branding. Changes flow from aletheia to ergon, never the reverse. Do not add ergon-specific code to this repository.

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -1,0 +1,124 @@
+# KAIROS: autonomous daemon
+
+> Specification for the oikonomos daemon subsystem and its KAIROS operating mode.
+
+---
+
+## Overview
+
+**Oikonomos** (crate: `aletheia-oikonomos`, directory: `crates/daemon/`) is the per-nous background task runner. It manages scheduled tasks, periodic attention checks, maintenance cycles, and autonomous operation.
+
+**KAIROS** is the daemon's autonomous mode — an agent that operates continuously without human prompting. Named for the Greek concept of the opportune moment: the daemon observes, waits, and acts when the time is right.
+
+---
+
+## Scope
+
+### What oikonomos does
+
+| Subsystem | Module | Purpose |
+|-----------|--------|---------|
+| Task runner | `runner.rs` | Cron/interval scheduling with failure tracking and graceful shutdown |
+| Scheduling | `schedule.rs` | Cron expressions (jiff-native parser), intervals, one-shots, jitter |
+| Prosoche | `prosoche.rs` | Periodic attention checks — agent surveys environment | 
+| Maintenance | `maintenance/` | Trace rotation, drift detection, DB monitoring, retention |
+| Coordination | `coordination.rs` | Child agent spawning with concurrency limits |
+| Triggers | `triggers.rs` | Event-driven activation: file watchers, webhooks |
+| Watchdog | `watchdog.rs` | Process heartbeat monitoring with auto-recovery |
+| State | `state.rs` | SQLite persistence, workspace config, single-instance locking |
+
+### What oikonomos does NOT do
+
+- **Dispatch orchestration** — energeia handles prompt dispatch, session management, and QA
+- **Cross-project coordination** — dianoia (#2291) handles attention allocation across projects
+- **Planning** — dianoia handles plan lifecycle, phase gates, stuck detection
+
+### Relationship to dianoia
+
+Oikonomos and dianoia are siblings, not parent/child:
+
+- **Oikonomos**: runs on a clock. Schedules tasks, fires on cron expressions, manages maintenance. Think cron + systemd watchdog.
+- **Dianoia**: runs on intent. Orchestrates multi-step plans, allocates attention across projects, detects stuck states. Think project manager.
+
+They share no code. Oikonomos calls nous actors via `DaemonBridge`; dianoia will coordinate via the planning adapter. Both are leaf crates with no cross-dependency.
+
+---
+
+## KAIROS mode
+
+KAIROS mode composes the daemon subsystems into continuous autonomous operation:
+
+```
+                    ┌─────────────┐
+                    │  TaskRunner  │
+                    │  (cron loop) │
+                    └──────┬──────┘
+                           │
+              ┌────────────┼────────────┐
+              ▼            ▼            ▼
+        ┌──────────┐ ┌──────────┐ ┌──────────┐
+        │ Prosoche │ │  Maint.  │ │ Triggers │
+        │ (attend) │ │ (rotate, │ │  (watch,  │
+        │          │ │  gc, ...)│ │  webhook) │
+        └────┬─────┘ └──────────┘ └─────┬────┘
+             │                          │
+             ▼                          ▼
+        ┌──────────┐           ┌──────────────┐
+        │  Daemon   │           │ Coordination │
+        │  Bridge   │           │ (child spawn)│
+        └────┬─────┘           └──────────────┘
+             │
+             ▼
+        ┌──────────┐
+        │   Nous   │
+        │  Actor   │
+        └──────────┘
+```
+
+### Scheduling
+
+Tasks use the `Schedule` enum:
+- `Cron(expr)` — standard 5/6-field cron expressions via jiff-native parser
+- `Interval(duration)` — fixed repeat
+- `Once(timestamp)` — fire-and-forget
+- `Startup` — run once at process start
+
+Jitter is deterministic per task ID (hash-based), preventing thundering herd when multiple tasks share the same cron expression.
+
+Active windows restrict execution to time ranges (e.g., `active_window: Some((8, 23))` for 8am-11pm).
+
+### Built-in tasks
+
+| Task | Schedule | Purpose |
+|------|----------|---------|
+| Prosoche | Cron | Periodic attention check |
+| TraceRotation | Cron | Compress and rotate old trace files |
+| DriftDetection | Cron | Compare instance against template config |
+| DbSizeMonitor | Cron | Alert on database growth |
+| RetentionExecution | Cron | Execute data retention policy |
+| DecayRefresh | Cron | Refresh temporal decay scores |
+| EntityDedup | Cron | Merge duplicate knowledge graph entities |
+| GraphRecompute | Cron | Recompute PageRank, centrality |
+| EmbeddingRefresh | Cron | Re-embed stale entities |
+| KnowledgeGc | Cron | Orphan removal, expired edge pruning |
+| IndexMaintenance | Cron | Rebuild/optimize graph indexes |
+| GraphHealthCheck | Cron | Diagnostic health check |
+| SkillDecay | Cron | Retire stale skills |
+| SelfAudit | Cron | Self-assessment against quality metrics |
+| EvolutionSearch | Cron | Mutate and benchmark agent configs |
+| SelfReflection | Cron | Agent evaluates recent performance |
+
+### Failure handling
+
+- Consecutive failures trigger exponential backoff (1min → 5min → 15min)
+- 3 consecutive failures auto-disable the task
+- Catch-up mode: missed cron windows within 24h are executed on startup
+- Watchdog monitors heartbeat; auto-restarts unresponsive tasks
+
+---
+
+## Status
+
+Oikonomos is implemented. KAIROS mode is scaffolded — the subsystems exist and are tested (185 tests), but full autonomous operation (prosoche → decision → action loop) is not yet wired end-to-end. Integration with dianoia for cross-project attention is planned for Phase 05e.
+
+See [PROSOCHE.md](PROSOCHE.md) for the attention subsystem detail.

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -49,3 +49,26 @@ theatron-desktop  (Dioxus desktop app)
 ```
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the full crate dependency graph.
+
+## Platform limitations
+
+### Wayland: no remote launch over SSH
+
+The desktop app cannot be launched over SSH on Wayland compositors. WebKitWebProcess spawns as a subprocess that cannot inherit the Wayland display socket from an SSH session — the compositor only allows processes from the local session to connect.
+
+Symptom:
+```
+(WebKitWebProcess:95849): Gtk-WARNING: cannot open display:
+** (aletheia-desktop:95722): ERROR: readPIDFromPeer: Unexpected short read from PID socket.
+```
+
+Workarounds:
+1. **Run locally, point at remote server.** Launch the desktop app on the machine with the display, configure it to connect to the remote Aletheia instance via the server URL.
+2. **Use X11 forwarding.** `ssh -X` works with X11/Xwayland, though performance is limited.
+3. **Use the TUI.** The terminal interface works over any SSH session.
+
+This is a WebKit/GTK limitation, not an Aletheia issue. Global hotkey registration is also unavailable on Wayland without the portal API — the app handles this gracefully by falling back to in-window shortcuts.
+
+### Global hotkeys
+
+On Wayland, the `KeyRegistration::Unavailable` path activates because Wayland security prevents applications from registering global hotkeys without portal support. The app continues to function; only the global shortcut is unavailable.


### PR DESCRIPTION
## Summary
- Update stale README metrics (v0.13.59, 23 crates, 348K LOC, 6200+ tests)
- Add KAIROS daemon specification (docs/DAEMON.md, 124 lines)
- Document ergon fork relationship in ARCHITECTURE.md
- Document Wayland SSH and global hotkey limitations in DESKTOP.md

Closes #2374, #2376, #2372, #2360