### PR TITLE
refactor: consolidate env::var calls through taxis (#2800)

### DIFF
--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use clap::Args;
 use snafu::prelude::*;
 
+use aletheia_koina::system::{Environment, RealSystem};
 use aletheia_taxis::oikos::Oikos;
 
 use crate::error::Result;
@@ -77,14 +78,11 @@ fn check_credential(provider: &str) {
         _ => return,
     };
 
-    let has_env = std::env::var(env_var)
-        .ok()
-        .filter(|v| !v.is_empty())
-        .is_some();
+    let env = RealSystem;
+    let has_env = env.var(env_var).filter(|v| !v.is_empty()).is_some();
 
     let has_auth_token = if provider == "anthropic" {
-        std::env::var("ANTHROPIC_AUTH_TOKEN")
-            .ok()
+        env.var("ANTHROPIC_AUTH_TOKEN")
             .filter(|v| !v.is_empty())
             .is_some()
     } else {

--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -6,6 +6,7 @@ use snafu::prelude::*;
 
 use clap::Subcommand;
 
+use aletheia_koina::system::{Environment, RealSystem};
 use aletheia_symbolon::credential::CredentialFile;
 use aletheia_taxis::oikos::Oikos;
 
@@ -115,7 +116,7 @@ pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Resu
                 ("OPENAI_API_KEY", "static API key"),
             ];
             for (var, key_type) in env_vars {
-                if let Ok(val) = std::env::var(var)
+                if let Some(val) = RealSystem.var(var)
                     && !val.is_empty()
                 {
                     if found_any {

--- a/crates/aletheia/src/commands/daemon.rs
+++ b/crates/aletheia/src/commands/daemon.rs
@@ -4,14 +4,19 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
+use aletheia_koina::system::{Environment, RealSystem};
+
 /// Fork the server to background by re-executing the binary without `--daemon`.
 ///
 /// WHY: `fork()` is unsafe inside a running tokio multi-thread runtime. Re-executing
 /// the binary avoids that hazard while still detaching from the terminal.
 pub(crate) async fn do_daemon() -> Result<()> {
-    let exe = std::env::current_exe().context("failed to locate executable")?;
+    let env = RealSystem;
+    let exe = env.current_exe().context("failed to locate executable")?;
 
-    let child_args: Vec<String> = std::env::args()
+    let child_args: Vec<String> = env
+        .args()
+        .into_iter()
         .skip(1)
         .filter(|a| a != "--daemon")
         .collect();
@@ -19,7 +24,7 @@ pub(crate) async fn do_daemon() -> Result<()> {
     // WHY: Redirect stderr to a crash log so daemon startup failures are
     // visible. Previously stdout+stderr were both /dev/null, so if the child
     // crashed (e.g., schema version mismatch), the error was lost entirely.
-    let instance_root = daemon_instance_root();
+    let instance_root = daemon_instance_root(&env);
     tokio::fs::create_dir_all(&instance_root)
         .await
         .with_context(|| format!("failed to create {}", instance_root.display()))?;
@@ -55,8 +60,8 @@ pub(crate) async fn do_daemon() -> Result<()> {
 }
 
 /// Resolve the instance root from CLI args or environment for PID file placement.
-fn daemon_instance_root() -> PathBuf {
-    let args: Vec<String> = std::env::args().collect();
+fn daemon_instance_root(env: &impl Environment) -> PathBuf {
+    let args = env.args();
     for (i, arg) in args.iter().enumerate() {
         if arg == "-r" || arg == "--instance-root" {
             if let Some(path) = args.get(i + 1) {
@@ -66,5 +71,6 @@ fn daemon_instance_root() -> PathBuf {
             return PathBuf::from(path);
         }
     }
-    std::env::var("ALETHEIA_ROOT").map_or_else(|_| PathBuf::from("instance"), PathBuf::from)
+    env.var("ALETHEIA_ROOT")
+        .map_or_else(|| PathBuf::from("instance"), PathBuf::from)
 }

--- a/crates/aletheia/src/commands/desktop.rs
+++ b/crates/aletheia/src/commands/desktop.rs
@@ -4,6 +4,8 @@ use std::process::Command;
 
 use clap::Args;
 
+use aletheia_koina::system::{Environment, RealSystem};
+
 const BINARY_NAME: &str = "theatron-desktop";
 
 #[derive(Debug, Clone, Args)]
@@ -65,7 +67,7 @@ pub(crate) fn run(args: &DesktopArgs) -> anyhow::Result<()> {
 
 /// Search `$PATH` for the desktop binary.
 fn find_in_path() -> Option<std::path::PathBuf> {
-    let path_var = std::env::var_os("PATH")?;
+    let path_var = RealSystem.var_os("PATH")?;
     std::env::split_paths(&path_var)
         .map(|dir| dir.join(BINARY_NAME))
         .find(|candidate| candidate.is_file())

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use snafu::prelude::*;
 use tracing::{info, warn};
 
+use aletheia_koina::system::{Environment, RealSystem};
 use aletheia_pylon::router::build_router;
 use aletheia_taxis::loader::load_config;
 use aletheia_taxis::oikos::Oikos;
@@ -165,8 +166,8 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     info!("shutting down");
 
     let shutdown_timeout = std::time::Duration::from_secs(
-        std::env::var("ALETHEIA_SHUTDOWN_TIMEOUT_SECS")
-            .ok()
+        RealSystem
+            .var("ALETHEIA_SHUTDOWN_TIMEOUT_SECS")
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(10),
     );

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use snafu::{ResultExt, Snafu};
 
 use aletheia_koina::secret::SecretString;
+use aletheia_koina::system::{Environment, RealSystem};
 
 #[derive(Debug, Snafu)]
 pub(crate) enum InitError {
@@ -23,7 +24,6 @@ pub(crate) enum InitError {
     },
     #[snafu(display("ANTHROPIC_API_KEY not set"))]
     MissingApiKey {
-        source: std::env::VarError,
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -157,7 +157,7 @@ fn print_success_outro(root: &std::path::Path) -> Result<(), InitError> {
 pub(crate) fn run(args: RunArgs) -> Result<(), InitError> {
     // WHY: pass the env var through a parameter so tests can call run_inner
     // directly with None and bypass ALETHEIA_ROOT without touching env state
-    run_inner(args, std::env::var("ALETHEIA_ROOT").ok().map(PathBuf::from))
+    run_inner(args, RealSystem.var("ALETHEIA_ROOT").map(PathBuf::from))
 }
 
 fn run_inner(args: RunArgs, env_root: Option<PathBuf>) -> Result<(), InitError> {
@@ -361,7 +361,9 @@ fn collect_credential() -> Result<Option<SecretString>, InitError> {
             Ok(Some(SecretString::from(key)))
         }
         "env" => {
-            let key = std::env::var("ANTHROPIC_API_KEY").context(MissingApiKeySnafu)?;
+            let key = RealSystem
+                .var("ANTHROPIC_API_KEY")
+                .ok_or_else(|| MissingApiKeySnafu.build())?;
             Ok(Some(SecretString::from(key)))
         }
         _ => Ok(None),

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -21,6 +21,7 @@ mod recall_sources;
 mod runtime;
 mod status;
 
+use aletheia_koina::system::{Environment, RealSystem};
 use anyhow::Result;
 use clap::Parser;
 
@@ -47,7 +48,7 @@ async fn main() -> Result<()> {
         Some(cmd) => return commands::dispatch(cmd, cli.instance_root.as_ref()).await,
     }
 
-    if cli.daemon && std::env::var("_ALETHEIA_DAEMON").is_err() {
+    if cli.daemon && RealSystem.var("_ALETHEIA_DAEMON").is_none() {
         return commands::daemon::do_daemon().await;
     }
 

--- a/crates/aletheia/src/runtime.rs
+++ b/crates/aletheia/src/runtime.rs
@@ -19,6 +19,7 @@ use aletheia_hermeneus::anthropic::AnthropicProvider;
 use aletheia_hermeneus::provider::{ProviderConfig, ProviderRegistry};
 use aletheia_koina::credential::{CredentialProvider, CredentialSource};
 use aletheia_koina::secret::SecretString;
+use aletheia_koina::system::{Environment, RealSystem};
 use aletheia_mneme::embedding::{
     DegradedEmbeddingProvider, EmbeddingConfig, EmbeddingProvider, create_provider,
 };
@@ -300,9 +301,7 @@ impl RuntimeBuilder {
         // JWT key resolution
         let jwt_key: Option<SecretString> =
             self.config.gateway.auth.signing_key.clone().or_else(|| {
-                std::env::var("ALETHEIA_JWT_SECRET")
-                    .ok()
-                    .map(SecretString::from)
+                RealSystem.var("ALETHEIA_JWT_SECRET").map(SecretString::from)
             });
         let jwt_config = match jwt_key {
             Some(k) => JwtConfig {
@@ -481,13 +480,10 @@ impl RuntimeBuilder {
             let http_client = Arc::new(reqwest::Client::new());
 
             // Academic source (Semantic Scholar)
-            let api_key = match std::env::var("SEMANTIC_SCHOLAR_API_KEY") {
-                Ok(key) => Some(key),
-                Err(e) => {
-                    tracing::warn!(error = %e, "SEMANTIC_SCHOLAR_API_KEY not set or invalid");
-                    None
-                }
-            };
+            let api_key = RealSystem.var("SEMANTIC_SCHOLAR_API_KEY").or_else(|| {
+                tracing::warn!("SEMANTIC_SCHOLAR_API_KEY not set");
+                None
+            });
             registry.register(Arc::new(
                 crate::recall_sources::academic::AcademicSource::new(
                     Arc::clone(&http_client),
@@ -747,7 +743,7 @@ fn validate_jwt(config: &AletheiaConfig) -> bool {
         .signing_key
         .as_ref()
         .map(|s| s.expose_secret().to_owned())
-        .or_else(|| std::env::var("ALETHEIA_JWT_SECRET").ok());
+        .or_else(|| RealSystem.var("ALETHEIA_JWT_SECRET"));
     let auth_mode = config.gateway.auth.mode.as_str();
     let jwt_check_label = "gateway.auth JWT key";
     if matches!(auth_mode, "token" | "jwt") {

--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use aletheia_koina::system::{Environment, RealSystem};
 use snafu::ResultExt;
 
 use crate::bridge::DaemonBridge;
@@ -319,11 +320,10 @@ pub(crate) async fn execute_builtin(
         BuiltinTask::ProposeRules => {
             let data_dir = maintenance.map_or_else(
                 || {
-                    let root = std::env::var("ALETHEIA_ROOT")
-                        .map_or_else(
-                            |_e| std::path::PathBuf::from("instance"),
-                            std::path::PathBuf::from,
-                        );
+                    let root = RealSystem.var("ALETHEIA_ROOT").map_or_else(
+                        || std::path::PathBuf::from("instance"),
+                        std::path::PathBuf::from,
+                    );
                     root.join("data")
                 },
                 |m| m.propose_rules.data_dir.clone(),

--- a/crates/daemon/src/maintenance/mod.rs
+++ b/crates/daemon/src/maintenance/mod.rs
@@ -1,5 +1,7 @@
 //! Instance maintenance services: trace rotation, drift detection, DB monitoring, retention.
 
+use aletheia_koina::system::{Environment, RealSystem};
+
 /// Database size monitoring with configurable warning and alert thresholds.
 pub(crate) mod db_monitor;
 /// Instance drift detection: compare a live instance against the example template.
@@ -32,8 +34,8 @@ pub struct ProposeRulesConfig {
 
 impl Default for ProposeRulesConfig {
     fn default() -> Self {
-        let root = std::env::var("ALETHEIA_ROOT").map_or_else(
-            |_e| std::path::PathBuf::from("instance"),
+        let root = RealSystem.var("ALETHEIA_ROOT").map_or_else(
+            || std::path::PathBuf::from("instance"),
             std::path::PathBuf::from,
         );
         Self {

--- a/crates/daemon/src/runner.rs
+++ b/crates/daemon/src/runner.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use aletheia_koina::system::{Environment, RealSystem};
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -1042,7 +1043,7 @@ fn sd_notify_stopping() {
 /// Returns `None` if the variable is not SET or unparseable. The recommended
 /// notification interval is half the watchdog timeout.
 fn sd_watchdog_interval() -> Option<Duration> {
-    let usec_str = std::env::var("WATCHDOG_USEC").ok()?;
+    let usec_str = RealSystem.var("WATCHDOG_USEC")?;
     let usec: u64 = usec_str.parse().ok()?;
     // WHY: notify at half the watchdog interval to avoid races.
     Some(Duration::from_micros(usec / 2))
@@ -1053,7 +1054,7 @@ fn sd_watchdog_interval() -> Option<Duration> {
 /// No-op on non-Unix platforms or when `$NOTIFY_SOCKET` is not SET.
 #[cfg(unix)]
 fn sd_notify(msg: &str) {
-    let Ok(socket_path) = std::env::var("NOTIFY_SOCKET") else {
+    let Some(socket_path) = RealSystem.var("NOTIFY_SOCKET") else {
         return;
     };
 

--- a/crates/hermeneus/src/cc/process.rs
+++ b/crates/hermeneus/src/cc/process.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
 
+use aletheia_koina::system::{Environment, RealSystem};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tracing::{debug, warn};
@@ -21,7 +22,9 @@ use super::parse::{self, CcEvent};
 /// the token via `CLAUDE_CODE_OAUTH_TOKEN` env var, which CC accepts as an
 /// override even without bare mode.
 fn read_oauth_token() -> std::io::Result<String> {
-    let home = std::env::var("HOME").map_err(|e| std::io::Error::other(e.to_string()))?;
+    let home = RealSystem
+        .var("HOME")
+        .ok_or_else(|| std::io::Error::other("HOME is not set"))?;
     let path = std::path::Path::new(&home).join(".claude/.credentials.json");
     let content = std::fs::read_to_string(&path)?;
     let parsed: serde_json::Value = serde_json::from_str(&content)

--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
 
+use aletheia_koina::system::{Environment, RealSystem};
 use tracing::{debug, info};
 
 use crate::anthropic::StreamEvent;
@@ -288,7 +289,7 @@ impl LlmProvider for CcProvider {
 fn find_cc_binary() -> Result<PathBuf> {
     // WHY: We don't use the `which` crate (not in workspace). Instead, try
     // spawning `claude --version` and capture the binary path from PATH resolution.
-    let paths = std::env::var_os("PATH").unwrap_or_default();
+    let paths = RealSystem.var_os("PATH").unwrap_or_default();
     for dir in std::env::split_paths(&paths) {
         let candidate = dir.join("claude");
         if candidate.is_file() {

--- a/crates/koina/src/system.rs
+++ b/crates/koina/src/system.rs
@@ -158,6 +158,27 @@ pub trait Environment: Send + Sync {
     /// Returns an OS error if the working directory cannot be determined (e.g.
     /// because it has been deleted).
     fn current_dir(&self) -> io::Result<PathBuf>;
+
+    /// Return the platform temporary directory.
+    ///
+    /// Mirrors [`std::env::temp_dir`]: honours `TMPDIR` on Unix and the
+    /// platform's default fallback (`/tmp`) otherwise.
+    #[must_use]
+    fn temp_dir(&self) -> PathBuf;
+
+    /// Return the full path to the current executable.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the executable path cannot be determined.
+    fn current_exe(&self) -> io::Result<PathBuf>;
+
+    /// Return the arguments that this process was started with.
+    ///
+    /// The first element is typically the executable path, matching
+    /// [`std::env::args`].
+    #[must_use]
+    fn args(&self) -> Vec<String>;
 }
 
 // ── RealSystem ────────────────────────────────────────────────────────────────
@@ -203,6 +224,12 @@ pub struct TestSystem {
     pub(crate) clock: Timestamp,
     /// Fake environment variables.
     pub(crate) env: HashMap<String, String>,
+    /// Fake temporary directory returned by [`Environment::temp_dir`].
+    pub(crate) temp_dir: PathBuf,
+    /// Fake executable path returned by [`Environment::current_exe`].
+    pub(crate) current_exe: PathBuf,
+    /// Fake process arguments returned by [`Environment::args`].
+    pub(crate) args: Vec<String>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -215,6 +242,9 @@ impl TestSystem {
             dirs: Arc::new(Mutex::new(HashSet::new())),
             clock: Timestamp::UNIX_EPOCH,
             env: HashMap::new(),
+            temp_dir: PathBuf::from("/tmp"),
+            current_exe: PathBuf::from("/test/bin/aletheia"),
+            args: vec!["aletheia".to_owned()],
         }
     }
 
@@ -229,6 +259,27 @@ impl TestSystem {
     #[must_use]
     pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.env.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set the fake temporary directory (builder pattern).
+    #[must_use]
+    pub fn with_temp_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.temp_dir = path.into();
+        self
+    }
+
+    /// Set the fake executable path (builder pattern).
+    #[must_use]
+    pub fn with_current_exe(mut self, path: impl Into<PathBuf>) -> Self {
+        self.current_exe = path.into();
+        self
+    }
+
+    /// Set the fake process arguments (builder pattern).
+    #[must_use]
+    pub fn with_args(mut self, args: Vec<String>) -> Self {
+        self.args = args;
         self
     }
 

--- a/crates/koina/src/system.rs
+++ b/crates/koina/src/system.rs
@@ -36,6 +36,7 @@
 //! assert!(!has_config(&sys, Path::new("/etc/missing.toml")), "missing file must not exist");
 //! ```
 
+use std::ffi::OsString;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -146,6 +147,13 @@ pub trait Environment: Send + Sync {
     /// Return the value of environment variable `name`, or `None` if unset.
     #[must_use]
     fn var(&self, name: &str) -> Option<String>;
+
+    /// Return the raw (possibly non-UTF-8) value of environment variable `name`.
+    ///
+    /// Mirrors [`std::env::var_os`] and preserves byte content on platforms
+    /// where paths (e.g. `PATH`) may contain non-UTF-8 data.
+    #[must_use]
+    fn var_os(&self, name: &str) -> Option<OsString>;
 
     /// Return all environment variables as `(name, value)` pairs.
     #[must_use]

--- a/crates/koina/src/system/system_impl.rs
+++ b/crates/koina/src/system/system_impl.rs
@@ -72,6 +72,18 @@ impl Environment for RealSystem {
     fn current_dir(&self) -> io::Result<PathBuf> {
         std::env::current_dir()
     }
+
+    fn temp_dir(&self) -> PathBuf {
+        std::env::temp_dir()
+    }
+
+    fn current_exe(&self) -> io::Result<PathBuf> {
+        std::env::current_exe()
+    }
+
+    fn args(&self) -> Vec<String> {
+        std::env::args().collect()
+    }
 }
 
 // ── TestSystem implementations ───────────────────────────────────────────────
@@ -197,5 +209,17 @@ impl Environment for TestSystem {
 
     fn current_dir(&self) -> io::Result<PathBuf> {
         Ok(PathBuf::from("/test"))
+    }
+
+    fn temp_dir(&self) -> PathBuf {
+        self.temp_dir.clone()
+    }
+
+    fn current_exe(&self) -> io::Result<PathBuf> {
+        Ok(self.current_exe.clone())
+    }
+
+    fn args(&self) -> Vec<String> {
+        self.args.clone()
     }
 }

--- a/crates/koina/src/system/system_impl.rs
+++ b/crates/koina/src/system/system_impl.rs
@@ -65,6 +65,10 @@ impl Environment for RealSystem {
         std::env::var(name).ok()
     }
 
+    fn var_os(&self, name: &str) -> Option<std::ffi::OsString> {
+        std::env::var_os(name)
+    }
+
     fn vars(&self) -> Vec<(String, String)> {
         std::env::vars().collect()
     }
@@ -198,6 +202,10 @@ impl Clock for TestSystem {
 impl Environment for TestSystem {
     fn var(&self, name: &str) -> Option<String> {
         self.env.get(name).cloned()
+    }
+
+    fn var_os(&self, name: &str) -> Option<std::ffi::OsString> {
+        self.env.get(name).map(Into::into)
     }
 
     fn vars(&self) -> Vec<(String, String)> {

--- a/crates/organon/src/builtins/computer_use/capture.rs
+++ b/crates/organon/src/builtins/computer_use/capture.rs
@@ -2,6 +2,8 @@
 
 use std::path::Path;
 
+use aletheia_koina::system::{Environment, RealSystem};
+
 use super::types::{ComputerAction, DiffRegion};
 
 /// Detect display server and return the appropriate capture command.
@@ -10,7 +12,7 @@ pub(super) fn capture_command(output_path: &Path) -> std::process::Command {
 
     // WHY: Check WAYLAND_DISPLAY first; if set, the session is Wayland and
     // scrot (X11-only) will not work. grim is the standard Wayland capture tool.
-    if std::env::var("WAYLAND_DISPLAY").is_ok() {
+    if RealSystem.var("WAYLAND_DISPLAY").is_some() {
         let mut cmd = std::process::Command::new("grim");
         cmd.arg(output.as_ref());
         cmd

--- a/crates/organon/src/builtins/computer_use/sandbox.rs
+++ b/crates/organon/src/builtins/computer_use/sandbox.rs
@@ -2,6 +2,8 @@
 
 use std::path::PathBuf;
 
+use aletheia_koina::system::{Environment, RealSystem};
+
 use super::actions::dispatch_action;
 use super::capture::{
     capture_command, capture_screen, compute_diff_region, describe_change, read_frame,
@@ -40,7 +42,7 @@ impl Default for ComputerUseSessionConfig {
                 PathBuf::from("/proc"),
                 PathBuf::from("/dev"),
             ],
-            allowed_write_paths: vec![std::env::temp_dir()],
+            allowed_write_paths: vec![RealSystem.temp_dir()],
             enforcement: SandboxEnforcement::Enforcing,
         }
     }
@@ -96,7 +98,7 @@ pub(super) fn execute_sandboxed_action(
     action: &ComputerAction,
     session_config: &ComputerUseSessionConfig,
 ) -> std::io::Result<ActionResult> {
-    let temp_dir = std::env::temp_dir();
+    let temp_dir = RealSystem.temp_dir();
     let before_path = temp_dir.join("aletheia_cu_before.png");
     let after_path = temp_dir.join("aletheia_cu_after.png");
 

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -14,6 +14,7 @@ use indexmap::IndexMap;
 
 use aletheia_koina::defaults::MAX_OUTPUT_BYTES;
 use aletheia_koina::id::ToolName;
+use aletheia_koina::system::{Environment, RealSystem};
 
 use crate::error::{self, Result};
 use crate::process_guard::ProcessGuard;
@@ -47,7 +48,7 @@ const MAX_WRITE_BYTES: usize = 10 * 1024 * 1024;
 /// than a confusing "no such file" error.
 fn expand_tilde_str(raw: &str) -> std::borrow::Cow<'_, str> {
     if let Some(rest) = raw.strip_prefix('~')
-        && let Ok(home) = std::env::var("HOME")
+        && let Some(home) = RealSystem.var("HOME")
     {
         return std::borrow::Cow::Owned(format!("{home}{rest}"));
     }

--- a/crates/organon/src/sandbox/config.rs
+++ b/crates/organon/src/sandbox/config.rs
@@ -7,6 +7,7 @@
 
 use std::path::{Path, PathBuf};
 
+use aletheia_koina::system::{Environment, RealSystem};
 use serde::{Deserialize, Serialize};
 
 /// Sandbox enforcement level.
@@ -42,7 +43,7 @@ pub enum EgressPolicy {
 pub(crate) fn expand_tilde(path: &Path) -> PathBuf {
     let s = path.to_string_lossy();
     if s.starts_with('~')
-        && let Ok(home) = std::env::var("HOME")
+        && let Some(home) = RealSystem.var("HOME")
     {
         let without_tilde = s.strip_prefix('~').unwrap_or(&s);
         return PathBuf::from(format!("{home}{without_tilde}"));
@@ -174,10 +175,10 @@ impl SandboxConfig {
             PathBuf::from("/dev"),
         ];
 
-        // WHY: Use std::env::temp_dir() instead of hardcoded /tmp to support
+        // WHY: Use RealSystem::temp_dir() instead of hardcoded /tmp to support
         // systems where the temp directory differs (e.g. /var/folders on macOS,
         // or a custom TMPDIR). Closes #1697.
-        let mut write_paths = vec![std::env::temp_dir()];
+        let mut write_paths = vec![RealSystem.temp_dir()];
 
         // WHY: System binary dirs are always executable. workspace and
         // allowed_roots are also added so agents can execute scripts they own

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -1,5 +1,6 @@
 //! Health check endpoint.
 
+use aletheia_koina::system::{Environment, RealSystem};
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -214,13 +215,10 @@ const EXPIRY_WARNING_THRESHOLD: u64 = 3600;
 /// Check credential validity (presence and expiry).
 fn check_credential_validity(state: &HealthState) -> HealthCheck {
     // Check for API key in environment
-    let env_key = match std::env::var("ANTHROPIC_API_KEY") {
-        Ok(key) => Some(key),
-        Err(e) => {
-            tracing::debug!(error = %e, "ANTHROPIC_API_KEY not set or unreadable");
-            None
-        }
-    };
+    let env_key = RealSystem.var("ANTHROPIC_API_KEY").or_else(|| {
+        tracing::debug!("ANTHROPIC_API_KEY not set");
+        None
+    });
 
     if let Some(key) = env_key {
         if key.is_empty() {

--- a/crates/symbolon/src/credential/providers.rs
+++ b/crates/symbolon/src/credential/providers.rs
@@ -8,6 +8,7 @@ use tracing::warn;
 
 use aletheia_koina::credential::{Credential, CredentialProvider, CredentialSource};
 use aletheia_koina::secret::SecretString;
+use aletheia_koina::system::{Environment, RealSystem};
 
 use super::file_ops::CredentialFile;
 use super::{CLOCK_SKEW_LEEWAY_SECS, FILE_MTIME_CHECK_INTERVAL, OAUTH_TOKEN_PREFIX, unix_epoch_ms};
@@ -45,7 +46,7 @@ impl EnvCredentialProvider {
 
 impl CredentialProvider for EnvCredentialProvider {
     fn get_credential(&self) -> Option<Credential> {
-        std::env::var(&self.var_name).ok().and_then(|v| {
+        RealSystem.var(&self.var_name).and_then(|v| {
             if v.is_empty() {
                 return None;
             }

--- a/crates/symbolon/src/credential/refresh.rs
+++ b/crates/symbolon/src/credential/refresh.rs
@@ -11,6 +11,7 @@ use zeroize::Zeroize;
 
 use aletheia_koina::credential::{Credential, CredentialProvider, CredentialSource};
 use aletheia_koina::secret::SecretString;
+use aletheia_koina::system::{Environment, RealSystem};
 
 use super::file_ops::CredentialFile;
 use super::providers::FileCredentialProvider;
@@ -575,7 +576,7 @@ pub async fn force_refresh(path: &Path) -> Result<CredentialFile, String> {
 /// Returns `None` if `$HOME` is not set.
 #[must_use]
 pub fn claude_code_default_path() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(|home| {
+    RealSystem.var_os("HOME").map(|home| {
         PathBuf::from(home)
             .join(".claude")
             .join(".credentials.json")

--- a/crates/theatron/tui/src/clipboard.rs
+++ b/crates/theatron/tui/src/clipboard.rs
@@ -1,3 +1,5 @@
+use aletheia_koina::system::{Environment, RealSystem};
+
 /// Copy text to the system clipboard.
 /// Tries arboard (native) first, falls back to OSC52 escape sequence.
 pub(crate) fn copy_to_clipboard(text: &str) -> Result<(), String> {
@@ -104,7 +106,7 @@ fn copy_osc52(text: &str) -> Result<(), String> {
     let encoded = STANDARD.encode(text.as_bytes());
 
     // NOTE: tmux requires an OSC52 passthrough wrapper for the escape sequence to reach the terminal
-    let seq = if std::env::var("TMUX").is_ok() {
+    let seq = if RealSystem.var("TMUX").is_some() {
         format!("\x1bPtmux;\x1b\x1b]52;c;{}\x07\x1b\\", encoded)
     } else {
         format!("\x1b]52;c;{}\x07", encoded)

--- a/crates/theatron/tui/src/config.rs
+++ b/crates/theatron/tui/src/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 
 use aletheia_koina::secret::SecretString;
+use aletheia_koina::system::{Environment, RealSystem};
 
 use crate::error::{ConfigDirSnafu, IoSnafu, Result, TomlSnafu};
 use crate::theme::ThemeMode;
@@ -112,8 +113,8 @@ impl Config {
     ) -> Result<Self> {
         let file_config = Self::load_file().unwrap_or_default();
 
-        let workspace_root = std::env::var("ALETHEIA_ROOT")
-            .ok()
+        let workspace_root = RealSystem
+            .var("ALETHEIA_ROOT")
             .map(std::path::PathBuf::from)
             .or_else(|| {
                 file_config

--- a/crates/theatron/tui/src/hyperlink.rs
+++ b/crates/theatron/tui/src/hyperlink.rs
@@ -2,6 +2,7 @@
 
 use std::sync::LazyLock;
 
+use aletheia_koina::system::{Environment, RealSystem};
 use regex::Regex;
 
 /// A link found during markdown rendering, positioned within the markdown lines.
@@ -62,8 +63,10 @@ pub(crate) fn supports_hyperlinks() -> bool {
 }
 
 fn probe_hyperlink_support() -> bool {
+    let env = RealSystem;
+
     // NOTE: TERM_PROGRAM: most reliable signal on macOS and some Linux terminals
-    if let Ok(prog) = std::env::var("TERM_PROGRAM") {
+    if let Some(prog) = env.var("TERM_PROGRAM") {
         match prog.as_str() {
             "iTerm.app" | "WezTerm" | "ghostty" | "Ghostty" | "kitty" => return true,
             _ => {
@@ -73,34 +76,34 @@ fn probe_hyperlink_support() -> bool {
     }
 
     // NOTE: Ghostty
-    if std::env::var("GHOSTTY_BIN_DIR").is_ok() || std::env::var("GHOSTTY_RESOURCES_DIR").is_ok() {
+    if env.var("GHOSTTY_BIN_DIR").is_some() || env.var("GHOSTTY_RESOURCES_DIR").is_some() {
         return true;
     }
 
     // NOTE: WezTerm
-    if std::env::var("WEZTERM_EXECUTABLE").is_ok() || std::env::var("WEZTERM_PANE").is_ok() {
+    if env.var("WEZTERM_EXECUTABLE").is_some() || env.var("WEZTERM_PANE").is_some() {
         return true;
     }
 
     // NOTE: Kitty
-    if std::env::var("KITTY_PID").is_ok() || std::env::var("KITTY_WINDOW_ID").is_ok() {
+    if env.var("KITTY_PID").is_some() || env.var("KITTY_WINDOW_ID").is_some() {
         return true;
     }
 
     // NOTE: Windows Terminal
-    if std::env::var("WT_SESSION").is_ok() {
+    if env.var("WT_SESSION").is_some() {
         return true;
     }
 
     // NOTE: foot
-    if let Ok(term) = std::env::var("TERM")
+    if let Some(term) = env.var("TERM")
         && (term == "foot" || term == "foot-extra")
     {
         return true;
     }
 
     // NOTE: Alacritty
-    if std::env::var("ALACRITTY_SOCKET").is_ok() {
+    if env.var("ALACRITTY_SOCKET").is_some() {
         return true;
     }
 

--- a/crates/theatron/tui/src/state/editor/mod.rs
+++ b/crates/theatron/tui/src/state/editor/mod.rs
@@ -17,6 +17,8 @@ pub(crate) use tree::{FileTreeState, GitFileStatus};
 
 use std::path::PathBuf;
 
+use aletheia_koina::system::{Environment, RealSystem};
+
 const DEFAULT_AUTOSAVE_SECS: u64 = 30;
 
 /// Full editor state: tabs, file tree, clipboard, and modal inputs.
@@ -130,7 +132,9 @@ impl EditorState {
 
 impl Default for EditorState {
     fn default() -> Self {
-        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let cwd = RealSystem
+            .current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."));
         Self::new(cwd)
     }
 }

--- a/crates/theatron/tui/src/theme.rs
+++ b/crates/theatron/tui/src/theme.rs
@@ -1,3 +1,4 @@
+use aletheia_koina::system::{Environment, RealSystem};
 use ratatui::style::{Color, Modifier, Style};
 
 /// Terminal color depth, detected at startup.
@@ -517,7 +518,7 @@ impl Theme {
 /// Format: `fg;bg` or `fg;X;bg` where values are ANSI color indices.
 /// Indices 0-6 are dark colors, 7+ are light. Defaults to dark when unset.
 fn detect_background() -> ThemeMode {
-    if let Ok(val) = std::env::var("COLORFGBG") {
+    if let Some(val) = RealSystem.var("COLORFGBG") {
         // WHY: Some terminals emit three values (e.g., "15;0;0"). The background
         // is always the last component.
         if let Some(bg_str) = val.rsplit(';').next()
@@ -535,8 +536,10 @@ fn detect_background() -> ThemeMode {
 
 /// Detect terminal color capability from environment variables.
 fn detect_color_depth() -> ColorDepth {
+    let env = RealSystem;
+
     // WHY: COLORTERM is the most reliable indicator: check it before TERM.
-    if let Ok(ct) = std::env::var("COLORTERM") {
+    if let Some(ct) = env.var("COLORTERM") {
         match ct.as_str() {
             "truecolor" | "24bit" => return ColorDepth::TrueColor,
             // NOTE: unrecognized COLORTERM value, check other env vars
@@ -544,7 +547,7 @@ fn detect_color_depth() -> ColorDepth {
         }
     }
 
-    if let Ok(tp) = std::env::var("TERM_PROGRAM") {
+    if let Some(tp) = env.var("TERM_PROGRAM") {
         match tp.as_str() {
             "iTerm.app" | "WezTerm" | "Alacritty" | "kitty" => return ColorDepth::TrueColor,
             // NOTE: unrecognized terminal program, continue probing
@@ -553,17 +556,17 @@ fn detect_color_depth() -> ColorDepth {
     }
 
     // NOTE: GNOME Terminal sets COLORTERM=truecolor, but VTE_VERSION is a reliable backup.
-    if std::env::var("VTE_VERSION").is_ok() {
+    if env.var("VTE_VERSION").is_some() {
         return ColorDepth::TrueColor;
     }
 
-    if let Ok(term) = std::env::var("TERM")
+    if let Some(term) = env.var("TERM")
         && term.contains("256color")
     {
         return ColorDepth::Color256;
     }
 
-    if std::env::var("TMUX").is_ok() {
+    if env.var("TMUX").is_some() {
         return ColorDepth::Color256;
     }
 

--- a/crates/theatron/tui/src/update/editor.rs
+++ b/crates/theatron/tui/src/update/editor.rs
@@ -1,11 +1,15 @@
 //! Message handlers for the file editor view.
 
+use aletheia_koina::system::{Environment, RealSystem};
+
 use crate::app::App;
 use crate::msg::ErrorToast;
 use crate::state::view_stack::View;
 
 pub(crate) fn handle_open(app: &mut App) {
-    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let cwd = RealSystem
+        .current_dir()
+        .unwrap_or_else(|_| std::path::PathBuf::from("."));
     app.layout.editor = crate::state::editor::EditorState::new(cwd);
     app.layout.view_stack.push(View::FileEditor);
 }

--- a/crates/theatron/tui/src/update/input/mod.rs
+++ b/crates/theatron/tui/src/update/input/mod.rs
@@ -1,3 +1,5 @@
+use aletheia_koina::system::{Environment, RealSystem};
+
 use crate::app::App;
 use crate::state::{ImageAttachment, QueuedMessage, YankSpan};
 
@@ -454,8 +456,9 @@ pub(crate) fn handle_copy_last_response(app: &App) {
 
 // WHY: blocking is intentional: TUI is suspended so the event loop is paused
 pub(crate) fn handle_compose_in_editor(app: &mut App) {
-    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-    let tmpfile = std::env::temp_dir().join("aletheia-compose.md");
+    let env = RealSystem;
+    let editor = env.var("EDITOR").unwrap_or_else(|| "vi".to_string());
+    let tmpfile = env.temp_dir().join("aletheia-compose.md");
     #[expect(
         clippy::disallowed_methods,
         reason = "theatron TUI reads configuration and exports from disk in synchronous initialization paths"

--- a/crates/theatron/tui/src/view/image.rs
+++ b/crates/theatron/tui/src/view/image.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 
+use aletheia_koina::system::{Environment, RealSystem};
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 
@@ -43,11 +44,13 @@ static IMAGE_CACHE: LazyLock<Mutex<ImageCache>> = LazyLock::new(|| Mutex::new(Ha
 /// Detect the terminal's graphics protocol support by inspecting environment
 /// variables. Checked once and cached via [`LazyLock`].
 fn detect_protocol() -> GraphicsProtocol {
+    let env = RealSystem;
+
     // Kitty: check KITTY_WINDOW_ID or TERM_PROGRAM
-    if std::env::var("KITTY_WINDOW_ID").is_ok() {
+    if env.var("KITTY_WINDOW_ID").is_some() {
         return GraphicsProtocol::Kitty;
     }
-    let term_program = std::env::var("TERM_PROGRAM").unwrap_or_default();
+    let term_program = env.var("TERM_PROGRAM").unwrap_or_default();
     if term_program.eq_ignore_ascii_case("kitty") {
         return GraphicsProtocol::Kitty;
     }
@@ -57,13 +60,13 @@ fn detect_protocol() -> GraphicsProtocol {
     if matches!(term_program_lower.as_str(), "foot" | "mlterm" | "wezterm") {
         return GraphicsProtocol::Sixel;
     }
-    let term = std::env::var("TERM").unwrap_or_default();
+    let term = env.var("TERM").unwrap_or_default();
     if term.contains("mlterm") {
         return GraphicsProtocol::Sixel;
     }
 
     // True color: COLORTERM is the standard signal
-    let colorterm = std::env::var("COLORTERM").unwrap_or_default();
+    let colorterm = env.var("COLORTERM").unwrap_or_default();
     if colorterm == "truecolor" || colorterm == "24bit" {
         return GraphicsProtocol::TrueColor;
     }

--- a/crates/theatron/tui/src/wizard/state.rs
+++ b/crates/theatron/tui/src/wizard/state.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use aletheia_koina::secret::SecretString;
+use aletheia_koina::system::{Environment, RealSystem};
 
 /// Number of wizard steps.
 pub(crate) const TOTAL_STEPS: usize = 5;
@@ -291,7 +292,8 @@ pub(crate) static MODEL_OPTIONS: &[SelectOption] = &[
 
 fn detected_provider() -> &'static str {
     // WHY: prefer Anthropic unless only OpenAI key is present
-    if std::env::var("OPENAI_API_KEY").is_ok() && std::env::var("ANTHROPIC_API_KEY").is_err() {
+    let env = RealSystem;
+    if env.var("OPENAI_API_KEY").is_some() && env.var("ANTHROPIC_API_KEY").is_none() {
         "openai"
     } else {
         "anthropic"
@@ -299,8 +301,9 @@ fn detected_provider() -> &'static str {
 }
 
 fn credential_status() -> String {
-    let a = std::env::var("ANTHROPIC_API_KEY").is_ok();
-    let o = std::env::var("OPENAI_API_KEY").is_ok();
+    let env = RealSystem;
+    let a = env.var("ANTHROPIC_API_KEY").is_some();
+    let o = env.var("OPENAI_API_KEY").is_some();
     match (a, o) {
         (true, true) => "ANTHROPIC_API_KEY ✓  OPENAI_API_KEY ✓".to_owned(),
         (true, false) => "ANTHROPIC_API_KEY ✓".to_owned(),


### PR DESCRIPTION
## Summary

Routes every direct `std::env::var` / `std::env::var_os` / `std::env::temp_dir` /
`std::env::current_exe` / `std::env::args` / `std::env::current_dir` call outside
`aletheia-taxis` through `aletheia_koina::system::{Environment, RealSystem}`.
The `Environment` trait is the canonical, test-substitutable seam for
process-environment access; consolidating on it unblocks future work to
flow all config through `AletheiaConfig` / `Oikos` without scattered direct
env reads.

Closes #2800.

## Approach

1. **Extend the trait first.** `koina::system::Environment` already carried
   `var`, `vars`, `current_dir`. Added `var_os`, `temp_dir`, `current_exe`,
   and `args` so every existing call site has a trait-method equivalent.
   `TestSystem` gained matching builder methods (`with_temp_dir`,
   `with_current_exe`, `with_args`) with sensible defaults so existing tests
   continue to compile.
2. **One crate per commit.** Each commit rewrites the call sites in a single
   crate (or one cohesive subsystem) and leaves the trait shape alone.
3. **Behaviour-preserving rewrite.** Every call site keeps the same
   defaults, fallbacks, and control flow; the delta is only the access path.

## Classification (non-test sites)

| Category | Count | Example |
|---|---|---|
| (a) App config read | 10 | `ALETHEIA_ROOT` in `daemon.rs`, `init/mod.rs`, `commands/server/mod.rs`, `theatron/tui/config.rs`, `daemon/execution.rs`, `daemon/maintenance/mod.rs` |
| (b) Secret read | 7 | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, `ALETHEIA_JWT_SECRET`, `SEMANTIC_SCHOLAR_API_KEY` (env-based fallback paths kept as-is) |
| (c) System read | ~25 | `HOME`, `PATH`, `TERM`, `TERM_PROGRAM`, `KITTY_WINDOW_ID`, `COLORTERM`, `TMUX`, `WAYLAND_DISPLAY`, etc. |
| (d) Test-only (left alone) | ~35 | `credential_tests.rs`, `hyperlink.rs` test blocks, `workspace_tests/`, `sandbox/tests/`, etc. |
| (e) Inside taxis / koina | 7 | The `Environment` impl itself (the canonical delegation point) |

## Per-crate changes

| Crate | Files | Call sites moved |
|---|---|---|
| `aletheia-koina` | `system.rs`, `system/system_impl.rs` | +6 trait methods (`var_os`, `temp_dir`, `current_exe`, `args`, and matching `TestSystem` impls) |
| `aletheia` | `main.rs`, `runtime.rs`, `init/mod.rs`, `commands/{daemon,credential,desktop,server/mod,add_nous}.rs` | 14 |
| `aletheia-oikonomos` (daemon) | `execution.rs`, `runner.rs`, `maintenance/mod.rs` | 5 |
| `aletheia-hermeneus` | `cc/process.rs`, `cc/provider.rs` | 3 |
| `aletheia-organon` | `builtins/{workspace,computer_use/sandbox,computer_use/capture}.rs`, `sandbox/config.rs` | 5 |
| `theatron-tui` | `config.rs`, `view/image.rs`, `theme.rs`, `clipboard.rs`, `hyperlink.rs`, `wizard/state.rs`, `update/{editor,input/mod}.rs`, `state/editor/mod.rs` | 23 |
| `aletheia-symbolon` | `credential/refresh.rs`, `credential/providers.rs` | 2 |
| `aletheia-pylon` | `handlers/health.rs` | 1 |

### Before / after inventory

Before the refactor (per the task's inventory grep):
```
grep -rn 'std::env::\|env::var' crates/ --include='*.rs' \
  | grep -v 'crates/taxis\|kanon:ignore\|//' | wc -l
# => 109
```

After:
```
# => 56
```

The 56 remaining matches break down as:

- **35 lines in test modules** (test scope is explicitly exempt per #2800):
  `organon/builtins/workspace_tests/*`, `organon/sandbox/tests/*`,
  `theatron/tui/src/hyperlink.rs` (test blocks), `theatron/tui/src/state/editor/tests.rs`,
  `theatron/tui/src/config.rs` (#[cfg(test)] block), `eval/src/persistence.rs`,
  `aletheia/tests/integration_server.rs`, `symbolon/src/credential_tests.rs`,
  `organon/sandbox/config.rs:260` (#[cfg(test)] block),
  `organon/sandbox/policy.rs:1572` (#[cfg(test)] block),
  `krites/src/data/tests/validity.rs`.
- **7 lines in `koina/src/system/system_impl.rs`**: the `Environment` trait
  implementation itself is the canonical `std::env` delegation point.
- **2 lines in `theatron-desktop/src/theme.rs`**: this crate is excluded
  from the workspace (`GTK3/webkit2gtk` system deps) and is built standalone.
  Touching it is out of scope for #2800's workspace-wide gate; left as-is.
- **2 lines using `std::env::split_paths`** (`aletheia/src/commands/desktop.rs`,
  `hermeneus/src/cc/provider.rs`): `split_paths` is a pure parser that
  operates on an `OsString` argument and does not access the process
  environment. Left alone because the task's goal is to consolidate
  _environment access_, not path-string parsing.

## Behaviour notes

- `RealSystem` methods delegate directly to the same `std::env::*` calls
  they replaced, so production behaviour is byte-identical.
- Two call sites lost a minor diagnostic distinction because the
  `Environment::var` signature returns `Option<String>` rather than
  `Result<String, VarError>`:
  - `crates/aletheia/src/runtime.rs`: the `SEMANTIC_SCHOLAR_API_KEY`
    warning no longer distinguishes `NotPresent` from `NotUnicode`.
  - `crates/pylon/src/handlers/health.rs`: the `ANTHROPIC_API_KEY` debug
    log likewise no longer carries a `VarError` variant.
  In practice an API key stored as invalid UTF-8 is not a reachable state,
  so the lost distinction has no operational effect.
- `crates/aletheia/src/init/mod.rs`: `InitError::MissingApiKey` no longer
  carries `source: std::env::VarError` because the call uses
  `RealSystem.var(...).ok_or_else(MissingApiKeySnafu.build)`. The user-
  facing error message (`"ANTHROPIC_API_KEY not set"`) is unchanged.

## Quality gate

- `CARGO_TARGET_DIR=/data/target cargo check --workspace` — green
- `CARGO_TARGET_DIR=/data/target cargo clippy --workspace --all-targets -- -D warnings` — green
- `CARGO_TARGET_DIR=/data/target cargo test --workspace` — all tests pass
  (default feature set, matching the pre-refactor baseline)

`cargo check --workspace --all-features` was **not** a workable gate on the
base commit: the `keyring` feature and `migrate-qdrant` feature have
pre-existing compile errors on `origin/main`. Filed as #3046 for the
`KeyringCredentialProvider` `pub(crate)` re-export issue; the `migrate-qdrant`
bitrot (`Fact::scope` and a `LowerHex` bound on a generic array) is a
separate substantially out-of-scope issue.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Manual spot-check of each rewritten call site to confirm unchanged
      default/fallback semantics

## Related

- Blocked by / related to: filed #3046 (symbolon `KeyringCredentialProvider`
  `pub(crate)` re-export bug, pre-existing on `main` but only surfaces with
  `--all-features`).