### PR TITLE
fix: replace silent wildcard on Role enum with explicit match + warning

### DIFF
--- a/crates/melete/src/prompt.rs
+++ b/crates/melete/src/prompt.rs
@@ -43,7 +43,12 @@ pub(crate) fn format_messages(messages: &[Message], include_tool_calls: bool) ->
             Role::System => "SYSTEM",
             Role::User => "USER",
             Role::Assistant => "ASSISTANT",
-            _ => "UNKNOWN",
+            // WHY: #[non_exhaustive] requires wildcard. Log so new variants
+            // are noticed instead of silently mapped.
+            _ => {
+                tracing::warn!(role = ?msg.role, "unknown message role in distillation");
+                "UNKNOWN"
+            }
         };
 
         match &msg.content {


### PR DESCRIPTION
Matches all 3 known hermeneus::Role variants explicitly in melete format_messages(). Adds tracing::warn on the #[non_exhaustive] wildcard arm so new variants are noticed.

Partial fix for #2845