### PR TITLE
feat(episteme): memory admission control gate for fact insertion (#2853)

### DIFF
--- a/crates/episteme/src/admission.rs
+++ b/crates/episteme/src/admission.rs
@@ -1,0 +1,443 @@
+//! Memory admission control: structured decision gate for knowledge graph insertion.
+//!
+//! Based on A-MAC (arxiv 2603.04549, Mar 2026) which formalizes admission as a
+//! five-factor decision: utility, confidence, novelty, recency, and content type
+//! prior. Without admission control, low-value facts accumulate, redundant facts
+//! enter alongside existing knowledge, and hallucinated extractions persist until
+//! temporal decay removes them.
+//!
+//! # Architecture
+//!
+//! The [`AdmissionPolicy`] trait defines the gate. [`KnowledgeStore::insert_fact`]
+//! calls `policy.should_admit()` before writing to the Datalog engine.
+//! [`DefaultAdmissionPolicy`] admits everything (preserving current behavior).
+//! [`StructuredAdmissionPolicy`] applies the five-factor decision.
+
+use crate::knowledge::Fact;
+
+/// Result of an admission check.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AdmissionDecision {
+    /// Fact should be admitted to the knowledge graph.
+    Admit,
+    /// Fact should be rejected. The reason is logged but not surfaced to the user.
+    Reject(AdmissionRejection),
+}
+
+impl AdmissionDecision {
+    /// Returns `true` if the fact is admitted.
+    pub fn is_admitted(&self) -> bool {
+        matches!(self, Self::Admit)
+    }
+}
+
+/// Reason for rejecting a fact at the admission gate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdmissionRejection {
+    /// Which factor(s) caused the rejection.
+    pub factor: RejectionFactor,
+    /// Human-readable explanation (logged at debug level).
+    pub reason: String,
+}
+
+/// The factor that caused a rejection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectionFactor {
+    /// The fact's predicted future utility is too low.
+    LowUtility,
+    /// The source confidence is below the admission threshold.
+    LowConfidence,
+    /// The fact is semantically redundant with existing knowledge.
+    LowNovelty,
+    /// The fact is too old to be worth storing.
+    Stale,
+    /// The content type has a low prior for admission.
+    LowTypePrior,
+    /// Combined score across all factors falls below threshold.
+    BelowThreshold,
+}
+
+impl std::fmt::Display for RejectionFactor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LowUtility => f.write_str("low_utility"),
+            Self::LowConfidence => f.write_str("low_confidence"),
+            Self::LowNovelty => f.write_str("low_novelty"),
+            Self::Stale => f.write_str("stale"),
+            Self::LowTypePrior => f.write_str("low_type_prior"),
+            Self::BelowThreshold => f.write_str("below_threshold"),
+        }
+    }
+}
+
+/// Scores from the five admission factors (all in 0.0..=1.0).
+#[derive(Debug, Clone)]
+pub struct AdmissionScores {
+    /// Predicted future utility (will this fact be needed later?).
+    pub utility: f64,
+    /// Source reliability (LLM extraction < user statement < external source).
+    pub confidence: f64,
+    /// Semantic novelty (1.0 = completely new, 0.0 = exact duplicate).
+    pub novelty: f64,
+    /// Temporal recency (1.0 = just now, decays toward 0.0).
+    pub recency: f64,
+    /// Content type prior (identity facts > preferences > transient observations).
+    pub type_prior: f64,
+}
+
+impl AdmissionScores {
+    /// Weighted combination of all five factors.
+    ///
+    /// Default weights from A-MAC: `utility` 0.25, `confidence` 0.20, `novelty` 0.25,
+    /// `recency` 0.15, `type_prior` 0.15.
+    pub fn combined(&self) -> f64 {
+        self.utility * 0.25
+            + self.confidence * 0.20
+            + self.novelty * 0.25
+            + self.recency * 0.15
+            + self.type_prior * 0.15
+    }
+}
+
+/// Gate that decides whether a fact should enter the knowledge graph.
+///
+/// Implementations range from [`DefaultAdmissionPolicy`] (admit all — current
+/// behavior) to [`StructuredAdmissionPolicy`] (five-factor A-MAC decision).
+pub trait AdmissionPolicy: Send + Sync {
+    /// Evaluate whether `fact` should be admitted.
+    ///
+    /// Implementations may query the existing knowledge graph (e.g. for novelty
+    /// checks) but should avoid expensive operations — this runs on every
+    /// `insert_fact` call.
+    fn should_admit(&self, fact: &Fact) -> AdmissionDecision;
+}
+
+/// Admits all facts that pass basic validation.
+///
+/// This preserves the pre-admission-control behavior: if a fact reaches
+/// `insert_fact`, it gets stored. Validation (non-empty content, content length
+/// limit, confidence range) is handled separately by `insert_fact` itself.
+#[derive(Debug, Clone, Default)]
+pub struct DefaultAdmissionPolicy;
+
+impl AdmissionPolicy for DefaultAdmissionPolicy {
+    fn should_admit(&self, _fact: &Fact) -> AdmissionDecision {
+        AdmissionDecision::Admit
+    }
+}
+
+/// Configuration for the structured admission policy.
+#[derive(Debug, Clone)]
+pub struct StructuredAdmissionConfig {
+    /// Minimum combined score to admit (0.0..=1.0). Default: 0.3.
+    pub threshold: f64,
+    /// Minimum confidence to admit without other factors. Default: 0.1.
+    pub min_confidence: f64,
+    /// Maximum age in hours before a fact is considered stale. Default: 2160 (90 days).
+    pub max_age_hours: f64,
+}
+
+impl Default for StructuredAdmissionConfig {
+    fn default() -> Self {
+        Self {
+            threshold: 0.3,
+            min_confidence: 0.1,
+            max_age_hours: 2160.0,
+        }
+    }
+}
+
+/// Five-factor admission policy based on A-MAC (arxiv 2603.04549).
+///
+/// Evaluates each fact against utility, confidence, novelty, recency, and
+/// content type prior. The combined weighted score must exceed the configured
+/// threshold for admission.
+///
+/// This is a heuristic gate — it catches obvious low-value insertions without
+/// requiring LLM evaluation. The weights and thresholds are tunable via
+/// [`StructuredAdmissionConfig`].
+#[derive(Debug, Clone)]
+pub struct StructuredAdmissionPolicy {
+    config: StructuredAdmissionConfig,
+}
+
+impl StructuredAdmissionPolicy {
+    /// Create a new structured admission policy with the given configuration.
+    pub fn new(config: StructuredAdmissionConfig) -> Self {
+        Self { config }
+    }
+
+    /// Score a fact across all five factors.
+    pub fn score(&self, fact: &Fact) -> AdmissionScores {
+        AdmissionScores {
+            utility: self.score_utility(fact),
+            confidence: self.score_confidence(fact),
+            novelty: 1.0, // Novelty requires store query — default to fully novel
+            recency: self.score_recency(fact),
+            type_prior: self.score_type_prior(fact),
+        }
+    }
+
+    /// Utility: content length as a rough proxy for information density.
+    ///
+    /// Very short facts (<10 chars) are likely noise. Very long facts are likely
+    /// substantive. The sigmoid maps `[0, 200]` chars to `[0.0, 1.0]`.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "content length well within f64 mantissa range for any realistic fact"
+    )]
+    #[expect(
+        clippy::as_conversions,
+        reason = "usize to f64 — content length is always small enough"
+    )]
+    #[expect(
+        clippy::unused_self,
+        reason = "method takes &self for API consistency; will use config for weight tuning"
+    )]
+    fn score_utility(&self, fact: &Fact) -> f64 {
+        let len = fact.content.len() as f64;
+        // Sigmoid centered at 50 chars, steepness 0.05
+        1.0 / (1.0 + (-0.05 * (len - 50.0)).exp())
+    }
+
+    /// Confidence: direct from the fact's provenance.
+    #[expect(
+        clippy::unused_self,
+        reason = "method takes &self for API consistency; will use config for weight tuning"
+    )]
+    fn score_confidence(&self, fact: &Fact) -> f64 {
+        fact.provenance.confidence
+    }
+
+    /// Recency: exponential decay based on how old the fact's `recorded_at` is.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "nanosecond delta between two timestamps is well within f64 mantissa range for any realistic timespan"
+    )]
+    #[expect(
+        clippy::as_conversions,
+        reason = "i128 nanosecond delta to f64 — precision loss is negligible at this scale"
+    )]
+    fn score_recency(&self, fact: &Fact) -> f64 {
+        let now = jiff::Timestamp::now();
+        let age_nanos = now.as_nanosecond() - fact.temporal.recorded_at.as_nanosecond();
+        if age_nanos <= 0 {
+            return 1.0;
+        }
+        let age_hours = age_nanos as f64 / 3_600_000_000_000.0;
+        // Exponential decay: half-life at max_age_hours / 3
+        let half_life = self.config.max_age_hours / 3.0;
+        (-age_hours * (2.0_f64.ln()) / half_life).exp()
+    }
+
+    /// Type prior: content types with higher base value get higher scores.
+    #[expect(
+        clippy::unused_self,
+        reason = "method takes &self for API consistency; will use config for type-specific priors"
+    )]
+    fn score_type_prior(&self, fact: &Fact) -> f64 {
+        match fact.fact_type.as_str() {
+            // Identity and preference facts have highest retention value
+            "identity" | "preference" | "user" | "feedback" => 0.9,
+            // Structural/project facts are high value
+            "project" | "reference" | "architecture" | "decision" => 0.8,
+            // Behavioral observations are medium value
+            "observation" | "pattern" | "skill" | "instinct" => 0.6,
+            // Session-scoped facts are lower value (often transient)
+            "session" | "context" | "ephemeral" => 0.3,
+            // Unknown types get a neutral prior
+            _ => 0.5,
+        }
+    }
+}
+
+impl AdmissionPolicy for StructuredAdmissionPolicy {
+    fn should_admit(&self, fact: &Fact) -> AdmissionDecision {
+        // Fast-reject: confidence below floor
+        if fact.provenance.confidence < self.config.min_confidence {
+            return AdmissionDecision::Reject(AdmissionRejection {
+                factor: RejectionFactor::LowConfidence,
+                reason: format!(
+                    "confidence {:.2} below minimum {:.2}",
+                    fact.provenance.confidence, self.config.min_confidence
+                ),
+            });
+        }
+
+        let scores = self.score(fact);
+        let combined = scores.combined();
+
+        if combined < self.config.threshold {
+            return AdmissionDecision::Reject(AdmissionRejection {
+                factor: RejectionFactor::BelowThreshold,
+                reason: format!(
+                    "combined score {combined:.3} below threshold {:.3} \
+                     (utility={:.2}, confidence={:.2}, novelty={:.2}, \
+                     recency={:.2}, type_prior={:.2})",
+                    self.config.threshold,
+                    scores.utility,
+                    scores.confidence,
+                    scores.novelty,
+                    scores.recency,
+                    scores.type_prior,
+                ),
+            });
+        }
+
+        AdmissionDecision::Admit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knowledge::{
+        EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
+    };
+
+    fn make_fact(content: &str, confidence: f64, fact_type: &str) -> Fact {
+        let now = jiff::Timestamp::now();
+        Fact {
+            id: crate::id::FactId::new("test-fact-id").unwrap_or_else(|_| unreachable!()),
+            nous_id: "test-nous".to_owned(),
+            fact_type: fact_type.to_owned(),
+            content: content.to_owned(),
+            scope: None,
+            temporal: FactTemporal {
+                valid_from: now,
+                valid_to: crate::knowledge::far_future(),
+                recorded_at: now,
+            },
+            provenance: FactProvenance {
+                confidence,
+                tier: EpistemicTier::Inferred,
+                source_session_id: None,
+                stability_hours: 0.0,
+            },
+            lifecycle: FactLifecycle {
+                superseded_by: None,
+                is_forgotten: false,
+                forgotten_at: None,
+                forget_reason: None,
+            },
+            access: FactAccess {
+                access_count: 0,
+                last_accessed_at: None,
+            },
+        }
+    }
+
+    #[test]
+    fn default_policy_admits_all() {
+        let policy = DefaultAdmissionPolicy;
+        let fact = make_fact("any content", 0.5, "observation");
+        assert!(policy.should_admit(&fact).is_admitted());
+    }
+
+    #[test]
+    fn structured_policy_admits_high_quality_fact() {
+        let policy = StructuredAdmissionPolicy::new(StructuredAdmissionConfig::default());
+        let fact = make_fact(
+            "The user prefers snake_case naming conventions for Rust variables",
+            0.95,
+            "preference",
+        );
+        assert!(policy.should_admit(&fact).is_admitted());
+    }
+
+    #[test]
+    fn structured_policy_rejects_low_confidence() {
+        let policy = StructuredAdmissionPolicy::new(StructuredAdmissionConfig::default());
+        let fact = make_fact("might be something", 0.05, "observation");
+        let decision = policy.should_admit(&fact);
+        assert!(!decision.is_admitted());
+        if let AdmissionDecision::Reject(r) = decision {
+            assert_eq!(r.factor, RejectionFactor::LowConfidence);
+        }
+    }
+
+    #[test]
+    fn structured_policy_rejects_low_combined_score() {
+        let config = StructuredAdmissionConfig {
+            threshold: 0.8, // Very strict
+            ..Default::default()
+        };
+        let policy = StructuredAdmissionPolicy::new(config);
+        // Short content, low confidence, ephemeral type — should fail
+        let fact = make_fact("ok", 0.15, "ephemeral");
+        let decision = policy.should_admit(&fact);
+        assert!(!decision.is_admitted());
+        if let AdmissionDecision::Reject(r) = decision {
+            assert_eq!(r.factor, RejectionFactor::BelowThreshold);
+        }
+    }
+
+    #[test]
+    fn type_prior_scores_are_ordered() {
+        let policy = StructuredAdmissionPolicy::new(StructuredAdmissionConfig::default());
+        let identity = make_fact("x", 0.5, "identity");
+        let project = make_fact("x", 0.5, "project");
+        let observation = make_fact("x", 0.5, "observation");
+        let ephemeral = make_fact("x", 0.5, "ephemeral");
+
+        assert!(policy.score_type_prior(&identity) > policy.score_type_prior(&project));
+        assert!(policy.score_type_prior(&project) > policy.score_type_prior(&observation));
+        assert!(policy.score_type_prior(&observation) > policy.score_type_prior(&ephemeral));
+    }
+
+    #[test]
+    fn utility_increases_with_content_length() {
+        let policy = StructuredAdmissionPolicy::new(StructuredAdmissionConfig::default());
+        let short = make_fact("hi", 0.5, "observation");
+        let medium = make_fact(
+            "The user prefers detailed explanations with examples",
+            0.5,
+            "observation",
+        );
+        let long = make_fact(
+            &"x".repeat(200),
+            0.5,
+            "observation",
+        );
+
+        assert!(policy.score_utility(&short) < policy.score_utility(&medium));
+        assert!(policy.score_utility(&medium) < policy.score_utility(&long));
+    }
+
+    #[test]
+    fn recency_decays_with_age() {
+        let policy = StructuredAdmissionPolicy::new(StructuredAdmissionConfig::default());
+        let now = jiff::Timestamp::now();
+
+        let recent = make_fact("x", 0.5, "observation");
+
+        let mut old = make_fact("x", 0.5, "observation");
+        old.temporal.recorded_at = now
+            .checked_sub(jiff::SignedDuration::from_hours(720))
+            .unwrap_or(now);
+
+        assert!(policy.score_recency(&recent) > policy.score_recency(&old));
+    }
+
+    #[test]
+    fn combined_score_is_weighted_average() {
+        let scores = AdmissionScores {
+            utility: 1.0,
+            confidence: 1.0,
+            novelty: 1.0,
+            recency: 1.0,
+            type_prior: 1.0,
+        };
+        let combined = scores.combined();
+        assert!((combined - 1.0).abs() < f64::EPSILON, "all 1.0 should combine to 1.0");
+
+        let scores_zero = AdmissionScores {
+            utility: 0.0,
+            confidence: 0.0,
+            novelty: 0.0,
+            recency: 0.0,
+            type_prior: 0.0,
+        };
+        assert!(scores_zero.combined().abs() < f64::EPSILON, "all 0.0 should combine to 0.0");
+    }
+}

--- a/crates/episteme/src/extract/observation.rs
+++ b/crates/episteme/src/extract/observation.rs
@@ -184,11 +184,7 @@ pub struct RawObservation {
 /// individual observation. Handles continuation lines (indented text
 /// that is part of the same bullet).
 #[must_use]
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "PR observation parser exercised from tests; steward wiring lands with the training extractor")
-)]
-pub(crate) fn parse_observations(pr_body: &str) -> Vec<RawObservation> {
+pub fn parse_observations(pr_body: &str) -> Vec<RawObservation> {
     let Some(section) = extract_observations_section(pr_body) else {
         return Vec::new();
     };
@@ -346,7 +342,7 @@ static FILE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Tags include crate names matching `crates/{name}` or backtick-wrapped
 /// crate references, and file paths matching common patterns.
 #[must_use]
-pub(crate) fn extract_tags(text: &str) -> Vec<String> {
+pub fn extract_tags(text: &str) -> Vec<String> {
     let mut tags = Vec::new();
 
     for cap in CRATE_PATH_RE.captures_iter(text) {

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -5,6 +5,10 @@ use super::{KnowledgeStore, queries};
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
     /// Insert or update a fact.
+    ///
+    /// The fact is validated (non-empty content, length limit, confidence range)
+    /// and then passed through the configured [`AdmissionPolicy`](crate::admission::AdmissionPolicy).
+    /// If the policy rejects the fact, returns [`Error::AdmissionRejected`](crate::error::Error::AdmissionRejected).
     #[instrument(skip(self, fact), fields(fact_id = %fact.id))]
     pub fn insert_fact(&self, fact: &crate::knowledge::Fact) -> crate::error::Result<()> {
         use snafu::ensure;
@@ -22,6 +26,22 @@ impl KnowledgeStore {
                 value: fact.provenance.confidence
             }
         );
+
+        // Admission control gate: check policy before persisting.
+        let decision = self.admission_policy.should_admit(fact);
+        if let crate::admission::AdmissionDecision::Reject(rejection) = decision {
+            tracing::debug!(
+                fact_id = %fact.id,
+                factor = %rejection.factor,
+                reason = %rejection.reason,
+                "fact rejected by admission policy"
+            );
+            return Err(crate::error::AdmissionRejectedSnafu {
+                reason: rejection.reason,
+            }
+            .build());
+        }
+
         let params = fact_to_params(fact);
         let result = self.run_mut(&queries::upsert_fact(), params);
         if result.is_ok() {

--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -204,16 +204,30 @@ impl From<crate::engine::NamedRows> for QueryResult {
 
 /// Configuration for `KnowledgeStore` initialization.
 #[cfg(feature = "mneme-engine")]
-#[derive(Clone, Copy, Debug)]
 pub struct KnowledgeConfig {
     /// Embedding dimension for the HNSW index.
     pub dim: usize,
+    /// Admission policy for fact insertion. Default: [`DefaultAdmissionPolicy`](crate::admission::DefaultAdmissionPolicy).
+    pub admission_policy: Box<dyn crate::admission::AdmissionPolicy>,
+}
+
+#[cfg(feature = "mneme-engine")]
+impl std::fmt::Debug for KnowledgeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KnowledgeConfig")
+            .field("dim", &self.dim)
+            .field("admission_policy", &"<dyn AdmissionPolicy>")
+            .finish()
+    }
 }
 
 #[cfg(feature = "mneme-engine")]
 impl Default for KnowledgeConfig {
     fn default() -> Self {
-        Self { dim: 384 }
+        Self {
+            dim: 384,
+            admission_policy: Box::new(crate::admission::DefaultAdmissionPolicy),
+        }
     }
 }
 
@@ -277,6 +291,8 @@ pub struct KnowledgeStore {
     dim: usize,
     /// Serializes read-modify-write access counter increments to prevent races.
     access_lock: std::sync::Mutex<()>,
+    /// Admission policy gate: checked before every fact insertion.
+    admission_policy: Box<dyn crate::admission::AdmissionPolicy>,
 }
 
 #[cfg(feature = "mneme-engine")]
@@ -312,6 +328,7 @@ impl KnowledgeStore {
             db: std::sync::Arc::new(db),
             dim: config.dim,
             access_lock: std::sync::Mutex::new(()),
+            admission_policy: config.admission_policy,
         };
         store.init_schema()?;
         Ok(std::sync::Arc::new(store))
@@ -342,6 +359,7 @@ impl KnowledgeStore {
             db: std::sync::Arc::new(db),
             dim: config.dim,
             access_lock: std::sync::Mutex::new(()),
+            admission_policy: config.admission_policy,
         };
         store.init_schema()?;
         Ok(std::sync::Arc::new(store))

--- a/crates/episteme/src/knowledge_store/tests/ddl.rs
+++ b/crates/episteme/src/knowledge_store/tests/ddl.rs
@@ -117,7 +117,7 @@ fn hybrid_search_empty_seeds_returns_results() {
     };
 
     let dim = 4;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
 
     let fact = Fact {
         id: crate::id::FactId::new("f1").expect("valid test id"),
@@ -198,7 +198,7 @@ fn hybrid_search_graph_aggregation() {
     };
 
     let dim = 4;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
 
     let f1 = Fact {
         id: crate::id::FactId::new("f1").expect("valid test id"),
@@ -372,7 +372,7 @@ fn hybrid_search_two_signal_no_graph() {
     };
 
     let dim = 4;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
 
     let fact = Fact {
         id: crate::id::FactId::new("f-twosig").expect("valid test id"),
@@ -462,7 +462,7 @@ fn hybrid_search_absent_signal_rank_is_negative_one() {
     };
 
     let dim = 4;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
 
     let fact = Fact {
         id: crate::id::FactId::new("f-bm25-only").expect("valid test id"),

--- a/crates/episteme/src/knowledge_store/tests/entities.rs
+++ b/crates/episteme/src/knowledge_store/tests/entities.rs
@@ -15,7 +15,7 @@ use crate::knowledge::{
 const DIM: usize = 4;
 
 fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
 }
 
 fn test_ts(s: &str) -> jiff::Timestamp {

--- a/crates/episteme/src/knowledge_store/tests/facts/crud.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/crud.rs
@@ -16,7 +16,7 @@ use crate::knowledge::{
 const DIM: usize = 4;
 
 fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
 }
 
 fn test_ts(s: &str) -> jiff::Timestamp {
@@ -56,7 +56,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
 
 #[test]
 fn query_timeout_returns_typed_error() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
 
     // WHY: Recursive transitive closure on a linear chain of N nodes requires N-1 semi-naive
     // fixpoint epochs. Each epoch checks the Poison flag. With N=2000 and timeout=50ms
@@ -87,7 +87,7 @@ reach[a, c] := reach[a, b], edge[b, c]
 
 #[test]
 fn query_without_timeout_succeeds() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
 
     let result = store.run_query_with_timeout("?[x] := x = 42", BTreeMap::new(), None);
 

--- a/crates/episteme/src/knowledge_store/tests/facts/queries.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/queries.rs
@@ -17,7 +17,7 @@ use crate::knowledge::{
 const DIM: usize = 4;
 
 fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
 }
 
 fn test_ts(s: &str) -> jiff::Timestamp {

--- a/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
@@ -17,7 +17,7 @@ use crate::knowledge::{
 const DIM: usize = 4;
 
 fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
 }
 
 fn test_ts(s: &str) -> jiff::Timestamp {

--- a/crates/episteme/src/knowledge_store/tests/proptests.rs
+++ b/crates/episteme/src/knowledge_store/tests/proptests.rs
@@ -18,7 +18,7 @@ use crate::knowledge::{
 const DIM: usize = 4;
 
 fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
 }
 
 fn test_ts(s: &str) -> jiff::Timestamp {
@@ -243,7 +243,7 @@ mod merge {
     const RELATION_TYPES: &[&str] = &["KNOWS", "WORKS_AT", "DEPENDS_ON", "USES", "PART_OF"];
 
     fn make_store() -> Arc<KnowledgeStore> {
-        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 })
+        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() })
             .expect("in-memory store should always open")
     }
 

--- a/crates/episteme/src/knowledge_store/tests/search.rs
+++ b/crates/episteme/src/knowledge_store/tests/search.rs
@@ -15,7 +15,7 @@ use crate::knowledge::{
 const DIM: usize = 4;
 
 fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
 }
 
 fn test_ts(s: &str) -> jiff::Timestamp {
@@ -169,7 +169,7 @@ mod correctness {
     const DIM: usize = 4;
 
     fn make_store() -> std::sync::Arc<KnowledgeStore> {
-        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM })
+        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() })
             .expect("open in-memory store")
     }
 

--- a/crates/episteme/src/knowledge_store/tests/skills.rs
+++ b/crates/episteme/src/knowledge_store/tests/skills.rs
@@ -14,7 +14,7 @@ use crate::knowledge::{
 const DIM: usize = 4;
 
 fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
 }
 
 fn test_ts(s: &str) -> jiff::Timestamp {

--- a/crates/episteme/src/knowledge_store/tests/temporal.rs
+++ b/crates/episteme/src/knowledge_store/tests/temporal.rs
@@ -14,7 +14,7 @@ use crate::knowledge::{
 const DIM: usize = 4;
 
 fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
 }
 
 fn test_ts(s: &str) -> jiff::Timestamp {

--- a/crates/episteme/src/lib.rs
+++ b/crates/episteme/src/lib.rs
@@ -15,6 +15,8 @@ pub use aletheia_eidos::knowledge;
 /// Error types (re-exported from `graphe`).
 pub use aletheia_graphe::error;
 
+/// Memory admission control: structured decision gate for knowledge graph insertion.
+pub mod admission;
 /// Causal edge store: directed graph of causal relationships between facts.
 pub mod causal;
 /// Conflict detection pipeline for fact insertion.

--- a/crates/graphe/src/error.rs
+++ b/crates/graphe/src/error.rs
@@ -227,6 +227,15 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Fact rejected by admission control policy.
+    #[snafu(display("admission rejected: {reason}"))]
+    AdmissionRejected {
+        /// Human-readable reason from the admission policy.
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// A timestamp string could not be parsed.
     #[snafu(display("invalid timestamp: {source}"))]
     InvalidTimestamp {

--- a/crates/integration-tests/tests/access_tracking.rs
+++ b/crates/integration-tests/tests/access_tracking.rs
@@ -27,7 +27,7 @@ fn ts(s: &str) -> jiff::Timestamp {
 }
 
 fn open_store(dim: usize) -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem")
 }
 
 fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -100,7 +100,7 @@ fn make_chunk(
 // TEST-02: Fact inserted via insert_fact is queryable and returns identical data.
 #[test]
 fn fact_round_trip() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
 
     let fact = Fact {
         id: FactId::new("f-1").expect("valid test id"),
@@ -147,7 +147,7 @@ fn fact_round_trip() {
 #[test]
 fn hnsw_vector_search() {
     let dim = 16;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
     let provider = MockEmbeddingProvider::new(dim);
 
     let texts = [
@@ -184,7 +184,7 @@ fn hnsw_vector_search() {
 // INTG-05: Schema version is queryable and matches SCHEMA_VERSION constant.
 #[test]
 fn schema_version_queryable() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
     let version = store.schema_version().expect("version");
     assert_eq!(version, 6);
 }
@@ -215,7 +215,7 @@ fn multiple_facts_ordered_by_confidence() {
 // INTG-04: spawn_blocking async wrappers work from #[tokio::test] context.
 #[tokio::test]
 async fn async_spawn_blocking_wrapper() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
 
     let fact = make_fact(
         "f-async",
@@ -238,7 +238,7 @@ async fn async_spawn_blocking_wrapper() {
 // Raw query escape hatch returns the expected relations.
 #[test]
 fn raw_query_escape_hatch() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
 
     let rows = store
         .run_query("::relations", BTreeMap::new())
@@ -254,7 +254,7 @@ fn raw_query_escape_hatch() {
 #[test]
 fn hybrid_retrieval_end_to_end() {
     let dim = 8;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
 
     let facts = [
         ("fact-1", "Rust is a systems programming language", 0.9f64),
@@ -348,7 +348,7 @@ fn hybrid_retrieval_end_to_end() {
 #[test]
 fn hnsw_connectivity_after_delete_reinsert_cycles() {
     let dim = 8;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
 
     let primes: [u64; 8] = [7, 11, 13, 17, 19, 23, 29, 31];
     let make_vec = |i: u64| -> Vec<f32> {

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -254,7 +254,7 @@ struct AuditRow {
 }
 
 fn open_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4 }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem")
 }
 
 #[path = "knowledge_lifecycle/forget.rs"]

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -77,6 +77,8 @@ pub mod training;
 
 // ── Knowledge pipeline (episteme) ──────────────────────────────────────────
 
+/// Memory admission control: structured decision gate for knowledge graph insertion.
+pub use aletheia_episteme::admission;
 /// Conflict detection pipeline for fact insertion.
 pub use aletheia_episteme::conflict;
 /// LLM-driven fact consolidation for knowledge maintenance.

--- a/crates/nous/src/recall_tests.rs
+++ b/crates/nous/src/recall_tests.rs
@@ -314,7 +314,7 @@ mod knowledge_bridge_tests {
     const DIM: usize = 4;
 
     fn make_store() -> Arc<KnowledgeStore> {
-        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM })
+        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() })
             .expect("open in-memory store")
     }
 


### PR DESCRIPTION
## Summary

Adds a structured admission control layer between fact validation and persistence, based on A-MAC (arxiv 2603.04549, Mar 2026). The admission gate evaluates each fact across five factors before allowing it into the knowledge graph.

### New: `episteme::admission` module

- **`AdmissionPolicy` trait**: `should_admit(fact) -> AdmissionDecision`
- **`DefaultAdmissionPolicy`**: admits all (preserves current behavior)
- **`StructuredAdmissionPolicy`**: five-factor weighted decision:
  - Utility (content length sigmoid)
  - Confidence (direct from provenance)
  - Novelty (placeholder — requires store query for dedup, deferred)
  - Recency (exponential decay from `recorded_at`)
  - Type prior (identity > preference > observation > ephemeral)
- **`AdmissionScores`**: transparent breakdown of all five factor scores
- **`AdmissionDecision`**: `Admit | Reject(factor, reason)`
- **`StructuredAdmissionConfig`**: tunable threshold (default 0.3), min confidence (0.1), max age (90 days)

### Wiring

- `KnowledgeConfig` gains an `admission_policy` field (defaults to `DefaultAdmissionPolicy`)
- `KnowledgeStore::insert_fact` calls `policy.should_admit()` before `run_mut`
- Rejected facts return `Error::AdmissionRejected` with the rejection reason
- Re-exported through `mneme::admission`

### Also in this PR

- Fix pre-existing bench visibility bug: `parse_observations` and `extract_tags` were downgraded to `pub(crate)` by the pub-visibility audit (#2763), but the episteme observation bench imports them externally. Restored to `pub`.

## Test plan

- [x] 8 unit tests: default admits all, structured admits high-quality, rejects low confidence, rejects below threshold, type prior ordering, utility increases with length, recency decays with age, combined score is weighted average
- [x] `cargo clippy -p aletheia-episteme --features mneme-engine --all-targets -- -D warnings` — green
- [x] `cargo test -p aletheia-episteme --features mneme-engine admission` — all 8 pass

Closes #2853

🤖 Generated with [Claude Code](https://claude.com/claude-code)