### PR TITLE
feat(bench): wire hermeneus parser benches into Cargo (#2802)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ name = "aletheia-hermeneus"
 version = "0.14.0"
 dependencies = [
  "aletheia-koina",
+ "criterion",
  "jiff",
  "prometheus",
  "proptest",

--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -37,6 +37,15 @@ test-core = []
 test-full = []
 
 [dev-dependencies]
+criterion = { workspace = true }
 proptest = { workspace = true }
 tokio = { workspace = true }
 wiremock = { workspace = true }
+
+# WHY: complexity::score_complexity runs on every message to pick a tier,
+# and the concurrency limiter's acquire/release cycle wraps every provider
+# call. Regressions in either surface as latency in every streamed
+# completion, so both belong in CI-tracked microbenchmarks.
+[[bench]]
+name = "parser"
+harness = false


### PR DESCRIPTION
## Summary
Repairs the broken state introduced by 0d12d665c (`fix(daemon): more clippy cleanup (#2958)`), which checked in `crates/hermeneus/benches/parser.rs` and `crates/episteme/tests/public_api.rs` without the matching Cargo wiring. As a result, `cargo bench -p aletheia-hermeneus --bench parser` from a clean checkout currently fails: the file exists but no `[[bench]]` entry registers it and `criterion` is not in `[dev-dependencies]`.

This PR adds:
- `criterion = { workspace = true }` under `[dev-dependencies]` in `crates/hermeneus/Cargo.toml`
- `[[bench]] name = "parser" / harness = false` (with WHY comment)
- A 1-line `Cargo.lock` update reflecting criterion's addition to hermeneus

No edits to `parser.rs` itself -- the file already in main is exactly what was authored alongside the Cargo wiring; the two halves were just split across the wrong commit.

## Why these benches matter
The 7 benches in `parser.rs` cover the public hot paths reachable from outside the crate, since the SSE parser itself lives in `pub(crate)` modules behind `cfg(test)` and is out of scope for #2802 per #2956's "needs internal access; will follow up" note:

| Bench | Time (--quick on menos) | Hot path |
|---|---|---|
| `usage_total` | ~746 ps | `Usage::total()` -- harness noise floor |
| `stop_reason_as_str` | ~5.9 ns | wire-format serialize on every completion response |
| `stop_reason_from_str` | ~8.9 ns | wire-format deserialize on every completion response |
| `classify_tool_name` | ~470 ns | `ToolResultType::classify` over 5 variants (compaction TTL pass) |
| `score_complexity_short` | ~207 ns | `complexity::score_complexity` short message |
| `score_complexity_long` | ~2.09 us | same, multi-regex realistic message |
| `concurrency_acquire_release` | ~277 ns | `AdaptiveConcurrencyLimiter::acquire` + `finish` uncontended fast path |

`score_complexity` is regex-heavy and runs on every user message when complexity routing is enabled; the concurrency limiter wraps every provider call; `classify_tool_name` runs on every tool result during compaction.

## Test plan
- [x] `CARGO_TARGET_DIR=/data/target cargo bench -p aletheia-hermeneus --bench parser -- --quick` -- 7/7 succeed
- [x] `CARGO_TARGET_DIR=/data/target cargo test -p aletheia-hermeneus` -- 254 unit + 17 integration + 1 doctest pass, no regressions
- [x] `CARGO_TARGET_DIR=/data/target cargo clippy -p aletheia-hermeneus --benches` -- zero warnings on `parser.rs` (pre-existing warnings in `metrics.rs` are unrelated and out of scope)

Refs #2802

🤖 Generated with [Claude Code](https://claude.com/claude-code)