### PR TITLE
fix: pricing, CC parser, export validation, credential refresh, session field naming

### DIFF
--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -177,6 +177,17 @@ pub(crate) fn export_agent(instance_root: Option<&PathBuf>, args: &ExportArgs) -
         None => Oikos::discover(),
     };
     let config = load_config(&oikos).whatever_context("failed to load config")?;
+
+    let agent_known = config.agents.list.iter().any(|a| a.id == nous_id.as_str());
+    let workspace_path = oikos.nous_dir(nous_id);
+    if !agent_known && !workspace_path.exists() {
+        whatever!(
+            "agent '{}' not found (no config entry and no workspace at {})",
+            nous_id,
+            workspace_path.display()
+        );
+    }
+
     let resolved = resolve_nous(&config, nous_id);
 
     let db_path = oikos.sessions_db();

--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -150,6 +150,15 @@ pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Resu
             }
         }
         Action::Refresh => {
+            // WHY: static API keys have no refresh token; attempting refresh
+            // produces a confusing OAuth troubleshooting message
+            if let Some(cred) = CredentialFile::load(&cred_path)
+                && !cred.has_refresh_token()
+            {
+                println!("Credential is a static API key; refresh is not applicable.");
+                return Ok(());
+            }
+
             println!("Refreshing OAuth token...");
             match symbolon::credential::force_refresh(&cred_path).await {
                 Ok(updated) => {

--- a/crates/hermeneus/src/cc/parse.rs
+++ b/crates/hermeneus/src/cc/parse.rs
@@ -56,6 +56,13 @@ pub(crate) enum CcEvent {
         #[serde(flatten)]
         _extra: serde_json::Value,
     },
+
+    /// User-turn echo event emitted by newer CC CLI versions. Ignored.
+    #[serde(rename = "user")]
+    User {
+        #[serde(flatten)]
+        _extra: serde_json::Value,
+    },
 }
 
 /// Assistant message body.
@@ -202,6 +209,13 @@ mod tests {
         let line = r#"{"type":"system","subtype":"init","session_id":"abc"}"#;
         let event = parse_event(line).unwrap();
         assert!(matches!(event, CcEvent::System { .. }));
+    }
+
+    #[test]
+    fn parse_user_event() {
+        let line = r#"{"type":"user","message":{"role":"user","content":"hello"}}"#;
+        let event = parse_event(line).unwrap();
+        assert!(matches!(event, CcEvent::User { .. }));
     }
 
     #[test]

--- a/crates/hermeneus/src/cc/process.rs
+++ b/crates/hermeneus/src/cc/process.rs
@@ -275,7 +275,7 @@ where
                 session_id = s;
                 got_result = true;
             }
-            CcEvent::System { .. } | CcEvent::RateLimit { .. } => {
+            CcEvent::System { .. } | CcEvent::RateLimit { .. } | CcEvent::User { .. } => {
                 // Ignored — informational events that don't affect the response.
             }
         }
@@ -468,7 +468,7 @@ where
                 session_id = s;
                 got_result = true;
             }
-            CcEvent::System { .. } | CcEvent::RateLimit { .. } => {}
+            CcEvent::System { .. } | CcEvent::RateLimit { .. } | CcEvent::User { .. } => {}
         }
     }
 

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -180,7 +180,7 @@ pub async fn list_sessions(
             status: s.status.as_str().to_owned(),
             message_count: s.metrics.message_count,
             updated_at: s.updated_at,
-            display_name: s.origin.display_name,
+            name: s.origin.display_name,
         })
         .collect();
 

--- a/crates/pylon/src/handlers/sessions/types.rs
+++ b/crates/pylon/src/handlers/sessions/types.rs
@@ -84,9 +84,9 @@ pub struct SessionListItem {
     pub message_count: i64,
     /// ISO 8601 last-updated timestamp.
     pub updated_at: String,
-    /// Human-readable display name, if set.
+    /// Human-readable name, if set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<String>,
+    pub name: Option<String>,
 }
 
 /// Session metadata returned by create and get endpoints.

--- a/crates/theatron/skene/src/api/types/mod.rs
+++ b/crates/theatron/skene/src/api/types/mod.rs
@@ -57,7 +57,7 @@ pub struct Session {
     #[serde(default)]
     pub updated_at: Option<String>,
     /// User-assigned display name.
-    #[serde(default)]
+    #[serde(default, alias = "name")]
     pub display_name: Option<String>,
 }
 
@@ -690,6 +690,19 @@ mod tests {
         let session: Session = serde_json::from_str(json).unwrap();
         assert_eq!(session.display_name.as_deref(), Some("My Chat"));
         assert_eq!(session.label(), "My Chat");
+    }
+
+    #[test]
+    fn session_deserialization_with_name_alias() {
+        let json = r#"{
+            "id": "s1",
+            "nous_id": "syn",
+            "session_key": "main",
+            "name": "Via Name"
+        }"#;
+        let session: Session = serde_json::from_str(json).unwrap();
+        assert_eq!(session.display_name.as_deref(), Some("Via Name"));
+        assert_eq!(session.label(), "Via Name");
     }
 
     #[test]

--- a/instance.example/config/aletheia.toml
+++ b/instance.example/config/aletheia.toml
@@ -120,6 +120,10 @@ workspace = "nous/main"
 # inputCostPerMtok = 3.0
 # outputCostPerMtok = 15.0
 
+# [pricing."claude-opus-4-6"]
+# inputCostPerMtok = 15.0
+# outputCostPerMtok = 75.0
+
 # --- Data retention ---
 # [data.retention]
 # sessionMaxAgeDays = 90


### PR DESCRIPTION
## Summary

Five quick fixes from deployment testing:

- **Opus pricing (#3166):** Added `[pricing."claude-opus-4-6"]` to example config so cost tracking works for Opus users.
- **CC parser user events (#3167):** Added `CcEvent::User` variant so the stream-json parser silently ignores `user` events from Claude Code 2.1+ instead of logging parse warnings.
- **Export validation (#3164):** `aletheia export nonexistent-agent` now returns exit 1 with a clear error instead of silently creating an empty file.
- **Credential refresh (#3165):** Detects static API keys and prints "refresh is not applicable" instead of attempting OAuth refresh and showing confusing troubleshooting steps.
- **Session field naming (#3159):** Renamed `SessionListItem.display_name` to `name` for consistency with `SessionResponse.name`. Added `#[serde(alias = "name")]` on the client type for backwards compatibility.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings`: zero warnings
- [x] `cargo test -p hermeneus --features cc-provider -p pylon -p aletheia -p graphe`: 1110 passed, 0 failed
- [x] New test: `parse_user_event` validates the CC parser handles user events

Closes #3159 #3164 #3165 #3166 #3167