### PR TITLE
fix: #2816 pagination-types

### DIFF
--- a/crates/pylon/src/handlers/knowledge/mod.rs
+++ b/crates/pylon/src/handlers/knowledge/mod.rs
@@ -36,10 +36,10 @@ pub struct FactsQuery {
     pub tier: Option<String>,
     /// Maximum results to return.
     #[serde(default = "default_limit")]
-    pub limit: usize,
+    pub limit: u32,
     /// Offset for pagination.
     #[serde(default)]
-    pub offset: usize,
+    pub offset: u32,
     /// Include forgotten facts.
     #[serde(default)]
     pub include_forgotten: bool,
@@ -66,9 +66,9 @@ const VALID_SORT_FIELDS: &[&str] = &[
 const VALID_ORDER_VALUES: &[&str] = &["asc", "desc"];
 
 /// Hard upper bound on the `limit` query parameter for all knowledge endpoints.
-const MAX_FACTS_LIMIT: usize = 1000;
+const MAX_FACTS_LIMIT: u32 = 1000;
 
-fn default_limit() -> usize {
+fn default_limit() -> u32 {
     100
 }
 
@@ -139,15 +139,15 @@ pub struct SearchQuery {
     #[serde(default)]
     pub nous_id: Option<String>,
     #[serde(default = "default_search_limit")]
-    pub limit: usize,
+    pub limit: u32,
 }
 
-fn default_search_limit() -> usize {
+fn default_search_limit() -> u32 {
     20
 }
 
 /// Hard upper bound on the `limit` query parameter for search.
-const MAX_SEARCH_LIMIT: usize = 1000;
+const MAX_SEARCH_LIMIT: u32 = 1000;
 
 /// Search result item.
 #[derive(Debug, Serialize)]
@@ -261,8 +261,8 @@ fn validate_sort_order(sort: &str, order: &str) -> Result<(), ApiError> {
         ("filter" = Option<String>, Query, description = "Text filter"),
         ("fact_type" = Option<String>, Query, description = "Fact type filter: knowledge, preference, skill, observation, etc."),
         ("tier" = Option<String>, Query, description = "Epistemic tier: verified, inferred, assumed"),
-        ("limit" = Option<usize>, Query, description = "Maximum results (default: 100, max: 1000)"),
-        ("offset" = Option<usize>, Query, description = "Pagination offset"),
+        ("limit" = Option<u32>, Query, description = "Maximum results (default: 100, max: 1000)"),
+        ("offset" = Option<u32>, Query, description = "Pagination offset"),
         ("include_forgotten" = Option<bool>, Query, description = "Include forgotten facts (default: false)"),
     ),
     responses(
@@ -320,8 +320,8 @@ pub async fn list_facts(
 
     sort_facts(&mut facts, &query.sort, &query.order);
 
-    let start = query.offset.min(facts.len());
-    let end = (start + query.limit).min(facts.len());
+    let start = (query.offset as usize).min(facts.len());
+    let end = (start + (query.limit as usize)).min(facts.len());
     // start and end are both bounded by facts.len() via .min()
     #[expect(
         clippy::indexing_slicing,

--- a/crates/pylon/src/handlers/knowledge/search.rs
+++ b/crates/pylon/src/handlers/knowledge/search.rs
@@ -23,7 +23,7 @@ use super::{
     params(
         ("q" = String, Query, description = "Search query text"),
         ("nous_id" = Option<String>, Query, description = "Filter by agent ID"),
-        ("limit" = Option<usize>, Query, description = "Maximum results (default: 20)"),
+        ("limit" = Option<u32>, Query, description = "Maximum results (default: 20)"),
     ),
     responses(
         (status = 200, description = "Search results ranked by relevance"),
@@ -65,8 +65,8 @@ pub async fn search(
         filter: None,
         fact_type: None,
         tier: None,
-        limit: 10_000,
-        offset: 0,
+        limit: 10_000_u32,
+        offset: 0_u32,
         include_forgotten: false,
     };
     let all_facts = get_stored_facts(&state, &facts_query);
@@ -106,7 +106,7 @@ pub async fn search(
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    results.truncate(query.limit);
+    results.truncate(query.limit as usize);
 
     Ok(Json(SearchResponse { results }))
 }
@@ -190,8 +190,7 @@ pub(super) fn get_stored_facts(
 ) -> Vec<aletheia_mneme::knowledge::Fact> {
     #[cfg(feature = "knowledge-store")]
     if let Some(ref store) = state.knowledge_store {
-        let fetch_limit =
-            i64::try_from((query.offset + query.limit).min(10_000)).unwrap_or(i64::MAX);
+        let fetch_limit = i64::from((query.offset + query.limit).min(10_000));
         let result = if let Some(nous_id) = query.nous_id.as_deref() {
             store.audit_all_facts(nous_id, fetch_limit)
         } else {


### PR DESCRIPTION
Closes #2816

Standardizes pagination parameter types across API endpoints:

**Changes:**
- `FactsQuery.limit`: `usize` → `u32`
- `FactsQuery.offset`: `usize` → `u32`
- `SearchQuery.limit`: `usize` → `u32`
- `MAX_FACTS_LIMIT`: `usize` → `u32`
- `MAX_SEARCH_LIMIT`: `usize` → `u32`
- Updated OpenAPI docs to reflect `u32` types
- Added proper type casts where needed for indexing operations

This ensures all pagination parameters use `u32` consistently across session and knowledge endpoints, matching the existing session list and history endpoints.