### PR TITLE
lint(taxis): promote documented public API to pub (#3014)

### DIFF
--- a/crates/taxis/src/interpolate.rs
+++ b/crates/taxis/src/interpolate.rs
@@ -38,9 +38,8 @@ use crate::error::{EnvVarRequiredSnafu, EnvVarUnterminatedSnafu, Result};
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// // WHY: interpolate_env_vars is pub(crate) — example shows intended usage.
 /// let out = aletheia_taxis::interpolate::interpolate_env_vars(
 ///     "[gateway]\nport = ${_TAXIS_UNSET_EXAMPLE:-18789}"
 /// )?;
@@ -57,7 +56,7 @@ use crate::error::{EnvVarRequiredSnafu, EnvVarUnterminatedSnafu, Result};
     clippy::double_must_use,
     reason = "kanon lint requires explicit #[must_use] on pub fns returning Result"
 )]
-pub(crate) fn interpolate_env_vars(content: &str) -> Result<String> {
+pub fn interpolate_env_vars(content: &str) -> Result<String> {
     let mut result = String::with_capacity(content.len());
     let mut rest = content;
 

--- a/crates/taxis/src/workspace_schema.rs
+++ b/crates/taxis/src/workspace_schema.rs
@@ -7,12 +7,11 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
 //! use std::path::Path;
 //! use aletheia_taxis::workspace_schema::{WorkspaceSchema, WorkspaceRequirement, RequirementKind};
 //!
 //! let schema = WorkspaceSchema::standard();
-//! // WHY: validate is pub(crate) — this example shows intended usage within the crate.
 //! if let Err(e) = schema.validate(Path::new("/srv/aletheia/instance/nous/main")) {
 //!     eprintln!("{e}");
 //! }
@@ -69,7 +68,7 @@ pub struct WorkspaceRequirement {
     workspace.display(),
     failures.join("\n  - ")
 ))]
-pub(crate) struct WorkspaceSchemaError {
+pub struct WorkspaceSchemaError {
     /// Path to the workspace root that failed validation.
     pub workspace: PathBuf,
     /// Human-readable description of each missing entry.
@@ -126,7 +125,7 @@ impl WorkspaceSchema {
         clippy::double_must_use,
         reason = "kanon lint requires explicit #[must_use] on pub fns returning Result"
     )]
-    pub(crate) fn validate(&self, workspace: &Path) -> Result<(), WorkspaceSchemaError> {
+    pub fn validate(&self, workspace: &Path) -> Result<(), WorkspaceSchemaError> {
         let mut failures: Vec<String> = Vec::new();
 
         for req in &self.requirements {


### PR DESCRIPTION
Closes #3014.

Promotes items that were documented as public API but were incorrectly scoped as `pub(crate)`:

- `WorkspaceSchema::validate` — enables external validation of workspace schemas
- `WorkspaceSchemaError` — error type returned by validate
- `interpolate::interpolate_env_vars` — user-facing environment variable interpolation

Also removes `ignore` from the doctests that now compile as public API.

All tests pass and clippy is clean.