### PR TITLE
chore(graphe): delete dead disk_monitor infrastructure (#2957)

### DIFF
--- a/crates/graphe/src/backup.rs
+++ b/crates/graphe/src/backup.rs
@@ -6,8 +6,6 @@ use rusqlite::Connection;
 use snafu::ResultExt;
 use tracing::{info, instrument, warn};
 
-use aletheia_koina::disk_space::DiskSpaceMonitor;
-
 use crate::error::{self, Result};
 
 /// Validate a backup path for safe SQL interpolation and optional directory containment.
@@ -67,7 +65,6 @@ fn validate_backup_path(path: &Path, backup_dir: Option<&Path>) -> Result<()> {
 pub struct BackupManager<'a> {
     conn: &'a Connection,
     backup_dir: PathBuf,
-    disk_monitor: Option<DiskSpaceMonitor>,
 }
 
 /// Outcome of creating a backup.
@@ -114,21 +111,10 @@ impl<'a> BackupManager<'a> {
         Self {
             conn,
             backup_dir: backup_dir.into(),
-            disk_monitor: None,
         }
     }
 
-    /// Attach a disk space monitor. Backups are non-essential and will be
-    /// skipped when disk space reaches the critical threshold.
-    #[expect(dead_code, reason = "daemon disk monitor integration pending")]
-    pub(crate) fn set_disk_monitor(&mut self, monitor: DiskSpaceMonitor) {
-        self.disk_monitor = Some(monitor);
-    }
-
     /// Create a `SQLite` backup using `VACUUM INTO`.
-    ///
-    /// Backups are non-essential writes. When disk space is critical, this
-    /// method returns `Ok(None)` instead of writing.
     ///
     /// # SQL injection defense
     ///
@@ -142,13 +128,6 @@ impl<'a> BackupManager<'a> {
     #[instrument(skip(self))]
     pub fn create_backup(&self) -> Result<Option<BackupResult>> {
         let backup_start = std::time::Instant::now();
-        if let Some(ref monitor) = self.disk_monitor
-            && !monitor.allow_non_essential_write()
-        {
-            let mb = monitor.status().available_bytes() / (1024 * 1024);
-            warn!(available_mb = mb, "skipping backup: disk space critical");
-            return Ok(None);
-        }
 
         std::fs::create_dir_all(&self.backup_dir).context(error::IoSnafu {
             path: self.backup_dir.clone(),
@@ -196,22 +175,8 @@ impl<'a> BackupManager<'a> {
     }
 
     /// Export all sessions as individual JSON files.
-    ///
-    /// Exports are non-essential writes. When disk space is critical, this
-    /// method returns `Ok(None)` instead of writing.
     #[instrument(skip(self))]
     pub fn export_sessions_json(&self, output_dir: &Path) -> Result<Option<ExportResult>> {
-        if let Some(ref monitor) = self.disk_monitor
-            && !monitor.allow_non_essential_write()
-        {
-            let mb = monitor.status().available_bytes() / (1024 * 1024);
-            warn!(
-                available_mb = mb,
-                "skipping JSON export: disk space critical"
-            );
-            return Ok(None);
-        }
-
         std::fs::create_dir_all(output_dir).context(error::IoSnafu {
             path: output_dir.to_path_buf(),
         })?;

--- a/crates/graphe/src/store/message.rs
+++ b/crates/graphe/src/store/message.rs
@@ -23,7 +23,6 @@ impl SessionStore {
         tool_name: Option<&str>,
         token_estimate: i64,
     ) -> Result<i64> {
-        self.check_disk("append_message");
         self.require_writable()?;
         let tx = self
             .conn

--- a/crates/graphe/src/store/mod.rs
+++ b/crates/graphe/src/store/mod.rs
@@ -19,7 +19,6 @@ use rusqlite::Connection;
 use snafu::ResultExt;
 use tracing::{error, info, instrument, warn};
 
-use aletheia_koina::disk_space::{DiskSpaceMonitor, DiskStatus};
 
 use crate::error::{self, Result};
 use crate::migration;
@@ -55,7 +54,6 @@ pub trait ConnectionHook: Send + Sync {
 /// The session store: wraps a `SQLite` connection with optional degraded mode.
 pub struct SessionStore {
     conn: Connection,
-    disk_monitor: Option<DiskSpaceMonitor>,
     mode: StoreMode,
     path: Option<PathBuf>,
     hook: Option<Box<dyn ConnectionHook>>,
@@ -111,7 +109,6 @@ impl SessionStore {
 
                     return Ok(Self {
                         conn: recovered_conn,
-                        disk_monitor: None,
                         mode,
                         path: Some(path.to_path_buf()),
                         hook: None,
@@ -131,7 +128,6 @@ impl SessionStore {
 
         Ok(Self {
             conn,
-            disk_monitor: None,
             mode: StoreMode::Normal,
             path: Some(path.to_path_buf()),
             hook: None,
@@ -166,7 +162,6 @@ impl SessionStore {
         migration::run_migrations(&conn)?;
         Ok(Self {
             conn,
-            disk_monitor: None,
             mode: StoreMode::Normal,
             path: None,
             hook: None,
@@ -193,41 +188,6 @@ impl SessionStore {
         let mut store = Self::open_in_memory()?;
         store.hook = Some(hook);
         Ok(store)
-    }
-
-    /// Attach a disk space monitor for pre-write checks.
-    #[expect(
-        dead_code,
-        reason = "disk_monitor infrastructure has no current caller; tracked for follow-up cleanup"
-    )]
-    pub(crate) fn set_disk_monitor(&mut self, monitor: DiskSpaceMonitor) {
-        self.disk_monitor = Some(monitor);
-    }
-
-    /// Emit tracing diagnostics based on current disk status.
-    ///
-    /// Database writes are essential and always proceed, but warnings and
-    /// errors are emitted so operators can respond before the disk fills.
-    pub(crate) fn check_disk(&self, operation: &str) {
-        if let Some(ref monitor) = self.disk_monitor {
-            match monitor.status() {
-                DiskStatus::Warning { available_bytes } => {
-                    let mb = available_bytes / (1024 * 1024);
-                    warn!(
-                        available_mb = mb,
-                        operation, "disk space low, database write proceeding"
-                    );
-                }
-                DiskStatus::Critical { available_bytes } => {
-                    let mb = available_bytes / (1024 * 1024);
-                    error!(
-                        available_mb = mb,
-                        operation, "disk space critical, database write proceeding (essential)"
-                    );
-                }
-                _ => {}
-            }
-        }
     }
 
     /// Lightweight liveness check: executes `SELECT 1` against the connection.

--- a/crates/graphe/src/store/session.rs
+++ b/crates/graphe/src/store/session.rs
@@ -54,7 +54,6 @@ impl SessionStore {
         parent_session_id: Option<&str>,
         model: Option<&str>,
     ) -> Result<Session> {
-        self.check_disk("create_session");
         self.require_writable()?;
         let session_type = SessionType::from_key(session_key);
 


### PR DESCRIPTION
graphe's disk_monitor setters and check_disk plumbing had zero callers (verified via workspace grep). Daemon uses koina's DiskSpaceMonitor directly. Deleting -77 lines.

Closes #2957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)