### PR TITLE
fix: panic paths → error returns

### DIFF
--- a/crates/aletheia/src/commands/repl.rs
+++ b/crates/aletheia/src/commands/repl.rs
@@ -121,6 +121,7 @@ fn run_repl(instance_root: Option<&PathBuf>) -> Result<()> {
                     run_query_and_print(&store, "::relations");
                     continue;
                 }
+                // NOTE: Unknown meta-commands fall through to Datalog processing.
                 _ => {}
             }
         }

--- a/crates/aletheia/src/recall_sources/llm_context.rs
+++ b/crates/aletheia/src/recall_sources/llm_context.rs
@@ -58,6 +58,7 @@ impl ModelCard {
                     "Pricing: ${input:.2}/MTok input, ${output:.2}/MTok output"
                 ));
             }
+            // NOTE: Pricing omitted when either cost is unavailable.
             _ => {}
         }
 

--- a/crates/daemon/src/kairos.rs
+++ b/crates/daemon/src/kairos.rs
@@ -159,6 +159,7 @@ pub async fn run_cycle(
                             result.skipped += 1;
                             continue;
                         }
+                        // NOTE: Same wave - continue processing.
                         _ => {}
                     }
                 }

--- a/crates/episteme/src/consolidation/mod.rs
+++ b/crates/episteme/src/consolidation/mod.rs
@@ -288,6 +288,7 @@ fn extract_json_array(s: &str) -> Option<&str> {
                     return s.get(start..=start + i);
                 }
             }
+            // NOTE: Non-bracket characters are ignored while searching for matching brackets.
             _ => {}
         }
     }

--- a/crates/episteme/src/instinct.rs
+++ b/crates/episteme/src/instinct.rs
@@ -462,6 +462,7 @@ pub(crate) fn aggregate_observations(observations: &[ToolObservation]) -> Vec<Be
             None => {
                 accum.first_observed = Some(obs.observed_at);
             }
+            // NOTE: Current observation is not earlier than the stored first_observed.
             _ => {}
         }
 
@@ -472,6 +473,7 @@ pub(crate) fn aggregate_observations(observations: &[ToolObservation]) -> Vec<Be
             None => {
                 accum.last_observed = Some(obs.observed_at);
             }
+            // NOTE: Current observation is not later than the stored last_observed.
             _ => {}
         }
     }

--- a/crates/graphe/src/error.rs
+++ b/crates/graphe/src/error.rs
@@ -298,6 +298,15 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Configuration parameter is invalid.
+    #[snafu(display("configuration error: {message}"))]
+    Configuration {
+        /// Error message describing the configuration issue.
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Result alias using mneme's [`Error`] type.

--- a/crates/graphe/src/retention.rs
+++ b/crates/graphe/src/retention.rs
@@ -81,7 +81,12 @@ impl RetentionPolicy {
             .checked_sub(jiff::SignedDuration::from_hours(
                 i64::from(self.session_max_age_days) * 24,
             ))
-            .expect("retention cutoff overflow");
+            .map_err(|_| {
+                error::ConfigurationSnafu {
+                    message: "retention cutoff overflow: session_max_age_days too large".to_string(),
+                }
+                .build()
+            })?;
         let cutoff_str = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ").to_string();
 
         let expired_sessions = find_expired_sessions(conn, &cutoff_str)?;
@@ -108,7 +113,13 @@ impl RetentionPolicy {
             .checked_sub(jiff::SignedDuration::from_hours(
                 i64::from(self.orphan_message_max_age_days) * 24,
             ))
-            .expect("orphan cutoff overflow");
+            .map_err(|_| {
+                error::ConfigurationSnafu {
+                    message: "orphan cutoff overflow: orphan_message_max_age_days too large"
+                        .to_string(),
+                }
+                .build()
+            })?;
         let orphan_cutoff_str = orphan_cutoff.strftime("%Y-%m-%dT%H:%M:%SZ").to_string();
         result.messages_deleted = delete_orphan_messages(conn, &orphan_cutoff_str)?;
         result.orphan_rows_deleted = delete_orphan_related_rows(conn)?;

--- a/crates/krites/src/v2/parse/lexer.rs
+++ b/crates/krites/src/v2/parse/lexer.rs
@@ -209,6 +209,7 @@ impl<'a> Lexer<'a> {
                 self.string()?;
                 return Ok(());
             }
+            // NOTE: Other characters fall through to multi-character operator matching.
             _ => {}
         }
 

--- a/crates/symbolon/src/credential/pkce.rs
+++ b/crates/symbolon/src/credential/pkce.rs
@@ -496,9 +496,13 @@ fn handle_callback_connection(
     expected_state: &str,
 ) -> Result<CallbackData> {
     // Set a timeout for accepting connections
+    #[expect(
+        clippy::expect_used,
+        reason = "set_nonblocking on a freshly bound listener should not fail"
+    )]
     listener
         .set_nonblocking(false)
-        .expect("should be able to set blocking mode");
+        .expect("set_nonblocking on a freshly bound listener should not fail");
 
     let (stream, addr) = listener.accept().context(AcceptConnectionSnafu)?;
     info!("received OAuth callback from {}", addr);


### PR DESCRIPTION
Part of #2762

This PR addresses panic path violations in library code by:

1. **Replacing .expect() with proper error returns:**
   - &grave;graphe/src/retention.rs&grave;: Convert timestamp overflow .expect() calls to return Configuration errors
   - &grave;graphe/src/error.rs&grave;: Add new Configuration error variant

2. **Adding #[expect] annotations:**
   - &grave;symbolon/src/credential/pkce.rs&grave;: Add #[expect(clippy::expect_used)] with reason for set_nonblocking call

3. **Documenting intentional empty match arms:**
   - Added explanatory NOTE comments to legitimate _ => {} patterns in:
     - &grave;aletheia/src/commands/repl.rs&grave;
     - &grave;aletheia/src/recall_sources/llm_context.rs&grave;
     - &grave;daemon/src/kairos.rs&grave;
     - &grave;episteme/src/consolidation/mod.rs&grave;
     - &grave;episteme/src/instinct.rs&grave;
     - &grave;krites/src/v2/parse/lexer.rs&grave;

The remaining .expect() calls in the codebase are either:
- In test code (excluded from fixes)
- Already have #[expect] annotations with valid reasons
- In vendored code (krites CozoDB)

All changes pass &grave;cargo check --workspace&grave;.