### PR TITLE
refactor(theatron): consolidate format_tokens into theatron-core

### DIFF
--- a/crates/theatron/core/src/format.rs
+++ b/crates/theatron/core/src/format.rs
@@ -1,0 +1,42 @@
+/// Format a token count with human-readable suffixes.
+///
+/// Returns `"1.5M"` for values ≥ 1,000,000, `"1.5K"` for values ≥ 1,000,
+/// and the raw count as a string for smaller values.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "display formatting; sub-unit precision is not meaningful"
+)]
+pub fn format_tokens(count: u64) -> String {
+    const K: u64 = 1_000;
+    const M: u64 = 1_000_000;
+    if count >= M {
+        format!("{:.1}M", count as f64 / M as f64)
+    } else if count >= K {
+        format!("{:.1}K", count as f64 / K as f64)
+    } else {
+        count.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_tokens_small() {
+        assert_eq!(format_tokens(0), "0");
+        assert_eq!(format_tokens(999), "999");
+    }
+
+    #[test]
+    fn format_tokens_kilo() {
+        assert_eq!(format_tokens(1_000), "1.0K");
+        assert_eq!(format_tokens(1_500), "1.5K");
+    }
+
+    #[test]
+    fn format_tokens_mega() {
+        assert_eq!(format_tokens(1_000_000), "1.0M");
+        assert_eq!(format_tokens(2_500_000), "2.5M");
+    }
+}

--- a/crates/theatron/core/src/lib.rs
+++ b/crates/theatron/core/src/lib.rs
@@ -8,6 +8,9 @@
 /// HTTP client, SSE connection, and per-message streaming.
 pub mod api;
 
+/// Shared formatting utilities (token counts, etc.) used by all frontends.
+pub mod format;
+
 /// Auto-discover a running aletheia server on the local network.
 pub mod discovery;
 

--- a/crates/theatron/desktop/src/state/metrics.rs
+++ b/crates/theatron/desktop/src/state/metrics.rs
@@ -430,26 +430,7 @@ pub(crate) fn project_month_end(current_spend: f64, day_of_month: u32, days_in_m
 
 // -- Display formatters -------------------------------------------------------
 
-/// Format a token count with K/M suffix.
-#[expect(
-    clippy::cast_precision_loss,
-    reason = "display-only: sub-token precision irrelevant"
-)]
-#[expect(
-    clippy::as_conversions,
-    reason = "u64 to f64 for human-readable formatting"
-)]
-pub(crate) fn format_tokens(count: u64) -> String {
-    const K: u64 = 1_000;
-    const M: u64 = 1_000_000;
-    if count >= M {
-        format!("{:.1}M", count as f64 / M as f64)
-    } else if count >= K {
-        format!("{:.1}K", count as f64 / K as f64)
-    } else {
-        count.to_string()
-    }
-}
+pub(crate) use theatron_core::format::format_tokens;
 
 /// Format a USD cost value.
 pub(crate) fn format_cost(value: f64) -> String {
@@ -714,13 +695,6 @@ mod tests {
     #[test]
     fn project_month_end_zero_day() {
         assert_eq!(project_month_end(10.0, 0, 30), 0.0);
-    }
-
-    #[test]
-    fn format_tokens_units() {
-        assert_eq!(format_tokens(500), "500");
-        assert_eq!(format_tokens(1500), "1.5K");
-        assert_eq!(format_tokens(2_500_000), "2.5M");
     }
 
     #[test]

--- a/crates/theatron/desktop/src/views/meta/reflection.rs
+++ b/crates/theatron/desktop/src/views/meta/reflection.rs
@@ -351,20 +351,4 @@ fn format_cost(value: f64) -> String {
     }
 }
 
-#[expect(
-    clippy::cast_precision_loss,
-    reason = "display-only: sub-token precision irrelevant"
-)]
-#[expect(clippy::as_conversions, reason = "u64 to f64 for human-readable formatting")]
-fn format_tokens(count: u64) -> String {
-    const K: u64 = 1_000;
-    const M: u64 = 1_000_000;
-
-    if count >= M {
-        format!("{:.1}M", count as f64 / M as f64)
-    } else if count >= K {
-        format!("{:.1}K", count as f64 / K as f64)
-    } else {
-        count.to_string()
-    }
-}
+use theatron_core::format::format_tokens;

--- a/crates/theatron/desktop/src/views/sessions/detail.rs
+++ b/crates/theatron/desktop/src/views/sessions/detail.rs
@@ -381,15 +381,8 @@ pub(crate) fn SessionDetail(
     }
 }
 
