### PR TITLE
feat(dokimion): EvalProvider trait for universal verification backbone

### DIFF
--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -9,12 +9,14 @@ pub(crate) mod cognitive;
 pub(crate) mod error;
 /// JSONL persistence for evaluation results as training data.
 pub mod persistence;
+/// Evaluation provider trait: pluggable scenario sources for programmatic use.
+pub mod provider;
 /// Evaluation report types for summarizing scenario results.
 pub mod report;
 /// Evaluation scenario runner: executes scenarios and collects results.
 pub mod runner;
 /// Scenario definition types: steps, assertions, and expected outcomes.
-pub(crate) mod scenario;
+pub mod scenario;
 /// Built-in evaluation scenarios for validating Aletheia runtime behavior.
 pub mod scenarios;
 /// SSE stream consumer for real-time evaluation output.

--- a/crates/eval/src/provider.rs
+++ b/crates/eval/src/provider.rs
@@ -1,0 +1,124 @@
+//! Evaluation provider trait: pluggable scenario sources.
+//!
+//! [`EvalProvider`] decouples scenario registration from execution. The runner
+//! no longer hardcodes `scenarios::all_scenarios()` — instead, callers provide
+//! a `Box<dyn EvalProvider>` that supplies the scenario set.
+//!
+//! WHY: dokimion was CLI-only. Making scenario sources pluggable enables:
+//! - Daemon probes running a subset of scenarios on a schedule
+//! - Canary prompt suites (W-12) as a separate provider
+//! - Phase gate checks composing multiple providers
+//! - A/B model evaluation with custom scenario sets
+
+use crate::scenario::Scenario;
+
+// ---------------------------------------------------------------------------
+// EvalProvider trait
+// ---------------------------------------------------------------------------
+
+/// Source of evaluation scenarios.
+///
+/// Implementations decide which scenarios to include. The runner calls
+/// [`provide`] once at the start of a run and executes the returned set.
+pub trait EvalProvider: Send + Sync {
+    /// Return the scenarios this provider supplies.
+    ///
+    /// Called once per eval run. Implementations may filter, compose, or
+    /// dynamically generate scenarios.
+    fn provide(&self) -> Vec<Box<dyn Scenario>>;
+
+    /// Human-readable name for display in reports.
+    fn name(&self) -> &str;
+}
+
+// ---------------------------------------------------------------------------
+// BuiltinProvider
+// ---------------------------------------------------------------------------
+
+/// Provider that returns all built-in dokimion scenarios.
+///
+/// This is the default when no custom provider is specified — it wraps
+/// [`scenarios::all_scenarios()`](crate::scenarios::all_scenarios).
+pub struct BuiltinProvider;
+
+impl EvalProvider for BuiltinProvider {
+    fn provide(&self) -> Vec<Box<dyn Scenario>> {
+        crate::scenarios::all_scenarios()
+    }
+
+    fn name(&self) -> &str {
+        "builtin"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CompositeProvider
+// ---------------------------------------------------------------------------
+
+/// Combines multiple providers into a single scenario set.
+///
+/// Scenarios are collected in provider order. Deduplication is the caller's
+/// responsibility (scenario IDs are not enforced unique across providers).
+pub struct CompositeProvider {
+    providers: Vec<Box<dyn EvalProvider>>,
+    name: String,
+}
+
+impl CompositeProvider {
+    /// Create a composite from a list of providers.
+    #[must_use]
+    pub fn new(providers: Vec<Box<dyn EvalProvider>>) -> Self {
+        let name = providers
+            .iter()
+            .map(|p| p.name())
+            .collect::<Vec<_>>()
+            .join("+");
+        Self { providers, name }
+    }
+}
+
+impl EvalProvider for CompositeProvider {
+    fn provide(&self) -> Vec<Box<dyn Scenario>> {
+        let mut scenarios = Vec::new();
+        for provider in &self.providers {
+            scenarios.extend(provider.provide());
+        }
+        scenarios
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_provider_returns_scenarios() {
+        let provider = BuiltinProvider;
+        let scenarios = provider.provide();
+        assert!(!scenarios.is_empty(), "builtin provider should return scenarios");
+        assert_eq!(provider.name(), "builtin");
+    }
+
+    #[test]
+    fn composite_provider_combines() {
+        let composite = CompositeProvider::new(vec![
+            Box::new(BuiltinProvider),
+            Box::new(BuiltinProvider),
+        ]);
+        let scenarios = composite.provide();
+        let single = BuiltinProvider.provide().len();
+        assert_eq!(scenarios.len(), single * 2);
+        assert_eq!(composite.name(), "builtin+builtin");
+    }
+
+    #[test]
+    fn empty_composite() {
+        let composite = CompositeProvider::new(vec![]);
+        assert!(composite.provide().is_empty());
+        assert!(composite.name().is_empty());
+    }
+}

--- a/crates/eval/src/runner.rs
+++ b/crates/eval/src/runner.rs
@@ -7,8 +7,8 @@ use tracing::{info, warn};
 use aletheia_koina::secret::SecretString;
 
 use crate::client::EvalClient;
+use crate::provider::{BuiltinProvider, EvalProvider};
 use crate::scenario::{Scenario, ScenarioOutcome, ScenarioResult};
-use crate::scenarios;
 
 /// Configuration for a scenario run.
 pub struct RunConfig {
@@ -44,25 +44,39 @@ pub struct RunReport {
 pub struct ScenarioRunner {
     config: RunConfig,
     client: EvalClient,
+    provider: Box<dyn EvalProvider>,
 }
 
 impl ScenarioRunner {
-    /// Create a new runner from the given configuration.
+    /// Create a new runner with the built-in scenario provider.
     #[must_use]
     pub fn new(config: RunConfig) -> Self {
+        Self::with_provider(config, Box::new(BuiltinProvider))
+    }
+
+    /// Create a runner with a custom scenario provider.
+    ///
+    /// Use this to supply canary suites, phase gate checks, or composed
+    /// scenario sets from multiple providers.
+    #[must_use]
+    pub fn with_provider(config: RunConfig, provider: Box<dyn EvalProvider>) -> Self {
         let client = EvalClient::new(
             &config.base_url,
             config.token.as_ref().map(|t| t.expose_secret().to_owned()),
         );
-        Self { config, client }
+        Self {
+            config,
+            client,
+            provider,
+        }
     }
 
     /// Run all scenarios matching the configured filter.
     #[expect(clippy::too_many_lines, reason = "sequential scenario orchestration")]
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), fields(provider = self.provider.name()))]
     pub async fn run(&self) -> RunReport {
         let start = Instant::now();
-        let all_scenarios = scenarios::all_scenarios();
+        let all_scenarios = self.provider.provide();
 
         let scenarios: Vec<Box<dyn Scenario>> = match &self.config.filter {
             Some(filter) => all_scenarios

--- a/crates/eval/src/scenario.rs
+++ b/crates/eval/src/scenario.rs
@@ -10,7 +10,7 @@ use crate::client::EvalClient;
 use crate::error::{self, Error, Result};
 
 /// Boxed future returned by scenario `run` methods.
-pub(crate) type ScenarioFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+pub type ScenarioFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 
 /// Metadata describing a scenario for display and filtering.
 #[derive(Debug, Clone)]
@@ -36,25 +36,34 @@ pub struct ScenarioMeta {
 #[non_exhaustive]
 pub enum ScenarioOutcome {
     /// Scenario completed within timeout without errors.
-    Passed { duration: Duration },
+    Passed {
+        /// Wall-clock execution time.
+        duration: Duration,
+    },
     /// Scenario returned an error or assertion failed.
-    Failed { duration: Duration, error: Error },
+    Failed {
+        /// Wall-clock execution time.
+        duration: Duration,
+        /// The error that caused failure.
+        error: Error,
+    },
     /// Scenario was not run (e.g. missing auth token or nous).
-    Skipped { reason: String },
+    Skipped {
+        /// Human-readable reason for skipping.
+        reason: String,
+    },
 }
 
 impl ScenarioOutcome {
     /// Returns `true` if the scenario passed.
     #[must_use]
-    #[expect(dead_code, reason = "eval scenario outcome query methods")]
-    pub(crate) fn is_passed(&self) -> bool {
+    pub fn is_passed(&self) -> bool {
         matches!(self, Self::Passed { .. })
     }
 
     /// Returns `true` if the scenario failed.
     #[must_use]
-    #[expect(dead_code, reason = "eval scenario outcome query methods")]
-    pub(crate) fn is_failed(&self) -> bool {
+    pub fn is_failed(&self) -> bool {
         matches!(self, Self::Failed { .. })
     }
 }


### PR DESCRIPTION
## Summary
- New `EvalProvider` trait: pluggable scenario sources for programmatic use
- `BuiltinProvider` wraps existing `all_scenarios()` (backward compatible)
- `CompositeProvider` combines multiple providers
- `ScenarioRunner::with_provider()` accepts custom scenario sets
- Made `scenario` module and `ScenarioFuture` type public

Unblocks W-12 (canary prompt suite), #2251 (A/B training pipeline), and KAIROS daemon probes.

Closes #2314

## Test plan
- [x] `cargo test -p aletheia-dokimion` — 143 tests pass
- [x] `cargo check --workspace` — zero errors
- [x] Provider unit tests: builtin returns scenarios, composite combines, empty composite works

🤖 Generated with [Claude Code](https://claude.com/claude-code)