### PR TITLE
fix(security): validate paths before filesystem operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,6 +3570,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true, features = ["sync", "time"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
 criterion = { workspace = true }
+tempfile = { workspace = true }
 
 # WHY: ID generation is on every session/turn/observation hot path. Track
 # regressions in the internal ULID/UUID implementations against external

--- a/crates/koina/src/fs.rs
+++ b/crates/koina/src/fs.rs
@@ -1,6 +1,66 @@
 //! Restricted filesystem helpers for writing sensitive files.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// Validate that `path` resolves within `root` after canonicalization.
+///
+/// Follows the security standard's path validation sequence:
+/// normalize -> check `allowed_roots` -> canonicalize -> re-check `allowed_roots`.
+///
+/// For paths that do not yet exist on disk, the parent directory is
+/// canonicalized and the final component is appended. This handles the
+/// common pattern of validating a file path before creating it.
+///
+/// # Errors
+///
+/// Returns [`std::io::Error`] if:
+/// - The path contains `..` components (pre-canonicalization check).
+/// - The canonicalized path does not start with the canonicalized root.
+/// - Canonicalization itself fails (e.g. root directory does not exist).
+pub fn validate_within_root(path: &Path, root: &Path) -> std::io::Result<PathBuf> {
+    // Pre-canonicalization: reject `..` components to catch obvious traversal
+    // attempts before touching the filesystem.
+    for component in path.components() {
+        if let std::path::Component::ParentDir = component {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "path contains '..' component: {}",
+                    path.display()
+                ),
+            ));
+        }
+    }
+
+    let canonical_root = std::fs::canonicalize(root)?;
+
+    // WHY: the target path may not exist yet (e.g. health check write test,
+    // new credential file). Canonicalize the parent, then append the filename.
+    let canonical_path = if path.exists() {
+        std::fs::canonicalize(path)?
+    } else {
+        let parent = path.parent().unwrap_or(path);
+        let canonical_parent = std::fs::canonicalize(parent)?;
+        match path.file_name() {
+            Some(name) => canonical_parent.join(name),
+            None => canonical_parent,
+        }
+    };
+
+    // Post-canonicalization containment check (catches symlink escapes).
+    if !canonical_path.starts_with(&canonical_root) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "path escapes root: {} is not within {}",
+                canonical_path.display(),
+                canonical_root.display()
+            ),
+        ));
+    }
+
+    Ok(canonical_path)
+}
 
 /// Write `content` to `path` atomically with 0600 permissions.
 ///
