### PR TITLE
feat(organon,agora,dianoia): parameterize tool and planning constants via taxis config (#2306)

### DIFF
--- a/crates/agora/src/listener.rs
+++ b/crates/agora/src/listener.rs
@@ -69,7 +69,8 @@ impl ChannelListener {
         }
     }
 
-    /// Maximum number of concurrent handler tasks per listener.
+    /// Maximum concurrent handler tasks. Matches
+    /// \.
     const MAX_CONCURRENT_HANDLERS: usize = 64;
 
     /// Run the listener loop, dispatching each message to the handler concurrently.

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -12,9 +12,12 @@ use koina::http::CONTENT_TYPE_JSON;
 use super::envelope::SignalEnvelope;
 use super::error::{self, Result};
 
-const RPC_TIMEOUT: Duration = Duration::from_secs(10);
-const HEALTH_TIMEOUT: Duration = Duration::from_secs(2);
-const RECEIVE_TIMEOUT: Duration = Duration::from_secs(15);
+/// Timeout for standard RPC calls. Matches `taxis::config::MessagingConfig::rpc_timeout_secs`.
+pub(crate) const RPC_TIMEOUT: Duration = Duration::from_secs(10);
+/// Timeout for health-check requests. Matches `taxis::config::MessagingConfig::health_timeout_secs`.
+pub(crate) const HEALTH_TIMEOUT: Duration = Duration::from_secs(2);
+/// Timeout for receive (poll) requests. Matches `taxis::config::MessagingConfig::receive_timeout_secs`.
+pub(crate) const RECEIVE_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Serialize)]
 struct RpcRequest<'a> {

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -26,17 +26,22 @@ use crate::types::{
 };
 use connection::{AccountState, ConnectionHealthReport, ConnectionState, reconnect_delay};
 
-const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
-const DEFAULT_BUFFER_CAPACITY: usize = 100;
+/// Default poll interval. Matches `taxis::config::MessagingConfig::poll_interval_ms`.
+pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// Default buffer capacity. Matches `taxis::config::MessagingConfig::buffer_capacity`.
+pub(crate) const DEFAULT_BUFFER_CAPACITY: usize = 100;
 
 /// Consecutive poll failures before the circuit breaker trips and polling halts.
 /// WHY: lowered from 20 to 5 because signal-cli being down is the common case
 /// (`auto_start=false`, user hasn't started it), and 20 retries at exponential
 /// backoff = several minutes of warn-level log spam before halting (#3104).
-const CIRCUIT_BREAKER_THRESHOLD: u32 = 5;
+/// Circuit breaker threshold. Matches \.
+pub(crate) const CIRCUIT_BREAKER_THRESHOLD: u32 = 5;
 
 /// Interval between health checks while the circuit breaker is open.
-const HALTED_HEALTH_CHECK_INTERVAL: Duration = Duration::from_mins(1);
+/// Interval between health checks while halted. Matches
+/// \.
+pub(crate) const HALTED_HEALTH_CHECK_INTERVAL: Duration = Duration::from_mins(1);
 
 /// Parsed Signal message target.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/dianoia/src/plan.rs
+++ b/crates/dianoia/src/plan.rs
@@ -5,7 +5,11 @@ use koina::ulid::Ulid;
 
 use crate::error::{self, Result};
 
-const DEFAULT_MAX_ITERATIONS: u32 = 10;
+/// Default maximum planning iterations.
+///
+/// Callers with access to the resolved taxis config should use
+/// `AgentBehaviorDefaults::planning_max_iterations` instead of this fallback.
+pub const DEFAULT_MAX_ITERATIONS: u32 = 10;
 
 /// An executable plan within a phase.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,6 +116,16 @@ impl Plan {
             blockers: Vec::new(),
             achievements: Vec::new(),
         }
