### PR TITLE
refactor(nous): parameterize distillation triggers

### DIFF
--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -347,7 +347,7 @@ mod tests {
         let config = DistillTriggerConfig::default();
         let result = should_trigger_distillation(&session, 200_000, &config);
         assert!(result.is_some());
-        assert!(result.unwrap().contains("120K"));
+        assert!(result.unwrap().contains("120000"));
     }
 
     #[test]

--- a/crates/nous/src/hooks/builtins/correction.rs
+++ b/crates/nous/src/hooks/builtins/correction.rs
@@ -799,6 +799,7 @@ mod tests {
             usage: crate::pipeline::TurnUsage::default(),
             signals: Vec::new(),
             stop_reason: "end_turn".to_owned(),
+            degraded: None,
         };
         let ctx = crate::hooks::TurnContext {
             result: &turn_result,


### PR DESCRIPTION
## Summary
Moves 6 hardcoded distillation constants into DistillTriggerConfig:
- context_token_trigger (120K)
- message_count_trigger (150)
- stale_session_days (7)
- stale_session_min_messages (20)
- never_distilled_message_trigger (30)
- legacy_threshold_min_messages (10)

All defaults match originals. Now configurable via aletheia.toml.

Part of #2306

## Test plan
- [x] `cargo check -p aletheia-nous` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)