### PR TITLE
refactor(koina): centralize config path and model string constants

### DIFF
--- a/crates/aletheia/src/init/helpers.rs
+++ b/crates/aletheia/src/init/helpers.rs
@@ -84,7 +84,7 @@ mod tests {
                 .and_then(|v| v.get("model"))
                 .and_then(|v| v.get("primary"))
                 .and_then(toml::Value::as_str),
-            Some("claude-sonnet-4-6")
+            Some(aletheia_koina::defaults::DEFAULT_MODEL_SHORT)
         );
         let list = agents
             .get("list")
@@ -208,7 +208,7 @@ mod tests {
         );
         assert_eq!(
             config["agents"]["defaults"]["model"]["primary"].as_str(),
-            Some("claude-sonnet-4-6"),
+            Some(aletheia_koina::defaults::DEFAULT_MODEL_SHORT),
             "default model should be claude-sonnet-4-6"
         );
     }

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -99,7 +99,7 @@ impl Default for Answers {
             root: PathBuf::from("./instance"),
             api_key: None,
             api_provider: "anthropic".to_owned(),
-            model: "claude-sonnet-4-6".to_owned(),
+            model: aletheia_koina::defaults::DEFAULT_MODEL_SHORT.to_owned(),
             agent_id: "pronoea".to_owned(),
             agent_name: "Pronoea".to_owned(),
             bind: "localhost".to_owned(),
@@ -133,7 +133,7 @@ fn build_non_interactive_answers(
         root,
         api_key,
         api_provider: api_provider.unwrap_or_else(|| "anthropic".to_owned()),
-        model: model.unwrap_or_else(|| "claude-sonnet-4-6".to_owned()),
+        model: model.unwrap_or_else(|| aletheia_koina::defaults::DEFAULT_MODEL_SHORT.to_owned()),
         auth_mode: auth_mode.unwrap_or_else(|| "none".to_owned()),
         credential_source,
         ..Answers::default()
@@ -203,7 +203,7 @@ fn run_inner(args: RunArgs, env_root: Option<PathBuf>) -> Result<(), InitError> 
                 .build()
             })?;
             let root_path = wa.root.clone();
-            let config_path = root_path.join("config/aletheia.toml");
+            let config_path = root_path.join(aletheia_koina::defaults::DEFAULT_CONFIG_PATH);
             if config_path.exists() {
                 let overwrite: bool = cliclack::confirm("Instance already exists. Overwrite?")
                     .initial_value(false)
@@ -228,7 +228,7 @@ fn run_inner(args: RunArgs, env_root: Option<PathBuf>) -> Result<(), InitError> 
         })?
     };
 
-    let config_path = answers.root.join("config/aletheia.toml");
+    let config_path = answers.root.join(aletheia_koina::defaults::DEFAULT_CONFIG_PATH);
     if config_path.exists() {
         if is_non_interactive {
             tracing::info!(
@@ -282,7 +282,7 @@ fn collect_interactive(mut answers: Answers) -> Result<Answers, InitError> {
     }
 
     let model: &str = cliclack::select("Default model")
-        .item("claude-sonnet-4-6", "claude-sonnet-4-6 (recommended)", "")
+        .item(aletheia_koina::defaults::DEFAULT_MODEL_SHORT, "claude-sonnet-4-6 (recommended)", "")
         .item("claude-opus-4-6", "claude-opus-4-6", "")
         .item("claude-haiku-4-5", "claude-haiku-4-5", "")
         .interact()

--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -22,7 +22,7 @@ pub(super) fn scaffold(answers: &Answers) -> Result<(), InitError> {
     }
 
     let config_toml = render_config(answers);
-    let config_path = root.join("config/aletheia.toml");
+    let config_path = root.join(aletheia_koina::defaults::DEFAULT_CONFIG_PATH);
     #[expect(
         clippy::disallowed_methods,
         reason = "aletheia CLI commands use synchronous filesystem operations for config and certificate generation"

--- a/crates/koina/src/defaults.rs
+++ b/crates/koina/src/defaults.rs
@@ -2,8 +2,14 @@
 //!
 //! Define once here. Never hardcode these values in another crate.
 
-/// Default LLM model identifier.
+/// Default configuration file path relative to instance root.
+pub const DEFAULT_CONFIG_PATH: &str = "config/aletheia.toml";
+
+/// Default LLM model identifier (full form).
 pub const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
+
+/// Default LLM model identifier (short form used in config files).
+pub const DEFAULT_MODEL_SHORT: &str = "claude-sonnet-4-6";
 
 /// Default maximum output tokens per LLM response.
 pub const MAX_OUTPUT_TOKENS: u32 = 16_384;

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -377,7 +377,7 @@ pub struct ModelSpec {
 impl Default for ModelSpec {
     fn default() -> Self {
         Self {
-            primary: "claude-sonnet-4-6".to_owned(),
+            primary: aletheia_koina::defaults::DEFAULT_MODEL_SHORT.to_owned(),
             fallbacks: Vec::new(),
             retries_before_fallback: 2,
         }

--- a/crates/theatron/tui/src/wizard/state.rs
+++ b/crates/theatron/tui/src/wizard/state.rs
@@ -272,7 +272,7 @@ pub(crate) static AUTH_OPTIONS: &[SelectOption] = &[
 
 pub(crate) static MODEL_OPTIONS: &[SelectOption] = &[
     SelectOption {
-        value: "claude-sonnet-4-6",
+        value: aletheia_koina::defaults::DEFAULT_MODEL_SHORT,
         label: "claude-sonnet-4-6 (recommended)",
     },
     SelectOption {
@@ -367,7 +367,7 @@ fn make_agent_step() -> StepState {
                 "pronoea",
                 "alphanumeric + hyphens, used in paths",
             ),
-            WizardField::select("Model", MODEL_OPTIONS, "claude-sonnet-4-6", ""),
+            WizardField::select("Model", MODEL_OPTIONS, aletheia_koina::defaults::DEFAULT_MODEL_SHORT, ""),
         ],
         cursor: 0,
         editing: None,
@@ -623,7 +623,7 @@ mod tests {
         assert_eq!(answers.auth_mode, "none");
         assert_eq!(answers.agent_name, "Pronoea");
         assert_eq!(answers.agent_id, "pronoea");
-        assert_eq!(answers.model, "claude-sonnet-4-6");
+        assert_eq!(answers.model, aletheia_koina::defaults::DEFAULT_MODEL_SHORT);
         assert!(answers.api_key.is_none());
     }
 


### PR DESCRIPTION
Continues #2308. Replaces #2519.