### PR TITLE
fix(pylon): cancel LLM turn on SSE client disconnect

### DIFF
--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -49,14 +49,22 @@ impl Drop for AbortOnDrop {
 /// Stream wrapper that holds an `AbortOnDrop` guard alongside the inner stream.
 ///
 /// When this stream is dropped (client disconnect), the guard aborts the
-/// associated spawned task. The `Stream` impl delegates entirely to the
-/// inner stream.
+/// associated spawned task AND cancels the client token. The abort handles
+/// the common case (task at an await point); the cancellation handles the
+/// edge case where the LLM HTTP call is buffering between yield points.
 ///
 /// WHY: `Unpin` bound is sufficient because `ReceiverStream` and its
 /// `Map` combinator both implement `Unpin`.
 struct GuardedStream<S> {
     inner: S,
     _guard: AbortOnDrop,
+    client_cancel: tokio_util::sync::CancellationToken,
+}
+
+impl<S> Drop for GuardedStream<S> {
+    fn drop(&mut self) {
+        self.client_cancel.cancel();
+    }
 }
 
 impl<S: tokio_stream::Stream + Unpin> tokio_stream::Stream for GuardedStream<S> {
@@ -154,6 +162,7 @@ pub async fn send_message(
                     _guard: AbortOnDrop(tokio::spawn(
                         async {}.instrument(tracing::info_span!("idempotent_noop")),
                     )),
+                    client_cancel: tokio_util::sync::CancellationToken::new(),
                 };
                 return Ok(Sse::new(stream).keep_alive(
                     KeepAlive::new()
@@ -238,6 +247,11 @@ pub async fn send_message(
         idempotency_key = idempotency_key.as_deref().unwrap_or(""),
     );
     let shutdown_token = state.shutdown.child_token();
+    // WHY: cancel the LLM turn when the SSE client disconnects, not just on
+    // server shutdown. Without this, a disconnected client still consumes
+    // LLM tokens until the turn completes (#2730).
+    let client_cancel = tokio_util::sync::CancellationToken::new();
+    let client_cancel_inner = client_cancel.clone();
     let turn_handle = tokio::spawn(
         async move {
             // WHY(#2113): Emit an immediate acknowledgment so the client never sees an empty
@@ -260,6 +274,10 @@ pub async fn send_message(
                 r = turn_fut => r,
                 () = shutdown_token.cancelled() => {
                     tracing::info!("shutdown: cancelling in-flight SSE turn");
+                    return;
+                }
+                () = client_cancel_inner.cancelled() => {
+                    tracing::info!("client disconnect: cancelling in-flight SSE turn");
                     return;
                 }
             };
@@ -317,6 +335,7 @@ pub async fn send_message(
     let stream = GuardedStream {
         inner: ReceiverStream::new(rx).map(sse_event_to_axum),
         _guard: AbortOnDrop(turn_handle),
+        client_cancel,
     };
 
     Ok(Sse::new(stream).keep_alive(
@@ -470,10 +489,12 @@ pub async fn stream_turn(
     );
 
     let shutdown_token = state.shutdown.child_token();
+    let stream_client_cancel = tokio_util::sync::CancellationToken::new();
+    let stream_client_cancel_inner = stream_client_cancel.clone();
     let stream_turn_handle = tokio::spawn(
         async move {
-            // WHY: cancel the in-flight turn when the server shuts down so Axum's graceful
-            // shutdown can drain open SSE connections rather than hanging indefinitely (#1723).
+            // WHY: cancel the in-flight turn on server shutdown OR client disconnect.
+            // Without the client cancel, a disconnected client still consumes LLM tokens (#2730).
             let turn_fut = handle.send_turn_streaming_with_session_id(
                 &session_key,
                 Some(sid.clone()),
@@ -485,6 +506,10 @@ pub async fn stream_turn(
                 r = turn_fut => r,
                 () = shutdown_token.cancelled() => {
                     tracing::info!("shutdown: cancelling in-flight streaming turn");
+                    return;
+                }
+                () = stream_client_cancel_inner.cancelled() => {
+                    tracing::info!("client disconnect: cancelling in-flight streaming turn");
                     return;
                 }
             };
@@ -556,6 +581,7 @@ pub async fn stream_turn(
             }
         }),
         _guard: AbortOnDrop(stream_turn_handle),
+        client_cancel: stream_client_cancel,
     };
 
     Ok(Sse::new(stream).keep_alive(


### PR DESCRIPTION
Closes #2730. Prevents wasted LLM tokens when clients disconnect mid-stream.