+    }
+
+    /// Set the maximum iteration limit (builder pattern).
+    ///
+    /// Use to override [`DEFAULT_MAX_ITERATIONS`] with a value from
+    /// `taxis::config::AgentBehaviorDefaults::planning_max_iterations`.
+    #[must_use]
+    pub fn with_max_iterations(mut self, max: u32) -> Self {
+        self.max_iterations = max;
+        self
     }
 
     /// Check if all dependencies are satisfied given completed plan IDs.

--- a/crates/dianoia/src/reconciler.rs
+++ b/crates/dianoia/src/reconciler.rs
@@ -103,9 +103,11 @@ pub struct ReconciliationSummary {
     pub total_conflicts: usize,
 }
 
-/// Tolerance in seconds for timestamp comparison. Differences within this
-/// window are treated as "in sync."
-const TIMESTAMP_TOLERANCE_SECS: i64 = 5;
+/// Default tolerance in seconds for timestamp comparison.
+///
+/// Callers with access to the resolved taxis config should use
+/// `AgentBehaviorDefaults::planning_reconciler_timestamp_tolerance_secs` instead.
+pub const DEFAULT_TIMESTAMP_TOLERANCE_SECS: i64 = 5;
 
 /// Reconcile two optional project snapshots into a single result.
 ///
