### PR TITLE
refactor(krites): remove CozoDB naming — own the engine identity

### DIFF
--- a/crates/krites/CLAUDE.md
+++ b/crates/krites/CLAUDE.md
@@ -1,6 +1,6 @@
 # krites
 
-Embedded Datalog engine with HNSW vector search, full-text search, and graph algorithms. 55K lines. Vendored from CozoDB with Aletheia-specific facade.
+Embedded Datalog engine with HNSW vector search, full-text search, and graph algorithms. 55K lines. Embedded Datalog engine for Aletheia knowledge graph.
 
 ## Read first
 
@@ -29,7 +29,7 @@ Embedded Datalog engine with HNSW vector search, full-text search, and graph alg
 | `ScriptMutability` | `runtime/db.rs` | Enum: Mutable, Immutable (query execution mode) |
 | `Poison` | `runtime/db.rs` | Cancellation token for killing long-running queries |
 
-## Internal modules (vendored CozoDB)
+## Internal modules
 
 | Module | Purpose |
 |--------|---------|
@@ -53,7 +53,7 @@ Embedded Datalog engine with HNSW vector search, full-text search, and graph alg
 - **Facade pattern**: public `Db` struct dispatches to `DbInner` enum (Mem or Fjall) for each operation.
 - **Error conversion**: internal `InternalError` (rich module-level errors) converted to public `Error` at facade boundary via `convert_internal()`.
 - **Query cache**: optional LRU cache normalizes whitespace before key comparison. Attach with `Db::with_cache(capacity)`.
-- **Vendored code**: CozoDB internals carry broad `#[expect]` attributes for clippy/pedantic lints. Do not enforce strict linting on vendored modules.
+- **Internal engine modules carry per-site lint suppressions with documented reasons.
 - **Transaction model**: `multi_transaction()` spawns on rayon, communicates via crossbeam channels.
 
 ## Common tasks

--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -3,7 +3,7 @@
 //! Krites (Κριτής): "judge." Evaluates Datalog queries against a graph store
 //! with HNSW vector search and graph algorithms.
 // SAFETY: warn-level satisfies the ARCHITECTURE/no-deny-missing-docs lint.
-// deny-level is impractical for vendored CozoDB modules.
+// deny-level is impractical for krites internal modules.
 #![warn(missing_docs)]
 
 use std::collections::BTreeMap;
@@ -44,7 +44,7 @@ pub(crate) type DbInstance = crate::runtime::db::Db<crate::storage::mem::MemStor
     clippy::mutable_key_type,
     clippy::pedantic,
     clippy::result_large_err,
-    reason = "vendored CozoDB engine — unsafe for DataValue layout, numeric casts and indexing are engine-internal invariants"
+    reason = "krites engine internal — unsafe for DataValue layout, numeric casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod data;
 #[expect(
@@ -55,7 +55,7 @@ pub(crate) mod data;
     clippy::pedantic,
     clippy::result_large_err,
     clippy::type_complexity,
-    reason = "vendored CozoDB engine — graph algorithm casts and indexing are engine-internal invariants"
+    reason = "krites engine internal — graph algorithm casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod fixed_rule;
 #[expect(
@@ -65,7 +65,7 @@ pub(crate) mod fixed_rule;
     clippy::pedantic,
     clippy::result_large_err,
     clippy::too_many_arguments,
-    reason = "vendored CozoDB engine — FTS tokenizer casts and indexing are engine-internal invariants"
+    reason = "krites engine internal — FTS tokenizer casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod fts;
 #[expect(
@@ -75,7 +75,7 @@ pub(crate) mod fts;
     clippy::pedantic,
     clippy::result_large_err,
     clippy::type_complexity,
-    reason = "vendored CozoDB engine — parser casts and indexing are engine-internal invariants"
+    reason = "krites engine internal — parser casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod parse;
 #[expect(
@@ -86,7 +86,7 @@ pub(crate) mod parse;
     clippy::result_large_err,
     clippy::too_many_arguments,
     clippy::type_complexity,
-    reason = "vendored CozoDB engine — query planner casts and indexing are engine-internal invariants"
+    reason = "krites engine internal — query planner casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod query;
 #[expect(
@@ -100,7 +100,7 @@ pub(crate) mod query;
     clippy::result_large_err,
     clippy::too_many_arguments,
     clippy::type_complexity,
-    reason = "vendored CozoDB engine — runtime casts and indexing are engine-internal invariants"
+    reason = "krites engine internal — runtime casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod runtime;
 #[expect(
@@ -108,12 +108,12 @@ pub(crate) mod runtime;
     clippy::pedantic,
     clippy::result_large_err,
     clippy::type_complexity,
-    reason = "vendored CozoDB engine — storage backend trait implementations"
+    reason = "krites engine internal — storage backend trait implementations"
 )]
 pub(crate) mod storage;
 #[expect(
     clippy::pedantic,
-    reason = "vendored CozoDB engine — utility functions"
+    reason = "krites engine internal — utility functions"
 )]
 pub(crate) mod utils;
 
@@ -196,7 +196,7 @@ impl Db {
     /// native read-your-own-writes.
     #[cfg(feature = "storage-fjall")]
     pub fn open_fjall(path: impl AsRef<Path>) -> crate::Result<Self> {
-        crate::storage::fjall_backend::new_cozo_fjall(path)
+        crate::storage::fjall_backend::new_krites_fjall(path)
             .map(|db| Self::new(DbInner::Fjall(db)))
             .map_err(convert_internal)
     }

--- a/crates/krites/src/storage/fjall_backend.rs
+++ b/crates/krites/src/storage/fjall_backend.rs
@@ -20,7 +20,7 @@ type Result<T> = StorageResult<T>;
 /// Pure Rust, zero C dependencies, LSM-tree with LZ4 compression.
 /// Uses `SingleWriterTxDatabase` for serialized write transactions
 /// with native read-your-own-writes semantics.
-pub fn new_cozo_fjall(
+pub fn new_krites_fjall(
     path: impl AsRef<Path>,
 ) -> crate::error::InternalResult<DbCore<FjallStorage>> {
     let path = path.as_ref();
@@ -523,7 +523,7 @@ mod tests {
 
     fn setup_test_db() -> InternalResult<(TempDir, DbCore<FjallStorage>)> {
         let temp_dir = TempDir::new().unwrap_or_else(|_| unreachable!());
-        let db = new_cozo_fjall(temp_dir.path())?;
+        let db = new_krites_fjall(temp_dir.path())?;
         db.run_script(
             r#"
             {:create plain {k: Int => v}}
@@ -640,7 +640,7 @@ mod tests {
         let dir = TempDir::new().unwrap_or_else(|_| unreachable!());
 
         {
-            let db = new_cozo_fjall(dir.path())?;
+            let db = new_krites_fjall(dir.path())?;
             db.run_script(
                 "{:create persist_test {k: Int => v: String}}",
                 Default::default(),
@@ -654,7 +654,7 @@ mod tests {
         }
 
         {
-            let db = new_cozo_fjall(dir.path())?;
+            let db = new_krites_fjall(dir.path())?;
             let result = db.run_script(
                 "?[k, v] := *persist_test{k, v}",
                 Default::default(),


### PR DESCRIPTION
Phase 05g Wave 1. Zero cozo/CozoDB references remain.