### PR TITLE
fix: cache regex patterns in LazyLock instead of recompiling per call

### DIFF
--- a/crates/energeia/src/steward/classify.rs
+++ b/crates/energeia/src/steward/classify.rs
@@ -60,6 +60,20 @@ static STRUCTURED_COMMENT_RE: LazyLock<Regex> =
 static REASON_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"reason\s*=\s*["']([^"']+)["']"#).expect("valid regex"));
 
+#[expect(
+    clippy::expect_used,
+    reason = "compile-time constant regex patterns cannot fail"
+)]
+static PROMPT_K_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[Kk]-?(\d{1,4})").expect("valid regex"));
+
+#[expect(
+    clippy::expect_used,
+    reason = "compile-time constant regex patterns cannot fail"
+)]
+static PROMPT_WORD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"prompt[\s-](\d{1,4})").expect("valid regex"));
+
 /// Determine aggregate CI status from individual check runs.
 ///
 /// When `required_checks` is non-empty, only checks whose name appears in
@@ -148,18 +162,12 @@ pub fn extract_prompt_number(pr: &PullRequest) -> Option<u32> {
 /// Recognized patterns: `K-NNN`, `KNNN`, `prompt NNN`
 #[must_use]
 pub(crate) fn extract_prompt_number_from_text(text: &str) -> Option<u32> {
-    // WHY: Use a simple regex to match common prompt number patterns.
-    // The patterns are tried in order of specificity.
-    let patterns = [
-        r"[Kk]-?(\d{1,4})",      // K-042, K042, k-42
-        r"prompt[\s-](\d{1,4})", // prompt 42, prompt-42
-    ];
+    // WHY: Patterns tried in order of specificity. Pre-compiled via LazyLock
+    // to avoid recompiling on every call.
+    let patterns: &[&LazyLock<Regex>] = &[&PROMPT_K_RE, &PROMPT_WORD_RE];
 
-    for pattern in &patterns {
-        // NOTE: Pattern compilation is cheap for these small patterns,
-        // and they're only used in classification (not hot path).
-        if let Ok(re) = Regex::new(pattern)
-            && let Some(caps) = re.captures(text)
+    for re in patterns {
+        if let Some(caps) = re.captures(text)
             && let Some(num_str) = caps.get(1)
             && let Ok(num) = num_str.as_str().parse::<u32>()
             && num > 0


### PR DESCRIPTION
## Summary

- Move two regex patterns in `extract_prompt_number_from_text()` from per-call `Regex::new()` to `static LazyLock<Regex>`, matching the existing pattern for all other regexes in the same file
- No behavioral change; only compilation overhead eliminated

Closes #2832