### PR TITLE
lint(melete): promote documented public API to pub (#3011)

### DIFF
--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -77,7 +77,7 @@ pub enum DistillSection {
 impl DistillSection {
     /// Markdown heading for this section.
     #[must_use]
-    pub(crate) fn heading(&self) -> String {
+    pub fn heading(&self) -> String {
         match self {
             Self::Summary => "## Summary".to_owned(),
             Self::TaskContext => "## Task Context".to_owned(),
@@ -92,7 +92,7 @@ impl DistillSection {
 
     /// Description text for this section (used in the system prompt).
     #[must_use]
-    pub(crate) fn description(&self) -> &str {
+    pub fn description(&self) -> &str {
         match self {
             Self::Summary => "One sentence describing what this conversation is about.",
             Self::TaskContext => {
@@ -125,7 +125,7 @@ impl DistillSection {
 
     /// All standard sections in default order.
     #[must_use]
-    pub(crate) fn all_standard() -> Vec<Self> {
+    pub fn all_standard() -> Vec<Self> {
         vec![
             Self::Summary,
             Self::TaskContext,
@@ -248,7 +248,7 @@ impl DistillEngine {
     /// Call once at the start of each conversation turn, before calling
     /// [`should_distill`][Self::should_distill]. Returns `true` if the engine is
     /// still in a backoff period and distillation should be skipped this turn.
-    pub(crate) fn tick_turn(&self) -> bool {
+    pub fn tick_turn(&self) -> bool {
         let mut state = self.lock_retry_state();
         if state.turns_to_skip > 0 {
             state.turns_to_skip -= 1;
@@ -264,7 +264,7 @@ impl DistillEngine {
     /// Returns `true` if the engine is in an active backoff period.
     ///
     /// Does not advance state. Use `tick_turn` to advance.
-    pub(crate) fn in_backoff(&self) -> bool {
+    pub fn in_backoff(&self) -> bool {
         self.lock_retry_state().turns_to_skip > 0
     }
 
@@ -277,7 +277,7 @@ impl DistillEngine {
     /// Returns true when message count meets the minimum (accounting for
     /// verbatim tail) AND the token estimate exceeds the threshold ratio
     /// of the context window.
-    pub(crate) fn should_distill(
+    pub fn should_distill(
         &self,
         message_count: usize,
         token_estimate: u64,
@@ -499,7 +499,7 @@ impl DistillEngine {
         expect(dead_code, reason = "test-only query API for distillation engine")
     )]
     /// Access the engine configuration.
-    pub(crate) fn config(&self) -> &DistillConfig {
+    pub fn config(&self) -> &DistillConfig {
         &self.config
     }
 }

--- a/crates/melete/src/error.rs
+++ b/crates/melete/src/error.rs
@@ -78,4 +78,4 @@ pub enum Error {
 }
 
 /// Convenience alias for `Result` with melete's [`Error`] type.
-pub(crate) type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/melete/src/flush.rs
+++ b/crates/melete/src/flush.rs
@@ -58,7 +58,7 @@ impl MemoryFlush {
             reason = "test-only constructor, production path not yet wired"
         )
     )]
-    pub(crate) fn empty() -> Self {
+    pub fn empty() -> Self {
         Self {
             decisions: vec![],
             corrections: vec![],
@@ -73,7 +73,7 @@ impl MemoryFlush {
         not(test),
         expect(dead_code, reason = "test-only query, production path not yet wired")
     )]
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.decisions.is_empty()
             && self.corrections.is_empty()
             && self.facts.is_empty()
@@ -89,7 +89,7 @@ impl MemoryFlush {
             reason = "test-only renderer, production path not yet wired"
         )
     )]
-    pub(crate) fn to_markdown(&self) -> String {
+    pub fn to_markdown(&self) -> String {
         let mut out = String::new();
 
         write_section(&mut out, "Decisions", &self.decisions);

--- a/crates/melete/src/similarity.rs
+++ b/crates/melete/src/similarity.rs
@@ -22,7 +22,7 @@ pub struct PruningStats {
 impl PruningStats {
     /// Percentage of chunks pruned (0.0 to 100.0).
     #[must_use]
-    pub(crate) fn reduction_percent(&self) -> f64 {
+    pub fn reduction_percent(&self) -> f64 {
         if self.total_chunks == 0 {
             return 0.0;
         }


### PR DESCRIPTION
Closes #3011.

Promotes "pub(crate)" items in the melete crate to "pub" that are documented as part of the public API and used externally:

- DistillEngine: tick_turn, in_backoff, should_distill, config
- MemoryFlush: empty, is_empty, to_markdown  
- PruningStats: reduction_percent
- DistillSection: heading, description, all_standard
- Result<T> type alias in error.rs

All workspace checks pass, tests pass, and clippy is clean.