### PR TITLE
fix: remove consecutive blank lines and replace deprecated term

### DIFF
--- a/crates/episteme/src/side_query.rs
+++ b/crates/episteme/src/side_query.rs
@@ -241,7 +241,6 @@ impl SideQuerySelector {
             });
         }
 
-        
         let filtered = self.filter_surfaced(manifest);
         if filtered.is_empty() {
             debug!("all manifest entries already surfaced");
@@ -254,7 +253,6 @@ impl SideQuerySelector {
         let manifest_text = filtered.format();
         let cache_key = compute_cache_key(query, &manifest_text);
 
-        
         {
             let mut cache = self
                 .cache

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -31,7 +31,7 @@ impl ToolResultType {
     #[must_use]
     pub fn classify(tool_name: &str) -> Self {
         let lower = tool_name.to_lowercase();
-        // WHY: classification mirrors CC's COMPACTABLE_TOOLS whitelist.
+        // WHY: classification mirrors CC's COMPACTABLE_TOOLS allowlist.
         // NOTE: web check before search because "web_search" should match WebResult, not SearchResult.
         if lower.contains("read")
             || lower.contains("edit")

--- a/crates/koina/src/disk_space.rs
+++ b/crates/koina/src/disk_space.rs
@@ -3,7 +3,6 @@
 use std::fmt;
 use std::path::Path;
 
-
 const BYTES_PER_MB: u64 = 1024 * 1024;
 
 /// Default warning threshold: 1 GB.

--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -3,7 +3,6 @@
 use snafu::ResultExt;
 use tracing::{info, instrument};
 
-
 use aletheia_hermeneus::models::names;
 use aletheia_hermeneus::provider::LlmProvider;
 use aletheia_hermeneus::types::{Content, Message as HermeneusMessage, Role as HermeneusRole};

--- a/crates/theatron/tui/src/msg.rs
+++ b/crates/theatron/tui/src/msg.rs
@@ -263,7 +263,6 @@ pub enum Msg {
     EditorModalCancel,
     EditorRefreshTree,
 
-
     ShowError(String),
 
     /// Cancel the active LLM turn immediately (Esc / Ctrl+C during streaming).
@@ -323,14 +322,6 @@ pub enum Msg {
         )
     )]
     MetricsHealthLoaded(bool),
-
-
-
-
-
-
-
-
 
     Tick,
 }
@@ -411,8 +402,6 @@ impl ErrorToast {
         self.created_at.elapsed() > std::time::Duration::from_secs(5)
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/theatron/tui/src/update/memory/mod.rs
+++ b/crates/theatron/tui/src/update/memory/mod.rs
@@ -7,7 +7,6 @@ mod handlers;
 #[cfg(test)]
 mod tests;
 
-
 pub(crate) use handlers::{
     handle_close, handle_confidence_backspace, handle_confidence_cancel, handle_confidence_input,
     handle_confidence_submit, handle_drift_tab_next, handle_drift_tab_prev, handle_drill_in,


### PR DESCRIPTION
## Summary

- Remove consecutive blank lines in 5 files: `koina/disk_space.rs`, `nous/distillation.rs`, `theatron-tui/msg.rs`, `theatron-tui/update/memory/mod.rs`, `episteme/side_query.rs`
- Replace deprecated term `whitelist` with `allowlist` in `hermeneus/types.rs` comment
- Formatting-only changes, no behavioral impact
- Skipped krites (vendored) and desktop violations per project rules

Closes #2773