### PR TITLE
fix(aletheia): detect fjall lock contention in CLI memory commands

### DIFF
--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -80,6 +80,9 @@ pub(crate) struct ExportSkillsArgs {
     /// Filter by domain tags (comma-separated)
     #[arg(short, long)]
     pub domain: Option<String>,
+    /// Server URL for lock detection
+    #[arg(long, default_value = "http://127.0.0.1:18789")]
+    pub url: String,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -513,10 +516,11 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
 ///
 /// Reads skill facts from an in-process `KnowledgeStore`, converts them to
 /// `SkillContent`, and writes `.claude/skills/<slug>/SKILL.md` files.
-pub(crate) fn export_skills(
+pub(crate) async fn export_skills(
     instance_root: Option<&PathBuf>,
     args: &ExportSkillsArgs,
 ) -> Result<()> {
+    guard_knowledge_lock(&args.url).await?;
     #[cfg(feature = "recall")]
     {
         use mneme::knowledge_store::KnowledgeStore;
@@ -781,7 +785,7 @@ fn generate_simple_embedding(text: &str) -> Vec<f32> {
 ///
 /// Returns an error with a helpful message if the server is reachable,
 /// preventing a confusing `FjallError::Locked` crash.
-async fn guard_knowledge_lock(url: &str) -> Result<()> {
+pub(crate) async fn guard_knowledge_lock(url: &str) -> Result<()> {
     let endpoint = format!("{url}/api/health");
     if let Ok(resp) = reqwest::get(&endpoint).await
         && (resp.status().is_success() || resp.status().as_u16() == 503)

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -98,7 +98,7 @@ pub(crate) async fn dispatch(cmd: Command, instance_root: Option<&PathBuf>) -> R
         Command::Import(a) => agent_io::import_agent(instance_root, &a).map_err(Into::into),
         Command::SeedSkills(a) => agent_io::seed_skills(&a).map_err(Into::into),
         Command::ExportSkills(a) => {
-            agent_io::export_skills(instance_root, &a).map_err(Into::into)
+            agent_io::export_skills(instance_root, &a).await.map_err(Into::into)
         }
         Command::ReviewSkills(a) => {
             agent_io::review_skills(instance_root, &a).await.map_err(Into::into)
@@ -113,7 +113,7 @@ pub(crate) async fn dispatch(cmd: Command, instance_root: Option<&PathBuf>) -> R
         Command::CheckConfig => check_config::run(instance_root).map_err(Into::into),
         Command::Config { action } => config::run(&action, instance_root).map_err(Into::into),
         Command::AddNous(a) => add_nous::run(instance_root, &a).await.map_err(Into::into),
-        Command::Repl(a) => repl::run(instance_root, &a).map_err(Into::into),
+        Command::Repl(a) => repl::run(instance_root, &a).await.map_err(Into::into),
         // NOTE: Serve is intercepted in main() before dispatch is called.
         // This arm exists only for match exhaustiveness.
         #[expect(

--- a/crates/aletheia/src/commands/repl.rs
+++ b/crates/aletheia/src/commands/repl.rs
@@ -12,7 +12,9 @@ use crate::error::Result;
 
 #[derive(Debug, Clone, Args)]
 pub(crate) struct ReplArgs {
-    // instance_root is inherited from the top-level -r flag; nothing extra needed.
+    /// Server URL for lock detection
+    #[arg(long, default_value = "http://127.0.0.1:18789")]
+    pub url: String,
 }
 
 #[cfg(feature = "recall")]
@@ -32,10 +34,12 @@ Datalog examples:
 
 /// Run the interactive Datalog REPL.
 ///
-/// WHY: Synchronous stdin loop — async is unnecessary here and would add
-/// complexity. The knowledge store holds an exclusive fjall lock, so the
-/// server must be stopped before starting the REPL.
-pub(crate) fn run(instance_root: Option<&PathBuf>, _args: &ReplArgs) -> Result<()> {
+/// WHY: the guard check is async (HTTP health probe), but the REPL loop itself
+/// is synchronous stdin I/O. We check for a running server first, then drop
+/// into the blocking loop.
+pub(crate) async fn run(instance_root: Option<&PathBuf>, args: &ReplArgs) -> Result<()> {
+    super::agent_io::guard_knowledge_lock(&args.url).await?;
+
     #[cfg(feature = "recall")]
     {
         run_repl(instance_root)


### PR DESCRIPTION
## Summary

- Extend `guard_knowledge_lock` to `export-skills` and `repl` commands, which also open the fjall knowledge store directly and crash with `FjallError: Locked` when the server is running
- The previous fix (6bb51a95, PR #3171) covered `review-skills` and `memory` but missed these two commands
- Promote `guard_knowledge_lock` to `pub(crate)` for cross-module reuse; add `--url` flag to `ExportSkillsArgs` and `ReplArgs`

## Test plan

- [x] `cargo check -p aletheia`: compiles clean
- [x] `cargo clippy -p aletheia`: no new warnings (pre-existing `hermeneus` Duration lint unrelated)
- [ ] Manual: run server, then `aletheia export-skills --nous-id test` -- should show friendly lock message
- [ ] Manual: run server, then `aletheia repl` -- should show friendly lock message
- [ ] Manual: stop server, then both commands proceed normally

Closes #3163

Gate-Passed: kanon 0.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)