@@ -43,4 +103,84 @@ pub fn write_restricted(path: &Path, content: &[u8]) -> std::io::Result<()> {
     std::fs::rename(&tmp, path)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_within_root_accepts_child_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let child = dir.path().join("config").join("aletheia.toml");
+        std::fs::create_dir_all(dir.path().join("config")).unwrap();
+        std::fs::write(&child, b"").unwrap();
+
+        let result = validate_within_root(&child, dir.path());
+        assert!(result.is_ok(), "child path should be accepted: {result:?}");
+    }
+
+    #[test]
+    fn validate_within_root_accepts_nonexistent_file_in_existing_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("data")).unwrap();
+        let nonexistent = dir.path().join("data").join("new-file.txt");
+
+        let result = validate_within_root(&nonexistent, dir.path());
+        assert!(
+            result.is_ok(),
+            "nonexistent file in existing parent should be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn validate_within_root_rejects_dotdot_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let escape = dir.path().join("data").join("..").join("..").join("etc").join("passwd");
+
+        let result = validate_within_root(&escape, dir.path());
+        assert!(result.is_err(), "path with '..' should be rejected");
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn validate_within_root_rejects_path_outside_root() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = outside.path().join("secret.txt");
+        std::fs::write(&outside_file, b"secret").unwrap();
+
+        let result = validate_within_root(&outside_file, root.path());
+        assert!(result.is_err(), "path outside root should be rejected");
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_within_root_rejects_symlink_escape() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = outside.path().join("secret.txt");
+        std::fs::write(&outside_file, b"secret").unwrap();
+
+        // Create a symlink inside root that points outside
+        let link = root.path().join("escape-link");
+        std::os::unix::fs::symlink(&outside_file, &link).unwrap();
+
+        let result = validate_within_root(&link, root.path());
+        assert!(
+            result.is_err(),
+            "symlink escaping root should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_within_root_accepts_root_itself() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = validate_within_root(dir.path(), dir.path());
+        assert!(result.is_ok(), "root itself should be accepted: {result:?}");
+    }
 }

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -166,13 +166,38 @@ fn check_provider_reachability(state: &HealthState) -> HealthCheck {
 async fn check_config_readable(state: &HealthState) -> HealthCheck {
     // Check for TOML config first, then JSON
     let config_dir = state.oikos.config();
+    let instance_root = state.oikos.root();
+
+    // WHY: validate that constructed config paths stay within the instance
+    // root to prevent path-traversal if the config directory is misconfigured.
     let toml_path = config_dir.join("aletheia.toml");
     let json_path = config_dir.join("aletheia.json");
 
     let config_path = if tokio::fs::metadata(&toml_path).await.is_ok() {
-        toml_path
+        match koina::fs::validate_within_root(&toml_path, instance_root) {
+            Ok(p) => p,
+            Err(e) => {
+                return HealthCheck {
+                    name: "config_readable",
+                    status: "fail",
+                    message: Some(format!("config path validation failed: {e}")),
+                };
+            }
+        }
     } else {
-        json_path
+        match koina::fs::validate_within_root(&json_path, instance_root) {
+            Ok(p) => p,
+            Err(e) => {
+                // WHY: json_path may not exist yet (first run); validation
+                // failure here means the parent directory itself is outside
+                // the instance root, which is a real misconfiguration.
+                return HealthCheck {
+                    name: "config_readable",
+                    status: "warn",
+                    message: Some(format!("config path validation failed: {e}")),
+                };
+            }
+        }
     };
 
     match tokio::fs::metadata(&config_path).await {
@@ -331,6 +356,7 @@ fn check_credential_validity(
 /// Check if the data directory is writable.
 async fn check_storage_writable(state: &HealthState) -> HealthCheck {
     let data_dir = state.oikos.data();
+    let instance_root = state.oikos.root();
 
     // Ensure data directory exists
     if let Err(e) = tokio::fs::create_dir_all(&data_dir).await {
@@ -341,7 +367,27 @@ async fn check_storage_writable(state: &HealthState) -> HealthCheck {
         };
     }
 
+    // WHY: validate that the data directory resolves within the instance
+    // root to prevent path-traversal if oikos is misconfigured.
+    if let Err(e) = koina::fs::validate_within_root(&data_dir, instance_root) {
+        return HealthCheck {
+            name: "storage_writable",
+            status: "fail",
+            message: Some(format!("data directory path validation failed: {e}")),
+        };
+    }
+
     let test_file = data_dir.join(".health-check-write-test");
+
+    // WHY: validate the test file path stays within the data directory
+    // (defense-in-depth against crafted data_dir values).
+    if let Err(e) = koina::fs::validate_within_root(&test_file, &data_dir) {
+        return HealthCheck {
+            name: "storage_writable",
+            status: "fail",
+            message: Some(format!("test file path validation failed: {e}")),
+        };
+    }
 
     match tokio::fs::write(&test_file, b"health-check").await {
         Ok(()) => {

--- a/crates/symbolon/src/credential/file_ops.rs
+++ b/crates/symbolon/src/credential/file_ops.rs
@@ -82,9 +82,27 @@ impl CredentialFile {
     /// are invisible and the chain falls back to a stale env-var token.
     #[must_use]
     pub fn load(path: &Path) -> Option<Self> {
+        // WHY: validate path stays within its parent directory to prevent
+        // path-traversal via crafted credential config paths (CodeQL
+        // "Uncontrolled data used in path expression").
+        let parent = path.parent()?;
+        if parent.exists()
+            && let Err(e) = koina::fs::validate_within_root(path, parent)
+        {
+            warn!(error = %e, path = %path.display(), "credential path validation failed");
+            return None;
+        }
+
         // WHY: orphaned .json.tmp files from crashed writes waste disk and confuse operators
         let tmp = path.with_extension("json.tmp");
         if tmp.exists() {
+            // WHY: validate derived tmp path before filesystem operations
+            if parent.exists()
+                && let Err(e) = koina::fs::validate_within_root(&tmp, parent)
+            {
+                warn!(error = %e, path = %tmp.display(), "temp file path validation failed");
+                return None;
+            }
             if let Err(e) = std::fs::remove_file(&tmp) {
                 warn!(error = %e, path = %tmp.display(), "failed to clean up orphaned temp file");
             } else {
@@ -129,6 +147,15 @@ impl CredentialFile {
     /// for the duration to prevent races with Claude Code.
     pub(crate) fn save(&self, path: &Path) -> std::io::Result<()> {
         use std::io::Write as _;
+
+        // WHY: validate path stays within its parent directory to prevent
+        // path-traversal via crafted credential config paths (CodeQL
+        // "Uncontrolled data used in path expression").
+        if let Some(parent) = path.parent()
+            && parent.exists()
+        {
+            koina::fs::validate_within_root(path, parent)?;
+        }
 
         let json = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
 


### PR DESCRIPTION
## Summary

- Add `koina::fs::validate_within_root(path, root)` shared utility that canonicalizes both paths and verifies containment, following the security standard's normalize -> check -> canonicalize -> re-check sequence
- Fix 7 CodeQL alerts in `pylon::handlers::health.rs`: config_dir and data_dir paths from Oikos validated against the instance root before filesystem I/O
- Fix 3 CodeQL alerts in `symbolon::credential::file_ops.rs`: credential file paths and derived temp file paths validated against their parent directory before read/write/delete
- 6 new tests covering: child paths, nonexistent files, `..` traversal, outside-root rejection, symlink escape, root-as-self

## Test plan

- [x] `cargo check -p koina -p pylon -p symbolon` passes
- [x] `cargo test -p koina -p pylon -p symbolon` passes (808 tests, 0 failures)
- [x] `cargo clippy -p koina -p pylon -p symbolon` zero warnings
- [ ] CodeQL re-scan confirms alerts resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)