### PR TITLE
fix: daemon stderr logging and explicit serve subcommand

### DIFF
--- a/crates/aletheia/src/commands/daemon.rs
+++ b/crates/aletheia/src/commands/daemon.rs
@@ -16,21 +16,32 @@ pub(crate) async fn do_daemon() -> Result<()> {
         .filter(|a| a != "--daemon")
         .collect();
 
+    // WHY: Redirect stderr to a crash log so daemon startup failures are
+    // visible. Previously stdout+stderr were both /dev/null, so if the child
+    // crashed (e.g., schema version mismatch), the error was lost entirely.
+    let instance_root = daemon_instance_root();
+    tokio::fs::create_dir_all(&instance_root)
+        .await
+        .with_context(|| format!("failed to create {}", instance_root.display()))?;
+    let crash_log_path = instance_root.join("logs").join("daemon-stderr.log");
+    if let Some(parent) = crash_log_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let stderr_file = std::fs::File::create(&crash_log_path)
+        .context("failed to create daemon stderr log")?;
+
     let child = std::process::Command::new(&exe)
         .args(&child_args)
         .env("_ALETHEIA_DAEMON", "1")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::from(stderr_file))
         .spawn()
         .context("failed to spawn background process")?;
 
     let pid = child.id();
 
-    let instance_root = daemon_instance_root();
-    tokio::fs::create_dir_all(&instance_root)
-        .await
-        .with_context(|| format!("failed to create {}", instance_root.display()))?;
+    // NOTE: instance_root already created above (before spawn, for stderr log).
     let pid_path = instance_root.join("aletheia.pid");
     tokio::fs::write(&pid_path, pid.to_string())
         .await

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -40,7 +40,7 @@ use commands::session_export::SessionExportArgs;
 use commands::tls;
 
 #[derive(Debug, Parser)]
-#[command(name = "aletheia", about = "Cognitive agent runtime", version)]
+#[command(name = "aletheia", about = "Cognitive agent runtime. Run with no subcommand to start the HTTP server.", version)]
 struct Cli {
     /// Path to instance root directory
     #[arg(short = 'r', long)]
@@ -72,6 +72,8 @@ struct Cli {
 
 #[derive(Debug, Clone, Subcommand)]
 enum Command {
+    /// Start the HTTP server (same as running with no subcommand)
+    Serve,
     /// Check if the server is running
     Health(HealthArgs),
     /// Manage database backups
@@ -158,8 +160,12 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    if let Some(cmd) = cli.command {
-        return dispatch_command(cmd, cli.instance_root.as_ref()).await;
+    // WHY: `Serve` is an explicit alias for running with no subcommand.
+    // Intercept it here before dispatch_command so it follows the same
+    // daemon/foreground code path as the default (no subcommand) case.
+    match cli.command {
+        Some(Command::Serve) | None => {}
+        Some(cmd) => return dispatch_command(cmd, cli.instance_root.as_ref()).await,
     }
 
     if cli.daemon && std::env::var("_ALETHEIA_DAEMON").is_err() {
@@ -252,6 +258,9 @@ async fn dispatch_command(cmd: Command, instance_root: Option<&PathBuf>) -> Resu
         Command::AddNous(a) => commands::add_nous::run(instance_root, &a)
             .await
             .map_err(Into::into),
+        // NOTE: Serve is intercepted in main() before dispatch_command is called.
+        // This arm exists only for match exhaustiveness.
+        Command::Serve => unreachable!("Serve handled in main"),
     }
 }
 


### PR DESCRIPTION
## Summary
- Daemon stderr → logs/daemon-stderr.log (was /dev/null — crash errors lost)
- Add `aletheia serve` subcommand (explicit alias for starting with no subcommand)
- Update --help text to clarify default behavior