### PR TITLE
test(krites): concurrency stress tests for unsafe Sync sites (#2864)

### DIFF
--- a/crates/krites/src/runtime/hnsw/mmap_storage.rs
+++ b/crates/krites/src/runtime/hnsw/mmap_storage.rs
@@ -89,8 +89,35 @@ enum StorageInner {
     Heap(Vec<u8>),
 }
 
-// WHY: the mmap pointer is process-wide and we control all access through
-// &self / &mut self, so Send + Sync is safe.
+// SAFETY: `StorageInner` contains a raw `*mut u8` (the mmap pointer) which makes
+// it `!Send + !Sync` by default. We assert both manually under the following
+// invariants, all of which are structurally enforced by the public API on the
+// owning `MmapVectorStorage`:
+//
+// 1. The pointer is set exactly twice: once in `create_inner` (during `open`,
+//    which returns an owned value before any sharing is possible) and once in
+//    `remap` (which takes `&mut self` on the owning storage). Both mutation
+//    points require unique access, so no thread can observe a torn pointer.
+//
+// 2. Read access goes through `as_bytes()`, which takes `&self` on the owning
+//    storage. Rust's aliasing rules guarantee that no `&mut self` call (i.e.
+//    `push` / `remap`) can overlap with any `&self` read, so the pointer is
+//    always either being uniquely updated or being shared for read.
+//
+// 3. The mmap region is backed by `MAP_SHARED` with `PROT_READ | PROT_WRITE`.
+//    Concurrent reads from multiple threads through `&self` are sound because
+//    (a) the kernel provides cache coherence for the mapped pages and (b) the
+//    only writer path is `push`, which goes through `write_at` on the backing
+//    `File` and then calls `remap` under `&mut self` — so the readable window
+//    grows monotonically and no reader ever observes a partially-written
+//    vector.
+//
+// 4. On `Drop`, `munmap` is called while the value is uniquely owned, so no
+//    other thread holds a reference to the pointer.
+//
+// `Send` is sound for the same reason: the owning `MmapVectorStorage` enforces
+// exclusive access during mutation, so transferring ownership between threads
+// never races with an active borrower.
 unsafe impl Send for StorageInner {}
 unsafe impl Sync for StorageInner {}
 
@@ -542,5 +569,59 @@ mod tests {
         let storage = MmapVectorStorage::open(&path, 4).unwrap_or_else(|_| unreachable!());
         assert!(storage.is_empty(), "empty file yields empty storage");
         assert!(storage.get(0).is_none(), "no vectors in empty storage");
+    }
+
+    /// Stress test: 16 threads × 1000 reads against a shared `MmapVectorStorage`.
+    ///
+    /// WHY: `StorageInner` carries a manual `unsafe impl Sync`. This test is a
+    /// runtime sanity check that concurrent `&self` reads through the Sync
+    /// boundary produce consistent results and do not crash the process.
+    /// Each thread reads every vector in the storage and asserts the payload
+    /// matches the deterministic pattern written during setup.
+    #[test]
+    fn concurrent_reads_are_consistent() {
+        const DIM: usize = 8;
+        const NUM_VECTORS: usize = 64;
+        const NUM_THREADS: usize = 16;
+        const READS_PER_THREAD: usize = 1000;
+
+        let dir = tempfile::tempdir().unwrap_or_else(|_| unreachable!());
+        let path = dir.path().join("stress.bin");
+        let mut storage = MmapVectorStorage::open(&path, DIM).unwrap_or_else(|_| unreachable!());
+
+        // Deterministic pattern: vector[i][j] = (i * DIM + j) as f32
+        for i in 0..NUM_VECTORS {
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "test fixture uses small integers well within f32 mantissa range"
+            )]
+            let vec: Vec<f32> = (0..DIM).map(|j| (i * DIM + j) as f32).collect();
+            storage.push(&vec).unwrap_or_else(|_| unreachable!());
+        }
+
+        let storage_ref = &storage;
+        std::thread::scope(|s| {
+            for _ in 0..NUM_THREADS {
+                s.spawn(move || {
+                    for _ in 0..READS_PER_THREAD {
+                        for i in 0..NUM_VECTORS {
+                            let v = storage_ref.get(i).unwrap_or_else(|| unreachable!());
+                            assert_eq!(v.len(), DIM, "vector length stable under concurrent read");
+                            for (j, &val) in v.iter().enumerate() {
+                                #[expect(
+                                    clippy::cast_precision_loss,
+                                    reason = "test fixture uses small integers well within f32 mantissa range"
+                                )]
+                                let expected = (i * DIM + j) as f32;
+                                assert!(
+                                    (val - expected).abs() < f32::EPSILON,
+                                    "vector[{i}][{j}] = {val}, expected {expected}"
+                                );
+                            }
+                        }
+                    }
+                });
+            }
+        });
     }
 }

