### PR TITLE
refactor(krites): localize lint suppressions in query module

### DIFF
--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -50,16 +50,6 @@ pub(crate) mod data;
 pub(crate) mod fixed_rule;
 pub(crate) mod fts;
 pub(crate) mod parse;
-#[expect(
-    clippy::as_conversions,
-    clippy::indexing_slicing,
-    clippy::mutable_key_type,
-    clippy::pedantic,
-    clippy::result_large_err,
-    clippy::too_many_arguments,
-    clippy::type_complexity,
-    reason = "krites engine internal — query planner casts and indexing are engine-internal invariants"
-)]
 pub(crate) mod query;
 #[expect(
     dead_code,

--- a/crates/krites/src/query/compile.rs
+++ b/crates/krites/src/query/compile.rs
@@ -1,4 +1,17 @@
 //! Query plan compilation from logical to relational algebra.
+#![expect(
+    clippy::as_conversions,
+    clippy::default_trait_access,
+    clippy::elidable_lifetime_names,
+    clippy::explicit_iter_loop,
+    clippy::indexing_slicing,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_lines,
+    clippy::unnecessary_semicolon,
+    clippy::wildcard_imports,
+    reason = "engine-internal query compiler — casts, indexing, and result size are structural"
+)]
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/krites/src/query/eval.rs
+++ b/crates/krites/src/query/eval.rs
@@ -1,4 +1,21 @@
 //! Query plan evaluation.
+#![expect(
+    clippy::as_conversions,
+    clippy::elidable_lifetime_names,
+    clippy::explicit_iter_loop,
+    clippy::indexing_slicing,
+    clippy::manual_let_else,
+    clippy::match_wildcard_for_single_variants,
+    clippy::mutable_key_type,
+    clippy::needless_pass_by_value,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::wildcard_imports,
+    reason = "engine-internal query evaluator — pass-by-value for Poison, indexing on validated bounds"
+)]
 
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;

--- a/crates/krites/src/query/graph.rs
+++ b/crates/krites/src/query/graph.rs
@@ -1,4 +1,11 @@
 //! Dependency graph analysis for stratification.
+#![expect(
+    clippy::cloned_instead_of_copied,
+    clippy::indexing_slicing,
+    clippy::needless_pass_by_value,
+    clippy::result_large_err,
+    reason = "engine-internal graph algorithms — indexing validated by construction"
+)]
 
 use std::cmp::min;
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/krites/src/query/logical.rs
+++ b/crates/krites/src/query/logical.rs
@@ -1,4 +1,13 @@
 //! Logical plan representation.
+#![expect(
+    clippy::match_same_arms,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::wildcard_imports,
+    reason = "engine-internal logical plan — match arms kept explicit for clarity"
+)]
+
 use std::collections::BTreeSet;
 
 use itertools::Itertools;

--- a/crates/krites/src/query/magic.rs
+++ b/crates/krites/src/query/magic.rs
@@ -1,4 +1,14 @@
 //! Magic sets query transformation.
+#![expect(
+    clippy::default_trait_access,
+    clippy::explicit_iter_loop,
+    clippy::needless_pass_by_value,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_lines,
+    clippy::wildcard_imports,
+    reason = "engine-internal magic sets rewrite — complex transformation with many intermediate collections"
+)]
 
 use std::collections::BTreeSet;
 use std::mem;

--- a/crates/krites/src/query/ra/filter.rs
+++ b/crates/krites/src/query/ra/filter.rs
@@ -1,3 +1,10 @@
+#![expect(
+    clippy::explicit_iter_loop,
+    clippy::iter_not_returning_iterator,
+    clippy::result_large_err,
+    reason = "engine-internal filter RA — iter returns TupleIter (boxed trait), not Self::Iterator"
+)]
+
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::data::expr::{Bytecode, Expr, eval_bytecode_pred};

--- a/crates/krites/src/query/ra/join.rs
+++ b/crates/krites/src/query/ra/join.rs
@@ -1,3 +1,20 @@
+#![expect(
+    clippy::as_conversions,
+    clippy::cloned_instead_of_copied,
+    clippy::elidable_lifetime_names,
+    clippy::from_iter_instead_of_collect,
+    clippy::indexing_slicing,
+    clippy::iter_not_returning_iterator,
+    clippy::match_same_arms,
+    clippy::mutable_key_type,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::single_match_else,
+    clippy::wildcard_imports,
+    reason = "engine-internal join operators — indexing validated by join_indices, mutable keys are Symbol"
+)]
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Formatter};
 use std::iter;

--- a/crates/krites/src/query/ra/mod.rs
+++ b/crates/krites/src/query/ra/mod.rs
@@ -1,4 +1,19 @@
 //! Relational algebra operators.
+#![expect(
+    clippy::default_trait_access,
+    clippy::explicit_iter_loop,
+    clippy::match_same_arms,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::stable_sort_primitive,
+    clippy::too_many_lines,
+    clippy::unnecessary_semicolon,
+    clippy::unnecessary_wraps,
+    clippy::wildcard_imports,
+    reason = "engine-internal relational algebra — match arms kept explicit, result size structural"
+)]
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Formatter};
 

--- a/crates/krites/src/query/ra/project.rs
+++ b/crates/krites/src/query/ra/project.rs
@@ -1,3 +1,10 @@
+#![expect(
+    clippy::iter_not_returning_iterator,
+    clippy::result_large_err,
+    clippy::wildcard_imports,
+    reason = "engine-internal unification RA — iter returns TupleIter (boxed trait)"
+)]
+
 use std::collections::{BTreeMap, BTreeSet};
 
 use itertools::Itertools;

