### PR TITLE
refactor: consolidate remaining duplicated utilities

### DIFF
--- a/crates/graphe/src/store/message.rs
+++ b/crates/graphe/src/store/message.rs
@@ -1,5 +1,6 @@
 //! Message operations, distillation pipeline, and usage recording.
 
+use aletheia_koina::defaults::CHARS_PER_TOKEN;
 use snafu::ResultExt;
 use tracing::{debug, info, instrument};
 
@@ -314,7 +315,7 @@ impl SessionStore {
             clippy::as_conversions,
             reason = "usize→i64: summary length fits in i64"
         )]
-        let token_estimate = (content.len() as i64 + 3) / 4;
+        let token_estimate = (content.len() as i64 + i64::from(CHARS_PER_TOKEN) - 1) / i64::from(CHARS_PER_TOKEN);
         tx.execute(
             "INSERT INTO messages (session_id, seq, role, content, is_distilled, token_estimate, created_at)
              VALUES (?1, 0, 'system', ?2, 0, ?3, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",

--- a/crates/koina/src/hex.rs
+++ b/crates/koina/src/hex.rs
@@ -1,0 +1,58 @@
+//! Hex encoding utilities.
+//!
+//! Provides a simple, allocation-efficient hex encoder for byte slices.
+
+const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
+
+/// Encode a byte slice as a lowercase hexadecimal string.
+///
+/// # Example
+///
+/// ```
+/// use aletheia_koina::hex::encode;
+///
+/// let encoded = encode(&[0xde, 0xad, 0xbe, 0xef]);
+/// assert_eq!(encoded, "deadbeef");
+/// ```
+#[must_use]
+pub fn encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        // b >> 4 is 0..=15 and b & 0x0f is 0..=15; the array has exactly 16 elements
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "nibble value 0..=15 always indexes into 16-element array"
+        )]
+        s.push(char::from(HEX_CHARS[usize::from(b >> 4)]));
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "nibble value 0..=15 always indexes into 16-element array"
+        )]
+        s.push(char::from(HEX_CHARS[usize::from(b & 0x0f)]));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_empty() {
+        assert_eq!(encode(&[]), "");
+    }
+
+    #[test]
+    fn encode_single_byte() {
+        assert_eq!(encode(&[0x00]), "00");
+        assert_eq!(encode(&[0x0f]), "0f");
+        assert_eq!(encode(&[0xf0]), "f0");
+        assert_eq!(encode(&[0xff]), "ff");
+    }
+
+    #[test]
+    fn encode_multiple_bytes() {
+        assert_eq!(encode(&[0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+        assert_eq!(encode(&[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]), "0123456789abcdef");
+    }
+}

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -36,6 +36,8 @@ pub mod retry;
 pub mod secret;
 /// Trait abstractions for filesystem, clock, and environment operations.
 pub mod system;
+/// Hex encoding utilities shared across Aletheia crates ([`hex::encode`]).
+pub mod hex;
 /// Time utilities: timestamp helpers shared across Aletheia crates ([`time::now_iso8601`]).
 pub mod time;
 /// Tracing subscriber initialization for human-readable and JSON log output.

--- a/crates/nous/src/working_state.rs
+++ b/crates/nous/src/working_state.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use aletheia_koina::defaults::CHARS_PER_TOKEN;
 use serde::{Deserialize, Serialize};
 
 use aletheia_hermeneus::types::{Message, ThinkingConfig, ToolDefinition};
@@ -354,7 +355,7 @@ impl WorkingState {
         }
 
         let content = parts.join("\n");
-        let token_estimate = u64::try_from(content.len() / 4).unwrap_or(0);
+        let token_estimate = u64::try_from(content.len() / CHARS_PER_TOKEN as usize).unwrap_or(0);
 
         Some(BootstrapSection {
             name: "WORKING_STATE".to_owned(),

--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -6,6 +6,7 @@
 
 use std::time::Duration;
 
+use aletheia_koina::hex;
 use rand::Rng;
 use tracing::instrument;
 
@@ -137,26 +138,6 @@ fn parse_key(raw: &str) -> Result<(&str, &str, &str)> {
 
 fn now_iso() -> String {
     aletheia_koina::time::now_iso8601()
-}
-
-mod hex {
-    const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
-
-    pub(super) fn encode(bytes: &[u8]) -> String {
-        let mut s = String::with_capacity(bytes.len() * 2);
-        for &b in bytes {
-            // SAFETY: nibble is 0..=15, HEX_CHARS has exactly 16 elements
-            let hi = usize::from(b >> 4);
-            let lo = usize::from(b & 0x0f);
-            if let Some(&ch) = HEX_CHARS.get(hi) {
-                s.push(char::from(ch));
-            }
-            if let Some(&ch) = HEX_CHARS.get(lo) {
-                s.push(char::from(ch));
-            }
-        }
-        s
-    }
 }
 
 #[cfg(test)]

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -8,6 +8,7 @@
 
 use std::path::{Path, PathBuf};
 
+use aletheia_koina::hex;
 use base64::Engine as _;
 use chacha20poly1305::aead::generic_array::GenericArray;
 use chacha20poly1305::aead::{Aead, AeadCore, OsRng};
@@ -129,23 +130,7 @@ fn hex_digit(b: u8) -> Option<u8> {
     }
 }
 
-fn to_hex(bytes: &[u8]) -> String {
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for &b in bytes {
-        // b >> 4 is 0..=15 and b & 0x0f is 0..=15; the array has exactly 16 elements
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "nibble value 0..=15 always indexes into 16-element array"
-        )]
-        s.push(char::from(b"0123456789abcdef"[usize::from(b >> 4)]));
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "nibble value 0..=15 always indexes into 16-element array"
-        )]
-        s.push(char::from(b"0123456789abcdef"[usize::from(b & 0x0f)]));
-    }
-    s
-}
+
 
 /// Generate a new random primary key and write it to the given path.
 ///
