### PR TITLE
fix: repair all pre-existing test compilation errors

### DIFF
--- a/crates/energeia/src/http/client.rs
+++ b/crates/energeia/src/http/client.rs
@@ -254,7 +254,9 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    // WHY: single-threaded runtime prevents non-deterministic event ordering
+    // when workspace tests run in parallel and CPU pressure delays subprocess I/O.
+    #[tokio::test(flavor = "current_thread")]
     async fn spawn_session_successful() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let lines = &[
@@ -277,7 +279,7 @@ mod tests {
         assert!((result.cost_usd - 0.10).abs() < f64::EPSILON);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn spawn_session_error_result() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let lines = &[
@@ -296,7 +298,7 @@ mod tests {
         assert!(!result.success);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn resume_session_works() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let lines = &[
@@ -316,7 +318,7 @@ mod tests {
         assert!(result.success);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn spawn_session_event_streaming() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let lines = &[

--- a/crates/energeia/src/store/fjall_store.rs
+++ b/crates/energeia/src/store/fjall_store.rs
@@ -912,6 +912,8 @@ mod tests {
             resume_count: 0,
             pr_url: Some("https://github.com/acme/repo/pull/42".to_owned()),
             error: None,
+            model: Some("claude-sonnet-4-20250514".to_owned()),
+            blast_radius: vec!["crates/test/".to_owned()],
         };
 
         let fact = store.record_training_data(session, &outcome).unwrap();

--- a/crates/episteme/src/knowledge_store/tests/causal.rs
+++ b/crates/episteme/src/knowledge_store/tests/causal.rs
@@ -4,10 +4,10 @@
     reason = "test assertions use direct indexing"
 )]
 
-use crate::id::FactId;
+use crate::id::{CausalEdgeId, FactId};
 use crate::knowledge::{
-    CausalEdge, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
-    TemporalOrdering, far_future,
+    CausalEdge, CausalRelationType, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance,
+    FactTemporal, TemporalOrdering, far_future,
 };
 use crate::knowledge_store::KnowledgeStore;
 
@@ -47,11 +47,14 @@ fn make_fact(id: &str, content: &str) -> Fact {
 /// Helper: create a causal edge.
 fn make_edge(cause: &str, effect: &str, confidence: f64) -> CausalEdge {
     CausalEdge {
-        cause: FactId::new(cause).expect("valid test id"),
-        effect: FactId::new(effect).expect("valid test id"),
+        id: CausalEdgeId::new(ulid::Ulid::new().to_string()).expect("valid test id"),
+        source_id: FactId::new(cause).expect("valid test id"),
+        target_id: FactId::new(effect).expect("valid test id"),
+        relationship_type: CausalRelationType::Caused,
         ordering: TemporalOrdering::Before,
         confidence,
-        created_at: jiff::Timestamp::now(),
+        evidence_session_id: None,
+        timestamp: jiff::Timestamp::now(),
     }
 }
 
@@ -77,7 +80,7 @@ fn insert_and_query_causal_edge() {
         .expect("query_effects should succeed");
     assert_eq!(effects.len(), 1, "should have one effect");
     assert_eq!(
-        effects[0].effect.as_str(),
+        effects[0].target_id.as_str(),
         "fact-b",
         "effect should be fact-b"
     );
@@ -91,7 +94,7 @@ fn insert_and_query_causal_edge() {
         .query_causes(&FactId::new("fact-b").expect("valid test id"))
         .expect("query_causes should succeed");
     assert_eq!(causes.len(), 1, "should have one cause");
-    assert_eq!(causes[0].cause.as_str(), "fact-a", "cause should be fact-a");
+    assert_eq!(causes[0].source_id.as_str(), "fact-a", "cause should be fact-a");
 }
 
 #[test]
@@ -288,11 +291,14 @@ fn causal_edge_with_concurrent_ordering() {
         .expect("insert c2");
 
     let edge = CausalEdge {
-        cause: FactId::new("c1").expect("valid test id"),
-        effect: FactId::new("c2").expect("valid test id"),
+        id: CausalEdgeId::new(ulid::Ulid::new().to_string()).expect("valid test id"),
+        source_id: FactId::new("c1").expect("valid test id"),
+        target_id: FactId::new("c2").expect("valid test id"),
+        relationship_type: CausalRelationType::Caused,
         ordering: TemporalOrdering::Concurrent,
         confidence: 0.75,
-        created_at: jiff::Timestamp::now(),
+        evidence_session_id: None,
+        timestamp: jiff::Timestamp::now(),
     };
     store
         .insert_causal_edge(&edge)

--- a/crates/episteme/src/trace_ingest.rs
+++ b/crates/episteme/src/trace_ingest.rs
@@ -574,14 +574,31 @@ mod tests {
 
     #[test]
     fn layer_on_event_via_tracing_subscriber() {
+        // WHY: TraceIngestLayer uses interior mutability (Mutex<Vec>), so we
+        // share it via Arc between the subscriber and the assertion code.
+        // tracing-subscriber 0.3+ doesn't impl Layer for Arc<L>, so we
+        // wrap in a newtype that delegates.
         let layer = std::sync::Arc::new(TraceIngestLayer::new());
-
-        // Clone an Arc handle so we can inspect the buffer after recording.
         let captured = std::sync::Arc::clone(&layer);
 
-        // Set a per-test default subscriber scoped to this thread.
+        struct ArcLayer(std::sync::Arc<TraceIngestLayer>);
+        impl<S> tracing_subscriber::Layer<S> for ArcLayer
+        where
+            S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+        {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                <TraceIngestLayer as tracing_subscriber::Layer<S>>::on_event(
+                    &self.0, event, ctx,
+                );
+            }
+        }
+
         let _guard = tracing_subscriber::registry()
-            .with(std::sync::Arc::clone(&layer))
+            .with(ArcLayer(std::sync::Arc::clone(&layer)))
             .set_default();
 
         tracing::info!(

--- a/crates/graphe/src/migration.rs
+++ b/crates/graphe/src/migration.rs
@@ -66,7 +66,7 @@ DROP TABLE IF EXISTS sessions;",
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     expires_at TEXT
 );
-CREATE INDEX IF NOT EXISTS idx_blackboard_key ON blackboard(key);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_blackboard_key ON blackboard(key);
 CREATE INDEX IF NOT EXISTS idx_blackboard_expires ON blackboard(expires_at);",
         down: "DROP TABLE IF EXISTS blackboard;",
     },


### PR DESCRIPTION
## Summary
Four independent fixes that eliminate all workspace test compilation errors:
- episteme causal tests: CausalEdge field renames
- episteme trace_ingest: Arc<Layer> newtype for tracing-subscriber compat
- energeia fjall_store: missing model + blast_radius in test fixture
- graphe blackboard: UNIQUE index for ON CONFLICT(key)

## Test plan
- [x] `cargo test --workspace` — 2,400+ tests compile, all pass except 1 flaky subprocess mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)