### PR TITLE
chore: retag misclassified SAFETY/PERF comments

### DIFF
--- a/crates/aletheia/src/runtime.rs
+++ b/crates/aletheia/src/runtime.rs
@@ -642,6 +642,7 @@ impl RuntimeBuilder {
                     recall: resolved.recall.into(),
                     tool_allowlist: None,
                     hooks: Default::default(),
+                    distillation: Default::default(),
                 };
                 nous_manager
                     .spawn(

--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -669,7 +669,7 @@ fn read_prometheus_counter(name: &str) -> u64 {
                 // protobuf's `.value()` on `Counter` gives the f64 count.
                 total += metric.get_counter().value();
             }
-            // SAFETY: Prometheus counter values are non-negative f64 totals from
+            // NOTE: Prometheus counter values are non-negative f64 totals from
             // monotonically increasing counters; practical counts are well within
             // u64 range and f64 mantissa (2^53). Truncation is intentional.
             #[expect(
@@ -701,7 +701,7 @@ fn read_prometheus_counter_with_label(name: &str, label_name: &str, label_value:
                     total += metric.get_counter().value();
                 }
             }
-            // SAFETY: Prometheus counter values are non-negative f64 totals from
+            // NOTE: Prometheus counter values are non-negative f64 totals from
             // monotonically increasing counters; practical counts are well within
             // u64 range and f64 mantissa (2^53). Truncation is intentional.
             #[expect(

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -198,7 +198,7 @@ pub(super) fn compute_tool_overlap(a: &[String], b: &[String]) -> f64 {
     if union == 0 {
         return 1.0;
     }
-    intersection as f64 / union as f64 // SAFETY: set counts fit f64
+    intersection as f64 / union as f64 // NOTE: set counts fit f64
 }
 
 /// Compute name similarity using longest common subsequence ratio.
@@ -223,7 +223,7 @@ pub(super) fn compute_name_similarity(a: &str, b: &str) -> f64 {
         return 1.0;
     }
     let lcs = lcs_char_length(&a_chars, &b_chars);
-    lcs as f64 / max_len as f64 // SAFETY: string lengths fit f64
+    lcs as f64 / max_len as f64 // NOTE: string lengths fit f64
 }
 
 /// Classic DP Longest Common Subsequence length for char slices.

