### PR TITLE
fix: audit fixes batch

### DIFF
--- a/crates/dianoia/src/error.rs
+++ b/crates/dianoia/src/error.rs
@@ -80,8 +80,10 @@ pub enum Error {
     },
 
     /// Failed to deserialize a project file from JSON.
-    #[snafu(display("workspace deserialization error"))]
+    #[snafu(display("failed to deserialize workspace at {}", path.display()))]
     WorkspaceDeserialize {
+        /// The path to the file that failed deserialization.
+        path: PathBuf,
         /// The underlying deserialization error.
         source: serde_json::Error,
         #[snafu(implicit)]
@@ -90,8 +92,10 @@ pub enum Error {
     },
 
     /// Failed to serialize a project to JSON.
-    #[snafu(display("workspace serialization error"))]
+    #[snafu(display("failed to serialize workspace at {}", path.display()))]
     WorkspaceSerialize {
+        /// The path to the file that failed serialization.
+        path: PathBuf,
         /// The underlying serialization error.
         source: serde_json::Error,
         #[snafu(implicit)]
@@ -122,8 +126,10 @@ pub enum Error {
     },
 
     /// Failed to deserialize a handoff file from JSON.
-    #[snafu(display("handoff deserialization error"))]
+    #[snafu(display("failed to deserialize handoff at {}", path.display()))]
     HandoffDeserialize {
+        /// The path to the file that failed deserialization.
+        path: PathBuf,
         /// The underlying deserialization error.
         source: serde_json::Error,
         #[snafu(implicit)]
@@ -132,8 +138,10 @@ pub enum Error {
     },
 
     /// Failed to serialize handoff context to JSON.
-    #[snafu(display("handoff serialization error"))]
+    #[snafu(display("failed to serialize handoff at {}", path.display()))]
     HandoffSerialize {
+        /// The path to the file that failed serialization.
+        path: PathBuf,
         /// The underlying serialization error.
         source: serde_json::Error,
         #[snafu(implicit)]

--- a/crates/dianoia/src/handoff.rs
+++ b/crates/dianoia/src/handoff.rs
@@ -145,7 +145,9 @@ impl HandoffFile {
         let json_path = self.json_path();
         let md_path = self.md_path();
 
-        let json = serde_json::to_string_pretty(context).context(error::HandoffSerializeSnafu)?;
+        let json = serde_json::to_string_pretty(context).context(error::HandoffSerializeSnafu {
+            path: &json_path,
+        })?;
         let markdown = context.to_markdown();
 
         #[expect(
@@ -184,7 +186,9 @@ impl HandoffFile {
         let contents = std::fs::read_to_string(&json_path)
             .context(error::HandoffIoSnafu { path: &json_path })?;
         let context: HandoffContext =
-            serde_json::from_str(&contents).context(error::HandoffDeserializeSnafu)?;
+            serde_json::from_str(&contents).context(error::HandoffDeserializeSnafu {
+                path: &json_path,
+            })?;
 
         Ok(Some(context))
     }

--- a/crates/dianoia/src/intent.rs
+++ b/crates/dianoia/src/intent.rs
@@ -295,14 +295,18 @@ impl IntentStore {
                 path: self.path.clone(),
             })?;
         let intents: Vec<Intent> =
-            serde_json::from_str(&contents).context(error::WorkspaceDeserializeSnafu)?;
+            serde_json::from_str(&contents).context(error::WorkspaceDeserializeSnafu {
+                path: self.path.clone(),
+            })?;
         Ok(intents)
     }
 
     /// Persist the full intent list to disk atomically with 0600 permissions.
     fn persist(&self, intents: &[Intent]) -> Result<()> {
         let json =
-            serde_json::to_string_pretty(intents).context(error::WorkspaceSerializeSnafu)?;
+            serde_json::to_string_pretty(intents).context(error::WorkspaceSerializeSnafu {
+                path: self.path.clone(),
+            })?;
         aletheia_koina::fs::write_restricted(&self.path, json.as_bytes()).context(
             error::WorkspaceIoSnafu {
                 path: self.path.clone(),

--- a/crates/dianoia/src/workspace.rs
+++ b/crates/dianoia/src/workspace.rs
@@ -72,7 +72,9 @@ impl ProjectWorkspace {
     #[must_use]
     pub fn save_project(&self, project: &Project) -> Result<()> {
         let layout = self.layout();
-        let json = serde_json::to_string_pretty(project).context(error::WorkspaceSerializeSnafu)?;
+        let json = serde_json::to_string_pretty(project).context(error::WorkspaceSerializeSnafu {
+            path: &layout.project_file,
+        })?;
         aletheia_koina::fs::write_restricted(&layout.project_file, json.as_bytes()).context(
             error::WorkspaceIoSnafu {
                 path: &layout.project_file,
@@ -96,7 +98,9 @@ impl ProjectWorkspace {
                 path: &layout.project_file,
             })?;
         let project: Project =
-            serde_json::from_str(&contents).context(error::WorkspaceDeserializeSnafu)?;
+            serde_json::from_str(&contents).context(error::WorkspaceDeserializeSnafu {
+                path: &layout.project_file,
+            })?;
         Ok(project)
     }
 

--- a/crates/koina/src/error.rs
+++ b/crates/koina/src/error.rs
@@ -45,8 +45,10 @@ pub enum Error {
     },
 
     /// Failed to serialize to JSON.
-    #[snafu(display("JSON serialization failed"))]
+    #[snafu(display("JSON serialization failed for {}", path.display()))]
     JsonSerialize {
+        /// The path to the file that failed serialization.
+        path: PathBuf,
         /// The underlying serialization error.
         source: serde_json::Error,
         #[snafu(implicit)]
@@ -55,8 +57,10 @@ pub enum Error {
     },
 
     /// Failed to deserialize from JSON.
-    #[snafu(display("JSON deserialization failed"))]
+    #[snafu(display("JSON deserialization failed for {}", path.display()))]
     JsonDeserialize {
+        /// The path to the file that failed deserialization.
+        path: PathBuf,
         /// The underlying deserialization error.
         source: serde_json::Error,
         #[snafu(implicit)]
@@ -106,9 +110,13 @@ mod tests {
     #[test]
     fn json_deserialize_error() {
         let err: std::result::Result<serde_json::Value, Error> =
-            serde_json::from_str("not json").context(JsonDeserializeSnafu);
+            serde_json::from_str("not json").context(JsonDeserializeSnafu {
+                path: PathBuf::from("/tmp/test.json"),
+            });
         assert!(err.is_err());
-        assert!(err.unwrap_err().to_string().contains("JSON"));
+        let msg = err.unwrap_err().to_string();
+        assert!(msg.contains("JSON"));
+        assert!(msg.contains("/tmp/test.json"));
     }
 
     #[test]

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -82,7 +82,7 @@ impl Default for NousLimits {
         use aletheia_koina::defaults as d;
         Self {
             max_tool_iterations: d::MAX_TOOL_ITERATIONS,
-            loop_detection_threshold: 3,
+            loop_detection_threshold: 5,
             consecutive_error_threshold: 4,
             loop_max_warnings: 2,
             session_token_cap: default_session_token_cap(),
@@ -355,7 +355,7 @@ mod tests {
             },
             limits: NousLimits {
                 max_tool_iterations: 10,
-                loop_detection_threshold: 5,
+                loop_detection_threshold: 5,  // Issue #2721: raised from 3 to reduce false positives
                 consecutive_error_threshold: 4,
                 loop_max_warnings: 2,
                 session_token_cap: 250_000,

--- a/crates/organon/src/builtins/computer_use/executor.rs
+++ b/crates/organon/src/builtins/computer_use/executor.rs
@@ -121,6 +121,8 @@ impl ToolExecutor for ComputerUseExecutor {
                         error::ExecutionFailedSnafu {
                             name: input.name.clone(),
                             message: format!("failed to serialize result: {e}"),
+                            exit_code: None,
+                            timed_out: false,
                         }
                         .build()
                     })?;

--- a/crates/organon/src/error.rs
+++ b/crates/organon/src/error.rs
@@ -39,10 +39,14 @@ pub enum Error {
     },
 
     /// Tool execution returned an error.
-    #[snafu(display("tool execution failed: {name}: {message}"))]
+    #[snafu(display("tool execution failed: {name}: {message} (exit_code: {exit_code:?}, timed_out: {timed_out})"))]
     ExecutionFailed {
         name: ToolName,
         message: String,
+        /// Process exit code, if available.
+        exit_code: Option<i32>,
+        /// Whether the execution timed out.
+        timed_out: bool,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -110,7 +110,7 @@ pub enum ApiError {
     },
 
     /// Config validation failed (422).
-    #[snafu(display("validation failed"))]
+    #[snafu(display("validation failed: {}", errors.join(", ")))]
     ValidationFailed {
         errors: Vec<String>,
         #[snafu(implicit)]

--- a/kimi-prompt.md
+++ b/kimi-prompt.md
@@ -1,0 +1,35 @@
+# Task: Fix audit issues #2721, #2722, #2723
+
+## Standards
+Read AGENTS.md. Skip Setup.
+
+## Issues
+
+### #2721: Loop detection threshold=3 is too aggressive
+Read: `gh issue view 2721 --json body`
+The stuck detection fires after 3 repeated errors, which is too sensitive for
+transient network issues. Raise the default to 5 or make it configurable
+(it may already be in StuckConfig — check).
+
+### #2722: Generic serialization errors erase file/field context
+Read: `gh issue view 2722 --json body`
+Serialization errors should include the file path or field name that failed.
+Add context to the error variants.
+
+### #2723: Validation errors display as empty; tool errors lack exit code
+Read: `gh issue view 2723 --json body`
+Check Display impls for validation errors — they may have empty messages.
+Tool execution errors should include the process exit code.
+
+## Validation
+cargo check --workspace
+
+## Completion
+git add -A
+git commit -m "fix: audit fixes — loop threshold, serialization context, validation display
+
+Closes #2721, #2722, #2723
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+git push origin fix/audit-batch
+gh pr create --title "fix: audit fixes batch" --body "Closes #2721, #2722, #2723"


### PR DESCRIPTION
Closes #2721, #2722, #2723

## Changes

### #2721: Loop detection threshold=3 is too aggressive
- Raised  default from 3 to 5 in 
- This reduces false positives from transient network issues while still catching actual infinite loops

### #2722: Generic serialization errors erase file/field context
- Added  field to , , ,  errors in 
- Added  field to  and  errors in 
- Updated all call sites to include the path context

### #2723: Validation errors display as empty; tool errors lack exit code
- Fixed  display message in  to include the actual validation errors
- Added  and  fields to  error in 
- Updated call site in  to include the new fields