### PR TITLE
feat(proskenion): daemonize — log-to-file, .desktop, clean window close (#3099)

### DIFF
--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "compact_str",
  "jiff",
@@ -3490,6 +3490,8 @@ dependencies = [
  "tokio-util",
  "toml 1.1.0+spec-1.1.0",
  "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4207,7 +4209,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bytes",
  "compact_str",
@@ -4858,6 +4860,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/theatron/proskenion/Cargo.toml
+++ b/crates/theatron/proskenion/Cargo.toml
@@ -52,6 +52,8 @@ serde_json = "1"
 
 # Logging
 tracing = "0.1"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Error handling
 snafu = "0.8"

--- a/crates/theatron/proskenion/assets/aletheia-proskenion.desktop
+++ b/crates/theatron/proskenion/assets/aletheia-proskenion.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Aletheia
+Comment=Aletheia AI Assistant
+Exec=proskenion
+Icon=aletheia
+Terminal=false
+Categories=Utility;Development;

--- a/crates/theatron/proskenion/src/lib.rs
+++ b/crates/theatron/proskenion/src/lib.rs
@@ -10,6 +10,8 @@
 pub mod api;
 /// Dioxus UI components for the desktop app.
 pub mod components;
+/// Log-to-file initialisation (daily-rolling, non-blocking).
+pub(crate) mod logging;
 /// Platform integration: system tray, global hotkeys, native menus, window state, notifications.
 pub(crate) mod platform;
 /// Background services: SSE connection, stream management, and state sync.
@@ -24,17 +26,26 @@ pub(crate) mod views;
 
 /// Launch the desktop application.
 ///
-/// Loads persisted window state and configures the desktop window before
-/// showing it. Platform features (tray, hotkeys, menus) are initialized
-/// once the connection is established.
-pub fn run() {
+/// Initialises log-to-file, loads persisted window state, and configures the
+/// desktop window before showing it. Closing the window exits the process
+/// cleanly — no minimize-to-tray, no hidden background process.
+///
+/// Pass `verbose = true` (e.g. from a `--verbose` CLI flag) to also emit logs
+/// to stderr. When `RUST_LOG` is set in the environment stderr output is added
+/// automatically regardless.
+pub fn run(verbose: bool) {
+    // WHY: Keep the guard alive for the process lifetime so the non-blocking
+    // writer thread flushes pending log records before the file is closed.
+    let _log_guard = logging::init(verbose);
+
+    tracing::info!("starting proskenion");
+
     // WHY: reqwest with rustls-no-provider requires an explicit crypto provider
-    // install before any Client is constructed, otherwise it panics (#2363).
     // install before any Client is constructed, otherwise it panics with
     // "No provider set" (#2363).
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    use dioxus::desktop::Config;
+    use dioxus::desktop::{Config, WindowCloseBehaviour};
 
     let window_state = platform::window_state::load_or_default();
 
@@ -55,9 +66,16 @@ pub fn run() {
     // WHY: Passing `None` removes the default OS menu bar (Window/Edit/Help)
     // that Dioxus injects via `MenuBuilderState::Unset`. The app's intentional
     // menu structure lives in `platform::menus` and will be wired in separately.
+    //
+    // WHY: `WindowCloseBehaviour::WindowCloses` ensures that clicking the close
+    // button exits the process cleanly. The app must not linger as a background
+    // process with no window — no tray icon is shown, so there would be no way
+    // to recover it. SSE disconnect and window-state persistence happen during
+    // the normal Dioxus shutdown sequence before the process exits.
     let config = Config::new()
         .with_window(window_builder)
-        .with_menu(None::<dioxus::desktop::muda::Menu>);
+        .with_menu(None::<dioxus::desktop::muda::Menu>)
+        .with_close_behaviour(WindowCloseBehaviour::WindowCloses);
 
     dioxus::LaunchBuilder::desktop()
         .with_cfg(config)

--- a/crates/theatron/proskenion/src/logging.rs
+++ b/crates/theatron/proskenion/src/logging.rs
@@ -1,0 +1,88 @@
+//! Log-to-file initialisation for the desktop application.
+//!
+//! Redirects tracing output to a daily-rolling file at
+//! `~/.local/share/aletheia/logs/proskenion.log` so the app runs cleanly
+//! without a terminal attached. When the `RUST_LOG` environment variable is
+//! set or `--verbose` is passed, a stderr layer is added on top.
+
+use std::path::PathBuf;
+
+use tracing_appender::rolling;
+use tracing_subscriber::fmt::Layer;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
+
+/// Initialise the global tracing subscriber.
+///
+/// Always writes to a daily-rolling file at
+/// `~/.local/share/aletheia/logs/proskenion.log`.
+/// Also emits to stderr when `RUST_LOG` is set in the environment or
+/// `verbose` is `true`.
+///
+/// The returned [`tracing_appender::non_blocking::WorkerGuard`] **must** be
+/// bound to a variable in `main` and kept alive for the duration of the
+/// process. Dropping it early flushes and closes the log file, silencing all
+/// subsequent log output.
+pub(crate) fn init(verbose: bool) -> tracing_appender::non_blocking::WorkerGuard {
+    let log_dir = log_directory();
+
+    // WHY: Create the directory here (not lazily) so any failure surfaces at
+    // startup rather than silently swallowing log lines.
+    if let Err(e) = std::fs::create_dir_all(&log_dir) {
+        eprintln!(
+            "proskenion: failed to create log directory {}: {e}",
+            log_dir.display()
+        );
+    }
+
+    let file_appender = rolling::daily(&log_dir, "proskenion.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    // File layer: always on, no ANSI, level from RUST_LOG or default info.
+    let file_layer = Layer::new()
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_filter(
+            EnvFilter::from_default_env()
+                .add_directive("proskenion=info".parse().unwrap_or_default()),
+        );
+
+    let subscriber = tracing_subscriber::registry().with(file_layer);
+
+    // Stderr layer: only when RUST_LOG is set or --verbose was passed.
+    let rust_log_set = std::env::var("RUST_LOG").is_ok();
+    if verbose || rust_log_set {
+        let stderr_layer = Layer::new()
+            .with_writer(std::io::stderr)
+            .with_ansi(true)
+            .with_filter(EnvFilter::from_default_env());
+        subscriber.with(stderr_layer).init();
+    } else {
+        subscriber.init();
+    }
+
+    guard
+}
+
+/// Resolve the log directory: `~/.local/share/aletheia/logs/`.
+fn log_directory() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("aletheia")
+        .join("logs")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_directory_ends_with_aletheia_logs() {
+        let dir = log_directory();
+        let s = dir.to_string_lossy();
+        assert!(
+            s.ends_with("aletheia/logs"),
+            "unexpected log dir: {s}"
+        );
+    }
+}

--- a/crates/theatron/proskenion/src/main.rs
+++ b/crates/theatron/proskenion/src/main.rs
@@ -1,5 +1,9 @@
 //! Entry point for the Aletheia desktop application.
 
 fn main() {
-    proskenion::run();
+    // WHY: Parse --verbose before handing off to the library so the flag is
+    // visible here without adding a CLI-parsing dependency. `args()` includes
+    // `argv[0]` (the binary name), so we skip it.
+    let verbose = std::env::args().skip(1).any(|a| a == "--verbose" || a == "-v");
+    proskenion::run(verbose);
 }

--- a/crates/theatron/proskenion/src/state/platform.rs
+++ b/crates/theatron/proskenion/src/state/platform.rs
@@ -189,14 +189,19 @@ impl QuickInputState {
 }
 
 /// Close behavior when the user clicks the window close button.
+///
+/// The Dioxus-level `WindowCloseBehaviour::WindowCloses` config enforces clean
+/// exit at the framework layer. `CloseBehavior` is the application-level
+/// mirror used by state/signal code. Both are set to `Quit`/`WindowCloses` so
+/// they stay in sync and the app never lingers as an invisible background process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum CloseBehavior {
     /// Minimize to system tray instead of quitting.
-    #[default]
     MinimizeToTray,
-    /// Quit the application.
+    /// Quit the application cleanly (disconnect SSE, persist state, exit).
+    #[default]
     Quit,
 }
 
@@ -297,8 +302,8 @@ mod tests {
     // -- CloseBehavior --
 
     #[test]
-    fn close_behavior_default_is_minimize_to_tray() {
-        assert_eq!(CloseBehavior::default(), CloseBehavior::MinimizeToTray);
+    fn close_behavior_default_is_quit() {
+        assert_eq!(CloseBehavior::default(), CloseBehavior::Quit);
     }
 
     #[test]
@@ -317,10 +322,10 @@ mod tests {
         let deserialized: Wrapper = toml::from_str(&serialized).unwrap();
         assert_eq!(deserialized.close, CloseBehavior::Quit);
 
-        let wrapper_default = Wrapper {
+        let wrapper_minimize = Wrapper {
             close: CloseBehavior::MinimizeToTray,
         };
-        let serialized = toml::to_string(&wrapper_default).unwrap();
+        let serialized = toml::to_string(&wrapper_minimize).unwrap();
         assert!(serialized.contains("minimize_to_tray"));
     }
 }


### PR DESCRIPTION
## Summary

- **`.desktop` file** — `assets/aletheia-proskenion.desktop` for GNOME/KDE app launchers (`Terminal=false`); double-click launches work without a terminal
- **Log-to-file** — new `src/logging.rs` module adds `tracing-appender` daily-rolling file appender at `~/.local/share/aletheia/logs/proskenion.log`; non-blocking writer; stderr layer added only when `RUST_LOG` is set or `--verbose`/`-v` flag passed
- **Clean window close** — `WindowCloseBehaviour::WindowCloses` set in Dioxus `Config`; `CloseBehavior` default changed from `MinimizeToTray` to `Quit` to stay in sync; no tray icon, no hidden background process
- **Verbose flag** — `run()` signature takes `verbose: bool`; `main.rs` parses `--verbose`/`-v` from argv without adding a CLI-parsing dependency

## Test plan

- [ ] `cargo check -p proskenion` passes (verified: clean)
- [ ] `cargo clippy -p proskenion` — no new warnings introduced (pre-existing 69 errors unchanged)
- [ ] `crates/theatron/proskenion/assets/aletheia-proskenion.desktop` exists with `Terminal=false`
- [ ] Install `.desktop` to `~/.local/share/applications/`, double-click from file manager — app launches without terminal
- [ ] Close window → process exits (verify via `ps aux | grep proskenion`)
- [ ] Logs appear at `~/.local/share/aletheia/logs/proskenion.log.*` after launch
- [ ] `proskenion --verbose` emits to stderr in addition to file

Closes #3099