### PR TITLE
fix(theatron-desktop): remove stale secondary_scroll refs

### DIFF
--- a/crates/theatron/desktop/src/state/view_preservation.rs
+++ b/crates/theatron/desktop/src/state/view_preservation.rs
@@ -74,7 +74,6 @@ mod tests {
             PreservedViewState {
                 scroll_top: 42.0,
                 input_text: "draft message".to_string(),
-                secondary_scroll: 0.0,
             },
         );
 

--- a/crates/theatron/desktop/src/views/chat.rs
+++ b/crates/theatron/desktop/src/views/chat.rs
@@ -74,7 +74,6 @@ pub(crate) fn Chat() -> Element {
             PreservedViewState {
                 scroll_top: scroll_top(),
                 input_text: input_state.read().text.clone(),
-                secondary_scroll: 0.0,
             },
         );
     });

--- a/crates/theatron/desktop/src/views/files/mod.rs
+++ b/crates/theatron/desktop/src/views/files/mod.rs
@@ -100,7 +100,6 @@ pub(crate) fn Files() -> Element {
             PreservedViewState {
                 scroll_top: 0.0,
                 input_text: path_text,
-                secondary_scroll: 0.0,
             },
         );
     });

--- a/crates/theatron/desktop/src/views/memory/mod.rs
+++ b/crates/theatron/desktop/src/views/memory/mod.rs
@@ -152,7 +152,6 @@ pub(crate) fn Memory() -> Element {
             PreservedViewState {
                 scroll_top: 0.0,
                 input_text: list_store.read().search_query.clone(),
-                secondary_scroll: 0.0,
             },
         );
     });

--- a/crates/theatron/desktop/src/views/sessions/mod.rs
+++ b/crates/theatron/desktop/src/views/sessions/mod.rs
@@ -101,7 +101,6 @@ pub(crate) fn Sessions() -> Element {
             PreservedViewState {
                 scroll_top: 0.0,
                 input_text: list_store.read().search_query.clone(),
-                secondary_scroll: 0.0,
             },
         );
     });


### PR DESCRIPTION
Fixes desktop build after dead code sweep