### PR TITLE
fix(nous,krites): wire distillation config + remove aggregation unwrap

### DIFF
--- a/crates/krites/src/v2/eval/query.rs
+++ b/crates/krites/src/v2/eval/query.rs
@@ -443,7 +443,7 @@ fn compute_aggregation(
             let mut max: Option<&Value> = None;
             for b in bindings {
                 if let Some(val) = b.get(var_name) {
-                    if max.is_none() || val > max.unwrap() {
+                    if max.is_none_or(|m| val > m) {
                         max = Some(val);
                     }
                 }
@@ -454,7 +454,7 @@ fn compute_aggregation(
             let mut min: Option<&Value> = None;
             for b in bindings {
                 if let Some(val) = b.get(var_name) {
-                    if min.is_none() || val < min.unwrap() {
+                    if min.is_none_or(|m| val < m) {
                         min = Some(val);
                     }
                 }

--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -244,7 +244,7 @@ impl NousActor {
             let Ok(Some(session)) = store.find_session_by_id(&session_id) else {
                 return false;
             };
-            let config = crate::distillation::DistillTriggerConfig::default();
+            let config = self.config.distillation.clone();
             crate::distillation::should_trigger_distillation(
                 &session,
                 u64::from(self.config.generation.context_window),

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -128,6 +128,13 @@ pub struct NousConfig {
     /// Turn-level hook configuration.
     #[serde(default)]
     pub hooks: HookConfig,
+    /// Distillation trigger configuration.
+    ///
+    /// Controls when context distillation fires: token thresholds, message
+    /// counts, stale session windows. Defaults match the original hardcoded
+    /// values for zero behavior change.
+    #[serde(default)]
+    pub distillation: crate::distillation::DistillTriggerConfig,
 }
 
 /// Configuration for turn-level behavior hooks.
@@ -203,6 +210,7 @@ impl Default for NousConfig {
             recall: RecallConfig::default(),
             tool_allowlist: None,
             hooks: HookConfig::default(),
+            distillation: crate::distillation::DistillTriggerConfig::default(),
         }
     }
 }

--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -21,7 +21,8 @@ use crate::error;
 ///
 /// All thresholds were previously hardcoded constants. Now configurable
 /// via `aletheia.toml [behavioral.distillation]`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 pub struct DistillTriggerConfig {
     /// Context token count that unconditionally triggers distillation.
     pub context_token_trigger: u64,

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -107,6 +107,7 @@ impl SpawnService for SpawnServiceImpl {
             recall: crate::recall::RecallConfig::default(),
             tool_allowlist,
             hooks: crate::config::HookConfig::default(),
+            distillation: crate::distillation::DistillTriggerConfig::default(),
         };
 
         // WHY: ephemeral sub-agents do not capture training data — their turns


### PR DESCRIPTION
## Summary
- #2613: DistillTriggerConfig now on NousConfig, read from actor (not default)
- #2616: is_none_or() replaces unwrap() in max/min aggregation

Closes #2613, #2616

🤖 Generated with [Claude Code](https://claude.com/claude-code)