### PR TITLE
fix(episteme): recover from RwLock poison

### DIFF
--- a/crates/episteme/src/embedding.rs
+++ b/crates/episteme/src/embedding.rs
@@ -289,10 +289,14 @@ mod candle_provider {
         fn encode_and_forward(&self, texts: &[&str]) -> EmbeddingResult<(Tensor, Tensor)> {
             // WHY: Read lock allows concurrent tokenization across callers.
             // Tokenizer::encode_batch takes &self, no mutation needed.
+            // WHY: unwrap_or_else(into_inner) recovers from poison instead of
+            // permanently failing. A prior panic may have left stale state, but
+            // the tokenizer is stateless (no accumulated mutation) so recovery
+            // is safe. This prevents one-panic-kills-all-recall (#2725).
             let tokenizer = self
                 .tokenizer
                 .read()
-                .map_err(|_poison| LockPoisonedSnafu.build())?;
+                .unwrap_or_else(|poison| poison.into_inner());
 
             let encodings = tokenizer.encode_batch(texts.to_vec(), true).map_err(|e| {
                 EmbedFailedSnafu {
@@ -323,10 +327,12 @@ mod candle_provider {
 
             // WHY: Read lock allows concurrent forward passes.
             // BertModel::forward takes &self, no mutation needed.
+            // WHY: same poison recovery as tokenizer. BertModel::forward is
+            // stateless (&self, no mutation) so recovery is safe.
             let model = self
                 .model
                 .read()
-                .map_err(|_poison| LockPoisonedSnafu.build())?;
+                .unwrap_or_else(|poison| poison.into_inner());
             let embeddings = model
                 .forward(&input_ids, &token_type_ids, Some(&attention_mask))
                 .map_err(Self::candle_err("model forward pass"))?;


### PR DESCRIPTION
Closes #2725. Prevents one-panic-kills-all-recall.