### PR TITLE
fix: deployment blockers — CC provider default, SSE keepalive, log noise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "indexmap 2.13.1",
  "koina",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "jiff",
  "koina",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "koina",
  "organon",
@@ -1683,7 +1683,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "eidos"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "jiff",
  "serde",
@@ -1705,7 +1705,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "energeia"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "eidos",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -2510,7 +2510,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "axum 0.8.8",
  "dokimion",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "fd-lock",
  "futures",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "dianoia",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "axum 0.8.8",
  "episteme",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
  "energeia",
@@ -4656,7 +4656,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -5833,7 +5833,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "compact_str",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "taxis"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -6242,14 +6242,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "futures",
  "indexmap 2.13.1",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # WARNING: embed-candle must remain in defaults. It has been accidentally
 # removed three times: #1263, #1326, #1378. A compile-time test in
 # tests/default_features.rs guards against recurrence.
-default = ["tui", "recall", "storage-fjall", "embed-candle"]
+default = ["tui", "recall", "storage-fjall", "embed-candle", "cc-provider"]
 # MCP server (Model Context Protocol). Disabled by default: adds context-window
 # cost and auth friction for local deployments. Enable with `--features mcp`.
 mcp = ["dep:diaporeia"]

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -108,7 +108,10 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     };
 
     if config.gateway.auth.mode == "none" {
-        warn!("auth mode is 'none' -- all requests granted Readonly role");
+        warn!(
+            none_role = %config.gateway.auth.none_role,
+            "auth mode is 'none' -- all requests granted configured role"
+        );
     }
     if config.gateway.auth.mode == "none"
         && bind_addr_str != "127.0.0.1"

--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -52,7 +52,7 @@ impl Default for CcProviderConfig {
     fn default() -> Self {
         Self {
             cc_binary: None,
-            default_model: "claude-sonnet-4-20250514".to_owned(),
+            default_model: "claude-opus-4-6".to_owned(),
             timeout: Duration::from_secs(300),
         }
     }
@@ -261,11 +261,13 @@ impl LlmProvider for CcProvider {
     }
 
     fn supports_model(&self, model: &str) -> bool {
-        // Accept either `cc/`-prefixed models or known model names.
-        if model.starts_with(CC_MODEL_PREFIX) {
-            return true;
-        }
-        SUPPORTED_MODELS.contains(&model)
+        // WHY: CC delegates model routing to the `claude` CLI, which handles
+        // all claude-* models internally. Accepting any claude-* prefix
+        // ensures new model IDs (e.g. claude-opus-4-7) work without updating
+        // the SUPPORTED_MODELS list. The `cc/` prefix is for explicit routing.
+        model.starts_with(CC_MODEL_PREFIX)
+            || model.starts_with("claude-")
+            || SUPPORTED_MODELS.contains(&model)
     }
 
     fn name(&self) -> &'static str {
@@ -304,7 +306,6 @@ fn find_cc_binary() -> Result<PathBuf> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::types::{CompletionRequest, Content, Message, Role};

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -214,10 +214,19 @@ impl ProviderRegistry {
     #[must_use]
     pub fn find_provider(&self, model: &str) -> Option<&dyn LlmProvider> {
         // kanon:ignore RUST/pub-visibility
-        self.providers
-            .iter()
-            .find(|e| e.provider.supports_model(model))
-            .map(|e| e.provider.as_ref())
+        for entry in &self.providers {
+            let matches = entry.provider.supports_model(model);
+            tracing::debug!(
+                provider = entry.provider.name(),
+                model,
+                matches,
+                "provider selection check"
+            );
+            if matches {
+                return Some(entry.provider.as_ref());
+            }
+        }
+        None
     }
 
     /// List all registered providers.

--- a/crates/organon/src/sandbox/policy.rs
+++ b/crates/organon/src/sandbox/policy.rs
@@ -429,14 +429,19 @@ pub fn apply_sandbox(
                  Set enforcement=permissive to run without sandboxing.",
             ));
         }
