### PR TITLE
fix(proskenion): embed CSS via include_str for reliable theme loading

### DIFF
--- a/crates/theatron/proskenion/src/lib.rs
+++ b/crates/theatron/proskenion/src/lib.rs
@@ -73,15 +73,18 @@ pub fn run(verbose: bool) {
     // to recover it. SSE disconnect and window-state persistence happen during
     // the normal Dioxus shutdown sequence before the process exits.
     //
-    // WHY: Dioxus desktop does not auto-inject CSS from the asset directory.
-    // We must add <link> tags via custom_head so the webview loads our design
-    // token system (tokens.css), theme definitions (themes.css), and base
-    // resets/animations (base.css).
-    let custom_head = r#"
-        <link rel="stylesheet" href="styles/tokens.css">
-        <link rel="stylesheet" href="styles/themes.css">
-        <link rel="stylesheet" href="styles/base.css">
-    "#;
+    // WHY: CSS is embedded via include_str! rather than served from the asset
+    // directory. External <link> tags resolve relative to the webview's base
+    // URL, which depends on the binary's working directory at launch. When the
+    // binary is installed to a different path (e.g. ~/ergon/bin/proskenion),
+    // the assets/ directory is not alongside it and the <link> tags 404
+    // silently, producing an unstyled white page.
+    let custom_head = format!(
+        "<style>{}</style><style>{}</style><style>{}</style>",
+        include_str!("../assets/styles/tokens.css"),
+        include_str!("../assets/styles/themes.css"),
+        include_str!("../assets/styles/base.css"),
+    );
 
     let config = Config::new()
         .with_window(window_builder)


### PR DESCRIPTION
## Summary

The desktop app renders unstyled (white page, no dark theme) when the binary is installed to a path separate from the source tree. The existing `<link rel="stylesheet">` tags resolve relative to the webview's base URL, which depends on the binary's working directory. When `assets/styles/` isn't alongside the binary, the stylesheets 404 silently.

Replace external `<link>` tags with `include_str!` inline `<style>` embeds for tokens.css, themes.css, and base.css. The full Aletheia dark/light theme now works regardless of where the binary is launched from.

## Before

Unstyled white page when running `~/ergon/bin/proskenion` (no CSS loaded).

## After

Full Aletheia dark theme renders correctly with all CSS variables active.

## Test plan

- [x] `cargo build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml --release`: compiles
- [x] Binary deployed to `~/ergon/bin/proskenion` and launched: dark theme renders

Closes #3145