### PR TITLE
fix: deployment upgrade path, CC provider routing, clippy zero-warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Register in `crates/organon/src/builtins/mod.rs` via `register_all()`.
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | `/api/v1/sessions` | List sessions (query: `nous_id`) |
-| POST | `/api/v1/sessions` | Create session |
+| POST | `/api/v1/sessions` | Create session (body: `nous_id`, `session_key`) |
 | POST | `/api/v1/sessions/stream` | Stream a turn (TUI webchat protocol) |
 | GET | `/api/v1/sessions/{id}` | Get session |
 | DELETE | `/api/v1/sessions/{id}` | Close (archive) session |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7091,6 +7091,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "taxis",
  "tempfile",
  "tokio",
  "toml 1.1.2+spec-1.1.0",

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -52,13 +52,13 @@ async fn main() -> Result<()> {
         return commands::daemon::do_daemon().await;
     }
 
-    commands::server::run(commands::server::Args {
+    Box::pin(commands::server::run(commands::server::Args {
         instance_root: cli.instance_root,
         bind: cli.bind,
         port: cli.port,
         log_level: cli.log_level,
         json_logs: cli.json_logs,
-    })
+    }))
     .await
     .map_err(Into::into)
 }

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -105,8 +105,9 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
 
     let credential_chain: Arc<dyn CredentialProvider> = Arc::new(CredentialChain::new(chain));
 
