### PR TITLE
refactor: move training capture from mneme to nous (#3175)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,15 +4051,11 @@ dependencies = [
  "eidos",
  "episteme",
  "graphe",
- "jiff",
  "krites",
  "proptest",
- "serde",
  "serde_json",
- "snafu",
  "tempfile",
  "tokio",
- "tracing",
  "tracing-subscriber",
 ]
 
@@ -4190,6 +4186,7 @@ version = "0.17.0"
 dependencies = [
  "criterion",
  "dianoia",
+ "eidos",
  "hermeneus",
  "indexmap 2.13.1",
  "jiff",

--- a/crates/mneme/CLAUDE.md
+++ b/crates/mneme/CLAUDE.md
@@ -29,6 +29,7 @@ Only types with downstream consumers are surfaced. Modules not listed here (admi
 | `episteme` | `recall` | `FactorScores`, `RecallEngine`, `RecallWeights`, `ScoredResult` | always |
 | `episteme` | `skill` | `SkillContent`, `export_skills_to_cc`, `parse_skill_md`, `scan_skill_dir` | always |
 | `episteme` | `skills` | `CandidateTracker`, `PendingSkill`, `SkillExtractor`, `ToolCallRecord`, `TrackResult` + `extract` submodule | always |
+| `eidos` | `training` | `TrainingConfig`, `TrainingRecord`, `TRAINING_RECORD_SCHEMA_VERSION` | always |
 | `krites` | `engine` | (full crate alias) | `mneme-engine` |
 
 ## Feature flags
@@ -42,6 +43,10 @@ Only types with downstream consumers are surfaced. Modules not listed here (admi
 | `embed-candle` | no | Local ML embeddings via candle |
 | `hnsw_rs` | no | Alternative HNSW vector index backend |
 | `test-support` | no | MockEmbeddingProvider and test helpers |
+
+## Training capture
+
+Training capture logic (`TrainingCapture`, `CaptureInput`, `CaptureStopReason`, quality gate) lives in `nous::training`, not here. Mneme re-exports only the shared types (`TrainingConfig`, `TrainingRecord`) from eidos. Training is a pipeline tap (side-effect observer on the turn loop), not a memory operation.
 
 ## Where to make changes
 

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -35,11 +35,6 @@ eidos = { path = "../eidos" }
 graphe = { path = "../graphe", default-features = false }
 episteme = { path = "../episteme", default-features = false }
 krites = { path = "../krites", optional = true }
-jiff = { workspace = true, features = ["serde"] }
-serde = { workspace = true }
-serde_json = { workspace = true }
-snafu = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 episteme = { path = "../episteme", features = ["test-support"] }

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -124,10 +124,23 @@ pub mod types {
     };
 }
 
-// ── Training data capture ─────────────────────────────────────────────
+// ── Training data types (eidos) ───────────────────────────────────────
+//
+// Training capture *logic* (the JSONL writer, quality gate, and
+// `TrainingCapture` struct) lives in `nous::training` — it is a pipeline
+// tap, not a memory operation. Mneme re-exports only the shared types
+// that the configuration layer needs.
 
-/// Training data capture: append-only JSONL writer for conversation turns.
-pub mod training;
+/// Training data types re-exported from eidos.
+///
+/// # Facade surface
+///
+/// [`TrainingConfig`](training::TrainingConfig),
+/// [`TrainingRecord`](training::TrainingRecord),
+/// [`TRAINING_RECORD_SCHEMA_VERSION`](training::TRAINING_RECORD_SCHEMA_VERSION)
+pub mod training {
+    pub use eidos::training::{TrainingConfig, TrainingRecord, TRAINING_RECORD_SCHEMA_VERSION};
+}
 
 // ── Knowledge pipeline (episteme) ──────────────────────────────────────────
 

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -20,6 +20,7 @@ test-full = ["test-core"]
 
 [dependencies]
 dianoia = { path = "../dianoia" }
+eidos = { path = "../eidos" }
 hermeneus = { path = "../hermeneus" }
 koina = { path = "../koina" }
 melete = { path = "../melete" }

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -258,7 +258,7 @@ pub struct PipelineConfig {
     pub stage_budget: StageBudget,
     /// Training data capture configuration.
     #[serde(default)]
-    pub training: mneme::training::TrainingConfig,
+    pub training: crate::training::TrainingConfig,
 }
 
 impl Default for PipelineConfig {
@@ -267,7 +267,7 @@ impl Default for PipelineConfig {
             history_budget_ratio: 0.6,
             extraction: None,
             stage_budget: StageBudget::default(),
-            training: mneme::training::TrainingConfig::default(),
+            training: crate::training::TrainingConfig::default(),
         }
     }
 }

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -62,6 +62,13 @@ pub(crate) mod skills;
 pub mod spawn_svc;
 /// Real-time streaming events for the turn pipeline.
 pub mod stream;
+/// Training data capture: append-only JSONL writer for conversation turns.
+///
+/// Pipeline tap that observes the turn loop and writes qualifying turns
+/// as JSON Lines for downstream fine-tuning. Types (`TrainingConfig`,
+/// `TrainingRecord`) live in eidos; capture logic lives here because it
+/// is a pipeline concern, not a memory operation.
+pub mod training;
 /// Task registry with progress streaming, cooperative cancellation, and GC.
 pub mod tasks;
 /// Self-tuning feedback loop: evidence-based parameter change proposals.

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -840,19 +840,19 @@ pub(crate) async fn run_pipeline(
     // turns enter the training corpus. Errors are logged, never propagated:
     // training capture must never block the pipeline.
     if pipeline_config.training.enabled {
-        match mneme::training::TrainingCapture::new(
+        match crate::training::TrainingCapture::new(
             oikos.root(),
             &pipeline_config.training,
         ) {
             Ok(capture) => {
-                capture.maybe_capture(mneme::training::CaptureInput {
+                capture.maybe_capture(crate::training::CaptureInput {
                     session_id: &input.session.id,
                     nous_id: &config.id,
                     user_message: &input.content,
                     assistant_response: &result.content,
                     model: &config.generation.model,
                     tokens: result.usage.total_tokens(),
-                    stop_reason: mneme::training::CaptureStopReason::parse(
+                    stop_reason: crate::training::CaptureStopReason::parse(
                         &result.stop_reason,
                     ),
                     has_tool_calls: !result.tool_calls.is_empty(),

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -121,7 +121,7 @@ impl SpawnService for SpawnServiceImpl {
             history_budget_ratio: 0.6,
             extraction: None,
             stage_budget: StageBudget::default(),
-            training: mneme::training::TrainingConfig::default(),
+            training: crate::training::TrainingConfig::default(),
         };
 
         let providers = Arc::clone(&self.providers);

--- a/crates/nous/src/training.rs
+++ b/crates/nous/src/training.rs
@@ -378,7 +378,7 @@ mod tests {
         assert_eq!(lines.len(), 3);
     }
 
-    // ── Quality gate: empty / whitespace ──────────────────────────────────
+    // -- Quality gate: empty / whitespace -----------------------------------------
 
     #[test]
     fn quality_gate_rejects_empty_response() {
@@ -416,7 +416,7 @@ mod tests {
         assert!(!capture.file_path().exists(), "no file should be created");
     }
 
-    // ── Quality gate: stop reasons ────────────────────────────────────────
+    // -- Quality gate: stop reasons -----------------------------------------------
 
     #[test]
     fn quality_gate_rejects_max_tokens_stop_reason() {
@@ -466,7 +466,7 @@ mod tests {
         assert!(!captured, "unknown stop reason should be rejected");
     }
 
-    // ── Quality gate: tool-use-only ───────────────────────────────────────
+    // -- Quality gate: tool-use-only ----------------------------------------------
 
     #[test]
     fn quality_gate_rejects_tool_use_only_turn() {
@@ -505,7 +505,7 @@ mod tests {
         assert!(captured, "tool-using turn that ended with text should be accepted");
     }
 
-    // ── Quality gate: happy path ──────────────────────────────────────────
+    // -- Quality gate: happy path -------------------------------------------------
 
     #[test]
     fn quality_gate_accepts_good_response() {
@@ -539,7 +539,7 @@ mod tests {
         assert!(captured, "stop_sequence with content should be accepted");
     }
 
-    // ── CaptureStopReason parsing ─────────────────────────────────────────
+    // -- CaptureStopReason parsing ------------------------------------------------
 
     #[test]
     fn capture_stop_reason_from_str() {
@@ -552,7 +552,7 @@ mod tests {
         assert_eq!(CaptureStopReason::parse("anything_else"), CaptureStopReason::Unknown);
     }
 
-    // ── Serde roundtrip ───────────────────────────────────────────────────
+    // -- Serde roundtrip ----------------------------------------------------------
 
     #[test]
     fn training_record_serde_roundtrip() {


### PR DESCRIPTION
## Summary

- Move training capture logic (`TrainingCapture`, `CaptureInput`, `CaptureStopReason`, quality gate) from `mneme::training` to `nous::training` -- training capture is a pipeline tap, not a memory operation
- Mneme retains a thin re-export of shared types (`TrainingConfig`, `TrainingRecord`, `TRAINING_RECORD_SCHEMA_VERSION`) from eidos for backward compatibility
- Remove 5 unused runtime dependencies from mneme (`jiff`, `serde`, `serde_json`, `snafu`, `tracing`) that were only needed by the capture logic

Closes #3175

## Test plan

- [x] `cargo check --workspace` -- zero errors
- [x] `cargo clippy --workspace` -- zero new warnings
- [x] `cargo test -p nous -p mneme` -- 765 nous tests + 11 mneme tests pass, including all training tests now running under `nous::training::tests`
- [x] All call sites updated from `mneme::training::` to `crate::training::` within nous
- [x] `mneme/CLAUDE.md` updated to document the move

🤖 Generated with [Claude Code](https://claude.com/claude-code)