### PR TITLE
chore: suppress 28 verified false-positive lint violations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,4 +123,3 @@ crates/theatron/desktop/target/
 # === SBOM artifacts (generated during build) ===
 bom.cdx.json
 *.cdx.json
-.kanon-lint-ignore

--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -1,0 +1,10 @@
+# Rules to skip for specific paths
+# Format: RULE/name:path/glob
+#
+# Every entry requires a tracking issue. No blanket category ignores.
+
+# WHY(#3169): 850 packages in workspace with vendored krites; threshold is 600
+MANIFEST/dep-count:Cargo.lock
+
+# WHY(#3169): XML namespace URI inside raw string literal, not a network endpoint
+SECURITY/insecure-transport:crates/poiesis/text/src/odt.rs

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -306,7 +306,7 @@ impl SendParams {
 
 fn normalize_url(url: &str) -> String {
     let trimmed = url.trim_end_matches('/');
-    if trimmed.starts_with("http://") || trimmed.starts_with("https://") { // SAFE: protocol detection, not endpoint construction
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") { // SAFE: protocol detection, not endpoint construction // kanon:ignore SECURITY/insecure-transport -- protocol detection, not an endpoint
         trimmed.to_owned()
     } else {
         format!("http://{trimmed}") // SAFE: signal-cli daemon is localhost-only, no network traversal

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -153,7 +153,7 @@ pub(crate) async fn run(args: Args) -> Result<()> {
         .with_graceful_shutdown(async move {
             shutdown_signal().await;
             // SAFETY: "token" here is a CancellationToken (shutdown coordination), not a credential
-            info!("signal received -- cancelling shutdown token");
+            info!("signal received -- cancelling shutdown token"); // kanon:ignore SECURITY/credential-logging -- logs signal event, not a credential
             token_for_signal.cancel();
         })
         .await

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -73,16 +73,16 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
         if cred.has_refresh_token() {
             if let Some(refreshing) = RefreshingCredentialProvider::new(cred_file.clone()) {
                 // SAFETY: logging file path, not credential value
-                info!(path = %cred_file.display(), "credential file found (OAuth auto-refresh)");
+                info!(path = %cred_file.display(), "credential file found (OAuth auto-refresh)"); // kanon:ignore SECURITY/credential-logging -- logs file path, not credential value
                 chain.push(Box::new(refreshing));
             } else {
                 // SAFETY: logging file path, not credential value
-                info!(path = %cred_file.display(), "credential file found (static)");
+                info!(path = %cred_file.display(), "credential file found (static)"); // kanon:ignore SECURITY/credential-logging -- logs file path, not credential value
                 chain.push(Box::new(FileCredentialProvider::new(cred_file.clone())));
             }
         } else {
             // SAFETY: logging file path, not credential value
-            info!(path = %cred_file.display(), "credential file found (static API key)");
+            info!(path = %cred_file.display(), "credential file found (static API key)"); // kanon:ignore SECURITY/credential-logging -- logs file path, not credential value
             chain.push(Box::new(FileCredentialProvider::new(cred_file.clone())));
         }
     }
@@ -111,7 +111,7 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
     let resolved_source = credential_chain.get_credential().map(|c| c.source);
     if let Some(ref source) = resolved_source {
         // SAFETY: logging credential source name (e.g. "oauth", "api-key"), not credential value
-        info!(source = %source, "credential resolved");
+        info!(source = %source, "credential resolved"); // kanon:ignore SECURITY/credential-logging -- logs source type string, not the secret
     } else {
         warn!(
             "no credential found -- server will start in degraded mode (no LLM)\n  \
@@ -139,7 +139,7 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
             Ok(provider) => {
                 registry.register(Box::new(provider));
                 // SAFETY: logging provider registration status, not credential value
-                info!("CC subprocess provider registered (OAuth credential detected)");
+                info!("CC subprocess provider registered (OAuth credential detected)"); // kanon:ignore SECURITY/credential-logging -- logs provider registration, no secret
             }
             Err(e) => {
                 tracing::debug!(error = %e, "CC provider unavailable, falling back to direct API");

--- a/crates/diaporeia/src/auth.rs
+++ b/crates/diaporeia/src/auth.rs
@@ -88,7 +88,7 @@ pub async fn mcp_auth(
         }
         Err(_err) => {
             // SAFETY: logging rejection status, not the token value
-            warn!("MCP request rejected: invalid Bearer token");
+            warn!("MCP request rejected: invalid Bearer token"); // kanon:ignore SECURITY/credential-logging -- logs rejection event, not the token
             unauthorized()
         }
     }

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -367,7 +367,7 @@ impl NousActor {
                 // dropping this branch before it resolves has no side effects.
                 () = self.channel.cancel.cancelled() => {
                     // SAFETY: "token" here is a CancellationToken (shutdown coordination), not a credential
-                    info!("cancellation token fired, draining and stopping");
+                    info!("cancellation token fired, draining and stopping"); // kanon:ignore SECURITY/credential-logging -- "token" means CancellationToken, not API token
                     break;
                 }
             }

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -115,7 +115,7 @@ impl ToolExecutor for WebFetchExecutor {
             let max_length = extract_opt_u64(&input.arguments, "maxLength").unwrap_or(50_000);
 
             // SAFE: protocol validation for user-supplied URLs, not endpoint construction
-            if !url.starts_with("http://") && !url.starts_with("https://") {
+            if !url.starts_with("http://") && !url.starts_with("https://") { // kanon:ignore SECURITY/insecure-transport -- URL validation, not construction
                 return Ok(ToolResult::error("URL must start with http:// or https://"));
             }
 

--- a/crates/pylon/src/discovery.rs
+++ b/crates/pylon/src/discovery.rs
@@ -78,7 +78,7 @@ pub(crate) async fn write_discovery_file(
     let port = port_from_bind(bind_addr);
 
     let info = DiscoveryInfo {
-        url: format!("http://{host}:{port}"), // SAFE: local/tailnet server, TLS handled at reverse-proxy layer
+        url: format!("http://{host}:{port}"), // SAFE: local/tailnet server, TLS handled at reverse-proxy layer // kanon:ignore SECURITY/insecure-transport -- local/tailnet server, TLS at reverse-proxy
         version: env!("CARGO_PKG_VERSION"),
         started_at: Timestamp::now().to_string(),
         tailscale_ip,

--- a/crates/symbolon/src/credential/device_code.rs
+++ b/crates/symbolon/src/credential/device_code.rs
@@ -397,7 +397,7 @@ pub async fn device_code_login(provider: &DeviceOAuthProvider) -> Result<Credent
     .await?;
 
     // SAFETY: logging success status, not the token value
-    info!("successfully obtained access token via device flow");
+    info!("successfully obtained access token via device flow"); // kanon:ignore SECURITY/credential-logging -- logs success message, not the token
     eprintln!("\n✓ Authentication successful!\n");
 
     // Step 4: Build credential file
@@ -481,7 +481,7 @@ where
     .await?;
 
     // SAFETY: logging success status, not the token value
-    info!("successfully obtained access token via device flow");
+    info!("successfully obtained access token via device flow"); // kanon:ignore SECURITY/credential-logging -- logs success message, not the token
 
     // Step 4: Build credential file
     let expires_at = token_response

--- a/crates/symbolon/src/credential/file_ops.rs
+++ b/crates/symbolon/src/credential/file_ops.rs
@@ -98,14 +98,14 @@ impl CredentialFile {
             // WHY: encrypted files must be decrypted before JSON parsing.
             let key = load_or_create_key(path)
                 // SAFETY: logging file path and error kind, not credential value
-                .map_err(|e| tracing::warn!(error = %e, path = %path.display(), "failed to load encryption key"))
+                .map_err(|e| tracing::warn!(error = %e, path = %path.display(), "failed to load encryption key")) // kanon:ignore SECURITY/credential-logging -- logs error on decrypt failure, not the credential
                 .ok()?;
             let plaintext = decrypt(&key, encoded.trim_end())
                 // SAFETY: logging file path and error kind, not credential value
-                .map_err(|e| tracing::warn!(error = %e, path = %path.display(), "failed to decrypt credential file"))
+                .map_err(|e| tracing::warn!(error = %e, path = %path.display(), "failed to decrypt credential file")) // kanon:ignore SECURITY/credential-logging -- logs error on decrypt failure, not the credential
                 .ok()?;
             String::from_utf8(plaintext)
-                .map_err(|e| tracing::warn!(error = %e, "decrypted credential is not valid UTF-8"))
+                .map_err(|e| tracing::warn!(error = %e, "decrypted credential is not valid UTF-8")) // kanon:ignore SECURITY/credential-logging -- logs UTF-8 error, not the credential
                 .ok()?
         } else {
             contents

--- a/crates/symbolon/src/credential/pkce.rs
+++ b/crates/symbolon/src/credential/pkce.rs
@@ -718,7 +718,7 @@ pub async fn pkce_login(provider: &OAuthProvider) -> Result<CredentialFile> {
     let token_response = exchange_code(&client, provider, &code, &pkce.verifier, port).await?;
 
     // SAFETY: logging success status, not the token value
-    info!("successfully obtained access token");
+    info!("successfully obtained access token"); // kanon:ignore SECURITY/credential-logging -- logs success status, not the token
 
     // Build credential file
     let expires_at = token_response

--- a/crates/symbolon/src/credential/refresh.rs
+++ b/crates/symbolon/src/credential/refresh.rs
@@ -255,7 +255,7 @@ fn try_reload_from_file(
         return;
     };
     // SAFETY: logging reload event, not credential value
-    info!("credential file changed externally while circuit open, reloading");
+    info!("credential file changed externally while circuit open, reloading"); // kanon:ignore SECURITY/credential-logging -- logs reload event, not credential value
     if let Ok(mut guard) = state.write() {
         *guard = Some(RefreshState {
             current_token: file_cred.token,
@@ -337,11 +337,11 @@ fn persist_refresh_success(
             }
             crate::metrics::record_token_refresh(true);
             // SAFETY: logging expiry duration, not the token value
-            info!(expires_in_secs = expires_in, "OAuth token refreshed");
+            info!(expires_in_secs = expires_in, "OAuth token refreshed"); // kanon:ignore SECURITY/credential-logging -- logs expiry duration, not the token
         }
         Err(e) => {
             // SAFETY: logging write-failure error, not the token value
-            error!(error = %e, "failed to write refreshed credential file, keeping previous in-memory token");
+            error!(error = %e, "failed to write refreshed credential file, keeping previous in-memory token"); // kanon:ignore SECURITY/credential-logging -- logs write-failure error, not the token
             crate::metrics::record_credential_write_failure();
             crate::metrics::record_token_refresh(true);
         }
@@ -388,7 +388,7 @@ async fn refresh_loop(
             biased;
             () = shutdown.cancelled() => {
                 // SAFETY: logging shutdown event, not credential value
-                info!("credential refresh loop shutting down");
+                info!("credential refresh loop shutting down"); // kanon:ignore SECURITY/credential-logging -- logs shutdown event, not credential value
                 break;
             }
             () = tokio::time::sleep(check_interval) => {}
@@ -455,7 +455,7 @@ async fn refresh_loop(
                 circuit_breaker.record_failure();
                 crate::metrics::record_token_refresh(false);
                 // SAFETY: logging retry status, not the token value
-                warn!("OAuth token refresh failed, will retry next cycle");
+                warn!("OAuth token refresh failed, will retry next cycle"); // kanon:ignore SECURITY/credential-logging -- logs retry status, not the token
             }
         }
     }

--- a/crates/theatron/koilon/src/update/selection.rs
+++ b/crates/theatron/koilon/src/update/selection.rs
@@ -257,7 +257,7 @@ fn extract_urls(text: &str) -> Vec<String> {
                 .trim_end_matches(',')
                 .trim_end_matches('.');
             // SAFE: protocol detection for URL extraction from text, not endpoint construction
-            if candidate.starts_with("http://") || candidate.starts_with("https://") {
+            if candidate.starts_with("http://") || candidate.starts_with("https://") { // kanon:ignore SECURITY/insecure-transport -- protocol detection for URL extraction, not endpoint construction
                 urls.push(candidate.to_string());
                 continue;
             }
@@ -271,7 +271,7 @@ fn extract_urls(text: &str) -> Vec<String> {
             .trim_end_matches(',')
             .trim_end_matches('.');
         // SAFE: protocol detection for URL extraction from text, not endpoint construction
-        if candidate.starts_with("http://") || candidate.starts_with("https://") {
+        if candidate.starts_with("http://") || candidate.starts_with("https://") { // kanon:ignore SECURITY/insecure-transport -- protocol detection for URL extraction, not endpoint construction
             urls.push(candidate.to_string());
         }
     }

--- a/crates/theatron/proskenion/src/services/connection.rs
+++ b/crates/theatron/proskenion/src/services/connection.rs
@@ -99,7 +99,7 @@ impl PylonClient {
             let value = format!("Bearer {token}");
             // SAFETY: log only the error kind, not the token value.
             let header_value = HeaderValue::from_str(&value).map_err(|_| {
-                tracing::debug!("auth token contains invalid header characters");
+                tracing::debug!("auth token contains invalid header characters"); // kanon:ignore SECURITY/credential-logging -- logs "invalid header characters" debug, not the token
                 ConnectionError::InvalidToken
             })?;
             headers.insert(AUTHORIZATION, header_value);

--- a/crates/theatron/skene/src/discovery.rs
+++ b/crates/theatron/skene/src/discovery.rs
@@ -69,7 +69,7 @@ fn build_candidates() -> Vec<Candidate> {
     // 2. LAN hostnames via .lan DNS suffix (AdGuard rewrites).
     for host in LAN_HOSTNAMES {
         candidates.push(Candidate {
-            base_url: format!("http://{host}.lan:{DEFAULT_PORT}"), // SAFE: trusted LAN, no public traversal
+            base_url: format!("http://{host}.lan:{DEFAULT_PORT}"), // SAFE: trusted LAN, no public traversal // kanon:ignore SECURITY/insecure-transport -- LAN discovery, trusted network
             label: "lan",
         });
     }
@@ -77,7 +77,7 @@ fn build_candidates() -> Vec<Candidate> {
     // 3. Tailscale IPs -- direct IP probe as fallback.
     for ip in TAILSCALE_IPS {
         candidates.push(Candidate {
-            base_url: format!("http://{ip}:{DEFAULT_PORT}"), // SAFE: Tailscale WireGuard tunnel, encrypted in transit
+            base_url: format!("http://{ip}:{DEFAULT_PORT}"), // SAFE: Tailscale WireGuard tunnel, encrypted in transit // kanon:ignore SECURITY/insecure-transport -- Tailscale WireGuard tunnel, encrypted in transit
             label: "tailscale",
         });
     }


### PR DESCRIPTION
## Summary

Closes #3169.

- Add `// kanon:ignore RULE-ID -- reason` inline suppressions for **19 SECURITY/credential-logging** and **8 SECURITY/insecure-transport** false positives across 14 source files
- Create `.kanon-lint-ignore` with entries for **MANIFEST/dep-count** (Cargo.lock, 850 packages in vendored workspace) and **SECURITY/insecure-transport** on `odt.rs` (XML namespace URI inside raw string literal where inline comment is impossible)
- Un-gitignore `.kanon-lint-ignore` so the file is tracked and effective in CI

All flagged lines log operational status messages, file paths, or perform protocol detection -- none expose actual credential values or construct insecure endpoints. No code logic changes.

**Before:** 3615 violations, 172 suppressed
**After:** 3587 violations, 199 suppressed (28 violations resolved)

## Test plan

- [x] `kanon lint . --summary` confirms 0 remaining SECURITY/credential-logging and SECURITY/insecure-transport violations
- [x] `kanon lint . --summary` confirms MANIFEST/dep-count on root Cargo.lock is suppressed
- [x] Verified no code logic changes (all diffs are comment-only additions)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)