### PR TITLE
refactor(krites): localize lint suppressions in runtime module

### DIFF
--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -61,19 +61,6 @@ pub(crate) mod parse;
     reason = "krites engine internal — query planner casts and indexing are engine-internal invariants"
 )]
 pub(crate) mod query;
-#[expect(
-    dead_code,
-    private_interfaces,
-    clippy::as_conversions,
-    clippy::indexing_slicing,
-    clippy::mutable_key_type,
-    clippy::needless_return,
-    clippy::pedantic,
-    clippy::result_large_err,
-    clippy::too_many_arguments,
-    clippy::type_complexity,
-    reason = "krites engine internal — runtime casts and indexing are engine-internal invariants"
-)]
 pub(crate) mod runtime;
 pub(crate) mod storage;
 #[expect(

--- a/crates/krites/src/runtime/hnsw/adaptive.rs
+++ b/crates/krites/src/runtime/hnsw/adaptive.rs
@@ -50,6 +50,7 @@ impl AdaptiveSearchConfig {
     }
 
     /// Whether to use exact search for the given dataset size.
+    #[expect(clippy::trivially_copy_pass_by_ref, reason = "&self is idiomatic")]
     pub(crate) fn should_use_exact(&self, dataset_size: usize) -> bool {
         dataset_size <= self.exact_threshold
     }
@@ -64,7 +65,7 @@ pub(crate) enum SearchStrategy {
     Approximate,
 }
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     /// Perform exact (brute-force) kNN search by scanning all vectors.
     ///
     /// Iterates over every canary entry in the index, computes the distance to

--- a/crates/krites/src/runtime/hnsw/put.rs
+++ b/crates/krites/src/runtime/hnsw/put.rs
@@ -19,7 +19,7 @@ use crate::runtime::error::InvalidOperationSnafu;
 use crate::runtime::relation::RelationHandle;
 use crate::runtime::transact::SessionTx;
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     /// Insert a single vector into the HNSW index.
     ///
     /// # Complexity
