### PR TITLE
refactor(hermeneus): wire retry to config

### DIFF
--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -16,13 +16,13 @@ use aletheia_koina::secret::SecretString;
 
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};
-use crate::provider::{LlmProvider, ModelPricing, ProviderConfig};
+use crate::provider::{LlmProvider, ModelPricing, ProviderConfig, RetrySettings};
 use crate::types::{CompletionRequest, CompletionResponse};
 
 use super::stream::{StreamAccumulator, StreamEvent, parse_sse_response};
 use super::wire::WireRequest;
 
-use crate::models::{DEFAULT_API_VERSION, DEFAULT_BASE_URL, DEFAULT_MAX_RETRIES, SUPPORTED_MODELS};
+use crate::models::{DEFAULT_API_VERSION, DEFAULT_BASE_URL, SUPPORTED_MODELS};
 
 use super::pricing::{backoff_delay, estimate_cost_with_cache};
 
@@ -38,6 +38,8 @@ pub struct AnthropicProvider {
     health: Arc<ProviderHealthTracker>,
     /// CC profile for request mimicry. `Some` when using OAuth credentials.
     cc_profile: Option<super::cc_profile::CcProfile>,
+    /// Retry and backoff settings.
+    retry_settings: RetrySettings,
 }
 
 /// Static credential provider for backward-compatible `from_config()`.
