### PR TITLE
fix(daemon): hold advisory flock correctly via rustix

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -35,6 +35,7 @@ tokio-util = { workspace = true }
 # WHY: daemon.toml workspace opt-in config
 toml = { workspace = true }
 rusqlite = { workspace = true }
+rustix = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -279,8 +279,16 @@ impl DaemonConfig {
 ///
 /// The lock file is created at `.aletheia/daemon.lock` in the workspace root.
 /// The lock is held for the lifetime of this guard and released on drop.
+///
+/// WHY raw flock instead of fd_lock's RAII guard: fd_lock::RwLockWriteGuard
+/// borrows the RwLock, making it impossible to store both in the same struct
+/// (self-referential). Using rustix::fs::flock() directly holds the advisory
+/// lock for the file descriptor's lifetime — dropping the File releases it.
 pub struct WorkspaceGuard {
-    _lock: fd_lock::RwLock<std::fs::File>,
+    // WHY: the advisory flock is held as long as this File is open.
+    // rustix::fs::flock(LOCK_EX | LOCK_NB) acquires it on construction;
+    // the OS releases it when the FD closes (struct drop).
+    _file: std::fs::File,
     path: PathBuf,
 }
 
@@ -311,29 +319,28 @@ impl WorkspaceGuard {
                 context: format!("opening lock file: {}", lock_path.display()),
             })?;
 
-        let mut lock = fd_lock::RwLock::new(file);
-
-        // NOTE: try_write() is non-blocking; returns Err if another process holds the lock.
-        // WHY: we probe with try_write() then immediately drop the guard. The RwLock
-        // itself keeps the file descriptor open and the advisory lock held for the
-        // lifetime of this struct.
-        if let Err(e) = lock.try_write() {
-            return Err(crate::error::TaskFailedSnafu {
-                task_id: "workspace-lock".to_owned(),
+        // WHY: LOCK_EX | LOCK_NB = exclusive + non-blocking.
+        // Returns EWOULDBLOCK if another process holds the lock.
+        // The lock is held until the file descriptor is closed (struct drop).
+        use rustix::fs::{FlockOperation, flock};
+        use std::os::fd::AsFd;
+        flock(&file.as_fd(), FlockOperation::NonBlockingLockExclusive).map_err(|e| {
+            crate::error::TaskFailedSnafu {
+                task_id: "workspace-lock",
                 reason: format!(
                     "another daemon instance holds the lock at {}: {e}",
                     lock_path.display()
                 ),
             }
-            .build());
-        }
+            .build()
+        })?;
 
         tracing::info!(
             path = %lock_path.display(),
             "workspace daemon lock acquired"
         );
         Ok(Self {
-            _lock: lock,
+            _file: file,
             path: lock_path,
         })
     }


### PR DESCRIPTION
Real correctness bug — flock was released immediately. Closes #2637