### PR TITLE
fix(symbolon): promote KeyringCredentialProvider to pub (#3046)

### DIFF
--- a/crates/symbolon/src/credential/keyring_provider.rs
+++ b/crates/symbolon/src/credential/keyring_provider.rs
@@ -13,7 +13,7 @@ const DEFAULT_USERNAME: &str = "api-token";
 ///
 /// Falls through silently when the keyring is unavailable (headless server,
 /// no D-Bus session, locked keychain) so downstream providers get a chance.
-pub(crate) struct KeyringCredentialProvider {
+pub struct KeyringCredentialProvider {
     service: String,
     username: String,
 }
@@ -22,7 +22,7 @@ impl KeyringCredentialProvider {
     /// Create a provider using the default service name (`aletheia`) and
     /// username (`api-token`).
     #[must_use]
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             service: DEFAULT_SERVICE.to_owned(),
             username: DEFAULT_USERNAME.to_owned(),


### PR DESCRIPTION
## Summary

`KeyringCredentialProvider` was `pub(crate)` but re-exported as `pub` from `credential/mod.rs`, causing E0365 when building with `--all-features` (keyring feature enabled).

One-line fix: `pub(crate)` -> `pub` on the struct and its `new()` constructor.

Closes #3046

🤖 Generated with [Claude Code](https://claude.com/claude-code)