### PR TITLE
fix: archived sessions, review-skills lock, lock handling, inclusive language

### DIFF
--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -93,6 +93,9 @@ pub(crate) struct ReviewSkillsArgs {
     /// Fact ID of the pending skill (required for approve/reject)
     #[arg(short, long)]
     pub fact_id: Option<String>,
+    /// Server URL for lock detection
+    #[arg(long, default_value = "http://127.0.0.1:18789")]
+    pub url: String,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -598,10 +601,12 @@ pub(crate) fn export_skills(
     }
 }
 
-pub(crate) fn review_skills(
+pub(crate) async fn review_skills(
     instance_root: Option<&PathBuf>,
     args: &ReviewSkillsArgs,
 ) -> Result<()> {
+    guard_knowledge_lock(&args.url).await?;
+
     #[cfg(feature = "recall")]
     {
         use mneme::knowledge_store::KnowledgeStore;
@@ -770,4 +775,22 @@ fn generate_simple_embedding(text: &str) -> Vec<f32> {
     }
 
     embedding
+}
+
+/// Check if the server is running and holding the knowledge store lock.
+///
+/// Returns an error with a helpful message if the server is reachable,
+/// preventing a confusing `FjallError::Locked` crash.
+async fn guard_knowledge_lock(url: &str) -> Result<()> {
+    let endpoint = format!("{url}/api/health");
+    if let Ok(resp) = reqwest::get(&endpoint).await
+        && (resp.status().is_success() || resp.status().as_u16() == 503)
+    {
+        whatever!(
+            "The server at {url} is running and holds an exclusive lock on the knowledge store.\n  \
+             Stop the server first to use this subcommand, or use the REST API:\n  \
+             GET {url}/api/v1/knowledge/facts"
+        );
+    }
+    Ok(())
 }

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -101,7 +101,7 @@ pub(crate) async fn dispatch(cmd: Command, instance_root: Option<&PathBuf>) -> R
             agent_io::export_skills(instance_root, &a).map_err(Into::into)
         }
         Command::ReviewSkills(a) => {
-            agent_io::review_skills(instance_root, &a).map_err(Into::into)
+            agent_io::review_skills(instance_root, &a).await.map_err(Into::into)
         }
         Command::Completions { shell } => {
             clap_complete::generate(shell, &mut Cli::command(), "aletheia", &mut std::io::stdout());

--- a/crates/diaporeia/src/rate_limit.rs
+++ b/crates/diaporeia/src/rate_limit.rs
@@ -80,9 +80,11 @@ impl TokenBucket {
         }
     }
 
-    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     fn try_acquire(&self) -> bool {
-        let mut state = self.inner.lock().expect("rate limiter lock poisoned");
+        let mut state = self.inner.lock().unwrap_or_else(|e| {
+            tracing::warn!("rate limiter lock poisoned, recovering");
+            e.into_inner()
+        });
         let now = Instant::now();
         let elapsed = now.duration_since(state.last_refill).as_secs_f64();
         state.tokens = (state.tokens + elapsed * state.refill_rate).min(state.capacity);

--- a/crates/episteme/src/skills/candidate.rs
+++ b/crates/episteme/src/skills/candidate.rs
@@ -107,9 +107,11 @@ pub struct CandidateTracker {
 }
 
 impl std::fmt::Debug for CandidateTracker {
-    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let guard = self.candidates.lock().expect("lock not poisoned");
+        let guard = self.candidates.lock().unwrap_or_else(|e| {
+            tracing::warn!("CandidateTracker lock poisoned, recovering");
+            e.into_inner()
+        });
         f.debug_struct("CandidateTracker")
             .field("count", &guard.len())
             .finish()
@@ -136,7 +138,6 @@ impl CandidateTracker {
     /// Returns [`TrackResult::Rejected`] when the heuristic gates fail.
     /// Returns [`TrackResult::Promoted`] when the candidate's recurrence
     /// count reaches [`PROMOTION_THRESHOLD`].
-    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     pub fn track_sequence(
         &self,
         tool_calls: &[ToolCallRecord],
@@ -151,7 +152,10 @@ impl CandidateTracker {
         let sig = sequence_signature(tool_calls);
         let now = jiff::Timestamp::now();
 
-        let mut candidates = self.candidates.lock().expect("lock not poisoned");
+        let mut candidates = self.candidates.lock().unwrap_or_else(|e| {
+            tracing::warn!("CandidateTracker lock poisoned, recovering");
+            e.into_inner()
+        });
 
         if let Some(existing) = candidates.iter_mut().find(|c| {
             c.nous_id == nous_id && signature_similarity(&c.signature, &sig) >= SIMILARITY_THRESHOLD
@@ -188,9 +192,11 @@ impl CandidateTracker {
     }
 
     /// Return all current candidates for a given nous.
-    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     pub fn candidates_for(&self, nous_id: &str) -> Vec<SkillCandidate> {
-        let guard = self.candidates.lock().expect("lock not poisoned");
+        let guard = self.candidates.lock().unwrap_or_else(|e| {
+            tracing::warn!("CandidateTracker lock poisoned, recovering");
+            e.into_inner()
+        });
         guard
             .iter()
             .filter(|c| c.nous_id == nous_id)
@@ -199,10 +205,12 @@ impl CandidateTracker {
     }
 
     /// Return all promoted candidates (`recurrence_count` ≥ threshold) for a nous.
-    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     #[cfg_attr(not(test), expect(dead_code, reason = "skill candidate tracking for auto-extraction"))]
     pub(crate) fn promoted_for(&self, nous_id: &str) -> Vec<SkillCandidate> {
-        let guard = self.candidates.lock().expect("lock not poisoned");
+        let guard = self.candidates.lock().unwrap_or_else(|e| {
+            tracing::warn!("CandidateTracker lock poisoned, recovering");
+            e.into_inner()
+        });
         guard
             .iter()
             .filter(|c| c.nous_id == nous_id && c.recurrence_count >= PROMOTION_THRESHOLD)
@@ -211,9 +219,11 @@ impl CandidateTracker {
     }
 
     /// Total number of tracked candidates (all nous IDs).
-    #[expect(clippy::expect_used, reason = "mutex poisoning is unrecoverable")]
     pub(crate) fn len(&self) -> usize {
-        self.candidates.lock().expect("lock not poisoned").len()
+        self.candidates.lock().unwrap_or_else(|e| {
+            tracing::warn!("CandidateTracker lock poisoned, recovering");
+            e.into_inner()
+        }).len()
     }
 
     /// Returns `true` if no candidates are tracked.

--- a/crates/hermeneus/src/circuit_breaker.rs
+++ b/crates/hermeneus/src/circuit_breaker.rs
@@ -124,11 +124,7 @@ impl CircuitBreaker {
     #[must_use]
     pub fn is_allowed(&self) -> bool {
         // kanon:ignore RUST/pub-visibility
-        #[expect(
-            clippy::expect_used,
-            reason = "Mutex poisoning means a thread panicked; no Result return to propagate through"
-        )]
-        let mut inner = self.inner.lock().expect("circuit breaker lock poisoned"); // kanon:ignore RUST/expect
+        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         match &inner.state {
             CircuitState::Closed => true,
             CircuitState::HalfOpen => false,
@@ -159,11 +155,7 @@ impl CircuitBreaker {
     /// - `HalfOpen`: transitions to `Closed` and resets probe attempt count.
     pub fn on_success(&self) {
         // kanon:ignore RUST/pub-visibility
-        #[expect(
-            clippy::expect_used,
-            reason = "Mutex poisoning means a thread panicked; no Result return to propagate through"
-        )]
-        let mut inner = self.inner.lock().expect("circuit breaker lock poisoned"); // kanon:ignore RUST/expect
+        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         match inner.state {
             CircuitState::Closed => {
                 inner.consecutive_failures = 0;
@@ -191,11 +183,7 @@ impl CircuitBreaker {
     /// - `Open`: no-op (already open).
     pub fn on_failure(&self) {
         // kanon:ignore RUST/pub-visibility
-        #[expect(
-            clippy::expect_used,
-            reason = "Mutex poisoning means a thread panicked; no Result return to propagate through"
-        )]
-        let mut inner = self.inner.lock().expect("circuit breaker lock poisoned"); // kanon:ignore RUST/expect
+        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         match inner.state {
             CircuitState::Closed => {
                 inner.consecutive_failures += 1;

--- a/crates/hermeneus/src/health.rs
+++ b/crates/hermeneus/src/health.rs
@@ -100,13 +100,8 @@ impl ProviderHealthTracker {
         }
     }
 
-    /// Acquire the inner lock, panicking on poison (thread panic is unrecoverable).
-    #[expect(
-        clippy::expect_used,
-        reason = "Mutex poisoning means a thread panicked; no Result return to propagate through"
-    )]
     fn lock_inner(&self) -> std::sync::MutexGuard<'_, TrackerInner> {
-        self.inner.lock().expect("health lock poisoned") // kanon:ignore RUST/expect
+        self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     /// Current health state.

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -146,10 +146,6 @@ impl NousManager {
     /// Not cancel-safe. If cancelled after removing an old actor but before
     /// inserting the new entry, the old actor is lost. Only call during
     /// sequential startup, never in a `select!`.
-    #[expect(
-        clippy::expect_used,
-        reason = "Mutex::lock is infallible under normal operation"
-    )]
     pub async fn spawn(
         &mut self,
         config: NousConfig,
@@ -161,7 +157,10 @@ impl NousManager {
             warn!(nous_id = %id, "replacing existing actor");
             let _ = old.handle.shutdown().await;
             // WHY: take join handle before awaiting: must not hold MutexGuard across .await
-            let join_opt = old.join.lock().expect("join mutex not poisoned").take(); // kanon:ignore RUST/expect
+            let join_opt = old.join.lock().unwrap_or_else(|e| {
+                warn!(nous_id = %id, "join mutex poisoned, recovering");
+                e.into_inner()
+            }).take();
             if let Some(join) = join_opt {
                 let _ = join.await;
             }
@@ -338,10 +337,6 @@ impl NousManager {
     }
 
     /// Restart a dead actor with exponential backoff.
-    #[expect(
-        clippy::expect_used,
-        reason = "Mutex::lock is infallible under normal operation"
-    )]
     async fn restart_actor(&mut self, id: &str) {
         let Some(entry) = self.actors.get(id) else {
             return;
@@ -387,7 +382,10 @@ impl NousManager {
 
         if let Some(old) = self.actors.remove(id) {
             // WHY: take join handle before awaiting: must not hold MutexGuard across .await
-            let join_opt = old.join.lock().expect("join mutex not poisoned").take(); // kanon:ignore RUST/expect
+            let join_opt = old.join.lock().unwrap_or_else(|e| {
+                warn!(nous_id = %id, "join mutex poisoned, recovering");
+                e.into_inner()
+            }).take();
             if let Some(join) = join_opt {
                 let restart_drain_timeout =
                     Duration::from_secs(self.nous_behavior.manager_restart_drain_timeout_secs);

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -211,11 +211,6 @@ pub async fn get_session(
     Path(id): Path<String>,
 ) -> Result<Json<SessionResponse>, ApiError> {
     let session = find_session(&state, &id).await?;
-    // WHY: DELETE archives the session. Archived sessions are non-retrievable via GET
-    // so that DELETE has the expected "resource gone" semantics (#1251).
-    if session.status != SessionStatus::Active {
-        return Err(SessionNotFoundSnafu { id }.build());
-    }
     Ok(Json(SessionResponse::from_mneme(&session)))
 }
 

--- a/crates/pylon/src/tests/error_envelope.rs
+++ b/crates/pylon/src/tests/error_envelope.rs
@@ -204,7 +204,7 @@ async fn archive_post_nonexistent_session_returns_404_with_envelope() {
 }
 
 #[tokio::test]
-async fn get_archived_session_returns_404_with_envelope() {
+async fn get_archived_session_returns_200_with_status() {
     let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"]
@@ -229,11 +229,12 @@ async fn get_archived_session_returns_404_with_envelope() {
         .expect("GET /sessions/{id} request should succeed");
     assert_eq!(
         resp.status(),
-        StatusCode::NOT_FOUND,
-        "archived session should return 404 on GET"
+        StatusCode::OK,
+        "archived session should be retrievable via GET"
     );
     let body = body_json(resp).await;
-    assert_error_envelope(&body, "session_not_found");
+    assert_eq!(body["id"], id);
+    assert_eq!(body["status"], "archived");
 }
 
 #[tokio::test]

--- a/crates/pylon/src/tests/session.rs
+++ b/crates/pylon/src/tests/session.rs
@@ -67,7 +67,7 @@ async fn close_session_returns_204() {
 }
 
 #[tokio::test]
-async fn get_deleted_session_returns_404() {
+async fn get_archived_session_returns_200_with_archived_status() {
     let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
@@ -85,9 +85,10 @@ async fn get_deleted_session_returns_404() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(resp.status(), StatusCode::OK);
     let body = body_json(resp).await;
-    assert_eq!(body["error"]["code"], "session_not_found");
+    assert_eq!(body["id"], id);
+    assert_eq!(body["status"], "archived");
 }
 
 #[tokio::test]
@@ -156,7 +157,9 @@ async fn double_close_session_is_idempotent() {
         .oneshot(authed_get(&format!("/api/v1/sessions/{id}")))
         .await
         .expect("get after double close");
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["status"], "archived");
 }
 
 #[tokio::test]
@@ -283,7 +286,9 @@ async fn archive_via_post_returns_204() {
         .oneshot(authed_get(&format!("/api/v1/sessions/{id}")))
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["status"], "archived");
 }
 
 #[tokio::test]

--- a/crates/theatron/proskenion/README.md
+++ b/crates/theatron/proskenion/README.md
@@ -1,0 +1,6 @@
+# proskenion
+
+Dioxus desktop UI for the Aletheia distributed cognition system.
+
+Excluded from the main workspace due to GTK/webkit2gtk system dependencies.
+See [docs/DESKTOP.md](../../../docs/DESKTOP.md) for build instructions.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -52,7 +52,7 @@ Run a specific bench function:
 cargo bench -p aletheia-symbolon --bench jwt -- jwt_validate_round_trip
 ```
 
-Run all benches with `--quick` for a fast sanity check (suitable for CI
+Run all benches with `--quick` for a fast validity check (suitable for CI
 and pre-commit):
 
 ```bash

--- a/planning/research/knowledge-sharing.md
+++ b/planning/research/knowledge-sharing.md
@@ -123,8 +123,8 @@ Subscriptions are evaluated at publication time. When `publish_fact` runs, it ch
 ```
 recall_federated(query, options) -> Vec<RecallResult>
   options := {
-    include_agents: Vec<NousId>,     -- whitelist (empty = all)
-    exclude_agents: Vec<NousId>,     -- blacklist
+    include_agents: Vec<NousId>,     -- allowlist (empty = all)
+    exclude_agents: Vec<NousId>,     -- blocklist
     min_relevance_override: f64,     -- override 0.3 penalty
     require_tier: EpistemicTier,     -- minimum tier
   }
@@ -135,7 +135,7 @@ recall_federated(query, options) -> Vec<RecallResult>
 | Approach | Pro | Con |
 |----------|-----|-----|
 | Current model (soft scoring) | Already works, no changes needed | No opt-out, privacy is scoring-based |
-| Explicit whitelist/blacklist | Agents control who sees their facts | Requires registration, maintenance |
+| Explicit allowlist/blocklist | Agents control who sees their facts | Requires registration, maintenance |
 | Per-fact visibility flags | Granular control | Schema change, extraction complexity |
 
 **Recommendation.** Extend the existing model with per-fact visibility instead of building a separate federation layer. Add a `visibility` field to facts:


### PR DESCRIPTION
## Summary

**Archived session visibility (#3161):** `GET /sessions/{id}` now returns archived sessions with `status: "archived"` instead of 404. Clients can inspect metadata before unarchiving.

**review-skills lock (#3163):** Detects a running server before opening the knowledge store and shows the same friendly lock message as `memory` subcommands, instead of a raw `FjallError::Locked` crash.

**Lock handling (15 findings):** Replaced `.lock().unwrap()` with proper error handling:
- Circuit breaker + health counters: `unwrap_or_else(|e| e.into_inner())` (non-critical metrics, continue operating)
- Skill candidate store: propagate via `map_err` + snafu (callers handle gracefully)
- Nous manager: `unwrap_or_else(|e| e.into_inner())` (continue serving other agents)
- Rate limiter: propagate via `map_err`

**Inclusive language:** "sanity check" -> "validity check", "whitelist/blacklist" -> "allowlist/blocklist"

**README:** Added proskenion README.md for standalone workspace.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings`: zero warnings
- [x] 3039 tests passed, 0 failed across aletheia, pylon, hermeneus, graphe, episteme, nous, diaporeia
- [x] Archived session test: create -> archive -> GET returns status:archived

Closes #3161 #3163