--- a/crates/krites/src/storage/fjall_backend.rs
+++ b/crates/krites/src/storage/fjall_backend.rs
@@ -133,10 +133,42 @@ pub struct FjallWriteTx<'s> {
     keyspace: &'s fjall::SingleWriterTxKeyspace,
 }
 
-// SAFETY: fjall's Snapshot is a read-only view with no interior mutability, so
-// sharing a reference across threads is sound. SingleWriterWriteTx is protected
-// by an external mutex guard at the call site, ensuring exclusive access while
-// the reference is live. Both impls are therefore safe to declare Sync.
+// SAFETY: `FjallReadTx` and `FjallWriteTx` borrow fjall internals that are not
+// currently marked `Sync` upstream, even though the contents they expose are
+// safe for shared access under the invariants below. The `StoreTx` trait takes
+// `&self` for read methods, which requires both wrappers to be `Sync` so the
+// outer `FjallTx` enum (carried across query worker threads via rayon) type-
+// checks. Asserting `Sync` manually is sound because:
+//
+// 1. `FjallReadTx::snapshot` is `fjall::Snapshot`, an immutable point-in-time
+//    LSM view. Its public API is `Readable::get`/`contains_key`/`range`, all of
+//    which take `&self` and perform purely read-only work on frozen SSTable
+//    references + an MVCC key cap. There is no interior mutability, no shared
+//    buffer, and no state that changes across calls, so concurrent `&self`
+//    calls from multiple threads are race-free by construction.
+//
+// 2. `FjallWriteTx::tx` is `fjall::SingleWriterWriteTx`, which — as the name
+//    implies — is the exclusive writer handle for the database. It is obtained
+//    by `SingleWriterTxDatabase::write_tx`, a call that serializes writers
+//    through an internal mutex. The handle itself is therefore never shared
+//    with a concurrent writer at the fjall layer, and all mutating methods
+//    on `FjallWriteTx` (`put`, `del`, `del_range_from_persisted`, `commit`) go
+//    through `&mut self` on the outer `FjallTx`. The only `&self` path that
+//    touches the write tx is `StoreTx::get`, which calls `Readable::get` on
+//    the tx — a read-your-own-writes query that fjall implements against the
+//    tx's immutable memtable snapshot, with no observable mutation. Concurrent
+//    `&self` gets on the same write tx are therefore sound for the same reason
+//    as (1).
+//
+// 3. Both wrappers carry a `&'s fjall::SingleWriterTxKeyspace`. The keyspace
+//    is a long-lived handle used only as a lookup key for reads; fjall already
+//    provides thread-safe access to the keyspace through its own internal
+//    synchronization.
+//
+// If fjall upstream adds `Sync` to its transaction types, these impls become
+// redundant and should be removed. Tracked implicitly in the fjall version
+// pin — any upgrade that surfaces native `Sync` will make the `#[expect]`
+// here unfulfilled and force cleanup.
 #[expect(
     unsafe_code,
     reason = "fjall transaction types require manual Sync; soundness documented above"
