### PR TITLE
lint(episteme, nous): reduce pub visibility sprawl (#2763)

### DIFF
--- a/crates/episteme/src/causal.rs
+++ b/crates/episteme/src/causal.rs
@@ -270,7 +270,7 @@ const CAUSAL_CUES: &[(&str, CausalRelationType, f64)] = &[
 /// the first match is used to gate edge creation. If multiple relations are
 /// needed, callers should segment text before calling.
 #[must_use]
-pub fn detect_causal_cue(text: &str) -> Option<(CausalRelationType, f64)> {
+pub(crate) fn detect_causal_cue(text: &str) -> Option<(CausalRelationType, f64)> {
     let lower = text.to_lowercase();
     CAUSAL_CUES
         .iter()
@@ -291,6 +291,9 @@ pub fn detect_causal_cue(text: &str) -> Option<(CausalRelationType, f64)> {
 /// # Errors
 /// Never fails — returns `Vec` rather than `Result` because extraction is
 /// best-effort; failure to detect causality is not an error condition.
+// PUBLIC: documented hook for RefinedExtraction.causal_signal consumers
+// (see extract/types.rs). Kept `pub` so external callers can drive the
+// pipeline until the first in-tree consumer lands.
 #[must_use]
 pub fn extract_causal_edges(
     session_text: &str,

--- a/crates/episteme/src/causal.rs
+++ b/crates/episteme/src/causal.rs
@@ -12,7 +12,8 @@
 //! is the product of individual edge confidences along the chain.
 //!
 //! Causal edges are heuristically extracted during session finalization.
-//! See [`extract_causal_edges`] for the extraction logic.
+//! See the crate-private `extract_causal_edges` helper for the extraction
+//! logic.
 
 use std::collections::{HashMap, HashSet};
 
@@ -291,11 +292,12 @@ pub(crate) fn detect_causal_cue(text: &str) -> Option<(CausalRelationType, f64)>
 /// # Errors
 /// Never fails — returns `Vec` rather than `Result` because extraction is
 /// best-effort; failure to detect causality is not an error condition.
-// PUBLIC: documented hook for RefinedExtraction.causal_signal consumers
-// (see extract/types.rs). Kept `pub` so external callers can drive the
-// pipeline until the first in-tree consumer lands.
 #[must_use]
-pub fn extract_causal_edges(
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "documented hook for RefinedExtraction.causal_signal consumers; exercised from tests until first in-tree caller lands")
+)]
+pub(crate) fn extract_causal_edges(
     session_text: &str,
     source_id: FactId,
     target_id: FactId,

--- a/crates/episteme/src/embedding_eval.rs
+++ b/crates/episteme/src/embedding_eval.rs
@@ -16,15 +16,16 @@
 //! ```ignore
 //! // WHY: MockEmbeddingProvider is gated behind the `test-support` feature.
 //! // This example shows the API but cannot compile in doctest mode.
+//! use std::path::Path;
 //! use aletheia_episteme::embedding::MockEmbeddingProvider;
-//! use aletheia_episteme::embedding_eval::{EvalDataset, evaluate_model};
+//! use aletheia_episteme::embedding_eval::{EvalDataset, compare_models};
 //!
-//! let dataset = EvalDataset::from_jsonl_str(r#"{"query":"foo","relevant_ids":["a"]}"#)
+//! let dataset = EvalDataset::from_jsonl_file(Path::new("eval.jsonl"))
 //!     .expect("JSONL must parse for valid test data");
 //! let provider = MockEmbeddingProvider::new(384);
 //! let corpus: Vec<(String, String)> = vec![("a".into(), "foo bar".into())];
-//! let result = evaluate_model(&provider, &dataset, &corpus, 5).unwrap();
-//! println!("Recall@5: {}", result.recall_at_k);
+//! let run = compare_models(&provider, None, &dataset, &corpus, 5).unwrap();
+//! println!("Recall@5: {}", run.baseline.recall_at_k);
 //! ```
 
 use snafu::Snafu;
@@ -109,7 +110,7 @@ impl EvalDataset {
     ///
     /// Returns [`EvalError::ParseFailed`] if any non-blank line is invalid JSON
     /// or missing required fields.
-    pub fn from_jsonl_str(s: &str) -> EvalResult<Self> {
+    pub(crate) fn from_jsonl_str(s: &str) -> EvalResult<Self> {
         let mut queries = Vec::new();
         for (idx, raw) in s.lines().enumerate() {
             let line = raw.trim();
@@ -234,7 +235,7 @@ pub struct EvalRunResult {
 /// Returns [`EvalError::EmptyCorpus`] or [`EvalError::EmptyDataset`] for
 /// empty inputs, and [`EvalError::EmbedFailed`] if the provider errors.
 #[instrument(skip(provider, dataset, corpus), fields(k = k, queries = dataset.queries.len(), corpus = corpus.len()))]
-pub fn evaluate_model(
+pub(crate) fn evaluate_model(
     provider: &dyn EmbeddingProvider,
     dataset: &EvalDataset,
     corpus: &[(String, String)],

--- a/crates/episteme/src/embedding_eval.rs
+++ b/crates/episteme/src/embedding_eval.rs
@@ -416,7 +416,7 @@ fn score_one_query(
 ///
 /// # Errors
 ///
-/// Propagates errors from [`evaluate_model`].
+/// Propagates errors from the crate-private `evaluate_model` helper.
 #[instrument(skip(baseline, candidate, dataset, corpus), fields(k = k))]
 pub fn compare_models(
     baseline: &dyn EmbeddingProvider,

--- a/crates/episteme/src/embedding_eval.rs
+++ b/crates/episteme/src/embedding_eval.rs
@@ -146,7 +146,11 @@ impl EvalDataset {
 
     /// Number of queries in this dataset.
     #[must_use]
-    pub fn len(&self) -> usize {
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "symmetry with is_empty; exercised from tests")
+    )]
+    pub(crate) fn len(&self) -> usize {
         self.queries.len()
     }
 

--- a/crates/episteme/src/extract/dispatch.rs
+++ b/crates/episteme/src/extract/dispatch.rs
@@ -154,7 +154,7 @@ pub struct ProjectScores {
     pub grade_distribution: HashMap<Grade, usize>,
 }
 
-/// Inputs to [`compute_grade`].
+/// Inputs to the crate-private `compute_grade` scoring helper.
 ///
 /// Bundles the boolean and counter flags into a single named record so the
 /// call sites are self-documenting and so the function signature stays

--- a/crates/episteme/src/extract/dispatch.rs
+++ b/crates/episteme/src/extract/dispatch.rs
@@ -189,7 +189,11 @@ pub struct GradeInputs {
 /// - C: multiple resumes or fixes
 /// - F: stuck or failed
 #[must_use]
-pub fn compute_grade(inputs: GradeInputs) -> Grade {
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "scoring helper exercised from tests; steward wiring lands with dispatch reporter")
+)]
+pub(crate) fn compute_grade(inputs: GradeInputs) -> Grade {
     if inputs.has_failure {
         return Grade::F;
     }

--- a/crates/episteme/src/extract/observation.rs
+++ b/crates/episteme/src/extract/observation.rs
@@ -342,7 +342,7 @@ static FILE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Tags include crate names matching `crates/{name}` or backtick-wrapped
 /// crate references, and file paths matching common patterns.
 #[must_use]
-pub fn extract_tags(text: &str) -> Vec<String> {
+pub(crate) fn extract_tags(text: &str) -> Vec<String> {
     let mut tags = Vec::new();
 
     for cap in CRATE_PATH_RE.captures_iter(text) {

--- a/crates/episteme/src/extract/observation.rs
+++ b/crates/episteme/src/extract/observation.rs
@@ -184,7 +184,11 @@ pub struct RawObservation {
 /// individual observation. Handles continuation lines (indented text
 /// that is part of the same bullet).
 #[must_use]
-pub fn parse_observations(pr_body: &str) -> Vec<RawObservation> {
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "PR observation parser exercised from tests; steward wiring lands with the training extractor")
+)]
+pub(crate) fn parse_observations(pr_body: &str) -> Vec<RawObservation> {
     let Some(section) = extract_observations_section(pr_body) else {
         return Vec::new();
     };

--- a/crates/episteme/src/extract/types.rs
+++ b/crates/episteme/src/extract/types.rs
@@ -125,8 +125,8 @@ pub struct RefinedExtraction {
     ///
     /// `Some((relation_type, confidence))` when the combined message text
     /// contains causal language ("because", "therefore", "caused by", etc.).
-    /// Callers can use this to trigger [`crate::causal::extract_causal_edges`]
-    /// with the relevant fact IDs.
+    /// Consumers can use this to drive the crate-private `extract_causal_edges`
+    /// helper with the relevant fact IDs.
     pub causal_signal: Option<(CausalRelationType, f64)>,
 }
 

--- a/crates/episteme/src/knowledge_store/search.rs
+++ b/crates/episteme/src/knowledge_store/search.rs
@@ -409,7 +409,11 @@ impl KnowledgeStore {
     ///
     /// Same as `search_tiered`: depends on tier reached.
     #[instrument(skip(self, rewriter, provider, context, config))]
-    pub async fn search_tiered_async(
+    #[expect(
+        dead_code,
+        reason = "async wrapper for search_tiered; kept crate-private until first caller wires it in"
+    )]
+    pub(crate) async fn search_tiered_async(
         self: &std::sync::Arc<Self>,
         base_query: HybridQuery,
         rewriter: std::sync::Arc<crate::query_rewrite::QueryRewriter>,

--- a/crates/episteme/src/manifest.rs
+++ b/crates/episteme/src/manifest.rs
@@ -55,10 +55,14 @@ impl From<MemoryHeaderRaw> for MemoryHeader {
     }
 }
 
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "test-only constructors; MemoryHeader is built via serde in lib builds")
+)]
 impl MemoryHeader {
     /// Create a new header with the required fields.
     #[must_use]
-    pub fn new(source_id: impl Into<String>, name: impl Into<String>, mtime_ms: i64) -> Self {
+    pub(crate) fn new(source_id: impl Into<String>, name: impl Into<String>, mtime_ms: i64) -> Self {
         Self {
             source_id: source_id.into(),
             name: name.into(),
@@ -69,7 +73,7 @@ impl MemoryHeader {
 
     /// Set the description (builder pattern).
     #[must_use]
-    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+    pub(crate) fn with_description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
     }

--- a/crates/episteme/src/manifest.rs
+++ b/crates/episteme/src/manifest.rs
@@ -101,7 +101,7 @@ impl MemoryManifest {
     /// Sorts by modification time descending and enforces the
     /// [`MAX_MEMORY_ENTRIES`] cap.
     #[must_use]
-    pub fn from_headers(mut headers: Vec<MemoryHeader>) -> Self {
+    pub(crate) fn from_headers(mut headers: Vec<MemoryHeader>) -> Self {
         headers.sort_by(|a, b| b.mtime_ms.cmp(&a.mtime_ms));
         headers.truncate(MAX_MEMORY_ENTRIES);
         Self { headers }
@@ -113,7 +113,7 @@ impl MemoryManifest {
     /// `- <source_id> <name>: <description>` (with description)
     /// `- <source_id> <name>` (without description)
     #[must_use]
-    pub fn format(&self) -> String {
+    pub(crate) fn format(&self) -> String {
         use std::fmt::Write;
         let mut out = String::with_capacity(self.headers.len() * 80);
         for h in &self.headers {
@@ -128,19 +128,19 @@ impl MemoryManifest {
 
     /// The headers in this manifest, in mtime-descending order.
     #[must_use]
-    pub fn headers(&self) -> &[MemoryHeader] {
+    pub(crate) fn headers(&self) -> &[MemoryHeader] {
         &self.headers
     }
 
     /// Number of entries in this manifest.
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.headers.len()
     }
 
     /// Whether this manifest contains no entries.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.headers.is_empty()
     }
 }

--- a/crates/episteme/src/query_rewrite.rs
+++ b/crates/episteme/src/query_rewrite.rs
@@ -15,7 +15,7 @@ use tracing::instrument;
 ///
 /// Keeps mneme independent of hermeneus. The nous layer bridges this trait
 /// to the full `LlmProvider` + `CompletionRequest` API.
-pub trait RewriteProvider: Send + Sync {
+pub(crate) trait RewriteProvider: Send + Sync {
     /// Generate a completion from a system prompt and user message.
     fn complete(&self, system: &str, user_message: &str) -> Result<String, RewriteError>;
 }
@@ -69,20 +69,20 @@ pub struct RewriteResult {
 }
 
 /// LLM-powered query rewriter for the recall pipeline.
-pub struct QueryRewriter {
+pub(crate) struct QueryRewriter {
     config: RewriteConfig,
 }
 
 impl QueryRewriter {
     /// Create a new query rewriter with the given configuration.
     #[must_use]
-    pub fn new(config: RewriteConfig) -> Self {
+    pub(crate) fn new(config: RewriteConfig) -> Self {
         Self { config }
     }
 
     /// Create a query rewriter with default configuration.
     #[must_use]
-    pub fn with_defaults() -> Self {
+    pub(crate) fn with_defaults() -> Self {
         Self::new(RewriteConfig::default())
     }
 
@@ -91,7 +91,7 @@ impl QueryRewriter {
     /// Returns the original query plus generated variants. Never fails;
     /// falls back to the original query on any error.
     #[instrument(skip(self, provider, context))]
-    pub fn rewrite(
+    pub(crate) fn rewrite(
         &self,
         query: &str,
         context: Option<&str>,

--- a/crates/episteme/src/side_query.rs
+++ b/crates/episteme/src/side_query.rs
@@ -34,13 +34,9 @@ const DEFAULT_CACHE_CAPACITY: usize = 64;
 
 /// Errors from side-query operations.
 #[derive(Debug, Snafu)]
-#[snafu(visibility(pub))]
+#[snafu(visibility(pub(crate)))]
 #[non_exhaustive]
-#[expect(
-    missing_docs,
-    reason = "snafu error variant fields are self-documenting via display format"
-)]
-pub enum SideQueryError {
+pub(crate) enum SideQueryError {
     /// The ranking model call failed.
     #[snafu(display("side-query ranker failed: {message}"))]
     RankerFailed {
@@ -57,7 +53,7 @@ pub enum SideQueryError {
 /// match the existing recall pipeline's sync trait pattern
 /// ([`EmbeddingProvider`](crate::embedding::EmbeddingProvider),
 /// [`VectorSearch`]).
-pub trait SideQueryRanker: Send + Sync {
+pub(crate) trait SideQueryRanker: Send + Sync {
     /// Rank memory entries by relevance to the query.
     ///
     /// # Arguments
@@ -198,17 +194,21 @@ impl RelevanceCache {
 /// Wraps a [`SideQueryRanker`] with `already_surfaced` tracking and LRU
 /// caching. Designed to run as a pre-filter stage before the 6-factor
 /// recall scoring in [`RecallEngine`](crate::recall::RecallEngine).
-pub struct SideQuerySelector {
+pub(crate) struct SideQuerySelector {
     config: SideQueryConfig,
     // WHY: std::sync::Mutex — lock never held across .await.
     already_surfaced: Mutex<HashSet<String>>,
     cache: Mutex<RelevanceCache>,
 }
 
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "impl used from tests; production wiring lands with recall pipeline integration")
+)]
 impl SideQuerySelector {
     /// Create a new selector with the given configuration.
     #[must_use]
-    pub fn new(config: SideQueryConfig) -> Self {
+    pub(crate) fn new(config: SideQueryConfig) -> Self {
         let cache = RelevanceCache::new(
             config.cache_capacity,
             Duration::from_secs(config.cache_ttl_secs),
@@ -231,7 +231,7 @@ impl SideQuerySelector {
     /// result is available.
     #[must_use = "selection result should be used for pre-filtering"]
     #[instrument(skip_all, fields(manifest_len = manifest.len()))]
-    pub fn select(
+    pub(crate) fn select(
         &self,
         query: &str,
         manifest: &MemoryManifest,
@@ -287,7 +287,7 @@ impl SideQuerySelector {
     }
 
     /// Mark source IDs as surfaced so they won't be re-selected.
-    pub fn mark_surfaced(&self, ids: &[String]) {
+    pub(crate) fn mark_surfaced(&self, ids: &[String]) {
         let mut surfaced = self.already_surfaced.lock();
         for id in ids {
             surfaced.insert(id.clone());
@@ -296,14 +296,14 @@ impl SideQuerySelector {
 
     /// Check whether a source ID has already been surfaced.
     #[must_use]
-    pub fn is_surfaced(&self, id: &str) -> bool {
+    pub(crate) fn is_surfaced(&self, id: &str) -> bool {
         self.already_surfaced.lock()
             .contains(id)
     }
 
     /// Number of entries in the relevance cache.
     #[must_use]
-    pub fn cache_len(&self) -> usize {
+    pub(crate) fn cache_len(&self) -> usize {
         self.cache.lock()
             .len()
     }

--- a/crates/episteme/src/trace_ingest.rs
+++ b/crates/episteme/src/trace_ingest.rs
@@ -20,9 +20,9 @@
 //!
 //! # Feature gate
 //!
-//! The [`TraceIngestLayer`] type is always available so it can be composed into
+//! The `TraceIngestLayer` type is always available so it can be composed into
 //! the subscriber stack without a feature check at the call site.  The
-//! [`TraceIngestLayer::flush`] method (which writes to the Datalog engine) is
+//! `TraceIngestLayer::flush` method (which writes to the Datalog engine) is
 //! gated on the `mneme-engine` feature; without it the buffer still fills but
 //! flushes are no-ops.
 
@@ -85,12 +85,13 @@ pub enum TraceEvent {
 
 /// DDL that creates the three `ops.*` relations in a Datalog database.
 ///
-/// Apply this before the first [`TraceIngestLayer::flush`] call.  In production
+/// Apply this before the first `TraceIngestLayer::flush` call.  In production
 /// the knowledge-store init path runs all DDL; this constant is exposed so
-/// tests and the init migration can reference the canonical schema.
+/// feature-gated tests and the init migration can reference the canonical
+/// schema. Only the `mneme-engine`-gated `engine_tests` mod reads it.
 #[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "schema referenced from tests; production init path is in knowledge_store::init")
+    not(all(test, feature = "mneme-engine")),
+    expect(dead_code, reason = "schema referenced from mneme-engine tests only; production init path lives in knowledge_store::init")
 )]
 pub(crate) const OPS_DDL: &[&str] = &[
     r":create ops_turns {
@@ -351,6 +352,10 @@ impl TraceIngestLayer {
     ///
     /// Prevents unbounded buffer growth when no knowledge store is wired in.
     #[cfg(not(feature = "mneme-engine"))]
+    #[expect(
+        dead_code,
+        reason = "fallback for feature-off builds; kept as a stable name so callers can switch between flush and flush_noop via cfg without renaming"
+    )]
     pub(crate) fn flush_noop(&self) {
         self.drain();
     }

--- a/crates/episteme/src/trace_ingest.rs
+++ b/crates/episteme/src/trace_ingest.rs
@@ -88,7 +88,11 @@ pub enum TraceEvent {
 /// Apply this before the first [`TraceIngestLayer::flush`] call.  In production
 /// the knowledge-store init path runs all DDL; this constant is exposed so
 /// tests and the init migration can reference the canonical schema.
-pub const OPS_DDL: &[&str] = &[
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "schema referenced from tests; production init path is in knowledge_store::init")
+)]
+pub(crate) const OPS_DDL: &[&str] = &[
     r":create ops_turns {
         session_id: String, nous_id: String =>
         model: String,
@@ -205,7 +209,7 @@ impl Visit for EventVisitor {
 ///     duration_ms = elapsed.as_millis() as i64,
 /// );
 /// ```
-pub struct TraceIngestLayer {
+pub(crate) struct TraceIngestLayer {
     buffer: std::sync::Arc<Mutex<Vec<TraceEvent>>>,
 }
 
@@ -217,10 +221,14 @@ impl Clone for TraceIngestLayer {
     }
 }
 
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "impl used from tests; production wiring lands with knowledge_store::init migration")
+)]
 impl TraceIngestLayer {
     /// Create a new ingest layer with an empty buffer.
     #[must_use]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             buffer: std::sync::Arc::new(Mutex::new(Vec::new())),
         }
@@ -231,7 +239,7 @@ impl TraceIngestLayer {
     /// This is the infallible variant — it returns events regardless of whether
     /// a knowledge store is available.  Use [`TraceIngestLayer::flush`] to write
     /// them to Datalog.
-    pub fn drain(&self) -> Vec<TraceEvent> {
+    pub(crate) fn drain(&self) -> Vec<TraceEvent> {
         let mut buf = self
             .buffer
             .lock();
@@ -239,7 +247,7 @@ impl TraceIngestLayer {
     }
 
     /// How many events are waiting in the buffer.
-    pub fn pending(&self) -> usize {
+    pub(crate) fn pending(&self) -> usize {
         self.buffer
             .lock()
             .len()
@@ -254,7 +262,7 @@ impl TraceIngestLayer {
     /// Requires the `mneme-engine` feature.  Without it this is a no-op that
     /// still drains the buffer (preventing unbounded growth).
     #[cfg(feature = "mneme-engine")]
-    pub fn flush(&self, store: &crate::knowledge_store::KnowledgeStore) {
+    pub(crate) fn flush(&self, store: &crate::knowledge_store::KnowledgeStore) {
         use std::collections::BTreeMap;
 
         use crate::engine::DataValue;
@@ -343,7 +351,7 @@ impl TraceIngestLayer {
     ///
     /// Prevents unbounded buffer growth when no knowledge store is wired in.
     #[cfg(not(feature = "mneme-engine"))]
-    pub fn flush_noop(&self) {
+    pub(crate) fn flush_noop(&self) {
         self.drain();
     }
 }


### PR DESCRIPTION
## Summary

Reduce `RUST/pub-visibility` sprawl across `crates/episteme/` and
`crates/nous/` against issue #2763.

- **episteme**: 60 violations → 25 (58% reduction, 35 items downgraded)
- **nous**: 0 flagged violations either before or after — every pub
  item in a non-`mod.rs`/non-whitelisted path was already tight

The 25 residual episteme violations are all items pinned by external
consumers (see "Items kept public" below). Touching `.kanon-lint-ignore`
is deliberately out of scope.

## Method

For each flagged item:

1. Grep the workspace for callers outside `crates/episteme/`. If any
   exist (including `crates/episteme/tests/public_api.rs`, which links
   as a separate crate), the item stays `pub`.
2. Otherwise, downgrade to `pub(crate)`.
3. When the downgraded item has no in-crate non-test caller, the
   resulting dead-code warning is silenced with
   `#[cfg_attr(not(test), expect(dead_code, reason = "..."))]` — the
   expectation only fires in lib builds (where the item is dead) and
   stays dormant in test builds (where inline tests exercise it).
4. Doc intra-links that now point at crate-private items are rewritten
   to plain code spans so rustdoc stops warning about private re-exports.

No `#[allow]` attributes introduced. No `.kanon-lint-ignore` entries
touched. No behavior changes.

## Per-commit breakdown

| Commit | File | Downgrades |
|---|---|---|
| `lint(episteme): reduce pub visibility in causal.rs` | `causal.rs` | `detect_causal_cue` → `pub(crate)` |
| `lint(episteme): reduce pub visibility in query_rewrite` | `query_rewrite.rs`, `knowledge_store/search.rs` | 5 items in the crate-private `query_rewrite` module; cascade-downgrade `search_tiered_async` + `#[expect(dead_code)]` |
| `lint(episteme): reduce pub visibility in manifest and observation::extract_tags` | `manifest.rs`, `extract/observation.rs` | 5 `MemoryManifest` methods; `extract_tags` |
| `lint(episteme): reduce pub visibility in trace_ingest` | `trace_ingest.rs` | `OPS_DDL`, `TraceIngestLayer` + impl methods via cfg_attr |
| `lint(episteme): reduce pub visibility in side_query` | `side_query.rs` | `SideQueryError`, `SideQueryRanker`, `SideQuerySelector` + impl methods |
| `lint(episteme): reduce pub visibility of test-only helpers` | `extract/dispatch.rs`, `embedding_eval.rs` | `compute_grade`, `EvalDataset::len` via cfg_attr |
| `lint(episteme): reduce pub visibility of MemoryHeader constructors` | `manifest.rs` | `MemoryHeader::new`, `with_description` via cfg_attr |
| `lint(embedding_eval): reduce pub visibility of internal helpers` | `embedding_eval.rs` | `evaluate_model`, `from_jsonl_str`; rewrite module doc example |
| `lint(episteme): reduce pub visibility of parse_observations` | `extract/observation.rs` | `parse_observations` via cfg_attr |
| `lint(episteme): downgrade extract_causal_edges and prune stale doc links` | `causal.rs`, `embedding_eval.rs`, `extract/dispatch.rs`, `extract/types.rs`, `trace_ingest.rs` | `extract_causal_edges` via cfg_attr; `flush_noop` expect; rewrite doc intra-links for now-private items |

## Items kept public with justification

| File | Symbol(s) | Why |
|---|---|---|
| `causal.rs` | `CausalError`, `CausalStore` (+ `new`, `add_edge`, `get_edge`, `all_edges`, `direct_causes`, `direct_effects`, `trace_causes`, `trace_effects`) | All pinned by `crates/episteme/tests/public_api.rs` as the crate's external API contract |
| `embedding_eval.rs` | `EvalError`, `EvalResult`, `EvalDataset::from_jsonl_file`, `EvalDataset::is_empty`, `compare_models` | Called from `crates/aletheia/src/commands/eval_embeddings.rs` via `aletheia_mneme::embedding_eval::*` re-export |
| `extract/observation.rs` | `ObservationType::classify`, `ObservationType::as_str`, `ObservationType::from_str_lossy` | Pinned by `public_api.rs` integration test |
| `extract/training.rs` | `extract_from_training_data`, `lessons_to_facts` | Called from `crates/daemon/src/execution.rs` |
| `ops_facts.rs` | `OpsFactExtractor`, `OpsFactExtractor::extract` | Pinned by `public_api.rs` integration test |
| `rule_proposals.rs` | `RuleProposalError`, `Result` alias, `propose_rules`, `write_proposals` | Called from `crates/daemon/src/execution.rs` |

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo check -p aletheia-episteme -p aletheia-nous --all-features` — clean
- [x] `cargo test -p aletheia-episteme -p aletheia-nous --all-features` — 1719 tests pass (1022 episteme lib unit + 690 nous lib unit + 7 proptest, 0 failures)
- [x] `kanon lint crates/episteme --rust --summary` — 60 → 25 `RUST/pub-visibility` violations

## Notes on the workspace baseline

Two pre-existing bugs showed up during verification and are out of scope
for this PR:

- `cargo check --workspace --all-features` fails on `aletheia-symbolon`
  (`KeyringCredentialProvider` is declared `pub(crate)` but re-exported
  as `pub` from `credential/mod.rs`). The `keyring` feature surface has
  been broken on main for at least the window this PR was authored in.
- Several pre-existing rustdoc "unresolved link" warnings remain in
  episteme (`CausalEdge`, `CausalStore`, `EmbeddingProvider`,
  `MAX_MEMORY_ENTRIES`, `PROMOTION_THRESHOLD`). Only the doc links this
  PR broke by downgrading items were rewritten here; the inherited
  warnings are not my regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)