--- a/crates/episteme/src/knowledge_store/search.rs
+++ b/crates/episteme/src/knowledge_store/search.rs
@@ -351,7 +351,7 @@ impl KnowledgeStore {
             };
             graph_results.push(HybridResult {
                 id: fact_id,
-                rrf_score: 1.0 / (60.0 + rank as f64 + 1.0), // SAFETY: rank fits f64
+                rrf_score: 1.0 / (60.0 + rank as f64 + 1.0), // NOTE: rank fits f64
                 bm25_rank: -1,
                 vec_rank: -1,
                 graph_rank: i64::try_from(rank + 1).unwrap_or(i64::MAX),

--- a/crates/episteme/src/recall.rs
+++ b/crates/episteme/src/recall.rs
@@ -323,7 +323,7 @@ impl RecallEngine {
     /// Apply a graph-enhanced scorer when graph recall is active,
     /// otherwise return the base score unchanged.
     ///
-    /// PERF: skips the `enhance` closure entirely when the relationship
+    /// NOTE: skips the `enhance` closure entirely when the relationship
     /// proximity weight is zero.
     #[must_use]
     fn graph_enhanced(&self, base: f64, enhance: impl FnOnce(f64) -> f64) -> f64 {

--- a/crates/episteme/src/side_query.rs
+++ b/crates/episteme/src/side_query.rs
@@ -134,7 +134,7 @@ struct CacheEntry {
 /// Keys are a combined hash of (query, `manifest_text`). Entries expire
 /// after a configurable TTL. Front = LRU, back = MRU.
 pub(crate) struct RelevanceCache {
-    // PERF: linear scan is acceptable for default capacity (64 entries).
+    // NOTE: linear scan is fine for small capacity (default 64).
     entries: Vec<(u64, CacheEntry)>,
     capacity: usize,
     ttl: Duration,

--- a/crates/hermeneus/src/concurrency.rs
+++ b/crates/hermeneus/src/concurrency.rs
@@ -279,7 +279,7 @@ impl AdaptiveConcurrencyLimiter {
                         (inner.limit + self.config.increase_step).min(self.config.max_limit);
                 }
                 RequestOutcome::Overload => {
-                    // SAFETY: f64::from(u32) is lossless; all u32 values fit in
+                    // NOTE: f64::from(u32) is lossless; all u32 values fit in
                     // f64 mantissa.
                     let limit_f64 = f64::from(inner.limit);
                     let decreased_f64 = (limit_f64 * self.config.decrease_factor).floor();

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -360,7 +360,7 @@ pub async fn rename(
         .build());
     }
 
-    // SAFETY: enforce max session name length to prevent oversized input.
+    // NOTE: enforce max session name length to prevent oversized input.
     if body.name.len() > MAX_SESSION_NAME_LEN {
         return Err(BadRequestSnafu {
             message: format!("name exceeds maximum length of {MAX_SESSION_NAME_LEN} bytes"),

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -190,7 +190,7 @@ pub async fn send_message(
         .build());
     }
 
-    // SAFETY: enforce max message size to prevent memory exhaustion from oversized payloads.
+    // NOTE: enforce max message size to prevent memory exhaustion from oversized payloads.
     if content.len() > MAX_MESSAGE_BYTES {
         return Err(BadRequestSnafu {
             message: format!("content exceeds maximum size of {MAX_MESSAGE_BYTES} bytes"),
@@ -374,7 +374,7 @@ pub async fn stream_turn(
         .build());
     }
 
-    // SAFETY: enforce max message size to prevent memory exhaustion from oversized payloads.
+    // NOTE: enforce max message size to prevent memory exhaustion from oversized payloads.
     if message.len() > MAX_MESSAGE_BYTES {
         return Err(BadRequestSnafu {
             message: format!("message exceeds maximum size of {MAX_MESSAGE_BYTES} bytes"),

--- a/crates/pylon/src/middleware/user_rate_limiter.rs
+++ b/crates/pylon/src/middleware/user_rate_limiter.rs
@@ -88,7 +88,7 @@ impl TokenBucket {
         } else {
             let deficit = 1.0 - self.tokens;
             let wait_secs = deficit / self.fill_rate;
-            // SAFETY: ceil() of a positive f64 ratio is always non-negative.
+            // NOTE: ceil() of a positive f64 ratio is always non-negative.
             #[expect(
                 clippy::cast_possible_truncation,
                 clippy::cast_sign_loss,

--- a/crates/theatron/tui/src/app/mod.rs
+++ b/crates/theatron/tui/src/app/mod.rs
@@ -363,7 +363,7 @@ impl App {
             }
         }
 
-        // SAFETY: sanitized at ingestion: all agent fields from API are sanitized here.
+        // NOTE: sanitized at ingestion: all agent fields from API are sanitized here.
         // Best-effort: if agent fetch fails, start with empty list and show error toast.
         let agents = match self.client.agents().await {
             Ok(a) => a,
@@ -541,7 +541,7 @@ impl App {
                         );
                         return;
                     }
-                    // SAFETY: sanitized at ingestion: all message fields from API.
+                    // NOTE: sanitized at ingestion: all message fields from API.
                     self.dashboard.messages = history
                         .into_iter()
                         .filter_map(|m| {

--- a/crates/theatron/tui/src/update/api.rs
+++ b/crates/theatron/tui/src/update/api.rs
@@ -6,7 +6,7 @@ use crate::sanitize::sanitize_for_display;
 use crate::state::{AgentState, AgentStatus, ChatMessage};
 
 #[tracing::instrument(skip_all, fields(count = agents.len()))]
-// SAFETY: sanitized at ingestion: all Agent fields from API are sanitized here.
+// NOTE: sanitized at ingestion: all Agent fields from API are sanitized here.
 pub(crate) fn handle_agents_loaded(app: &mut App, agents: Vec<Agent>) {
     app.dashboard.agents = agents
         .into_iter()
@@ -32,7 +32,7 @@ pub(crate) fn handle_agents_loaded(app: &mut App, agents: Vec<Agent>) {
 }
 
 #[tracing::instrument(skip_all, fields(%nous_id, count = sessions.len()))]
-// SAFETY: sanitized at ingestion: session keys and fields from API are sanitized here.
+// NOTE: sanitized at ingestion: session keys and fields from API are sanitized here.
 pub(crate) fn handle_sessions_loaded(app: &mut App, nous_id: NousId, sessions: Vec<Session>) {
     if let Some(agent) = app.dashboard.agents.iter_mut().find(|a| a.id == nous_id) {
         agent.sessions = sanitize_sessions(sessions);
@@ -40,7 +40,7 @@ pub(crate) fn handle_sessions_loaded(app: &mut App, nous_id: NousId, sessions: V
 }
 
 #[tracing::instrument(skip_all, fields(count = messages.len()))]
-// SAFETY: sanitized at ingestion: all message content from API is sanitized here.
+// NOTE: sanitized at ingestion: all message content from API is sanitized here.
 pub(crate) fn handle_history_loaded(app: &mut App, messages: Vec<HistoryMessage>) {
     app.dashboard.messages = messages
         .into_iter()
@@ -145,7 +145,7 @@ pub(crate) async fn handle_session_picker_archive(app: &mut App) {
 }
 
 #[tracing::instrument(skip_all)]
-// SAFETY: sanitized at ingestion: error messages may contain external data.
+// NOTE: sanitized at ingestion: error messages may contain external data.
 pub(crate) fn handle_show_error(app: &mut App, msg: String) {
     app.viewport.error_toast = Some(ErrorToast::new(sanitize_for_display(&msg).into_owned()));
 }

--- a/crates/theatron/tui/src/update/command.rs
+++ b/crates/theatron/tui/src/update/command.rs
@@ -401,7 +401,7 @@ async fn execute_recall(app: &mut App, query: &str) {
     let query = query.to_string();
     match client.recall(&nous_id, &query).await {
         Ok(result) => {
-            // SAFETY: sanitized at ingestion: recall results from memory API.
+            // NOTE: sanitized at ingestion: recall results from memory API.
             let clean = sanitize_for_display(&result).into_owned();
             let display = if clean.len() > 200 {
                 format!("{}...", safe_truncate(&clean, 200))

--- a/crates/theatron/tui/src/update/settings.rs
+++ b/crates/theatron/tui/src/update/settings.rs
@@ -4,7 +4,7 @@ use crate::sanitize::sanitize_for_display;
 use crate::state::Overlay;
 use crate::state::settings::{EditState, FieldType, SaveStatus, SettingsOverlay};
 
-// SAFETY: sanitized at ingestion: config from API is sanitized via sanitize_config_json.
+// NOTE: sanitized at ingestion: config from API is sanitized via sanitize_config_json.
 pub(crate) async fn handle_open(app: &mut App) {
     match app.client.config().await {
         Ok(config) => {
@@ -19,7 +19,7 @@ pub(crate) async fn handle_open(app: &mut App) {
     }
 }
 
-// SAFETY: sanitized at ingestion: config values from API are sanitized in SettingsOverlay.
+// NOTE: sanitized at ingestion: config values from API are sanitized in SettingsOverlay.
 // Config values are mostly numbers/bools; string values are sanitized by sanitize_config_json.
 pub(crate) fn handle_loaded(app: &mut App, config: serde_json::Value) {
     let clean_config = sanitize_config_json(config);
@@ -177,7 +177,7 @@ pub(crate) fn handle_saved(app: &mut App) {
     app.rebuild_virtual_scroll();
 }
 
-// SAFETY: sanitized at ingestion: error messages may contain external data.
+// NOTE: sanitized at ingestion: error messages may contain external data.
 pub(crate) fn handle_save_error(app: &mut App, msg: String) {
     if let Some(Overlay::Settings(s)) = &mut app.layout.overlay {
         s.save_status = SaveStatus::Error(sanitize_for_display(&msg).into_owned());

--- a/crates/theatron/tui/src/update/sse.rs
+++ b/crates/theatron/tui/src/update/sse.rs
@@ -10,7 +10,7 @@ use crate::state::{ActiveTool, AgentState, AgentStatus, ChatMessage};
 const RECONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
 #[tracing::instrument(skip_all)]
-// SAFETY: sanitized at ingestion: agent data from API is sanitized here on SSE reconnect.
+// NOTE: sanitized at ingestion: agent data from API is sanitized here on SSE reconnect.
 pub(crate) async fn handle_sse_connected(app: &mut App) {
     let was_disconnected = !app.connection.sse_connected;
     app.connection.sse_connected = true;
@@ -143,7 +143,7 @@ pub(crate) async fn handle_sse_turn_after(app: &mut App, nous_id: NousId, sessio
 }
 
 #[tracing::instrument(skip_all, fields(%nous_id, %tool_name))]
-// SAFETY: sanitized at ingestion: tool name from SSE event.
+// NOTE: sanitized at ingestion: tool name from SSE event.
 pub(crate) fn handle_sse_tool_called(app: &mut App, nous_id: NousId, tool_name: String) {
     if let Some(agent) = app.dashboard.agents.iter_mut().find(|a| a.id == nous_id) {
         agent.active_tool = Some(ActiveTool {
@@ -197,7 +197,7 @@ pub(crate) fn handle_sse_distill_before(app: &mut App, nous_id: NousId) {
 }
 
 #[tracing::instrument(skip_all, fields(%nous_id, %stage))]
-// SAFETY: sanitized at ingestion: distill stage from SSE event.
+// NOTE: sanitized at ingestion: distill stage from SSE event.
 pub(crate) fn handle_sse_distill_stage(app: &mut App, nous_id: NousId, stage: String) {
     if let Some(agent) = app.dashboard.agents.iter_mut().find(|a| a.id == nous_id) {
         agent.compaction_stage = Some(sanitize_for_display(&stage).into_owned());

--- a/crates/theatron/tui/src/update/streaming/mod.rs
+++ b/crates/theatron/tui/src/update/streaming/mod.rs
@@ -38,11 +38,11 @@ pub(crate) fn handle_stream_turn_start(app: &mut App, turn_id: TurnId, nous_id: 
 }
 
 #[tracing::instrument(skip_all, fields(len = text.len()))]
-// SAFETY: sanitized at ingestion: streaming text from LLM API.
+// NOTE: sanitized at ingestion: streaming text from LLM API.
 pub(crate) fn handle_stream_text_delta(app: &mut App, text: String) {
     app.connection.stream_phase = crate::state::StreamPhase::Streaming;
     let clean = sanitize_for_display(&text);
-    // PERF: Line-by-line streaming. Buffer partial lines and flush only complete
+    // NOTE: Line-by-line streaming. Buffer partial lines and flush only complete
     // lines (ending in `\n`) to streaming_text. The incomplete tail stays in the
     // line buffer. This prevents markdown re-parses on every token within a line.
     app.connection.streaming_line_buffer.push_str(&clean);
@@ -58,7 +58,7 @@ pub(crate) fn handle_stream_text_delta(app: &mut App, text: String) {
 }
 
 #[tracing::instrument(skip_all, fields(len = text.len()))]
-// SAFETY: sanitized at ingestion: thinking text from LLM API.
+// NOTE: sanitized at ingestion: thinking text from LLM API.
 pub(crate) fn handle_stream_thinking_delta(app: &mut App, text: String) {
     app.connection.stream_phase = crate::state::StreamPhase::Thinking;
     let clean = sanitize_for_display(&text);
@@ -67,7 +67,7 @@ pub(crate) fn handle_stream_thinking_delta(app: &mut App, text: String) {
 }
 
 #[tracing::instrument(skip_all, fields(%tool_name))]
-// SAFETY: sanitized at ingestion: tool names from stream API.
+// NOTE: sanitized at ingestion: tool names from stream API.
 pub(crate) fn handle_stream_tool_start(
     app: &mut App,
     tool_name: String,
@@ -132,7 +132,7 @@ pub(crate) fn handle_stream_tool_result(
 }
 
 #[tracing::instrument(skip_all, fields(%tool_name, %risk))]
-// SAFETY: sanitized at ingestion: tool approval data from stream API.
+// NOTE: sanitized at ingestion: tool approval data from stream API.
 pub(crate) fn handle_stream_tool_approval_required(
     app: &mut App,
     turn_id: TurnId,
@@ -203,7 +203,7 @@ pub(crate) fn handle_stream_plan_complete(app: &mut App, status: String) {
 }
 
 #[tracing::instrument(skip_all)]
-// SAFETY: sanitized at ingestion: plan step labels and roles from stream API.
+// NOTE: sanitized at ingestion: plan step labels and roles from stream API.
 pub(crate) fn handle_stream_plan_proposed(app: &mut App, plan: Plan) {
     app.layout.overlay = Some(Overlay::PlanApproval(PlanApprovalOverlay {
         plan_id: plan.id,
@@ -223,7 +223,7 @@ pub(crate) fn handle_stream_plan_proposed(app: &mut App, plan: Plan) {
 }
 
 #[tracing::instrument(skip_all)]
-// SAFETY: sanitized at ingestion: streaming_text already sanitized via handle_stream_text_delta,
+// NOTE: sanitized at ingestion: streaming_text already sanitized via handle_stream_text_delta,
 // model name from API is sanitized here.
 pub(crate) async fn handle_stream_turn_complete(app: &mut App, outcome: TurnOutcome) {
     app.connection.stream_phase = crate::state::StreamPhase::Done;
@@ -344,7 +344,7 @@ pub(crate) fn handle_stream_turn_abort(app: &mut App, reason: String) {
 }
 
 #[tracing::instrument(skip_all)]
-// SAFETY: sanitized at ingestion: error messages may contain external data.
+// NOTE: sanitized at ingestion: error messages may contain external data.
 pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
     tracing::error!("stream error: {msg}");
     app.connection.state_epoch = app.connection.state_epoch.wrapping_add(1);
@@ -368,7 +368,7 @@ pub(crate) fn handle_stream_error(app: &mut App, msg: String) {
 }
 
 #[tracing::instrument(skip_all)]
-// SAFETY: sanitized at ingestion: streaming_text already sanitized via handle_stream_text_delta.
+// NOTE: sanitized at ingestion: streaming_text already sanitized via handle_stream_text_delta.
 pub(crate) async fn handle_cancel_turn(app: &mut App) {
     let turn_id = match app.connection.active_turn_id.take() {
         Some(id) => id,


### PR DESCRIPTION
Batch retag of ~30 comments per kanon structured comment standards.
Closes #2620, #2621, #2622, #2623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)