### PR TITLE
test: inline coverage for marshal.rs and accumulator.rs (#2809)

### DIFF
--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -792,3 +792,278 @@ pub(super) fn parse_epistemic_tier(s: &str) -> crate::knowledge::EpistemicTier {
         }
     }
 }
+
+#[cfg(all(test, feature = "mneme-engine"))]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::engine::DataValue;
+    use crate::knowledge::EpistemicTier;
+
+    // ─────────────────────────────────────────────────────────
+    // compute_tool_overlap — Jaccard similarity on string slices
+    // ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn tool_overlap_identical_sets() {
+        let a = vec!["read".to_owned(), "write".to_owned(), "bash".to_owned()];
+        let b = vec!["read".to_owned(), "write".to_owned(), "bash".to_owned()];
+        assert!((compute_tool_overlap(&a, &b) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn tool_overlap_disjoint_sets() {
+        let a = vec!["read".to_owned(), "write".to_owned()];
+        let b = vec!["bash".to_owned(), "grep".to_owned()];
+        assert!(compute_tool_overlap(&a, &b).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn tool_overlap_partial_intersection() {
+        // 2 shared of 4 total = 0.5
+        let a = vec!["read".to_owned(), "write".to_owned(), "bash".to_owned()];
+        let b = vec!["read".to_owned(), "write".to_owned(), "grep".to_owned()];
+        let result = compute_tool_overlap(&a, &b);
+        assert!((result - 0.5).abs() < f64::EPSILON, "expected 0.5, got {result}");
+    }
+
+    #[test]
+    fn tool_overlap_both_empty_returns_one() {
+        let a: Vec<String> = Vec::new();
+        let b: Vec<String> = Vec::new();
+        assert!((compute_tool_overlap(&a, &b) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn tool_overlap_one_empty_returns_zero() {
+        let a = vec!["read".to_owned()];
+        let b: Vec<String> = Vec::new();
+        assert!(compute_tool_overlap(&a, &b).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn tool_overlap_duplicates_deduplicated() {
+        // Duplicates in input should be collapsed by the HashSet
+        let a = vec!["read".to_owned(), "read".to_owned(), "write".to_owned()];
+        let b = vec!["read".to_owned(), "write".to_owned()];
+        assert!((compute_tool_overlap(&a, &b) - 1.0).abs() < f64::EPSILON);
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // compute_name_similarity — LCS ratio
+    // ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn name_similarity_identical() {
+        assert!((compute_name_similarity("Alice", "Alice") - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn name_similarity_case_insensitive() {
+        // LCS runs on lowercased strings
+        assert!((compute_name_similarity("Alice", "alice") - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn name_similarity_completely_different() {
+        // "abc" vs "xyz" — LCS length 0, ratio 0.0
+        assert!(compute_name_similarity("abc", "xyz").abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn name_similarity_substring_match() {
+        // "kitten" vs "kit" — LCS = "kit" (3), max_len = 6, ratio = 0.5
+        let result = compute_name_similarity("kitten", "kit");
+        assert!((result - 0.5).abs() < f64::EPSILON, "expected 0.5, got {result}");
+    }
+
+    #[test]
+    fn name_similarity_both_empty() {
+        assert!((compute_name_similarity("", "") - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn name_similarity_one_empty() {
+        assert!(compute_name_similarity("hello", "").abs() < f64::EPSILON);
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // lcs_char_length — the DP kernel
+    // ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn lcs_exact_match() {
+        let a: Vec<char> = "abc".chars().collect();
+        let b: Vec<char> = "abc".chars().collect();
+        assert_eq!(lcs_char_length(&a, &b), 3);
+    }
+
+    #[test]
+    fn lcs_partial_match() {
+        // "abcde" vs "ace" → LCS = "ace" (3)
+        let a: Vec<char> = "abcde".chars().collect();
+        let b: Vec<char> = "ace".chars().collect();
+        assert_eq!(lcs_char_length(&a, &b), 3);
+    }
+
+    #[test]
+    fn lcs_no_match() {
+        let a: Vec<char> = "abc".chars().collect();
+        let b: Vec<char> = "xyz".chars().collect();
+        assert_eq!(lcs_char_length(&a, &b), 0);
+    }
+
+    #[test]
+    fn lcs_empty_inputs() {
+        let empty: Vec<char> = Vec::new();
+        let a: Vec<char> = "abc".chars().collect();
+        assert_eq!(lcs_char_length(&empty, &a), 0);
+        assert_eq!(lcs_char_length(&a, &empty), 0);
+        assert_eq!(lcs_char_length(&empty, &empty), 0);
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // extract_str / extract_optional_str — DataValue extraction
+    // ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_str_from_str_value() {
+        let val = DataValue::Str("hello".into());
+        let result = extract_str(&val).expect("should extract");
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn extract_str_rejects_non_str() {
+        let val = DataValue::from(42i64);
+        let result = extract_str(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_optional_str_from_null() {
+        let val = DataValue::Null;
+        let result = extract_optional_str(&val).expect("should extract");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_optional_str_from_str_value() {
+        let val = DataValue::Str("present".into());
+        let result = extract_optional_str(&val).expect("should extract");
+        assert_eq!(result.as_deref(), Some("present"));
+    }
+
+    #[test]
+    fn extract_optional_str_rejects_other_types() {
+        let val = DataValue::Bool(true);
+        let result = extract_optional_str(&val);
+        assert!(result.is_err());
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // extract_float / extract_int / extract_bool
+    // ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_float_from_float_value() {
+        let val = DataValue::from(1.5_f64);
+        let result = extract_float(&val).expect("should extract");
+        assert!((result - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn extract_float_rejects_str() {
+        let val = DataValue::Str("not a number".into());
+        let result = extract_float(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_int_from_int_value() {
+        let val = DataValue::from(42i64);
+        let result = extract_int(&val).expect("should extract");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn extract_int_rejects_str() {
+        let val = DataValue::Str("42".into());
+        let result = extract_int(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_bool_true() {
+        let val = DataValue::Bool(true);
+        let result = extract_bool(&val).expect("should extract");
+        assert!(result);
+    }
+
+    #[test]
+    fn extract_bool_false() {
+        let val = DataValue::Bool(false);
+        let result = extract_bool(&val).expect("should extract");
+        assert!(!result);
+    }
+
+    #[test]
+    fn extract_bool_rejects_int() {
+        let val = DataValue::from(1i64);
+        let result = extract_bool(&val);
+        assert!(result.is_err());
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // parse_epistemic_tier — string → enum mapping
+    // ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_verified_tier() {
+        assert_eq!(parse_epistemic_tier("verified"), EpistemicTier::Verified);
+    }
+
+    #[test]
+    fn parse_inferred_tier() {
+        assert_eq!(parse_epistemic_tier("inferred"), EpistemicTier::Inferred);
+    }
+
+    #[test]
+    fn parse_assumed_tier() {
+        assert_eq!(parse_epistemic_tier("assumed"), EpistemicTier::Assumed);
+    }
+
+    #[test]
+    fn parse_unknown_tier_defaults_to_assumed() {
+        // Unknown strings fall back to Assumed (with a warn log)
+        assert_eq!(parse_epistemic_tier("bogus"), EpistemicTier::Assumed);
+        assert_eq!(parse_epistemic_tier(""), EpistemicTier::Assumed);
+        assert_eq!(parse_epistemic_tier("VERIFIED"), EpistemicTier::Assumed);
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // build_hybrid_query — script rendering
+    // ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn build_hybrid_query_contains_limits() {
+        use super::super::HybridQuery;
+        let query = HybridQuery {
+            text: "test query".to_owned(),
+            embedding: vec![0.1_f32; 384],
+            seed_entities: Vec::new(),
+            limit: 20,
+            ef: 50,
+        };
+        let script = build_hybrid_query(&query);
+        // The script should include the limit and ef parameters somewhere
+        assert!(
+            script.contains("20") || script.contains("$limit"),
+            "script should reference the limit"
+        );
+        assert!(
+            script.contains("50") || script.contains("$ef"),
+            "script should reference the ef parameter"
+        );
+    }
+}

--- a/crates/hermeneus/src/anthropic/stream/accumulator.rs
+++ b/crates/hermeneus/src/anthropic/stream/accumulator.rs
@@ -363,3 +363,426 @@ impl StreamAccumulator {
         }
     }
 }
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "tests assert against known-length content vecs"
+)]
+mod tests {
+    use super::super::super::wire::{
+        WireContentBlockStart, WireDelta, WireMessageDeltaBody, WireMessageDeltaUsage,
+        WireMessageStart, WireStreamEvent, WireUsage,
+    };
+    use super::*;
+
+    fn usage(input: u64, cache_write: u64, cache_read: u64) -> WireUsage {
+        WireUsage {
+            input_tokens: input,
+            output_tokens: 0,
+            cache_creation_input_tokens: cache_write,
+            cache_read_input_tokens: cache_read,
+        }
+    }
+
+    fn start_event(id: &str, model: &str) -> WireStreamEvent {
+        WireStreamEvent::MessageStart {
+            message: WireMessageStart {
+                id: id.to_owned(),
+                model: model.to_owned(),
+                usage: usage(10, 0, 0),
+            },
+        }
+    }
+
+    fn delta_event(delta: WireDelta, index: u32) -> WireStreamEvent {
+        WireStreamEvent::ContentBlockDelta { index, delta }
+    }
+
+    fn stop_event(reason: &str, output_tokens: u64) -> WireStreamEvent {
+        WireStreamEvent::MessageDelta {
+            delta: WireMessageDeltaBody {
+                stop_reason: reason.to_owned(),
+            },
+            usage: WireMessageDeltaUsage {
+                output_tokens,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn accumulator_captures_message_metadata() {
+        let mut acc = StreamAccumulator::new();
+        let mut events = Vec::new();
+        acc.process_event(start_event("msg_01", "claude-opus"), &mut |e| {
+            events.push(e);
+        })
+        .expect("process should succeed");
+
+        let response = acc.finish();
+        assert_eq!(response.id, "msg_01");
+        assert_eq!(response.model, "claude-opus");
+        assert_eq!(response.usage.input_tokens, 10);
+    }
+
+    #[test]
+    fn accumulator_builds_text_block_from_deltas() {
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        acc.process_event(start_event("msg_02", "claude-opus"), &mut on_event)
+            .expect("start");
+        acc.process_event(
+            WireStreamEvent::ContentBlockStart {
+                index: 0,
+                content_block: WireContentBlockStart::Text {
+                    text: String::new(),
+                },
+            },
+            &mut on_event,
+        )
+        .expect("block start");
+        acc.process_event(
+            delta_event(
+                WireDelta::TextDelta {
+                    text: "Hello, ".to_owned(),
+                },
+                0,
+            ),
+            &mut on_event,
+        )
+        .expect("delta 1");
+        acc.process_event(
+            delta_event(
+                WireDelta::TextDelta {
+                    text: "world!".to_owned(),
+                },
+                0,
+            ),
+            &mut on_event,
+        )
+        .expect("delta 2");
+        acc.process_event(
+            WireStreamEvent::ContentBlockStop { index: 0 },
+            &mut on_event,
+        )
+        .expect("block stop");
+        acc.process_event(stop_event("end_turn", 42), &mut on_event)
+            .expect("message stop");
+
+        let response = acc.finish();
+        assert_eq!(response.content.len(), 1);
+        match &response.content[0] {
+            ContentBlock::Text { text, .. } => assert_eq!(text, "Hello, world!"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+        assert_eq!(response.usage.output_tokens, 42);
+    }
+
+    #[test]
+    fn accumulator_builds_tool_use_from_json_deltas() {
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        acc.process_event(start_event("msg_03", "claude-opus"), &mut on_event)
+            .expect("start");
+        acc.process_event(
+            WireStreamEvent::ContentBlockStart {
+                index: 0,
+                content_block: WireContentBlockStart::ToolUse {
+                    id: "toolu_1".to_owned(),
+                    name: "Read".to_owned(),
+                },
+            },
+            &mut on_event,
+        )
+        .expect("tool start");
+        acc.process_event(
+            delta_event(
+                WireDelta::InputJsonDelta {
+                    partial_json: r#"{"path":"/tmp/"#.to_owned(),
+                },
+                0,
+            ),
+            &mut on_event,
+        )
+        .expect("delta 1");
+        acc.process_event(
+            delta_event(
+                WireDelta::InputJsonDelta {
+                    partial_json: r#"foo.txt"}"#.to_owned(),
+                },
+                0,
+            ),
+            &mut on_event,
+        )
+        .expect("delta 2");
+        acc.process_event(stop_event("tool_use", 5), &mut on_event)
+            .expect("stop");
+
+        let response = acc.finish();
+        match &response.content[0] {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "toolu_1");
+                assert_eq!(name, "Read");
+                assert_eq!(input["path"].as_str(), Some("/tmp/foo.txt"));
+            }
+            other => panic!("expected ToolUse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accumulator_handles_empty_tool_input() {
+        // WHY: a tool with zero arguments sends no InputJsonDelta events;
+        // the builder's input_json stays empty and should materialize as {}.
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        acc.process_event(start_event("msg_04", "claude-opus"), &mut on_event)
+            .expect("start");
+        acc.process_event(
+            WireStreamEvent::ContentBlockStart {
+                index: 0,
+                content_block: WireContentBlockStart::ToolUse {
+                    id: "toolu_2".to_owned(),
+                    name: "NoArgTool".to_owned(),
+                },
+            },
+            &mut on_event,
+        )
+        .expect("tool start");
+        acc.process_event(stop_event("tool_use", 2), &mut on_event)
+            .expect("stop");
+
+        let response = acc.finish();
+        match &response.content[0] {
+            ContentBlock::ToolUse { input, .. } => {
+                assert!(input.is_object(), "empty input should be empty object");
+                assert_eq!(input.as_object().expect("object").len(), 0);
+            }
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn accumulator_handles_malformed_tool_json_gracefully() {
+        // WHY: a malformed JSON delta must not crash the accumulator; it
+        // returns an error object so the agent can retry.
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        acc.process_event(start_event("msg_05", "claude-opus"), &mut on_event)
+            .expect("start");
+        acc.process_event(
+            WireStreamEvent::ContentBlockStart {
+                index: 0,
+                content_block: WireContentBlockStart::ToolUse {
+                    id: "toolu_3".to_owned(),
+                    name: "BadTool".to_owned(),
+                },
+            },
+            &mut on_event,
+        )
+        .expect("tool start");
+        acc.process_event(
+            delta_event(
+                WireDelta::InputJsonDelta {
+                    partial_json: r#"{"broken":"#.to_owned(),
+                },
+                0,
+            ),
+            &mut on_event,
+        )
+        .expect("delta");
+        acc.process_event(stop_event("tool_use", 3), &mut on_event)
+            .expect("stop");
+
+        let response = acc.finish();
+        match &response.content[0] {
+            ContentBlock::ToolUse { input, .. } => {
+                assert!(
+                    input.get("_parse_error").is_some(),
+                    "malformed JSON should surface as _parse_error: {input:?}"
+                );
+            }
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn accumulator_builds_thinking_block() {
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        acc.process_event(start_event("msg_06", "claude-opus"), &mut on_event)
+            .expect("start");
+        acc.process_event(
+            WireStreamEvent::ContentBlockStart {
+                index: 0,
+                content_block: WireContentBlockStart::Thinking {
+                    thinking: String::new(),
+                },
+            },
+            &mut on_event,
+        )
+        .expect("block start");
+        acc.process_event(
+            delta_event(
+                WireDelta::ThinkingDelta {
+                    thinking: "Let me think... ".to_owned(),
+                },
+                0,
+            ),
+            &mut on_event,
+        )
+        .expect("thinking");
+        acc.process_event(
+            delta_event(
+                WireDelta::SignatureDelta {
+                    signature: "sig123".to_owned(),
+                },
+                0,
+            ),
+            &mut on_event,
+        )
+        .expect("signature");
+        acc.process_event(stop_event("end_turn", 10), &mut on_event)
+            .expect("stop");
+
+        let response = acc.finish();
+        match &response.content[0] {
+            ContentBlock::Thinking { thinking, signature } => {
+                assert_eq!(thinking, "Let me think... ");
+                assert_eq!(signature.as_deref(), Some("sig123"));
+            }
+            other => panic!("expected Thinking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accumulator_supports_sparse_block_indices() {
+        // WHY: the stream can send block index 2 before 1, and the accumulator
+        // should grow its blocks vec to accommodate. The gap should be filled
+        // with empty text blocks.
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        acc.process_event(start_event("msg_07", "claude-opus"), &mut on_event)
+            .expect("start");
+        acc.process_event(
+            WireStreamEvent::ContentBlockStart {
+                index: 2,
+                content_block: WireContentBlockStart::Text {
+                    text: "third".to_owned(),
+                },
+            },
+            &mut on_event,
+        )
+        .expect("block 2");
+        acc.process_event(stop_event("end_turn", 5), &mut on_event)
+            .expect("stop");
+
+        let response = acc.finish();
+        assert_eq!(response.content.len(), 3, "should have 3 blocks (gaps filled)");
+    }
+
+    #[test]
+    fn accumulator_accumulates_cache_tokens_from_message_delta() {
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        acc.process_event(start_event("msg_08", "claude-opus"), &mut on_event)
+            .expect("start");
+        // First message_delta sends some cache_creation tokens
+        acc.process_event(
+            WireStreamEvent::MessageDelta {
+                delta: WireMessageDeltaBody {
+                    stop_reason: "end_turn".to_owned(),
+                },
+                usage: WireMessageDeltaUsage {
+                    output_tokens: 50,
+                    cache_creation_input_tokens: 100,
+                    cache_read_input_tokens: 200,
+                },
+            },
+            &mut on_event,
+        )
+        .expect("delta");
+
+        let response = acc.finish();
+        assert_eq!(response.usage.output_tokens, 50);
+        assert_eq!(response.usage.cache_write_tokens, 100);
+        assert_eq!(response.usage.cache_read_tokens, 200);
+    }
+
+    #[test]
+    fn accumulator_rejects_error_event() {
+        use super::super::super::wire::WireErrorDetail;
+
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        let result = acc.process_event(
+            WireStreamEvent::Error {
+                error: WireErrorDetail {
+                    error_type: "overloaded_error".to_owned(),
+                    message: "server is at capacity".to_owned(),
+                },
+            },
+            &mut on_event,
+        );
+        assert!(result.is_err(), "error event should propagate as Err");
+    }
+
+    #[test]
+    fn accumulator_ignores_ping_and_message_stop() {
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        acc.process_event(start_event("msg_09", "claude-opus"), &mut on_event)
+            .expect("start");
+        acc.process_event(WireStreamEvent::Ping {}, &mut on_event)
+            .expect("ping");
+        acc.process_event(WireStreamEvent::MessageStop {}, &mut on_event)
+            .expect("message stop");
+
+        let response = acc.finish();
+        assert_eq!(response.id, "msg_09");
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+    }
+
+    #[test]
+    fn accumulator_finish_without_stop_defaults_to_end_turn() {
+        let mut acc = StreamAccumulator::new();
+        acc.process_event(start_event("msg_10", "claude-opus"), &mut |_| {})
+            .expect("start");
+        let response = acc.finish();
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+    }
+
+    #[test]
+    fn delta_for_nonexistent_block_index_ignored() {
+        let mut acc = StreamAccumulator::new();
+        let mut on_event = |_: StreamEvent| {};
+
+        acc.process_event(start_event("msg_11", "claude-opus"), &mut on_event)
+            .expect("start");
+        // No ContentBlockStart — delta references non-existent index
+        acc.process_event(
+            delta_event(
+                WireDelta::TextDelta {
+                    text: "orphan".to_owned(),
+                },
+                0,
+            ),
+            &mut on_event,
+        )
+        .expect("orphan delta should not error");
+
+        let response = acc.finish();
+        assert_eq!(response.content.len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Addresses 2 of the 11 files flagged by #2809 that had zero inline `#[cfg(test)]` modules:

- **episteme/src/knowledge_store/marshal.rs** (794 LOC) — 33 tests
- **hermeneus/src/anthropic/stream/accumulator.rs** (365 LOC) — 12 tests

### marshal.rs coverage

- Jaccard tool overlap (identical, disjoint, partial, empty, duplicates)
- LCS name similarity (identical, case-insensitive, different, substring, empty)
- LCS DP kernel (exact match, partial, no match, empty inputs)
- DataValue extraction helpers (str, optional_str, float, int, bool — happy path + type-mismatch rejection)
- Epistemic tier parsing (verified/inferred/assumed + unknown fallback)
- Hybrid query script rendering

### accumulator.rs coverage

Full SSE state machine exercise:

- Message metadata capture from MessageStart
- Text block delta accumulation
- Tool use JSON delta assembly across chunks
- Empty tool input → empty object
- Malformed JSON → graceful `_parse_error` fallback
- Thinking + signature block
- Sparse content block indices (gaps filled with empty text blocks)
- Cache token accumulation from MessageDelta
- Error event propagation as `Err`
- Ping / MessageStop ignored
- `finish()` without stop → default to `EndTurn`
- Orphan delta (no matching block) tolerated

## Test plan
- [x] `cargo test -p episteme --features mneme-engine marshal` — 33/33 pass
- [x] `cargo test -p hermeneus anthropic::stream::accumulator` — 12/12 pass
- [x] `cargo clippy -p episteme --features mneme-engine --all-targets -- -D warnings` — green
- [x] `cargo clippy -p hermeneus --all-targets -- -D warnings` — green

Progress on #2809 (2 of 11 files addressed — remaining 8: facts.rs, put.rs, stages.rs, streaming.rs, turn.rs, background.rs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)