### PR TITLE
fix(nous): adopt DB session ID for daemon-originated turns (#3103)

### DIFF
--- a/crates/nous/src/actor/tests.rs
+++ b/crates/nous/src/actor/tests.rs
@@ -610,3 +610,82 @@ async fn session_id_adoption_prevents_fk_divergence() {
     handle.shutdown().await.expect("shutdown");
     join.await.expect("join");
 }
+
+/// Regression test for #3103: prosoche daemon FK constraint failure.
+///
+/// Simulates the scenario where the daemon's "daemon:prosoche" session already
+/// exists in the DB (from a previous cycle), but the actor has no in-memory
+/// session for that key (e.g., after restart or LRU eviction). The daemon
+/// bridge calls `send_turn` with `session_id: None`, so the actor generates a
+/// new ULID — which diverges from the DB's canonical ID.
+///
+/// Before the fix, `find_or_create_session` would return the existing DB
+/// session silently (ON CONFLICT DO NOTHING), but `finalize` would call
+/// `append_message` with the actor's newly generated ID (no DB row) →
+/// FOREIGN KEY constraint failure and silent data loss.
+///
+/// After the fix, the actor adopts the DB session ID returned by
+/// `find_or_create_session`, so finalize uses the correct ID.
+#[tokio::test]
+async fn prosoche_daemon_adopts_existing_db_session_id() {
+    let store = mneme::store::SessionStore::open_in_memory().expect("in-memory store");
+    // WHY: SessionId requires UUID v4 format
+    let existing_db_id = "660e8400-e29b-41d4-a716-446655440001";
+
+    // Simulate an existing DB session for the "daemon:prosoche" key
+    // (as would exist from a previous prosoche cycle).
+    store
+        .create_session(
+            existing_db_id,
+            "test-agent",
+            "daemon:prosoche",
+            None,
+            Some("test-model"),
+        )
+        .expect("create pre-existing prosoche session");
+
+    let store = Arc::new(tokio::sync::Mutex::new(store));
+    // WHY: Actor has no in-memory session for "daemon:prosoche" — simulates
+    // restart or eviction. The daemon bridge sends with session_id: None.
+    let (handle, join, _dir) = spawn_test_actor_with_store(Arc::clone(&store));
+
+    // NOTE: Daemon bridge calls send_turn (not send_turn_with_session_id),
+    // so session_id is None — the actor must discover and adopt the DB ID.
+    let result = handle
+        .send_turn("daemon:prosoche", "Run your prosoche heartbeat check.")
+        .await
+        .expect("turn should succeed without FK constraint failure");
+    assert_eq!(result.content, "Hello from actor!");
+
+    let store_guard = store.lock().await;
+
+    // WHY: Messages must be under the existing DB session ID, not a new ULID.
+    let history = store_guard
+        .get_history(existing_db_id, None)
+        .expect("history under existing DB session ID");
+    assert!(
+        history.len() >= 2,
+        "expected at least 2 messages under existing DB session ID, got {}",
+        history.len()
+    );
+
+    // WHY: No orphan session should be created — only one session for
+    // "daemon:prosoche" should exist.
+    let all_sessions = store_guard
+        .list_sessions(Some("test-agent"))
+        .expect("list sessions");
+    assert_eq!(
+        all_sessions.len(),
+        1,
+        "should have exactly 1 session (no orphan), got {}",
+        all_sessions.len()
+    );
+    assert_eq!(
+        all_sessions[0].id, existing_db_id,
+        "surviving session must be the original DB session ID"
+    );
+
+    drop(store_guard);
+    handle.shutdown().await.expect("shutdown");
+    join.await.expect("join");
+}

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -267,18 +267,37 @@ impl NousActor {
         // Persist session to store BEFORE spawning the pipeline task.
         if let Some(ref store) = self.stores.session_store {
             let guard = store.lock().await;
-            if let Err(e) = guard.find_or_create_session(
+            match guard.find_or_create_session(
                 &session.id,
                 &session.nous_id,
                 &session.session_key,
                 Some(&session.model),
                 None,
             ) {
-                warn!(
-                    session_id = %session.id,
-                    error = %e,
-                    "failed to pre-persist session — pipeline will retry in finalize"
-                );
+                Ok(db_session) if db_session.id != session.id => {
+                    // WHY(#3103): The DB already had a session for (nous_id, session_key)
+                    // with a different ID (e.g., from a previous cycle or a restart).
+                    // find_or_create_session returns the canonical DB ID via
+                    // ON CONFLICT DO NOTHING + SELECT. If we kept the actor's generated
+                    // ID, finalize would call append_message with an ID that has no
+                    // DB row → FOREIGN KEY constraint failure and silent data loss.
+                    // Adopt the DB session ID so the actor and DB stay in sync.
+                    debug!(
+                        actor_id = %session.id,
+                        db_id = %db_session.id,
+                        session_key = %session.session_key,
+                        "adopting DB session ID — actor ID diverged from DB"
+                    );
+                    session.id.clone_from(&db_session.id);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    warn!(
+                        session_id = %session.id,
+                        error = %e,
+                        "failed to pre-persist session — pipeline will retry in finalize"
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- `spawn_pipeline_task` in `NousActor` now captures the return value of `find_or_create_session` and adopts the DB session ID when it differs from the actor's in-memory session ID
- Prevents FK constraint failure when the daemon's `"daemon:prosoche"` session already exists in the DB but the actor has no in-memory entry (after restart or LRU eviction)
- The daemon bridge calls `send_turn` with `session_id: None`, so without this fix the actor generates a fresh ULID, `find_or_create_session` silently returns the existing DB row (via `ON CONFLICT DO NOTHING + SELECT`), and `finalize` then calls `append_message` with the wrong ID → FK violation and silent data loss

## Root cause

`find_or_create_session` uses `INSERT ... ON CONFLICT(nous_id, session_key) DO NOTHING` followed by a `SELECT`. When the actor restarts and generates a new ULID for `"daemon:prosoche"`, the INSERT is ignored, and the SELECT returns the **original** DB ID. The old code discarded this return value, so the actor continued using the new (wrong) ID all the way into finalize.

The fix is a single match arm: if `db_session.id != session.id`, adopt the DB ID in the actor's in-memory `SessionState` before cloning it into `PipelineInput`.

## Test plan

- [x] `cargo check -p nous` — clean
- [x] `cargo clippy -p nous -- -D warnings` — zero warnings
- [x] `cargo test -p nous` — 696 tests pass
- [x] New regression test `prosoche_daemon_adopts_existing_db_session_id` covers the exact failure scenario: pre-existing DB session, fresh actor, `send_turn` with `session_id: None`, verifies messages land under the original DB session ID with no orphan sessions
- [x] Existing test `divergent_session_id_causes_fk_violation` in `finalize.rs` continues to document the failure mode

Closes #3103

🤖 Generated with [Claude Code](https://claude.com/claude-code)