### PR TITLE
fix(krites): replace LGPL priority-queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,6 @@ dependencies = [
  "ordered-float 5.3.0",
  "pest",
  "pest_derive",
- "priority-queue",
  "proptest",
  "rand 0.9.2",
  "rayon",
@@ -4508,17 +4507,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "priority-queue"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
-dependencies = [
- "equivalent",
- "indexmap 2.13.1",
- "serde",
 ]
 
 [[package]]

--- a/crates/krites/Cargo.toml
+++ b/crates/krites/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { workspace = true }
 # Engine core
 rayon = { workspace = true }
 ordered-float = "5.3.0"
-priority-queue = "2.7"
+
 smallvec = { version = "1.13.2", features = ["serde", "write", "union", "const_generics", "const_new"] }
 compact_str = { workspace = true }
 serde = { workspace = true }

--- a/crates/krites/src/fixed_rule/algos/all_pairs_shortest_path.rs
+++ b/crates/krites/src/fixed_rule/algos/all_pairs_shortest_path.rs
@@ -1,11 +1,11 @@
 //! All-pairs shortest path (Floyd-Warshall).
 use std::cmp::Reverse;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BinaryHeap};
 
 use compact_str::CompactString;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
-use priority_queue::PriorityQueue;
+
 use rayon::prelude::*;
 
 use crate::data::expr::Expr;
