### PR TITLE
feat(training): enrich records with episteme classification labels (#3177)

### DIFF
--- a/crates/eidos/src/training.rs
+++ b/crates/eidos/src/training.rs
@@ -31,7 +31,7 @@ impl Default for TrainingConfig {
 /// Bump this constant whenever fields are added, removed, or change
 /// semantics so that records from different epochs can be distinguished
 /// at read time.
-pub const TRAINING_RECORD_SCHEMA_VERSION: u32 = 1;
+pub const TRAINING_RECORD_SCHEMA_VERSION: u32 = 2;
 
 /// A single training record representing one conversation turn.
 ///
@@ -59,6 +59,29 @@ pub struct TrainingRecord {
     pub tokens: u64,
     /// When the turn was captured.
     pub timestamp: Timestamp,
+
+    // ── Episteme classification labels (v2) ──────────────────────────
+
+    /// Classified turn type from episteme's heuristic classifier.
+    ///
+    /// Values: `discussion`, `tool_heavy`, `planning`, `debugging`,
+    /// `correction`, `procedural`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_type: Option<String>,
+    /// Whether the turn contains an explicit correction of prior information.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_correction: Option<bool>,
+    /// Classified fact types detected in the turn content.
+    ///
+    /// Values: `identity`, `preference`, `skill`, `relationship`,
+    /// `event`, `task`, `observation`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fact_types: Option<Vec<String>>,
+    /// Aggregate quality score for the turn (0.0--1.0).
+    ///
+    /// Derived from turn-type confidence boost and correction signal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quality_score: Option<f32>,
 }
 
 #[cfg(test)]
@@ -84,6 +107,10 @@ mod tests {
             model: "claude-opus-4-20250514".to_owned(),
             tokens: 200,
             timestamp: Timestamp::UNIX_EPOCH,
+            turn_type: Some("discussion".to_owned()),
+            is_correction: Some(false),
+            fact_types: Some(vec!["observation".to_owned()]),
+            quality_score: Some(0.75),
         };
 
         let json = serde_json::to_string(&record).expect("serialize");
@@ -91,15 +118,36 @@ mod tests {
         assert_eq!(back.schema_version, TRAINING_RECORD_SCHEMA_VERSION);
         assert_eq!(back.session_id, record.session_id);
         assert_eq!(back.tokens, record.tokens);
+        assert_eq!(back.turn_type.as_deref(), Some("discussion"));
+        assert_eq!(back.is_correction, Some(false));
+        assert_eq!(back.fact_types.as_deref(), Some(&["observation".to_owned()][..]));
+        assert_eq!(back.quality_score, Some(0.75));
     }
 
     #[test]
     fn training_record_deserialize_missing_schema_version() {
         // Records written before schema_version existed should deserialize
-        // with schema_version defaulting to 0.
+        // with schema_version defaulting to 0 and new fields as None.
         let json = r#"{"session_id":"ses-old","nous_id":"syn","user_message":"hi","assistant_response":"hello","model":"test","tokens":10,"timestamp":"1970-01-01T00:00:00Z"}"#;
         let record: TrainingRecord = serde_json::from_str(json).expect("deserialize legacy");
         assert_eq!(record.schema_version, 0);
         assert_eq!(record.session_id, "ses-old");
+        assert!(record.turn_type.is_none());
+        assert!(record.is_correction.is_none());
+        assert!(record.fact_types.is_none());
+        assert!(record.quality_score.is_none());
+    }
+
+    #[test]
+    fn training_record_v1_backward_compat() {
+        // WHY: v1 records have schema_version but no episteme labels.
+        // Deserialization must succeed with all label fields as None.
+        let v1_json = r#"{"schema_version":1,"session_id":"ses-1","nous_id":"syn","user_message":"hi","assistant_response":"hello","model":"test","tokens":100,"timestamp":"1970-01-01T00:00:00Z"}"#;
+        let record: TrainingRecord = serde_json::from_str(v1_json).expect("v1 deserialize");
+        assert_eq!(record.schema_version, 1);
+        assert!(record.turn_type.is_none());
+        assert!(record.is_correction.is_none());
+        assert!(record.fact_types.is_none());
+        assert!(record.quality_score.is_none());
     }
 }

--- a/crates/episteme/src/extract/refinement.rs
+++ b/crates/episteme/src/extract/refinement.rs
@@ -28,7 +28,7 @@ pub enum TurnType {
 impl TurnType {
     /// Returns the confidence boost applied to facts extracted from this turn type.
     #[must_use]
-    pub(crate) fn confidence_boost(self) -> f64 {
+    pub fn confidence_boost(self) -> f64 {
         match self {
             Self::Planning => 0.1,
             Self::Correction => 0.2,
@@ -73,7 +73,7 @@ impl std::fmt::Display for TurnType {
 /// 5. Procedural patterns → `Procedural`
 /// 6. Default → `Discussion`
 #[must_use]
-pub(crate) fn classify_turn(content: &str) -> TurnType {
+pub fn classify_turn(content: &str) -> TurnType {
     let lower = content.to_lowercase();
 
     if has_correction_patterns(&lower) {
@@ -279,7 +279,7 @@ impl std::fmt::Display for FactType {
 
 /// Classify a fact's type from its content using keyword heuristics.
 #[must_use]
-pub(crate) fn classify_fact(content: &str) -> FactType {
+pub fn classify_fact(content: &str) -> FactType {
     let lower = content.to_lowercase();
 
     if has_identity_patterns(&lower) {
@@ -411,7 +411,7 @@ pub struct CorrectionSignal {
 
 /// Detect whether content contains an explicit correction.
 #[must_use]
-pub(crate) fn detect_correction(content: &str) -> CorrectionSignal {
+pub fn detect_correction(content: &str) -> CorrectionSignal {
     let lower = content.to_lowercase();
     let is_correction = has_correction_patterns(&lower);
     CorrectionSignal {

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -184,6 +184,10 @@ pub mod extract {
         ConversationMessage, ExtractionConfig, ExtractionEngine, ExtractionError,
         ExtractionProvider, LlmCallSnafu,
     };
+
+    /// Context-dependent extraction refinement: turn classification, correction
+    /// detection, quality filters, and fact type classification.
+    pub use episteme::extract::refinement;
 }
 
 /// Instinct system: behavioral memory from tool usage patterns.

--- a/crates/mneme/src/training.rs
+++ b/crates/mneme/src/training.rs
@@ -121,10 +121,10 @@ impl CaptureStopReason {
 
 /// Borrowed inputs to [`TrainingCapture::maybe_capture`].
 ///
-/// Bundles the per-turn fields into a single record so the call sites
-/// remain self-documenting and so the function signature stays under the
+/// Bundles per-turn fields into a single record so the call sites remain
+/// self-documenting and so the function signature stays under the
 /// workspace's `too_many_arguments` threshold.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct CaptureInput<'a> {
     /// Session identifier the turn belongs to.
     pub session_id: &'a str,
@@ -146,6 +146,17 @@ pub struct CaptureInput<'a> {
     /// are not useful training data — they teach the model to produce
     /// empty text responses.
     pub has_tool_calls: bool,
+
+    // ── Episteme classification labels ───────────────────────────────
+
+    /// Classified turn type (e.g. `discussion`, `planning`, `correction`).
+    pub turn_type: Option<&'a str>,
+    /// Whether the turn contains an explicit correction.
+    pub is_correction: Option<bool>,
+    /// Classified fact types detected in the combined turn content.
+    pub fact_types: Option<Vec<String>>,
+    /// Aggregate quality score (0.0--1.0).
+    pub quality_score: Option<f32>,
 }
 
 /// Append-only training data writer.
@@ -226,7 +237,7 @@ impl TrainingCapture {
     /// filtered out by the quality gate. I/O errors are logged as
     /// warnings and do not propagate: training capture must never
     /// block the pipeline.
-    pub fn maybe_capture(&self, input: CaptureInput<'_>) -> bool {
+    pub fn maybe_capture(&self, input: &CaptureInput<'_>) -> bool {
         // WHY: empty and whitespace-only responses teach the model to produce
         // vacuous output. `.trim().is_empty()` catches both `""` and `"  \n"`.
         if input.assistant_response.trim().is_empty() {
@@ -268,6 +279,10 @@ impl TrainingCapture {
             model: input.model.to_owned(),
             tokens: input.tokens,
             timestamp: Timestamp::now(),
+            turn_type: input.turn_type.map(str::to_owned),
+            is_correction: input.is_correction,
+            fact_types: input.fact_types.clone(),
+            quality_score: input.quality_score,
         };
 
         match self.write_record(&record) {
@@ -306,6 +321,10 @@ mod tests {
             tokens: 150,
             stop_reason: CaptureStopReason::EndTurn,
             has_tool_calls: false,
+            turn_type: None,
+            is_correction: None,
+            fact_types: None,
+            quality_score: None,
         }
     }
 
@@ -334,6 +353,10 @@ mod tests {
             model: "claude-opus-4-20250514".to_owned(),
             tokens: 150,
             timestamp: Timestamp::UNIX_EPOCH,
+            turn_type: Some("discussion".to_owned()),
+            is_correction: Some(false),
+            fact_types: None,
+            quality_score: None,
         };
         capture.write_record(&record).expect("write");
 
@@ -348,6 +371,7 @@ mod tests {
         assert_eq!(parsed.user_message, "Hello");
         assert_eq!(parsed.assistant_response, "Hi there!");
         assert_eq!(parsed.tokens, 150);
+        assert_eq!(parsed.turn_type.as_deref(), Some("discussion"));
     }
 
     #[test]
@@ -369,6 +393,10 @@ mod tests {
                 model: "test-model".to_owned(),
                 tokens: 100,
                 timestamp: Timestamp::UNIX_EPOCH,
+                turn_type: None,
+                is_correction: None,
+                fact_types: None,
+                quality_score: None,
             };
             capture.write_record(&record).expect("write");
         }
@@ -389,7 +417,7 @@ mod tests {
         };
         let capture = TrainingCapture::new(dir.path(), &config).expect("new");
 
-        let captured = capture.maybe_capture(CaptureInput {
+        let captured = capture.maybe_capture(&CaptureInput {
             assistant_response: "",
             ..good_input()
         });
@@ -407,7 +435,7 @@ mod tests {
         let capture = TrainingCapture::new(dir.path(), &config).expect("new");
 
         for ws in ["  ", "\n", "\t\n  ", "   \n\n   "] {
-            let captured = capture.maybe_capture(CaptureInput {
+            let captured = capture.maybe_capture(&CaptureInput {
                 assistant_response: ws,
                 ..good_input()
             });
@@ -427,7 +455,7 @@ mod tests {
         };
         let capture = TrainingCapture::new(dir.path(), &config).expect("new");
 
-        let captured = capture.maybe_capture(CaptureInput {
+        let captured = capture.maybe_capture(&CaptureInput {
             stop_reason: CaptureStopReason::MaxTokens,
             ..good_input()
         });
@@ -443,7 +471,7 @@ mod tests {
         };
         let capture = TrainingCapture::new(dir.path(), &config).expect("new");
 
-        let captured = capture.maybe_capture(CaptureInput {
+        let captured = capture.maybe_capture(&CaptureInput {
             stop_reason: CaptureStopReason::Degraded,
             ..good_input()
         });
@@ -459,7 +487,7 @@ mod tests {
         };
         let capture = TrainingCapture::new(dir.path(), &config).expect("new");
 
-        let captured = capture.maybe_capture(CaptureInput {
+        let captured = capture.maybe_capture(&CaptureInput {
             stop_reason: CaptureStopReason::Unknown,
             ..good_input()
         });
@@ -477,7 +505,7 @@ mod tests {
         };
         let capture = TrainingCapture::new(dir.path(), &config).expect("new");
 
-        let captured = capture.maybe_capture(CaptureInput {
+        let captured = capture.maybe_capture(&CaptureInput {
             assistant_response: "Let me check that.",
             stop_reason: CaptureStopReason::ToolUse,
             has_tool_calls: true,
@@ -496,7 +524,7 @@ mod tests {
         let capture = TrainingCapture::new(dir.path(), &config).expect("new");
 
         // Turn that used tools but ended with text (end_turn)
-        let captured = capture.maybe_capture(CaptureInput {
+        let captured = capture.maybe_capture(&CaptureInput {
             assistant_response: "Based on the file contents, here is the answer.",
             stop_reason: CaptureStopReason::EndTurn,
             has_tool_calls: true,
@@ -516,7 +544,7 @@ mod tests {
         };
         let capture = TrainingCapture::new(dir.path(), &config).expect("new");
 
-        let captured = capture.maybe_capture(good_input());
+        let captured = capture.maybe_capture(&good_input());
         assert!(captured);
 
         let content = std::fs::read_to_string(capture.file_path()).expect("read");
@@ -532,7 +560,7 @@ mod tests {
         };
         let capture = TrainingCapture::new(dir.path(), &config).expect("new");
 
-        let captured = capture.maybe_capture(CaptureInput {
+        let captured = capture.maybe_capture(&CaptureInput {
             stop_reason: CaptureStopReason::StopSequence,
             ..good_input()
         });
@@ -565,6 +593,10 @@ mod tests {
             model: "claude-opus-4-20250514".to_owned(),
             tokens: 200,
             timestamp: Timestamp::UNIX_EPOCH,
+            turn_type: Some("planning".to_owned()),
+            is_correction: Some(true),
+            fact_types: Some(vec!["skill".to_owned(), "preference".to_owned()]),
+            quality_score: Some(0.9),
         };
 
         let json = serde_json::to_string(&record).expect("serialize");
@@ -572,5 +604,37 @@ mod tests {
         assert_eq!(back.schema_version, TRAINING_RECORD_SCHEMA_VERSION);
         assert_eq!(back.session_id, record.session_id);
         assert_eq!(back.tokens, record.tokens);
+        assert_eq!(back.turn_type.as_deref(), Some("planning"));
+        assert_eq!(back.is_correction, Some(true));
+        assert_eq!(back.fact_types.as_deref(), Some(&["skill".to_owned(), "preference".to_owned()][..]));
+        assert_eq!(back.quality_score, Some(0.9));
+    }
+
+    #[test]
+    fn labels_persisted_in_maybe_capture() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = TrainingConfig {
+            enabled: true,
+            path: "training".to_owned(),
+        };
+        let capture = TrainingCapture::new(dir.path(), &config).expect("new");
+
+        let captured = capture.maybe_capture(&CaptureInput {
+            turn_type: Some("correction"),
+            is_correction: Some(true),
+            fact_types: Some(vec!["preference".to_owned()]),
+            quality_score: Some(0.7),
+            ..good_input()
+        });
+        assert!(captured);
+
+        let content = std::fs::read_to_string(capture.file_path()).expect("read");
+        let parsed: TrainingRecord =
+            serde_json::from_str(content.lines().next().expect("one line")).expect("parse");
+        assert_eq!(parsed.schema_version, TRAINING_RECORD_SCHEMA_VERSION);
+        assert_eq!(parsed.turn_type.as_deref(), Some("correction"));
+        assert_eq!(parsed.is_correction, Some(true));
+        assert_eq!(parsed.fact_types.as_deref(), Some(&["preference".to_owned()][..]));
+        assert_eq!(parsed.quality_score, Some(0.7));
     }
 }

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -845,7 +845,29 @@ pub(crate) async fn run_pipeline(
             &pipeline_config.training,
         ) {
             Ok(capture) => {
-                capture.maybe_capture(mneme::training::CaptureInput {
+                // WHY: compute episteme classification labels at capture time
+                // using the same lightweight heuristics that extract_refined
+                // uses during background extraction. These are pure,
+                // synchronous functions — no LLM call needed.
+                let combined = format!("{}\n{}", input.content, result.content);
+                let turn_type = mneme::extract::refinement::classify_turn(&combined);
+                let correction = mneme::extract::refinement::detect_correction(&combined);
+                let fact_type = mneme::extract::refinement::classify_fact(&combined);
+
+                // WHY: quality score aggregates the turn-type confidence boost
+                // and correction signal into a single 0.0--1.0 value. Base of
+                // 0.5 (neutral) plus boosts from turn type and correction.
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    clippy::as_conversions,
+                    reason = "f64→f32: quality score range [0.0, 1.0] fits in f32"
+                )]
+                let quality_score = (0.5_f64 + turn_type.confidence_boost()
+                    + correction.confidence_boost)
+                    .min(1.0) as f32; // kanon:ignore RUST/as-cast
+
+                let turn_type_str = turn_type.to_string();
+                capture.maybe_capture(&mneme::training::CaptureInput {
                     session_id: &input.session.id,
                     nous_id: &config.id,
                     user_message: &input.content,
@@ -856,6 +878,10 @@ pub(crate) async fn run_pipeline(
                         &result.stop_reason,
                     ),
                     has_tool_calls: !result.tool_calls.is_empty(),
+                    turn_type: Some(&turn_type_str),
+                    is_correction: Some(correction.is_correction),
+                    fact_types: Some(vec![fact_type.to_string()]),
+                    quality_score: Some(quality_score),
                 });
             }
             Err(e) => {


### PR DESCRIPTION
## Summary

- Wires episteme's lightweight heuristic classifiers (turn type, correction detection, fact type classification) into training data capture at pipeline time
- Adds `turn_type`, `is_correction`, `fact_types`, `quality_score` to `TrainingRecord` (schema v2) with `#[serde(default)]` for backward compat
- Promotes `classify_turn`, `detect_correction`, `classify_fact`, `confidence_boost` to `pub` in `episteme::extract::refinement` and re-exports through mneme facade
- Computes labels synchronously at the capture call site in the nous pipeline (no LLM call, same heuristics as `extract_refined`)

## Changes

| Crate | File | Change |
|-------|------|--------|
| eidos | `training.rs` | Add 4 optional label fields, bump schema to v2, backward compat tests |
| episteme | `extract/refinement.rs` | Promote 4 functions from `pub(crate)` to `pub` |
| mneme | `lib.rs` | Re-export `episteme::extract::refinement` through facade |
| mneme | `training.rs` | Add label fields to `CaptureInput`, wire into record, `Copy` -> `Clone` + by-ref, new test |
| nous | `pipeline/mod.rs` | Compute episteme labels at training capture site |

## Test plan

- [x] `cargo check --workspace` — zero errors
- [x] `cargo clippy --workspace` — zero new warnings (only pre-existing hermeneus duration warning)
- [x] `cargo test -p eidos` — 173 tests pass (incl. new `training_record_v1_backward_compat`)
- [x] `cargo test -p mneme` — 15 tests pass (incl. new `labels_persisted_in_maybe_capture`)
- [x] `cargo test -p episteme` — 1,124 tests pass
- [x] v0 records (no schema_version) deserialize with defaults
- [x] v1 records (schema_version=1, no labels) deserialize with `None` labels
- [x] v2 records round-trip with all label fields populated

Closes #3177

🤖 Generated with [Claude Code](https://claude.com/claude-code)