@@ -133,7 +135,8 @@ impl AnthropicProvider {
                 .clone()
                 .unwrap_or_else(|| DEFAULT_BASE_URL.to_owned()),
             api_version: DEFAULT_API_VERSION.to_owned(),
-            max_retries: config.max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
+            max_retries: config.retry_settings.max_retries,
+            retry_settings: config.retry_settings.clone(),
             pricing: Self::merge_pricing(config),
             health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
             cc_profile: None, // API key mode — no mimicry needed
@@ -183,10 +186,11 @@ impl AnthropicProvider {
                 .clone()
                 .unwrap_or_else(|| DEFAULT_BASE_URL.to_owned()),
             api_version: DEFAULT_API_VERSION.to_owned(),
-            max_retries: config.max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
+            max_retries: config.retry_settings.max_retries,
             pricing: Self::merge_pricing(config),
             health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
             cc_profile,
+            retry_settings: config.retry_settings.clone(),
         };
         if !provider.base_url.starts_with("https://") && !is_loopback_url(&provider.base_url) {
             return Err(error::ProviderInitSnafu {
@@ -264,7 +268,7 @@ impl AnthropicProvider {
                     max = self.max_retries,
                     "retrying streaming request after transient error"
                 );
-                tokio::time::sleep(backoff_delay(attempt, last_error.as_ref())).await;
+                tokio::time::sleep(backoff_delay(attempt, last_error.as_ref(), &self.retry_settings)).await;
             }
 
             let (token_prefix, credential_source) = self.credential_log_info();
@@ -679,7 +683,7 @@ impl AnthropicProvider {
 
         for attempt in 0..=self.max_retries {
             if attempt > 0 {
-                tokio::time::sleep(backoff_delay(attempt, last_error.as_ref())).await;
+                tokio::time::sleep(backoff_delay(attempt, last_error.as_ref(), &self.retry_settings)).await;
             }
 
             let (token_prefix, credential_source) = self.credential_log_info();

--- a/crates/hermeneus/src/anthropic/client_tests.rs
+++ b/crates/hermeneus/src/anthropic/client_tests.rs
@@ -13,8 +13,8 @@ use aletheia_koina::secret::SecretString;
 use super::*;
 use crate::anthropic::pricing::{backoff_delay, estimate_cost, model_family};
 use crate::error::Error;
-use crate::models::BACKOFF_MAX_MS;
-use crate::provider::{LlmProvider, ProviderConfig};
+use crate::models::{BACKOFF_MAX_MS, BACKOFF_BASE_MS, BACKOFF_FACTOR};
+use crate::provider::{LlmProvider, ProviderConfig, RetrySettings};
 use crate::types::{CompletionRequest, Content, Message, Role};
 
 fn test_config_with(base_url: &str) -> ProviderConfig {
@@ -23,9 +23,15 @@ fn test_config_with(base_url: &str) -> ProviderConfig {
         api_key: Some(SecretString::from("test-key")),
         base_url: Some(base_url.to_owned()),
         default_model: None,
-        max_retries: Some(0),
+        max_retries: None,
         pricing: HashMap::new(),
         cc_mimicry: None,
+        retry_settings: RetrySettings {
+            max_retries: 0,
+            backoff_base_ms: BACKOFF_BASE_MS,
+            backoff_factor: BACKOFF_FACTOR as u32,
+            backoff_max_ms: BACKOFF_MAX_MS,
+        },
     }
 }
 
@@ -476,7 +482,8 @@ fn backoff_delay_respects_retry_after() {
         retry_after_ms: 5000_u64,
     }
     .build();
-    let delay = backoff_delay(1, Some(&err));
+    let settings = RetrySettings::default();
+    let delay = backoff_delay(1, Some(&err), &settings);
     assert_eq!(
         delay,
         Duration::from_millis(5000),
@@ -486,9 +493,10 @@ fn backoff_delay_respects_retry_after() {
 
 #[test]
 fn backoff_delay_exponential_growth() {
-    let d1 = backoff_delay(1, None);
-    let d2 = backoff_delay(2, None);
-    let d3 = backoff_delay(3, None);
+    let settings = RetrySettings::default();
+    let d1 = backoff_delay(1, None, &settings);
+    let d2 = backoff_delay(2, None, &settings);
+    let d3 = backoff_delay(3, None, &settings);
     assert!(d1 < d2, "attempt 2 delay should exceed attempt 1");
     assert!(d2 < d3, "attempt 3 delay should exceed attempt 2");
     assert!(

--- a/crates/hermeneus/src/anthropic/pricing.rs
+++ b/crates/hermeneus/src/anthropic/pricing.rs
@@ -6,8 +6,7 @@ use std::time::Duration;
 use aletheia_koina::retry::BackoffStrategy;
 
 use crate::error;
-use crate::models::{BACKOFF_BASE_MS, BACKOFF_MAX_MS};
-use crate::provider::ModelPricing;
+use crate::provider::{ModelPricing, RetrySettings};
 
 /// Derive the model family name by stripping the last dash-separated segment.
 ///
@@ -120,17 +119,23 @@ pub(crate) fn estimate_cost_with_cache(
     }
 }
 
-pub(crate) fn backoff_delay(attempt: u32, last_error: Option<&error::Error>) -> Duration {
+pub(crate) fn backoff_delay(
+    attempt: u32,
+    last_error: Option<&error::Error>,
+    settings: &RetrySettings,
+) -> Duration {
     if let Some(error::Error::RateLimited { retry_after_ms, .. }) = last_error {
         return Duration::from_millis(*retry_after_ms);
     }
 
     let strategy = BackoffStrategy::ExponentialJitter {
-        base: Duration::from_millis(BACKOFF_BASE_MS),
-        factor: 2,
-        max_delay: Duration::from_millis(BACKOFF_MAX_MS),
+        base: Duration::from_millis(settings.backoff_base_ms),
+        factor: settings.backoff_factor,
+        max_delay: Duration::from_millis(settings.backoff_max_ms),
     };
     // WHY: call site passes 1-indexed attempt; delay_for_attempt is 0-indexed
     let delay = strategy.delay_for_attempt(attempt.saturating_sub(1));
     delay.max(Duration::from_millis(100))
 }
+
+

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -36,7 +36,8 @@ pub mod local;
 pub mod metrics;
 /// Model constants and API configuration defaults.
 pub mod models;
-/// [`LlmProvider`](provider::LlmProvider), [`ProviderConfig`](provider::ProviderConfig), and [`ProviderRegistry`](provider::ProviderRegistry).
+/// [`LlmProvider`](provider::LlmProvider), [`ProviderConfig`](provider::ProviderConfig),
+/// [`ProviderRegistry`](provider::ProviderRegistry), and [`RetrySettings`](provider::RetrySettings).
 pub mod provider;
 /// Shared mock provider for tests across the workspace.
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -77,6 +77,31 @@ pub struct ModelPricing {
     pub output_cost_per_mtok: f64,
 }
 
+/// Retry and backoff settings for provider operations.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct RetrySettings {
+    /// Maximum retry attempts for transient failures.
+    pub max_retries: u32,
+    /// Base backoff duration in milliseconds.
+    pub backoff_base_ms: u64,
+    /// Backoff multiplier (exponential factor).
+    pub backoff_factor: u32,
+    /// Maximum backoff duration in milliseconds.
+    pub backoff_max_ms: u64,
+}
+
+impl Default for RetrySettings {
+    fn default() -> Self {
+        Self {
+            max_retries: crate::models::DEFAULT_MAX_RETRIES,
+            backoff_base_ms: crate::models::BACKOFF_BASE_MS,
+            backoff_factor: crate::models::BACKOFF_FACTOR as u32,
+            backoff_max_ms: crate::models::BACKOFF_MAX_MS,
+        }
+    }
+}
+
 /// Configuration for provider initialization.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProviderConfig {
@@ -89,6 +114,7 @@ pub struct ProviderConfig {
     /// Default model to use.
     pub default_model: Option<String>,
     /// Maximum retries on transient failures.
+    /// Deprecated: Use `retry_settings.max_retries` instead.
     pub max_retries: Option<u32>,
     /// Per-model pricing for cost metrics. Keyed by model name.
     #[serde(default)]
@@ -99,6 +125,9 @@ pub struct ProviderConfig {
     /// using API keys).
     #[serde(default)]
     pub cc_mimicry: Option<bool>,
+    /// Retry and backoff configuration.
+    #[serde(default)]
+    pub retry_settings: RetrySettings,
 }
 
 impl Default for ProviderConfig {
@@ -155,9 +184,10 @@ impl Default for ProviderConfig {
             api_key: None,
             base_url: None,
             default_model: Some("claude-opus-4-20250514".to_owned()),
-            max_retries: Some(3),
+            max_retries: None, // Deprecated: use retry_settings
             pricing,
             cc_mimicry: None,
+            retry_settings: RetrySettings::default(),
         }
     }
 }


### PR DESCRIPTION
Part of #2306

Wires the hardcoded retry/timeout constants in hermeneus to configurable settings:

- Adds `RetrySettings` struct with `max_retries`, `backoff_base_ms`, `backoff_factor`, `backoff_max_ms`
- Adds `retry_settings` field to `ProviderConfig`, using the existing constants as defaults
- Updates `AnthropicProvider` to store and use `RetrySettings` for backoff delays
- Keeps constants in `models.rs` as fallback defaults (not deleted)
- Deprecates the standalone `max_retries` field in favor of `retry_settings.max_retries`