### PR TITLE
feat(krites): v2 HNSW + FTS/BM25 indexes

### DIFF
--- a/crates/krites/src/v2/index/fts.rs
+++ b/crates/krites/src/v2/index/fts.rs
@@ -1,0 +1,404 @@
+//! Full-text search index with BM25 scoring.
+//!
+//! Invoked via `~facts:content_fts{id | query: $q, k: $k, score_kind: 'bm25'}`
+//! in episteme's recall pipeline.
+//!
+//! Implementation: inverted index with term frequency tracking and BM25
+//! scoring. Supports simple tokenization, English stemming (via
+//! rust-stemmers), and stopword filtering.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::RwLock;
+
+use crate::v2::error::{self, Result};
+use crate::v2::value::Value;
+
+use super::Index;
+
+// ---------------------------------------------------------------------------
+// FTS configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for the full-text search index.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct FtsConfig {
+    /// Name of the tokenizer ("simple" or "unicode").
+    pub tokenizer: String,
+    /// Whether to apply stemming.
+    pub stem: bool,
+    /// Language for stemming.
+    pub language: String,
+    /// Whether to filter stopwords.
+    pub filter_stopwords: bool,
+}
+
+impl Default for FtsConfig {
+    fn default() -> Self {
+        Self {
+            tokenizer: "simple".to_owned(),
+            stem: true,
+            language: "english".to_owned(),
+            filter_stopwords: true,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BM25 parameters
+// ---------------------------------------------------------------------------
+
+const BM25_K1: f64 = 1.2;
+const BM25_B: f64 = 0.75;
+
+// ---------------------------------------------------------------------------
+// FTS index
+// ---------------------------------------------------------------------------
+
+/// Full-text search index with BM25 scoring.
+pub struct FtsIndex {
+    name: String,
+    config: FtsConfig,
+    /// Inverted index: term → set of (doc_id, term_frequency).
+    index: RwLock<InvertedIndex>,
+}
+
+struct InvertedIndex {
+    /// term → vec of (doc_id, term_frequency)
+    postings: HashMap<String, Vec<(Vec<u8>, u32)>>,
+    /// doc_id → document length (in tokens)
+    doc_lengths: HashMap<Vec<u8>, u32>,
+    /// Total documents indexed.
+    doc_count: usize,
+    /// Sum of all document lengths (for avgdl).
+    total_length: u64,
+}
+
+impl InvertedIndex {
+    fn new() -> Self {
+        Self {
+            postings: HashMap::new(),
+            doc_lengths: HashMap::new(),
+            doc_count: 0,
+            total_length: 0,
+        }
+    }
+}
+
+impl FtsIndex {
+    /// Create a new FTS index.
+    #[must_use]
+    pub fn new(name: impl Into<String>, config: FtsConfig) -> Self {
+        Self {
+            name: name.into(),
+            config,
+            index: RwLock::new(InvertedIndex::new()),
+        }
+    }
+
+    /// Tokenize text into terms.
+    fn tokenize(&self, text: &str) -> Vec<String> {
+        let tokens: Vec<String> = text
+            .split(|c: char| !c.is_alphanumeric() && c != '\'')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_lowercase())
+            .collect();
+
+        let tokens = if self.config.filter_stopwords {
+            tokens
+                .into_iter()
+                .filter(|t| !is_stopword(t))
+                .collect()
+        } else {
+            tokens
+        };
+
+        if self.config.stem {
+            tokens.into_iter().map(|t| stem_english(&t)).collect()
+        } else {
+            tokens
+        }
+    }
+}
+
+impl Index for FtsIndex {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn upsert(&self, id: &[u8], value: &Value) -> Result<()> {
+        let text = match value {
+            Value::Str(s) => s.to_string(),
+            _ => {
+                return Err(error::IndexSnafu {
+                    index_name: self.name.clone(),
+                    message: format!("expected string for FTS, got {}", value.type_name()),
+                }
+                .build())
+            }
+        };
+
+        let terms = self.tokenize(&text);
+        let doc_len = terms.len() as u32;
+
+        let mut idx = self.index.write().map_err(|_| {
+            error::IndexSnafu {
+                index_name: self.name.clone(),
+                message: "lock poisoned",
+            }
+            .build()
+        })?;
+
+        // Remove old entry if exists (upsert).
+        if let Some(old_len) = idx.doc_lengths.remove(id) {
+            idx.total_length -= u64::from(old_len);
+            idx.doc_count -= 1;
+            for postings in idx.postings.values_mut() {
+                postings.retain(|(doc_id, _)| doc_id != id);
+            }
+        }
+
+        // Count term frequencies.
+        let mut tf_map: HashMap<String, u32> = HashMap::new();
+        for term in &terms {
+            *tf_map.entry(term.clone()).or_insert(0) += 1;
+        }
+
+        // Add to postings.
+        for (term, tf) in tf_map {
+            idx.postings
+                .entry(term)
+                .or_default()
+                .push((id.to_vec(), tf));
+        }
+
+        idx.doc_lengths.insert(id.to_vec(), doc_len);
+        idx.doc_count += 1;
+        idx.total_length += u64::from(doc_len);
+
+        Ok(())
+    }
+
+    fn remove(&self, id: &[u8]) -> Result<()> {
+        let mut idx = self.index.write().map_err(|_| {
+            error::IndexSnafu {
+                index_name: self.name.clone(),
+                message: "lock poisoned",
+            }
+            .build()
+        })?;
+
+        if let Some(old_len) = idx.doc_lengths.remove(id) {
+            idx.total_length -= u64::from(old_len);
+            idx.doc_count -= 1;
+            for postings in idx.postings.values_mut() {
+                postings.retain(|(doc_id, _)| doc_id != id);
+            }
+        }
+        Ok(())
+    }
+
+    fn search(
+        &self,
+        query: &Value,
+        k: usize,
+        _params: &BTreeMap<String, Value>,
+    ) -> Result<Vec<(Vec<u8>, f64)>> {
+        let query_text = match query {
+            Value::Str(s) => s.to_string(),
+            _ => {
+                return Err(error::IndexSnafu {
+                    index_name: self.name.clone(),
+                    message: format!("expected string query, got {}", query.type_name()),
+                }
+                .build())
+            }
+        };
+
+        let query_terms = self.tokenize(&query_text);
+        if query_terms.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let idx = self.index.read().map_err(|_| {
+            error::IndexSnafu {
+                index_name: self.name.clone(),
+                message: "lock poisoned",
+            }
+            .build()
+        })?;
+
+        let n = idx.doc_count as f64;
+        let avgdl = if idx.doc_count > 0 {
+            idx.total_length as f64 / n
+        } else {
+            1.0
+        };
+
+        // Accumulate BM25 scores per document.
+        let mut scores: HashMap<Vec<u8>, f64> = HashMap::new();
+
+        for term in &query_terms {
+            let Some(postings) = idx.postings.get(term) else {
+                continue;
+            };
+
+            let df = postings.len() as f64;
+            // IDF: log((N - df + 0.5) / (df + 0.5) + 1)
+            let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+
+            for (doc_id, tf) in postings {
+                let tf_f64 = f64::from(*tf);
+                let dl = f64::from(idx.doc_lengths.get(doc_id).copied().unwrap_or(1));
+
+                // BM25 term score
+                let numerator = tf_f64 * (BM25_K1 + 1.0);
+                let denominator = tf_f64 + BM25_K1 * (1.0 - BM25_B + BM25_B * dl / avgdl);
+                let score = idf * numerator / denominator;
+
+                *scores.entry(doc_id.clone()).or_insert(0.0) += score;
+            }
+        }
+
+        // Sort by score descending (higher = more relevant).
+        // WHY: BM25 scores are relevance scores, not distances.
+        // Convert to distance = 1/score for consistency with Index trait.
+        let mut results: Vec<(Vec<u8>, f64)> = scores
+            .into_iter()
+            .map(|(id, score)| {
+                let distance = if score > 0.0 { 1.0 / score } else { f64::MAX };
+                (id, distance)
+            })
+            .collect();
+
+        results.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.truncate(k);
+        Ok(results)
+    }
+
+    fn len(&self) -> usize {
+        self.index
+            .read()
+            .map(|idx| idx.doc_count)
+            .unwrap_or(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Text processing
+// ---------------------------------------------------------------------------
+
+/// Simple English stemmer (Porter-like suffix stripping).
+fn stem_english(word: &str) -> String {
+    // WHY: rust-stemmers is already a krites dependency. Use it.
+    use rust_stemmers::{Algorithm, Stemmer};
+    let stemmer = Stemmer::create(Algorithm::English);
+    stemmer.stem(word).to_string()
+}
+
+/// English stopword check.
+fn is_stopword(word: &str) -> bool {
+    static STOPWORDS: &[&str] = &[
+        "a", "an", "and", "are", "as", "at", "be", "but", "by", "for",
+        "from", "had", "has", "have", "he", "her", "his", "how", "i",
+        "if", "in", "into", "is", "it", "its", "just", "me", "my",
+        "no", "not", "of", "on", "or", "our", "out", "own", "say",
+        "she", "so", "some", "than", "that", "the", "their", "them",
+        "then", "there", "these", "they", "this", "those", "through",
+        "to", "too", "up", "us", "very", "was", "we", "were", "what",
+        "when", "where", "which", "who", "will", "with", "would", "you",
+        "your",
+    ];
+    STOPWORDS.contains(&word)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn text_val(s: &str) -> Value {
+        Value::Str(Arc::from(s))
+    }
+
+    #[test]
+    fn insert_and_search() {
+        let idx = FtsIndex::new("test", FtsConfig::default());
+
+        idx.upsert(b"d1", &text_val("rust programming language")).unwrap();
+        idx.upsert(b"d2", &text_val("python scripting language")).unwrap();
+        idx.upsert(b"d3", &text_val("rust compiler optimization")).unwrap();
+
+        let results = idx.search(&text_val("rust"), 3, &BTreeMap::new()).unwrap();
+        assert_eq!(results.len(), 2); // d1 and d3 contain "rust"
+    }
+
+    #[test]
+    fn bm25_prefers_shorter_docs() {
+        let idx = FtsIndex::new("test", FtsConfig::default());
+
+        idx.upsert(b"short", &text_val("rust")).unwrap();
+        idx.upsert(b"long", &text_val("rust is a systems programming language with memory safety guarantees")).unwrap();
+
+        let results = idx.search(&text_val("rust"), 2, &BTreeMap::new()).unwrap();
+        // Shorter doc should score higher (lower distance) for "rust"
+        assert_eq!(results[0].0, b"short");
+    }
+
+    #[test]
+    fn upsert_replaces() {
+        let idx = FtsIndex::new("test", FtsConfig::default());
+
+        idx.upsert(b"d1", &text_val("old content")).unwrap();
+        idx.upsert(b"d1", &text_val("new content")).unwrap();
+
+        assert_eq!(idx.len(), 1);
+        let results = idx.search(&text_val("old"), 1, &BTreeMap::new()).unwrap();
+        assert!(results.is_empty()); // "old" should not match after replace
+    }
+
+    #[test]
+    fn remove() {
+        let idx = FtsIndex::new("test", FtsConfig::default());
+
+        idx.upsert(b"d1", &text_val("hello world")).unwrap();
+        idx.remove(b"d1").unwrap();
+
+        assert_eq!(idx.len(), 0);
+        let results = idx.search(&text_val("hello"), 1, &BTreeMap::new()).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn stemming_matches() {
+        let idx = FtsIndex::new("test", FtsConfig::default());
+
+        idx.upsert(b"d1", &text_val("programming languages")).unwrap();
+        // "programs" should match via stemming (program -> program, programming -> program)
+        let results = idx.search(&text_val("programs"), 1, &BTreeMap::new()).unwrap();
+        assert!(!results.is_empty());
+    }
+
+    #[test]
+    fn stopwords_filtered() {
+        let idx = FtsIndex::new("test", FtsConfig::default());
+
+        idx.upsert(b"d1", &text_val("the quick brown fox")).unwrap();
+        // "the" is a stopword — should not match
+        let results = idx.search(&text_val("the"), 1, &BTreeMap::new()).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn empty_query() {
+        let idx = FtsIndex::new("test", FtsConfig::default());
+        idx.upsert(b"d1", &text_val("hello")).unwrap();
+        let results = idx.search(&text_val(""), 1, &BTreeMap::new()).unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/krites/src/v2/index/hnsw.rs
+++ b/crates/krites/src/v2/index/hnsw.rs
@@ -1,0 +1,315 @@
+//! HNSW (Hierarchical Navigable Small World) vector index.
+//!
+//! Approximate nearest neighbor search for embedding vectors. Used by
+//! the `~embeddings:semantic_idx{...}` query pattern in episteme's
+//! recall pipeline.
+//!
+//! Implementation: brute-force exact search for correctness. Will be
+//! replaced with a proper HNSW graph when the index grows beyond ~10K
+//! vectors. The Index trait boundary insulates callers from this.
+//!
+//! WHY brute-force first: HNSW is complex (~800 LOC for a proper
+//! implementation with layered graph, ef_construction, neighbor selection).
+//! Starting with exact search lets us validate the query integration
+//! end-to-end before optimizing the index structure.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use crate::v2::error::{self, Result};
+use crate::v2::value::{Value, VectorValue};
+
+use super::Index;
+
+// ---------------------------------------------------------------------------
+// HNSW configuration
+// ---------------------------------------------------------------------------
+
+/// Distance metric for vector comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DistanceMetric {
+    /// Cosine similarity (1 - cos_sim as distance).
+    Cosine,
+    /// Euclidean (L2) distance.
+    Euclidean,
+}
+
+/// Configuration for the HNSW index.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct HnswConfig {
+    /// Vector dimensionality.
+    pub dim: usize,
+    /// Distance metric.
+    pub metric: DistanceMetric,
+    /// ef parameter for search (higher = more accurate, slower).
+    pub ef_search: usize,
+}
+
+impl Default for HnswConfig {
+    fn default() -> Self {
+        Self {
+            dim: 384, // WHY: common embedding dimension (bge-small, all-MiniLM)
+            metric: DistanceMetric::Cosine,
+            ef_search: 200,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HNSW index
+// ---------------------------------------------------------------------------
+
+/// Vector index using exact brute-force search.
+///
+/// Stores vectors in memory, computes distances on every search.
+/// Suitable for <10K vectors. For larger indexes, replace internals
+/// with a proper HNSW graph while keeping the same Index trait.
+pub struct HnswIndex {
+    name: String,
+    config: HnswConfig,
+    vectors: Arc<RwLock<Vec<(Vec<u8>, Vec<f32>)>>>,
+}
+
+impl HnswIndex {
+    /// Create a new HNSW index.
+    #[must_use]
+    pub fn new(name: impl Into<String>, config: HnswConfig) -> Self {
+        Self {
+            name: name.into(),
+            config,
+            vectors: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+}
+
+impl Index for HnswIndex {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn upsert(&self, id: &[u8], value: &Value) -> Result<()> {
+        let vec = extract_f32_vector(value, self.config.dim)?;
+        let mut vectors = self.vectors.write().map_err(|_| {
+            error::IndexSnafu {
+                index_name: self.name.clone(),
+                message: "lock poisoned",
+            }
+            .build()
+        })?;
+
+        // WHY: upsert semantics — replace if ID exists, else append.
+        if let Some(entry) = vectors.iter_mut().find(|(eid, _)| eid == id) {
+            entry.1 = vec;
+        } else {
+            vectors.push((id.to_vec(), vec));
+        }
+        Ok(())
+    }
+
+    fn remove(&self, id: &[u8]) -> Result<()> {
+        let mut vectors = self.vectors.write().map_err(|_| {
+            error::IndexSnafu {
+                index_name: self.name.clone(),
+                message: "lock poisoned",
+            }
+            .build()
+        })?;
+        vectors.retain(|(eid, _)| eid != id);
+        Ok(())
+    }
+
+    fn search(
+        &self,
+        query: &Value,
+        k: usize,
+        _params: &BTreeMap<String, Value>,
+    ) -> Result<Vec<(Vec<u8>, f64)>> {
+        let query_vec = extract_f32_vector(query, self.config.dim)?;
+        let vectors = self.vectors.read().map_err(|_| {
+            error::IndexSnafu {
+                index_name: self.name.clone(),
+                message: "lock poisoned",
+            }
+            .build()
+        })?;
+
+        let mut scored: Vec<(Vec<u8>, f64)> = vectors
+            .iter()
+            .map(|(id, vec)| {
+                let dist = match self.config.metric {
+                    DistanceMetric::Cosine => cosine_distance(&query_vec, vec),
+                    DistanceMetric::Euclidean => euclidean_distance(&query_vec, vec),
+                };
+                (id.clone(), dist)
+            })
+            .collect();
+
+        // WHY: sort by distance ascending (lower = more similar).
+        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(k);
+        Ok(scored)
+    }
+
+    fn len(&self) -> usize {
+        self.vectors
+            .read()
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Distance functions
+// ---------------------------------------------------------------------------
+
+fn cosine_distance(a: &[f32], b: &[f32]) -> f64 {
+    let mut dot = 0.0_f64;
+    let mut norm_a = 0.0_f64;
+    let mut norm_b = 0.0_f64;
+
+    for (x, y) in a.iter().zip(b.iter()) {
+        let x = f64::from(*x);
+        let y = f64::from(*y);
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom == 0.0 {
+        1.0 // WHY: zero vectors are maximally distant.
+    } else {
+        1.0 - (dot / denom) // Cosine distance = 1 - cosine_similarity
+    }
+}
+
+fn euclidean_distance(a: &[f32], b: &[f32]) -> f64 {
+    let sum: f64 = a
+        .iter()
+        .zip(b.iter())
+        .map(|(x, y)| {
+            let d = f64::from(*x) - f64::from(*y);
+            d * d
+        })
+        .sum();
+    sum.sqrt()
+}
+
+/// Extract f32 vector from a Value, validating dimensionality.
+fn extract_f32_vector(value: &Value, expected_dim: usize) -> Result<Vec<f32>> {
+    match value {
+        Value::Vector(VectorValue::F32(data)) => {
+            if expected_dim > 0 && data.len() != expected_dim {
+                return Err(error::IndexSnafu {
+                    index_name: "hnsw",
+                    message: format!(
+                        "dimension mismatch: expected {expected_dim}, got {}",
+                        data.len()
+                    ),
+                }
+                .build());
+            }
+            Ok(data.to_vec())
+        }
+        Value::Vector(VectorValue::F64(data)) => {
+            if expected_dim > 0 && data.len() != expected_dim {
+                return Err(error::IndexSnafu {
+                    index_name: "hnsw",
+                    message: format!(
+                        "dimension mismatch: expected {expected_dim}, got {}",
+                        data.len()
+                    ),
+                }
+                .build());
+            }
+            Ok(data.iter().map(|&x| x as f32).collect())
+        }
+        _ => Err(error::IndexSnafu {
+            index_name: "hnsw",
+            message: format!("expected vector, got {}", value.type_name()),
+        }
+        .build()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn make_vec(values: &[f32]) -> Value {
+        Value::Vector(VectorValue::F32(Arc::from(values)))
+    }
+
+    #[test]
+    fn insert_and_search() {
+        let idx = HnswIndex::new("test", HnswConfig { dim: 3, ..HnswConfig::default() });
+
+        idx.upsert(b"v1", &make_vec(&[1.0, 0.0, 0.0])).unwrap();
+        idx.upsert(b"v2", &make_vec(&[0.0, 1.0, 0.0])).unwrap();
+        idx.upsert(b"v3", &make_vec(&[0.9, 0.1, 0.0])).unwrap();
+
+        let results = idx.search(&make_vec(&[1.0, 0.0, 0.0]), 2, &BTreeMap::new()).unwrap();
+        assert_eq!(results.len(), 2);
+        // v1 should be closest (exact match), v3 second.
+        assert_eq!(results[0].0, b"v1");
+        assert_eq!(results[1].0, b"v3");
+    }
+
+    #[test]
+    fn upsert_replaces() {
+        let idx = HnswIndex::new("test", HnswConfig { dim: 2, ..HnswConfig::default() });
+
+        idx.upsert(b"v1", &make_vec(&[1.0, 0.0])).unwrap();
+        idx.upsert(b"v1", &make_vec(&[0.0, 1.0])).unwrap();
+
+        assert_eq!(idx.len(), 1);
+        let results = idx.search(&make_vec(&[0.0, 1.0]), 1, &BTreeMap::new()).unwrap();
+        assert_eq!(results[0].0, b"v1");
+        assert!(results[0].1 < 0.01); // nearly zero distance after update
+    }
+
+    #[test]
+    fn remove() {
+        let idx = HnswIndex::new("test", HnswConfig { dim: 2, ..HnswConfig::default() });
+
+        idx.upsert(b"v1", &make_vec(&[1.0, 0.0])).unwrap();
+        idx.upsert(b"v2", &make_vec(&[0.0, 1.0])).unwrap();
+        assert_eq!(idx.len(), 2);
+
+        idx.remove(b"v1").unwrap();
+        assert_eq!(idx.len(), 1);
+    }
+
+    #[test]
+    fn dimension_mismatch() {
+        let idx = HnswIndex::new("test", HnswConfig { dim: 3, ..HnswConfig::default() });
+        let result = idx.upsert(b"v1", &make_vec(&[1.0, 0.0]));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cosine_distance_identical() {
+        let dist = cosine_distance(&[1.0, 0.0], &[1.0, 0.0]);
+        assert!(dist.abs() < 1e-10);
+    }
+
+    #[test]
+    fn cosine_distance_orthogonal() {
+        let dist = cosine_distance(&[1.0, 0.0], &[0.0, 1.0]);
+        assert!((dist - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn euclidean_distance_works() {
+        let dist = euclidean_distance(&[0.0, 0.0], &[3.0, 4.0]);
+        assert!((dist - 5.0).abs() < 1e-10);
+    }
+}

--- a/crates/krites/src/v2/index/mod.rs
+++ b/crates/krites/src/v2/index/mod.rs
@@ -1,0 +1,56 @@
+//! Index abstractions for krites v2.
+//!
+//! Indexes accelerate specific query patterns beyond what full relation
+//! scans can achieve. Invoked via the `~relation:index_name{}` syntax
+//! in Datalog queries.
+//!
+//! Two index types:
+//! - [`HnswIndex`] — approximate nearest neighbor for embedding vectors
+//! - [`FtsIndex`] — full-text search with BM25 scoring
+
+pub mod fts;
+pub mod hnsw;
+
+use std::collections::BTreeMap;
+
+use crate::v2::error::Result;
+use crate::v2::value::Value;
+
+// ---------------------------------------------------------------------------
+// Index trait
+// ---------------------------------------------------------------------------
+
+/// An index over a stored relation for accelerated queries.
+///
+/// Indexes are created by `::hnsw create` or `::fts create` DDL commands
+/// and queried via `~relation:index_name{... | query: $q, k: $k}` syntax.
+pub trait Index: Send + Sync {
+    /// Index name (e.g., "semantic_idx", "content_fts").
+    fn name(&self) -> &str;
+
+    /// Insert or update an entry in the index.
+    fn upsert(&self, id: &[u8], value: &Value) -> Result<()>;
+
+    /// Remove an entry from the index.
+    fn remove(&self, id: &[u8]) -> Result<()>;
+
+    /// Search the index. Returns `(id_bytes, score)` pairs ordered by relevance.
+    ///
+    /// `query`: the search term (string for FTS, vector for HNSW).
+    /// `k`: maximum results to return.
+    /// `params`: additional index-specific parameters (e.g., `ef` for HNSW).
+    fn search(
+        &self,
+        query: &Value,
+        k: usize,
+        params: &BTreeMap<String, Value>,
+    ) -> Result<Vec<(Vec<u8>, f64)>>;
+
+    /// Number of entries in the index.
+    fn len(&self) -> usize;
+
+    /// Whether the index is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/crates/krites/src/v2/mod.rs
+++ b/crates/krites/src/v2/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod error;
 pub mod eval;
+pub mod index;
 pub mod parse;
 pub mod rows;
 pub mod schema;


### PR DESCRIPTION
## Summary
- `Index` trait: upsert/remove/search with (id, score) results
- `HnswIndex`: brute-force cosine/euclidean vector search
- `FtsIndex`: inverted index with BM25, stemming, stopwords
- 14 tests

Part of #2284

## Test plan
- [x] `cargo test -p aletheia-krites --features krites-v2 -- v2::index` — 14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)