### PR TITLE
Task: Push blanket lint suppressions to individual sites — storage module pilot

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,34 @@
+# Task: Push blanket lint suppressions to individual sites — storage module pilot
+
+Skip the Setup section — you're already in a worktree.
+
+## Context
+
+krites (crates/krites/) is an embedded Datalog engine. Its lib.rs has module-level `#[expect(...)]` annotations that suppress clippy lints across entire modules. This hides the actual suppression sites.
+
+This task: push suppressions from lib.rs down to individual functions/items in the `storage` module only (smallest, 1.7K LOC). This is a pilot for the full overhaul.
+
+## What to do
+
+1. Read `crates/krites/src/lib.rs` — find the `#[expect]` block for the `storage` module
+2. Note which lints are suppressed (e.g., `clippy::as_conversions`, `clippy::indexing_slicing`, etc.)
+3. Remove the blanket suppression for `storage` from lib.rs
+4. Run `cargo clippy -p krites 2>&1` — collect all new warnings in `storage/` files
+5. For each warning: add `#[expect(clippy::lint_name, reason = "...")]` on the specific function or impl block
+6. The reason must explain WHY (e.g., `reason = "u32-to-usize widening is safe on 64-bit"`)
+
+## Rules
+
+- Do NOT fix the underlying issues — only add per-site suppressions with reasons
+- Only touch files in `crates/krites/src/storage/`
+- Run `cargo clippy -p krites` after — zero warnings
+- Run `cargo test -p krites` — all tests pass
+- Commit: `refactor(krites): localize lint suppressions in storage module`
+- Gate-Passed: kanon 0.1.0
+
+## Acceptance criteria
+
+- Zero module-level `#[expect]` for the storage module in lib.rs
+- Every individual `#[expect]` has a `reason = "..."` string
+- `cargo clippy -p krites` — zero warnings
+- `cargo test -p krites` — all pass

--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -103,13 +103,6 @@ pub(crate) mod query;
     reason = "krites engine internal — runtime casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod runtime;
-#[expect(
-    dead_code,
-    clippy::pedantic,
-    clippy::result_large_err,
-    clippy::type_complexity,
-    reason = "krites engine internal — storage backend trait implementations"
-)]
 pub(crate) mod storage;
 #[expect(
     clippy::pedantic,

--- a/crates/krites/src/storage/error.rs
+++ b/crates/krites/src/storage/error.rs
@@ -6,6 +6,10 @@ use snafu::Snafu;
 #[snafu(visibility(pub(crate)))]
 #[non_exhaustive]
 pub enum StorageError {
+    #[expect(
+        clippy::doc_markdown,
+        reason = "API method names in doc comment are readable without backticks"
+    )]
     /// A storage backend operation failed (e.g., begin_write, open_table, commit).
     #[snafu(display("transaction failed ({backend}): {message}"))]
     TransactionFailed {

--- a/crates/krites/src/storage/mem.rs
+++ b/crates/krites/src/storage/mem.rs
@@ -24,6 +24,10 @@ type Result<T> = StorageResult<T>;
 /// Create a database backed by memory.
 /// This is the fastest storage, but non-persistent.
 /// Supports concurrent readers but only a single writer.
+#[expect(
+    clippy::result_large_err,
+    reason = "engine Error size is inherited from InternalError"
+)]
 pub fn new_mem_db() -> crate::error::InternalResult<crate::DbCore<MemStorage>> {
     let ret = crate::DbCore::new(MemStorage::default())?;
     ret.initialize()?;
@@ -43,6 +47,11 @@ impl<'s> Storage<'s> for MemStorage {
         "mem"
     }
 
+    #[expect(
+        clippy::redundant_closure_for_method_calls,
+        clippy::default_trait_access,
+        reason = "explicit closure and Default::default are kept for readability"
+    )]
     fn transact(&'s self, write: bool) -> Result<Self::Tx> {
         Ok(if write {
             let wtr = self.store.write().unwrap_or_else(|e| e.into_inner());
@@ -57,6 +66,10 @@ impl<'s> Storage<'s> for MemStorage {
         Ok(())
     }
 
+    #[expect(
+        clippy::redundant_closure_for_method_calls,
+        reason = "poison error into_inner is explicit for readability"
+    )]
     fn batch_put<'a>(
         &'a self,
         data: Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + 'a>,
@@ -122,6 +135,10 @@ impl<'s> StoreTx<'s> for MemTx<'s> {
         }
     }
 
+    #[expect(
+        clippy::explicit_iter_loop,
+        reason = "explicit .iter() call is kept for clarity"
+    )]
     fn del_range_from_persisted(&mut self, lower: &[u8], upper: &[u8]) -> Result<()> {
         match self {
             MemTx::Reader(_) => Err(WriteInReadTransactionSnafu.build()),
@@ -169,6 +186,10 @@ impl<'s> StoreTx<'s> for MemTx<'s> {
         }
     }
 
+    #[expect(
+        clippy::result_large_err,
+        reason = "engine Error size is inherited from InternalError"
+    )]
     fn range_scan_tuple<'a>(
         &'a self,
         lower: &[u8],
@@ -221,6 +242,10 @@ impl<'s> StoreTx<'s> for MemTx<'s> {
         }
     }
 
+    #[expect(
+        clippy::result_large_err,
+        reason = "engine Error size is inherited from InternalError"
+    )]
     fn range_scan<'a>(
         &'a self,
         lower: &[u8],
@@ -277,6 +302,12 @@ where
     T: Iterator<Item = (&'a Vec<u8>, &'a Vec<u8>)>,
 {
     #[inline]
+    #[expect(
+        clippy::result_large_err,
+        clippy::unnecessary_wraps,
+        clippy::semicolon_if_nothing_returned,
+        reason = "uniform Result return and statement style are kept for code consistency"
+    )]
     fn fill_cache(&mut self) -> InternalResult<()> {
         if self.change_cache.is_none()
             && let Some(kmv) = self.change_iter.next()
@@ -294,6 +325,11 @@ where
     }
 
     #[inline]