-/// Format a token count with K/M suffixes.
 fn format_tokens(count: u32) -> String {
-    if count >= 1_000_000 {
-        format!("{:.1}M", f64::from(count) / 1_000_000.0)
-    } else if count >= 1_000 {
-        format!("{:.1}K", f64::from(count) / 1_000.0)
-    } else {
-        count.to_string()
-    }
+    theatron_core::format::format_tokens(u64::from(count))
 }
 
 fn format_pct(ratio: f64) -> String {

--- a/crates/theatron/tui/src/state/metrics.rs
+++ b/crates/theatron/tui/src/state/metrics.rs
@@ -115,23 +115,9 @@ impl MetricsState {
         rate
     }
 
-    /// Format a token count as "1.2M", "34.5k", or "34".
+    /// Format a token count as "1.5M", "1.5K", or "34".
     pub(crate) fn format_tokens(tokens: u64) -> String {
-        if tokens >= 1_000_000 {
-            #[expect(
-                clippy::cast_precision_loss,
-                reason = "display formatting; sub-unit precision is not meaningful"
-            )]
-            return format!("{:.1}M", tokens as f64 / 1_000_000.0);
-        }
-        if tokens >= 1_000 {
-            #[expect(
-                clippy::cast_precision_loss,
-                reason = "display formatting; sub-unit precision is not meaningful"
-            )]
-            return format!("{:.1}k", tokens as f64 / 1_000.0);
-        }
-        tokens.to_string()
+        theatron_core::format::format_tokens(tokens)
     }
 
     /// Formatted uptime string: "2h 15m", "45m 30s", or "12s".
@@ -264,7 +250,7 @@ mod tests {
 
     #[test]
     fn format_tokens_kilo() {
-        assert_eq!(MetricsState::format_tokens(1500), "1.5k");
+        assert_eq!(MetricsState::format_tokens(1500), "1.5K");
     }
 
     #[test]

--- a/crates/theatron/tui/src/view/overlay/mod.rs
+++ b/crates/theatron/tui/src/view/overlay/mod.rs
@@ -530,8 +530,8 @@ fn render_context_budget(app: &App, frame: &mut Frame, area: Rect, theme: &Theme
     let token_line = match (used, total) {
         (Some(u), Some(t)) => format!(
             "{pct}%  {bar}  ({} / {} tokens)",
-            format_tokens(u),
-            format_tokens(t)
+            theatron_core::format::format_tokens(u64::from(u)),
+            theatron_core::format::format_tokens(u64::from(t))
         ),
         _ => format!("{pct}%  {bar}"),
     };
@@ -573,16 +573,6 @@ fn render_context_budget(app: &App, frame: &mut Frame, area: Rect, theme: &Theme
         .wrap(Wrap { trim: false })
         .style(ratatui::style::Style::default());
     frame.render_widget(para, inner);
-}
-
-fn format_tokens(n: u32) -> String {
-    if n >= 1_000_000 {
-        format!("{}M", n / 1_000_000)
-    } else if n >= 1_000 {
-        format!("{}K", n / 1_000)
-    } else {
-        format!("{n}")
-    }
 }
 
 fn render_decision_card(

--- a/crates/theatron/tui/src/view/status_bar.rs
+++ b/crates/theatron/tui/src/view/status_bar.rs
@@ -493,8 +493,8 @@ fn context_gauge_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
         spans.push(Span::styled(
             format!(
                 "  ({} / {})",
-                format_token_count(used),
-                format_token_count(total)
+                theatron_core::format::format_tokens(u64::from(used)),
+                theatron_core::format::format_tokens(u64::from(total))
             ),
             theme.style_muted(),
         ));
@@ -505,16 +505,6 @@ fn context_gauge_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
     }
 
     spans
-}
-
-fn format_token_count(n: u32) -> String {
-    if n >= 1_000_000 {
-        format!("{}M", n / 1_000_000)
-    } else if n >= 1_000 {
-        format!("{}K", n / 1_000)
-    } else {
-        format!("{n}")
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `theatron_core::format::format_tokens(u64) -> String` as the single canonical implementation
- Replaces 6 duplicated copies across `theatron-desktop` and `theatron-tui`
- Normalises output format to `"1.5K"` / `"1.5M"` (desktop majority convention); the TUI state variant used lowercase `"k"` and the overlay/status-bar variants used integer division — both are now consistent
- `u32` callers use `u64::from()` at the call site; `MetricsState::format_tokens` delegates to the core function, preserving existing associated-function call sites in the TUI view layer

## Notes

`cargo check -p theatron-desktop` fails with `E0560: struct PreservedViewState has no field named secondary_scroll` — pre-existing breakage introduced by the dead code sweep in #2687 (removed the field but not the struct literal initialisers). Not caused by this PR.

`cargo check -p theatron-tui` passes clean.

Part of #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)