-    if let Some(cred) = credential_chain.get_credential() {
-        info!(source = %cred.source, "credential resolved");
+    let resolved_source = credential_chain.get_credential().map(|c| c.source);
+    if let Some(ref source) = resolved_source {
+        info!(source = %source, "credential resolved");
     } else {
         warn!(
             "no credential found -- server will start in degraded mode (no LLM)\n  \
@@ -120,18 +121,20 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
         ..ProviderConfig::default()
     };
 
-    // WHY: Register CC subprocess provider first when available. CC handles
-    // OAuth attestation correctly, so it takes priority over the direct
-    // Anthropic client for matching models. The Anthropic provider serves
-    // as fallback (e.g., when using API keys, which don't need attestation).
+    // WHY: Only register CC subprocess provider when the credential source
+    // is not "api-key" AND the resolved credential is OAuth. The CC provider
+    // accepts all claude-* models and wins first-match routing, so registering
+    // it unconditionally causes API key users to be routed through the CC CLI
+    // unnecessarily, and OAuth tokens to be forwarded raw to the API (which
+    // rejects them with 401).
     #[cfg(feature = "cc-provider")]
-    {
+    if cred_source != "api-key" && resolved_source == Some(CredentialSource::OAuth) {
         use hermeneus::cc::{CcProvider, CcProviderConfig};
         let cc_config = CcProviderConfig::default();
         match CcProvider::new(&cc_config) {
             Ok(provider) => {
                 registry.register(Box::new(provider));
-                info!("CC subprocess provider registered (preferred for OAuth)");
+                info!("CC subprocess provider registered (OAuth credential detected)");
             }
             Err(e) => {
                 tracing::debug!(error = %e, "CC provider unavailable, falling back to direct API");

--- a/crates/aletheia/src/status.rs
+++ b/crates/aletheia/src/status.rs
@@ -194,7 +194,7 @@ fn print_checks(checks: &[HealthCheck], color: bool) {
             .as_deref()
             .map(|m| format!(" ({m})"))
             .unwrap_or_default();
-        println!("    {:<18}{}{}", check.name, status, msg);
+        println!("    {:<24}{}{}", check.name, status, msg);
     }
     println!();
 }

--- a/crates/hermeneus/src/cc/process.rs
+++ b/crates/hermeneus/src/cc/process.rs
@@ -506,6 +506,7 @@ mod tests {
     fn write_script(name: &str, body: &str) -> PathBuf {
         let path = std::env::temp_dir().join(format!("hermeneus_test_{name}_{}.sh", std::process::id()));
         let script = format!("#!/bin/sh\n{body}\n");
+        #[expect(clippy::disallowed_methods, reason = "test helper writes temp scripts, async not needed")]
         fs::write(&path, script.as_bytes()).unwrap();
         fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
         path

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -26,6 +26,7 @@ use symbolon::jwt::{JwtConfig, JwtManager};
 use symbolon::types::Role;
 use taxis::oikos::Oikos;
 
+#[expect(clippy::too_many_lines, reason = "test server setup is inherently verbose")]
 async fn start_test_server() -> (String, String, tempfile::TempDir) {
     install_crypto_provider();
     let dir = tempfile::TempDir::new().expect("tmpdir");

--- a/crates/krites/src/runtime/hnsw/put.rs
+++ b/crates/krites/src/runtime/hnsw/put.rs
@@ -845,7 +845,6 @@ impl<'a> SessionTx<'a> {
 #[expect(
     clippy::unwrap_used,
     clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
     reason = "test assertions and test-only numeric casts"
 )]
 mod tests {

--- a/crates/nous/src/tuning/evidence.rs
+++ b/crates/nous/src/tuning/evidence.rs
@@ -106,6 +106,7 @@ fn standard_deviation(values: &[f64]) -> f64 {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
 mod tests {
     use super::*;
 

--- a/crates/nous/src/tuning/mod.rs
+++ b/crates/nous/src/tuning/mod.rs
@@ -368,7 +368,11 @@ pub fn build_override_fact_content(
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test assertions may panic on failure"
+)]
 mod tests {
     use super::*;
 
@@ -517,7 +521,7 @@ mod tests {
     #[test]
     fn parameter_value_to_f64_roundtrips() {
         assert!((parameter_value_to_f64(&ParameterValue::Int(42)) - 42.0).abs() < f64::EPSILON);
-        assert!((parameter_value_to_f64(&ParameterValue::Float(3.14)) - 3.14).abs() < f64::EPSILON);
+        assert!((parameter_value_to_f64(&ParameterValue::Float(2.78)) - 2.78).abs() < f64::EPSILON);
         assert!((parameter_value_to_f64(&ParameterValue::Bool(true)) - 1.0).abs() < f64::EPSILON);
         assert!((parameter_value_to_f64(&ParameterValue::Bool(false)) - 0.0).abs() < f64::EPSILON);
         assert!((parameter_value_to_f64(&ParameterValue::Duration(100)) - 100.0).abs() < f64::EPSILON);

--- a/crates/nous/src/tuning/signals.rs
+++ b/crates/nous/src/tuning/signals.rs
@@ -121,6 +121,11 @@ fn compute_competence_trajectory(samples: &[MetricSample]) -> Option<f64> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test assertions may panic on failure"
+)]
 mod tests {
     use super::*;
 

--- a/crates/nous/src/uncertainty.rs
+++ b/crates/nous/src/uncertainty.rs
@@ -673,7 +673,13 @@ mod tests {
     fn pruning_keeps_most_recent_points() {
         let t = tracker();
         let max = taxis::config::AgentBehaviorDefaults::default().uncertainty_max_calibration_points;
-        for i in 0..(max + 10) as u32 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::as_conversions,
+            reason = "test value fits in u32"
+        )]
+        let limit = (max + 10) as u32;
+        for i in 0..limit {
             t.record("syn", "coding", 0.5, i % 2 == 0).unwrap();
         }
 

--- a/crates/organon/src/builtins/parameters.rs
+++ b/crates/organon/src/builtins/parameters.rs
@@ -207,6 +207,7 @@ mod tests {
                 server_tool_config: ServerToolConfig::default(),
             })),
             active_tools: Arc::new(RwLock::new(HashSet::new())),
+            tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
         }
     }
 

--- a/crates/poiesis/sheet/src/ods.rs
+++ b/crates/poiesis/sheet/src/ods.rs
@@ -148,6 +148,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, reason = "test assertion")]
     fn ods_produces_nonempty_bytes() {
         let r = OdsRenderer::new();
         let bytes = r.render(&sample_doc()).expect("ODS render failed");
@@ -155,6 +156,8 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, reason = "test assertion")]
+    #[expect(clippy::indexing_slicing, reason = "test assertions on known-good data")]
     fn ods_starts_with_pk_magic() {
         // WHY: ODS is a ZIP archive; valid files start with PK (0x50 0x4B).
         let r = OdsRenderer::new();

--- a/crates/poiesis/sheet/src/xlsx.rs
+++ b/crates/poiesis/sheet/src/xlsx.rs
@@ -196,6 +196,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, reason = "test assertion")]
     fn xlsx_produces_nonempty_bytes() {
         let r = XlsxRenderer::new();
         let bytes = r.render(&sample_doc()).expect("XLSX render failed");
@@ -203,6 +204,8 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, reason = "test assertion")]
+    #[expect(clippy::indexing_slicing, reason = "test assertions on known-good data")]
     fn xlsx_starts_with_pk_magic() {
         // WHY: XLSX is a ZIP archive; valid files start with PK (0x50 0x4B).
         let r = XlsxRenderer::new();

--- a/crates/poiesis/slides/src/pptx.rs
+++ b/crates/poiesis/slides/src/pptx.rs
@@ -157,6 +157,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, reason = "test assertions")]
     fn pptx_produces_nonempty_bytes() {
         let r = PptxRenderer::new();
         let bytes = r.render(&sample_doc()).expect("PPTX render failed");
@@ -164,6 +165,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test assertions on known-good data")]
     fn pptx_starts_with_pk_magic() {
         // WHY: PPTX is a ZIP/OOXML archive; valid files start with PK (0x50 0x4B).
         let r = PptxRenderer::new();

--- a/crates/poiesis/text/src/odt.rs
+++ b/crates/poiesis/text/src/odt.rs
@@ -357,6 +357,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, reason = "test assertion")]
     fn odt_produces_nonempty_bytes() {
         let r = OdtRenderer::new();
         let bytes = r.render(&sample_doc()).expect("ODT render failed");
@@ -364,6 +365,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test assertions on known-good data")]
     fn odt_starts_with_pk_magic() {
         // WHY: ZIP files start with PK (0x50 0x4B).
         let r = OdtRenderer::new();

--- a/crates/poiesis/text/src/pdf.rs
+++ b/crates/poiesis/text/src/pdf.rs
@@ -405,6 +405,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::indexing_slicing, reason = "test assertion on known-good data")]
     fn wrap_words_empty() {
         let lines = wrap_words("", 80);
         assert_eq!(lines.len(), 1);
@@ -412,6 +413,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, reason = "test assertion")]
     fn pdf_renderer_produces_nonempty_bytes() {
         // WHY: skips if no system font is installed (CI may not have one).
         let renderer = match PdfRenderer::new() {

--- a/crates/taxis/src/config/config_tests.rs
+++ b/crates/taxis/src/config/config_tests.rs
@@ -825,7 +825,6 @@ fn new_sections_survive_serde_roundtrip() {
 // ─── Wave 0 (#2306): config schema for 190 behavioral constants ──────────────
 
 #[test]
-#[expect(clippy::too_many_lines, reason = "every field must be verified")]
 fn deployment_defaults_match_original_constants() {
     let nb = NousBehaviorConfig::default();
     // nous::actor::DEGRADED_PANIC_THRESHOLD = 5
@@ -974,7 +973,6 @@ fn deployment_defaults_match_original_constants() {
 }
 
 #[test]
-#[expect(clippy::too_many_lines, reason = "every field must be verified")]
 fn per_agent_defaults_match_original_constants() {
     let ab = AgentBehaviorDefaults::default();
 
@@ -1207,7 +1205,8 @@ fn agent_behavior_defaults_survive_serde_roundtrip() {
 fn new_deployment_sections_are_absent_in_default_toml() {
     // WHY: operators must be able to omit all new sections from aletheia.toml
     // and still get identical behaviour. This confirms `#[serde(default)]` works.
-    let json = r#"{}"#;
+    let json = r"{}";
+
     let config: AletheiaConfig = serde_json::from_str(json).expect("parse empty json");
     assert_eq!(
         config.nous_behavior.degraded_panic_threshold, 5,

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -1108,7 +1108,7 @@ mod tests {
     #[test]
     fn accepts_valid_api_limits() {
         let section = json!({
-            "maxMessageBytes": 262144,
+            "maxMessageBytes": 262_144,
             "maxHistoryLimit": 1000,
             "defaultHistoryLimit": 50
         });
@@ -1158,7 +1158,7 @@ mod tests {
         let section = json!({
             "maxPatternLength": 1000,
             "subprocessTimeoutSecs": 60,
-            "maxWriteBytes": 10485760
+            "maxWriteBytes": 10_485_760
         });
         assert!(
             validate_section("toolLimits", &section).is_ok(),

--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.15.1"
+version = "0.17.0"
 dependencies = [
  "compact_str",
  "jiff",
@@ -4209,7 +4209,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.15.1"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "compact_str",

--- a/crates/theatron/proskenion/src/components/connection_indicator.rs
+++ b/crates/theatron/proskenion/src/components/connection_indicator.rs
@@ -78,9 +78,9 @@ impl ConnectionIndicator {
 const INDICATOR_STYLE: &str = "\
     display: flex; \
     align-items: center; \
-    gap: var(--space-2); \
-    padding: var(--space-2) var(--space-3); \
-    font-size: var(--text-xs); \
+    gap: 6px; \
+    padding: 4px 8px; \
+    font-size: var(--text-xs, 0.75rem); \
     opacity: 0.85;\
 ";
 

--- a/crates/theatron/proskenion/src/components/topbar.rs
+++ b/crates/theatron/proskenion/src/components/topbar.rs
@@ -164,7 +164,7 @@ pub(crate) fn TopBar() -> Element {
                                 if !emoji.is_empty() {
                                     span { style: "font-size: var(--text-base);", "{emoji}" }
                                 }
-                                span { "{name}" }
+                                span { "{name} " }
                                 span {
                                     style: "font-size: var(--text-xs); color: var(--text-muted);",
                                     "{status_label}"

--- a/crates/thesauros/Cargo.toml
+++ b/crates/thesauros/Cargo.toml
@@ -27,4 +27,5 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }
+taxis = { path = "../taxis" }
 tempfile = { workspace = true }

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -15,7 +15,7 @@ sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev
 **Fedora:**
 
 ```bash
-sudo dnf install gtk3-devel webkit2gtk4.1-devel
+sudo dnf install gtk3-devel webkit2gtk4.1-devel libxdo-devel
 ```
 
 **macOS:** No additional dependencies. WebKit is bundled with the OS.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -60,6 +60,32 @@ The embedded Datalog engine (knowledge store) manages its own schema versioning 
 
 **Always back up before upgrading.** While migrations are tested, restoring from backup is the safest recovery path if something goes wrong.
 
+### Upgrading from <0.16 to >=0.16 (fjall session store)
+
+Version 0.16.0 changed the default session store backend from SQLite to fjall.
+Both backends use the same path (`data/sessions.db`), but SQLite creates a file
+while fjall creates a directory. Upgrading without preparation causes a startup
+crash.
+
+Additionally, `data/knowledge.fjall` may be incompatible if it was created by an
+older fjall version (the error message will mention `InvalidTag(CompressionType)`).
+
+**Before deploying the new binary:**
+
+```bash
+# Stop the service
+systemctl --user stop aletheia
+
+# Back up and move conflicting files
+mkdir -p instance/data/pre-0.16-archive
+mv instance/data/sessions.db* instance/data/pre-0.16-archive/
+mv instance/data/knowledge.fjall instance/data/pre-0.16-archive/
+```
+
+The new binary will create fresh fjall stores on startup. Existing session
+history from SQLite is not automatically migrated; it is preserved in the
+archive directory for manual export if needed.
+
 ---
 
 


### PR DESCRIPTION
## Summary

- **CC provider only registers for OAuth credentials** (#3138): The CC subprocess provider now checks `credential.source != "api-key"` and verifies the resolved credential is OAuth before registering. Previously it registered unconditionally when `claude` was on PATH, intercepting all `claude-*` model requests regardless of credential type and sending OAuth tokens directly to the API (401 rejection).

- **Upgrade guide for <0.16 to >=0.16** (#3139): Documents the SQLite-to-fjall migration for both `sessions.db` (path collision: file vs directory) and `knowledge.fjall` (incompatible compression format across fjall versions).

- **Status CLI column width** (#3140): Widened check name column from 18 to 24 chars so `provider_reachability` and `credential_validity` don't run into the PASS/FAIL label.

- **Session API docs** (#3141): Added `session_key` required field to `POST /sessions` in CLAUDE.md.

- **Desktop build deps** (#3142): Added `libxdo-devel` to Fedora build instructions in DESKTOP.md.

- **Desktop tab label spacing** (#3143): Added space between agent name and lifecycle state in topbar tabs.

- **Connection indicator spacing** (#3144): Use explicit px values in connection indicator CSS so spacing works without theme variables loaded.

- **Clippy zero-warnings on `--all-targets`**: Fixed pre-existing warnings across 14 files in 10 crates: `Box::pin` large future in main, missing `tool_config` field in organon test mock, missing `taxis` dev-dep in thesauros, stale `#[expect]` annotations, numeric literal separators, `#[expect]` annotations for test assertion patterns in poiesis/nous/krites/taxis/integration-tests.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`: zero warnings
- [x] `cargo test --workspace`: 300 passed, 1 flaky (ETXTBSY race in hermeneus CC process test, pre-existing)
- [x] `cargo build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml`: compiles
- [x] Deployed 0.17.0 locally, `aletheia health` returns all 7 checks PASS

Closes #3138 #3139 #3140 #3141 #3142 #3143 #3144