### PR TITLE
feat(taxis,organon,aletheia): parameter registry + agent tool + CLI describe (#2306)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "indexmap 2.13.1",
  "koina",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "jiff",
  "koina",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "koina",
  "organon",
@@ -1920,7 +1920,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "eidos"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "jiff",
  "serde",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "eidos",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -2806,7 +2806,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "axum 0.8.8",
  "dokimion",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "fd-lock",
  "futures",
@@ -4046,7 +4046,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "dianoia",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "axum 0.8.8",
  "episteme",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "energeia",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "jiff",
  "snafu",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "poiesis-core",
  "rust_xlsxwriter",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "poiesis-core",
  "ppt-rs",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "krilla",
  "poiesis-core",
@@ -5264,7 +5264,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -6595,7 +6595,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "compact_str",
@@ -6850,7 +6850,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -6963,7 +6963,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -7075,14 +7075,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "futures",
  "indexmap 2.13.1",

--- a/crates/aletheia/src/commands/config.rs
+++ b/crates/aletheia/src/commands/config.rs
@@ -1,4 +1,4 @@
-//! `aletheia config`: encryption key management and config encryption.
+//! `aletheia config`: encryption key management, config encryption, and parameter description.
 
 use std::path::PathBuf;
 
@@ -7,6 +7,7 @@ use snafu::prelude::*;
 
 use taxis::encrypt;
 use taxis::oikos::Oikos;
+use taxis::registry::{self, ParameterTier};
 
 use crate::error::Result;
 
@@ -16,12 +17,36 @@ pub(crate) enum Action {
     InitKey,
     /// Encrypt sensitive plaintext values in aletheia.toml
     Encrypt,
+    /// List tunable parameters with metadata, bounds, and tuning guidance
+    Describe {
+        /// Filter by config section (e.g. "agents.defaults.behavior", "knowledge")
+        #[arg(long)]
+        section: Option<String>,
+        /// Filter by affected subsystem (e.g. "distillation", "competence")
+        #[arg(long)]
+        affects: Option<String>,
+        /// Show only self-tunable parameters
+        #[arg(long)]
+        self_tunable: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub(crate) fn run(action: &Action, instance_root: Option<&PathBuf>) -> Result<()> {
     match action {
         Action::InitKey => run_init_key(),
         Action::Encrypt => run_encrypt(instance_root),
+        Action::Describe {
+            section,
+            affects,
+            self_tunable,
+            json,
+        } => {
+            run_describe(section.as_deref(), affects.as_deref(), *self_tunable, *json);
+            Ok(())
+        }
     }
 }
 
@@ -74,4 +99,64 @@ fn run_encrypt(instance_root: Option<&PathBuf>) -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn run_describe(section: Option<&str>, affects: Option<&str>, self_tunable: bool, json: bool) {
+    let all = registry::all_specs();
+
+    let filtered: Vec<_> = all
+        .iter()
+        .filter(|s| {
+            if let Some(sec) = section
+                && !s.section.contains(sec)
+            {
+                return false;
+            }
+            if let Some(aff) = affects
+                && !s.affects.contains(aff)
+            {
+                return false;
+            }
+            if self_tunable && s.tier != ParameterTier::SelfTuning {
+                return false;
+            }
+            true
+        })
+        .collect();
+
+    if json {
+        // WHY: serde_json::to_string_pretty cannot fail on Vec<&ParameterSpec>
+        // since all fields are serializable static types.
+        let json_output = serde_json::to_string_pretty(&filtered)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"));
+        println!("{json_output}");
+        return;
+    }
+
+    if filtered.is_empty() {
+        println!("No parameters match the given filters.");
+        return;
+    }
+
+    println!("{} parameter(s) found:\n", filtered.len());
+
+    for spec in &filtered {
+        println!("{}", spec.key);
+        println!("  Section:        {}", spec.section);
+        println!("  Tier:           {}", spec.tier);
+        println!("  Default:        {}", spec.default);
+        if let Some((min, max)) = spec.bounds {
+            println!("  Bounds:         [{min}, {max}]");
+        }
+        println!(
+            "  Hot-reloadable: {}",
+            if spec.hot_reloadable { "yes" } else { "no" }
+        );
+        println!("  Description:    {}", spec.description);
+        println!("  Affects:        {}", spec.affects);
+        println!("  Outcome signal: {}", spec.outcome_signal);
+        println!("  Evidence:       {}", spec.evidence_required);
+        println!("  Direction:      {}", spec.direction_hint);
+        println!();
+    }
 }

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -18,6 +18,8 @@ pub mod enable_tool;
 pub mod energeia;
 /// Filesystem navigation tools (grep, find, ls).
 pub mod filesystem;
+/// Parameter registry query tool (discover tunable parameters).
+pub mod parameters;
 /// Knowledge graph and session memory tools (remember, recall).
 pub mod memory;
 /// Planning project management tools (create, status, execute, verify).
@@ -68,6 +70,7 @@ pub fn register_all_with_sandbox(
     planning::register(registry)?;
     research::register(registry)?;
     triage::register(registry)?;
+    parameters::register(registry)?;
     #[cfg(feature = "energeia")]
     // WHY: No EnergeiaServices provided at this registration level — callers that
     // have services configured should use energeia::register(registry, Some(services)).

--- a/crates/organon/src/builtins/parameters.rs
+++ b/crates/organon/src/builtins/parameters.rs
@@ -1,0 +1,308 @@
+//! Agent tool for discovering tunable parameters and their metadata.
+//!
+//! Lets agents (and operators through agent conversations) query what
+//! configuration knobs exist, what they control, and how they should be tuned.
+
+use std::fmt::Write;
+use std::future::Future;
+use std::pin::Pin;
+
+use indexmap::IndexMap;
+
+use koina::id::ToolName;
+use taxis::registry::{self, ParameterSpec, ParameterTier};
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+/// Filter specs against the optional section/affects/tier inputs.
+fn matches_filters(
+    spec: &ParameterSpec,
+    section: Option<&str>,
+    affects: Option<&str>,
+    tier: Option<&str>,
+) -> bool {
+    if let Some(sec) = section
+        && !spec.section.contains(sec)
+    {
+        return false;
+    }
+    if let Some(aff) = affects
+        && !spec.affects.contains(aff)
+    {
+        return false;
+    }
+    if let Some(t) = tier {
+        let tier_match = match t {
+            "deployment" => spec.tier == ParameterTier::Deployment,
+            "per-agent" | "peragent" | "per_agent" => spec.tier == ParameterTier::PerAgent,
+            "self-tuning" | "selftuning" | "self_tuning" => spec.tier == ParameterTier::SelfTuning,
+            _ => true,
+        };
+        if !tier_match {
+            return false;
+        }
+    }
+    true
+}
+
+/// Format a single spec into the output buffer.
+fn format_spec(out: &mut String, spec: &ParameterSpec) {
+    let _ = writeln!(out, "## {}", spec.key);
+    let _ = writeln!(out, "  Section: {}", spec.section);
+    let _ = writeln!(out, "  Tier: {}", spec.tier);
+    let _ = writeln!(out, "  Default: {}", spec.default);
+    if let Some((min, max)) = spec.bounds {
+        let _ = writeln!(out, "  Bounds: [{min}, {max}]");
+    }
+    let _ = writeln!(
+        out,
+        "  Hot-reloadable: {}",
+        if spec.hot_reloadable { "yes" } else { "no" }
+    );
+    let _ = writeln!(out, "  Description: {}", spec.description);
+    let _ = writeln!(out, "  Affects: {}", spec.affects);
+    let _ = writeln!(out, "  Outcome signal: {}", spec.outcome_signal);
+    let _ = writeln!(out, "  Evidence required: {}", spec.evidence_required);
+    let _ = writeln!(out, "  Direction hint: {}\n", spec.direction_hint);
+}
+
+struct QueryParametersExecutor;
+
+impl ToolExecutor for QueryParametersExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let section = input
+                .arguments
+                .get("section")
+                .and_then(serde_json::Value::as_str);
+            let affects = input
+                .arguments
+                .get("affects")
+                .and_then(serde_json::Value::as_str);
+            let tier = input
+                .arguments
+                .get("tier")
+                .and_then(serde_json::Value::as_str);
+
+            let all = registry::all_specs();
+
+            let filtered: Vec<_> = all
+                .iter()
+                .filter(|s| matches_filters(s, section, affects, tier))
+                .collect();
+
+            if filtered.is_empty() {
+                return Ok(ToolResult::text(
+                    "No parameters match the given filters.".to_owned(),
+                ));
+            }
+
+            let mut output = format!("Found {} parameter(s):\n\n", filtered.len());
+            for spec in &filtered {
+                format_spec(&mut output, spec);
+            }
+
+            Ok(ToolResult::text(output))
+        })
+    }
+}
+
+fn query_parameters_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("query_parameters"), // kanon:ignore RUST/expect
+        description: "Query tunable system parameters and their metadata. \
+                      Returns parameter specs with defaults, bounds, tuning tier, \
+                      and outcome signals for self-tuning."
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "section".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Filter by config section (e.g. 'knowledge', 'agents.defaults.behavior')"
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "affects".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Filter by affected subsystem (e.g. 'distillation', 'competence_scoring')"
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "tier".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Filter by tuning tier: 'deployment', 'per-agent', or 'self-tuning'"
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![],
+        },
+        category: ToolCategory::System,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: true,
+    }
+}
+
+/// Register the `query_parameters` tool into the registry.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(query_parameters_def(), Box::new(QueryParametersExecutor))?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    use koina::id::{NousId, SessionId, ToolName};
+
+    use crate::testing::install_crypto_provider;
+    use crate::types::{ServerToolConfig, ToolContext, ToolInput, ToolServices};
+
+    use super::*;
+
+    fn mock_ctx() -> ToolContext {
+        install_crypto_provider();
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: std::path::PathBuf::from("/tmp/test"),
+            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+            services: Some(Arc::new(ToolServices {
+                cross_nous: None,
+                messenger: None,
+                note_store: None,
+                blackboard_store: None,
+                spawn: None,
+                planning: None,
+                knowledge: None,
+                http_client: reqwest::Client::new(),
+                lazy_tool_catalog: vec![],
+                server_tool_config: ServerToolConfig::default(),
+            })),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    #[tokio::test]
+    async fn query_all_returns_results() {
+        let ctx = mock_ctx();
+        let executor = QueryParametersExecutor;
+        let input = ToolInput {
+            name: ToolName::from_static("query_parameters"),
+            tool_use_id: "toolu_1".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error, "expected successful result");
+        assert!(
+            result.content.text_summary().contains("parameter(s)"),
+            "expected output to contain parameter count"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_by_section_filters() {
+        let ctx = mock_ctx();
+        let executor = QueryParametersExecutor;
+        let input = ToolInput {
+            name: ToolName::from_static("query_parameters"),
+            tool_use_id: "toolu_2".to_owned(),
+            arguments: serde_json::json!({"section": "knowledge"}),
+        };
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error, "expected successful result");
+        let text = result.content.text_summary();
+        assert!(
+            text.contains("knowledge"),
+            "expected output to contain knowledge section specs"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_by_tier_filters() {
+        let ctx = mock_ctx();
+        let executor = QueryParametersExecutor;
+        let input = ToolInput {
+            name: ToolName::from_static("query_parameters"),
+            tool_use_id: "toolu_3".to_owned(),
+            arguments: serde_json::json!({"tier": "self-tuning"}),
+        };
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error, "expected successful result");
+        let text = result.content.text_summary();
+        assert!(
+            text.contains("self-tuning"),
+            "expected output to reference self-tuning tier"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_no_match_returns_message() {
+        let ctx = mock_ctx();
+        let executor = QueryParametersExecutor;
+        let input = ToolInput {
+            name: ToolName::from_static("query_parameters"),
+            tool_use_id: "toolu_4".to_owned(),
+            arguments: serde_json::json!({"section": "nonexistent_section_xyz"}),
+        };
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error, "expected non-error result");
+        assert!(
+            result
+                .content
+                .text_summary()
+                .contains("No parameters match"),
+            "expected no-match message"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_by_affects_filters() {
+        let ctx = mock_ctx();
+        let executor = QueryParametersExecutor;
+        let input = ToolInput {
+            name: ToolName::from_static("query_parameters"),
+            tool_use_id: "toolu_5".to_owned(),
+            arguments: serde_json::json!({"affects": "distillation"}),
+        };
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error, "expected successful result");
+        let text = result.content.text_summary();
+        assert!(
+            text.contains("distillation"),
+            "expected output to reference distillation"
+        );
+    }
+}

--- a/crates/taxis/src/lib.rs
+++ b/crates/taxis/src/lib.rs
@@ -24,6 +24,8 @@ pub mod oikos;
 pub mod preflight;
 /// Config redaction: strips secrets before API exposure.
 pub mod redact;
+/// Static parameter registry: metadata for every tunable constant.
+pub mod registry;
 /// Hot-reload classification: restart vs live update.
 pub mod reload;
 /// Config section validation.

--- a/crates/taxis/src/registry.rs
+++ b/crates/taxis/src/registry.rs
@@ -1,0 +1,1066 @@
+//! Static parameter registry: metadata for every tunable constant.
+//!
+//! Each [`ParameterSpec`] describes one knob in the configuration surface:
+//! what it controls, its valid range, whether agents can self-tune it, and
+//! what outcome signal a tuning loop should optimise for.
+
+use std::sync::LazyLock;
+
+/// Classification of who should tune a parameter and when.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum ParameterTier {
+    /// Operator sets at deployment time; not self-tunable.
+    Deployment,
+    /// Operator or agent may override per-agent via config.
+    PerAgent,
+    /// Eligible for automated tuning by the self-tuning loop.
+    SelfTuning,
+}
+
+impl std::fmt::Display for ParameterTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Deployment => f.write_str("deployment"),
+            Self::PerAgent => f.write_str("per-agent"),
+            Self::SelfTuning => f.write_str("self-tuning"),
+        }
+    }
+}
+
+/// Hint for which direction improves the outcome signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum TuningDirection {
+    /// Increasing the value generally improves the outcome signal.
+    Higher,
+    /// Decreasing the value generally improves the outcome signal.
+    Lower,
+    /// Optimal direction depends on deployment context.
+    Contextual,
+}
+
+impl std::fmt::Display for TuningDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Higher => f.write_str("higher"),
+            Self::Lower => f.write_str("lower"),
+            Self::Contextual => f.write_str("contextual"),
+        }
+    }
+}
+
+/// A typed default value for a parameter.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(untagged)]
+pub enum ParameterValue {
+    /// Integer parameter.
+    Int(i64),
+    /// Floating-point parameter.
+    Float(f64),
+    /// Boolean toggle.
+    Bool(bool),
+    /// Duration in the unit described by the parameter key (seconds, milliseconds, etc.).
+    Duration(u64),
+}
+
+impl std::fmt::Display for ParameterValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Int(v) => write!(f, "{v}"),
+            Self::Float(v) => write!(f, "{v}"),
+            Self::Bool(v) => write!(f, "{v}"),
+            Self::Duration(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+/// Metadata for a single tunable parameter.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ParameterSpec {
+    /// Dotted config key (e.g. `"agents.defaults.behavior.distillationContextTokenTrigger"`).
+    pub key: &'static str,
+    /// Config section this parameter lives in.
+    pub section: &'static str,
+    /// Who should tune this parameter.
+    pub tier: ParameterTier,
+    /// Default value compiled into the binary.
+    pub default: ParameterValue,
+    /// Optional `(min, max)` numeric bounds.
+    pub bounds: Option<(f64, f64)>,
+    /// Whether the parameter can be changed without restarting.
+    pub hot_reloadable: bool,
+    /// Human-readable description.
+    pub description: &'static str,
+    /// Which subsystem behavior this parameter affects.
+    pub affects: &'static str,
+    /// Outcome signal that a tuning loop should optimise for.
+    pub outcome_signal: &'static str,
+    /// What evidence is needed before changing this parameter.
+    pub evidence_required: &'static str,
+    /// Hint for which direction improves the outcome signal.
+    pub direction_hint: TuningDirection,
+}
+
+/// Return every registered parameter spec.
+#[must_use]
+pub fn all_specs() -> &'static [ParameterSpec] {
+    &REGISTRY
+}
+
+/// Return specs whose `section` matches `section`.
+#[must_use]
+pub fn specs_by_section(section: &str) -> Vec<&'static ParameterSpec> {
+    REGISTRY.iter().filter(|s| s.section == section).collect()
+}
+
+/// Return specs whose `affects` field contains `outcome`.
+#[must_use]
+pub fn specs_affecting(outcome: &str) -> Vec<&'static ParameterSpec> {
+    REGISTRY.iter().filter(|s| s.affects.contains(outcome)).collect()
+}
+
+/// Look up a single spec by its dotted key.
+#[must_use]
+pub fn spec_by_key(key: &str) -> Option<&'static ParameterSpec> {
+    REGISTRY.iter().find(|s| s.key == key)
+}
+
+// ---------------------------------------------------------------------------
+// Static registry — populated at first access via LazyLock
+// ---------------------------------------------------------------------------
+
+static REGISTRY: LazyLock<Vec<ParameterSpec>> = LazyLock::new(build_registry);
+
+// NOTE(#2306): 769 lines: the registry is a single data declaration — one Vec literal
+// of ParameterSpec entries. Splitting it into separate functions would scatter the
+// registry across files without improving readability. The function is pure data.
+#[expect(
+    clippy::too_many_lines,
+    reason = "static data declaration: one Vec literal of 50+ ParameterSpec entries"
+)]
+fn build_registry() -> Vec<ParameterSpec> {
+    vec![
+        // ===================================================================
+        // Distillation
+        // ===================================================================
+        ParameterSpec {
+            key: "agents.defaults.behavior.distillationContextTokenTrigger",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Int(120_000),
+            bounds: Some((10_000.0, 500_000.0)),
+            hot_reloadable: true,
+            description: "Context token count that triggers automatic distillation",
+            affects: "distillation_frequency",
+            outcome_signal: "turn_quality_post_distillation",
+            evidence_required: "A/B comparison of turn quality and cost before/after threshold change",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.distillationMessageCountTrigger",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Int(150),
+            bounds: Some((10.0, 1000.0)),
+            hot_reloadable: true,
+            description: "Message count that triggers distillation",
+            affects: "distillation_frequency",
+            outcome_signal: "turn_quality_post_distillation",
+            evidence_required: "Session length distribution analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.distillationStaleSessionDays",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::PerAgent,
+            default: ParameterValue::Duration(7),
+            bounds: Some((1.0, 90.0)),
+            hot_reloadable: true,
+            description: "Days idle before a session is considered stale for distillation",
+            affects: "distillation_frequency",
+            outcome_signal: "stale_session_cleanup_rate",
+            evidence_required: "Session idle time distribution",
+            direction_hint: TuningDirection::Lower,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.distillationStaleMinMessages",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::PerAgent,
+            default: ParameterValue::Int(20),
+            bounds: Some((1.0, 200.0)),
+            hot_reloadable: true,
+            description: "Minimum messages required for stale-session distillation",
+            affects: "distillation_frequency",
+            outcome_signal: "stale_session_cleanup_rate",
+            evidence_required: "Session length distribution",
+            direction_hint: TuningDirection::Lower,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.distillationNeverDistilledTrigger",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::PerAgent,
+            default: ParameterValue::Int(30),
+            bounds: Some((5.0, 500.0)),
+            hot_reloadable: true,
+            description: "Message count trigger for sessions never distilled",
+            affects: "distillation_frequency",
+            outcome_signal: "first_distillation_quality",
+            evidence_required: "First-distillation quality metrics",
+            direction_hint: TuningDirection::Lower,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.distillationMaxBackoffTurns",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Int(8),
+            bounds: Some((1.0, 50.0)),
+            hot_reloadable: true,
+            description: "Maximum backoff turns before distillation is forced",
+            affects: "distillation_frequency",
+            outcome_signal: "distillation_backoff_effectiveness",
+            evidence_required: "Backoff-vs-force distillation quality comparison",
+            direction_hint: TuningDirection::Higher,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.distillationMaxToolResultLen",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::PerAgent,
+            default: ParameterValue::Int(500),
+            bounds: Some((50.0, 5000.0)),
+            hot_reloadable: true,
+            description: "Maximum character length for truncated tool results in distillation prompts",
+            affects: "distillation_quality",
+            outcome_signal: "distillation_summary_fidelity",
+            evidence_required: "Comparison of distillation accuracy at different truncation points",
+            direction_hint: TuningDirection::Higher,
+        },
+
+        // ===================================================================
+        // Competence scoring
+        // ===================================================================
+        ParameterSpec {
+            key: "agents.defaults.behavior.competenceCorrectionPenalty",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.05),
+            bounds: Some((0.001, 0.5)),
+            hot_reloadable: true,
+            description: "Competence score penalty per correction",
+            affects: "competence_scoring",
+            outcome_signal: "correction_rate_trend",
+            evidence_required: "Correction frequency and severity over 100+ turns",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.competenceSuccessBonus",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.02),
+            bounds: Some((0.001, 0.2)),
+            hot_reloadable: true,
+            description: "Competence score bonus per successful turn",
+            affects: "competence_scoring",
+            outcome_signal: "competence_score_stability",
+            evidence_required: "Score trajectory analysis over 200+ turns",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.competenceDisagreementPenalty",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.01),
+            bounds: Some((0.001, 0.2)),
+            hot_reloadable: true,
+            description: "Competence score penalty per user disagreement",
+            affects: "competence_scoring",
+            outcome_signal: "user_satisfaction_correlation",
+            evidence_required: "User feedback correlation analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.competenceMinScore",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Float(0.1),
+            bounds: Some((0.0, 0.5)),
+            hot_reloadable: true,
+            description: "Competence score floor",
+            affects: "competence_scoring",
+            outcome_signal: "recovery_from_low_competence",
+            evidence_required: "Agent recovery behavior at minimum score",
+            direction_hint: TuningDirection::Lower,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.competenceMaxScore",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Float(0.95),
+            bounds: Some((0.5, 1.0)),
+            hot_reloadable: true,
+            description: "Competence score ceiling",
+            affects: "competence_scoring",
+            outcome_signal: "score_distribution_shape",
+            evidence_required: "Long-term score distribution analysis",
+            direction_hint: TuningDirection::Higher,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.competenceDefaultScore",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Float(0.5),
+            bounds: Some((0.1, 0.95)),
+            hot_reloadable: true,
+            description: "Initial competence score for a new agent",
+            affects: "competence_scoring",
+            outcome_signal: "new_agent_calibration_speed",
+            evidence_required: "Time-to-accurate-score for new agents",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.competenceEscalationFailureThreshold",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::PerAgent,
+            default: ParameterValue::Float(0.30),
+            bounds: Some((0.05, 0.8)),
+            hot_reloadable: true,
+            description: "Competence score below which escalation fires",
+            affects: "competence_scoring",
+            outcome_signal: "escalation_precision",
+            evidence_required: "False-positive and false-negative escalation rates",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // Knowledge — conflict resolution
+        // ===================================================================
+        ParameterSpec {
+            key: "knowledge.conflictIntraBatchDedupThreshold",
+            section: "knowledge",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.95),
+            bounds: Some((0.5, 1.0)),
+            hot_reloadable: true,
+            description: "Similarity threshold above which intra-batch candidates are merged",
+            affects: "knowledge_dedup",
+            outcome_signal: "duplicate_fact_rate",
+            evidence_required: "Duplicate fact rate at different thresholds",
+            direction_hint: TuningDirection::Higher,
+        },
+        ParameterSpec {
+            key: "knowledge.conflictCandidateDistanceThreshold",
+            section: "knowledge",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.28),
+            bounds: Some((0.05, 0.8)),
+            hot_reloadable: true,
+            description: "Maximum vector distance for a fact to be a conflict candidate",
+            affects: "knowledge_conflict_resolution",
+            outcome_signal: "conflict_detection_recall",
+            evidence_required: "Conflict detection recall/precision at different thresholds",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "knowledge.conflictMaxCandidates",
+            section: "knowledge",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(5),
+            bounds: Some((1.0, 50.0)),
+            hot_reloadable: true,
+            description: "Maximum conflict candidates evaluated per fact",
+            affects: "knowledge_conflict_resolution",
+            outcome_signal: "conflict_resolution_latency",
+            evidence_required: "Latency and accuracy tradeoff at different candidate counts",
+            direction_hint: TuningDirection::Higher,
+        },
+        ParameterSpec {
+            key: "knowledge.decayReinforcementBoost",
+            section: "knowledge",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.02),
+            bounds: Some((0.001, 0.2)),
+            hot_reloadable: true,
+            description: "Confidence boost per reinforcement event",
+            affects: "knowledge_confidence",
+            outcome_signal: "fact_confidence_calibration",
+            evidence_required: "Confidence vs. accuracy correlation analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "knowledge.decayCrossAgentBonusPerAgent",
+            section: "knowledge",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.15),
+            bounds: Some((0.0, 0.5)),
+            hot_reloadable: true,
+            description: "Confidence bonus per additional corroborating agent",
+            affects: "knowledge_confidence",
+            outcome_signal: "cross_agent_fact_accuracy",
+            evidence_required: "Multi-agent corroboration accuracy metrics",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "knowledge.decayMaxCrossAgentMultiplier",
+            section: "knowledge",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Float(1.75),
+            bounds: Some((1.0, 5.0)),
+            hot_reloadable: true,
+            description: "Cap on total cross-agent confidence multiplier",
+            affects: "knowledge_confidence",
+            outcome_signal: "cross_agent_fact_accuracy",
+            evidence_required: "Multi-agent confidence distribution analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // Knowledge — dedup weights
+        // ===================================================================
+        ParameterSpec {
+            key: "agents.defaults.behavior.knowledgeDedupWeightName",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.4),
+            bounds: Some((0.0, 1.0)),
+            hot_reloadable: true,
+            description: "Weight of name similarity in dedup scoring",
+            affects: "knowledge_dedup",
+            outcome_signal: "dedup_precision_recall",
+            evidence_required: "Dedup accuracy at different weight combinations",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.knowledgeDedupWeightEmbed",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.3),
+            bounds: Some((0.0, 1.0)),
+            hot_reloadable: true,
+            description: "Weight of embedding similarity in dedup scoring",
+            affects: "knowledge_dedup",
+            outcome_signal: "dedup_precision_recall",
+            evidence_required: "Dedup accuracy at different weight combinations",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.knowledgeDedupJwThreshold",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.85),
+            bounds: Some((0.5, 1.0)),
+            hot_reloadable: true,
+            description: "Jaro-Winkler score above which strings are considered similar",
+            affects: "knowledge_dedup",
+            outcome_signal: "dedup_precision_recall",
+            evidence_required: "Name-match accuracy at different JW thresholds",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.knowledgeDedupEmbedThreshold",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.80),
+            bounds: Some((0.5, 1.0)),
+            hot_reloadable: true,
+            description: "Cosine similarity above which embeddings are considered similar",
+            affects: "knowledge_dedup",
+            outcome_signal: "dedup_precision_recall",
+            evidence_required: "Embedding-match accuracy at different thresholds",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // Knowledge — fact lifecycle thresholds
+        // ===================================================================
+        ParameterSpec {
+            key: "agents.defaults.behavior.factActiveThreshold",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.7),
+            bounds: Some((0.3, 1.0)),
+            hot_reloadable: true,
+            description: "Confidence above which a fact is considered Active",
+            affects: "knowledge_fact_lifecycle",
+            outcome_signal: "fact_stage_distribution",
+            evidence_required: "Fact lifecycle stage distribution analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.factFadingThreshold",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.3),
+            bounds: Some((0.05, 0.7)),
+            hot_reloadable: true,
+            description: "Confidence below which a fact is considered Fading",
+            affects: "knowledge_fact_lifecycle",
+            outcome_signal: "fact_stage_distribution",
+            evidence_required: "Fact lifecycle stage distribution analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.factDormantThreshold",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Float(0.1),
+            bounds: Some((0.0, 0.3)),
+            hot_reloadable: true,
+            description: "Confidence below which a fact is considered Dormant",
+            affects: "knowledge_fact_lifecycle",
+            outcome_signal: "fact_stage_distribution",
+            evidence_required: "Dormant fact recovery rate analysis",
+            direction_hint: TuningDirection::Lower,
+        },
+
+        // ===================================================================
+        // Tool limits
+        // ===================================================================
+        ParameterSpec {
+            key: "toolLimits.maxPatternLength",
+            section: "toolLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(1_000),
+            bounds: Some((10.0, 100_000.0)),
+            hot_reloadable: true,
+            description: "Maximum character length for glob patterns",
+            affects: "tool_filesystem",
+            outcome_signal: "glob_timeout_rate",
+            evidence_required: "Pattern length vs. execution time distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "toolLimits.subprocessTimeoutSecs",
+            section: "toolLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(60),
+            bounds: Some((5.0, 600.0)),
+            hot_reloadable: true,
+            description: "Timeout in seconds for filesystem subprocess commands",
+            affects: "tool_filesystem",
+            outcome_signal: "subprocess_timeout_rate",
+            evidence_required: "Subprocess execution time distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "toolLimits.maxWriteBytes",
+            section: "toolLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(10_485_760),
+            bounds: Some((1024.0, 104_857_600.0)),
+            hot_reloadable: true,
+            description: "Maximum bytes per workspace write operation (default 10 MiB)",
+            affects: "tool_workspace",
+            outcome_signal: "write_rejection_rate",
+            evidence_required: "Write size distribution analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "toolLimits.maxReadBytes",
+            section: "toolLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(52_428_800),
+            bounds: Some((1024.0, 524_288_000.0)),
+            hot_reloadable: true,
+            description: "Maximum bytes per workspace read operation (default 50 MiB)",
+            affects: "tool_workspace",
+            outcome_signal: "read_rejection_rate",
+            evidence_required: "Read size distribution analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "toolLimits.maxCommandLength",
+            section: "toolLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(10_000),
+            bounds: Some((100.0, 1_000_000.0)),
+            hot_reloadable: true,
+            description: "Maximum character length of a shell command",
+            affects: "tool_workspace",
+            outcome_signal: "command_rejection_rate",
+            evidence_required: "Command length distribution analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "toolLimits.messageMaxLen",
+            section: "toolLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(4_000),
+            bounds: Some((100.0, 100_000.0)),
+            hot_reloadable: true,
+            description: "Maximum characters per intra-session message",
+            affects: "tool_communication",
+            outcome_signal: "message_truncation_rate",
+            evidence_required: "Message length distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "toolLimits.interSessionMaxMessageLen",
+            section: "toolLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(100_000),
+            bounds: Some((1000.0, 1_000_000.0)),
+            hot_reloadable: true,
+            description: "Maximum characters per inter-session message",
+            affects: "tool_communication",
+            outcome_signal: "inter_session_message_truncation_rate",
+            evidence_required: "Inter-session message length distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "toolLimits.interSessionMaxTimeoutSecs",
+            section: "toolLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(300),
+            bounds: Some((10.0, 3600.0)),
+            hot_reloadable: true,
+            description: "Maximum wait timeout in seconds for inter-session messages",
+            affects: "tool_communication",
+            outcome_signal: "inter_session_timeout_rate",
+            evidence_required: "Inter-session response time distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // API limits
+        // ===================================================================
+        ParameterSpec {
+            key: "apiLimits.maxMessageBytes",
+            section: "apiLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(262_144),
+            bounds: Some((1024.0, 10_485_760.0)),
+            hot_reloadable: true,
+            description: "Maximum bytes per streaming message body (default 256 KiB)",
+            affects: "api_message_handling",
+            outcome_signal: "message_rejection_rate",
+            evidence_required: "Message size distribution analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "apiLimits.maxHistoryLimit",
+            section: "apiLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(1_000),
+            bounds: Some((10.0, 100_000.0)),
+            hot_reloadable: true,
+            description: "Maximum messages returned by the history endpoint",
+            affects: "api_history",
+            outcome_signal: "history_request_latency",
+            evidence_required: "History endpoint latency vs. limit analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "apiLimits.maxImportBatchSize",
+            section: "apiLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(1_000),
+            bounds: Some((1.0, 100_000.0)),
+            hot_reloadable: true,
+            description: "Maximum facts in a single bulk-import request",
+            affects: "api_knowledge_import",
+            outcome_signal: "import_throughput",
+            evidence_required: "Import batch size vs. throughput and error rate",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "apiLimits.idempotencyTtlSecs",
+            section: "apiLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(300),
+            bounds: Some((10.0, 86_400.0)),
+            hot_reloadable: true,
+            description: "TTL in seconds for idempotency key cache entries",
+            affects: "api_idempotency",
+            outcome_signal: "idempotency_cache_hit_rate",
+            evidence_required: "Retry timing distribution analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "apiLimits.idempotencyCapacity",
+            section: "apiLimits",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(10_000),
+            bounds: Some((100.0, 1_000_000.0)),
+            hot_reloadable: true,
+            description: "Maximum idempotency cache entries (LRU cap)",
+            affects: "api_idempotency",
+            outcome_signal: "idempotency_cache_eviction_rate",
+            evidence_required: "Cache utilization and eviction rate analysis",
+            direction_hint: TuningDirection::Higher,
+        },
+
+        // ===================================================================
+        // Timeouts and retry
+        // ===================================================================
+        ParameterSpec {
+            key: "timeouts.llmCallSecs",
+            section: "timeouts",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(300),
+            bounds: Some((30.0, 3600.0)),
+            hot_reloadable: true,
+            description: "Maximum wall-clock seconds for a single LLM API call",
+            affects: "llm_latency",
+            outcome_signal: "llm_timeout_rate",
+            evidence_required: "LLM call duration distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "retry.maxAttempts",
+            section: "retry",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(3),
+            bounds: Some((0.0, 10.0)),
+            hot_reloadable: true,
+            description: "Maximum number of retry attempts after an initial transient failure",
+            affects: "llm_reliability",
+            outcome_signal: "retry_success_rate",
+            evidence_required: "Retry success rate by attempt number",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "retry.backoffBaseMs",
+            section: "retry",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(1_000),
+            bounds: Some((100.0, 30_000.0)),
+            hot_reloadable: true,
+            description: "Initial exponential backoff delay in milliseconds",
+            affects: "llm_reliability",
+            outcome_signal: "retry_success_rate",
+            evidence_required: "Retry timing vs. success rate analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "retry.backoffMaxMs",
+            section: "retry",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(30_000),
+            bounds: Some((100.0, 300_000.0)),
+            hot_reloadable: true,
+            description: "Maximum backoff delay cap in milliseconds",
+            affects: "llm_reliability",
+            outcome_signal: "retry_success_rate",
+            evidence_required: "Backoff ceiling vs. retry outcome analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // Safety
+        // ===================================================================
+        ParameterSpec {
+            key: "agents.defaults.behavior.safetyLoopDetectionThreshold",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::PerAgent,
+            default: ParameterValue::Int(3),
+            bounds: Some((1.0, 20.0)),
+            hot_reloadable: true,
+            description: "Consecutive identical tool-call sequences before loop detection fires",
+            affects: "safety_loop_detection",
+            outcome_signal: "loop_detection_precision",
+            evidence_required: "False-positive loop detection rate",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.safetyConsecutiveErrorThreshold",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::PerAgent,
+            default: ParameterValue::Int(4),
+            bounds: Some((1.0, 20.0)),
+            hot_reloadable: true,
+            description: "Consecutive errors before the pipeline aborts with a safety interrupt",
+            affects: "safety_error_handling",
+            outcome_signal: "unnecessary_abort_rate",
+            evidence_required: "Abort necessity analysis at different thresholds",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "agents.defaults.behavior.safetySessionTokenCap",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(500_000),
+            bounds: Some((10_000.0, 5_000_000.0)),
+            hot_reloadable: true,
+            description: "Hard token cap for a single session",
+            affects: "safety_cost_control",
+            outcome_signal: "session_cost_distribution",
+            evidence_required: "Session token usage distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // Capacity
+        // ===================================================================
+        ParameterSpec {
+            key: "capacity.maxToolOutputBytes",
+            section: "capacity",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(51_200),
+            bounds: Some((0.0, 10_485_760.0)),
+            hot_reloadable: true,
+            description: "Maximum bytes returned by a single tool call before truncation (0 to disable)",
+            affects: "tool_output_quality",
+            outcome_signal: "tool_output_truncation_rate",
+            evidence_required: "Tool output size distribution",
+            direction_hint: TuningDirection::Higher,
+        },
+        ParameterSpec {
+            key: "capacity.opusContextTokens",
+            section: "capacity",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(1_000_000),
+            bounds: Some((200_000.0, 2_000_000.0)),
+            hot_reloadable: false,
+            description: "Context window token limit applied to Opus-class models",
+            affects: "model_context_window",
+            outcome_signal: "context_utilization_rate",
+            evidence_required: "Context utilization and quality at different window sizes",
+            direction_hint: TuningDirection::Higher,
+        },
+
+        // ===================================================================
+        // Nous behavior
+        // ===================================================================
+        ParameterSpec {
+            key: "nousBehavior.loopDetectionWindow",
+            section: "nousBehavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(50),
+            bounds: Some((5.0, 500.0)),
+            hot_reloadable: true,
+            description: "Number of recent tool calls scanned for loop detection",
+            affects: "safety_loop_detection",
+            outcome_signal: "loop_detection_precision",
+            evidence_required: "Window size vs. detection accuracy analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "nousBehavior.gcIntervalSecs",
+            section: "nousBehavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(300),
+            bounds: Some((30.0, 3600.0)),
+            hot_reloadable: true,
+            description: "Completed-task garbage collection interval in seconds",
+            affects: "resource_management",
+            outcome_signal: "memory_usage_trend",
+            evidence_required: "Memory usage vs. GC interval analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "nousBehavior.managerHealthIntervalSecs",
+            section: "nousBehavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(30),
+            bounds: Some((5.0, 300.0)),
+            hot_reloadable: true,
+            description: "Agent health poll interval in seconds",
+            affects: "agent_health_monitoring",
+            outcome_signal: "failure_detection_latency",
+            evidence_required: "Time-to-detect-failure at different poll intervals",
+            direction_hint: TuningDirection::Lower,
+        },
+
+        // ===================================================================
+        // Provider behavior
+        // ===================================================================
+        ParameterSpec {
+            key: "providerBehavior.nonStreamingTimeoutSecs",
+            section: "providerBehavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(120),
+            bounds: Some((10.0, 600.0)),
+            hot_reloadable: true,
+            description: "Timeout in seconds for non-streaming LLM requests",
+            affects: "llm_latency",
+            outcome_signal: "non_streaming_timeout_rate",
+            evidence_required: "Non-streaming request duration distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "providerBehavior.complexityLowThreshold",
+            section: "providerBehavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Int(30),
+            bounds: Some((0.0, 100.0)),
+            hot_reloadable: true,
+            description: "Complexity score below which Haiku-class model is selected",
+            affects: "model_routing",
+            outcome_signal: "model_routing_cost_quality_tradeoff",
+            evidence_required: "Quality and cost comparison across routing thresholds",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "providerBehavior.complexityHighThreshold",
+            section: "providerBehavior",
+            tier: ParameterTier::SelfTuning,
+            default: ParameterValue::Int(70),
+            bounds: Some((0.0, 100.0)),
+            hot_reloadable: true,
+            description: "Complexity score above which Opus-class model is selected",
+            affects: "model_routing",
+            outcome_signal: "model_routing_cost_quality_tradeoff",
+            evidence_required: "Quality and cost comparison across routing thresholds",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // Messaging
+        // ===================================================================
+        ParameterSpec {
+            key: "messaging.pollIntervalMs",
+            section: "messaging",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(2_000),
+            bounds: Some((100.0, 60_000.0)),
+            hot_reloadable: true,
+            description: "How often Semeion polls for new channel messages in milliseconds",
+            affects: "message_latency",
+            outcome_signal: "message_delivery_latency",
+            evidence_required: "Message delivery latency distribution",
+            direction_hint: TuningDirection::Lower,
+        },
+        ParameterSpec {
+            key: "messaging.circuitBreakerThreshold",
+            section: "messaging",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(5),
+            bounds: Some((1.0, 50.0)),
+            hot_reloadable: true,
+            description: "Consecutive channel errors before the channel is halted",
+            affects: "message_reliability",
+            outcome_signal: "channel_availability",
+            evidence_required: "Channel error patterns and recovery times",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // Daemon behavior
+        // ===================================================================
+        ParameterSpec {
+            key: "daemonBehavior.watchdogBackoffBaseSecs",
+            section: "daemonBehavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(2),
+            bounds: Some((1.0, 60.0)),
+            hot_reloadable: true,
+            description: "Base duration in seconds for watchdog restart backoff",
+            affects: "daemon_reliability",
+            outcome_signal: "restart_recovery_time",
+            evidence_required: "Restart backoff vs. recovery time analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+        ParameterSpec {
+            key: "daemonBehavior.watchdogBackoffCapSecs",
+            section: "daemonBehavior",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(300),
+            bounds: Some((10.0, 3600.0)),
+            hot_reloadable: true,
+            description: "Maximum watchdog restart backoff duration in seconds",
+            affects: "daemon_reliability",
+            outcome_signal: "restart_recovery_time",
+            evidence_required: "Maximum downtime tolerance analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+    ]
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_is_non_empty() {
+        let specs = all_specs();
+        assert!(
+            specs.len() >= 30,
+            "expected at least 30 parameter specs, got {}",
+            specs.len()
+        );
+    }
+
+    #[test]
+    fn all_keys_are_unique() {
+        let specs = all_specs();
+        let mut seen = std::collections::HashSet::new();
+        for spec in specs {
+            assert!(
+                seen.insert(spec.key),
+                "duplicate key in registry: {}",
+                spec.key
+            );
+        }
+    }
+
+    #[test]
+    fn spec_by_key_finds_known_parameter() {
+        let spec = spec_by_key("agents.defaults.behavior.distillationContextTokenTrigger");
+        assert!(spec.is_some(), "expected to find distillation context token trigger spec");
+        let spec = spec.unwrap();
+        assert_eq!(spec.tier, ParameterTier::SelfTuning);
+    }
+
+    #[test]
+    fn spec_by_key_returns_none_for_unknown() {
+        assert!(spec_by_key("nonexistent.key").is_none());
+    }
+
+    #[test]
+    fn specs_by_section_filters_correctly() {
+        let specs = specs_by_section("knowledge");
+        assert!(
+            !specs.is_empty(),
+            "expected at least one knowledge section spec"
+        );
+        for spec in &specs {
+            assert_eq!(spec.section, "knowledge");
+        }
+    }
+
+    #[test]
+    fn specs_affecting_filters_correctly() {
+        let specs = specs_affecting("distillation");
+        assert!(
+            !specs.is_empty(),
+            "expected at least one spec affecting distillation"
+        );
+        for spec in &specs {
+            assert!(
+                spec.affects.contains("distillation"),
+                "spec {} does not affect distillation",
+                spec.key
+            );
+        }
+    }
+
+    #[test]
+    fn bounds_are_valid_where_present() {
+        for spec in all_specs() {
+            if let Some((min, max)) = spec.bounds {
+                assert!(
+                    min <= max,
+                    "spec {}: bounds min ({}) > max ({})",
+                    spec.key,
+                    min,
+                    max
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn all_specs_have_non_empty_fields() {
+        for spec in all_specs() {
+            assert!(!spec.key.is_empty(), "spec has empty key");
+            assert!(!spec.section.is_empty(), "spec {} has empty section", spec.key);
+            assert!(!spec.description.is_empty(), "spec {} has empty description", spec.key);
+            assert!(!spec.affects.is_empty(), "spec {} has empty affects", spec.key);
+            assert!(!spec.outcome_signal.is_empty(), "spec {} has empty outcome_signal", spec.key);
+            assert!(
+                !spec.evidence_required.is_empty(),
+                "spec {} has empty evidence_required",
+                spec.key
+            );
+        }
+    }
+}

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -122,11 +122,15 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
         "timeouts" => validate_timeouts(value, &mut errors),
         "capacity" => validate_capacity(value, &mut errors),
         "retry" => validate_retry(value, &mut errors),
-        // NOTE: pass-through sections with no validation rules (includes Wave 0
-        // behavioral-constant stubs; real validation added in Wave 5, #2306).
-        "packs" | "pricing" | "sandbox" | "logging" | "mcp" | "localProvider" | "training"
-        | "nousBehavior" | "knowledge" | "providerBehavior" | "apiLimits"
-        | "daemonBehavior" | "toolLimits" | "messaging" => {}
+        "nousBehavior" => validate_nous_behavior(value, &mut errors),
+        "knowledge" => validate_knowledge(value, &mut errors),
+        "providerBehavior" => validate_provider_behavior(value, &mut errors),
+        "apiLimits" => validate_api_limits(value, &mut errors),
+        "daemonBehavior" => validate_daemon_behavior(value, &mut errors),
+        "toolLimits" => validate_tool_limits(value, &mut errors),
+        "messaging" => validate_messaging(value, &mut errors),
+        // NOTE: pass-through sections with no validation rules.
+        "packs" | "pricing" | "sandbox" | "logging" | "mcp" | "localProvider" | "training" => {}
         _ => errors.push(format!("unknown config section: {section}")),
     }
 
@@ -437,6 +441,186 @@ fn check_port(parent: &Value, key: &str, label: &str, errors: &mut Vec<String>) 
     {
         errors.push(format!("{label} must be between 1 and 65535"));
     }
+}
+
+/// Reject a numeric field if its value is outside `[min, max]`.
+fn check_range_f64(parent: &Value, key: &str, min: f64, max: f64, errors: &mut Vec<String>) {
+    if let Some(val) = parent.get(key).and_then(Value::as_f64)
+        && (val < min || val > max)
+    {
+        errors.push(format!("{key} must be between {min} and {max}, got {val}"));
+    }
+}
+
+/// Reject a u64 field if its value is outside `[min, max]`.
+fn check_range_u64(parent: &Value, key: &str, min: u64, max: u64, errors: &mut Vec<String>) {
+    if let Some(val) = parent.get(key).and_then(Value::as_u64)
+        && (val < min || val > max)
+    {
+        errors.push(format!("{key} must be between {min} and {max}, got {val}"));
+    }
+}
+
+fn validate_nous_behavior(value: &Value, errors: &mut Vec<String>) {
+    check_range_u64(value, "degradedPanicThreshold", 1, 100, errors);
+    check_range_u64(value, "degradedWindowSecs", 1, 86_400, errors);
+    check_range_u64(value, "inboxRecvTimeoutSecs", 1, 3600, errors);
+    check_range_u64(value, "inboxCapacity", 1, 10_000, errors);
+    check_range_u64(value, "maxSpawnedTasks", 1, 1_000, errors);
+    check_range_u64(value, "maxSessions", 1, 100_000, errors);
+    check_range_u64(value, "gcIntervalSecs", 30, 3600, errors);
+    check_range_u64(value, "loopDetectionWindow", 5, 500, errors);
+    check_range_u64(value, "cycleDetectionMaxLen", 1, 100, errors);
+    check_range_u64(value, "selfAuditEventThreshold", 1, 10_000, errors);
+    check_range_u64(value, "managerHealthIntervalSecs", 5, 300, errors);
+    check_range_u64(value, "managerPingTimeoutSecs", 1, 60, errors);
+    check_range_u64(value, "managerMaxRestartBackoffSecs", 1, 86_400, errors);
+    check_range_u64(value, "managerRestartDrainTimeoutSecs", 1, 600, errors);
+    check_range_u64(value, "managerRestartDecayWindowSecs", 60, 86_400, errors);
+}
+
+fn validate_knowledge(value: &Value, errors: &mut Vec<String>) {
+    check_range_u64(value, "conflictMaxLlmCallsPerFact", 1, 20, errors);
+    check_range_f64(
+        value,
+        "conflictIntraBatchDedupThreshold",
+        0.5,
+        1.0,
+        errors,
+    );
+    check_range_f64(
+        value,
+        "conflictCandidateDistanceThreshold",
+        0.01,
+        1.0,
+        errors,
+    );
+    check_range_u64(value, "conflictMaxCandidates", 1, 50, errors);
+    check_range_f64(value, "decayReinforcementBoost", 0.001, 1.0, errors);
+    check_range_f64(value, "decayMaxReinforcementBonus", 0.0, 10.0, errors);
+    check_range_f64(value, "decayCrossAgentBonusPerAgent", 0.0, 1.0, errors);
+    check_range_f64(value, "decayMaxCrossAgentMultiplier", 1.0, 10.0, errors);
+    check_range_f64(value, "extractionConfidenceThreshold", 0.0, 1.0, errors);
+    check_range_u64(value, "extractionMinFactLength", 1, 1000, errors);
+    check_range_u64(value, "extractionMaxFactLength", 10, 10_000, errors);
+
+    // INVARIANT: min length must be less than max length.
+    let min_len = value
+        .get("extractionMinFactLength")
+        .and_then(Value::as_u64);
+    let max_len = value
+        .get("extractionMaxFactLength")
+        .and_then(Value::as_u64);
+    if let (Some(min), Some(max)) = (min_len, max_len)
+        && min > max
+    {
+        errors.push(format!(
+            "extractionMinFactLength ({min}) must not exceed extractionMaxFactLength ({max})"
+        ));
+    }
+}
+
+fn validate_provider_behavior(value: &Value, errors: &mut Vec<String>) {
+    check_range_u64(value, "nonStreamingTimeoutSecs", 10, 600, errors);
+    check_range_u64(value, "sseDefaultRetryMs", 100, 60_000, errors);
+    check_range_f64(value, "concurrencyEwmaAlpha", 0.0, 1.0, errors);
+    check_range_f64(
+        value,
+        "concurrencyLatencyThresholdSecs",
+        1.0,
+        300.0,
+        errors,
+    );
+    check_range_u64(value, "complexityLowThreshold", 0, 100, errors);
+    check_range_u64(value, "complexityHighThreshold", 0, 100, errors);
+
+    // INVARIANT: low threshold must be <= high threshold.
+    let low = value
+        .get("complexityLowThreshold")
+        .and_then(Value::as_u64);
+    let high = value
+        .get("complexityHighThreshold")
+        .and_then(Value::as_u64);
+    if let (Some(l), Some(h)) = (low, high)
+        && l > h
+    {
+        errors.push(format!(
+            "complexityLowThreshold ({l}) must not exceed complexityHighThreshold ({h})"
+        ));
+    }
+}
+
+fn validate_api_limits(value: &Value, errors: &mut Vec<String>) {
+    check_range_u64(value, "maxSessionNameLen", 1, 10_000, errors);
+    check_range_u64(value, "maxIdentifierBytes", 1, 10_000, errors);
+    check_range_u64(value, "maxHistoryLimit", 1, 100_000, errors);
+    check_range_u64(value, "defaultHistoryLimit", 1, 100_000, errors);
+    check_range_u64(value, "maxMessageBytes", 1024, 104_857_600, errors);
+    check_range_u64(value, "maxFactsLimit", 1, 100_000, errors);
+    check_range_u64(value, "maxSearchLimit", 1, 100_000, errors);
+    check_range_u64(value, "maxImportBatchSize", 1, 100_000, errors);
+    check_range_u64(value, "idempotencyTtlSecs", 10, 86_400, errors);
+    check_range_u64(value, "idempotencyCapacity", 100, 10_000_000, errors);
+    check_range_u64(value, "idempotencyMaxKeyLength", 1, 1024, errors);
+
+    // INVARIANT: default history limit must be <= max history limit.
+    let default_limit = value
+        .get("defaultHistoryLimit")
+        .and_then(Value::as_u64);
+    let max_limit = value
+        .get("maxHistoryLimit")
+        .and_then(Value::as_u64);
+    if let (Some(d), Some(m)) = (default_limit, max_limit)
+        && d > m
+    {
+        errors.push(format!(
+            "defaultHistoryLimit ({d}) must not exceed maxHistoryLimit ({m})"
+        ));
+    }
+}
+
+fn validate_daemon_behavior(value: &Value, errors: &mut Vec<String>) {
+    check_range_u64(value, "watchdogBackoffBaseSecs", 1, 60, errors);
+    check_range_u64(value, "watchdogBackoffCapSecs", 10, 3600, errors);
+    check_range_u64(value, "prosocheAnomalySampleSize", 2, 1000, errors);
+    check_range_u64(value, "runnerOutputBriefHeadLines", 1, 100, errors);
+    check_range_u64(value, "runnerOutputBriefTailLines", 1, 100, errors);
+
+    // INVARIANT: backoff base must be <= backoff cap.
+    let base = value
+        .get("watchdogBackoffBaseSecs")
+        .and_then(Value::as_u64);
+    let cap = value.get("watchdogBackoffCapSecs").and_then(Value::as_u64);
+    if let (Some(b), Some(c)) = (base, cap)
+        && b > c
+    {
+        errors.push(format!(
+            "watchdogBackoffBaseSecs ({b}) must not exceed watchdogBackoffCapSecs ({c})"
+        ));
+    }
+}
+
+fn validate_tool_limits(value: &Value, errors: &mut Vec<String>) {
+    check_range_u64(value, "maxPatternLength", 10, 100_000, errors);
+    check_range_u64(value, "subprocessTimeoutSecs", 5, 600, errors);
+    check_range_u64(value, "maxWriteBytes", 1024, 1_073_741_824, errors);
+    check_range_u64(value, "maxReadBytes", 1024, 1_073_741_824, errors);
+    check_range_u64(value, "maxCommandLength", 100, 1_000_000, errors);
+    check_range_u64(value, "messageMaxLen", 100, 1_000_000, errors);
+    check_range_u64(value, "interSessionMaxMessageLen", 1000, 10_000_000, errors);
+    check_range_u64(value, "interSessionMaxTimeoutSecs", 10, 3600, errors);
+}
+
+fn validate_messaging(value: &Value, errors: &mut Vec<String>) {
+    check_range_u64(value, "pollIntervalMs", 100, 60_000, errors);
+    check_range_u64(value, "bufferCapacity", 1, 100_000, errors);
+    check_range_u64(value, "circuitBreakerThreshold", 1, 100, errors);
+    check_range_u64(value, "haltedHealthCheckIntervalSecs", 1, 3600, errors);
+    check_range_u64(value, "rpcTimeoutSecs", 1, 300, errors);
+    check_range_u64(value, "healthTimeoutSecs", 1, 60, errors);
+    check_range_u64(value, "receiveTimeoutSecs", 1, 300, errors);
+    check_range_u64(value, "agentDispatchTimeoutSecs", 10, 3600, errors);
+    check_range_u64(value, "maxConcurrentHandlers", 1, 10_000, errors);
 }
 
 #[cfg(test)]
@@ -805,6 +989,190 @@ mod tests {
         assert!(
             err.errors.iter().any(|e| e.contains("maxToolIterations")),
             "error should mention maxToolIterations, got: {err:?}"
+        );
+    }
+
+    // --- Wave 5: behavioral section validators ---
+
+    #[test]
+    fn rejects_invalid_nous_behavior() {
+        let section = json!({ "loopDetectionWindow": 1 });
+        let result = validate_section("nousBehavior", &section);
+        assert!(
+            result.is_err(),
+            "loopDetectionWindow below minimum should be rejected"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_nous_behavior() {
+        let section = json!({
+            "loopDetectionWindow": 50,
+            "gcIntervalSecs": 300,
+            "managerHealthIntervalSecs": 30
+        });
+        assert!(
+            validate_section("nousBehavior", &section).is_ok(),
+            "valid nous behavior config should be accepted"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_knowledge() {
+        let section = json!({ "conflictIntraBatchDedupThreshold": 0.1 });
+        let result = validate_section("knowledge", &section);
+        assert!(
+            result.is_err(),
+            "intra-batch dedup threshold below 0.5 should be rejected"
+        );
+    }
+
+    #[test]
+    fn rejects_knowledge_min_exceeding_max_fact_length() {
+        let section = json!({
+            "extractionMinFactLength": 600,
+            "extractionMaxFactLength": 500
+        });
+        let result = validate_section("knowledge", &section);
+        assert!(
+            result.is_err(),
+            "min fact length exceeding max should be rejected"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_knowledge() {
+        let section = json!({
+            "conflictIntraBatchDedupThreshold": 0.95,
+            "conflictMaxCandidates": 5,
+            "decayReinforcementBoost": 0.02
+        });
+        assert!(
+            validate_section("knowledge", &section).is_ok(),
+            "valid knowledge config should be accepted"
+        );
+    }
+
+    #[test]
+    fn rejects_complexity_low_exceeding_high() {
+        let section = json!({
+            "complexityLowThreshold": 80,
+            "complexityHighThreshold": 30
+        });
+        let result = validate_section("providerBehavior", &section);
+        assert!(
+            result.is_err(),
+            "low complexity threshold exceeding high should be rejected"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_provider_behavior() {
+        let section = json!({
+            "nonStreamingTimeoutSecs": 120,
+            "complexityLowThreshold": 30,
+            "complexityHighThreshold": 70
+        });
+        assert!(
+            validate_section("providerBehavior", &section).is_ok(),
+            "valid provider behavior config should be accepted"
+        );
+    }
+
+    #[test]
+    fn rejects_api_limits_default_exceeding_max_history() {
+        let section = json!({
+            "defaultHistoryLimit": 2000,
+            "maxHistoryLimit": 1000
+        });
+        let result = validate_section("apiLimits", &section);
+        assert!(
+            result.is_err(),
+            "default history limit exceeding max should be rejected"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_api_limits() {
+        let section = json!({
+            "maxMessageBytes": 262144,
+            "maxHistoryLimit": 1000,
+            "defaultHistoryLimit": 50
+        });
+        assert!(
+            validate_section("apiLimits", &section).is_ok(),
+            "valid API limits config should be accepted"
+        );
+    }
+
+    #[test]
+    fn rejects_daemon_backoff_base_exceeding_cap() {
+        let section = json!({
+            "watchdogBackoffBaseSecs": 50,
+            "watchdogBackoffCapSecs": 10
+        });
+        let result = validate_section("daemonBehavior", &section);
+        assert!(
+            result.is_err(),
+            "backoff base exceeding cap should be rejected"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_daemon_behavior() {
+        let section = json!({
+            "watchdogBackoffBaseSecs": 2,
+            "watchdogBackoffCapSecs": 300
+        });
+        assert!(
+            validate_section("daemonBehavior", &section).is_ok(),
+            "valid daemon behavior config should be accepted"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_tool_limits() {
+        let section = json!({ "maxPatternLength": 1 });
+        let result = validate_section("toolLimits", &section);
+        assert!(
+            result.is_err(),
+            "maxPatternLength below minimum should be rejected"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_tool_limits() {
+        let section = json!({
+            "maxPatternLength": 1000,
+            "subprocessTimeoutSecs": 60,
+            "maxWriteBytes": 10485760
+        });
+        assert!(
+            validate_section("toolLimits", &section).is_ok(),
+            "valid tool limits config should be accepted"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_messaging() {
+        let section = json!({ "pollIntervalMs": 10 });
+        let result = validate_section("messaging", &section);
+        assert!(
+            result.is_err(),
+            "pollIntervalMs below 100 should be rejected"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_messaging() {
+        let section = json!({
+            "pollIntervalMs": 2000,
+            "bufferCapacity": 100,
+            "circuitBreakerThreshold": 5
+        });
+        assert!(
+            validate_section("messaging", &section).is_ok(),
+            "valid messaging config should be accepted"
         );
     }
 }


### PR DESCRIPTION
## Summary

Wave 5 of #2306: builds the metadata layer that makes the 190 parameterized constants (waves 0-4) discoverable, queryable, and eventually self-tunable.

- **Parameter Registry** (`taxis/src/registry.rs`): static registry of 50 `ParameterSpec` entries via `LazyLock`, covering distillation, competence, knowledge, tool limits, API limits, timeouts, retry, safety, capacity, nous behavior, provider, messaging, and daemon. Public API: `all_specs()`, `specs_by_section()`, `specs_affecting()`, `spec_by_key()`.
- **Agent Tool** (`organon/src/builtins/parameters.rs`): `query_parameters` builtin tool with section/affects/tier filters. Auto-activated, System category. Registered in `register_all()`.
- **Operator CLI** (`aletheia/src/commands/config.rs`): `aletheia config describe` subcommand with `--section`, `--affects`, `--self-tunable`, and `--json` flags.
- **Validators** (`taxis/src/validate.rs`): real range-check validators for all 7 behavioral config sections (`nousBehavior`, `knowledge`, `providerBehavior`, `apiLimits`, `daemonBehavior`, `toolLimits`, `messaging`) with cross-field invariant checks (e.g. min < max, base <= cap, low <= high).

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test -p taxis -p organon -p aletheia` passes (all new tests green)
- [x] `cargo clippy -p taxis -p organon -- -D warnings` passes (zero new warnings)
- [x] Registry has 50+ specs with unique keys, valid bounds, non-empty fields
- [x] Agent tool returns filtered results for section/affects/tier queries
- [x] Validators reject out-of-range values and cross-field invariant violations
- [x] Validators accept valid default configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)