+    #[expect(
+        clippy::result_large_err,
+        clippy::needless_continue,
+        reason = "engine Error size is inherited; continue explicitly skips deleted entries"
+    )]
     fn next_inner(&mut self) -> InternalResult<Option<(Vec<u8>, Vec<u8>)>> {
         let corrupted = || {
             crate::error::InternalError::from(
@@ -362,6 +398,12 @@ struct CacheIter<'a> {
 
 impl CacheIter<'_> {
     #[inline]
+    #[expect(
+        clippy::result_large_err,
+        clippy::unnecessary_wraps,
+        clippy::semicolon_if_nothing_returned,
+        reason = "uniform Result return and statement style are kept for code consistency"
+    )]
     fn fill_cache(&mut self) -> InternalResult<()> {
         if self.change_cache.is_none()
             && let Some(kmv) = self.change_iter.next()
@@ -379,6 +421,11 @@ impl CacheIter<'_> {
     }
 
     #[inline]
+    #[expect(
+        clippy::result_large_err,
+        clippy::needless_continue,
+        reason = "engine Error size is inherited; continue explicitly skips deleted entries"
+    )]
     fn next_inner(&mut self) -> InternalResult<Option<Tuple>> {
         let corrupted = || {
             crate::error::InternalError::from(
@@ -434,6 +481,10 @@ impl Iterator for CacheIter<'_> {
     }
 }
 
+#[expect(
+    clippy::doc_markdown,
+    reason = "bare GitHub URL in doc comment is readable as-is"
+)]
 /// Keep an eye on https://github.com/rust-lang/rust/issues/49638
 pub(crate) struct SkipIterator<'a> {
     pub(crate) inner: &'a BTreeMap<Vec<u8>, Vec<u8>>,
@@ -443,6 +494,10 @@ pub(crate) struct SkipIterator<'a> {
     pub(crate) size_hint: Option<usize>,
 }
 
+#[expect(
+    clippy::elidable_lifetime_names,
+    reason = "explicit lifetime matches the struct definition"
+)]
 impl<'a> Iterator for SkipIterator<'a> {
     type Item = Tuple;
 
@@ -479,6 +534,10 @@ struct SkipDualIterator<'a> {
     next_bound: Vec<u8>,
 }
 
+#[expect(
+    clippy::elidable_lifetime_names,
+    reason = "explicit lifetime matches the struct definition"
+)]
 impl<'a> Iterator for SkipDualIterator<'a> {
     type Item = Tuple;
 

--- a/crates/krites/src/storage/mod.rs
+++ b/crates/krites/src/storage/mod.rs
@@ -14,6 +14,10 @@ pub(crate) mod fjall_backend;
 pub(crate) mod mem;
 pub(crate) mod temp;
 
+#[expect(
+    dead_code,
+    reason = "trait contract used by concrete storage backends"
+)]
 /// Swappable storage trait for the mneme engine.
 pub trait Storage<'s>: Send + Sync + Clone {
     /// The associated transaction type used by this engine
@@ -32,6 +36,10 @@ pub trait Storage<'s>: Send + Sync + Clone {
     /// Put multiple key-value pairs into the database.
     /// No duplicate data will be sent, and the order data come in is strictly ascending.
     /// There will be no other access to the database while this function is running.
+    #[expect(
+        clippy::type_complexity,
+        reason = "boxed iterator type is required for heterogeneous storage backends"
+    )]
     fn batch_put<'a>(
         &'a self,
         data: Box<dyn Iterator<Item = StorageResult<(Vec<u8>, Vec<u8>)>> + 'a>,
@@ -128,6 +136,10 @@ pub trait StoreTx<'s>: Sync {
     /// `lower` is inclusive whereas `upper` is exclusive.
     ///
     /// Iterator items use [`InternalResult`] for compatibility with engine-internal callers.
+    #[expect(
+        clippy::type_complexity,
+        reason = "boxed iterator type is required for heterogeneous storage backends"
+    )]
     fn range_scan<'a>(
         &'a self,
         lower: &[u8],

--- a/crates/krites/src/storage/temp.rs
+++ b/crates/krites/src/storage/temp.rs
@@ -22,6 +22,10 @@ impl<'s> Storage<'s> for TempStorage {
         "temp"
     }
 
+    #[expect(
+        clippy::default_trait_access,
+        reason = "BTreeMap::default in TempTx construction"
+    )]
     fn transact(&'s self, _write: bool) -> Result<Self::Tx> {
         Ok(TempTx {
             store: Default::default(),
@@ -83,6 +87,10 @@ impl<'s> StoreTx<'s> for TempTx {
         Ok(())
     }
 
+    #[expect(
+        clippy::result_large_err,
+        reason = "engine Error size is inherited from InternalError"
+    )]
     fn range_scan_tuple<'a>(
         &'a self,
         lower: &[u8],
@@ -116,6 +124,10 @@ impl<'s> StoreTx<'s> for TempTx {
         )
     }
 
+    #[expect(
+        clippy::result_large_err,
+        reason = "engine Error size is inherited from InternalError"
+    )]
     fn range_scan<'a>(
         &'a self,
         lower: &[u8],


### PR DESCRIPTION
Dispatched by kimi-dispatch from prompt: `krites-wave2-pilot.md`

Kimi CLI v1.30.0 — worktree-isolated, sequential execution.

```
Prompt: /tmp/krites-wave2-pilot.md
Branch: refactor/krites-wave2-pilot-20260415T100728Z
Kimi exit: 0
Commits: 1
```