### PR TITLE
fix: remaining deployment issues — CC binary, SSE parse, health, signal, fjall, session IDs

### DIFF
--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -30,7 +30,10 @@ const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const DEFAULT_BUFFER_CAPACITY: usize = 100;
 
 /// Consecutive poll failures before the circuit breaker trips and polling halts.
-const CIRCUIT_BREAKER_THRESHOLD: u32 = 20;
+/// WHY: lowered from 20 to 5 because signal-cli being down is the common case
+/// (`auto_start=false`, user hasn't started it), and 20 retries at exponential
+/// backoff = several minutes of warn-level log spam before halting (#3104).
+const CIRCUIT_BREAKER_THRESHOLD: u32 = 5;
 
 /// Interval between health checks while the circuit breaker is open.
 const HALTED_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(60);

--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -129,6 +129,16 @@ pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Resu
                 }
             }
 
+            // Check CC provider availability
+            if let Some(cc_path) = symbolon::credential::claude_code_default_path() {
+                if cc_path.exists() {
+                    println!("CC provider: Claude Code credentials found at {}", cc_path.display());
+                    found_any = true;
+                } else {
+                    println!("CC provider: {} (not found)", cc_path.display());
+                }
+            }
+
             if !found_any {
                 println!("No credential found.");
                 println!("Checked: {} (not found)", cred_path.display());

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -222,11 +222,24 @@ pub(super) fn open_knowledge_store(
         std::fs::create_dir_all(parent)
             .whatever_context("failed to CREATE knowledge store directory")?;
     }
-    let store = mneme::knowledge_store::KnowledgeStore::open_fjall(
+    let store = match mneme::knowledge_store::KnowledgeStore::open_fjall(
         &kb_path,
         mneme::knowledge_store::KnowledgeConfig::default(),
-    )
-    .whatever_context("failed to open knowledge store")?;
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("InvalidTag") || msg.contains("CompressionType") {
+                tracing::error!(
+                    path = %kb_path.display(),
+                    "Knowledge store format incompatible (written by older fjall version). \
+                     Back up data/knowledge.fjall and delete it to start fresh. \
+                     Session data in sessions.db is NOT affected."
+                );
+            }
+            return Err(e).whatever_context("failed to open knowledge store");
+        }
+    };
     info!(path = %kb_path.display(), dim = 384, "knowledge store opened (fjall)");
     Ok(Some(store))
 }

--- a/crates/hermeneus/src/cc/parse.rs
+++ b/crates/hermeneus/src/cc/parse.rs
@@ -48,6 +48,14 @@ pub(crate) enum CcEvent {
         #[serde(flatten)]
         _extra: serde_json::Value,
     },
+
+    /// Rate-limit status event emitted by newer CC CLI versions. Ignored —
+    /// the rate limit info is informational and doesn't affect the response.
+    #[serde(rename = "rate_limit_event")]
+    RateLimit {
+        #[serde(flatten)]
+        _extra: serde_json::Value,
+    },
 }
 
 /// Assistant message body.

--- a/crates/hermeneus/src/cc/process.rs
+++ b/crates/hermeneus/src/cc/process.rs
@@ -265,8 +265,8 @@ where
                 session_id = s;
                 got_result = true;
             }
-            CcEvent::System { .. } => {
-                // Ignored.
+            CcEvent::System { .. } | CcEvent::RateLimit { .. } => {
+                // Ignored — informational events that don't affect the response.
             }
         }
     }
@@ -458,7 +458,7 @@ where
                 session_id = s;
                 got_result = true;
             }
-            CcEvent::System { .. } => {}
+            CcEvent::System { .. } | CcEvent::RateLimit { .. } => {}
         }
     }
 

