### PR TITLE
fix(security): address CodeQL cleartext and hardcoded crypto alerts

### DIFF
--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -105,7 +105,12 @@ async fn fetch_session(
         );
     }
     let url = format!("{base_url}{API_V1}/sessions/{session_id}");
-    // codequality:ignore -- non-HTTPS guard above warns on cleartext to non-localhost URLs
+    // SAFETY: cleartext transmission risk is mitigated. The CLI default is
+    // localhost (http://127.0.0.1:18789) which never leaves the machine. The
+    // guard above (lines 97-106) logs a warning when the operator overrides
+    // --url to a non-HTTPS, non-localhost target, making the risk explicit.
+    // This is a local operator tool, not a library API — the operator controls
+    // the URL and accepts the risk when pointing at a remote HTTP endpoint.
     let resp = client.get(&url).send().await.map_err(|e| {
         if e.is_connect() {
             crate::error::Error::msg(format!(
@@ -145,7 +150,9 @@ async fn fetch_history(
         );
     }
     let url = format!("{base_url}{API_V1}/sessions/{session_id}/history");
-    // codequality:ignore -- non-HTTPS guard above warns on cleartext to non-localhost URLs
+    // SAFETY: cleartext transmission risk is mitigated — see the identical
+    // comment in `fetch_session` above. The non-HTTPS guard on lines 137-145
+    // warns when the operator targets a remote HTTP endpoint.
     let resp = client
         .get(&url)
         .send()

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -103,7 +103,7 @@ fn build_http_client() -> Result<Client> {
     // SSE parser's idle detection handles actual stall recovery.
     Client::builder()
         .connect_timeout(Duration::from_secs(10))
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_mins(1))
         .build()
         .map_err(|e| {
             error::ProviderInitSnafu {
@@ -749,7 +749,11 @@ impl AnthropicProvider {
                 headers.insert("idempotency-key", val);
             }
 
-            // codequality:ignore -- HTTPS enforced by constructor (from_config / with_credential_provider)
+            // SAFETY: cleartext transmission is impossible here. Both constructors
+            // (`from_config` and `with_credential_provider`) reject non-HTTPS base
+            // URLs unless the target is loopback (localhost / 127.0.0.1). The
+            // `base_url` field is immutable after construction, so by the time we
+            // reach this request the scheme has already been validated.
             let response = match self
                 .client
                 .post(format!("{}/v1/messages", self.base_url))

--- a/crates/symbolon/src/store/sqlite_store.rs
+++ b/crates/symbolon/src/store/sqlite_store.rs
@@ -354,6 +354,8 @@ fn get_schema_version(conn: &Connection) -> Result<u32> {
         .context(error::DatabaseSnafu)?;
 
     if !table_exists {
+        // SAFETY(CodeQL hard-coded-credentials): this is a schema version sentinel
+        // (0 = fresh database, apply all DDL), not a cryptographic key or secret.
         return Ok(0);
     }
 


### PR DESCRIPTION
## Summary

- Replace generic `codequality:ignore` comments with structured `// SAFETY:` annotations documenting why each CodeQL alert is a false positive
- **hermeneus client.rs:755** — constructors enforce HTTPS or loopback; `base_url` is immutable after validation
- **session_export.rs:109,150** — CLI tool defaults to localhost; non-HTTPS guard warns on remote HTTP targets
- **symbolon sqlite_store.rs:357** — `return Ok(0)` is a schema version sentinel, not a cryptographic constant
- Fix pre-existing clippy `duration_suboptimal_units` warning in hermeneus (`from_secs(60)` -> `from_mins(1)`)

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace` — zero new warnings (one pre-existing diaporeia dead_code)
- [ ] CodeQL re-scan should recognize SAFETY annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)