### PR TITLE
refactor(krites): localize lint suppressions in parse module

### DIFF
--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -68,15 +68,6 @@ pub(crate) mod fixed_rule;
     reason = "krites engine internal — FTS tokenizer casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod fts;
-#[expect(
-    clippy::as_conversions,
-    clippy::indexing_slicing,
-    clippy::needless_return,
-    clippy::pedantic,
-    clippy::result_large_err,
-    clippy::type_complexity,
-    reason = "krites engine internal — parser casts and indexing are engine-internal invariants"
-)]
 pub(crate) mod parse;
 #[expect(
     clippy::as_conversions,

--- a/crates/krites/src/parse/expr.rs
+++ b/crates/krites/src/parse/expr.rs
@@ -1,4 +1,12 @@
 //! Expression parsing from Datalog source.
+#![expect(
+    clippy::as_conversions,
+    clippy::indexing_slicing,
+    clippy::needless_return,
+    clippy::pedantic,
+    clippy::result_large_err,
+    reason = "Datalog expression parser — numeric casts for Unicode escapes, indexing into pest pairs by structural position, InternalError is the crate-wide Result type"
+)]
 
 use std::collections::BTreeMap;
 use std::sync::LazyLock;

--- a/crates/krites/src/parse/fts.rs
+++ b/crates/krites/src/parse/fts.rs
@@ -1,4 +1,10 @@
 //! Full-text search clause parsing.
+#![expect(
+    clippy::as_conversions,
+    clippy::pedantic,
+    clippy::result_large_err,
+    reason = "FTS query parser — numeric cast for boost weight, InternalError is the crate-wide Result type"
+)]
 
 use std::sync::LazyLock;
 

--- a/crates/krites/src/parse/imperative.rs
+++ b/crates/krites/src/parse/imperative.rs
@@ -1,4 +1,10 @@
 //! Imperative script parsing.
+#![expect(
+    clippy::pedantic,
+    clippy::result_large_err,
+    reason = "Imperative block parser — InternalError is the crate-wide Result type, pedantic style deferred"
+)]
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 

--- a/crates/krites/src/parse/mod.rs
+++ b/crates/krites/src/parse/mod.rs
@@ -1,4 +1,10 @@
 //! AST for the datalog query language.
+#![expect(
+    clippy::needless_return,
+    clippy::pedantic,
+    clippy::result_large_err,
+    reason = "Datalog parser top-level — InternalError is the crate-wide Result type, pedantic style deferred"
+)]
 
 use std::cmp::{max, min};
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/krites/src/parse/query/atoms.rs
+++ b/crates/krites/src/parse/query/atoms.rs
@@ -1,5 +1,12 @@
 //! Rule and atom parsing: rules, disjunctions, atoms, applications.
 //! Datalog query parsing.
+#![expect(
+    clippy::indexing_slicing,
+    clippy::pedantic,
+    clippy::result_large_err,
+    clippy::type_complexity,
+    reason = "Atom parser — indexing into structurally-known pest pairs, aggregate return tuples, InternalError is the crate-wide Result type"
+)]
 
 use std::collections::BTreeMap;
 

--- a/crates/krites/src/parse/query/fixed_rules.rs
+++ b/crates/krites/src/parse/query/fixed_rules.rs
@@ -1,5 +1,12 @@
 //! Fixed rule parsing.
 //! Datalog query parsing.
+#![expect(
+    clippy::as_conversions,
+    clippy::needless_return,
+    clippy::pedantic,
+    clippy::result_large_err,
+    reason = "Fixed rule parser — CompactString-to-str coercion via as, InternalError is the crate-wide Result type"
+)]
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/krites/src/parse/query/program.rs
+++ b/crates/krites/src/parse/query/program.rs
@@ -1,5 +1,10 @@
 //! Query program parsing and construction.
 //! Datalog query parsing.
+#![expect(
+    clippy::pedantic,
+    clippy::result_large_err,
+    reason = "Query program parser — InternalError is the crate-wide Result type, pedantic style deferred"
+)]
 
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;

--- a/crates/krites/src/parse/schema.rs
+++ b/crates/krites/src/parse/schema.rs
@@ -1,4 +1,10 @@
 //! Schema definition parsing.
+#![expect(
+    clippy::as_conversions,
+    clippy::pedantic,
+    clippy::result_large_err,
+    reason = "Schema parser — CompactString-to-str coercion via as, InternalError is the crate-wide Result type"
+)]
 
 use std::collections::BTreeSet;
 

--- a/crates/krites/src/parse/sys/parse.rs
+++ b/crates/krites/src/parse/sys/parse.rs
@@ -1,4 +1,10 @@
-//! parse_sys implementation.
+//! `parse_sys` implementation.
+#![expect(
+    clippy::pedantic,
+    clippy::result_large_err,
+    reason = "System command parser — InternalError is the crate-wide Result type, pedantic style deferred"
+)]
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary
- Remove blanket `#[expect]` block for the `parse` module from `crates/krites/src/lib.rs`
- Add file-level `#![expect]` inner attributes to each of the 9 parse source files, declaring only the lints each file actually triggers
- Each suppression carries a reason specific to its parser context (Unicode escapes, pest pair indexing, InternalError Result type, etc.)

## Gate
- `cargo clippy -p krites`: zero warnings
- `cargo test -p krites`: 19/19 pass

## Test plan
- [x] `cargo clippy -p krites` produces zero warnings after the change
- [x] `cargo test -p krites` all 19 tests pass
- [x] No unfulfilled `#[expect]` attributes (no lint was suppressed unnecessarily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)