--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -289,18 +289,36 @@ impl LlmProvider for CcProvider {
 
 /// Find the `claude` binary in `PATH`.
 fn find_cc_binary() -> Result<PathBuf> {
-    // WHY: We don't use the `which` crate (not in workspace). Instead, try
-    // spawning `claude --version` and capture the binary path from PATH resolution.
+    // 1. Search PATH (standard resolution).
     let paths = RealSystem.var_os("PATH").unwrap_or_default();
     for dir in std::env::split_paths(&paths) {
         let candidate = dir.join("claude");
         if candidate.is_file() {
-            debug!(path = %candidate.display(), "found claude binary");
+            debug!(path = %candidate.display(), "found claude binary in PATH");
             return Ok(candidate);
         }
     }
+
+    // 2. Check well-known installation paths (covers systemd user sessions
+    //    where ~/.local/bin may not be in PATH — see #3106).
+    if let Some(home) = RealSystem.var_os("HOME") {
+        let home = PathBuf::from(home);
+        for subdir in &[".local/bin/claude", ".claude/bin/claude"] {
+            let candidate = home.join(subdir);
+            if candidate.is_file() {
+                tracing::info!(
+                    path = %candidate.display(),
+                    "found claude binary outside PATH (consider adding its directory to PATH)"
+                );
+                return Ok(candidate);
+            }
+        }
+    }
+
     Err(error::ProviderInitSnafu {
-        message: "claude CLI binary not found in PATH. Install Claude Code: https://docs.anthropic.com/en/docs/claude-code".to_owned(),
+        message: "claude CLI binary not found in PATH or ~/.local/bin. \
+                  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code"
+            .to_owned(),
     }
     .build())
 }

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -199,19 +199,30 @@ impl SessionId {
         Self(Uuid::new_v4())
     }
 
-    /// Parse from a UUID string (hyphenated format).
+    /// Parse from a UUID string (hyphenated) or ULID string (Crockford base32).
+    ///
+    /// Accepts both formats for backwards compatibility: newer sessions use UUID,
+    /// older sessions may have ULID-format IDs in the database (#3101).
     ///
     /// # Errors
-    /// Returns an error if the string is not a valid UUID.
+    /// Returns an error if the string is neither a valid UUID nor a valid ULID.
     #[must_use = "returns a parsed session identifier that should not be discarded"]
     pub fn parse(s: &str) -> Result<Self, IdError> {
-        Uuid::parse_str(s)
-            .map(Self)
-            .map_err(|_e| IdError::InvalidFormat {
-                kind: "SessionId",
-                value: s.to_owned(),
-                reason: "invalid UUID format".to_owned(),
-            })
+        // Try UUID first (most common in current code).
+        if let Ok(uuid) = Uuid::parse_str(s) {
+            return Ok(Self(uuid));
+        }
+        // Fall back to ULID for legacy compatibility.
+        if let Ok(ulid) = s.parse::<crate::ulid::Ulid>() {
+            // WHY: ULID and UUID are both 128-bit. Reinterpret the ULID's
+            // u128 as UUID bytes to produce a stable, round-trippable ID.
+            return Ok(Self(Uuid::from_u128(ulid.as_u128())));
+        }
+        Err(IdError::InvalidFormat {
+            kind: "SessionId",
+            value: s.to_owned(),
+            reason: "invalid session ID (expected UUID or ULID format)".to_owned(),
+        })
     }
 }
 

--- a/crates/koina/src/uuid.rs
+++ b/crates/koina/src/uuid.rs
@@ -33,6 +33,15 @@ impl Uuid {
         Self(bytes)
     }
 
