### PR TITLE
refactor(koina): centralize config path and model string constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "aletheia-taxis",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "owo-colors",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "jiff",
  "serde",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-energeia"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "compact_str",
  "jiff",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-energeia",
  "aletheia-hermeneus",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aes-gcm",
  "aletheia-koina",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.58"
+version = "0.13.59"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/aletheia/src/init/helpers.rs
+++ b/crates/aletheia/src/init/helpers.rs
@@ -84,7 +84,7 @@ mod tests {
                 .and_then(|v| v.get("model"))
                 .and_then(|v| v.get("primary"))
                 .and_then(toml::Value::as_str),
-            Some("claude-sonnet-4-6")
+            Some(aletheia_koina::defaults::DEFAULT_MODEL_SHORT)
         );
         let list = agents
             .get("list")

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -99,7 +99,7 @@ impl Default for Answers {
             root: PathBuf::from("./instance"),
             api_key: None,
             api_provider: "anthropic".to_owned(),
-            model: "claude-sonnet-4-6".to_owned(),
+            model: aletheia_koina::defaults::DEFAULT_MODEL_SHORT.to_owned(),
             agent_id: "pronoea".to_owned(),
             agent_name: "Pronoea".to_owned(),
             bind: "localhost".to_owned(),
@@ -133,7 +133,7 @@ fn build_non_interactive_answers(
         root,
         api_key,
         api_provider: api_provider.unwrap_or_else(|| "anthropic".to_owned()),
-        model: model.unwrap_or_else(|| "claude-sonnet-4-6".to_owned()),
+        model: model.unwrap_or_else(|| aletheia_koina::defaults::DEFAULT_MODEL_SHORT.to_owned()),
         auth_mode: auth_mode.unwrap_or_else(|| "none".to_owned()),
         credential_source,
         ..Answers::default()
@@ -203,7 +203,7 @@ fn run_inner(args: RunArgs, env_root: Option<PathBuf>) -> Result<(), InitError> 
                 .build()
             })?;
             let root_path = wa.root.clone();
-            let config_path = root_path.join("config/aletheia.toml");
+            let config_path = root_path.join(aletheia_koina::defaults::DEFAULT_CONFIG_PATH);
             if config_path.exists() {
                 let overwrite: bool = cliclack::confirm("Instance already exists. Overwrite?")
                     .initial_value(false)
@@ -228,12 +228,13 @@ fn run_inner(args: RunArgs, env_root: Option<PathBuf>) -> Result<(), InitError> 
         })?
     };
 
-    let config_path = answers.root.join("config/aletheia.toml");
+    let config_path = answers.root.join(aletheia_koina::defaults::DEFAULT_CONFIG_PATH);
     if config_path.exists() {
         if is_non_interactive {
             tracing::info!(
                 path = %answers.root.display(),
-                "instance already exists — skipping (delete config/aletheia.toml to re-initialize)"
+                "instance already exists — skipping (delete {} to re-initialize)",
+                aletheia_koina::defaults::DEFAULT_CONFIG_PATH
             );
             return Ok(());
         }

--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -22,7 +22,7 @@ pub(super) fn scaffold(answers: &Answers) -> Result<(), InitError> {
     }
 
     let config_toml = render_config(answers);
-    let config_path = root.join("config/aletheia.toml");
+    let config_path = root.join(aletheia_koina::defaults::DEFAULT_CONFIG_PATH);
     #[expect(
         clippy::disallowed_methods,
         reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"

--- a/crates/koina/src/defaults.rs
+++ b/crates/koina/src/defaults.rs
@@ -2,6 +2,15 @@
 //!
 //! Define once here. Never hardcode these values in another crate.
 
+/// Default configuration file path relative to instance root.
+pub const DEFAULT_CONFIG_PATH: &str = "config/aletheia.toml";
+
+/// Default LLM model identifier (full form).
+pub const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
+
+/// Default LLM model identifier (short form used in config files).
+pub const DEFAULT_MODEL_SHORT: &str = "claude-sonnet-4-6";
+
 /// Default maximum output tokens per LLM response.
 pub const MAX_OUTPUT_TOKENS: u32 = 16_384;
 

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -377,7 +377,7 @@ pub struct ModelSpec {
 impl Default for ModelSpec {
     fn default() -> Self {
         Self {
-            primary: "claude-sonnet-4-6".to_owned(),
+            primary: aletheia_koina::defaults::DEFAULT_MODEL_SHORT.to_owned(),
             fallbacks: Vec::new(),
             retries_before_fallback: 2,
         }

--- a/crates/theatron/tui/src/wizard/state.rs
+++ b/crates/theatron/tui/src/wizard/state.rs
@@ -272,7 +272,7 @@ pub(crate) static AUTH_OPTIONS: &[SelectOption] = &[
 
 pub(crate) static MODEL_OPTIONS: &[SelectOption] = &[
     SelectOption {
-        value: "claude-sonnet-4-6",
+        value: aletheia_koina::defaults::DEFAULT_MODEL_SHORT,
         label: "claude-sonnet-4-6 (recommended)",
     },
     SelectOption {
@@ -367,7 +367,7 @@ fn make_agent_step() -> StepState {
                 "pronoea",
                 "alphanumeric + hyphens, used in paths",
             ),
-            WizardField::select("Model", MODEL_OPTIONS, "claude-sonnet-4-6", ""),
+            WizardField::select("Model", MODEL_OPTIONS, aletheia_koina::defaults::DEFAULT_MODEL_SHORT, ""),
         ],
         cursor: 0,
         editing: None,


### PR DESCRIPTION
Continues #2308.