### PR TITLE
feat(hermeneus): separate streaming timeout

### DIFF
--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -38,6 +38,8 @@ pub struct AnthropicProvider {
     health: Arc<ProviderHealthTracker>,
     /// CC profile for request mimicry. `Some` when using OAuth credentials.
     cc_profile: Option<super::cc_profile::CcProfile>,
+    /// Timeout for streaming (SSE) requests. `None` disables the timeout.
+    streaming_timeout: Option<Duration>,
 }
 
 /// Static credential provider for backward-compatible `from_config()`.
@@ -65,6 +67,26 @@ impl CredentialProvider for StaticCredentialProvider {
 /// Per-request timeout for non-streaming completions.
 const NON_STREAMING_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// Default timeout for streaming (SSE) completions.
+///
+/// Streaming responses accumulate over minutes for long tasks, so a much
+/// longer timeout than non-streaming requests is needed. Operators can
+/// override via `ProviderConfig::streaming_timeout_secs`.
+const DEFAULT_STREAMING_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Resolve the streaming timeout from an optional override value.
+///
+/// - `None` → `DEFAULT_STREAMING_TIMEOUT` (600 s)
+/// - `Some(0)` → no timeout (`None`)
+/// - `Some(n)` → `Duration::from_secs(n)`
+fn resolve_streaming_timeout(secs: Option<u64>) -> Option<Duration> {
+    match secs {
+        None => Some(DEFAULT_STREAMING_TIMEOUT),
+        Some(0) => None,
+        Some(n) => Some(Duration::from_secs(n)),
+    }
+}
+
 /// Returns true when the URL is safe to use without TLS.
 ///
 /// Localhost addresses never leave the machine, so cleartext is acceptable
@@ -78,10 +100,11 @@ fn build_http_client() -> Result<Client> {
     // install_default() is idempotent: subsequent calls return Err and are ignored.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    // TODO(#2181): separate streaming timeout. The client-level timeout applies
-    // to the full response lifecycle. Streaming requests set no per-request
-    // timeout (relying on the SSE parser's idle detection instead); non-streaming
-    // requests override with NON_STREAMING_TIMEOUT.
+    // WHY: No client-level timeout — streaming requests use a per-call
+    // tokio::time::timeout wrapping parse_sse_response; non-streaming requests
+    // use a per-request .timeout(NON_STREAMING_TIMEOUT). A client-level timeout
+    // would apply to the full response lifecycle and would incorrectly cut off
+    // long streaming responses.
     Client::builder()
         .connect_timeout(Duration::from_secs(10))
         .build()
@@ -138,6 +161,7 @@ impl AnthropicProvider {
             pricing: Self::merge_pricing(config),
             health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
             cc_profile: None, // API key mode — no mimicry needed
+            streaming_timeout: resolve_streaming_timeout(config.streaming_timeout_secs),
         };
         // TODO(#2178): add allow_insecure config field
         if !provider.base_url.starts_with("https://") && !is_loopback_url(&provider.base_url) {
@@ -189,6 +213,7 @@ impl AnthropicProvider {
             pricing: Self::merge_pricing(config),
             health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
             cc_profile,
+            streaming_timeout: resolve_streaming_timeout(config.streaming_timeout_secs),
         };
         // TODO(#2178): add allow_insecure config field
         if !provider.base_url.starts_with("https://") && !is_loopback_url(&provider.base_url) {
@@ -324,8 +349,7 @@ impl AnthropicProvider {
 
             let mut accumulator = StreamAccumulator::new();
             let mut content_started = false;
-
-            let stream_result = parse_sse_response(&mut response, &mut accumulator, &mut |event| {
+            let mut on_event_wrapper = |event: StreamEvent| {
                 if matches!(
                     event,
                     StreamEvent::TextDelta { .. }
@@ -338,8 +362,33 @@ impl AnthropicProvider {
                     content_started = true;
                 }
                 on_event(event);
-            })
-            .await;
+            };
+
+            let stream_result = if let Some(timeout_dur) = self.streaming_timeout {
+                match tokio::time::timeout(
+                    timeout_dur,
+                    parse_sse_response(&mut response, &mut accumulator, &mut on_event_wrapper),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_elapsed) => {
+                        tracing::warn!(
+                            timeout_secs = timeout_dur.as_secs(),
+                            "SSE streaming timed out"
+                        );
+                        Err(error::ApiRequestSnafu {
+                            message: format!(
+                                "streaming timeout after {}s",
+                                timeout_dur.as_secs()
+                            ),
+                        }
+                        .build())
+                    }
+                }
+            } else {
+                parse_sse_response(&mut response, &mut accumulator, &mut on_event_wrapper).await
+            };
 
             match stream_result {
                 Ok(()) => {

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -99,6 +99,12 @@ pub struct ProviderConfig {
     /// using API keys).
     #[serde(default)]
     pub cc_mimicry: Option<bool>,
+    /// Timeout in seconds for streaming (SSE) requests. Defaults to 600s.
+    ///
+    /// Streaming responses accumulate over minutes, so a much longer timeout
+    /// than non-streaming requests (120s) is needed. Set to `0` to disable.
+    #[serde(default)]
+    pub streaming_timeout_secs: Option<u64>,
 }
 
 impl Default for ProviderConfig {
@@ -158,6 +164,7 @@ impl Default for ProviderConfig {
             max_retries: Some(3),
             pricing,
             cc_mimicry: None,
+            streaming_timeout_secs: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `streaming_timeout_secs: Option<u64>` to `ProviderConfig` (default: 600s, `0` = no timeout)
- Stores `streaming_timeout: Option<Duration>` on `AnthropicProvider`
- Wraps `parse_sse_response` with `tokio::time::timeout` when a timeout is configured
- Resolves the `TODO(#2181)` comment in `build_http_client` with a proper explanation

## Rationale

The existing `NON_STREAMING_TIMEOUT` (120s) was implicitly the only timeout in the Anthropic provider, and it was only applied to non-streaming requests. Streaming SSE responses for long tasks can run for several minutes — operators need a separate, longer default (600s) that is independently configurable.

## Test plan

- [ ] `cargo check -p aletheia-hermeneus` passes (verified locally)
- [ ] Set `streaming_timeout_secs = 1` in config and confirm a slow stream returns an `ApiRequest` error with "streaming timeout"
- [ ] Set `streaming_timeout_secs = 0` and confirm no timeout is applied (unlimited)
- [ ] Omit the field entirely and confirm the 600s default applies

Closes #2601