--- a/crates/krites/src/query/ra/search.rs
+++ b/crates/krites/src/query/ra/search.rs
@@ -1,3 +1,12 @@
+#![expect(
+    clippy::default_trait_access,
+    clippy::indexing_slicing,
+    clippy::iter_not_returning_iterator,
+    clippy::result_large_err,
+    clippy::wildcard_imports,
+    reason = "engine-internal search RA — indexing on bind_idx validated during compilation"
+)]
+
 use std::collections::BTreeMap;
 use std::fmt::Write;
 

--- a/crates/krites/src/query/ra/sort.rs
+++ b/crates/krites/src/query/ra/sort.rs
@@ -1,3 +1,10 @@
+#![expect(
+    clippy::indexing_slicing,
+    clippy::iter_not_returning_iterator,
+    clippy::result_large_err,
+    reason = "engine-internal reorder RA — indexing validated by old_order_indices lookup"
+)]
+
 use std::collections::BTreeMap;
 
 use itertools::Itertools;

--- a/crates/krites/src/query/ra/sources.rs
+++ b/crates/krites/src/query/ra/sources.rs
@@ -1,3 +1,17 @@
+#![expect(
+    clippy::default_trait_access,
+    clippy::explicit_iter_loop,
+    clippy::if_not_else,
+    clippy::indexing_slicing,
+    clippy::iter_not_returning_iterator,
+    clippy::mutable_key_type,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_arguments,
+    clippy::unnecessary_wraps,
+    reason = "engine-internal source RAs — indexing validated by join construction, mutable keys are Symbol"
+)]
+
 use std::collections::{BTreeMap, BTreeSet};
 
 use either::{Left, Right};

--- a/crates/krites/src/query/reorder.rs
+++ b/crates/krites/src/query/reorder.rs
@@ -1,4 +1,13 @@
 //! Join reordering heuristics.
+#![expect(
+    clippy::explicit_iter_loop,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_lines,
+    clippy::wildcard_imports,
+    reason = "engine-internal join reordering — complex pattern matching over atom types"
+)]
+
 use std::collections::BTreeSet;
 use std::mem;
 

--- a/crates/krites/src/query/sort.rs
+++ b/crates/krites/src/query/sort.rs
@@ -1,4 +1,15 @@
 //! Sort operators for query output.
+#![expect(
+    clippy::elidable_lifetime_names,
+    clippy::indexing_slicing,
+    clippy::needless_pass_by_value,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::unnecessary_wraps,
+    clippy::unused_self,
+    reason = "engine-internal sort — indexing validated by head_indices lookup"
+)]
+
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 

--- a/crates/krites/src/query/stored/extractors.rs
+++ b/crates/krites/src/query/stored/extractors.rs
@@ -1,4 +1,13 @@
 //! Data extraction helpers for stored relation operations.
+#![expect(
+    clippy::default_trait_access,
+    clippy::explicit_iter_loop,
+    clippy::indexing_slicing,
+    clippy::result_large_err,
+    clippy::wildcard_imports,
+    reason = "engine-internal data extractors — indexing validated by make_extractor callers"
+)]
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 

--- a/crates/krites/src/query/stored/mutation.rs
+++ b/crates/krites/src/query/stored/mutation.rs
@@ -1,6 +1,23 @@
 //! Stored relation mutation: put, delete, and index maintenance.
 //! SessionTx methods for stored relation mutation and FTS/HNSW/LSH index maintenance.
 //! Stored relation access operators.
+#![expect(
+    clippy::default_trait_access,
+    clippy::doc_markdown,
+    clippy::elidable_lifetime_names,
+    clippy::explicit_iter_loop,
+    clippy::indexing_slicing,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::type_complexity,
+    clippy::unnecessary_semicolon,
+    clippy::unused_self,
+    clippy::wildcard_imports,
+    reason = "engine-internal mutation — many arguments required for trigger/callback propagation"
+)]
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;

--- a/crates/krites/src/query/stored/validation.rs
+++ b/crates/krites/src/query/stored/validation.rs
@@ -1,6 +1,22 @@
 //! Stored relation validation: ensure constraints and removal operations.
 //! SessionTx methods for stored relation mutation and FTS/HNSW/LSH index maintenance.
 //! Stored relation access operators.
+#![expect(
+    clippy::as_conversions,
+    clippy::default_trait_access,
+    clippy::doc_markdown,
+    clippy::elidable_lifetime_names,
+    clippy::implicit_clone,
+    clippy::indexing_slicing,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::similar_names,
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::wildcard_imports,
+    reason = "engine-internal validation — many arguments for trigger/callback propagation"
+)]
 
 use std::collections::BTreeSet;
 

--- a/crates/krites/src/query/stratify.rs
+++ b/crates/krites/src/query/stratify.rs
@@ -1,4 +1,14 @@
 //! Datalog program stratification.
+#![expect(
+    clippy::cloned_instead_of_copied,
+    clippy::default_trait_access,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::too_many_lines,
+    clippy::wildcard_imports,
+    reason = "engine-internal stratification — complex graph analysis with BTreeMap defaults"
+)]
+
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 


### PR DESCRIPTION
## Summary
- Remove blanket `#[expect]` block covering the entire `query` module from `lib.rs`
- Add per-file `#![expect]` inner attributes to each of the 18 query source files, scoped to only the lints each file actually triggers
- Every suppression carries a reason string explaining the justification

## Gate
- `cargo clippy -p krites`: zero warnings from query module (0 query warnings, pre-existing fixed_rule unfulfilled expectations unchanged)
- `cargo test -p krites --lib`: 309 passed, 0 failed

## Test plan
- [x] `cargo clippy -p krites` — zero new warnings
- [x] `cargo test -p krites --lib` — all 309 tests pass
- [x] No query files appear in clippy output

🤖 Generated with [Claude Code](https://claude.com/claude-code)