### PR TITLE
fix(theatron-desktop): desktop QoL — NOUS label, dark theme, collapsed sidebar, Ctrl+B

### DIFF
--- a/crates/theatron/desktop/Cargo.lock
+++ b/crates/theatron/desktop/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-koina"
-version = "0.13.63"
+version = "0.13.64"
 dependencies = [
  "compact_str",
  "jiff",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.13.63"
+version = "0.13.64"
 dependencies = [
  "aletheia-koina",
  "bytes",

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -1,3 +1,7 @@
+# WHY: Explicit [workspace] prevents cargo from walking up to the root
+# workspace and failing with "not in workspace" when building standalone.
+[workspace]
+
 [package]
 name = "theatron-desktop"
 # WHY: explicit values instead of workspace inheritance because this crate

--- a/crates/theatron/desktop/src/app.rs
+++ b/crates/theatron/desktop/src/app.rs
@@ -11,6 +11,8 @@ use crate::platform;
 use crate::services::toast::provide_toast_context;
 use crate::services::{config, settings_config};
 use crate::state::agents::AgentStore;
+use crate::state::app::TabBar;
+use crate::state::commands::CommandStore;
 use crate::state::connection::ConnectionState;
 use crate::state::notifications::{DndState, NotificationHistory};
 use crate::state::platform::{CloseBehavior, HotkeyState, QuickInputState, TrayState, WindowState};
@@ -20,12 +22,12 @@ use crate::views::chat::Chat;
 use crate::views::connect::ConnectView;
 use crate::views::files::Files;
 use crate::views::memory::Memory;
+use crate::views::meta::Meta;
 use crate::views::metrics::Metrics;
 use crate::views::metrics::tool_detail::ToolDetailView;
 use crate::views::ops::Ops;
 use crate::views::planning::{Planning, PlanningProject};
 use crate::views::sessions::Sessions;
-use crate::views::meta::Meta;
 use crate::views::settings::Settings;
 use crate::views::settings::wizard::SetupWizard;
 
@@ -86,7 +88,6 @@ fn MetricsToolDetail(tool_name: String) -> Element {
 pub(crate) fn App() -> Element {
     let loaded_settings = use_hook(settings_config::load_or_default);
     let loaded_config = use_hook(config::load_or_default);
-    let initial_theme = loaded_settings.appearance_settings().theme_mode();
     let first_run = use_hook(settings_config::is_first_run);
     let loaded_window_state = use_hook(platform::window_state::load_or_default);
 
@@ -96,6 +97,9 @@ pub(crate) fn App() -> Element {
     let appearance = use_signal(|| loaded_settings.appearance_settings());
     let keybindings = use_signal(|| loaded_settings.keybinding_store());
     let is_first_run = use_signal(|| first_run);
+
+    // NOTE: Force dark mode for theme consistency across all platforms.
+    let initial_theme = crate::theme::ThemeMode::Dark;
 
     // NOTE: Provide signals as context so all views can access them.
     use_context_provider(|| connection_state);
@@ -118,7 +122,7 @@ pub(crate) fn App() -> Element {
 
     rsx! {
         ThemeProvider {
-            initial_mode: Some(initial_theme),
+            initial_mode: Some(initial_theme), // Force dark mode
             if needs_wizard {
                 SetupWizard {}
             } else if needs_connect {
@@ -152,6 +156,10 @@ fn ConnectedApp() -> Element {
     // and before the Router (whose layout.rs also needs it). Providing here ensures
     // both the tray sync coroutine and all routed views see the same store.
     use_context_provider(|| Signal::new(AgentStore::new()));
+    // WHY: Provide here (not layout.rs) so they are scoped to the connected state
+    // and not the connect view.
+    use_context_provider(|| Signal::new(CommandStore::new()));
+    use_context_provider(|| Signal::new(TabBar::new()));
 
     // WHY: Start SSE coroutine here (not in App) so it only runs when connected
     // and has access to the finalized connection config.

--- a/crates/theatron/desktop/src/components/agent_sidebar.rs
+++ b/crates/theatron/desktop/src/components/agent_sidebar.rs
@@ -75,9 +75,29 @@ fn derive_status(nous_id: &NousId, event_state: &EventState) -> AgentStatus {
 /// Reads `Signal<AgentStore>` and `Signal<EventState>` from context. Provides
 /// the section of the sidebar that lists agents with colored status indicators.
 #[component]
-pub(crate) fn AgentSidebarView() -> Element {
+pub(crate) fn AgentSidebarView(collapsed: bool) -> Element {
     let mut store = use_context::<Signal<AgentStore>>();
     let event_state = use_context::<Signal<EventState>>();
+
+    // When collapsed, just show a minimal indicator.
+    if collapsed {
+        let agent_count = store.read().all().len();
+        return rsx! {
+            div {
+                style: "display: flex; flex-direction: column; align-items: center; padding: 8px 0;",
+                span {
+                    style: "font-size: 10px; color: #555; writing-mode: vertical-rl; text-orientation: mixed;",
+                    "NOUS"
+                }
+                if agent_count > 0 {
+                    span {
+                        style: "font-size: 10px; color: #22c55e; margin-top: 4px;",
+                        "● {agent_count}"
+                    }
+                }
+            }
+        };
+    }
 
     let agents: Vec<(NousId, String, String, AgentStatus, bool)> = {
         let s = store.read();
@@ -101,9 +121,9 @@ pub(crate) fn AgentSidebarView() -> Element {
     rsx! {
         div {
             style: "{SIDEBAR_SECTION_STYLE}",
-            div { style: "{SECTION_LABEL_STYLE}", "Agents" }
+            div { style: "{SECTION_LABEL_STYLE}", "NOUS" }
             if agents.is_empty() {
-                div { style: "{EMPTY_AGENTS_STYLE}", "No agents" }
+                div { style: "{EMPTY_AGENTS_STYLE}", "No nous" }
             } else {
                 for (id , name , emoji , status , is_active) in agents {
                     {

--- a/crates/theatron/desktop/src/layout.rs
+++ b/crates/theatron/desktop/src/layout.rs
@@ -5,14 +5,22 @@ use dioxus::prelude::*;
 use crate::app::Route;
 use crate::components::agent_sidebar::AgentSidebarView;
 use crate::components::connection_indicator::ConnectionIndicatorView;
-use crate::state::agents::AgentStore;
-use crate::state::app::TabBar;
-use crate::state::commands::CommandStore;
 use crate::state::navigation::NavAction;
 use crate::state::pipeline::RoutingState;
 use crate::state::view_preservation::ViewPreservationStore;
 
-const SIDEBAR_STYLE: &str = "\
+const SIDEBAR_COLLAPSED_STYLE: &str = "\
+    width: 48px; \
+    background: var(--bg-sidebar, #1a1a2e); \
+    color: var(--text-primary, #e0e0e0); \
+    padding: 16px 0; \
+    display: flex; \
+    flex-direction: column; \
+    gap: 4px; \
+    flex-shrink: 0;\
+";
+
+const SIDEBAR_EXPANDED_STYLE: &str = "\
     width: 220px; \
     background: var(--bg-sidebar, var(--bg-surface)); \
     color: var(--text-primary); \
@@ -48,6 +56,18 @@ const NAV_LINK_STYLE: &str = "\
     border-radius: var(--radius-md); \
     color: var(--text-primary); \
     text-decoration: none; \
+    font-size: var(--text-sm); \
+    white-space: nowrap;\
+";
+
+const NAV_LINK_ICON_ONLY_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: center; \
+    padding: 8px 12px; \
+    border-radius: var(--radius-md); \
+    color: var(--text-primary, #e0e0e0); \
+    text-decoration: none; \
     font-size: var(--text-sm);\
 ";
 
@@ -59,18 +79,13 @@ const NAV_DIVIDER_STYLE: &str = "\
 
 /// Layout shell rendered around all routes.
 ///
-/// Provides `Signal<AgentStore>`, `Signal<CommandStore>`, and `Signal<TabBar>`
-/// as context so child views can access them. The agent sidebar is rendered
-/// here so it persists across route changes.
+/// Provides `Signal<NavAction>` as context so child views can access it.
+/// The agent sidebar is rendered here so it persists across route changes.
 ///
-/// Global keyboard shortcuts (Ctrl+1--7, Ctrl+K, Escape) are handled here
-/// via `onkeydown` on the root layout div.
+/// Global keyboard shortcuts (Ctrl+1--7, Ctrl+K, Ctrl+B, Escape) are handled
+/// here via `onkeydown` on the root layout div.
 #[component]
 pub(crate) fn Layout() -> Element {
-    // WHY: AgentStore is provided by ConnectedApp (app.rs) so tray sync and
-    // all routed views share the same store instance.
-    use_context_provider(|| Signal::new(CommandStore::new()));
-    use_context_provider(|| Signal::new(TabBar::new()));
     use_context_provider(|| Signal::new(Option::<NavAction>::None));
 
     // WHY: View preservation store survives route changes so views can
@@ -84,8 +99,17 @@ pub(crate) fn Layout() -> Element {
 
     // Command palette open state -- shared with the keyboard handler.
     let palette_open = use_signal(|| false);
+    // Sidebar collapsed state -- default to collapsed.
+    let sidebar_collapsed = use_signal(|| true);
 
-    let keyboard_handler = crate::services::keybindings::use_global_keyboard(palette_open);
+    let keyboard_handler =
+        crate::services::keybindings::use_global_keyboard(palette_open, sidebar_collapsed);
+
+    let sidebar_style = if *sidebar_collapsed.read() {
+        SIDEBAR_COLLAPSED_STYLE
+    } else {
+        SIDEBAR_EXPANDED_STYLE
+    };
 
     rsx! {
         div {
@@ -96,21 +120,28 @@ pub(crate) fn Layout() -> Element {
             "aria-label": "Aletheia application",
 
             nav {
-                style: "{SIDEBAR_STYLE}",
+                style: "{sidebar_style}",
                 role: "navigation",
                 "aria-label": "Main navigation",
-                div { style: "{BRAND_STYLE}", "Aletheia" }
-                NavItem { to: Route::Chat {}, icon: "[C]", label: "Chat", shortcut: "Ctrl+1" }
-                NavItem { to: Route::Files {}, icon: "[F]", label: "Files", shortcut: "Ctrl+2" }
-                NavItem { to: Route::Planning {}, icon: "[P]", label: "Planning", shortcut: "Ctrl+3" }
-                NavItem { to: Route::Memory {}, icon: "[M]", label: "Memory", shortcut: "Ctrl+4" }
-                NavItem { to: Route::Metrics {}, icon: "[X]", label: "Metrics", shortcut: "Ctrl+5" }
-                NavItem { to: Route::Ops {}, icon: "[O]", label: "Ops", shortcut: "Ctrl+6" }
-                NavItem { to: Route::Sessions {}, icon: "[T]", label: "Sessions", shortcut: "Ctrl+7" }
-                NavItem { to: Route::Meta {}, icon: "[I]", label: "Insights", shortcut: "" }
-                NavItem { to: Route::Settings {}, icon: "[S]", label: "Settings", shortcut: "" }
+                if !*sidebar_collapsed.read() {
+                    div { style: "{BRAND_STYLE}", "Aletheia" }
+                } else {
+                    div {
+                        style: "font-size: 18px; font-weight: bold; padding: 8px 0; margin-bottom: 8px; text-align: center; color: var(--text-heading, #ffffff);",
+                        "A"
+                    }
+                }
+                NavItem { to: Route::Chat {}, icon: "[C]", label: "Chat", shortcut: "Ctrl+1", collapsed: *sidebar_collapsed.read() }
+                NavItem { to: Route::Files {}, icon: "[F]", label: "Files", shortcut: "Ctrl+2", collapsed: *sidebar_collapsed.read() }
+                NavItem { to: Route::Planning {}, icon: "[P]", label: "Planning", shortcut: "Ctrl+3", collapsed: *sidebar_collapsed.read() }
+                NavItem { to: Route::Memory {}, icon: "[M]", label: "Memory", shortcut: "Ctrl+4", collapsed: *sidebar_collapsed.read() }
+                NavItem { to: Route::Metrics {}, icon: "[X]", label: "Metrics", shortcut: "Ctrl+5", collapsed: *sidebar_collapsed.read() }
+                NavItem { to: Route::Ops {}, icon: "[O]", label: "Ops", shortcut: "Ctrl+6", collapsed: *sidebar_collapsed.read() }
+                NavItem { to: Route::Sessions {}, icon: "[T]", label: "Sessions", shortcut: "Ctrl+7", collapsed: *sidebar_collapsed.read() }
+                NavItem { to: Route::Meta {}, icon: "[I]", label: "Insights", shortcut: "", collapsed: *sidebar_collapsed.read() }
+                NavItem { to: Route::Settings {}, icon: "[S]", label: "Settings", shortcut: "", collapsed: *sidebar_collapsed.read() }
                 div { style: "{NAV_DIVIDER_STYLE}", role: "separator" }
-                AgentSidebarView {}
+                AgentSidebarView { collapsed: *sidebar_collapsed.read() }
                 div { style: "flex: 1;" }
                 ConnectionIndicatorView {}
             }
@@ -130,20 +161,28 @@ fn NavItem(
     icon: &'static str,
     label: &'static str,
     shortcut: &'static str,
+    collapsed: bool,
 ) -> Element {
     let title = if shortcut.is_empty() {
         label.to_string()
     } else {
         format!("{label} ({shortcut})")
     };
+    let style = if collapsed {
+        NAV_LINK_ICON_ONLY_STYLE
+    } else {
+        NAV_LINK_STYLE
+    };
     rsx! {
         Link {
             to,
-            style: "{NAV_LINK_STYLE}",
+            style: "{style}",
             "aria-label": "{title}",
             title: "{title}",
             span { "aria-hidden": "true", "{icon}" }
-            span { "{label}" }
+            if !collapsed {
+                span { "{label}" }
+            }
         }
     }
 }

--- a/crates/theatron/desktop/src/services/keybindings.rs
+++ b/crates/theatron/desktop/src/services/keybindings.rs
@@ -16,6 +16,7 @@
 //! | Ctrl+6        | Navigate → Ops                |
 //! | Ctrl+7        | Navigate → Sessions           |
 //! | Ctrl+K        | Open command palette          |
+//! | Ctrl+B        | Toggle sidebar                |
 //! | Ctrl+F or /   | Focus in-view search          |
 //! | Escape        | Dismiss modal / deselect      |
 //! | Arrow keys    | List navigation               |
@@ -33,6 +34,8 @@ pub(crate) enum KeyAction {
     NavigateTo(Route),
     /// Open the command palette.
     OpenPalette,
+    /// Toggle sidebar collapsed/expanded.
+    ToggleSidebar,
     /// Open / focus an in-view search bar.
     FocusSearch,
     /// Dismiss modal, close palette, deselect list item.
@@ -62,6 +65,7 @@ pub(crate) fn decode_key_raw(key: &str, ctrl: bool) -> KeyAction {
             "6" => KeyAction::NavigateTo(Route::Ops {}),
             "7" => KeyAction::NavigateTo(Route::Sessions {}),
             "k" | "K" => KeyAction::OpenPalette,
+            "b" | "B" => KeyAction::ToggleSidebar,
             "f" | "F" => KeyAction::FocusSearch,
             _ => KeyAction::Unhandled,
         };
@@ -91,6 +95,7 @@ pub(crate) fn decode_key(event: &KeyboardData) -> KeyAction {
 /// to attach to the root `div`.
 pub(crate) fn use_global_keyboard(
     mut palette_open: Signal<bool>,
+    mut sidebar_collapsed: Signal<bool>,
 ) -> impl FnMut(Event<KeyboardData>) {
     move |evt: Event<KeyboardData>| {
         match decode_key(&evt.data()) {
@@ -101,6 +106,10 @@ pub(crate) fn use_global_keyboard(
             KeyAction::OpenPalette => {
                 let current = *palette_open.read();
                 palette_open.set(!current);
+            }
+            KeyAction::ToggleSidebar => {
+                let current = *sidebar_collapsed.read();
+                sidebar_collapsed.set(!current);
             }
             KeyAction::FocusSearch => {
                 // NOTE: Each view handles search focus internally.
@@ -122,23 +131,38 @@ mod tests {
 
     #[test]
     fn ctrl_1_navigates_to_chat() {
-        assert_eq!(decode_key_raw("1", true), KeyAction::NavigateTo(Route::Chat {}));
+        assert_eq!(
+            decode_key_raw("1", true),
+            KeyAction::NavigateTo(Route::Chat {})
+        );
     }
 
     #[test]
     fn ctrl_2_navigates_to_files() {
-        assert_eq!(decode_key_raw("2", true), KeyAction::NavigateTo(Route::Files {}));
+        assert_eq!(
+            decode_key_raw("2", true),
+            KeyAction::NavigateTo(Route::Files {})
+        );
     }
 
     #[test]
     fn ctrl_7_navigates_to_sessions() {
-        assert_eq!(decode_key_raw("7", true), KeyAction::NavigateTo(Route::Sessions {}));
+        assert_eq!(
+            decode_key_raw("7", true),
+            KeyAction::NavigateTo(Route::Sessions {})
+        );
     }
 
     #[test]
     fn ctrl_k_opens_palette() {
         assert_eq!(decode_key_raw("k", true), KeyAction::OpenPalette);
         assert_eq!(decode_key_raw("K", true), KeyAction::OpenPalette);
+    }
+
+    #[test]
+    fn ctrl_b_toggles_sidebar() {
+        assert_eq!(decode_key_raw("b", true), KeyAction::ToggleSidebar);
+        assert_eq!(decode_key_raw("B", true), KeyAction::ToggleSidebar);
     }
 
     #[test]

--- a/crates/theatron/desktop/src/state/metrics.rs
+++ b/crates/theatron/desktop/src/state/metrics.rs
@@ -38,7 +38,10 @@ pub(crate) enum DateRange {
     Last7Days,
     Last30Days,
     Last90Days,
-    Custom { from: String, to: String },
+    Custom {
+        from: String,
+        to: String,
+    },
 }
 
 impl DateRange {
@@ -124,7 +127,10 @@ pub(crate) struct TokenSeriesPoint {
 }
 
 impl TokenSeriesPoint {
-    #[expect(dead_code, reason = "used when series filtering by agent/model is implemented")]
+    #[expect(
+        dead_code,
+        reason = "used when series filtering by agent/model is implemented"
+    )]
     pub(crate) fn total(&self) -> u64 {
         self.input_tokens.saturating_add(self.output_tokens)
     }
@@ -298,13 +304,13 @@ pub(crate) struct AgentCostRow {
     pub prev_period_cost: f64,
 }
 
+#[expect(clippy::as_conversions, reason = "count to f64 for cost ratio")]
 impl AgentCostRow {
     pub(crate) fn cost_per_session(&self) -> f64 {
         if self.session_count == 0 {
             0.0
         } else {
-            #[expect(clippy::as_conversions, reason = "session count to f64 for cost ratio")]
-            { self.total_cost / self.session_count as f64 }
+            self.total_cost / self.session_count as f64
         }
     }
 
@@ -312,8 +318,7 @@ impl AgentCostRow {
         if self.message_count == 0 {
             0.0
         } else {
-            #[expect(clippy::as_conversions, reason = "message count to f64 for cost ratio")]
-            { self.total_cost / self.message_count as f64 }
+            self.total_cost / self.message_count as f64
         }
     }
 
@@ -321,8 +326,7 @@ impl AgentCostRow {
         if self.output_tokens == 0 {
             0.0
         } else {
-            #[expect(clippy::as_conversions, reason = "token count to f64 for cost ratio")]
-            { self.total_cost / (self.output_tokens as f64 / 1000.0) }
+            self.total_cost / (self.output_tokens as f64 / 1000.0)
         }
     }
 }
@@ -416,11 +420,7 @@ pub(crate) fn budget_bar_color(pct: f64) -> &'static str {
 /// Project month-end spend via linear extrapolation.
 ///
 /// Returns 0.0 if `day_of_month` is 0 (guard against division by zero).
-pub(crate) fn project_month_end(
-    current_spend: f64,
-    day_of_month: u32,
-    days_in_month: u32,
-) -> f64 {
+pub(crate) fn project_month_end(current_spend: f64, day_of_month: u32, days_in_month: u32) -> f64 {
     if day_of_month == 0 || days_in_month == 0 {
         return 0.0;
     }
@@ -435,7 +435,10 @@ pub(crate) fn project_month_end(
     clippy::cast_precision_loss,
     reason = "display-only: sub-token precision irrelevant"
 )]
-#[expect(clippy::as_conversions, reason = "u64 to f64 for human-readable formatting")]
+#[expect(
+    clippy::as_conversions,
+    reason = "u64 to f64 for human-readable formatting"
+)]
 pub(crate) fn format_tokens(count: u64) -> String {
     const K: u64 = 1_000;
     const M: u64 = 1_000_000;
@@ -506,7 +509,10 @@ fn epoch_secs_to_ymd(secs: u64) -> (u32, u32, u32) {
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let y = if m <= 2 { y + 1 } else { y };
     {
-        #[expect(clippy::as_conversions, reason = "calendar components fit u32 for valid dates")]
+        #[expect(
+            clippy::as_conversions,
+            reason = "calendar components fit u32 for valid dates"
+        )]
         let result = (y as u32, m as u32, d as u32);
         result
     }
@@ -557,8 +563,7 @@ pub(crate) fn cost_per_1k_output(model: &str) -> f64 {
 /// Consistent accent color for an agent by list position.
 pub(crate) fn agent_color(index: usize) -> &'static str {
     const PALETTE: &[&str] = &[
-        "#5b6af0", "#10b981", "#f59e0b", "#f43f5e",
-        "#0ea5e9", "#8b5cf6", "#ec4899", "#14b8a6",
+        "#5b6af0", "#10b981", "#f59e0b", "#f43f5e", "#0ea5e9", "#8b5cf6", "#ec4899", "#14b8a6",
     ];
     PALETTE[index % PALETTE.len()]
 }
@@ -606,11 +611,7 @@ pub(crate) fn sort_agent_token_rows(
 }
 
 /// Sort agent cost rows in-place.
-pub(crate) fn sort_agent_cost_rows(
-    rows: &mut Vec<AgentCostRow>,
-    col: AgentCostSort,
-    dir: SortDir,
-) {
+pub(crate) fn sort_agent_cost_rows(rows: &mut Vec<AgentCostRow>, col: AgentCostSort, dir: SortDir) {
     rows.sort_by(|a, b| {
         let cmp = match col {
             AgentCostSort::Name => a.name.cmp(&b.name),
@@ -656,7 +657,10 @@ mod tests {
     fn compute_delta_down_direction() {
         let d = compute_delta_f64(80.0, 100.0);
         assert!(!d.is_up, "80 vs 100 should be down");
-        assert!((d.delta_pct - 20.0).abs() < 0.01, "delta magnitude must be 20%");
+        assert!(
+            (d.delta_pct - 20.0).abs() < 0.01,
+            "delta magnitude must be 20%"
+        );
     }
 
     #[test]
@@ -701,7 +705,10 @@ mod tests {
     #[test]
     fn project_month_end_linear() {
         let projected = project_month_end(15.0, 15, 30);
-        assert!((projected - 30.0).abs() < 0.01, "half-month should project to double");
+        assert!(
+            (projected - 30.0).abs() < 0.01,
+            "half-month should project to double"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Renames "Agents" → "NOUS" in sidebar section label and empty state (user-visible strings only, code identifiers unchanged)
- Forces dark theme unconditionally (`ThemeMode::Dark`) for cross-platform consistency
- Sidebar starts collapsed (48px icon-only) by default; Ctrl+B toggles to 220px expanded
- Adds `ToggleSidebar` `KeyAction` variant and Ctrl+B decode to keybindings service with test
- Moves `CommandStore`/`TabBar` providers from `layout.rs` to `ConnectedApp` in `app.rs`, eliminating the duplicate provider path that existed alongside `AgentStore`
- Adds `[workspace]` to `desktop/Cargo.toml` so `cargo build --manifest-path` works without the "not in workspace" error (pre-existing build breakage)
- Consolidates three per-method `#[expect(clippy::as_conversions)]` attributes to a single impl-block attribute in `metrics.rs`

## Test plan

- [ ] Build passes: `CARGO_TARGET_DIR=/data/target cargo build --manifest-path crates/theatron/desktop/Cargo.toml`
- [ ] Sidebar starts collapsed on launch (48px, icon-only)
- [ ] Ctrl+B expands sidebar to 220px, second press collapses
- [ ] Sidebar section shows "NOUS" label; empty state shows "No nous"
- [ ] App launches in dark theme regardless of system preference
- [ ] Ctrl+K opens command palette (unchanged)
- [ ] Ctrl+1–7 nav shortcuts (unchanged)

Closes #2409, closes #2410. Replaces #2546.