@@ -612,6 +612,7 @@ impl<'a> SessionTx<'a> {
                 let tuple = res.ok()?;
 
                 #[expect(clippy::cast_sign_loss, reason = "HNSW indices are non-negative")]
+                #[expect(clippy::cast_possible_truncation, reason = "HNSW index fits in usize on all platforms")]
                 // INVARIANT: HNSW index tuples store int values at these positions
                 let key_idx = tuple[2 * key_len + 3]
                     .get_int()
@@ -782,6 +783,7 @@ impl<'a> SessionTx<'a> {
                     if let DataValue::Vec(v) = v {
                         #[expect(
                             clippy::cast_possible_truncation,
+                            clippy::cast_possible_wrap,
                             reason = "HNSW layer indices bounded by m_max (< i32::MAX)"
                         )]
                         let sidx_i32 = sidx as i32;

--- a/crates/krites/src/runtime/hnsw/remove.rs
+++ b/crates/krites/src/runtime/hnsw/remove.rs
@@ -11,7 +11,7 @@ use crate::runtime::error::InvalidOperationSnafu;
 use crate::runtime::relation::RelationHandle;
 use crate::runtime::transact::SessionTx;
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     /// Remove all vectors associated with a tuple from the HNSW index.
     ///
     /// # Complexity
@@ -31,6 +31,7 @@ impl<'a> SessionTx<'a> {
             .filter_map(|t| match t {
                 Ok(t) => {
                     #[expect(clippy::cast_sign_loss, reason = "HNSW indices are non-negative")]
+                    #[expect(clippy::cast_possible_truncation, reason = "HNSW index fits in usize on all platforms")]
                     // INVARIANT: HNSW index tuples store int values at index positions
                     let idx = t[orig_table.metadata.keys.len() + 1]
                         .get_int()

--- a/crates/krites/src/runtime/hnsw/search.rs
+++ b/crates/krites/src/runtime/hnsw/search.rs
@@ -17,7 +17,7 @@ use crate::runtime::error::InvalidOperationSnafu;
 use crate::runtime::transact::SessionTx;
 use crate::{DataValue, SourceSpan};
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     /// Perform k-nearest neighbors search on an HNSW index.
     ///
     /// # Complexity

--- a/crates/krites/src/runtime/hnsw/types.rs
+++ b/crates/krites/src/runtime/hnsw/types.rs
@@ -93,6 +93,7 @@ impl VectorCache {
                     }))
                 }
                 _ => {
+                    #[expect(clippy::needless_return, reason = "explicit return for early exit in match arm")]
                     return Err(InvalidOperationSnafu {
                         op: "hnsw_l2",
                         reason: format!("Cannot compute L2 distance between {:?} and {:?}", v1, v2),
@@ -119,6 +120,7 @@ impl VectorCache {
                     Ok(1.0 - dot / (a_norm * b_norm).sqrt())
                 }
                 _ => {
+                    #[expect(clippy::needless_return, reason = "explicit return for early exit in match arm")]
                     return Err(InvalidOperationSnafu {
                         op: "hnsw_cosine",
                         reason: format!(
@@ -140,6 +142,7 @@ impl VectorCache {
                     Ok(1. - dot)
                 }
                 _ => {
+                    #[expect(clippy::needless_return, reason = "explicit return for early exit in match arm")]
                     return Err(InvalidOperationSnafu {
                         op: "hnsw_ip",
                         reason: format!(

--- a/crates/krites/src/runtime/minhash_lsh.rs
+++ b/crates/krites/src/runtime/minhash_lsh.rs
@@ -19,7 +19,7 @@ use crate::runtime::relation::RelationHandle;
 use crate::runtime::transact::SessionTx;
 use crate::{DataValue, Expr, SourceSpan, Symbol};
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     pub(crate) fn del_lsh_index_item(
         &mut self,
         tuple: &[DataValue],

--- a/crates/krites/src/runtime/mod.rs
+++ b/crates/krites/src/runtime/mod.rs
@@ -1,14 +1,155 @@
 //! Runtime execution layer for the Datalog engine.
+#[expect(
+    clippy::redundant_closure_for_method_calls,
+    clippy::semicolon_if_nothing_returned,
+    reason = "engine callback wiring — pedantic style lints"
+)]
 pub(crate) mod callback;
+#[expect(
+    dead_code,
+    private_interfaces,
+    clippy::default_trait_access,
+    clippy::inline_always,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::struct_field_names,
+    clippy::type_complexity,
+    clippy::unnecessary_wraps,
+    clippy::unused_self,
+    reason = "engine database core — internal API surface, dead code for optional features"
+)]
 pub(crate) mod db;
 pub(crate) mod error;
+#[expect(
+    dead_code,
+    clippy::default_trait_access,
+    clippy::doc_markdown,
+    clippy::explicit_iter_loop,
+    clippy::if_not_else,
+    clippy::indexing_slicing,
+    clippy::items_after_statements,
+    clippy::needless_pass_by_value,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_lines,
+    clippy::type_complexity,
+    clippy::unnecessary_semicolon,
+    clippy::unnecessary_wraps,
+    clippy::unused_self,
+    reason = "engine query executor — complex control flow with bounds-checked indexing"
+)]
 pub(crate) mod exec;
+#[expect(
+    clippy::as_conversions,
+    clippy::default_trait_access,
+    clippy::doc_markdown,
+    clippy::indexing_slicing,
+    clippy::manual_let_else,
+    clippy::match_same_arms,
+    clippy::mutable_key_type,
+    clippy::range_plus_one,
+    clippy::redundant_closure_for_method_calls,
+    clippy::ref_option,
+    clippy::result_large_err,
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_wraps,
+    reason = "HNSW vector index — unsafe geometry, bounds-checked indexing, numeric casts for index math"
+)]
 pub(crate) mod hnsw;
+#[expect(
+    clippy::default_trait_access,
+    clippy::explicit_iter_loop,
+    clippy::needless_continue,
+    clippy::redundant_closure_for_method_calls,
+    clippy::redundant_else,
+    clippy::ref_option,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_arguments,
+    reason = "imperative execution — complex control flow with early returns"
+)]
 pub(crate) mod imperative;
+#[expect(
+    clippy::as_conversions,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::default_trait_access,
+    clippy::doc_markdown,
+    clippy::explicit_iter_loop,
+    clippy::indexing_slicing,
+    clippy::many_single_char_names,
+    clippy::mutable_key_type,
+    clippy::range_plus_one,
+    clippy::redundant_closure_for_method_calls,
+    clippy::ref_option,
+    clippy::result_large_err,
+    clippy::too_many_arguments,
+    clippy::uninlined_format_args,
+    reason = "MinHash LSH — numeric casts and indexing for hash computation"
+)]
 pub(crate) mod minhash_lsh;
+#[expect(
+    clippy::as_conversions,
+    clippy::assigning_clones,
+    clippy::default_trait_access,
+    clippy::doc_markdown,
+    clippy::explicit_iter_loop,
+    clippy::if_not_else,
+    clippy::indexing_slicing,
+    clippy::needless_pass_by_value,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_lines,
+    clippy::trivially_copy_pass_by_ref,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_semicolon,
+    reason = "relation system — storage key encoding, bounds-checked tuple indexing"
+)]
 pub(crate) mod relation;
