### PR TITLE
lint(aletheia): clear binary crate clippy backlog

### DIFF
--- a/crates/aletheia/src/commands/eval_embeddings.rs
+++ b/crates/aletheia/src/commands/eval_embeddings.rs
@@ -63,10 +63,6 @@ struct CorpusEntry {
 
 /// Parse a corpus JSONL file into `(id, text)` pairs.
 fn load_corpus(path: &std::path::Path) -> Result<Vec<(String, String)>> {
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "synchronous filesystem I/O is correct here; eval-embeddings runs outside the async runtime"
-    )]
     let contents = std::fs::read_to_string(path)
         .whatever_context(format!("cannot read corpus file: {}", path.display()))?;
 
@@ -204,7 +200,7 @@ fn print_table(run: &aletheia_mneme::embedding_eval::EvalRunResult) {
 }
 
 /// Entry point for the `eval-embeddings` subcommand.
-pub(crate) fn run(args: EvalEmbeddingsArgs) -> Result<()> {
+pub(crate) fn run(args: &EvalEmbeddingsArgs) -> Result<()> {
     use aletheia_mneme::embedding::{EmbeddingConfig, create_provider};
     use aletheia_mneme::embedding_eval::{EvalDataset, compare_models};
 

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -6,8 +6,8 @@ use clap::Subcommand;
 use snafu::prelude::*;
 
 use aletheia_oikonomos::maintenance::{
-    DbMonitor, DbMonitoringConfig, DriftDetectionConfig, DriftDetector, MaintenanceConfig,
-    TraceRotationConfig, TraceRotator,
+    AutoDreamConfig, DbMonitor, DbMonitoringConfig, DriftDetectionConfig, DriftDetector,
+    MaintenanceConfig, ProposeRulesConfig, TraceRotationConfig, TraceRotator,
 };
 use aletheia_oikonomos::runner::TaskRunner;
 use aletheia_taxis::loader::load_config;
@@ -188,9 +188,9 @@ pub(crate) fn build_config(
         },
         knowledge_maintenance: aletheia_oikonomos::maintenance::KnowledgeMaintenanceConfig {
             enabled: settings.knowledge_maintenance_enabled,
-            auto_dream: Default::default(),
+            auto_dream: AutoDreamConfig::default(),
         },
-        propose_rules: Default::default(),
+        propose_rules: ProposeRulesConfig::default(),
         cron: aletheia_oikonomos::cron::CronConfig {
             evolution: aletheia_oikonomos::cron::CronEvolutionConfig {
                 enabled: settings.cron_tasks.evolution.enabled,

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -92,7 +92,7 @@ pub(crate) async fn dispatch(cmd: Command, instance_root: Option<&PathBuf>) -> R
         Command::Tui(_) => anyhow::bail!("TUI not available - rebuild with `--features tui`"),
         Command::Desktop(a) => desktop::run(&a),
         Command::Eval(a) => eval::run(a).await.map_err(Into::into),
-        Command::EvalEmbeddings(a) => eval_embeddings::run(a).map_err(Into::into),
+        Command::EvalEmbeddings(ref a) => eval_embeddings::run(a).map_err(Into::into),
         Command::Export(a) => agent_io::export_agent(instance_root, &a).map_err(Into::into),
         Command::SessionExport(a) => session_export::run(&a).await.map_err(Into::into),
         Command::Import(a) => agent_io::import_agent(instance_root, &a).map_err(Into::into),

--- a/crates/aletheia/src/external_tools.rs
+++ b/crates/aletheia/src/external_tools.rs
@@ -5,7 +5,7 @@
 //! that forwards tool calls to the configured endpoint.
 //!
 //! WHY: Different deployments have different MCP servers available.  A menos
-//! instance has Semantic Scholar + PubMed + kanon-mcp.  A verda instance has
+//! instance has Semantic Scholar + `PubMed` + kanon-mcp.  A verda instance has
 //! none.  This module lets operators declare available tools per-deployment
 //! without hardcoded tool assumptions.
 
@@ -118,9 +118,8 @@ pub(crate) struct ToolManifestEntry {
 #[must_use]
 pub(crate) fn load_tools_config(oikos: &Oikos) -> ExternalToolsConfig {
     let toml_path = oikos.config().join("aletheia.toml");
-    let content = match std::fs::read_to_string(&toml_path) {
-        Ok(c) => c,
-        Err(_) => return ExternalToolsConfig::default(),
+    let Ok(content) = std::fs::read_to_string(&toml_path) else {
+        return ExternalToolsConfig::default();
     };
 
     // WHY: parse the full TOML and extract only the [tools] table rather than
@@ -161,7 +160,7 @@ pub(crate) fn load_tools_config(oikos: &Oikos) -> ExternalToolsConfig {
 pub(crate) fn register_external_tools(
     config: &ExternalToolsConfig,
     registry: &mut ToolRegistry,
-    http_client: reqwest::Client,
+    http_client: &reqwest::Client,
 ) -> ToolManifest {
     let mut manifest = ToolManifest {
         required: Vec::new(),
@@ -171,12 +170,12 @@ pub(crate) fn register_external_tools(
     // WHY: process required tools first so startup warnings about missing
     // required tools appear before optional tool info.
     for (name, entry) in &config.required {
-        let result = register_single_tool(name, entry, registry, &http_client);
+        let result = register_single_tool(name, entry, registry, http_client);
         manifest.required.push(result);
     }
 
     for (name, entry) in &config.optional {
-        let result = register_single_tool(name, entry, registry, &http_client);
+        let result = register_single_tool(name, entry, registry, http_client);
         manifest.optional.push(result);
     }
 
@@ -210,17 +209,14 @@ fn register_single_tool(
         };
     }
 
-    let endpoint = match &entry.endpoint {
-        Some(ep) => ep.clone(),
-        None => {
-            warn!(tool = name, "external tool has no endpoint configured");
-            return ToolManifestEntry {
-                name: name.to_owned(),
-                kind: entry.kind,
-                available: false,
-                description,
-            };
-        }
+    let Some(endpoint) = entry.endpoint.clone() else {
+        warn!(tool = name, "external tool has no endpoint configured");
+        return ToolManifestEntry {
+            name: name.to_owned(),
+            kind: entry.kind,
+            available: false,
+            description,
+        };
     };
 
     let tool_name = match ToolName::new(name) {
@@ -364,6 +360,7 @@ impl ToolExecutor for ExternalToolExecutor {
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
 
@@ -510,7 +507,7 @@ no_endpoint = { type = "mcp" }
         let mut registry = ToolRegistry::new();
         let client = reqwest::Client::new();
 
-        let manifest = register_external_tools(&config, &mut registry, client);
+        let manifest = register_external_tools(&config, &mut registry, &client);
 
         // NOTE: file_ops is builtin but not registered in empty registry → unavailable
         assert_eq!(manifest.required.len(), 1);

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -376,10 +376,9 @@ use scaffold::scaffold;
 
 #[cfg(feature = "tui")]
 fn wizard_answers_to_answers(wa: &theatron_tui::wizard::WizardAnswers) -> Answers {
-    use aletheia_koina::secret::SecretString;
     Answers {
         root: wa.root.clone(),
-        api_key: wa.api_key.clone().map(SecretString::from),
+        api_key: wa.api_key.clone(),
         api_provider: wa.api_provider.clone(),
         model: wa.model.clone(),
         agent_id: wa.agent_id.clone(),

--- a/crates/aletheia/src/recall_sources/academic.rs
+++ b/crates/aletheia/src/recall_sources/academic.rs
@@ -83,8 +83,17 @@ impl RecallSource for AcademicSource {
                     let content = format_paper(&paper);
                     // NOTE: Position-based relevance: rank 0 = 1.0, declining linearly.
                     // Semantic Scholar returns results in relevance order.
+                    #[expect(
+                        clippy::as_conversions,
+                        clippy::cast_precision_loss,
+                        reason = "clamped_limit ≤ 100: well within f64 mantissa"
+                    )]
                     let denominator = (clamped_limit.max(1)) as f64;
-                    #[expect(clippy::cast_precision_loss, reason = "rank index is small enough that f64 precision is sufficient")]
+                    #[expect(
+                        clippy::as_conversions,
+                        clippy::cast_precision_loss,
+                        reason = "rank index ≤ 100: well within f64 mantissa"
+                    )]
                     let relevance = 1.0 - (rank as f64 / denominator);
                     SourceResult {
                         content,
@@ -98,7 +107,7 @@ impl RecallSource for AcademicSource {
         })
     }
 
-    fn source_type(&self) -> &str {
+    fn source_type(&self) -> &'static str {
         "academic"
     }
 
@@ -116,10 +125,10 @@ fn format_paper(paper: &Paper) -> String {
         parts.push(paper.title.clone());
     }
 
-    if let Some(ref abs) = paper.r#abstract {
-        if !abs.is_empty() {
-            parts.push(abs.clone());
-        }
+    if let Some(ref abs) = paper.r#abstract
+        && !abs.is_empty()
+    {
+        parts.push(abs.clone());
     }
 
     if let Some(citations) = paper.citation_count {
@@ -144,6 +153,10 @@ struct SearchResponse {
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[expect(
+    clippy::struct_field_names,
+    reason = "field name matches Semantic Scholar API JSON key 'paperId'"
+)]
 struct Paper {
     paper_id: String,
     title: String,
@@ -154,6 +167,8 @@ struct Paper {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::indexing_slicing, reason = "test data has known structure")]
 mod tests {
     use super::*;
 

--- a/crates/aletheia/src/recall_sources/llm_context.rs
+++ b/crates/aletheia/src/recall_sources/llm_context.rs
@@ -52,13 +52,12 @@ impl ModelCard {
             parts.push(format!("Capabilities: {}", caps.join(", ")));
         }
 
-        match (self.input_cost_per_mtok, self.output_cost_per_mtok) {
-            (Some(input), Some(output)) => {
-                parts.push(format!(
-                    "Pricing: ${input:.2}/MTok input, ${output:.2}/MTok output"
-                ));
-            }
-            _ => {}
+        if let (Some(input), Some(output)) =
+            (self.input_cost_per_mtok, self.output_cost_per_mtok)
+        {
+            parts.push(format!(
+                "Pricing: ${input:.2}/MTok input, ${output:.2}/MTok output"
+            ));
         }
 
         parts.join("\n")
@@ -97,19 +96,18 @@ impl ModelCard {
         }
         // WHY: Specific context size queries (e.g., "256k context") match
         // models whose window is at or above the requested size.
-        if let Some(requested_k) = extract_context_size_k(query_lower) {
-            if self.context_window >= requested_k * 1000 {
-                score += 0.4;
-            }
+        if let Some(requested_k) = extract_context_size_k(query_lower)
+            && self.context_window >= requested_k * 1000
+        {
+            score += 0.4;
         }
 
-        if query_lower.contains("cost")
+        if (query_lower.contains("cost")
             || query_lower.contains("price")
-            || query_lower.contains("pricing")
+            || query_lower.contains("pricing"))
+            && self.input_cost_per_mtok.is_some()
         {
-            if self.input_cost_per_mtok.is_some() {
-                score += 0.2;
-            }
+            score += 0.2;
         }
 
         score.min(1.0)
@@ -121,15 +119,16 @@ fn extract_context_size_k(query: &str) -> Option<u64> {
     let bytes = query.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i].is_ascii_digit() {
+        let Some(&b) = bytes.get(i) else { break };
+        if b.is_ascii_digit() {
             let start = i;
-            while i < bytes.len() && bytes[i].is_ascii_digit() {
+            while bytes.get(i).is_some_and(u8::is_ascii_digit) {
                 i += 1;
             }
             // WHY: Check for 'k' suffix immediately after digits.
-            if i < bytes.len() && (bytes[i] == b'k' || bytes[i] == b'K') {
-                // SAFETY: start and i are bounds-checked above (start <= i < bytes.len())
-                #[expect(clippy::string_slice, reason = "bounds verified: start <= i < bytes.len()")]
+            if bytes.get(i).is_some_and(|&b| b == b'k' || b == b'K') {
+                // SAFETY: start..i are within bounds (guarded by .get() above)
+                #[expect(clippy::string_slice, reason = "bounds verified via .get() checks above")]
                 if let Ok(n) = query[start..i].parse::<u64>() {
                     return Some(n);
                 }
@@ -208,7 +207,7 @@ impl RecallSource for LlmContextSource {
         })
     }
 
-    fn source_type(&self) -> &str {
+    fn source_type(&self) -> &'static str {
         "llm_context"
     }
 
@@ -265,6 +264,9 @@ fn anthropic_model_cards() -> Vec<ModelCard> {
 }
 
 #[cfg(test)]
+#[expect(clippy::indexing_slicing, reason = "test data has known structure")]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
     use super::*;
 

--- a/crates/aletheia/src/recall_sources/mod.rs
+++ b/crates/aletheia/src/recall_sources/mod.rs
@@ -43,7 +43,7 @@ pub(crate) trait RecallSource: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result<Vec<SourceResult>, RecallSourceError>> + Send + 'a>>;
 
     /// Identifier for this source type (e.g., `"academic"`, `"llm_context"`).
-    fn source_type(&self) -> &str;
+    fn source_type(&self) -> &'static str;
 
     /// Whether the source is currently available for queries.
     fn available(&self) -> bool;
@@ -141,6 +141,7 @@ impl RecallSourceRegistry {
 }
 
 #[cfg(test)]
+#[expect(clippy::indexing_slicing, reason = "test data has known structure")]
 mod tests {
     use super::*;
 
@@ -162,7 +163,7 @@ mod tests {
             Box::pin(async move { Ok(results) })
         }
 
-        fn source_type(&self) -> &str {
+        fn source_type(&self) -> &'static str {
             self.type_name
         }
 

--- a/crates/aletheia/src/runtime.rs
+++ b/crates/aletheia/src/runtime.rs
@@ -231,61 +231,12 @@ impl RuntimeBuilder {
             }
         }
 
-        let jwt_key = self
-            .config
-            .gateway
-            .auth
-            .signing_key
-            .as_ref()
-            .map(|s| s.expose_secret().to_owned())
-            .or_else(|| std::env::var("ALETHEIA_JWT_SECRET").ok());
-        let auth_mode = self.config.gateway.auth.mode.as_str();
-        let jwt_check_label = "gateway.auth JWT key";
-        if matches!(auth_mode, "token" | "jwt") {
-            match jwt_key.as_deref() {
-                Some("CHANGE-ME-IN-PRODUCTION") | None => {
-                    println!(
-                        "  [FAIL] {jwt_check_label}: key is still the default placeholder\n         \
-                         Set gateway.auth.signingKey in aletheia.toml or ALETHEIA_JWT_SECRET env var.\n         \
-                         Generate one with: openssl rand -hex 32"
-                    );
-                    all_ok = false;
-                }
-                Some(_) => println!("  [pass] {jwt_check_label}"),
-            }
-        } else {
-            println!("  [pass] {jwt_check_label} (auth mode '{auth_mode}' -- JWT not required)");
+        if !validate_jwt(&self.config) {
+            all_ok = false;
         }
 
-        // External tools
-        let tools_config = crate::external_tools::load_tools_config(&self.oikos);
-        let total = tools_config.required.len() + tools_config.optional.len();
-        if total > 0 {
-            let mut tools_ok = true;
-            for (name, entry) in &tools_config.required {
-                if entry.kind != crate::external_tools::ExternalToolKind::Builtin
-                    && entry.endpoint.is_none()
-                {
-                    println!("  [FAIL] tools.required.{name}: missing endpoint");
-                    tools_ok = false;
-                }
-            }
-            for (name, entry) in &tools_config.optional {
-                if entry.kind != crate::external_tools::ExternalToolKind::Builtin
-                    && entry.endpoint.is_none()
-                {
-                    println!("  [warn] tools.optional.{name}: missing endpoint");
-                }
-            }
-            if tools_ok {
-                println!(
-                    "  [pass] tools ({} required, {} optional)",
-                    tools_config.required.len(),
-                    tools_config.optional.len()
-                );
-            } else {
-                all_ok = false;
-            }
+        if !validate_external_tools(&self.oikos) {
+            all_ok = false;
         }
 
         println!();
@@ -416,7 +367,7 @@ impl RuntimeBuilder {
         let tool_manifest = crate::external_tools::register_external_tools(
             &tools_config,
             &mut tool_registry,
-            reqwest::Client::new(),
+            &reqwest::Client::new(),
         );
         if tool_manifest.available_count() > 0 || !tools_config.required.is_empty() {
             info!(
@@ -650,7 +601,7 @@ impl RuntimeBuilder {
                     cache_enabled: resolved.capabilities.cache_enabled,
                     recall: resolved.recall.into(),
                     tool_allowlist: None,
-                    hooks: Default::default(),
+                    hooks: aletheia_nous::config::HookConfig::default(),
                 };
                 nous_manager
                     .spawn(
@@ -784,6 +735,71 @@ impl RuntimeBuilder {
             shutdown_token,
         })
     }
+}
+
+// -- Validation helpers (extracted from RuntimeBuilder::validate) ----------------
+
+/// Validate JWT key configuration. Returns `true` if valid.
+fn validate_jwt(config: &AletheiaConfig) -> bool {
+    let jwt_key = config
+        .gateway
+        .auth
+        .signing_key
+        .as_ref()
+        .map(|s| s.expose_secret().to_owned())
+        .or_else(|| std::env::var("ALETHEIA_JWT_SECRET").ok());
+    let auth_mode = config.gateway.auth.mode.as_str();
+    let jwt_check_label = "gateway.auth JWT key";
+    if matches!(auth_mode, "token" | "jwt") {
+        match jwt_key.as_deref() {
+            Some("CHANGE-ME-IN-PRODUCTION") | None => {
+                println!(
+                    "  [FAIL] {jwt_check_label}: key is still the default placeholder\n         \
+                     Set gateway.auth.signingKey in aletheia.toml or ALETHEIA_JWT_SECRET env var.\n         \
+                     Generate one with: openssl rand -hex 32"
+                );
+                return false;
+            }
+            Some(_) => println!("  [pass] {jwt_check_label}"),
+        }
+    } else {
+        println!("  [pass] {jwt_check_label} (auth mode '{auth_mode}' -- JWT not required)");
+    }
+    true
+}
+
+/// Validate external tools configuration. Returns `true` if valid.
+fn validate_external_tools(oikos: &Oikos) -> bool {
+    let tools_config = crate::external_tools::load_tools_config(oikos);
+    let total = tools_config.required.len() + tools_config.optional.len();
+    if total == 0 {
+        return true;
+    }
+
+    let mut tools_ok = true;
+    for (name, entry) in &tools_config.required {
+        if entry.kind != crate::external_tools::ExternalToolKind::Builtin
+            && entry.endpoint.is_none()
+        {
+            println!("  [FAIL] tools.required.{name}: missing endpoint");
+            tools_ok = false;
+        }
+    }
+    for (name, entry) in &tools_config.optional {
+        if entry.kind != crate::external_tools::ExternalToolKind::Builtin
+            && entry.endpoint.is_none()
+        {
+            println!("  [warn] tools.optional.{name}: missing endpoint");
+        }
+    }
+    if tools_ok {
+        println!(
+            "  [pass] tools ({} required, {} optional)",
+            tools_config.required.len(),
+            tools_config.optional.len()
+        );
+    }
+    tools_ok
 }
 
 // -- Setup helpers (moved FROM commands/server/setup.rs) -----------------------
@@ -1020,10 +1036,6 @@ fn build_signal_provider(
     Some(Arc::new(provider))
 }
 
-#[expect(
-    clippy::expect_used,
-    reason = "channel registration is infallible for unique providers"
-)]
 fn start_inbound_dispatch(
     config: &AletheiaConfig,
     nous_manager: &Arc<NousManager>,


### PR DESCRIPTION
## Summary
- Fix all 46 clippy errors (26 lib + 20 test-scope) in `crates/aletheia/`, the last crate with clippy warnings
- Root-cause fixes where practical: `.get()` over indexing, let-chains, pass-by-reference, helper extraction
- `#[expect(rule, reason)]` only where the violation is provably safe (API field names, small integer casts, test assertions)

### Fix categories
| Category | Count | Approach |
|---|---:|---|
| `indexing_slicing` | 16 | `.get()` for byte parsing; module `#[expect]` for test data |
| `expect_used`/`unwrap_used` | 8 | module `#[expect]` for test assertions |
| `collapsible_if` | 3 | let-chains / combined conditions |
| `single_match_else` | 2 | `if let` / `let else` |
| `default_trait_access` | 3 | explicit `Type::default()` |
| `needless_pass_by_value` | 2 | changed to `&T` |
| `unfulfilled_lint_expectations` | 2 | removed stale `#[expect]` |
| `unnecessary_literal_bound` | 2 | changed trait to `&'static str` |
| `too_many_lines` | 1 | extracted `validate_jwt()` + `validate_external_tools()` |
| `as_conversions`/`cast_precision_loss` | 2 | `#[expect]` with proof (values ≤ 100) |
| `struct_field_names` | 1 | `#[expect]` (mirrors API JSON key) |
| `doc_markdown` | 1 | backtick `PubMed` |
| `let_else` | 1 | converted match-return to `let else` |
| `useless_conversion` | 1 | removed redundant `.map(SecretString::from)` |

## Test plan
- [x] `cargo clippy --all-targets -p aletheia -- -D warnings` passes clean
- [x] `cargo test -p aletheia` — 141 tests pass (104 unit + 36 smoke + 1 integration skipped)
- [x] No library crates modified
- [x] No behavioral changes