### PR TITLE
fix(pylon,hermeneus): idempotency key scoping + SSE retry config

### DIFF
--- a/crates/hermeneus/src/anthropic/error.rs
+++ b/crates/hermeneus/src/anthropic/error.rs
@@ -88,22 +88,21 @@ fn extract_retry_after(response: &Response) -> Option<u64> {
         .map(|secs| secs * 1000)
 }
 
-// TODO(#2183): SSE error events carry no retry-after header. This hardcoded
-// value is used when the stream reports overload/rate-limit inside a 200
-// response body. Consider parsing a retry delay from the SSE event payload
-// if Anthropic adds one, or deriving from the exponential backoff schedule.
-const SSE_DEFAULT_RETRY_MS: u64 = 1000;
-
 /// Map an SSE stream error event to a hermeneus error.
 ///
 /// Unlike HTTP errors, SSE errors arrive inside a 200 response body.
 /// The error type string determines retryability:
 /// - `overloaded_error` / `rate_limit_error` → `RateLimited` (retryable)
 /// - Everything else → `ApiError` (not retried)
+///
+/// WHY(#2600): SSE error events carry no retry-after header. Uses
+/// `BACKOFF_BASE_MS` from `models` as the initial retry delay so the
+/// backoff is consistent with the rest of the retry schedule rather than
+/// a separate hardcoded constant.
 pub(crate) fn map_sse_error(detail: super::wire::WireErrorDetail) -> crate::error::Error {
     match detail.error_type.as_str() {
         "overloaded_error" | "rate_limit_error" => crate::error::RateLimitedSnafu {
-            retry_after_ms: SSE_DEFAULT_RETRY_MS,
+            retry_after_ms: crate::models::BACKOFF_BASE_MS,
         }
         .build(),
         _ => crate::error::ApiSnafu {

--- a/crates/pylon/src/idempotency.rs
+++ b/crates/pylon/src/idempotency.rs
@@ -98,10 +98,10 @@ impl IdempotencyCache {
         let mut inner = self.lock_inner();
         inner.evict_expired();
 
-        // TODO(#2200): Cache keys are not scoped per user. The `sub` claim from
-        // Claims is not available at this layer because the cache operates below
-        // the auth extractor. Callers should prefix the key with the user's `sub`
-        // before calling check_or_insert to prevent cross-user key collisions.
+        // WHY(#2200): Keys are scoped per user by the caller. The handler
+        // prefixes the raw header value with `{sub}:` before calling
+        // check_or_insert, so keys from different users never collide even
+        // when they send the same Idempotency-Key header value.
         if let Some(entry) = inner.entries.get(key) {
             return match &entry.state {
                 EntryState::InFlight => LookupResult::Conflict,


### PR DESCRIPTION
## Summary

- **#2599 fix(pylon):** The `check_or_insert` TODO comment incorrectly implied per-user key scoping was missing. The handler in `streaming.rs` already prefixes keys with `{claims.sub}:` before calling `check_or_insert`. Updated the comment to document this correctly.
- **#2600 fix(hermeneus):** SSE error events (`overloaded_error`, `rate_limit_error`) were using a local `SSE_DEFAULT_RETRY_MS = 1000` constant for `retry_after_ms`. Replaced with `crate::models::BACKOFF_BASE_MS` so the initial SSE retry delay is consistent with the rest of the exponential backoff schedule.

## Test plan

- [ ] `cargo check -p aletheia-pylon` passes (verified)
- [ ] `cargo check -p aletheia-hermeneus` passes (verified)
- [ ] Existing idempotency tests in `crates/pylon/src/tests/idempotency.rs` still pass
- [ ] Existing SSE error mapping tests in `crates/hermeneus/src/anthropic/error.rs` still pass (assert `retry_after_ms: 1000` which matches `BACKOFF_BASE_MS`)

Fixes #2599, #2600