@@ -175,7 +160,7 @@ pub fn generate_primary_key(path: &Path) -> Result<()> {
     let mut key = [0u8; KEY_LEN];
     rand::fill(&mut key);
 
-    let hex = to_hex(&key);
+    let hex = hex::encode(&key);
     aletheia_koina::fs::write_restricted(path, hex.as_bytes()).context(
         error::WriteConfigSnafu {
             path: path.to_path_buf(),

--- a/crates/theatron/core/src/format.rs
+++ b/crates/theatron/core/src/format.rs
@@ -18,6 +18,62 @@ pub fn format_tokens(count: u64) -> String {
     }
 }
 
+/// Format a duration in milliseconds as a human-readable string.
+///
+/// Returns `"150ms"` for sub-second durations, `"2.5s"` for seconds,
+/// and `"2.5m"` for minutes.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "display formatting; sub-unit precision is not meaningful"
+)]
+pub fn format_duration(ms: u64) -> String {
+    if ms >= 60_000 {
+        format!("{:.1}m", ms as f64 / 60_000.0)
+    } else if ms >= 1_000 {
+        format!("{:.1}s", ms as f64 / 1_000.0)
+    } else {
+        format!("{ms}ms")
+    }
+}
+
+/// Format a duration in seconds as a human-readable string.
+///
+/// Returns `"45s"` for sub-minute durations, `"2.5m"` for minutes,
+/// and `"2.0h"` for hours.
+pub fn format_duration_secs(secs: f64) -> String {
+    if secs < 60.0 {
+        format!("{secs:.0}s")
+    } else if secs < 3_600.0 {
+        let mins = secs / 60.0;
+        format!("{mins:.1}m")
+    } else {
+        let hours = secs / 3_600.0;
+        format!("{hours:.1}h")
+    }
+}
+
+/// Truncate a string to `max_chars` characters, appending ellipsis if truncated.
+///
+/// Counts Unicode characters (not bytes), and uses `"…"` (U+2026) as the
+/// ellipsis character.
+///
+/// # Example
+///
+/// ```
+/// use theatron_core::format::truncate_str;
+///
+/// assert_eq!(truncate_str("hello world", 8), "hello w…");
+/// assert_eq!(truncate_str("hello", 10), "hello");
+/// ```
+pub fn truncate_str(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+        format!("{truncated}\u{2026}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -38,5 +94,67 @@ mod tests {
     fn format_tokens_mega() {
         assert_eq!(format_tokens(1_000_000), "1.0M");
         assert_eq!(format_tokens(2_500_000), "2.5M");
+    }
+
+    #[test]
+    fn format_duration_milliseconds() {
+        assert_eq!(format_duration(50), "50ms");
+        assert_eq!(format_duration(999), "999ms");
+    }
+
+    #[test]
+    fn format_duration_seconds() {
+        assert_eq!(format_duration(1_000), "1.0s");
+        assert_eq!(format_duration(2_500), "2.5s");
+        assert_eq!(format_duration(10_000), "10.0s");
+    }
+
+    #[test]
+    fn format_duration_minutes() {
+        assert_eq!(format_duration(60_000), "1.0m");
+        assert_eq!(format_duration(150_000), "2.5m");
+    }
+
+    #[test]
+    fn format_duration_secs_seconds() {
+        assert_eq!(format_duration_secs(45.0), "45s");
+    }
+
+    #[test]
+    fn format_duration_secs_minutes() {
+        assert_eq!(format_duration_secs(150.0), "2.5m");
+    }
+
+    #[test]
+    fn format_duration_secs_hours() {
+        assert_eq!(format_duration_secs(7_200.0), "2.0h");
+    }
+
+    #[test]
+    fn truncate_str_short() {
+        assert_eq!(truncate_str("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_str_exact() {
+        assert_eq!(truncate_str("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_str_long() {
+        let result = truncate_str("hello world", 8);
+        assert!(result.ends_with('\u{2026}'));
+        assert_eq!(result.chars().count(), 8);
+    }
+
+    #[test]
+    fn truncate_str_empty() {
+        assert_eq!(truncate_str("", 5), "");
+    }
+
+    #[test]
+    fn truncate_str_unicode() {
+        // Unicode characters should be counted correctly, not bytes
+        assert_eq!(truncate_str("héllo world", 8), "héllo w\u{2026}");
     }
 }

--- a/crates/theatron/desktop/src/components/plan_card.rs
+++ b/crates/theatron/desktop/src/components/plan_card.rs
@@ -1,6 +1,7 @@
 //! Plan card component for execution view.
 
 use dioxus::prelude::*;
+use theatron_core::format::format_duration_secs;
 
 use crate::state::execution::{ExecutionPlan, StepStatus};
 
@@ -182,10 +183,10 @@ pub(crate) fn PlanCard(plan: ExecutionPlan) -> Element {
                 div {
                     style: "{TIME_ROW}",
                     if let Some(elapsed) = plan.elapsed_secs {
-                        span { "{format_duration(elapsed)} elapsed" }
+                        span { "{format_duration_secs(elapsed)} elapsed" }
                     }
                     if let Some(remaining) = plan.estimated_remaining_secs {
-                        span { "~{format_duration(remaining)} remaining" }
+                        span { "~{format_duration_secs(remaining)} remaining" }
                     }
                 }
             }
@@ -221,18 +222,6 @@ fn agent_status_color(status: &str) -> &'static str {
         "idle" | "waiting" => "#f59e0b",
         "error" | "failed" => "#ef4444",
         _ => "#666",
-    }
-}
-
-fn format_duration(secs: f64) -> String {
-    if secs < 60.0 {
-        format!("{secs:.0}s")
-    } else if secs < 3600.0 {
-        let mins = secs / 60.0;
-        format!("{mins:.1}m")
-    } else {
-        let hours = secs / 3600.0;
-        format!("{hours:.1}h")
     }
 }
 
@@ -276,18 +265,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn format_duration_seconds() {
-        assert_eq!(format_duration(45.0), "45s");
-    }
-
-    #[test]
-    fn format_duration_minutes() {
-        assert_eq!(format_duration(150.0), "2.5m");
-    }
-
-    #[test]
-    fn format_duration_hours() {
-        assert_eq!(format_duration(7200.0), "2.0h");
-    }
 }

--- a/crates/theatron/desktop/src/components/tool_panel.rs
+++ b/crates/theatron/desktop/src/components/tool_panel.rs
@@ -1,6 +1,7 @@
 //! Expandable tool call panel component.
 
 use dioxus::prelude::*;
+use theatron_core::format::format_duration;
 
 use crate::state::tools::ToolCallState;
 
@@ -154,20 +155,7 @@ pub(crate) fn ToolPanel(tool: ToolCallState) -> Element {
     }
 }
 
-/// Format a duration in milliseconds to a human-readable badge string.
-fn format_duration(ms: u64) -> String {
-    if ms < 1000 {
-        format!("{ms}ms")
-    } else {
-        let secs = ms / 1000;
-        let remainder = ms % 1000;
-        if remainder == 0 {
-            format!("{secs}s")
-        } else {
-            format!("{secs}.{:01}s", remainder / 100)
-        }
-    }
-}
+
 
 /// Pretty-print a JSON value for display in the tool panel.
 fn format_json(value: &serde_json::Value) -> String {
@@ -178,19 +166,6 @@ fn format_json(value: &serde_json::Value) -> String {
 mod tests {
     use super::*;
     use crate::state::tools::ToolStatus;
-
-    #[test]
-    fn format_duration_milliseconds() {
-        assert_eq!(format_duration(50), "50ms");
-        assert_eq!(format_duration(999), "999ms");
-    }
-
-    #[test]
-    fn format_duration_seconds() {
-        assert_eq!(format_duration(1000), "1s");
-        assert_eq!(format_duration(2500), "2.5s");
-        assert_eq!(format_duration(10_000), "10s");
-    }
 
     #[test]
     fn format_json_pretty_prints() {

--- a/crates/theatron/desktop/src/state/tool_metrics.rs
+++ b/crates/theatron/desktop/src/state/tool_metrics.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 
+pub(crate) use theatron_core::format::format_duration as format_duration_ms;
+
 // -- API response types -------------------------------------------------------
 
 /// Top-level response from `/api/tool-stats`.
@@ -147,17 +149,6 @@ pub(crate) fn format_delta(delta: i64) -> String {
         format!("+{delta}")
     } else {
         format!("{delta}")
-    }
-}
-
-/// Formats a duration in milliseconds as a human-readable string.
-pub(crate) fn format_duration_ms(ms: u64) -> String {
-    if ms >= 60_000 {
-        format!("{:.1}m", ms as f64 / 60_000.0)
-    } else if ms >= 1_000 {
-        format!("{:.1}s", ms as f64 / 1_000.0)
-    } else {
-        format!("{ms}ms")
     }
 }
 

--- a/crates/theatron/tui/src/diff/mod.rs
+++ b/crates/theatron/tui/src/diff/mod.rs
@@ -12,8 +12,9 @@ pub(crate) use types::{DiffViewState, compute_diff};
 
 #[cfg(test)]
 use crate::theme::Theme;
+pub(crate) use theatron_core::format::truncate_str;
 #[cfg(test)]
-pub(crate) use parse::{parse_hunk_header, truncate_str};
+pub(crate) use parse::parse_hunk_header;
 #[cfg(test)]
 pub(crate) use render::{render_side_by_side, render_unified, render_word_diff};
 #[cfg(test)]

--- a/crates/theatron/tui/src/diff/parse.rs
+++ b/crates/theatron/tui/src/diff/parse.rs
@@ -105,27 +105,7 @@ pub(crate) fn parse_hunk_header(line: &str) -> (usize, usize) {
     (old_start, new_start)
 }
 
-pub(crate) fn truncate_str(s: &str, max_chars: usize) -> String {
-    if s.len() <= max_chars {
-        s.to_string()
-    } else {
-        let mut end = max_chars.min(s.len());
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        let truncated = s.get(..end).unwrap_or(s);
-        if end >= 2 {
-            format!(
-                "{}…",
-                truncated
-                    .get(..truncated.len().saturating_sub(1))
-                    .unwrap_or(truncated)
-            )
-        } else {
-            truncated.to_string()
-        }
-    }
-}
+
 
 pub(super) fn pad_to(s: String, width: usize) -> String {
     if s.len() >= width {

--- a/crates/theatron/tui/src/diff/render.rs
+++ b/crates/theatron/tui/src/diff/render.rs
@@ -7,7 +7,8 @@ use similar::{ChangeTag, TextDiff};
 
 use crate::theme::Theme;
 
-use super::parse::{pad_to, truncate_str};
+use super::parse::pad_to;
+use super::truncate_str;
 use super::types::{DiffChange, DiffMode, DiffViewState, FileDiff, collapse_to_replacements};
 
 pub(crate) fn render_unified(file: &FileDiff, theme: &Theme) -> Vec<Line<'static>> {

--- a/crates/theatron/tui/src/state/ops/helpers.rs
+++ b/crates/theatron/tui/src/state/ops/helpers.rs
@@ -1,6 +1,7 @@
 //! Helper functions for tool categorization, argument extraction, and diff parsing.
 
 use super::types::{OpsDiffEntry, ToolCategory};
+use theatron_core::format::truncate_str;
 
 /// Maximum length for the inline primary arg display.
 const PRIMARY_ARG_MAX_LEN: usize = 40;
@@ -54,16 +55,6 @@ pub(crate) fn extract_primary_arg(json_str: &str, _tool_name: &str) -> Option<St
         }
     }
     None
-}
-
-/// Truncate a string to `max_len` chars, appending ellipsis if truncated.
-pub(super) fn truncate_str(s: &str, max_len: usize) -> String {
-    if s.chars().count() <= max_len {
-        s.to_string()
-    } else {
-        let truncated: String = s.chars().take(max_len.saturating_sub(1)).collect();
-        format!("{truncated}\u{2026}")
-    }
 }
 
 /// Extract a one-line error summary from tool result text.

--- a/crates/theatron/tui/src/view/memory/mod.rs
+++ b/crates/theatron/tui/src/view/memory/mod.rs
@@ -639,6 +639,8 @@ pub(super) fn tier_style(theme: &Theme, tier: &str) -> Style {
     }
 }
 
+use theatron_core::format::truncate_str;
+
 fn event_type_style(theme: &Theme, event_type: &str) -> Style {
     match event_type {
         "created" => theme.style_success(),
@@ -650,28 +652,12 @@ fn event_type_style(theme: &Theme, event_type: &str) -> Style {
 }
 
 pub(super) fn truncate(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
-        s.to_string()
-    } else {
-        format!("{}…", s.get(..max_len.saturating_sub(1)).unwrap_or(s))
-    }
+    truncate_str(s, max_len)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn truncate_short_string() {
-        assert_eq!(truncate("hello", 10), "hello");
-    }
-
-    #[test]
-    fn truncate_long_string() {
-        let result = truncate("this is a very long string", 10);
-        assert!(result.len() <= 12); // 9 chars + ellipsis (multi-byte)
-        assert!(result.ends_with('…'));
-    }
 
     #[test]
     fn confidence_style_high() {

--- a/crates/theatron/tui/src/view/metrics.rs
+++ b/crates/theatron/tui/src/view/metrics.rs
@@ -5,6 +5,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use theatron_core::format::truncate_str;
 
 use crate::app::App;
 use crate::state::metrics::{MetricsState, sparkline};
@@ -275,50 +276,8 @@ fn render_status_bar(frame: &mut Frame, area: Rect, theme: &Theme) {
     frame.render_widget(paragraph, area);
 }
 
-fn truncate_str(s: &str, max_chars: usize) -> String {
-    let mut chars = s.chars();
-    let mut result = String::with_capacity(max_chars + 1);
-    let mut count = 0;
-    while count < max_chars {
-        match chars.next() {
-            Some(c) => {
-                result.push(c);
-                count += 1;
-            }
-            None => break,
-        }
-    }
-    if chars.next().is_some() {
-        // Replace last char with ellipsis indicator.
-        result.pop();
-        result.push('…');
-    }
-    result
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn truncate_str_short() {
-        assert_eq!(truncate_str("hello", 10), "hello");
-    }
-
-    #[test]
-    fn truncate_str_exact() {
-        assert_eq!(truncate_str("hello", 5), "hello");
-    }
-
-    #[test]
-    fn truncate_str_long() {
-        let result = truncate_str("hello world", 8);
-        assert!(result.ends_with('…'));
-        assert_eq!(result.chars().count(), 8);
-    }
-
-    #[test]
-    fn truncate_str_empty() {
-        assert_eq!(truncate_str("", 5), "");
-    }
 }


### PR DESCRIPTION
Closes #2651

This PR consolidates the remaining duplicated utilities as specified in #2651:

## Changes

### 1. Hex encoding (koina::hex::encode)
- **New**: Added `koina::hex::encode` function
- **Replaced**:
  - `taxis::encrypt::to_hex` (custom implementation)
  - `symbolon::api_key::hex::encode` (local module)
  - `symbolon` was using `hex` crate, now uses `koina::hex`

### 2. Token estimate constant (koina::defaults::CHARS_PER_TOKEN)
- **Replaced hardcoded `/ 4`**:
  - `graphe/src/store/message.rs:317`
  - `nous/src/working_state.rs:357`

### 3. Duration formatting (theatron_core::format)
- **Added**: `format_duration` (ms input) and `format_duration_secs` (seconds input)
- **Replaced**:
  - `theatron-desktop/components/plan_card.rs` (3 duplicate implementations)
  - `theatron-desktop/components/tool_panel.rs`
  - `theatron-desktop/state/tool_metrics.rs`

### 4. String truncation (theatron_core::format::truncate_str)
- **Added**: Unicode-correct `truncate_str` using character counts
- **Replaced**:
  - `theatron-tui/src/diff/parse.rs`
  - `theatron-tui/src/state/ops/helpers.rs`
  - `theatron-tui/src/view/metrics.rs`
- **Fixed**: `theatron-tui/src/view/memory/mod.rs` had byte-length bug (`s.len()` instead of `chars().count()`)

## Summary
- 6 duplicate implementations removed
- 11 files modified
- 1 new file created (`koina/src/hex.rs`)
- All consolidated utilities now have proper unit tests in their canonical locations