### PR TITLE
fix(mneme): include mneme-engine in default features

### DIFF
--- a/crates/mneme/CLAUDE.md
+++ b/crates/mneme/CLAUDE.md
@@ -21,7 +21,7 @@ Mneme was decomposed into eidos, graphe, episteme, and krites. This crate re-exp
 |---------|---------|---------|
 | `sqlite` | yes | SQLite session store (graphe backend) |
 | `graph-algo` | yes | Graph algorithms in episteme + krites |
-| `mneme-engine` | no | Datalog engine (krites) + typed query builder |
+| `mneme-engine` | yes | Datalog engine (krites) + typed query builder |
 | `storage-fjall` | no | Fjall LSM-tree backend (requires mneme-engine) |
 | `embed-candle` | no | Local ML embeddings via candle |
 | `hnsw_rs` | no | Alternative HNSW vector index backend |

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -13,7 +13,10 @@ workspace = true
 [features]
 # WHY: fjall is the new default session backend — pure Rust, zero C dependency.
 # sqlite is preserved for migration parity and operator opt-in.
-default = ["fjall", "graph-algo"]
+# mneme-engine enables the Datalog knowledge store and typed query builder —
+# without it, downstream consumers get the session store but not the knowledge
+# engine that the crate description promises.
+default = ["fjall", "graph-algo", "mneme-engine"]
 fjall = ["graphe/fjall"]
 graph-algo = ["episteme/graph-algo"]
 # Gates MockEmbeddingProvider and other test helpers. No test code in release binaries.


### PR DESCRIPTION
## Summary

- Add `mneme-engine` to `crates/mneme/Cargo.toml` default features so downstream consumers get the Datalog knowledge store and typed query builder without explicit feature opt-in
- Update `crates/mneme/CLAUDE.md` feature table to reflect the new default

Closes #3174

## Test plan

- [x] `cargo check -p mneme` passes (default features now include mneme-engine)
- [x] `cargo check -p mneme --no-default-features` passes (no regression)
- [x] `cargo clippy -p mneme --tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)