### PR TITLE
fix: add deny.toml skip entries for 7 unskipped duplicate warnings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -153,6 +153,28 @@ skip = [
 
     # WHY: toml_edit pins winnow 0.7. Canonical: winnow 1.0 (toml 1.x).
     { name = "winnow", version = "=0.7.15" },
+
+    # WHY: kqueue-sys (macOS notify backend) pins bitflags 1.x.
+    # Canonical: bitflags 2.x. Harmless on Linux; blocked on kqueue-sys upgrade.
+    { name = "bitflags", version = "=1.3.2" },
+
+    # WHY: older RustCrypto crates (blake2/argon2 chain via symbolon) pin the
+    # 0.10.x generation of block-buffer, crypto-common, digest, and sha2.
+    # Canonical: 0.12/0.2/0.11/0.11 respectively. Blocked until argon2/blake2
+    # release versions using the RustCrypto 0.2 trait family.
+    { name = "block-buffer", version = "=0.10.4" },
+    { name = "crypto-common", version = "=0.1.7" },
+    { name = "digest", version = "=0.10.7" },
+    { name = "sha2", version = "=0.10.9" },
+
+    # WHY: chacha20poly1305 0.10 (via taxis encryption) pins chacha20 0.9.
+    # Canonical: chacha20 0.10 (rand 0.10 via rmcp). Blocked until
+    # chacha20poly1305 upgrades to chacha20 0.10.
+    { name = "chacha20", version = "=0.9.1" },
+
+    # WHY: toml 0.8 (figment dependency) pins toml_edit 0.22. Same root cause
+    # as the existing toml/serde_spanned/toml_datetime skips above.
+    { name = "toml_edit", version = "=0.22.27" },
 ]
 
 [sources]


### PR DESCRIPTION
## Summary

- Add skip entries for 7 duplicate crate warnings reported by `cargo deny check`
- Each entry documents the root cause and what blocks resolution upstream
- Duplicates: bitflags 1.x (kqueue-sys), block-buffer/crypto-common/digest/sha2 0.10.x (RustCrypto argon2/blake2 chain), chacha20 0.9 (chacha20poly1305), toml_edit 0.22 (figment's toml 0.8)

Closes #2790