+#[expect(
+    clippy::as_conversions,
+    clippy::needless_pass_by_value,
+    clippy::redundant_closure_for_method_calls,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_lines,
+    clippy::unnecessary_wraps,
+    clippy::unused_self,
+    reason = "system relation handlers — internal dispatch, numeric casts for metadata"
+)]
 pub(crate) mod sys;
+#[expect(
+    clippy::as_conversions,
+    clippy::default_trait_access,
+    clippy::explicit_iter_loop,
+    clippy::implicit_clone,
+    clippy::indexing_slicing,
+    clippy::needless_pass_by_value,
+    clippy::result_large_err,
+    clippy::single_match_else,
+    reason = "temp store — bounds-checked indexing for intermediate tuple storage"
+)]
 pub(crate) mod temp_store;
 #[cfg(test)]
 mod tests;
+#[expect(
+    clippy::as_conversions,
+    clippy::default_trait_access,
+    clippy::doc_markdown,
+    clippy::ignored_unit_patterns,
+    clippy::indexing_slicing,
+    clippy::needless_pass_by_value,
+    clippy::redundant_closure_for_method_calls,
+    clippy::redundant_else,
+    clippy::result_large_err,
+    clippy::semicolon_if_nothing_returned,
+    clippy::too_many_lines,
+    clippy::trivially_copy_pass_by_ref,
+    clippy::uninlined_format_args,
+    reason = "transaction layer — storage key encoding, bounds-checked indexing"
+)]
 pub(crate) mod transact;

--- a/crates/krites/src/runtime/relation/index_create.rs
+++ b/crates/krites/src/runtime/relation/index_create.rs
@@ -21,7 +21,7 @@ use crate::utils::TempCollector;
 
 use super::handles::{InputRelationHandle, RelationHandle, RelationId};
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     pub(crate) fn create_minhash_lsh_index(&mut self, config: &MinHashLshConfig) -> Result<()> {
         let mut rel_handle = self.get_relation(&config.base_relation, true)?;
 

--- a/crates/krites/src/runtime/relation/index_management.rs
+++ b/crates/krites/src/runtime/relation/index_management.rs
@@ -19,7 +19,7 @@ use crate::utils::TempCollector;
 
 use super::handles::{AccessLevel, InputRelationHandle, RelationId};
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     pub(crate) fn create_index(
         &mut self,
         rel_name: &Symbol,

--- a/crates/krites/src/runtime/relation/relation_crud.rs
+++ b/crates/krites/src/runtime/relation/relation_crud.rs
@@ -17,7 +17,7 @@ use crate::runtime::transact::SessionTx;
 
 use super::handles::{AccessLevel, InputRelationHandle, RelationHandle, RelationId};
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     pub(crate) fn relation_exists(&self, name: &str) -> Result<bool> {
         let key = DataValue::from(name);
         let encoded = vec![key].encode_as_key(RelationId::SYSTEM);

--- a/crates/krites/src/runtime/transact.rs
+++ b/crates/krites/src/runtime/transact.rs
@@ -35,7 +35,7 @@ fn storage_version_key() -> Vec<u8> {
 const STATUS_STR: &str = "status";
 const OK_STR: &str = "OK";
 
-impl<'a> SessionTx<'a> {
+impl SessionTx<'_> {
     pub(crate) fn get_returning_rows(
         &self,
         callback_collector: &CallbackCollector,


### PR DESCRIPTION
## Summary
- Remove blanket `#[expect]` block from `lib.rs` for the `runtime` module (10 lints covering `dead_code`, `private_interfaces`, `clippy::pedantic`, `clippy::result_large_err`, etc.)
- Push suppressions to per-submodule `#[expect]` blocks in `runtime/mod.rs` — each of the 11 submodules (callback, db, exec, hnsw, imperative, minhash_lsh, relation, sys, temp_store, transact) gets only the specific lints it triggers
- Fix `impl<'a> SessionTx<'a>` -> `impl SessionTx<'_>` across 9 files (needless_lifetimes is a late-pass lint that cannot be suppressed at module level)
- Add per-site `#[expect]` for `cast_possible_truncation`, `cast_possible_wrap`, `needless_return`, and `trivially_copy_pass_by_ref` in HNSW code

## Test plan
- [x] `cargo clippy -p krites` — zero new warnings (21 pre-existing in `fixed_rule/` unchanged)
- [x] `cargo test -p krites` — 19 default tests pass
- [x] `cargo test -p krites --features test-core` — 317 tests pass
- [x] `cargo check -p krites` — clean compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)