+    /// Create a UUID from a raw 128-bit value (big-endian byte order).
+    ///
+    /// WHY: Used for ULID-to-UUID conversion where the 128-bit value needs to
+    /// be reinterpreted as a UUID for storage (#3101).
+    #[must_use]
+    pub fn from_u128(v: u128) -> Self {
+        Self(v.to_be_bytes())
+    }
+
     /// Parse a UUID from a hyphenated string (e.g., "550e8400-e29b-41d4-a716-446655440000").
     ///
     /// # Errors

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -268,46 +268,48 @@ fn check_credential_validity(state: &HealthState) -> HealthCheck {
     let creds_dir = state.oikos.credentials();
     let cred_file = creds_dir.join("anthropic.json");
 
-    match symbolon::credential::CredentialFile::load(&cred_file) {
-        Some(cred_file) => {
-            // Check if token is expired or expiring soon
-            if let Some(remaining_secs) = cred_file.seconds_remaining() {
-                const CLOCK_SKEW_LEEWAY: i64 = 30;
-                const EXPIRY_WARNING_THRESHOLD: i64 = 3600;
+    if let Some(cred_file) = symbolon::credential::CredentialFile::load(&cred_file) {
+        // Check if token is expired or expiring soon
+        if let Some(remaining_secs) = cred_file.seconds_remaining() {
+            const CLOCK_SKEW_LEEWAY: i64 = 30;
+            const EXPIRY_WARNING_THRESHOLD: i64 = 3600;
 
-                if remaining_secs < CLOCK_SKEW_LEEWAY {
-                    HealthCheck {
-                        name: "credential_validity",
-                        status: "warn",
-                        message: Some("credential file token has expired".to_owned()),
-                    }
-                } else if remaining_secs < EXPIRY_WARNING_THRESHOLD {
-                    HealthCheck {
-                        name: "credential_validity",
-                        status: "warn",
-                        message: Some("credential file token expires soon".to_owned()),
-                    }
-                } else {
-                    HealthCheck {
-                        name: "credential_validity",
-                        status: "pass",
-                        message: None,
-                    }
-                }
-            } else {
-                // No expiry set - static API key
-                HealthCheck {
+            if remaining_secs < CLOCK_SKEW_LEEWAY {
+                return HealthCheck {
                     name: "credential_validity",
-                    status: "pass",
-                    message: None,
-                }
+                    status: "warn",
+                    message: Some("credential file token has expired".to_owned()),
+                };
+            } else if remaining_secs < EXPIRY_WARNING_THRESHOLD {
+                return HealthCheck {
+                    name: "credential_validity",
+                    status: "warn",
+                    message: Some("credential file token expires soon".to_owned()),
+                };
             }
         }
-        None => HealthCheck {
+        return HealthCheck {
+            name: "credential_validity",
+            status: "pass",
+            message: None,
+        };
+    }
+
+    // Check if CC provider handles auth (Claude Code credentials)
+    let cc_credentials = symbolon::credential::claude_code_default_path()
+        .is_some_and(|p| p.exists());
+    if cc_credentials {
+        HealthCheck {
+            name: "credential_validity",
+            status: "pass",
+            message: Some("Claude Code credentials available (CC provider handles auth)".to_owned()),
+        }
+    } else {
+        HealthCheck {
             name: "credential_validity",
             status: "warn",
-            message: Some("no credentials found (ANTHROPIC_API_KEY not set, no credential file)".to_owned()),
-        },
+            message: Some("no credentials found (ANTHROPIC_API_KEY not set, no credential file, no Claude Code credentials)".to_owned()),
+        }
     }
 }
 

--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "compact_str",
  "jiff",
@@ -4207,7 +4207,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "compact_str",


### PR DESCRIPTION
Fixes 7 deployment-test issues in one PR:

| Issue | Fix |
|---|---|
| #3105 | Parse CC \`rate_limit_event\` — no more warn spam from newer claude CLI |
| #3106 | CC binary lookup checks \`~/.local/bin\` + \`~/.claude/bin\` as fallback |
| #3092 | Health check recognizes CC credentials as valid |
| #3095 | \`credential status\` shows CC provider availability |
| #3104 | Signal circuit breaker threshold 20→5 (less log spam) |
| #3094 | Fjall format mismatch shows recovery instructions |
| #3101 | SessionId accepts both UUID and ULID formats |

Also adds \`Uuid::from_u128\` for ULID→UUID conversion.

\`cargo clippy --workspace --all-targets -- -D warnings\` clean.

Closes #3092, #3094, #3095, #3101, #3104, #3105, #3106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)