### PR TITLE
lint(theatron, pylon): reduce pub visibility sprawl (#2763)

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -535,6 +535,11 @@ RUST/pub-visibility:crates/taxis/src/workspace_schema.rs
 RUST/pub-visibility:crates/theatron/core/src/api/client.rs
 RUST/pub-visibility:crates/theatron/core/src/api/sse.rs
 RUST/pub-visibility:crates/theatron/core/src/api/streaming.rs
+# WHY: SseStream is re-exported from the theatron facade crate and consumed by
+# theatron-desktop's API layer. The generic stream struct cannot carry derive
+# attributes the lint uses for exemption, so the pub items here are genuine
+# public API rather than false positives.
+RUST/pub-visibility:crates/theatron/core/src/sse.rs
 RUST/pub-visibility:crates/theatron/tui/src/error.rs
 RUST/pub-visibility:crates/theatron/tui/src/state/command.rs
 

--- a/crates/pylon/src/discovery.rs
+++ b/crates/pylon/src/discovery.rs
@@ -19,11 +19,7 @@ const DISCOVERY_FILE: &str = ".discovery.json";
 /// Errors from writing the discovery file.
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
-#[expect(
-    missing_docs,
-    reason = "snafu error variant fields are self-documenting via display format"
-)]
-pub enum DiscoveryError {
+pub(crate) enum DiscoveryError {
     /// Failed to serialize discovery info to JSON.
     #[snafu(display("failed to serialize discovery info: {source}"))]
     Serialize { source: serde_json::Error },
@@ -38,16 +34,16 @@ pub enum DiscoveryError {
 
 /// Contents of the discovery file written to `instance/data/.discovery.json`.
 #[derive(Debug, Serialize)]
-pub struct DiscoveryInfo {
+pub(crate) struct DiscoveryInfo {
     /// Server URL reachable from the local machine, e.g. `http://localhost:18789`.
-    pub url: String,
+    pub(crate) url: String,
     /// Crate version from `Cargo.toml`.
-    pub version: &'static str,
+    pub(crate) version: &'static str,
     /// ISO 8601 timestamp when the server started.
-    pub started_at: String,
+    pub(crate) started_at: String,
     /// Tailscale IP address, if the node is on a tailnet.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tailscale_ip: Option<String>,
+    pub(crate) tailscale_ip: Option<String>,
 }
 
 /// Write the discovery file to `data_dir/.discovery.json`.
@@ -66,7 +62,7 @@ pub struct DiscoveryInfo {
 /// Not cancel-safe. If cancelled after writing the temp file but before
 /// the rename, the temp file is left behind. Subsequent calls will succeed
 /// but leave stale temp files.
-pub async fn write_discovery_file(
+pub(crate) async fn write_discovery_file(
     data_dir: &Path,
     bind_addr: &str,
 ) -> Result<(), DiscoveryError> {
@@ -112,7 +108,7 @@ pub async fn write_discovery_file(
 /// # Cancel safety
 ///
 /// Cancel-safe. File removal is atomic; no partial state on cancellation.
-pub async fn remove_discovery_file(data_dir: &Path) {
+pub(crate) async fn remove_discovery_file(data_dir: &Path) {
     let path = data_dir.join(DISCOVERY_FILE);
     if let Err(e) = tokio::fs::remove_file(&path).await
         && e.kind() != std::io::ErrorKind::NotFound

--- a/crates/theatron/tui/src/command/mod.rs
+++ b/crates/theatron/tui/src/command/mod.rs
@@ -1,5 +1,5 @@
 /// Command registry and fuzzy matching for the `:` command palette.
-use crate::fuzzy::FuzzyMatcher;
+use crate::fuzzy::fuzzy_match;
 use crate::state::AgentState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -218,7 +218,6 @@ pub fn build_suggestions(input: &str, agents: &[AgentState]) -> Vec<Suggestion> 
         None => input,
     };
 
-    let matcher = FuzzyMatcher::new();
     let mut suggestions: Vec<Suggestion> = Vec::new();
 
     if query.is_empty() {
@@ -238,7 +237,7 @@ pub fn build_suggestions(input: &str, agents: &[AgentState]) -> Vec<Suggestion> 
         }
     } else {
         for cmd in COMMANDS {
-            if let Some(score) = best_match(&matcher, cmd, query) {
+            if let Some(score) = best_match(cmd, query) {
                 suggestions.push(Suggestion {
                     label: cmd.name.to_string(),
                     description: cmd.description.to_string(),
@@ -253,15 +252,15 @@ pub fn build_suggestions(input: &str, agents: &[AgentState]) -> Vec<Suggestion> 
 
         for agent in agents {
             let mut best: Option<i64> = None;
-            if let Some(result) = matcher.fuzzy_match(&agent.name, query) {
+            if let Some(result) = fuzzy_match(&agent.name, query) {
                 best = Some(result.score);
             }
-            if let Some(result) = matcher.fuzzy_match(&agent.id, query) {
+            if let Some(result) = fuzzy_match(&agent.id, query) {
                 best = best.map_or(Some(result.score), |prev| Some(prev.max(result.score)));
             }
             // NOTE: Also match "agent <name>" as a compound so typing "agent syn" surfaces the agent.
             let compound = format!("agent {}", agent.name);
-            if let Some(result) = matcher.fuzzy_match(&compound, query) {
+            if let Some(result) = fuzzy_match(&compound, query) {
                 best = best.map_or(Some(result.score), |prev| Some(prev.max(result.score)));
             }
             if let Some(score) = best {
@@ -297,18 +296,18 @@ fn agent_suggestion(agent: &AgentState, score: i64) -> Suggestion {
     }
 }
 
-fn best_match(matcher: &FuzzyMatcher, cmd: &Command, query: &str) -> Option<i64> {
+fn best_match(cmd: &Command, query: &str) -> Option<i64> {
     let mut best: Option<i64> = None;
 
-    if let Some(result) = matcher.fuzzy_match(cmd.name, query) {
+    if let Some(result) = fuzzy_match(cmd.name, query) {
         best = Some(result.score);
     }
     for alias in cmd.aliases {
-        if let Some(result) = matcher.fuzzy_match(alias, query) {
+        if let Some(result) = fuzzy_match(alias, query) {
             best = best.map_or(Some(result.score), |prev| Some(prev.max(result.score)));
         }
     }
-    if let Some(result) = matcher.fuzzy_match(cmd.description, query) {
+    if let Some(result) = fuzzy_match(cmd.description, query) {
         best = best.map_or(Some(result.score), |prev| Some(prev.max(result.score)));
     }
 

--- a/crates/theatron/tui/src/fuzzy.rs
+++ b/crates/theatron/tui/src/fuzzy.rs
@@ -1,4 +1,10 @@
 //! Simple subsequence fuzzy matcher for command palette and slash completion.
+//!
+//! Scores are calculated based on:
+//! - Consecutive matches (bonus)
+//! - Word boundary matches (bonus)
+//! - Start of string match (bonus)
+//! - Shorter candidates with same match quality score higher
 
 /// Result of a fuzzy match, containing the score and match positions.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9,105 +15,87 @@ pub(crate) struct MatchResult {
     pub(crate) indices: Vec<usize>,
 }
 
-/// A simple subsequence fuzzy matcher.
+/// Match a pattern against a candidate string.
 ///
-/// Scores are calculated based on:
-/// - Consecutive matches (bonus)
-/// - Word boundary matches (bonus)
-/// - Start of string match (bonus)
-/// - Shorter candidates with same match quality score higher
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct FuzzyMatcher;
-
-impl FuzzyMatcher {
-    /// Create a new fuzzy matcher.
-    #[must_use]
-    pub(crate) const fn new() -> Self {
-        Self
+/// Returns `Some(MatchResult)` if the pattern is a subsequence of the candidate,
+/// `None` otherwise. The match is case-insensitive.
+pub(crate) fn fuzzy_match(candidate: &str, pattern: &str) -> Option<MatchResult> {
+    if pattern.is_empty() {
+        return Some(MatchResult {
+            score: 0,
+            indices: Vec::new(),
+        });
     }
 
-    /// Match a pattern against a candidate string.
-    ///
-    /// Returns `Some(MatchResult)` if the pattern is a subsequence of the candidate,
-    /// `None` otherwise. The match is case-insensitive.
-    pub(crate) fn fuzzy_match(&self, candidate: &str, pattern: &str) -> Option<MatchResult> {
-        if pattern.is_empty() {
-            return Some(MatchResult {
-                score: 0,
-                indices: Vec::new(),
-            });
-        }
+    let candidate_lower = candidate.to_lowercase();
+    let pattern_lower = pattern.to_lowercase();
 
-        let candidate_lower = candidate.to_lowercase();
-        let pattern_lower = pattern.to_lowercase();
+    let mut indices = Vec::new();
+    let mut pattern_chars = pattern_lower.chars().peekable();
+    let mut current_pattern_char = pattern_chars.next()?;
 
-        let mut indices = Vec::new();
-        let mut pattern_chars = pattern_lower.chars().peekable();
-        let mut current_pattern_char = pattern_chars.next()?;
-
-        for (idx, candidate_char) in candidate_lower.char_indices() {
-            if candidate_char == current_pattern_char {
-                indices.push(idx);
-                match pattern_chars.next() {
-                    Some(c) => current_pattern_char = c,
-                    None => break,
-                }
+    for (idx, candidate_char) in candidate_lower.char_indices() {
+        if candidate_char == current_pattern_char {
+            indices.push(idx);
+            match pattern_chars.next() {
+                Some(c) => current_pattern_char = c,
+                None => break,
             }
         }
-
-        // Pattern not fully matched
-        if indices.len() != pattern.len() {
-            return None;
-        }
-
-        let score = Self::calculate_score(candidate, &indices);
-
-        Some(MatchResult { score, indices })
     }
 
-    /// Calculate a score for a match based on heuristics.
-    fn calculate_score(candidate: &str, indices: &[usize]) -> i64 {
-        let mut score: i64 = 100; // Base score
+    // Pattern not fully matched
+    if indices.len() != pattern.len() {
+        return None;
+    }
 
-        // Bonus for matching at the start
-        if let Some(&first) = indices.first()
-            && first == 0
-        {
-            score += 50;
-        }
+    let score = calculate_score(candidate, &indices);
 
-        // Bonus for consecutive matches
-        for window in indices.windows(2) {
-            let prev = window[0];
-            let curr = window[1];
-            let prev_char = candidate.chars().nth(prev);
-            let curr_char = candidate.chars().nth(curr);
+    Some(MatchResult { score, indices })
+}
 
-            if let (Some(p), Some(c)) = (prev_char, curr_char) {
-                // Consecutive character bonus
-                if curr == prev + p.len_utf8() {
-                    score += 30;
-                }
+/// Calculate a score for a match based on heuristics.
+fn calculate_score(candidate: &str, indices: &[usize]) -> i64 {
+    let mut score: i64 = 100; // Base score
 
-                // Word boundary bonus (after space, hyphen, underscore, etc.)
-                if is_word_boundary(p) && !is_word_boundary(c) {
-                    score += 25;
-                }
+    // Bonus for matching at the start
+    if let Some(&first) = indices.first()
+        && first == 0
+    {
+        score += 50;
+    }
+
+    // Bonus for consecutive matches
+    for window in indices.windows(2) {
+        let prev = window[0];
+        let curr = window[1];
+        let prev_char = candidate.chars().nth(prev);
+        let curr_char = candidate.chars().nth(curr);
+
+        if let (Some(p), Some(c)) = (prev_char, curr_char) {
+            // Consecutive character bonus
+            if curr == prev + p.len_utf8() {
+                score += 30;
+            }
+
+            // Word boundary bonus (after space, hyphen, underscore, etc.)
+            if is_word_boundary(p) && !is_word_boundary(c) {
+                score += 25;
             }
         }
-
-        // Penalty for length (shorter is better). Saturate at i64::MAX for
-        // the impossible >2^63 string case; the lint-clean path matters more
-        // than the unreachable branch.
-        let candidate_len = i64::try_from(candidate.chars().count()).unwrap_or(i64::MAX);
-        score -= candidate_len * 2;
-
-        // Bonus for matching more of the pattern.
-        let match_count = i64::try_from(indices.len()).unwrap_or(i64::MAX);
-        score += match_count * 10;
-
-        score
     }
+
+    // Penalty for length (shorter is better). Saturate at i64::MAX for
+    // the impossible >2^63 string case; the lint-clean path matters more
+    // than the unreachable branch.
+    let candidate_len = i64::try_from(candidate.chars().count()).unwrap_or(i64::MAX);
+    score -= candidate_len * 2;
+
+    // Bonus for matching more of the pattern.
+    let match_count = i64::try_from(indices.len()).unwrap_or(i64::MAX);
+    score += match_count * 10;
+
+    score
 }
 
 /// Check if a character is a word boundary.
@@ -122,88 +110,77 @@ mod tests {
 
     #[test]
     fn empty_pattern_matches_everything() {
-        let matcher = FuzzyMatcher::new();
-        let result = matcher.fuzzy_match("hello", "").unwrap();
+        let result = fuzzy_match("hello", "").unwrap();
         assert_eq!(result.score, 0);
         assert!(result.indices.is_empty());
     }
 
     #[test]
     fn exact_match_scores_high() {
-        let matcher = FuzzyMatcher::new();
-        let result = matcher.fuzzy_match("quit", "quit").unwrap();
+        let result = fuzzy_match("quit", "quit").unwrap();
         assert!(result.score > 100);
     }
 
     #[test]
     fn partial_match_works() {
-        let matcher = FuzzyMatcher::new();
-        let result = matcher.fuzzy_match("sessions", "sess").unwrap();
+        let result = fuzzy_match("sessions", "sess").unwrap();
         assert_eq!(result.indices, vec![0, 1, 2, 3]);
         assert!(result.score > 0);
     }
 
     #[test]
     fn case_insensitive_match() {
-        let matcher = FuzzyMatcher::new();
-        let result = matcher.fuzzy_match("Sessions", "sess").unwrap();
+        let result = fuzzy_match("Sessions", "sess").unwrap();
         assert_eq!(result.indices, vec![0, 1, 2, 3]);
     }
 
     #[test]
     fn non_match_returns_none() {
-        let matcher = FuzzyMatcher::new();
-        assert!(matcher.fuzzy_match("quit", "xyz").is_none());
+        assert!(fuzzy_match("quit", "xyz").is_none());
     }
 
     #[test]
     fn consecutive_bonus_applied() {
-        let matcher = FuzzyMatcher::new();
         // "sess" in "sessions" is consecutive
-        let consecutive = matcher.fuzzy_match("sessions", "sess").unwrap();
+        let consecutive = fuzzy_match("sessions", "sess").unwrap();
         // "sns" in "sessions" is not consecutive
-        let non_consecutive = matcher.fuzzy_match("sessions", "sns").unwrap();
+        let non_consecutive = fuzzy_match("sessions", "sns").unwrap();
         assert!(consecutive.score > non_consecutive.score);
     }
 
     #[test]
     fn start_bonus_applied() {
-        let matcher = FuzzyMatcher::new();
         // "quit" at start
-        let at_start = matcher.fuzzy_match("quit now", "quit").unwrap();
+        let at_start = fuzzy_match("quit now", "quit").unwrap();
         // "quit" not at start
-        let not_at_start = matcher.fuzzy_match("please quit", "quit").unwrap();
+        let not_at_start = fuzzy_match("please quit", "quit").unwrap();
         assert!(at_start.score > not_at_start.score);
     }
 
     #[test]
     fn word_boundary_bonus() {
-        let matcher = FuzzyMatcher::new();
         // "cmd" matches at word boundaries in "my-cmd-here"
-        let boundary_match = matcher.fuzzy_match("my-cmd-here", "cmd").unwrap();
+        let boundary_match = fuzzy_match("my-cmd-here", "cmd").unwrap();
         assert!(boundary_match.score > 0);
     }
 
     #[test]
     fn shorter_candidate_scores_higher() {
-        let matcher = FuzzyMatcher::new();
-        let short = matcher.fuzzy_match("quit", "q").unwrap();
-        let long = matcher.fuzzy_match("quite-long-name-here", "q").unwrap();
+        let short = fuzzy_match("quit", "q").unwrap();
+        let long = fuzzy_match("quite-long-name-here", "q").unwrap();
         assert!(short.score > long.score);
     }
 
     #[test]
     fn fuzzy_skips_characters() {
-        let matcher = FuzzyMatcher::new();
         // "qt" matches "quit" by skipping 'u' and 'i'
-        let result = matcher.fuzzy_match("quit", "qt").unwrap();
+        let result = fuzzy_match("quit", "qt").unwrap();
         assert_eq!(result.indices, vec![0, 3]);
     }
 
     #[test]
     fn unicode_handling() {
-        let matcher = FuzzyMatcher::new();
-        let result = matcher.fuzzy_match("héllo world", "hw").unwrap();
+        let result = fuzzy_match("héllo world", "hw").unwrap();
         assert_eq!(result.indices, vec![0, 7]);
     }
 }

--- a/crates/theatron/tui/src/fuzzy.rs
+++ b/crates/theatron/tui/src/fuzzy.rs
@@ -2,11 +2,11 @@
 
 /// Result of a fuzzy match, containing the score and match positions.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MatchResult {
+pub(crate) struct MatchResult {
     /// Match score (higher is better).
-    pub score: i64,
+    pub(crate) score: i64,
     /// Indices of matched characters in the candidate string.
-    pub indices: Vec<usize>,
+    pub(crate) indices: Vec<usize>,
 }
 
 /// A simple subsequence fuzzy matcher.
@@ -17,12 +17,12 @@ pub struct MatchResult {
 /// - Start of string match (bonus)
 /// - Shorter candidates with same match quality score higher
 #[derive(Debug, Clone, Copy, Default)]
-pub struct FuzzyMatcher;
+pub(crate) struct FuzzyMatcher;
 
 impl FuzzyMatcher {
     /// Create a new fuzzy matcher.
     #[must_use]
-    pub const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self
     }
 
@@ -30,18 +30,7 @@ impl FuzzyMatcher {
     ///
     /// Returns `Some(MatchResult)` if the pattern is a subsequence of the candidate,
     /// `None` otherwise. The match is case-insensitive.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use theatron_tui::fuzzy::FuzzyMatcher;
-    ///
-    /// let matcher = FuzzyMatcher::new();
-    /// assert!(matcher.fuzzy_match("quit", "q").is_some());
-    /// assert!(matcher.fuzzy_match("quit", "qt").is_some());
-    /// assert!(matcher.fuzzy_match("quit", "xyz").is_none());
-    /// ```
-    pub fn fuzzy_match(&self, candidate: &str, pattern: &str) -> Option<MatchResult> {
+    pub(crate) fn fuzzy_match(&self, candidate: &str, pattern: &str) -> Option<MatchResult> {
         if pattern.is_empty() {
             return Some(MatchResult {
                 score: 0,

--- a/crates/theatron/tui/src/state/input.rs
+++ b/crates/theatron/tui/src/state/input.rs
@@ -17,7 +17,7 @@ pub struct InputState {
 
 impl InputState {
     /// Trigger cursor flash on input activity.
-    pub fn trigger_cursor_flash(&mut self) {
+    pub(crate) fn trigger_cursor_flash(&mut self) {
         self.cursor_flash_until = Some(
             std::time::Instant::now()
                 + std::time::Duration::from_millis(CURSOR_FLASH_DURATION_MS),
@@ -25,7 +25,7 @@ impl InputState {
     }
 
     /// Check if the cursor should be flashing (blinking) right now.
-    pub fn is_cursor_flashing(&self) -> bool {
+    pub(crate) fn is_cursor_flashing(&self) -> bool {
         self.cursor_flash_until
             .is_some_and(|t| t > std::time::Instant::now())
     }

--- a/crates/theatron/tui/src/update/slash.rs
+++ b/crates/theatron/tui/src/update/slash.rs
@@ -1,7 +1,7 @@
 /// Slash-command autocomplete update handlers.
 use crate::app::App;
-use crate::fuzzy::FuzzyMatcher;
 use crate::command::COMMANDS;
+use crate::fuzzy::fuzzy_match;
 use crate::state::SlashSuggestion;
 
 pub(crate) fn handle_open(app: &mut App) {
@@ -69,7 +69,6 @@ const MAX_SLASH_SUGGESTIONS: usize = 8;
 
 fn refresh_suggestions(app: &mut App) {
     let query = app.interaction.slash_complete.query.clone();
-    let matcher = FuzzyMatcher::new();
 
     let mut scored: Vec<(i64, SlashSuggestion)> = COMMANDS
         .iter()
@@ -85,15 +84,15 @@ fn refresh_suggestions(app: &mut App) {
                 ));
             }
             let mut best: Option<i64> = None;
-            if let Some(result) = matcher.fuzzy_match(cmd.name, &query) {
+            if let Some(result) = fuzzy_match(cmd.name, &query) {
                 best = Some(result.score);
             }
             for alias in cmd.aliases {
-                if let Some(result) = matcher.fuzzy_match(alias, &query) {
+                if let Some(result) = fuzzy_match(alias, &query) {
                     best = best.map_or(Some(result.score), |p| Some(p.max(result.score)));
                 }
             }
-            if let Some(result) = matcher.fuzzy_match(cmd.description, &query) {
+            if let Some(result) = fuzzy_match(cmd.description, &query) {
                 best = best.map_or(Some(result.score), |p| Some(p.max(result.score)));
             }
             best.map(|score| {


### PR DESCRIPTION
## Summary

Narrows `pub` visibility in `crates/theatron/` and `crates/pylon/` per #2763 and #2899. All items flagged by `basanos::check_pub_visibility` are now either downgraded to `pub(crate)` (when only used within their own crate) or exempted via `.kanon-lint-ignore` with a WHY (when verified to be genuine public API consumed by another crate).

## Violations resolved

Canonical `kanon lint . --rust` count for `crates/theatron/` and `crates/pylon/`:

| Crate | Before | After |
|-------|:------:|:-----:|
| theatron-tui | 4 | 0 |
| theatron-core | 2 | 0 |
| pylon | 1 | 0 |
| **Total** | **7** | **0** |

## Per-file changes

### `crates/theatron/tui/src/fuzzy.rs`
`FuzzyMatcher::new` / `FuzzyMatcher::fuzzy_match` were the only flagged items; both are reachable only from `theatron-tui`'s command palette (`command/mod.rs`) and slash completion (`update/slash.rs`). Downgrade + refactor (`FuzzyMatcher` was a zero-sized unit struct whose method triggered `clippy::unused_self` once the visibility narrowed, so the struct and its `new()` are dropped and `fuzzy_match` / `calculate_score` become module-level free functions). `MatchResult` becomes `pub(crate)`. Removes the external-path doctest (`use theatron_tui::fuzzy::FuzzyMatcher;`) that forced `pub` exposure — existing unit tests already cover every case.

### `crates/theatron/tui/src/state/input.rs`
`InputState::trigger_cursor_flash` and `InputState::is_cursor_flashing` are only invoked by handlers in `update/input/` and the input renderer — both inside theatron-tui. Downgraded to `pub(crate)`.

### `crates/pylon/src/discovery.rs`
`DiscoveryError`, `DiscoveryInfo`, `write_discovery_file`, and `remove_discovery_file` are only called from `pylon::server`. theatron uses its own `theatron_core::discovery` client (which talks to the already-written `.discovery.json`) rather than importing pylon's writer, so none of these types cross a crate boundary. All four are downgraded to `pub(crate)`. The `#[expect(missing_docs)]` on `DiscoveryError` is dropped because `missing_docs` no longer applies to a non-public item.

### `.kanon-lint-ignore` (theatron-core exemption)
`crates/theatron/core/src/sse.rs` is added to the ignore list. `SseStream<S>` is the only flagged item and it IS genuine public API: it's consumed by `theatron-desktop`'s `api/sse.rs` and `api/streaming.rs` via `theatron_core::sse::SseStream`, and re-exported by the `theatron` facade crate (`crates/theatron/src/lib.rs`). Its single-field generic wrapper cannot carry `Debug`/`Clone`/`Serialize` derives (because the stream type parameter `S` is not `Clone`), so the basanos derive-based exemption does not apply. Adding the file-level ignore with a WHY comment is the same pattern already used for `api/client.rs`, `api/sse.rs`, `api/streaming.rs`, and `tui/src/error.rs`.

## Items kept `pub` (with justification)

| Item | File | Reason |
|------|------|--------|
| `SseStream<S>`, `SseStream::new` | `crates/theatron/core/src/sse.rs` | Re-exported by theatron facade crate and consumed by theatron-desktop's API layer. Exempted via `.kanon-lint-ignore`. |

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p theatron-core -p theatron-tui -p aletheia-pylon --all-features` — 1474 tests pass (0 failures, 5 ignored)
- [x] `kanon lint . --rust` — 0 `RUST/pub-visibility` violations in theatron/pylon (down from 7)

## Notes

- `cargo check --workspace --all-features` fails on pre-existing errors in the `aletheia` binary crate (missing `tracing::debug` macro, private `store`/`delete` methods in symbolon's keyring provider, `Fact.scope` field, `LowerHex` trait bound) — all unrelated to theatron/pylon and present on `origin/main` before this branch. The scoped test command above exercises all `--all-features` code paths in the touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)