@@ -155,12 +155,12 @@ pub(crate) fn dijkstra_cost_only(
     poison: Poison,
 ) -> Result<Vec<f32>> {
     let mut distance = vec![f32::INFINITY; edges.node_count() as usize];
-    let mut pq = PriorityQueue::new();
+    let mut pq = BinaryHeap::new();
     let mut back_pointers = vec![u32::MAX; edges.node_count() as usize];
     distance[start as usize] = 0.;
-    pq.push(start, Reverse(OrderedFloat(0.)));
+    pq.push((Reverse(OrderedFloat(0.)), start));
 
-    while let Some((node, Reverse(OrderedFloat(cost)))) = pq.pop() {
+    while let Some((Reverse(OrderedFloat(cost)), node)) = pq.pop() {
         if cost > distance[node as usize] {
             continue;
         }
@@ -171,7 +171,7 @@ pub(crate) fn dijkstra_cost_only(
 
             let nxt_cost = cost + path_weight;
             if nxt_cost < distance[nxt_node as usize] {
-                pq.push_increase(nxt_node, Reverse(OrderedFloat(nxt_cost)));
+                pq.push((Reverse(OrderedFloat(nxt_cost)), nxt_node));
                 distance[nxt_node as usize] = nxt_cost;
                 back_pointers[nxt_node as usize] = node;
             }

--- a/crates/krites/src/fixed_rule/algos/astar.rs
+++ b/crates/krites/src/fixed_rule/algos/astar.rs
@@ -1,10 +1,10 @@
 //! A* shortest path search.
 use std::cmp::Reverse;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BinaryHeap};
 
 use compact_str::CompactString;
 use ordered_float::OrderedFloat;
-use priority_queue::PriorityQueue;
+
 
 use crate::data::expr::{Expr, eval_bytecode};
 use crate::data::symb::Symbol;
@@ -98,11 +98,11 @@ fn astar(
     };
     let mut back_trace: BTreeMap<DataValue, DataValue> = Default::default();
     let mut g_score: BTreeMap<DataValue, f64> = BTreeMap::from([(start_node.clone(), 0.)]);
-    let mut open_set: PriorityQueue<DataValue, (Reverse<OrderedFloat<f64>>, usize)> =
-        PriorityQueue::new();
-    open_set.push(start_node.clone(), (Reverse(OrderedFloat(0.)), 0));
+    let mut open_set: BinaryHeap<(Reverse<OrderedFloat<f64>>, usize, DataValue)> =
+        BinaryHeap::new();
+    open_set.push((Reverse(OrderedFloat(0.)), 0, start_node.clone()));
     let mut sub_priority: usize = 0;
-    while let Some((node, (Reverse(OrderedFloat(cost)), _))) = open_set.pop() {
+    while let Some((Reverse(OrderedFloat(cost)), _, node)) = open_set.pop() {
         if node == *goal_node {
             let mut current = node;
             let mut ret = vec![];
@@ -162,13 +162,11 @@ fn astar(
 
                 let heuristic_cost = eval_heuristic(&edge_dst_tuple)?;
                 sub_priority += 1;
-                open_set.push_increase(
+                open_set.push((
+                    Reverse(OrderedFloat(tentative_cost_to_dst + heuristic_cost)),
+                    sub_priority,
                     edge_dst.clone(),
-                    (
-                        Reverse(OrderedFloat(tentative_cost_to_dst + heuristic_cost)),
-                        sub_priority,
-                    ),
-                );
+                ));
             }
             poison.check()?;
         }

--- a/crates/krites/src/fixed_rule/algos/kruskal.rs
+++ b/crates/krites/src/fixed_rule/algos/kruskal.rs
@@ -1,11 +1,11 @@
 //! Minimum spanning tree (Kruskal).
 use std::cmp::Reverse;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BinaryHeap};
 
 use compact_str::CompactString;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
-use priority_queue::PriorityQueue;
+
 
 use crate::data::expr::Expr;
 use crate::data::symb::Symbol;
@@ -54,17 +54,17 @@ impl FixedRule for MinimumSpanningForestKruskal {
 }
 
 fn kruskal(edges: &DirectedCsrGraph<f32>, poison: Poison) -> Result<Vec<(u32, u32, f32)>> {
-    let mut pq = PriorityQueue::new();
+    let mut pq: BinaryHeap<(Reverse<OrderedFloat<f32>>, u32, u32)> = BinaryHeap::new();
     let mut uf = UnionFind::new(edges.node_count());
     let mut mst = Vec::with_capacity((edges.node_count() - 1) as usize);
     for from in 0..edges.node_count() {
         for target in edges.out_neighbors_with_values(from) {
             let to = target.target;
             let cost = target.value;
-            pq.push((from, to), Reverse(OrderedFloat(cost)));
+            pq.push((Reverse(OrderedFloat(cost)), from, to));
         }
     }
-    while let Some(((from, to), Reverse(OrderedFloat(cost)))) = pq.pop() {
+    while let Some((Reverse(OrderedFloat(cost)), from, to)) = pq.pop() {
         if uf.connected(from, to) {
             continue;
         }

--- a/crates/krites/src/fixed_rule/algos/prim.rs
+++ b/crates/krites/src/fixed_rule/algos/prim.rs
@@ -1,10 +1,10 @@
 //! Minimum spanning tree (Prim).
 use std::cmp::Reverse;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BinaryHeap};
 
 use compact_str::CompactString;
 use ordered_float::OrderedFloat;
-use priority_queue::PriorityQueue;
+
 
 use crate::data::expr::Expr;
 use crate::data::symb::Symbol;
@@ -79,28 +79,30 @@ fn prim(
 ) -> Result<Vec<(u32, u32, f32)>> {
     let mut visited = vec![false; graph.node_count() as usize];
     let mut mst_edges = Vec::with_capacity((graph.node_count() - 1) as usize);
-    let mut pq = PriorityQueue::new();
+    let mut pq: BinaryHeap<(Reverse<OrderedFloat<f32>>, u32, u32)> = BinaryHeap::new();
 
-    let mut relax_edges_at_node = |node: u32, pq: &mut PriorityQueue<_, _>| {
-        visited[node as usize] = true;
-        for target in graph.out_neighbors_with_values(node) {
+    let mut start_node = starting;
+    loop {
+        visited[start_node as usize] = true;
+        for target in graph.out_neighbors_with_values(start_node) {
             let to_node = target.target;
             let cost = target.value;
             if visited[to_node as usize] {
                 continue;
             }
-            pq.push_increase(to_node, (Reverse(OrderedFloat(cost)), node));
+            pq.push((Reverse(OrderedFloat(cost)), start_node, to_node));
         }
-    };
-
-    relax_edges_at_node(starting, &mut pq);
-
-    while let Some((to_node, (Reverse(OrderedFloat(cost)), from_node))) = pq.pop() {
         if mst_edges.len() == (graph.node_count() - 1) as usize {
             break;
         }
+        let Some((Reverse(OrderedFloat(cost)), from_node, to_node)) = pq.pop() else {
+            break;
+        };
+        if visited[to_node as usize] {
+            continue;
+        }
         mst_edges.push((from_node, to_node, cost));
-        relax_edges_at_node(to_node, &mut pq);
+        start_node = to_node;
         poison.check()?;
     }
 

--- a/crates/krites/src/fixed_rule/algos/shortest_path_dijkstra.rs
+++ b/crates/krites/src/fixed_rule/algos/shortest_path_dijkstra.rs
@@ -1,12 +1,12 @@
 //! Weighted shortest path (Dijkstra).
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::iter;
 
 use compact_str::CompactString;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
-use priority_queue::PriorityQueue;
+
 use rayon::prelude::*;
 use smallvec::{SmallVec, smallvec};
 
@@ -253,13 +253,13 @@ pub(crate) fn dijkstra<FE: ForbiddenEdge, FN: ForbiddenNode, G: Goal + Clone>(
 ) -> Vec<(u32, f32, Vec<u32>)> {
     let graph_size = edges.node_count();
     let mut distance = vec![f32::INFINITY; graph_size as usize];
-    let mut pq = PriorityQueue::new();
+    let mut pq = BinaryHeap::new();
     let mut back_pointers = vec![u32::MAX; graph_size as usize];
     distance[start as usize] = 0.;
-    pq.push(start, Reverse(OrderedFloat(0.)));
+    pq.push((Reverse(OrderedFloat(0.)), start));
     let mut goals_remaining = goals.clone();
 
-    while let Some((node, Reverse(OrderedFloat(cost)))) = pq.pop() {
+    while let Some((Reverse(OrderedFloat(cost)), node)) = pq.pop() {
         if cost > distance[node as usize] {
             continue;
         }
@@ -276,7 +276,7 @@ pub(crate) fn dijkstra<FE: ForbiddenEdge, FN: ForbiddenNode, G: Goal + Clone>(
             }
             let nxt_cost = cost + path_weight;
             if nxt_cost < distance[nxt_node as usize] {
-                pq.push_increase(nxt_node, Reverse(OrderedFloat(nxt_cost)));
+                pq.push((Reverse(OrderedFloat(nxt_cost)), nxt_node));
                 distance[nxt_node as usize] = nxt_cost;
                 back_pointers[nxt_node as usize] = node;
             }
@@ -318,13 +318,13 @@ pub(crate) fn dijkstra_keep_ties<FE: ForbiddenEdge, FN: ForbiddenNode, G: Goal +
     poison: Poison,
 ) -> Result<Vec<(u32, f32, Vec<u32>)>> {
     let mut distance = vec![f32::INFINITY; edges.node_count() as usize];
-    let mut pq = PriorityQueue::new();
+    let mut pq = BinaryHeap::new();
     let mut back_pointers: Vec<SmallVec<[u32; 1]>> = vec![smallvec![]; edges.node_count() as usize];
     distance[start as usize] = 0.;
-    pq.push(start, Reverse(OrderedFloat(0.)));
+    pq.push((Reverse(OrderedFloat(0.)), start));
     let mut goals_remaining = goals.clone();
 
-    while let Some((node, Reverse(OrderedFloat(cost)))) = pq.pop() {
+    while let Some((Reverse(OrderedFloat(cost)), node)) = pq.pop() {
         if cost > distance[node as usize] {
             continue;
         }
@@ -341,12 +341,11 @@ pub(crate) fn dijkstra_keep_ties<FE: ForbiddenEdge, FN: ForbiddenNode, G: Goal +
             }
             let nxt_cost = cost + path_weight;
             if nxt_cost < distance[nxt_node as usize] {
-                pq.push_increase(nxt_node, Reverse(OrderedFloat(nxt_cost)));
+                pq.push((Reverse(OrderedFloat(nxt_cost)), nxt_node));
                 distance[nxt_node as usize] = nxt_cost;
                 back_pointers[nxt_node as usize].clear();
                 back_pointers[nxt_node as usize].push(node);
             } else if nxt_cost == distance[nxt_node as usize] {
-                pq.push_increase(nxt_node, Reverse(OrderedFloat(nxt_cost)));
                 back_pointers[nxt_node as usize].push(node);
             }
             poison.check()?;

--- a/crates/krites/src/runtime/hnsw/adaptive.rs
+++ b/crates/krites/src/runtime/hnsw/adaptive.rs
@@ -7,8 +7,9 @@
     dead_code,
     reason = "infrastructure for future HNSW search-path integration"
 )]
+use std::collections::BinaryHeap;
+
 use ordered_float::OrderedFloat;
-use priority_queue::PriorityQueue;
 
 use super::types::{CompoundKey, VectorCache};
 use crate::DataValue;
@@ -86,7 +87,7 @@ impl<'a> SessionTx<'a> {
         let key_len = base_handle.metadata.keys.len();
 
         // Max-heap: we push all candidates and pop the worst when > k.
-        let mut top_k: PriorityQueue<CompoundKey, OrderedFloat<f64>> = PriorityQueue::new();
+        let mut top_k: BinaryHeap<(OrderedFloat<f64>, CompoundKey)> = BinaryHeap::new();
 
         for res in idx_handle.scan_prefix(self, &canary_prefix) {
             let tuple = match res {
@@ -127,7 +128,7 @@ impl<'a> SessionTx<'a> {
                 Err(_) => continue,
             };
 
-            top_k.push(cand_key, OrderedFloat(dist));
+            top_k.push((OrderedFloat(dist), cand_key));
             if top_k.len() > k {
                 top_k.pop();
             }
@@ -135,7 +136,7 @@ impl<'a> SessionTx<'a> {
 
         // Collect results in ascending distance order.
         let mut results: Vec<(CompoundKey, f64)> = Vec::with_capacity(top_k.len());
-        while let Some((key, OrderedFloat(dist))) = top_k.pop() {
+        while let Some((OrderedFloat(dist), key)) = top_k.pop() {
             results.push((key, dist));
         }
         results.reverse();

--- a/crates/krites/src/runtime/hnsw/put.rs
+++ b/crates/krites/src/runtime/hnsw/put.rs
@@ -1,9 +1,9 @@
 //! SessionTx methods for HNSW vector insertion.
 
 use std::cmp::{Reverse, max};
+use std::collections::BinaryHeap;
 
 use ordered_float::OrderedFloat;
-use priority_queue::PriorityQueue;
 use rustc_hash::FxHashSet;
 use tracing::warn;
 
@@ -88,8 +88,8 @@ impl<'a> SessionTx<'a> {
             let ep_key = (ep_t_key, ep_idx, ep_subidx);
             vec_cache.ensure_key(&ep_key, orig_table, self)?;
             let ep_distance = vec_cache.v_dist(q, &ep_key)?;
-            let mut found_nn = PriorityQueue::new();
-            found_nn.push(ep_key, OrderedFloat(ep_distance));
+            let mut found_nn: BinaryHeap<(OrderedFloat<f64>, CompoundKey)> = BinaryHeap::new();
+            found_nn.push((OrderedFloat(ep_distance), ep_key));
             let target_level = manifest.get_random_level();
             if target_level < bottom_level {
                 self.hnsw_put_fresh_at_levels(
@@ -161,7 +161,7 @@ impl<'a> SessionTx<'a> {
                 self.store_tx
                     .put(&self_tuple_key_bytes, &self_tuple_val_bytes)?;
 
-                for (neighbour, Reverse(OrderedFloat(dist))) in neighbours.iter() {
+                for (Reverse(OrderedFloat(dist)), neighbour) in neighbours.iter() {
                     let mut out_key = Vec::with_capacity(orig_table.metadata.keys.len() * 2 + 5);
                     let out_val = vec![
                         DataValue::from(*dist),
@@ -287,11 +287,11 @@ impl<'a> SessionTx<'a> {
     ) -> Result<usize> {
         vec_cache.ensure_key(target_key, orig_table, self)?;
         let vec = vec_cache.get_key(target_key).clone();
-        let mut candidates = PriorityQueue::new();
+        let mut candidates: BinaryHeap<(OrderedFloat<f64>, CompoundKey)> = BinaryHeap::new();
         for (neighbour_key, neighbour_dist) in
             self.hnsw_get_neighbours(target_key, level, idx_table, false)?
         {
-            candidates.push(neighbour_key, OrderedFloat(neighbour_dist));
+            candidates.push((OrderedFloat(neighbour_dist), neighbour_key));
         }
         let new_candidates = self.hnsw_select_neighbours_heuristic(
             &vec,
@@ -304,15 +304,15 @@ impl<'a> SessionTx<'a> {
             vec_cache,
         )?;
         let mut old_candidate_set = FxHashSet::default();
-        for (old, _) in &candidates {
+        for (_, old) in &candidates {
             old_candidate_set.insert(old.clone());
         }
         let mut new_candidate_set = FxHashSet::default();
-        for (new, _) in &new_candidates {
+        for (_, new) in &new_candidates {
             new_candidate_set.insert(new.clone());
         }
         let new_degree = new_candidates.len();
-        for (new, Reverse(OrderedFloat(new_dist))) in new_candidates {
+        for (Reverse(OrderedFloat(new_dist)), new) in new_candidates {
             if !old_candidate_set.contains(&new) {
                 let mut new_key = Vec::with_capacity(orig_table.metadata.keys.len() * 2 + 5);
                 let new_val = vec![
@@ -333,7 +333,7 @@ impl<'a> SessionTx<'a> {
                 self.store_tx.put(&new_key_bytes, &new_val_bytes)?;
             }
         }
-        for (old, OrderedFloat(old_dist)) in candidates {
+        for (OrderedFloat(old_dist), old) in candidates {
             if !new_candidate_set.contains(&old) {
                 let mut old_key = Vec::with_capacity(orig_table.metadata.keys.len() * 2 + 5);
                 old_key.push(DataValue::from(level));
@@ -386,37 +386,37 @@ impl<'a> SessionTx<'a> {
     fn hnsw_select_neighbours_heuristic(
         &self,
         q: &Vector,
-        found: &PriorityQueue<CompoundKey, OrderedFloat<f64>>,
+        found: &BinaryHeap<(OrderedFloat<f64>, CompoundKey)>,
         m: usize,
         level: i64,
         manifest: &HnswIndexManifest,
         idx_table: &RelationHandle,
         orig_table: &RelationHandle,
         vec_cache: &mut VectorCache,
-    ) -> Result<PriorityQueue<CompoundKey, Reverse<OrderedFloat<f64>>>> {
-        let mut candidates = PriorityQueue::new();
-        let mut ret: PriorityQueue<CompoundKey, Reverse<OrderedFloat<_>>> = PriorityQueue::new();
-        let mut discarded: PriorityQueue<_, Reverse<OrderedFloat<_>>> = PriorityQueue::new();
-        for (item, dist) in found.iter() {
-            candidates.push(item.clone(), Reverse(*dist));
+    ) -> Result<BinaryHeap<(Reverse<OrderedFloat<f64>>, CompoundKey)>> {
+        let mut candidates: BinaryHeap<(Reverse<OrderedFloat<f64>>, CompoundKey)> = BinaryHeap::new();
+        let mut ret: BinaryHeap<(Reverse<OrderedFloat<f64>>, CompoundKey)> = BinaryHeap::new();
+        let mut discarded: BinaryHeap<(Reverse<OrderedFloat<f64>>, CompoundKey)> = BinaryHeap::new();
+        for (dist, item) in found.iter() {
+            candidates.push((Reverse(*dist), item.clone()));
         }
         if manifest.extend_candidates {
-            for (item, _) in found.iter() {
+            for (_, item) in found.iter() {
                 for (neighbour_key, _) in self.hnsw_get_neighbours(item, level, idx_table, false)? {
                     vec_cache.ensure_key(&neighbour_key, orig_table, self)?;
                     let dist = vec_cache.v_dist(q, &neighbour_key)?;
-                    candidates.push(
-                        (neighbour_key.0, neighbour_key.1, neighbour_key.2),
+                    candidates.push((
                         Reverse(OrderedFloat(dist)),
-                    );
+                        (neighbour_key.0.clone(), neighbour_key.1, neighbour_key.2),
+                    ));
                 }
             }
         }
         while !candidates.is_empty() && ret.len() < m {
-            let (cand_key, Reverse(OrderedFloat(cand_dist_to_q))) =
+            let (Reverse(OrderedFloat(cand_dist_to_q)), cand_key) =
                 candidates.pop().unwrap_or_else(|| unreachable!());
             let mut should_add = true;
-            for (existing, _) in ret.iter() {
+            for (_, existing) in ret.iter() {
                 vec_cache.ensure_key(&cand_key, orig_table, self)?;
                 vec_cache.ensure_key(existing, orig_table, self)?;
                 let dist_to_existing = vec_cache.k_dist(existing, &cand_key)?;
@@ -426,16 +426,16 @@ impl<'a> SessionTx<'a> {
                 }
             }
             if should_add {
-                ret.push(cand_key, Reverse(OrderedFloat(cand_dist_to_q)));
+                ret.push((Reverse(OrderedFloat(cand_dist_to_q)), cand_key));
             } else if manifest.keep_pruned_connections {
-                discarded.push(cand_key, Reverse(OrderedFloat(cand_dist_to_q)));
+                discarded.push((Reverse(OrderedFloat(cand_dist_to_q)), cand_key));
             }
         }
         if manifest.keep_pruned_connections {
             while !discarded.is_empty() && ret.len() < m {
-                let (nearest_triple, Reverse(OrderedFloat(nearest_dist))) =
+                let (Reverse(OrderedFloat(nearest_dist)), nearest_triple) =
                     discarded.pop().unwrap_or_else(|| unreachable!());
-                ret.push(nearest_triple, Reverse(OrderedFloat(nearest_dist)));
+                ret.push((Reverse(OrderedFloat(nearest_dist)), nearest_triple));
             }
         }
         Ok(ret)
@@ -451,7 +451,7 @@ impl<'a> SessionTx<'a> {
         cur_level: i64,
         orig_table: &RelationHandle,
         idx_table: &RelationHandle,
-        found_nn: &mut PriorityQueue<CompoundKey, OrderedFloat<f64>>,
+        found_nn: &mut BinaryHeap<(OrderedFloat<f64>, CompoundKey)>,
         vec_cache: &mut VectorCache,
     ) -> Result<()> {
         self.hnsw_search_level_pooled(
@@ -470,7 +470,7 @@ impl<'a> SessionTx<'a> {
         cur_level: i64,
         orig_table: &RelationHandle,
         idx_table: &RelationHandle,
-        found_nn: &mut PriorityQueue<CompoundKey, OrderedFloat<f64>>,
+        found_nn: &mut BinaryHeap<(OrderedFloat<f64>, CompoundKey)>,
         vec_cache: &mut VectorCache,
         visited_pool: Option<&VisitedPool>,
     ) -> Result<()> {
@@ -478,16 +478,16 @@ impl<'a> SessionTx<'a> {
             Some(pool) => pool.acquire(),
             None => FxHashSet::default(),
         };
-        let mut candidates: PriorityQueue<CompoundKey, Reverse<OrderedFloat<f64>>> =
-            PriorityQueue::new();
+        let mut candidates: BinaryHeap<(Reverse<OrderedFloat<f64>>, CompoundKey)> =
+            BinaryHeap::new();
 
-        for item in found_nn.iter() {
-            visited.insert(item.0.clone());
-            candidates.push(item.0.clone(), Reverse(*item.1));
+        for (dist, item) in found_nn.iter() {
+            visited.insert(item.clone());
+            candidates.push((Reverse(*dist), item.clone()));
         }
 
-        while let Some((candidate, Reverse(OrderedFloat(candidate_dist)))) = candidates.pop() {
-            let (_, OrderedFloat(furtherest_dist)) =
+        while let Some((Reverse(OrderedFloat(candidate_dist)), candidate)) = candidates.pop() {
+            let (OrderedFloat(furtherest_dist), _) =
                 found_nn.peek().unwrap_or_else(|| unreachable!());
             let furtherest_dist = *furtherest_dist;
             if candidate_dist > furtherest_dist {
@@ -501,11 +501,11 @@ impl<'a> SessionTx<'a> {
                 }
                 vec_cache.ensure_key(&neighbour_key, orig_table, self)?;
                 let neighbour_dist = vec_cache.v_dist(q, &neighbour_key)?;
-                let (_, OrderedFloat(cand_furtherest_dist)) =
+                let (OrderedFloat(cand_furtherest_dist), _) =
                     found_nn.peek().unwrap_or_else(|| unreachable!());
                 if found_nn.len() < ef || neighbour_dist < *cand_furtherest_dist {
-                    candidates.push(neighbour_key.clone(), Reverse(OrderedFloat(neighbour_dist)));
-                    found_nn.push(neighbour_key.clone(), OrderedFloat(neighbour_dist));
+                    candidates.push((Reverse(OrderedFloat(neighbour_dist)), neighbour_key.clone()));
+                    found_nn.push((OrderedFloat(neighbour_dist), neighbour_key.clone()));
                     if found_nn.len() > ef {
                         found_nn.pop();
                     }

--- a/crates/krites/src/runtime/hnsw/search.rs
+++ b/crates/krites/src/runtime/hnsw/search.rs
@@ -2,10 +2,11 @@
 //! SessionTx methods for HNSW vector index operations.
 //! Hierarchical Navigable Small World vector index.
 
-use ordered_float::OrderedFloat;
-use priority_queue::PriorityQueue;
+use std::collections::BinaryHeap;
 
-use super::types::{DEFAULT_VECTOR_CACHE_CAPACITY, VectorCache};
+use ordered_float::OrderedFloat;
+
+use super::types::{CompoundKey, DEFAULT_VECTOR_CACHE_CAPACITY, VectorCache};
 use super::visited_pool::VisitedPool;
 use crate::data::expr::{Bytecode, eval_bytecode_pred};
 use crate::data::program::HnswSearch;
@@ -91,8 +92,8 @@ impl<'a> SessionTx<'a> {
             let ep_key = (ep_t_key, ep_idx, ep_subidx);
             vec_cache.ensure_key(&ep_key, &config.base_handle, self)?;
             let ep_distance = vec_cache.v_dist(&q, &ep_key)?;
-            let mut found_nn = PriorityQueue::new();
-            found_nn.push(ep_key, OrderedFloat(ep_distance));
+            let mut found_nn: BinaryHeap<(OrderedFloat<f64>, CompoundKey)> = BinaryHeap::new();
+            found_nn.push((OrderedFloat(ep_distance), ep_key));
             let pool = VisitedPool::with_defaults();
             for current_level in bottom_level..0 {
                 self.hnsw_search_level_pooled(
@@ -128,7 +129,7 @@ impl<'a> SessionTx<'a> {
 
             let mut ret = vec![];
 
-            while let Some((cand_key, OrderedFloat(distance))) = found_nn.pop() {
+            while let Some((OrderedFloat(distance), cand_key)) = found_nn.pop() {
                 if let Some(r) = config.radius
                     && distance > r
                 {

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,6 @@ allow = [
     "CC0-1.0",
     "0BSD",
     "MPL-2.0",              # option-ext, smartstring
-    "LGPL-3.0-or-later",    # priority-queue
     "CDLA-Permissive-2.0",  # webpki-roots, webpki-root-certs
 ]
 confidence-threshold = 0.8


### PR DESCRIPTION
License compliance: Replace LGPL-2.1+ priority-queue crate with MIT-licensed std::collections::BinaryHeap.

**Changes:**
- Removed \+priority-queue` dependency from Cargo.toml
- Removed LGPL-3.0-or-later license exception from deny.toml  
- Refactored 8 files to use BinaryHeap API

Closes #2698