@@ -462,6 +494,7 @@ impl Iterator for CollectedSkipIterator {
 )]
 mod tests {
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     use tempfile::TempDir;
 
@@ -671,6 +704,142 @@ mod tests {
             ScriptMutability::Immutable,
         )?;
         assert_eq!(result.rows.len(), 1);
+
+        Ok(())
+    }
+
+    /// Stress test: 16 threads × 1000 concurrent read queries against the same db.
+    ///
+    /// WHY: `FjallReadTx` carries a manual `unsafe impl Sync`. This test
+    /// exercises the Sync boundary from many threads simultaneously and
+    /// asserts each query returns the same deterministic result set. A crash
+    /// or torn read would fail the correctness check.
+    #[test]
+    fn stress_concurrent_reads() -> InternalResult<()> {
+        const NUM_THREADS: usize = 16;
+        const QUERIES_PER_THREAD: usize = 1000;
+        const NUM_ROWS: i64 = 100;
+
+        let (_dir, db) = setup_test_db()?;
+
+        // Seed deterministic data.
+        let mut to_import = BTreeMap::new();
+        to_import.insert(
+            "plain".to_string(),
+            crate::NamedRows {
+                headers: vec!["k".to_string(), "v".to_string()],
+                rows: (0..NUM_ROWS)
+                    .map(|i| vec![DataValue::from(i), DataValue::from(i * 3)])
+                    .collect(),
+                next: None,
+            },
+        );
+        db.import_relations(to_import)?;
+
+        let expected_rows = usize::try_from(NUM_ROWS).unwrap_or_else(|_| unreachable!());
+        std::thread::scope(|s| {
+            for _ in 0..NUM_THREADS {
+                let db = db.clone();
+                s.spawn(move || {
+                    for _ in 0..QUERIES_PER_THREAD {
+                        let result = db
+                            .run_script(
+                                "?[k, v] := *plain{k, v}",
+                                Default::default(),
+                                ScriptMutability::Immutable,
+                            )
+                            .unwrap_or_else(|_| unreachable!());
+                        assert_eq!(
+                            result.rows.len(),
+                            expected_rows,
+                            "concurrent read saw partial relation"
+                        );
+                    }
+                });
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Stress test: 1 writer + 15 readers hitting the same db.
+    ///
+    /// WHY: fjall's `SingleWriterWriteTx` serializes writers internally, but
+    /// readers open independent snapshot transactions. The `Sync` asserts
+    /// on `FjallReadTx` and `FjallWriteTx` must hold while a live writer is
+    /// mutating the LSM. This test verifies no reader observes a torn row
+    /// (headers mismatched, partial vector, or panic) across 1000 writes.
+    #[test]
+    fn stress_mixed_read_write() -> InternalResult<()> {
+        const NUM_READERS: usize = 15;
+        const NUM_WRITES: i64 = 1000;
+
+        let (_dir, db) = setup_test_db()?;
+
+        // Seed some initial data so readers have something to read from the start.
+        let mut to_import = BTreeMap::new();
+        to_import.insert(
+            "plain".to_string(),
+            crate::NamedRows {
+                headers: vec!["k".to_string(), "v".to_string()],
+                rows: (0..10)
+                    .map(|i| vec![DataValue::from(i), DataValue::from(i * 7)])
+                    .collect(),
+                next: None,
+            },
+        );
+        db.import_relations(to_import)?;
+
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        std::thread::scope(|s| {
+            // Readers: keep querying until the writer signals completion.
+            for _ in 0..NUM_READERS {
+                let db = db.clone();
+                let done = Arc::clone(&done);
+                s.spawn(move || {
+                    while !done.load(std::sync::atomic::Ordering::Relaxed) {
+                        let result = db
+                            .run_script(
+                                "?[k, v] := *plain{k, v}",
+                                Default::default(),
+                                ScriptMutability::Immutable,
+                            )
+                            .unwrap_or_else(|_| unreachable!());
+                        // Every row must have exactly 2 columns matching the
+                        // relation schema. A torn read would surface here.
+                        for row in &result.rows {
+                            assert_eq!(row.len(), 2, "schema consistent under concurrent writes");
+                        }
+                    }
+                });
+            }
+
+            // Writer: upsert rows in a loop.
+            let db_writer = db.clone();
+            let done_writer = Arc::clone(&done);
+            s.spawn(move || {
+                for i in 10..NUM_WRITES {
+                    db_writer
+                        .run_script(
+                            &format!("?[k, v] <- [[{i}, {}]] :put plain {{k => v}}", i * 7),
+                            Default::default(),
+                            ScriptMutability::Mutable,
+                        )
+                        .unwrap_or_else(|_| unreachable!());
+                }
+                done_writer.store(true, std::sync::atomic::Ordering::Relaxed);
+            });
+        });
+
+        // Final consistency check: all writes visible.
+        let result = db.run_script(
+            "?[k, v] := *plain{k, v}",
+            Default::default(),
+            ScriptMutability::Immutable,
+        )?;
+        let expected_total = usize::try_from(NUM_WRITES).unwrap_or_else(|_| unreachable!());
+        assert_eq!(result.rows.len(), expected_total, "all writes persisted");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Adds runtime stress tests and strengthens safety comments for the two manual `unsafe impl Sync` sites in krites, addressing the first two of three asks in #2864.

### Strengthened safety comments

- **`StorageInner`** (`crates/krites/src/runtime/hnsw/mmap_storage.rs`) — documents the four invariants that make the raw mmap pointer safe to share: (1) pointer mutation only through `&mut self`, (2) reads gated by `&self` on the owning storage, (3) `MAP_SHARED` cache coherence + monotonic-grow write path, (4) `Drop` runs under unique ownership.
- **`FjallReadTx` / `FjallWriteTx`** (`crates/krites/src/storage/fjall_backend.rs`) — documents why fjall's `Snapshot` (immutable point-in-time view) and `SingleWriterWriteTx` (serialized writer with read-your-own-writes against an immutable memtable snapshot) are race-free under `&self` access, even though upstream fjall doesn't yet mark them `Sync`. Notes that any future upstream `Sync` will make the `#[expect(unsafe_code)]` unfulfilled and force cleanup.

### Stress tests added

- `concurrent_reads_are_consistent` (mmap_storage): 16 threads × 1000 reads × 64 vectors of dim 8, each thread asserts every vector matches a deterministic payload.
- `stress_concurrent_reads` (fjall_backend): 16 threads × 1000 read queries against 100 seeded rows, each asserts the full relation is visible.
- `stress_mixed_read_write` (fjall_backend): 1 writer + 15 readers. Writer upserts 1000 rows while readers continuously scan. Readers assert row schema (exactly 2 columns) is stable; final check asserts all writes persisted.

### Deferred to follow-up

Loom model-checking (the third ask in #2864). `loom` is not yet a workspace dep and introducing it is a separate scope decision — it would replace `std::thread::scope` with `loom::thread::spawn` and add exhaustive interleaving analysis on top of these runtime sanity tests. Will be tracked in a new issue once this merges.

## Test plan

- [x] `cargo test -p aletheia-krites --features storage-fjall concurrent_reads_are_consistent` — passes
- [x] `cargo test -p aletheia-krites --features storage-fjall stress_concurrent_reads` — passes
- [x] `cargo test -p aletheia-krites --features storage-fjall stress_mixed_read_write` — passes
- [x] `cargo clippy -p aletheia-krites --features storage-fjall --all-targets -- -D warnings` — green
- [x] All pre-existing mmap_storage + fjall_backend tests still pass

Closes #2864 (partial — loom deferred to follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)