@@ -120,6 +122,7 @@ const TIMESTAMP_TOLERANCE_SECS: i64 = 5;
 pub(crate) fn reconcile(
     db_snapshot: Option<&ProjectSnapshot>,
     fs_snapshot: Option<&ProjectSnapshot>,
+    tolerance_secs: i64,
 ) -> ReconciliationResult {
     match (db_snapshot, fs_snapshot) {
         (Some(db), None) => ReconciliationResult {
@@ -146,12 +149,12 @@ pub(crate) fn reconcile(
             errors: vec!["no snapshots provided".to_owned()],
         },
 
-        (Some(db), Some(fs)) => reconcile_both(db, fs),
+        (Some(db), Some(fs)) => reconcile_both(db, fs, tolerance_secs),
     }
 }
 
 /// Reconcile when both sources have the project.
-fn reconcile_both(db: &ProjectSnapshot, fs: &ProjectSnapshot) -> ReconciliationResult {
+fn reconcile_both(db: &ProjectSnapshot, fs: &ProjectSnapshot, tolerance_secs: i64) -> ReconciliationResult {
     let project_id = db.project.id.to_string();
     let mut conflicts = Vec::new();
 
@@ -163,9 +166,9 @@ fn reconcile_both(db: &ProjectSnapshot, fs: &ProjectSnapshot) -> ReconciliationR
         .as_second()
         .saturating_sub(fs.project.updated_at.as_second());
 
-    let (direction, winner) = if diff_secs > TIMESTAMP_TOLERANCE_SECS {
+    let (direction, winner) = if diff_secs > tolerance_secs {
         (ReconciliationDirection::DbToFiles, SnapshotOrigin::Database)
-    } else if diff_secs < -TIMESTAMP_TOLERANCE_SECS {
+    } else if diff_secs < -tolerance_secs {
         (
             ReconciliationDirection::FilesToDb,
             SnapshotOrigin::Filesystem,
@@ -255,6 +258,7 @@ fn detect_conflicts(db: &Project, fs: &Project, conflicts: &mut Vec<ConflictEntr
 pub(crate) fn reconcile_all(
     db_snapshots: &[ProjectSnapshot],
     fs_snapshots: &[ProjectSnapshot],
+    tolerance_secs: i64,
 ) -> ReconciliationSummary {
     let mut seen = std::collections::HashSet::new();
     let mut results = Vec::new();
@@ -270,7 +274,7 @@ pub(crate) fn reconcile_all(
         }
         let db = db_by_id.get(id).copied();
         let fs = fs_by_id.get(id).copied();
-        results.push(reconcile(db, fs));
+        results.push(reconcile(db, fs, tolerance_secs));
     }
 
     let total_errors: usize = results.iter().map(|r| r.errors.len()).sum();
@@ -312,7 +316,7 @@ mod tests {
         let project = make_project("db-only");
         let snap = make_snapshot(project.clone(), SnapshotOrigin::Database);
 
-        let result = reconcile(Some(&snap), None);
+        let result = reconcile(Some(&snap), None, DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(result.direction, ReconciliationDirection::DbOnly);
         assert!(result.conflicts.is_empty());
@@ -324,7 +328,7 @@ mod tests {
         let project = make_project("fs-only");
         let snap = make_snapshot(project.clone(), SnapshotOrigin::Filesystem);
 
-        let result = reconcile(None, Some(&snap));
+        let result = reconcile(None, Some(&snap), DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(result.direction, ReconciliationDirection::FilesOnly);
         assert!(result.conflicts.is_empty());
@@ -333,7 +337,7 @@ mod tests {
 
     #[test]
     fn no_snapshots_returns_error() {
-        let result = reconcile(None, None);
+        let result = reconcile(None, None, DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(result.direction, ReconciliationDirection::InSync);
         assert!(!result.errors.is_empty());
@@ -346,7 +350,7 @@ mod tests {
         let db = make_snapshot(project.clone(), SnapshotOrigin::Database);
         let fs = make_snapshot(project, SnapshotOrigin::Filesystem);
 
-        let result = reconcile(Some(&db), Some(&fs));
+        let result = reconcile(Some(&db), Some(&fs), DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(result.direction, ReconciliationDirection::InSync);
         assert!(result.conflicts.is_empty());
@@ -371,7 +375,7 @@ mod tests {
             origin: SnapshotOrigin::Filesystem,
         };
 
-        let result = reconcile(Some(&db), Some(&fs));
+        let result = reconcile(Some(&db), Some(&fs), DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(result.direction, ReconciliationDirection::DbToFiles);
         assert_eq!(
@@ -398,7 +402,7 @@ mod tests {
             origin: SnapshotOrigin::Filesystem,
         };
 
-        let result = reconcile(Some(&db), Some(&fs));
+        let result = reconcile(Some(&db), Some(&fs), DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(result.direction, ReconciliationDirection::FilesToDb);
         assert_eq!(
@@ -422,7 +426,7 @@ mod tests {
         let db = make_snapshot(db_project, SnapshotOrigin::Database);
         let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
 
-        let result = reconcile(Some(&db), Some(&fs));
+        let result = reconcile(Some(&db), Some(&fs), DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert!(!result.conflicts.is_empty());
         let name_conflict = result.conflicts.iter().find(|c| c.field == "name").unwrap();
@@ -446,7 +450,7 @@ mod tests {
         let db = make_snapshot(db_project, SnapshotOrigin::Database);
         let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
 
-        let result = reconcile(Some(&db), Some(&fs));
+        let result = reconcile(Some(&db), Some(&fs), DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         let state_conflict = result
             .conflicts
@@ -473,7 +477,7 @@ mod tests {
         let db = make_snapshot(db_project, SnapshotOrigin::Database);
         let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
 
-        let result = reconcile(Some(&db), Some(&fs));
+        let result = reconcile(Some(&db), Some(&fs), DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         let phase_conflict = result
             .conflicts
@@ -499,7 +503,7 @@ mod tests {
             make_snapshot(p3, SnapshotOrigin::Filesystem),
         ];
 
-        let summary = reconcile_all(&db_snaps, &fs_snaps);
+        let summary = reconcile_all(&db_snaps, &fs_snaps, DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(summary.projects.len(), 3);
 
@@ -526,7 +530,7 @@ mod tests {
         let db = make_snapshot(db_project, SnapshotOrigin::Database);
         let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
 
-        let result = reconcile(Some(&db), Some(&fs));
+        let result = reconcile(Some(&db), Some(&fs), DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(result.direction, ReconciliationDirection::InSync);
     }
@@ -547,7 +551,7 @@ mod tests {
         let db = make_snapshot(db_project, SnapshotOrigin::Database);
         let fs = make_snapshot(fs_project, SnapshotOrigin::Filesystem);
 
-        let result = reconcile(Some(&db), Some(&fs));
+        let result = reconcile(Some(&db), Some(&fs), DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(result.direction, ReconciliationDirection::FilesToDb);
         let name_conflict = result.conflicts.iter().find(|c| c.field == "name").unwrap();
@@ -556,7 +560,7 @@ mod tests {
 
     #[test]
     fn reconcile_all_empty_inputs() {
-        let summary = reconcile_all(&[], &[]);
+        let summary = reconcile_all(&[], &[], DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert!(summary.projects.is_empty());
         assert_eq!(summary.total_errors, 0);
@@ -576,7 +580,7 @@ mod tests {
         let db_snaps = vec![make_snapshot(db_project, SnapshotOrigin::Database)];
         let fs_snaps = vec![make_snapshot(fs_project, SnapshotOrigin::Filesystem)];
 
-        let summary = reconcile_all(&db_snaps, &fs_snaps);
+        let summary = reconcile_all(&db_snaps, &fs_snaps, DEFAULT_TIMESTAMP_TOLERANCE_SECS);
 
         assert_eq!(summary.total_errors, 0);
         assert!(

--- a/crates/dianoia/src/stuck.rs
+++ b/crates/dianoia/src/stuck.rs
@@ -4,13 +4,11 @@ use std::collections::VecDeque;
 
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_HISTORY_WINDOW: usize = 20;
-const DEFAULT_REPEATED_ERROR_THRESHOLD: u32 = 3;
-const DEFAULT_SAME_ARGS_THRESHOLD: u32 = 3;
-const DEFAULT_ALTERNATING_THRESHOLD: u32 = 3;
-const DEFAULT_ESCALATING_RETRY_THRESHOLD: u32 = 3;
-
 /// Configuration for stuck detection thresholds.
+///
+/// Defaults match `taxis::config::AgentBehaviorDefaults::planning_stuck_*` fields.
+/// Callers should construct from the resolved taxis config rather than relying
+/// on `Default`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StuckConfig {
     /// How many identical consecutive errors trigger detection.
@@ -28,11 +26,11 @@ pub struct StuckConfig {
 impl Default for StuckConfig {
     fn default() -> Self {
         Self {
-            repeated_error_threshold: DEFAULT_REPEATED_ERROR_THRESHOLD,
-            same_args_threshold: DEFAULT_SAME_ARGS_THRESHOLD,
-            alternating_threshold: DEFAULT_ALTERNATING_THRESHOLD,
-            escalating_retry_threshold: DEFAULT_ESCALATING_RETRY_THRESHOLD,
-            history_window: DEFAULT_HISTORY_WINDOW,
+            repeated_error_threshold: 3,
+            same_args_threshold: 3,
+            alternating_threshold: 3,
+            escalating_retry_threshold: 3,
+            history_window: 20,
         }
     }
 }

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -16,8 +16,12 @@ use crate::types::{
     ToolDef, ToolInput, ToolResult,
 };
 
-const DEFAULT_TIMEOUT_SECS: u64 = 300;
-const MAX_DISPATCH_TASKS: usize = 10;
+/// Default timeout for spawned sub-agents. Matches
+/// `taxis::config::MessagingConfig::agent_dispatch_timeout_secs`.
+pub(crate) const DEFAULT_TIMEOUT_SECS: u64 = 300;
+/// Maximum concurrent dispatch tasks. Matches
+/// `taxis::config::AgentBehaviorDefaults::tool_agent_dispatch_max_tasks`.
+pub(crate) const MAX_DISPATCH_TASKS: usize = 10;
 
 struct SessionsSpawnExecutor;
 

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -15,9 +15,15 @@ use crate::types::{
     ToolInput, ToolResult,
 };
 
-const MESSAGE_MAX_LEN: usize = 4000;
-const INTER_SESSION_MAX_MESSAGE_LEN: usize = 100_000;
-const INTER_SESSION_MAX_TIMEOUT_SECS: u64 = 300;
+/// Maximum characters per intra-session message. Matches
+/// `taxis::config::ToolLimitsConfig::message_max_len`.
+pub(crate) const MESSAGE_MAX_LEN: usize = 4000;
+/// Maximum characters per inter-session message. Matches
+/// `taxis::config::ToolLimitsConfig::inter_session_max_message_len`.
+pub(crate) const INTER_SESSION_MAX_MESSAGE_LEN: usize = 100_000;
+/// Maximum wait timeout for inter-session messages. Matches
+/// `taxis::config::ToolLimitsConfig::inter_session_max_timeout_secs`.
+pub(crate) const INTER_SESSION_MAX_TIMEOUT_SECS: u64 = 300;
 
 struct MessageExecutor;
 

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -47,7 +47,9 @@ fn canonicalize_and_revalidate(
 /// WHY: Unbounded patterns can trigger catastrophic backtracking in the regex
 /// engine (`ReDoS`). Cap at 1000 chars which covers all legitimate search
 /// patterns. Closes #2167.
-const MAX_PATTERN_LENGTH: usize = 1000;
+/// Maximum character length for search/find patterns. Matches
+/// `taxis::config::ToolLimitsConfig::max_pattern_length`.
+pub(crate) const MAX_PATTERN_LENGTH: usize = 1000;
 
 fn truncate_output(mut output: String) -> String {
     if output.len() > MAX_OUTPUT_BYTES {

--- a/crates/organon/src/builtins/memory/datalog.rs
+++ b/crates/organon/src/builtins/memory/datalog.rs
@@ -19,8 +19,12 @@ use crate::builtins::workspace::extract_str;
 use super::require_services;
 
 const MUTATION_KEYWORDS: &[&str] = &[":put", ":rm", ":replace", ":create", ":ensure"];
-const DEFAULT_ROW_LIMIT: usize = 100;
-const DEFAULT_TIMEOUT_SECS: f64 = 5.0;
+/// Default row limit for query results. Matches
+/// `taxis::config::AgentBehaviorDefaults::tool_datalog_default_row_limit`.
+pub(crate) const DEFAULT_ROW_LIMIT: usize = 100;
+/// Default query timeout in seconds. Matches
+/// `taxis::config::AgentBehaviorDefaults::tool_datalog_default_timeout_secs`.
+pub(crate) const DEFAULT_TIMEOUT_SECS: f64 = 5.0;
 
 struct DatalogQueryExecutor;
 

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -25,8 +25,12 @@ fn relativize_path(path: &Path, workspace: &Path) -> String {
         .to_string()
 }
 
-const MAX_IMAGE_BYTES: u64 = 20 * 1024 * 1024;
-const MAX_PDF_BYTES: u64 = 32 * 1024 * 1024;
+/// Maximum image file size in bytes. Matches
+/// `taxis::config::AgentBehaviorDefaults::tool_max_image_bytes`.
+pub(crate) const MAX_IMAGE_BYTES: u64 = 20 * 1024 * 1024;
+/// Maximum PDF file size in bytes. Matches
+/// `taxis::config::AgentBehaviorDefaults::tool_max_pdf_bytes`.
+pub(crate) const MAX_PDF_BYTES: u64 = 32 * 1024 * 1024;
 
 enum MediaKind {
     Image(&'static str),

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -39,7 +39,9 @@ fn sanitize_path_in_msg(path: &std::path::Path) -> String {
 ///
 /// WHY: Prevents disk exhaustion or fork-bomb-like abuse via oversized writes.
 /// Closes #1714.
-const MAX_WRITE_BYTES: usize = 10 * 1024 * 1024;
+/// Maximum content size for the write tool. Matches
+/// `taxis::config::ToolLimitsConfig::max_write_bytes`.
+pub(crate) const MAX_WRITE_BYTES: usize = 10 * 1024 * 1024;
 
 /// Expand a leading `~` in a path string to the HOME environment variable.
 ///
@@ -199,10 +201,14 @@ pub(crate) fn extract_opt_f64(args: &serde_json::Value, field: &str) -> Option<f
 }
 
 /// Maximum file size the read tool will process.
-const MAX_READ_BYTES: u64 = 50 * 1024 * 1024; // 50 MB
+/// Maximum file size the read tool will process. Matches
+/// `taxis::config::ToolLimitsConfig::max_read_bytes`.
+pub(crate) const MAX_READ_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Maximum command string length for exec.
-const MAX_COMMAND_LENGTH: usize = 10_000; // 10 KB
+/// Maximum command string length for exec. Matches
+/// `taxis::config::ToolLimitsConfig::max_command_length`.
+pub(crate) const MAX_COMMAND_LENGTH: usize = 10_000;
 
 /// Files that the LLM must not overwrite.
 const PROTECTED_FILES: &[&str] = &[

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -1179,6 +1179,9 @@ pub struct MessagingConfig {
     /// Default timeout in seconds for agent-dispatch tool calls. Default: 300.
     /// Mirrors `organon::builtins::agent::DEFAULT_TIMEOUT_SECS`.
     pub agent_dispatch_timeout_secs: u64,
+    /// Maximum concurrent inbound-message handler tasks. Default: 64.
+    /// Mirrors `agora::listener::ChannelListener::MAX_CONCURRENT_HANDLERS`.
+    pub max_concurrent_handlers: usize,
 }
 
 impl Default for MessagingConfig {
@@ -1192,6 +1195,7 @@ impl Default for MessagingConfig {
             health_timeout_secs: 2,
             receive_timeout_secs: 15,
             agent_dispatch_timeout_secs: 300,
+            max_concurrent_handlers: 64,
         }
     }
 }
@@ -1337,6 +1341,9 @@ pub struct AgentBehaviorDefaults {
     /// Escalating retry pattern depth before stuck detection fires. Default: 3.
     /// Mirrors `dianoia::stuck::DEFAULT_ESCALATING_RETRY_THRESHOLD`.
     pub planning_stuck_escalating_retry_threshold: u32,
+    /// Seconds of timestamp difference treated as "in sync" during reconciliation. Default: 5.
+    /// Mirrors `dianoia::reconciler::TIMESTAMP_TOLERANCE_SECS`.
+    pub planning_reconciler_timestamp_tolerance_secs: i64,
 
     // --- Knowledge tuning (instinct / surprise / rules / dedup) ---
     /// Minimum observations before an instinct is eligible. Default: 5.
@@ -1472,6 +1479,7 @@ impl Default for AgentBehaviorDefaults {
             planning_stuck_same_args_threshold: 3,
             planning_stuck_alternating_threshold: 3,
             planning_stuck_escalating_retry_threshold: 3,
+            planning_reconciler_timestamp_tolerance_secs: 5,
             // Knowledge tuning
             knowledge_instinct_min_observations: 5,
             knowledge_instinct_min_success_rate: 0.80,


### PR DESCRIPTION
## Summary

- **Wave 4 (#2306):** Document and parameterize all hardcoded behavioral constants in organon, agora, and dianoia with taxis config field references
- **organon (7 files):** Make all tool limit consts `pub(crate)` with doc comments linking to `ToolLimitsConfig`, `AgentBehaviorDefaults`, and `MessagingConfig` fields — covers agent dispatch timeouts, file size limits, command length, pattern length, communication limits, and datalog query defaults
- **agora (3 files):** Document semeion poll interval, buffer capacity, circuit breaker threshold, halted health check interval, RPC/health/receive timeouts, and listener concurrent handler cap with taxis config field references
- **dianoia (3 files):** Remove 5 module-level consts from stuck.rs (inline into Default impl), make `Plan::DEFAULT_MAX_ITERATIONS` pub with `with_max_iterations()` builder, parameterize reconciler `TIMESTAMP_TOLERANCE_SECS` via function arguments
- **taxis (1 file):** Add `max_concurrent_handlers` to `MessagingConfig`, add `planning_reconciler_timestamp_tolerance_secs` to `AgentBehaviorDefaults`

## Test plan

- [x] `cargo check --workspace` — compiles clean
- [x] `cargo test -p organon -p agora -p dianoia` — all pass
- [x] `cargo clippy -p organon -p agora -p dianoia -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)