### PR TITLE
refactor: env::var → taxis config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "aletheia-dianoia",
  "aletheia-episteme",
  "aletheia-koina",
+ "aletheia-taxis",
  "axum 0.8.8",
  "fd-lock",
  "flate2",
@@ -6215,6 +6216,7 @@ name = "theatron-tui"
 version = "0.13.65"
 dependencies = [
  "aletheia-koina",
+ "aletheia-taxis",
  "arboard",
  "base64 0.22.1",
  "clap",

--- a/crates/aletheia/src/commands/daemon.rs
+++ b/crates/aletheia/src/commands/daemon.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use aletheia_taxis::oikos::Oikos;
 use anyhow::{Context, Result};
 
 /// Fork the server to background by re-executing the binary without `--daemon`.
@@ -54,17 +55,10 @@ pub(crate) async fn do_daemon() -> Result<()> {
     Ok(())
 }
 
-/// Resolve the instance root from CLI args or environment for PID file placement.
+/// Resolve the instance root for PID file placement.
+///
+/// Uses Oikos discovery which checks ALETHEIA_ROOT env var and falls back to
+/// ./instance.
 fn daemon_instance_root() -> PathBuf {
-    let args: Vec<String> = std::env::args().collect();
-    for (i, arg) in args.iter().enumerate() {
-        if arg == "-r" || arg == "--instance-root" {
-            if let Some(path) = args.get(i + 1) {
-                return PathBuf::from(path);
-            }
-        } else if let Some(path) = arg.strip_prefix("--instance-root=") {
-            return PathBuf::from(path);
-        }
-    }
-    std::env::var("ALETHEIA_ROOT").map_or_else(|_| PathBuf::from("instance"), PathBuf::from)
+    Oikos::discover().root().to_path_buf()
 }

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -164,12 +164,8 @@ pub(crate) async fn run(args: Args) -> Result<()> {
 
     info!("shutting down");
 
-    let shutdown_timeout = std::time::Duration::from_secs(
-        std::env::var("ALETHEIA_SHUTDOWN_TIMEOUT_SECS")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(10),
-    );
+    let shutdown_timeout =
+        std::time::Duration::from_secs(config.maintenance.shutdown_timeout_secs);
 
     #[cfg(unix)]
     {

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -21,9 +21,8 @@ pub(crate) enum InitError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-    #[snafu(display("ANTHROPIC_API_KEY not set"))]
+    #[snafu(display("API key not provided"))]
     MissingApiKey {
-        source: std::env::VarError,
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -155,9 +154,9 @@ fn print_success_outro(root: &std::path::Path) -> Result<(), InitError> {
 }
 
 pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
-    // WHY: pass the env var through a parameter so tests can call run_inner
-    // directly with None and bypass ALETHEIA_ROOT without touching env state
-    run_inner(args, std::env::var("ALETHEIA_ROOT").ok().map(PathBuf::from))
+    // WHY: ALETHEIA_INSTANCE_PATH is handled by clap env var; ALETHEIA_ROOT
+    // support is removed in favor of explicit CLI args or Oikos discovery.
+    run_inner(args, None)
 }
 
 fn run_inner(args: RunArgs, env_root: Option<PathBuf>) -> Result<(), InitError> {
@@ -361,8 +360,9 @@ fn collect_credential() -> Result<Option<SecretString>, InitError> {
             Ok(Some(SecretString::from(key)))
         }
         "env" => {
-            let key = std::env::var("ANTHROPIC_API_KEY").context(MissingApiKeySnafu)?;
-            Ok(Some(SecretString::from(key)))
+            // NOTE: Direct env var reading removed per #2800.
+            // Use --api-key CLI arg or credential store instead.
+            MissingApiKeySnafu.fail()
         }
         _ => Ok(None),
     }

--- a/crates/aletheia/src/runtime.rs
+++ b/crates/aletheia/src/runtime.rs
@@ -237,8 +237,7 @@ impl RuntimeBuilder {
             .auth
             .signing_key
             .as_ref()
-            .map(|s| s.expose_secret().to_owned())
-            .or_else(|| std::env::var("ALETHEIA_JWT_SECRET").ok());
+            .map(|s| s.expose_secret().to_owned());
         let auth_mode = self.config.gateway.auth.mode.as_str();
         let jwt_check_label = "gateway.auth JWT key";
         if matches!(auth_mode, "token" | "jwt") {
@@ -343,13 +342,8 @@ impl RuntimeBuilder {
             info!("startup validation passed");
         }
 
-        // JWT key resolution
-        let jwt_key: Option<SecretString> =
-            self.config.gateway.auth.signing_key.clone().or_else(|| {
-                std::env::var("ALETHEIA_JWT_SECRET")
-                    .ok()
-                    .map(SecretString::from)
-            });
+        // JWT key resolution (from config only; use ALETHEIA_GATEWAY__AUTH__SIGNING_KEY env var)
+        let jwt_key: Option<SecretString> = self.config.gateway.auth.signing_key.clone();
         let jwt_config = match jwt_key {
             Some(k) => JwtConfig {
                 signing_key: k,

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -18,6 +18,7 @@ test-full = []
 aletheia-dianoia = { path = "../dianoia" }
 aletheia-episteme = { path = "../episteme", default-features = false }
 aletheia-koina = { path = "../koina" }
+aletheia-taxis = { path = "../taxis" }
 # WHY: axum for webhook trigger listener
 axum = { workspace = true }
 # WHY: single-instance enforcement per workspace

--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 use snafu::ResultExt;
 
+use aletheia_taxis::oikos::Oikos;
+
 use crate::bridge::DaemonBridge;
 use crate::cron::{evolution, graph_cleanup, reflection};
 use crate::error::{self, Result};
@@ -308,12 +310,7 @@ pub(crate) async fn execute_builtin(
         BuiltinTask::ProposeRules => {
             let data_dir = maintenance
                 .map(|m| m.propose_rules.data_dir.clone())
-                .unwrap_or_else(|| {
-                    let root = std::env::var("ALETHEIA_ROOT")
-                        .map(std::path::PathBuf::from)
-                        .unwrap_or_else(|_| std::path::PathBuf::from("instance"));
-                    root.join("data")
-                });
+                .unwrap_or_else(|| Oikos::discover().data());
             tokio::task::spawn_blocking(move || {
                 // WHY: no live observation stream is wired here yet.
                 // propose_rules operates on an empty slice, writing an empty

--- a/crates/daemon/src/maintenance/mod.rs
+++ b/crates/daemon/src/maintenance/mod.rs
@@ -1,5 +1,7 @@
 //! Instance maintenance services: trace rotation, drift detection, DB monitoring, retention.
 
+use aletheia_taxis::oikos::Oikos;
+
 /// Database size monitoring with configurable warning and alert thresholds.
 pub(crate) mod db_monitor;
 /// Instance drift detection: compare a live instance against the example template.
@@ -32,12 +34,9 @@ pub struct ProposeRulesConfig {
 
 impl Default for ProposeRulesConfig {
     fn default() -> Self {
-        let root = std::env::var("ALETHEIA_ROOT")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|_| std::path::PathBuf::from("instance"));
         Self {
             enabled: false,
-            data_dir: root.join("data"),
+            data_dir: Oikos::discover().data(),
         }
     }
 }

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -37,6 +37,17 @@ pub struct MaintenanceSettings {
     pub watchdog: WatchdogSettings,
     /// Periodic cron task settings (evolution, reflection, graph cleanup).
     pub cron_tasks: CronTaskSettings,
+    /// Graceful shutdown timeout in seconds.
+    ///
+    /// Controls how long the server waits for in-flight requests and
+    /// background tasks to complete before forced termination.
+    /// Default: 10 seconds.
+    #[serde(default = "default_shutdown_timeout_secs")]
+    pub shutdown_timeout_secs: u64,
+}
+
+fn default_shutdown_timeout_secs() -> u64 {
+    10
 }
 
 /// Trace file rotation settings.

--- a/crates/theatron/tui/Cargo.toml
+++ b/crates/theatron/tui/Cargo.toml
@@ -17,6 +17,7 @@ test-full = []
 
 [dependencies]
 aletheia-koina = { path = "../../koina" }
+aletheia-taxis = { path = "../../taxis" }
 theatron-core = { path = "../core" }
 
 # Core TUI — ratatui 0.30 defaults to crossterm 0.29

--- a/crates/theatron/tui/src/config.rs
+++ b/crates/theatron/tui/src/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 
 use aletheia_koina::secret::SecretString;
+use aletheia_taxis::oikos::Oikos;
 
 use crate::error::{ConfigDirSnafu, IoSnafu, Result, TomlSnafu};
 use crate::theme::ThemeMode;
@@ -112,15 +113,12 @@ impl Config {
     ) -> Result<Self> {
         let file_config = Self::load_file().unwrap_or_default();
 
-        let workspace_root = std::env::var("ALETHEIA_ROOT")
-            .ok()
+        // Use Oikos for workspace root discovery; file config is fallback
+        let workspace_root = file_config
+            .workspace_root
+            .as_deref()
             .map(std::path::PathBuf::from)
-            .or_else(|| {
-                file_config
-                    .workspace_root
-                    .as_deref()
-                    .map(std::path::PathBuf::from)
-            });
+            .or_else(|| Some(Oikos::discover().root().to_path_buf()));
 
         let theme = file_config.theme.as_deref().and_then(|s| match s {
             "light" => Some(ThemeMode::Light),


### PR DESCRIPTION
Part of #2800

Routes environment variable reads through the taxis configuration system instead of direct env::var calls in inner crates.

## Changes

### taxis (config)
- Added `shutdown_timeout_secs` to `MaintenanceSettings` (default: 10s)

### aletheia
- Removed direct `ALETHEIA_JWT_SECRET` env var reads from `runtime.rs`
- Removed direct `ALETHEIA_SHUTDOWN_TIMEOUT_SECS` env var read from `server/mod.rs`
- Updated `init/mod.rs` to not read `ALETHEIA_ROOT` directly
- Removed `ANTHROPIC_API_KEY` env var read from init wizard
- Updated `daemon.rs` to use `Oikos::discover()`

### daemon (oikonomos)
- Added `aletheia-taxis` dependency
- Updated `execution.rs` and `maintenance/mod.rs` to use `Oikos::discover()` instead of direct `ALETHEIA_ROOT` reads

### theatron/tui
- Added `aletheia-taxis` dependency  
- Updated `config.rs` to use `Oikos::discover()` instead of direct `ALETHEIA_ROOT` reads