### PR TITLE
feat(daemon): self-prompting with rate-limited feedback loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-agora",
  "aletheia-dianoia",
@@ -120,14 +120,14 @@ dependencies = [
 
 [[package]]
 name = "aletheia-agora"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
+ "aletheia-organon",
  "aletheia-taxis",
  "indexmap 2.13.1",
  "prometheus",
  "reqwest 0.13.2",
- "rustls",
  "serde",
  "serde_json",
  "snafu",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dianoia"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-diaporeia"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
  "aletheia-mneme",
@@ -180,13 +180,13 @@ dependencies = [
 
 [[package]]
 name = "aletheia-dokimion"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
+ "aletheia-organon",
  "owo-colors",
  "regex",
  "reqwest 0.13.2",
- "rustls",
  "serde",
  "serde_json",
  "snafu",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-eidos"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "jiff",
  "serde",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-energeia"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-episteme"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-eidos",
  "aletheia-graphe",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-graphe"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-eidos",
  "aletheia-koina",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-hermeneus"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
  "jiff",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-integration-tests"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-dokimion",
  "aletheia-hermeneus",
@@ -323,7 +323,6 @@ dependencies = [
  "axum 0.8.8",
  "jiff",
  "reqwest 0.13.2",
- "rustls",
  "serde_json",
  "tempfile",
  "tokio",
@@ -334,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "compact_str",
  "jiff",
@@ -355,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-krites"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aho-corasick",
  "aletheia-eidos",
@@ -399,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-melete"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -418,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-mneme"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-eidos",
  "aletheia-episteme",
@@ -433,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-nous"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-dianoia",
  "aletheia-hermeneus",
@@ -462,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-oikonomos"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
  "axum 0.8.8",
@@ -485,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-organon"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-energeia",
  "aletheia-hermeneus",
@@ -514,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-pylon"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-hermeneus",
  "aletheia-koina",
@@ -548,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-symbolon"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aes-gcm",
  "aletheia-koina",
@@ -577,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-taxis"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
  "base64 0.22.1",
@@ -595,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-thesauros"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
  "aletheia-organon",
@@ -6220,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
  "bytes",
@@ -6239,7 +6238,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-tui"
-version = "0.13.59"
+version = "0.13.63"
 dependencies = [
  "aletheia-koina",
  "arboard",

--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -289,6 +289,18 @@ pub(crate) async fn execute_builtin(
         BuiltinTask::GraphCleanup => {
             graph_cleanup::execute_graph_cleanup(nous_id, knowledge_executor).await
         }
+        BuiltinTask::SelfPrompt => {
+            // NOTE: SelfPrompt is dispatched inline by the runner after
+            // extracting a follow-up from prosoche output. This arm handles
+            // the case where it's registered as a standalone task (should not
+            // happen in normal operation).
+            Ok(ExecutionResult {
+                success: false,
+                output: Some(
+                    "self-prompt must be dispatched via runner follow-up extraction".to_owned(),
+                ),
+            })
+        }
         BuiltinTask::RetentionExecution => {
             let Some(executor) = retention_executor else {
                 tracing::info!("retention execution skipped — no executor configured");

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -29,6 +29,8 @@ pub mod metrics;
 pub mod prosoche;
 /// Per-nous background task runner with cron scheduling, failure tracking, and graceful shutdown.
 pub mod runner;
+/// Self-prompting: daemon-initiated follow-up actions with rate limiting.
+pub mod self_prompt;
 /// Scheduling primitives: cron, interval, one-shot, jitter, and active time windows.
 pub mod schedule;
 /// SQLite-backed persistence, workspace config, and single-instance locking.
@@ -53,4 +55,5 @@ mod assertions {
     assert_impl_all!(super::state::DaemonConfig: Send, Sync);
     assert_impl_all!(super::coordination::Coordinator: Send);
     assert_impl_all!(super::triggers::TriggerRouter: Send, Sync);
+    assert_impl_all!(super::self_prompt::SelfPromptConfig: Send, Sync);
 }

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -88,6 +88,10 @@ pub struct TaskRunner {
     state_store: Option<crate::state::TaskStateStore>,
     /// Output mode: full or brief (truncated).
     output_mode: DaemonOutputMode,
+    /// Self-prompt rate limiter (tracks per-agent dispatch counts).
+    self_prompt_limiter: crate::self_prompt::SelfPromptLimiter,
+    /// Self-prompt configuration (enabled, rate limits).
+    self_prompt_config: crate::self_prompt::SelfPromptConfig,
 }
 
 /// Tracks a task that is currently executing.
@@ -133,6 +137,8 @@ impl TaskRunner {
             in_flight: HashMap::new(),
             state_store: None,
             output_mode: DaemonOutputMode::Full,
+            self_prompt_limiter: crate::self_prompt::SelfPromptLimiter::new(1),
+            self_prompt_config: crate::self_prompt::SelfPromptConfig::default(),
         }
     }
 
@@ -153,6 +159,8 @@ impl TaskRunner {
             in_flight: HashMap::new(),
             state_store: None,
             output_mode: DaemonOutputMode::Full,
+            self_prompt_limiter: crate::self_prompt::SelfPromptLimiter::new(1),
+            self_prompt_config: crate::self_prompt::SelfPromptConfig::default(),
         }
     }
 
@@ -195,6 +203,17 @@ impl TaskRunner {
     #[must_use]
     pub fn with_output_mode(mut self, mode: DaemonOutputMode) -> Self {
         self.output_mode = mode;
+        self
+    }
+
+    /// Configure self-prompting behavior (rate-limited daemon-initiated follow-ups).
+    ///
+    /// WHY: self-prompting enables proactive work when prosoche checks identify
+    /// items needing attention. Must be explicitly enabled with rate limits.
+    #[must_use]
+    pub fn with_self_prompt(mut self, config: crate::self_prompt::SelfPromptConfig) -> Self {
+        self.self_prompt_limiter = crate::self_prompt::SelfPromptLimiter::new(config.max_per_hour);
+        self.self_prompt_config = config;
         self
     }
 
@@ -583,6 +602,7 @@ impl TaskRunner {
                 match in_flight.handle.await {
                     Ok(Ok(result)) => {
                         self.log_result(&task_id, &result);
+                        self.maybe_queue_self_prompt(&task_id, &result);
                         self.record_task_completion(&task_id, duration);
                     }
                     Ok(Err(e)) => {
@@ -622,6 +642,84 @@ impl TaskRunner {
                 tracing::info!(task_id = %task_id, output = %truncated, "task output (brief)");
             }
         }
+    }
+
+    /// Check if a completed task's output contains a `## Follow-up` section
+    /// and, if self-prompting is enabled and rate-allowed, spawn a self-prompt.
+    ///
+    /// WHY: self-prompting closes the feedback loop. A prosoche check that finds
+    /// something wrong can request a follow-up action without human intervention.
+    /// Rate limiting ensures this never runs away.
+    fn maybe_queue_self_prompt(&mut self, task_id: &str, result: &ExecutionResult) {
+        if !self.self_prompt_config.enabled {
+            return;
+        }
+
+        let Some(output) = result.output.as_deref() else {
+            return;
+        };
+
+        let Some(follow_up) = crate::self_prompt::extract_follow_up(output) else {
+            return;
+        };
+
+        if !self.self_prompt_limiter.is_allowed(&self.nous_id) {
+            tracing::info!(
+                nous_id = %self.nous_id,
+                task_id = %task_id,
+                "self-prompt rate limited  -  skipping follow-up"
+            );
+            return;
+        }
+
+        self.self_prompt_limiter.record(&self.nous_id);
+
+        let bridge = self.bridge.clone();
+        let nous_id = self.nous_id.clone();
+        let task_id_owned = task_id.to_owned();
+
+        // WHY: spawn as a detached task. Self-prompt execution should not block
+        // the main scheduler loop. Failures are logged but do not affect the
+        // originating task's status.
+        tokio::spawn(async move {
+            tracing::info!(
+                nous_id = %nous_id,
+                source_task = %task_id_owned,
+                prompt_len = follow_up.len(),
+                "dispatching self-prompt from follow-up"
+            );
+            let result = crate::self_prompt::execute_self_prompt(
+                &nous_id,
+                &follow_up,
+                bridge.as_deref(),
+            )
+            .await;
+            match result {
+                Ok(r) if r.success => {
+                    tracing::info!(
+                        nous_id = %nous_id,
+                        source_task = %task_id_owned,
+                        "self-prompt dispatched successfully"
+                    );
+                }
+                Ok(r) => {
+                    tracing::warn!(
+                        nous_id = %nous_id,
+                        source_task = %task_id_owned,
+                        output = ?r.output,
+                        "self-prompt dispatch returned failure"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        nous_id = %nous_id,
+                        source_task = %task_id_owned,
+                        error = %e,
+                        "self-prompt dispatch error"
+                    );
+                }
+            }
+        });
     }
 
     /// Record a successful task completion and UPDATE scheduling.

--- a/crates/daemon/src/runner_tests.rs
+++ b/crates/daemon/src/runner_tests.rs
@@ -819,3 +819,136 @@ fn with_state_store_persists_across_restarts() {
         );
     }
 }
+
+// -- Self-prompt integration tests --
+
+#[test]
+fn with_self_prompt_builder_configures_limiter() {
+    let token = CancellationToken::new();
+    let config = crate::self_prompt::SelfPromptConfig {
+        enabled: true,
+        max_per_hour: 5,
+    };
+    let runner = TaskRunner::new("test-nous", token).with_self_prompt(config);
+    assert!(runner.self_prompt_config.enabled);
+    assert_eq!(runner.self_prompt_config.max_per_hour, 5);
+}
+
+#[test]
+fn self_prompt_disabled_by_default() {
+    let token = CancellationToken::new();
+    let runner = TaskRunner::new("test-nous", token);
+    assert!(
+        !runner.self_prompt_config.enabled,
+        "self-prompting must be disabled by default"
+    );
+}
+
+#[tokio::test]
+async fn self_prompt_not_queued_when_disabled() {
+    let token = CancellationToken::new();
+    let bridge: Arc<dyn DaemonBridge> = Arc::new(crate::bridge::NoopBridge);
+    let mut runner = TaskRunner::with_bridge("test-nous", token, bridge);
+    runner.register(make_echo_task("test-task"));
+
+    // Simulate a result with a follow-up section
+    let result = ExecutionResult {
+        success: true,
+        output: Some("## Follow-up\nInvestigate disk usage.\n".to_owned()),
+    };
+    runner.maybe_queue_self_prompt("test-task", &result);
+
+    // Give a moment for any spawned task (there should be none)
+    // kanon:ignore TESTING/sleep-in-test reason = "verifying no async task was spawned; brief yield to confirm absence"
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // No way to directly inspect spawned tasks, but we verify the limiter
+    // was not invoked (count stays 0)
+    assert_eq!(
+        runner.self_prompt_limiter.count("test-nous"),
+        0,
+        "limiter should not be touched when disabled"
+    );
+}
+
+#[tokio::test]
+async fn self_prompt_queued_when_enabled_with_follow_up() {
+    let token = CancellationToken::new();
+    let bridge: Arc<dyn DaemonBridge> = Arc::new(crate::bridge::NoopBridge);
+    let config = crate::self_prompt::SelfPromptConfig {
+        enabled: true,
+        max_per_hour: 3,
+    };
+    let mut runner =
+        TaskRunner::with_bridge("test-nous", token, bridge).with_self_prompt(config);
+    runner.register(make_echo_task("test-task"));
+
+    let result = ExecutionResult {
+        success: true,
+        output: Some("## Follow-up\nCheck /data disk usage.\n".to_owned()),
+    };
+    runner.maybe_queue_self_prompt("test-task", &result);
+
+    assert_eq!(
+        runner.self_prompt_limiter.count("test-nous"),
+        1,
+        "limiter should record the dispatched self-prompt"
+    );
+}
+
+#[tokio::test]
+async fn self_prompt_rate_limited_after_max() {
+    let token = CancellationToken::new();
+    let bridge: Arc<dyn DaemonBridge> = Arc::new(crate::bridge::NoopBridge);
+    let config = crate::self_prompt::SelfPromptConfig {
+        enabled: true,
+        max_per_hour: 1,
+    };
+    let mut runner =
+        TaskRunner::with_bridge("test-nous", token, bridge).with_self_prompt(config);
+    runner.register(make_echo_task("test-task"));
+
+    let result = ExecutionResult {
+        success: true,
+        output: Some("## Follow-up\nFirst action.\n".to_owned()),
+    };
+    runner.maybe_queue_self_prompt("test-task", &result);
+    assert_eq!(runner.self_prompt_limiter.count("test-nous"), 1);
+
+    // Second attempt should be rate-limited
+    let result2 = ExecutionResult {
+        success: true,
+        output: Some("## Follow-up\nSecond action.\n".to_owned()),
+    };
+    runner.maybe_queue_self_prompt("test-task", &result2);
+    assert_eq!(
+        runner.self_prompt_limiter.count("test-nous"),
+        1,
+        "second self-prompt should be rate-limited"
+    );
+}
+
+#[test]
+fn self_prompt_no_follow_up_no_dispatch() {
+    let token = CancellationToken::new();
+    let bridge: Arc<dyn DaemonBridge> = Arc::new(crate::bridge::NoopBridge);
+    let config = crate::self_prompt::SelfPromptConfig {
+        enabled: true,
+        max_per_hour: 5,
+    };
+    let mut runner =
+        TaskRunner::with_bridge("test-nous", token, bridge).with_self_prompt(config);
+    runner.register(make_echo_task("test-task"));
+
+    let result = ExecutionResult {
+        success: true,
+        output: Some("Everything is fine. No issues.".to_owned()),
+    };
+    runner.maybe_queue_self_prompt("test-task", &result);
+
+    assert_eq!(
+        runner.self_prompt_limiter.count("test-nous"),
+        0,
+        "no follow-up section should mean no dispatch"
+    );
+}

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -117,6 +117,8 @@ pub enum BuiltinTask {
     SelfReflection,
     /// Periodic knowledge graph cleanup: orphan removal and stale entity pruning.
     GraphCleanup,
+    /// Self-prompt: daemon-initiated follow-up action from a prosoche check.
+    SelfPrompt,
 }
 
 impl Schedule {

--- a/crates/daemon/src/self_prompt.rs
+++ b/crates/daemon/src/self_prompt.rs
@@ -1,0 +1,390 @@
+//! Self-prompting: daemon-initiated follow-up actions from prosoche checks.
+//!
+//! WHY: a nous should initiate work proactively, not just respond to user
+//! messages. When a prosoche check identifies something needing attention, the
+//! daemon extracts the follow-up and sends a self-prompt via the bridge. Rate
+//! limiting prevents runaway loops.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Session key used for all self-prompt dispatches.
+///
+/// WHY: separate session key prevents self-prompts from interfering with user
+/// sessions. Users can check `daemon:self-prompt` when they want to review
+/// autonomous actions.
+pub const SELF_PROMPT_SESSION_KEY: &str = "daemon:self-prompt";
+
+/// Configuration for self-prompting behavior.
+///
+/// WHY: self-prompting must be opt-in and rate-limited. Without explicit
+/// enablement, the daemon never sends itself follow-up prompts. Without rate
+/// limits, a misidentified attention item could trigger an unbounded loop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelfPromptConfig {
+    /// Whether self-prompting is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Maximum self-prompts per hour per agent.
+    ///
+    /// WHY: rate limit prevents runaway loops. A prosoche check that always
+    /// produces a `## Follow-up` section would otherwise generate unbounded work.
+    #[serde(default = "default_max_per_hour")]
+    pub max_per_hour: u32,
+}
+
+fn default_max_per_hour() -> u32 {
+    1
+}
+
+impl Default for SelfPromptConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_per_hour: default_max_per_hour(),
+        }
+    }
+}
+
+/// Tracks self-prompt counts per agent for rate limiting.
+///
+/// Uses a sliding window: timestamps older than 1 hour are pruned on each check.
+#[derive(Debug)]
+pub(crate) struct SelfPromptLimiter {
+    /// Per-agent timestamps of dispatched self-prompts.
+    windows: HashMap<String, Vec<jiff::Timestamp>>,
+    /// Maximum allowed per hour (from config).
+    max_per_hour: u32,
+}
+
+impl SelfPromptLimiter {
+    /// Create a new limiter with the given rate cap.
+    pub(crate) fn new(max_per_hour: u32) -> Self {
+        Self {
+            windows: HashMap::new(),
+            max_per_hour,
+        }
+    }
+
+    /// Check whether a self-prompt is allowed for the given agent right now.
+    ///
+    /// Prunes expired entries as a side effect.
+    pub(crate) fn is_allowed(&mut self, nous_id: &str) -> bool {
+        let cutoff = jiff::Timestamp::now()
+            .checked_sub(jiff::SignedDuration::from_hours(1))
+            .unwrap_or_default();
+
+        let timestamps = self.windows.entry(nous_id.to_owned()).or_default();
+
+        // Prune entries older than 1 hour.
+        timestamps.retain(|ts| *ts > cutoff);
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "vec len is bounded by max_per_hour which is u32"
+        )]
+        let count = timestamps.len() as u32;
+        count < self.max_per_hour
+    }
+
+    /// Record that a self-prompt was dispatched for the given agent.
+    pub(crate) fn record(&mut self, nous_id: &str) {
+        self.windows
+            .entry(nous_id.to_owned())
+            .or_default()
+            .push(jiff::Timestamp::now());
+    }
+
+    /// Current count of self-prompts in the window for the given agent.
+    #[cfg(test)]
+    pub(crate) fn count(&mut self, nous_id: &str) -> usize {
+        let cutoff = jiff::Timestamp::now()
+            .checked_sub(jiff::SignedDuration::from_hours(1))
+            .unwrap_or_default();
+
+        let timestamps = self.windows.entry(nous_id.to_owned()).or_default();
+        timestamps.retain(|ts| *ts > cutoff);
+        timestamps.len()
+    }
+}
+
+/// Extract a self-prompt from prosoche or task output.
+///
+/// Looks for a `## Follow-up` markdown section in the output text. Everything
+/// after that heading (until the next `##` heading or end of string) becomes the
+/// self-prompt content.
+///
+/// WHY: structured extraction means the agent controls what becomes a
+/// self-prompt. Free-form text won't accidentally trigger follow-ups.
+pub(crate) fn extract_follow_up(output: &str) -> Option<String> {
+    // Find the `## Follow-up` heading (case-insensitive for the word "follow-up").
+    let lower = output.to_lowercase();
+    let marker = "## follow-up";
+
+    let start_idx = lower.find(marker)?;
+    let content_start = start_idx + marker.len();
+
+    // Skip the rest of the heading line.
+    let after_heading = &output[content_start..];
+    let line_end = after_heading.find('\n').unwrap_or(after_heading.len());
+    let body_start = content_start + line_end;
+
+    if body_start >= output.len() {
+        return None;
+    }
+
+    let body = &output[body_start..];
+
+    // Terminate at the next `##` heading or end of string.
+    let end = body
+        .find("\n## ")
+        .map_or(body.len(), |pos| pos);
+
+    let content = body[..end].trim();
+
+    if content.is_empty() {
+        None
+    } else {
+        Some(content.to_owned())
+    }
+}
+
+/// Execute a self-prompt: send the extracted follow-up to the nous via the bridge.
+pub(crate) async fn execute_self_prompt(
+    nous_id: &str,
+    prompt: &str,
+    bridge: Option<&dyn crate::bridge::DaemonBridge>,
+) -> crate::error::Result<crate::runner::ExecutionResult> {
+    let Some(bridge) = bridge else {
+        return Ok(crate::runner::ExecutionResult {
+            success: false,
+            output: Some("no bridge configured".to_owned()),
+        });
+    };
+
+    tracing::info!(
+        nous_id = %nous_id,
+        prompt_len = prompt.len(),
+        "dispatching self-prompt"
+    );
+
+    match bridge
+        .send_prompt(nous_id, SELF_PROMPT_SESSION_KEY, prompt)
+        .await
+    {
+        Ok(result) => {
+            tracing::info!(
+                nous_id = %nous_id,
+                success = result.success,
+                "self-prompt dispatch succeeded"
+            );
+            Ok(crate::runner::ExecutionResult {
+                success: true,
+                output: Some("self-prompt dispatched".to_owned()),
+            })
+        }
+        Err(e) => {
+            tracing::warn!(
+                nous_id = %nous_id,
+                error = %e,
+                "self-prompt dispatch failed"
+            );
+            Ok(crate::runner::ExecutionResult {
+                success: false,
+                output: Some(format!("self-prompt dispatch failed: {e}")),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    // -- SelfPromptConfig tests --
+
+    #[test]
+    fn default_config_disabled() {
+        let config = SelfPromptConfig::default();
+        assert!(!config.enabled, "self-prompting must be disabled by default");
+        assert_eq!(config.max_per_hour, 1);
+    }
+
+    #[test]
+    fn config_serialization_roundtrip() {
+        let config = SelfPromptConfig {
+            enabled: true,
+            max_per_hour: 3,
+        };
+        let json = serde_json::to_string(&config).expect("serialize");
+        let back: SelfPromptConfig = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.enabled);
+        assert_eq!(back.max_per_hour, 3);
+    }
+
+    #[test]
+    fn config_deserialize_defaults() {
+        let json = "{}";
+        let config: SelfPromptConfig = serde_json::from_str(json).expect("deserialize");
+        assert!(!config.enabled);
+        assert_eq!(config.max_per_hour, 1);
+    }
+
+    // -- SelfPromptLimiter tests --
+
+    #[test]
+    fn limiter_allows_first_prompt() {
+        let mut limiter = SelfPromptLimiter::new(1);
+        assert!(
+            limiter.is_allowed("test-nous"),
+            "first prompt should be allowed"
+        );
+    }
+
+    #[test]
+    fn limiter_blocks_after_max() {
+        let mut limiter = SelfPromptLimiter::new(1);
+        limiter.record("test-nous");
+        assert!(
+            !limiter.is_allowed("test-nous"),
+            "second prompt within window should be blocked"
+        );
+    }
+
+    #[test]
+    fn limiter_allows_different_agents() {
+        let mut limiter = SelfPromptLimiter::new(1);
+        limiter.record("nous-a");
+        assert!(
+            limiter.is_allowed("nous-b"),
+            "different agent should be independent"
+        );
+    }
+
+    #[test]
+    fn limiter_tracks_count() {
+        let mut limiter = SelfPromptLimiter::new(5);
+        limiter.record("test-nous");
+        limiter.record("test-nous");
+        limiter.record("test-nous");
+        assert_eq!(limiter.count("test-nous"), 3);
+    }
+
+    #[test]
+    fn limiter_higher_max_allows_multiple() {
+        let mut limiter = SelfPromptLimiter::new(3);
+        limiter.record("test-nous");
+        limiter.record("test-nous");
+        assert!(
+            limiter.is_allowed("test-nous"),
+            "should allow up to max_per_hour"
+        );
+        limiter.record("test-nous");
+        assert!(
+            !limiter.is_allowed("test-nous"),
+            "should block at max_per_hour"
+        );
+    }
+
+    // -- extract_follow_up tests --
+
+    #[test]
+    fn extract_follow_up_basic() {
+        let output = "Some output\n\n## Follow-up\n\nCheck disk space on /data.\n";
+        let follow_up = extract_follow_up(output).expect("should extract");
+        assert_eq!(follow_up, "Check disk space on /data.");
+    }
+
+    #[test]
+    fn extract_follow_up_case_insensitive() {
+        let output = "Results:\n## follow-up\nReview memory usage trends.\n";
+        let follow_up = extract_follow_up(output).expect("should extract");
+        assert_eq!(follow_up, "Review memory usage trends.");
+    }
+
+    #[test]
+    fn extract_follow_up_stops_at_next_heading() {
+        let output = concat!(
+            "## Summary\nAll good.\n",
+            "## Follow-up\nInvestigate slow query.\n",
+            "## Notes\nExtra info.\n",
+        );
+        let follow_up = extract_follow_up(output).expect("should extract");
+        assert_eq!(follow_up, "Investigate slow query.");
+    }
+
+    #[test]
+    fn extract_follow_up_multiline() {
+        let output = concat!(
+            "## Follow-up\n",
+            "1. Check disk usage on /data\n",
+            "2. Review database size growth\n",
+            "3. Prune old trace files\n",
+        );
+        let follow_up = extract_follow_up(output).expect("should extract");
+        assert!(follow_up.contains("Check disk usage"));
+        assert!(follow_up.contains("Prune old trace files"));
+    }
+
+    #[test]
+    fn extract_follow_up_none_when_missing() {
+        let output = "Everything is fine.\n## Summary\nNo issues.\n";
+        assert!(extract_follow_up(output).is_none());
+    }
+
+    #[test]
+    fn extract_follow_up_none_when_empty_body() {
+        let output = "## Follow-up\n\n## Next Section\nStuff.\n";
+        assert!(
+            extract_follow_up(output).is_none(),
+            "empty follow-up body should return None"
+        );
+    }
+
+    #[test]
+    fn extract_follow_up_none_when_heading_only() {
+        let output = "## Follow-up";
+        assert!(
+            extract_follow_up(output).is_none(),
+            "heading-only should return None"
+        );
+    }
+
+    // -- execute_self_prompt tests --
+
+    #[tokio::test]
+    async fn execute_without_bridge_returns_failure() {
+        let result = execute_self_prompt("test-nous", "do something", None)
+            .await
+            .expect("should not error");
+        assert!(!result.success);
+        assert!(result.output.expect("has output").contains("no bridge"));
+    }
+
+    #[tokio::test]
+    async fn execute_with_noop_bridge_dispatches() {
+        let bridge = crate::bridge::NoopBridge;
+        let result = execute_self_prompt("test-nous", "investigate disk", Some(&bridge))
+            .await
+            .expect("should not error");
+        // NOTE: NoopBridge returns success=false, but the dispatch itself succeeds.
+        assert!(result.success);
+        assert!(result
+            .output
+            .expect("has output")
+            .contains("self-prompt dispatched"));
+    }
+
+    // -- Session key constant test --
+
+    #[test]
+    fn session_key_is_daemon_prefixed() {
+        assert!(
+            SELF_PROMPT_SESSION_KEY.starts_with("daemon:"),
+            "self-prompt session key must use daemon: prefix"
+        );
+    }
+}

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -178,6 +178,14 @@ pub struct DaemonConfig {
     /// Brief output mode: truncate tool results and model responses in logs.
     #[serde(default)]
     pub brief_output: bool,
+
+    /// Self-prompting configuration: daemon-initiated follow-up actions.
+    ///
+    /// WHY: self-prompting must be opt-in. Without explicit enablement, the
+    /// daemon never sends itself follow-up prompts. Rate limiting prevents
+    /// runaway loops from misconfigured attention checks.
+    #[serde(default)]
+    pub self_prompt: crate::self_prompt::SelfPromptConfig,
 }
 
 fn default_max_children() -> usize {
@@ -194,6 +202,7 @@ impl Default for DaemonConfig {
             webhook_port: None,
             watch_paths: Vec::new(),
             brief_output: false,
+            self_prompt: crate::self_prompt::SelfPromptConfig::default(),
         }
     }
 }


### PR DESCRIPTION
Add self-prompting to the daemon. When a task result contains a Follow-up section, the runner extracts it and dispatches a self-prompt via the bridge. SelfPromptConfig in DaemonConfig, disabled by default. Rate-limited per agent via sliding window. 23 new tests. Closes #2386