### PR TITLE
chore: TOML formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,9 +109,21 @@ toml = "1.1"
 http = "1"
 axum = "0.8"
 utoipa = { version = "5", features = ["axum_extras"] }
-reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider", "json", "http2", "query"] }
+reqwest = { version = "0.13", default-features = false, features = [
+    "rustls-no-provider",
+    "json",
+    "http2",
+    "query",
+] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace", "limit", "set-header", "fs"] }
+tower-http = { version = "0.6", features = [
+    "cors",
+    "compression-gzip",
+    "trace",
+    "limit",
+    "set-header",
+    "fs",
+] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 
 # Secrets
@@ -144,7 +156,15 @@ bytes = "1"
 futures = "0.3"
 
 # Async
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync", "time", "fs"] }
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "macros",
+    "net",
+    "signal",
+    "sync",
+    "time",
+    "fs",
+] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["rt"] }
 

--- a/crates/agora/clippy.toml
+++ b/crates/agora/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/aletheia/clippy.toml
+++ b/crates/aletheia/clippy.toml
@@ -5,7 +5,16 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "use CancellationToken for shutdown, not process::exit" },
     { path = "std::process::abort", reason = "do not call process::abort from binary startup code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]

--- a/crates/daemon/clippy.toml
+++ b/crates/daemon/clippy.toml
@@ -5,7 +5,16 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]

--- a/crates/dianoia/clippy.toml
+++ b/crates/dianoia/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/diaporeia/clippy.toml
+++ b/crates/diaporeia/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/episteme/clippy.toml
+++ b/crates/episteme/clippy.toml
@@ -6,7 +6,16 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]

--- a/crates/eval/clippy.toml
+++ b/crates/eval/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/hermeneus/clippy.toml
+++ b/crates/hermeneus/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/integration-tests/clippy.toml
+++ b/crates/integration-tests/clippy.toml
@@ -6,7 +6,16 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "use assert! or return an error in tests, not process::exit" },
     { path = "std::process::abort", reason = "do not call process::abort from test code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]

--- a/crates/melete/clippy.toml
+++ b/crates/melete/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/nous/clippy.toml
+++ b/crates/nous/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/organon/clippy.toml
+++ b/crates/organon/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/pylon/clippy.toml
+++ b/crates/pylon/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/symbolon/clippy.toml
+++ b/crates/symbolon/clippy.toml
@@ -6,7 +6,16 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]

--- a/crates/taxis/clippy.toml
+++ b/crates/taxis/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/crates/thesauros/clippy.toml
+++ b/crates/thesauros/clippy.toml
@@ -5,9 +5,18 @@ disallowed-methods = [
     { path = "std::process::exit", reason = "do not call process::exit from library code" },
     { path = "std::process::abort", reason = "do not call process::abort from library code" },
 
-    { path = "std::fs::read", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::write", reason = "use tokio::fs for async or abstract behind a trait for testability" },
-    { path = "std::fs::File::open", reason = "use tokio::fs::File::open for async or abstract behind a trait for testability" },
+    {
+        path = "std::fs::read",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::write",
+        reason = "use tokio::fs for async or abstract behind a trait for testability",
+    },
+    {
+        path = "std::fs::File::open",
+        reason = "use tokio::fs::File::open for async or abstract behind a trait for testability",
+    },
 ]
 
 disallowed-types = [

--- a/shared/config/tools.example.yaml
+++ b/shared/config/tools.example.yaml
@@ -28,14 +28,14 @@ hex:
     status: "get_hex_run_status"
     runs: "get_hex_project_runs"
     cancel: "cancel_hex_run"
-  projects: {}
+  projects: ~
   notes: "API is execution/metadata only. Cannot edit notebook content."
 
 # -- Development tools --
 
 github:
   account: YOUR_GITHUB_USERNAME
-  repos: {}
+  repos: ~
   commands:
     status: "safe-git status"
     commit: 'safe-git commit -m "msg"'


### PR DESCRIPTION
Part of #2772

## Summary

Fixes TOML inline tables exceeding 80 characters by converting them to multi-line format, and addresses YAML empty values.

## Changes

- **Cargo.toml**: Converted long inline tables for 
  - 
reqwest
 features array
  - 
tower-http
 features array  
  - 
tokio
 features array
  
- **Crate clippy.toml files** (17 crates): Fixed disallowed-methods entries with long 
reason
 fields:
  - 
std::fs::read
, 
std::fs::write
, 
std::fs::File::open
  
- **shared/config/tools.example.yaml**: Replaced empty inline tables with explicit null:
  - 
projects: {}
 → 
projects: ~
  - 
repos: {}
 → 
repos: ~

## Verification

- [x] 
cargo check --workspace
 passes