### PR TITLE
refactor(krites): localize lint suppressions in fts module

### DIFF
--- a/crates/krites/src/fts/ast.rs
+++ b/crates/krites/src/fts/ast.rs
@@ -24,7 +24,7 @@ impl FtsLiteral {
                 value: CompactString::from(&t.text),
                 is_prefix: false,
                 booster: self.booster,
-            })
+            });
         }
     }
 }
@@ -53,6 +53,7 @@ impl FtsExpr {
         match self {
             FtsExpr::Literal(l) => l.booster == 0. || l.value.is_empty(),
             FtsExpr::Near(FtsNear { literals, .. }) => literals.is_empty(),
+            #[expect(clippy::match_same_arms, reason = "FTS AST variants listed separately for clarity")]
             FtsExpr::And(v) => v.is_empty(),
             FtsExpr::Or(v) => v.is_empty(),
             FtsExpr::Not(lhs, _) => lhs.is_empty(),
@@ -68,7 +69,7 @@ impl FtsExpr {
                         FtsExpr::And(es) => flattened.extend(es),
                         e => {
                             if !e.is_empty() {
-                                flattened.push(e)
+                                flattened.push(e);
                             }
                         }
                     }
@@ -89,7 +90,7 @@ impl FtsExpr {
                         FtsExpr::Or(es) => flattened.extend(es),
                         e => {
                             if !e.is_empty() {
-                                flattened.push(e)
+                                flattened.push(e);
                             }
                         }
                     }

--- a/crates/krites/src/fts/indexing.rs
+++ b/crates/krites/src/fts/indexing.rs
@@ -35,6 +35,7 @@ impl FtsCache {
     /// # Complexity
     ///
     /// O(1) cached, or O(1) for the underlying range count operation.
+    #[expect(clippy::result_large_err, reason = "FTS error carries structured tokenization context")]
     fn get_n_for_relation(&mut self, rel: &RelationHandle, tx: &SessionTx<'_>) -> Result<usize> {
         Ok(match self.total_n_cache.entry(rel.name.clone()) {
             Entry::Vacant(v) => {
@@ -54,6 +55,12 @@ impl FtsCache {
     ///
     /// O(D) where D is documents with indexed terms. Scans term entries
     /// and computes unique document lengths.
+    #[expect(
+        clippy::indexing_slicing,
+        clippy::mutable_key_type,
+        clippy::result_large_err,
+        reason = "FTS index tuple layout is a known invariant; DataValue keys are structurally immutable; FTS error carries structured context"
+    )]
     fn get_avg_dl_for_relation(&mut self, idx: &RelationHandle, tx: &SessionTx<'_>) -> Result<f64> {
         Ok(match self.avg_dl_cache.entry(idx.name.clone()) {
             Entry::Occupied(o) => *o.get(),
@@ -96,6 +103,7 @@ impl FtsCache {
                     // INVARIANT: doc count is a usize representing indexed documents;
                     // precision loss at >2^53 documents is irrelevant for avg_dl.
                     #[expect(
+                        clippy::as_conversions,
                         clippy::cast_precision_loss,
                         reason = "doc count fits f64 in any realistic corpus"
                     )]
@@ -125,6 +133,7 @@ struct LiteralStats {
 ///
 /// O(1) arithmetic operations. Uses the standard BM25 formula with
 /// configurable k1 and b parameters.
+#[expect(clippy::too_many_arguments, reason = "BM25 formula requires all statistical parameters")]
 pub(crate) fn bm25_compute_score(
     tf: usize,
     df: usize,
@@ -142,18 +151,21 @@ pub(crate) fn bm25_compute_score(
         return 0.0;
     }
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
-        reason = "i64 to f64: precision loss acceptable"
+        reason = "BM25 scoring operates in f64 — usize term/doc counts are small enough"
     )]
     let tf = tf as f64;
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
-        reason = "i64 to f64: precision loss acceptable"
+        reason = "BM25 scoring operates in f64 — usize term/doc counts are small enough"
     )]
     let df = df as f64;
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
-        reason = "i64 to f64: precision loss acceptable"
+        reason = "BM25 scoring operates in f64 — usize term/doc counts are small enough"
     )]
     let n = n as f64;
     let dl = f64::from(dl);
@@ -162,13 +174,19 @@ pub(crate) fn bm25_compute_score(
     idf * normalized_tf * booster
 }
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     /// Search for a literal term in the FTS index.
     ///
     /// # Complexity
     ///
     /// O(log T + M) where T is unique terms, M is matching documents.
     /// Uses prefix scan for range queries.
+    #[expect(
+        clippy::as_conversions,
+        clippy::indexing_slicing,
+        clippy::result_large_err,
+        reason = "CompactString-to-str cast; FTS index tuple layout is a known invariant; FTS error carries structured context"
+    )]
     fn fts_search_literal(
         &self,
         literal: &FtsLiteral,
@@ -275,6 +293,12 @@ impl<'a> SessionTx<'a> {
     ///
     /// O(Q * (log T + D)) where Q is query terms, T is unique terms, D is docs.
     /// AND/OR/Near operations merge document sets with varying complexity.
+    #[expect(
+        clippy::mutable_key_type,
+        clippy::result_large_err,
+        clippy::too_many_lines,
+        reason = "DataValue keys are structurally immutable in FTS index lookups; FTS error carries structured context; search dispatches all AST node types"
+    )]
     fn fts_search_impl(
         &self,
         ast: &FtsExpr,
@@ -375,7 +399,7 @@ impl<'a> SessionTx<'a> {
                             Some(prev_pos) => {
                                 let mut inner_coll = FxHashSet::default();
                                 for p in prev_pos {
-                                    for pi in x.position_info.iter() {
+                                    for pi in &x.position_info {
                                         let cur = pi.position;
                                         if cur > p {
                                             if cur - p <= *distance {
@@ -426,21 +450,24 @@ impl<'a> SessionTx<'a> {
         config: &FtsSearch,
     ) -> f64 {
         #[expect(
+            clippy::as_conversions,
             clippy::cast_precision_loss,
-            reason = "i64 to f64: precision loss acceptable"
+            reason = "TF/TF-IDF scoring operates in f64 — usize counts are small enough"
         )]
         let tf = tf as f64;
         match config.score_kind {
             FtsScoreKind::Tf => tf * booster,
             FtsScoreKind::TfIdf | FtsScoreKind::Bm25 => {
                 #[expect(
+                    clippy::as_conversions,
                     clippy::cast_precision_loss,
-                    reason = "i64 to f64: precision loss acceptable"
+                    reason = "TF-IDF scoring operates in f64 — usize counts are small enough"
                 )]
                 let n_found_docs = n_found_docs as f64;
                 #[expect(
+                    clippy::as_conversions,
                     clippy::cast_precision_loss,
-                    reason = "i64 to f64: precision loss acceptable"
+                    reason = "TF-IDF scoring operates in f64 — usize counts are small enough"
                 )]
                 let idf = (1.0 + (n_total as f64 - n_found_docs + 0.5) / (n_found_docs + 0.5)).ln();
                 tf * idf * booster
@@ -453,6 +480,11 @@ impl<'a> SessionTx<'a> {
     ///
     /// O(tokenize + search + rank) = O(L + Q*(log T + D) + D log D) where
     /// L is query length, Q is terms, T is unique terms, D is matching docs.
+    #[expect(
+        clippy::ref_option,
+        clippy::result_large_err,
+        reason = "filter_code borrows caller's Option — changing to Option<&T> would alter call sites; FTS error carries structured context"
+    )]
     pub(crate) fn fts_search(
         &self,
         q: &str,
@@ -521,6 +553,11 @@ impl<'a> SessionTx<'a> {
     ///
     /// O(L) where L is the tokenized length of the document. Each unique term
     /// requires one index write (amortized O(1) with LSM).
+    #[expect(
+        clippy::indexing_slicing,
+        clippy::result_large_err,
+        reason = "FTS index tuple layout is a known invariant; FTS error carries structured context"
+    )]
     pub(crate) fn put_fts_index_item(
         &mut self,
         tuple: &[DataValue],
@@ -574,8 +611,8 @@ impl<'a> SessionTx<'a> {
             val[0] = DataValue::List(from);
             val[1] = DataValue::List(to);
             val[2] = DataValue::List(position);
-            let key_bytes = idx_handle.encode_key_for_store(&key, Default::default())?;
-            let val_bytes = idx_handle.encode_val_only_for_store(&val, Default::default())?;
+            let key_bytes = idx_handle.encode_key_for_store(&key, SourceSpan::default())?;
+            let val_bytes = idx_handle.encode_val_only_for_store(&val, SourceSpan::default())?;
             self.store_tx.put(&key_bytes, &val_bytes)?;
         }
         Ok(())
@@ -586,6 +623,11 @@ impl<'a> SessionTx<'a> {
     ///
     /// O(L) where L is the tokenized length. Deletes each term entry
     /// for the document (amortized O(1) per deletion with LSM).
+    #[expect(
+        clippy::indexing_slicing,
+        clippy::result_large_err,
+        reason = "FTS index tuple layout is a known invariant; FTS error carries structured context"
+    )]
     pub(crate) fn del_fts_index_item(
         &mut self,
         tuple: &[DataValue],
@@ -619,7 +661,7 @@ impl<'a> SessionTx<'a> {
         }
         for text in collector {
             key[0] = DataValue::Str(text);
-            let key_bytes = idx_handle.encode_key_for_store(&key, Default::default())?;
+            let key_bytes = idx_handle.encode_key_for_store(&key, SourceSpan::default())?;
             self.store_tx.del(&key_bytes)?;
         }
         Ok(())

--- a/crates/krites/src/fts/mod.rs
+++ b/crates/krites/src/fts/mod.rs
@@ -57,17 +57,26 @@ impl TokenizerConfig {
         }
         hasher.finalize_fixed()
     }
+    #[expect(
+        clippy::result_large_err,
+        reason = "FTS error carries structured tokenization context"
+    )]
     pub(crate) fn build(&self, filters: &[Self]) -> Result<TextAnalyzer> {
         let tokenizer = self.construct_tokenizer()?;
         let token_filters = filters
             .iter()
-            .map(|filter| filter.construct_token_filter())
+            .map(Self::construct_token_filter)
             .collect::<Result<Vec<_>>>()?;
         Ok(TextAnalyzer {
             tokenizer,
             token_filters,
         })
     }
+    #[expect(
+        clippy::as_conversions,
+        clippy::result_large_err,
+        reason = "CompactString-to-str cast for match; FTS error carries structured tokenization context"
+    )]
     pub(crate) fn construct_tokenizer(&self) -> Result<Box<dyn Tokenizer>> {
         Ok(match &self.name as &str {
             "Raw" => Box::new(RawTokenizer),
@@ -145,6 +154,12 @@ impl TokenizerConfig {
             }
         })
     }
+    #[expect(
+        clippy::as_conversions,
+        clippy::result_large_err,
+        clippy::too_many_lines,
+        reason = "CompactString-to-str cast for match; FTS error carries structured tokenization context; filter dispatch covers all supported filters"
+    )]
     pub(crate) fn construct_token_filter(&self) -> Result<BoxTokenFilter> {
         Ok(match &self.name as &str {
             "AlphaNumOnly" => AlphaNumOnlyFilter.into(),
@@ -217,7 +232,7 @@ impl TokenizerConfig {
                     .map_err(|e| {
                         crate::error::InternalError::from(
                             TokenizationFailedSnafu {
-                                message: format!("Failed to load dictionary: {}", e),
+                                message: format!("Failed to load dictionary: {e}"),
                             }
                             .build(),
                         )
@@ -269,7 +284,7 @@ impl TokenizerConfig {
                     "turkish" => Language::Turkish,
                     lang => {
                         return Err(TokenizationFailedSnafu {
-                            message: format!("Unsupported language: {}", lang),
+                            message: format!("Unsupported language: {lang}"),
                         }
                         .build()
                         .into());
@@ -334,6 +349,7 @@ pub(crate) struct TokenizerCache {
 }
 
 impl TokenizerCache {
+    #[expect(clippy::result_large_err, reason = "FTS error carries structured tokenization context")]
     pub(crate) fn get(
         &self,
         tokenizer_name: &str,
@@ -341,25 +357,25 @@ impl TokenizerCache {
         filters: &[TokenizerConfig],
     ) -> Result<Arc<TextAnalyzer>> {
         {
-            let idx_cache = self.named_cache.read().unwrap_or_else(|e| e.into_inner());
+            let idx_cache = self.named_cache.read().unwrap_or_else(std::sync::PoisonError::into_inner);
             if let Some(analyzer) = idx_cache.get(tokenizer_name) {
                 return Ok(analyzer.clone());
             }
         }
         let hash = tokenizer.config_hash(filters);
         {
-            let hashed_cache = self.hashed_cache.read().unwrap_or_else(|e| e.into_inner());
+            let hashed_cache = self.hashed_cache.read().unwrap_or_else(std::sync::PoisonError::into_inner);
             if let Some(analyzer) = hashed_cache.get(hash.as_ref()) {
-                let mut idx_cache = self.named_cache.write().unwrap_or_else(|e| e.into_inner());
+                let mut idx_cache = self.named_cache.write().unwrap_or_else(std::sync::PoisonError::into_inner);
                 idx_cache.insert(tokenizer_name.into(), analyzer.clone());
                 return Ok(analyzer.clone());
             }
         }
         {
             let analyzer = Arc::new(tokenizer.build(filters)?);
-            let mut hashed_cache = self.hashed_cache.write().unwrap_or_else(|e| e.into_inner());
+            let mut hashed_cache = self.hashed_cache.write().unwrap_or_else(std::sync::PoisonError::into_inner);
             hashed_cache.insert(hash.as_ref().to_vec(), analyzer.clone());
-            let mut idx_cache = self.named_cache.write().unwrap_or_else(|e| e.into_inner());
+            let mut idx_cache = self.named_cache.write().unwrap_or_else(std::sync::PoisonError::into_inner);
             idx_cache.insert(tokenizer_name.into(), analyzer.clone());
             Ok(analyzer)
         }

--- a/crates/krites/src/fts/tokenizer/alphanum_only.rs
+++ b/crates/krites/src/fts/tokenizer/alphanum_only.rs
@@ -10,7 +10,8 @@ pub(crate) struct AlphaNumOnlyFilterStream<'a> {
     tail: BoxTokenStream<'a>,
 }
 
-impl<'a> AlphaNumOnlyFilterStream<'a> {
+impl AlphaNumOnlyFilterStream<'_> {
+    #[expect(clippy::unused_self, reason = "method predicate follows TokenFilter pattern for consistency")]
     fn predicate(&self, token: &Token) -> bool {
         token.text.chars().all(|c| c.is_ascii_alphanumeric())
     }
@@ -22,7 +23,7 @@ impl TokenFilter for AlphaNumOnlyFilter {
     }
 }
 
-impl<'a> TokenStream for AlphaNumOnlyFilterStream<'a> {
+impl TokenStream for AlphaNumOnlyFilterStream<'_> {
     fn advance(&mut self) -> bool {
         while self.tail.advance() {
             if self.predicate(self.tail.token()) {

--- a/crates/krites/src/fts/tokenizer/ascii_folding_filter/fold_table.rs
+++ b/crates/krites/src/fts/tokenizer/ascii_folding_filter/fold_table.rs
@@ -3,8 +3,11 @@
 //! Maps Unicode characters to their ASCII equivalents where one exists.
 //! Dispatches to sub-tables by character category.
 
+#[expect(clippy::too_many_lines, reason = "generated Unicode folding table — one match arm per codepoint")]
 mod fold_digits_symbols;
+#[expect(clippy::too_many_lines, reason = "generated Unicode folding table — one match arm per codepoint")]
 mod fold_letters_a_m;
+#[expect(clippy::too_many_lines, reason = "generated Unicode folding table — one match arm per codepoint")]
 mod fold_letters_n_z;
 
 use fold_digits_symbols::fold_digit_or_symbol;

--- a/crates/krites/src/fts/tokenizer/ascii_folding_filter/mod.rs
+++ b/crates/krites/src/fts/tokenizer/ascii_folding_filter/mod.rs
@@ -23,7 +23,7 @@ pub(crate) struct AsciiFoldingFilterTokenStream<'a> {
     tail: BoxTokenStream<'a>,
 }
 
-impl<'a> TokenStream for AsciiFoldingFilterTokenStream<'a> {
+impl TokenStream for AsciiFoldingFilterTokenStream<'_> {
     fn advance(&mut self) -> bool {
         if !self.tail.advance() {
             return false;

--- a/crates/krites/src/fts/tokenizer/lower_caser.rs
+++ b/crates/krites/src/fts/tokenizer/lower_caser.rs
@@ -31,7 +31,7 @@ fn to_lowercase_unicode(text: &str, output: &mut String) {
     }
 }
 
-impl<'a> TokenStream for LowerCaserTokenStream<'a> {
+impl TokenStream for LowerCaserTokenStream<'_> {
     fn advance(&mut self) -> bool {
         if !self.tail.advance() {
             return false;

--- a/crates/krites/src/fts/tokenizer/ngram_tokenizer.rs
+++ b/crates/krites/src/fts/tokenizer/ngram_tokenizer.rs
@@ -8,21 +8,21 @@ use crate::fts::tokenizer::BoxTokenStream;
 /// Beware however, in presence of multiple value for the same field,
 /// the position will be `POSITION_GAP * index of value`.
 ///
-/// Example 1: `hello` would be tokenized as (min_gram: 2, max_gram: 3, prefix_only: false)
+/// Example 1: `hello` would be tokenized as (`min_gram`: 2, `max_gram`: 3, `prefix_only`: false)
 ///
 /// | Term     | he  | hel | el  | ell | ll  | llo | lo |
 /// |----------|-----|-----|-----|-----|-----|-----|----|
 /// | Position | 0   | 0   | 0   | 0   | 0   | 0   | 0  |
 /// | Offsets  | 0,2 | 0,3 | 1,3 | 1,4 | 2,4 | 2,5 | 3,5|
 ///
-/// Example 2: `hello` would be tokenized as (min_gram: 2, max_gram: 5, prefix_only: **true**)
+/// Example 2: `hello` would be tokenized as (`min_gram`: 2, `max_gram`: 5, `prefix_only`: **true**)
 ///
 /// | Term     | he  | hel | hell  | hello |
 /// |----------|-----|-----|-------|-------|
 /// | Position | 0   | 0   | 0     | 0     |
 /// | Offsets  | 0,2 | 0,3 | 0,4   | 0,5   |
 ///
-/// Example 3: `hεllo` (non-ascii) would be tokenized as (min_gram: 2, max_gram: 5, prefix_only:
+/// Example 3: `hεllo` (non-ascii) would be tokenized as (`min_gram`: 2, `max_gram`: 5, `prefix_only`:
 /// **true**)
 ///
 /// | Term     | hε  | hεl | hεll  | hεllo |
@@ -107,11 +107,11 @@ impl NgramTokenizer {
     }
 }
 
-/// TokenStream associate to the `NgramTokenizer`
+/// `TokenStream` associate to the [`NgramTokenizer`].
 pub(crate) struct NgramTokenStream<'a> {
     /// parameters
     ngram_charidx_iterator: StutteringIterator<CodepointFrontiers<'a>>,
-    /// true if the NgramTokenStream is in prefix mode.
+    /// true if the `NgramTokenStream` is in prefix mode.
     prefix_only: bool,
     /// input
     text: &'a str,
@@ -134,7 +134,7 @@ impl Tokenizer for NgramTokenizer {
     }
 }
 
-impl<'a> TokenStream for NgramTokenStream<'a> {
+impl TokenStream for NgramTokenStream<'_> {
     fn advance(&mut self) -> bool {
         if let Some((offset_from, offset_to)) = self.ngram_charidx_iterator.next() {
             if self.prefix_only && offset_from > 0 {
@@ -220,6 +220,7 @@ where
 {
     type Item = (usize, usize);
 
+    #[expect(clippy::indexing_slicing, reason = "cursor is bounded by memory.len() via modular arithmetic")]
     fn next(&mut self) -> Option<(usize, usize)> {
         if self.gram_len > self.max_gram {
             self.gram_len = self.min_gram;
@@ -261,9 +262,10 @@ impl<'a> CodepointFrontiers<'a> {
     }
 }
 
-impl<'a> Iterator for CodepointFrontiers<'a> {
+impl Iterator for CodepointFrontiers<'_> {
     type Item = usize;
 
+    #[expect(clippy::indexing_slicing, reason = "is_empty() guard ensures index 0 is valid")]
     fn next(&mut self) -> Option<usize> {
         self.next_el.inspect(|&offset| {
             if self.s.is_empty() {
@@ -284,6 +286,11 @@ const CODEPOINT_UTF8_WIDTH: [u8; 16] = [1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2
 // the first byte.
 //
 // To do that we count the number of higher significant bits set to `1`.
+#[expect(
+    clippy::as_conversions,
+    clippy::indexing_slicing,
+    reason = "u8-to-usize widening cast is lossless; top-4-bit index into 16-element table is always in bounds"
+)]
 fn utf8_codepoint_width(b: u8) -> usize {
     let higher_4_bits = (b as usize) >> 4;
     CODEPOINT_UTF8_WIDTH[higher_4_bits] as usize

--- a/crates/krites/src/fts/tokenizer/remove_long.rs
+++ b/crates/krites/src/fts/tokenizer/remove_long.rs
@@ -19,7 +19,7 @@ impl RemoveLongFilter {
     }
 }
 
-impl<'a> RemoveLongFilterStream<'a> {
+impl RemoveLongFilterStream<'_> {
     fn predicate(&self, token: &Token) -> bool {
         token.text.len() < self.token_length_limit
     }
@@ -39,7 +39,7 @@ pub(crate) struct RemoveLongFilterStream<'a> {
     tail: BoxTokenStream<'a>,
 }
 
-impl<'a> TokenStream for RemoveLongFilterStream<'a> {
+impl TokenStream for RemoveLongFilterStream<'_> {
     fn advance(&mut self) -> bool {
         while self.tail.advance() {
             if self.predicate(self.tail.token()) {

--- a/crates/krites/src/fts/tokenizer/simple_tokenizer.rs
+++ b/crates/krites/src/fts/tokenizer/simple_tokenizer.rs
@@ -23,7 +23,7 @@ impl Tokenizer for SimpleTokenizer {
     }
 }
 
-impl<'a> SimpleTokenStream<'a> {
+impl SimpleTokenStream<'_> {
     fn search_token_end(&mut self) -> usize {
         (&mut self.chars)
             .filter(|(_, c)| !c.is_alphanumeric())
@@ -33,7 +33,7 @@ impl<'a> SimpleTokenStream<'a> {
     }
 }
 
-impl<'a> TokenStream for SimpleTokenStream<'a> {
+impl TokenStream for SimpleTokenStream<'_> {
     fn advance(&mut self) -> bool {
         self.token.text.clear();
         self.token.position = self.token.position.wrapping_add(1);

--- a/crates/krites/src/fts/tokenizer/split_compound_words.rs
+++ b/crates/krites/src/fts/tokenizer/split_compound_words.rs
@@ -14,6 +14,7 @@ impl SplitCompoundWords {
     /// The dictionary will be used to construct an [`AhoCorasick`] automaton
     /// with reasonable defaults. See [`from_automaton`][Self::from_automaton] if
     /// more control over its construction is required.
+    #[expect(clippy::result_large_err, reason = "FTS error carries structured tokenization context")]
     pub(crate) fn from_dictionary<I, P>(dict: I) -> Result<Self>
     where
         I: IntoIterator<Item = P>,
@@ -63,7 +64,7 @@ struct SplitCompoundWordsTokenStream<'a> {
     parts: Vec<Token>,
 }
 
-impl<'a> SplitCompoundWordsTokenStream<'a> {
+impl SplitCompoundWordsTokenStream<'_> {
     fn split(&mut self) {
         let token = self.tail.token();
         let mut text = token.text.as_str();
@@ -94,7 +95,7 @@ impl<'a> SplitCompoundWordsTokenStream<'a> {
     }
 }
 
-impl<'a> TokenStream for SplitCompoundWordsTokenStream<'a> {
+impl TokenStream for SplitCompoundWordsTokenStream<'_> {
     fn advance(&mut self) -> bool {
         self.parts.pop();
 

--- a/crates/krites/src/fts/tokenizer/stemmer.rs
+++ b/crates/krites/src/fts/tokenizer/stemmer.rs
@@ -32,6 +32,7 @@ pub(crate) enum Language {
 
 impl Language {
     fn algorithm(self) -> Algorithm {
+        #[expect(clippy::enum_glob_use, reason = "local import for concise match arms in Language-to-Algorithm mapping")]
         use self::Language::*;
         match self {
             Arabic => Algorithm::Arabic,
@@ -97,7 +98,7 @@ pub(crate) struct StemmerTokenStream<'a> {
     buffer: String,
 }
 
-impl<'a> TokenStream for StemmerTokenStream<'a> {
+impl TokenStream for StemmerTokenStream<'_> {
     fn advance(&mut self) -> bool {
         if !self.tail.advance() {
             return false;

--- a/crates/krites/src/fts/tokenizer/stop_word_filter/mod.rs
+++ b/crates/krites/src/fts/tokenizer/stop_word_filter/mod.rs
@@ -20,6 +20,7 @@ impl StopWordFilter {
     /// Creates a new [`StopWordFilter`] for the given ISO 639-1 language code.
     ///
     /// Supports 58 languages from the [stopwords-iso](https://github.com/stopwords-iso/stopwords-iso/) project.
+    #[expect(clippy::result_large_err, reason = "FTS error carries structured tokenization context")]
     pub(crate) fn for_lang(language: &str) -> Result<Self> {
         let words = match language {
             "af" => stopwords::AF,
@@ -82,7 +83,7 @@ impl StopWordFilter {
             "zu" => stopwords::ZU,
             _ => {
                 return Err(TokenizationFailedSnafu {
-                    message: format!("Unsupported stop word language: {}", language),
+                    message: format!("Unsupported stop word language: {language}"),
                 }
                 .build()
                 .into());
@@ -114,13 +115,13 @@ impl TokenFilter for StopWordFilter {
     }
 }
 
-impl<'a> StopWordFilterStream<'a> {
+impl StopWordFilterStream<'_> {
     fn predicate(&self, token: &Token) -> bool {
         !self.words.contains(&token.text)
     }
 }
 
-impl<'a> TokenStream for StopWordFilterStream<'a> {
+impl TokenStream for StopWordFilterStream<'_> {
     fn advance(&mut self) -> bool {
         while self.tail.advance() {
             if self.predicate(self.tail.token()) {

--- a/crates/krites/src/fts/tokenizer/stop_word_filter/stopwords/mod.rs
+++ b/crates/krites/src/fts/tokenizer/stop_word_filter/stopwords/mod.rs
@@ -3,16 +3,44 @@
 //! Source: stopwords-iso project (MIT license).
 
 #[rustfmt::skip]
+#[expect(
+    clippy::needless_raw_string_hashes,
+    clippy::unicode_not_nfc,
+    reason = "stopword data imported verbatim from stopwords-iso — preserving source encoding"
+)]
 mod af_da;
 #[rustfmt::skip]
+#[expect(
+    clippy::needless_raw_string_hashes,
+    reason = "stopword data imported verbatim from stopwords-iso"
+)]
 mod nl_de;
 #[rustfmt::skip]
+#[expect(
+    clippy::needless_raw_string_hashes,
+    clippy::unicode_not_nfc,
+    reason = "stopword data imported verbatim from stopwords-iso — preserving source encoding"
+)]
 mod el_ja;
 #[rustfmt::skip]
+#[expect(
+    clippy::needless_raw_string_hashes,
+    clippy::unicode_not_nfc,
+    reason = "stopword data imported verbatim from stopwords-iso — preserving source encoding"
+)]
 mod ko_ro;
 #[rustfmt::skip]
+#[expect(
+    clippy::needless_raw_string_hashes,
+    reason = "stopword data imported verbatim from stopwords-iso"
+)]
 mod ru_ur;
 #[rustfmt::skip]
+#[expect(
+    clippy::needless_raw_string_hashes,
+    clippy::unicode_not_nfc,
+    reason = "stopword data imported verbatim from stopwords-iso — preserving source encoding"
+)]
 mod vi_zu;
 
 pub(crate) use af_da::AF;

--- a/crates/krites/src/fts/tokenizer/tokenizer_impl.rs
+++ b/crates/krites/src/fts/tokenizer/tokenizer_impl.rs
@@ -18,7 +18,7 @@ pub(crate) struct Token {
     pub(crate) offset_from: usize,
     /// Offset (byte index) of the last character of the token + 1.
     /// The text that generated the token should be obtained by
-    /// &text[token.offset_from..token.offset_to]
+    /// `&text[token.offset_from..token.offset_to]`
     pub(crate) offset_to: usize,
     /// Position, expressed in number of tokens.
     pub(crate) position: usize,
@@ -199,7 +199,7 @@ impl<'a> Deref for BoxTokenStream<'a> {
         &*self.0
     }
 }
-impl<'a> DerefMut for BoxTokenStream<'a> {
+impl DerefMut for BoxTokenStream<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut *self.0
     }

--- a/crates/krites/src/fts/tokenizer/whitespace_tokenizer.rs
+++ b/crates/krites/src/fts/tokenizer/whitespace_tokenizer.rs
@@ -23,7 +23,7 @@ impl Tokenizer for WhitespaceTokenizer {
     }
 }
 
-impl<'a> WhitespaceTokenStream<'a> {
+impl WhitespaceTokenStream<'_> {
     fn search_token_end(&mut self) -> usize {
         (&mut self.chars)
             .filter(|(_, c)| c.is_ascii_whitespace())
@@ -33,7 +33,7 @@ impl<'a> WhitespaceTokenStream<'a> {
     }
 }
 
-impl<'a> TokenStream for WhitespaceTokenStream<'a> {
+impl TokenStream for WhitespaceTokenStream<'_> {
     fn advance(&mut self) -> bool {
         self.token.text.clear();
         self.token.position = self.token.position.wrapping_add(1);

--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -58,15 +58,6 @@ pub(crate) mod data;
     reason = "krites engine internal — graph algorithm casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod fixed_rule;
-#[expect(
-    clippy::as_conversions,
-    clippy::indexing_slicing,
-    clippy::mutable_key_type,
-    clippy::pedantic,
-    clippy::result_large_err,
-    clippy::too_many_arguments,
-    reason = "krites engine internal — FTS tokenizer casts and indexing are engine-internal invariants"
-)]
 pub(crate) mod fts;
 #[expect(
     clippy::as_conversions,


### PR DESCRIPTION
## Summary

- Remove blanket `#[expect]` block covering the `fts` module from `lib.rs` (6 lints suppressed at module level)
- Push per-site `#[expect(lint, reason = "...")]` suppressions to 17 individual files across `fts/` and `fts/tokenizer/`
- Fix pedantic lint issues directly where practical: elide unnecessary lifetimes, inline format args, use method references over closures, add backticks in doc comments
- Retain module-level suppressions only for generated data files (stopword lists, Unicode folding tables) where warnings pervade every line

## Test plan

- [x] `cargo clippy -p krites` -- zero warnings
- [x] `cargo test -p krites` -- 19 tests pass

Generated with [Claude Code](https://claude.com/claude-code)