-        // WHY: Log when Landlock is available but enforcement is permissive so operators
-        // know syscall violations are only logged, not blocked. Closes #1718.
+        // WHY: Log ONCE when Landlock is available but enforcement is permissive so
+        // operators know syscall violations are only logged, not blocked. Closes #1718.
+        // Changed from per-call warn to once-per-process to avoid log spam (#3102).
         (Some(_), SandboxEnforcement::Permissive) => {
-            tracing::warn!(
-                enforcement = "permissive",
-                "sandbox enforcement=permissive: policy violations are logged but not \
-                 blocked. Set enforcement=enforcing for production deployments."
-            );
+            use std::sync::atomic::{AtomicBool, Ordering};
+            static WARNED: AtomicBool = AtomicBool::new(false);
+            if !WARNED.swap(true, Ordering::Relaxed) {
+                tracing::warn!(
+                    enforcement = "permissive",
+                    "sandbox enforcement=permissive: policy violations are logged but not \
+                     blocked. Set enforcement=enforcing for production deployments."
+                );
+            }
         }
         // NOTE: Landlock ABI available and enforcement=enforcing, proceed with sandbox setup
         (Some(_), SandboxEnforcement::Enforcing) => {}

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -614,7 +614,11 @@ pub async fn events(
     // WHY: emit periodic comment-only events so the connection stays alive and
     // proxies do not close it. Real domain events require a broadcast channel
     // wired into AppState: deferred to issue #1248.
-    let stream = IntervalStream::new(tokio::time::interval(Duration::from_secs(30)))
+    // WHY: keepalive interval (15s) must be well below the client read timeout
+    // (45s in skene) to prevent false disconnects. The IntervalStream and
+    // axum KeepAlive are belt-and-suspenders: either alone would work but
+    // both together ensure at least one event arrives per client timeout window.
+    let stream = IntervalStream::new(tokio::time::interval(Duration::from_secs(15)))
         .map(|_| Ok::<Event, Infallible>(Event::default().comment("keepalive")));
 
     Sse::new(stream).keep_alive(

--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -18,26 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aletheia-koina"
-version = "0.13.65"
-dependencies = [
- "compact_str",
- "jiff",
- "rand 0.9.2",
- "regex",
- "rustix",
- "serde",
- "serde_json",
- "snafu",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "ulid",
- "uuid",
- "zeroize",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,6 +2391,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "koina"
+version = "0.14.1"
+dependencies = [
+ "compact_str",
+ "jiff",
+ "rand 0.9.2",
+ "regex",
+ "rustix",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3471,6 +3469,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proskenion"
+version = "0.13.1"
+dependencies = [
+ "dioxus",
+ "dirs",
+ "form_urlencoded",
+ "futures-util",
+ "notify-rust",
+ "pulldown-cmark",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "skene",
+ "snafu",
+ "syntect",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "toml 1.1.0+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4184,6 +4206,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "skene"
+version = "0.14.1"
+dependencies = [
+ "bytes",
+ "compact_str",
+ "futures-core",
+ "futures-util",
+ "koina",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4525,48 +4565,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "theatron-core"
-version = "0.13.65"
-dependencies = [
- "aletheia-koina",
- "bytes",
- "compact_str",
- "futures-core",
- "futures-util",
- "reqwest",
- "rustls",
- "serde",
- "serde_json",
- "snafu",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "theatron-desktop"
-version = "0.13.1"
-dependencies = [
- "dioxus",
- "dirs",
- "form_urlencoded",
- "futures-util",
- "notify-rust",
- "pulldown-cmark",
- "reqwest",
- "rustls",
- "serde",
- "serde_json",
- "snafu",
- "syntect",
- "tempfile",
- "theatron-core",
- "tokio",
- "tokio-util",
- "toml 1.1.0+spec-1.1.0",
- "tracing",
 ]
 
 [[package]]
@@ -5000,17 +4998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ulid"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
-dependencies = [
- "rand 0.9.2",
- "serde",
- "web-time",
-]
-
-[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5076,7 +5063,6 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5301,16 +5287,6 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/theatron/skene/src/api/sse.rs
+++ b/crates/theatron/skene/src/api/sse.rs
@@ -15,9 +15,10 @@ use crate::sse::SseStream;
 use super::types::SseEvent;
 
 /// If no SSE event is received within this window, the connection is treated as
-/// stale and a reconnect is triggered. Default covers quiet periods between pings
-/// while still detecting hung connections promptly.
-const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// stale and a reconnect is triggered. Must be > 2× the server's keepalive
+/// interval (15s) to tolerate jitter. The 45s value matches proskenion's
+/// `HEARTBEAT_TIMEOUT` and provides 3× margin over the server ping interval.
+const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
 
 /// Manages the global SSE connection to /api/v1/events.
 /// Runs in a background task, sends parsed events through a channel.


### PR DESCRIPTION
Fixes 6 deployment-test issues. The CRITICAL blocker (#3097) turned out to be a systemd PATH issue (claude CLI not in PATH), but this PR adds defensive improvements anyway:

- **cc-provider** now a default feature (was opt-in)
- CC provider accepts all \`claude-*\` models (prefix match)
- Default model changed to claude-opus-4-6
- Diagnostic tracing in find_provider()
- SSE keepalive: client timeout 30s→45s, server interval 30s→15s
- "Readonly role" warning now shows actual configured role
- Sandbox permissive warning fires once per process, not per call

Closes #3097, #3100, #3096, #3093, #3102 (partial). Refs #3106 (root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)