### PR TITLE
fix(pylon): return 404 for archived sessions on GET (#3196)

### DIFF
--- a/crates/integration-tests/tests/cross_crate_pipeline/lifecycle.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline/lifecycle.rs
@@ -327,5 +327,5 @@ async fn session_lifecycle_create_list_archive_unarchive_rename() {
         .iter()
         .find(|s| s["id"] == id)
         .expect("session should be in list");
-    assert_eq!(our_session["display_name"], "My Renamed Session");
+    assert_eq!(our_session["name"], "My Renamed Session");
 }

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -211,6 +211,12 @@ pub async fn get_session(
     Path(id): Path<String>,
 ) -> Result<Json<SessionResponse>, ApiError> {
     let session = find_session(&state, &id).await?;
+    // WHY: archived sessions must not be visible via normal GET (#3196).
+    // The unarchive endpoint uses `find_session` directly (any status),
+    // so this filter only affects the read path.
+    if session.status == SessionStatus::Archived {
+        return Err(SessionNotFoundSnafu { id: id.clone() }.build());
+    }
     Ok(Json(SessionResponse::from_mneme(&session)))
 }
 

--- a/crates/pylon/src/tests/error_envelope.rs
+++ b/crates/pylon/src/tests/error_envelope.rs
@@ -204,7 +204,7 @@ async fn archive_post_nonexistent_session_returns_404_with_envelope() {
 }
 
 #[tokio::test]
-async fn get_archived_session_returns_200_with_status() {
+async fn get_archived_session_returns_404() {
     let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"]
@@ -222,6 +222,7 @@ async fn get_archived_session_returns_200_with_status() {
         "archive via DELETE should return 204"
     );
 
+    // WHY: archived sessions must not be visible via normal GET (#3196).
     let resp = router
         .clone()
         .oneshot(authed_get(&format!("/api/v1/sessions/{id}")))
@@ -229,12 +230,11 @@ async fn get_archived_session_returns_200_with_status() {
         .expect("GET /sessions/{id} request should succeed");
     assert_eq!(
         resp.status(),
-        StatusCode::OK,
-        "archived session should be retrievable via GET"
+        StatusCode::NOT_FOUND,
+        "archived session should not be retrievable via GET"
     );
     let body = body_json(resp).await;
-    assert_eq!(body["id"], id);
-    assert_eq!(body["status"], "archived");
+    assert_error_envelope(&body, "session_not_found");
 }
 
 #[tokio::test]

--- a/crates/pylon/src/tests/session.rs
+++ b/crates/pylon/src/tests/session.rs
@@ -67,7 +67,7 @@ async fn close_session_returns_204() {
 }
 
 #[tokio::test]
-async fn get_archived_session_returns_200_with_archived_status() {
+async fn get_archived_session_returns_404() {
     let (router, _dir) = app().await;
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
@@ -79,16 +79,14 @@ async fn get_archived_session_returns_200_with_archived_status() {
         .unwrap();
     assert_eq!(del.status(), StatusCode::NO_CONTENT);
 
+    // WHY: archived sessions must not be visible via normal GET (#3196).
     let resp = router
         .clone()
         .oneshot(authed_get(&format!("/api/v1/sessions/{id}")))
         .await
         .unwrap();
 
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = body_json(resp).await;
-    assert_eq!(body["id"], id);
-    assert_eq!(body["status"], "archived");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -152,14 +150,13 @@ async fn double_close_session_is_idempotent() {
         .expect("second close");
     assert_eq!(second.status(), StatusCode::NO_CONTENT);
 
+    // WHY: archived sessions must not be visible via normal GET (#3196).
     let resp = router
         .clone()
         .oneshot(authed_get(&format!("/api/v1/sessions/{id}")))
         .await
         .expect("get after double close");
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = body_json(resp).await;
-    assert_eq!(body["status"], "archived");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -281,14 +278,13 @@ async fn archive_via_post_returns_204() {
     let resp = router.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 
+    // WHY: archived sessions must not be visible via normal GET (#3196).
     let resp = router
         .clone()
         .oneshot(authed_get(&format!("/api/v1/sessions/{id}")))
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = body_json(resp).await;
-    assert_eq!(body["status"], "archived");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- GET `/api/v1/sessions/{id}` now returns 404 for archived sessions, matching the documented API response (`"Session not found or deleted"`). The `unarchive` endpoint continues to use `find_session` (any status) so it can locate and reactivate archived sessions.
- Fixed the `session_lifecycle` integration test's rename assertion: `display_name` -> `name` to match the actual JSON field emitted by `SessionListItem`.
- Updated 4 pylon unit tests that expected GET to return 200 with archived status to expect 404.

## Test plan

- [x] `cargo test -p integration-tests --test cross_crate_pipeline -- session_lifecycle` passes
- [x] `cargo test -p pylon` passes (362 + 34 tests, 0 failures)
- [x] `cargo clippy -p pylon -p integration-tests` clean (no new warnings)

Closes #3196

🤖 Generated with [Claude Code](https://claude.com/claude-code)