### PR TITLE
refactor(krites/data): full structural overhaul — snafu errors, quality (#3214)

### DIFF
--- a/crates/krites/src/data/aggr/mod.rs
+++ b/crates/krites/src/data/aggr/mod.rs
@@ -35,6 +35,15 @@ pub(crate) use numeric::{
     AggrStdDev, AggrSum, AggrVariance, MeetAggrMax, MeetAggrMin, MeetAggrMinCost,
 };
 
+/// A named aggregation operator that can run in either "normal" (accumulating)
+/// or "meet" (lattice-monotone) mode.
+///
+/// Normal aggregations accumulate values one at a time via [`NormalAggrObj::set`],
+/// then produce a final result via [`NormalAggrObj::get`].
+///
+/// Meet aggregations maintain a running lattice value that converges in
+/// fixed-point iteration: [`MeetAggrObj::update`] returns whether the value
+/// changed, allowing the engine to detect convergence.
 pub(crate) struct Aggregation {
     pub(crate) name: &'static str,
     pub(crate) is_meet: bool,
@@ -53,13 +62,29 @@ impl Clone for Aggregation {
     }
 }
 
+/// Accumulating aggregation: values are fed one at a time, final result read at end.
+///
+/// # Contract
+/// - `set` is called zero or more times with individual values.
+/// - `get` is called once after all values have been set; it must not panic.
+/// - Type mismatches in `set` return `DataError::TypeMismatch`.
 pub(crate) trait NormalAggrObj: Send + Sync {
+    /// Feed a single value into the accumulator.
     fn set(&mut self, value: &DataValue) -> Result<()>;
+    /// Produce the aggregated result.
     fn get(&self) -> Result<DataValue>;
 }
 
+/// Lattice-monotone (meet) aggregation for fixed-point convergence.
+///
+/// # Contract
+/// - `init_val` returns the identity element for the lattice.
+/// - `update` merges `right` into `left`, returning `true` if `left` changed.
+/// - The engine calls `update` repeatedly until it returns `false` for all rows.
 pub(crate) trait MeetAggrObj: Send + Sync {
+    /// The lattice identity value (e.g., `true` for AND, `Null` for MIN).
     fn init_val(&self) -> DataValue;
+    /// Merge `right` into `left`. Returns `true` if `left` was modified.
     fn update(&self, left: &mut DataValue, right: &DataValue) -> Result<bool>;
 }
 

--- a/crates/krites/src/data/error.rs
+++ b/crates/krites/src/data/error.rs
@@ -179,4 +179,5 @@ pub(crate) enum DataError {
     },
 }
 
+/// Convenience alias for results returning [`DataError`].
 pub(crate) type DataResult<T> = std::result::Result<T, DataError>;

--- a/crates/krites/src/data/functions/aggregate.rs
+++ b/crates/krites/src/data/functions/aggregate.rs
@@ -1,10 +1,7 @@
-//! List, collection, set operations, and range functions.
+//! List construction, concatenation, get/set, and JSON merge functions.
 #![expect(clippy::as_conversions, reason = "numeric aggregation requires i64/usize/f64 casts — values are engine-internal")]
-#![expect(clippy::mutable_key_type, reason = "DataValue contains interior-mutable Regex; BTreeSet/Map usage is engine-internal")]
 #![expect(clippy::unnecessary_wraps, reason = "op_list and op_maybe_get return Result for API consistency with other builtins")]
 #![expect(clippy::redundant_else, reason = "else after early return keeps the fallback visually grouped")]
-#![expect(clippy::default_trait_access, reason = "BTreeMap::default() replaced by ::new() is more idiomatic")]
-use std::collections::BTreeSet;
 
 use itertools::Itertools;
 use serde_json::{Value, json};
@@ -16,6 +13,8 @@ use crate::data::value::{DataValue, JsonData};
 
 use super::arg;
 
+/// Deep-merge two JSON values: objects merge recursively, arrays concatenate,
+/// otherwise the second value wins.
 pub(crate) fn deep_merge_json(value1: JsonValue, value2: JsonValue) -> JsonValue {
     match (value1, value2) {
         (JsonValue::Object(mut obj1), JsonValue::Object(obj2)) => {
@@ -33,6 +32,10 @@ pub(crate) fn deep_merge_json(value1: JsonValue, value2: JsonValue) -> JsonValue
     }
 }
 
+/// Resolve a possibly-negative index against a total length.
+///
+/// Negative indices count from the end. Returns an error if out of bounds.
+/// `is_upper` controls whether `index == total` is valid (for exclusive upper bounds).
 pub(crate) fn get_index(mut i: i64, total: usize, is_upper: bool) -> Result<usize> {
     if i < 0 {
         #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
@@ -54,6 +57,7 @@ pub(crate) fn get_index(mut i: i64, total: usize, is_upper: bool) -> Result<usiz
     })
 }
 
+/// Convert a `serde_json` [`Value`] to a [`DataValue`], wrapping arrays and objects as JSON.
 pub(crate) fn json2val(res: Value) -> DataValue {
     use compact_str::CompactString;
     match res {
@@ -124,6 +128,7 @@ fn get_json_path_immutable_local<'a>(
     Ok(pointer)
 }
 
+/// Get element by index (list) or key/path (JSON). Used by `op_get` and `op_maybe_get`.
 pub(crate) fn get_impl(args: &[DataValue]) -> Result<DataValue> {
     match arg(args, 0)? {
         DataValue::List(l) => {
@@ -197,14 +202,16 @@ pub(crate) fn get_impl(args: &[DataValue]) -> Result<DataValue> {
     }
 }
 
+/// Construct a list from all arguments.
 pub(crate) fn op_list(args: &[DataValue]) -> Result<DataValue> {
     Ok(DataValue::List(args.to_vec()))
 }
 
+/// Concatenate strings, lists, or JSON objects.
 pub(crate) fn op_concat(args: &[DataValue]) -> Result<DataValue> {
     match arg(args, 0)? {
         DataValue::Str(_) => {
-            let mut ret: String = Default::default();
+            let mut ret = String::new();
             for arg in args {
                 if let DataValue::Str(s) = arg {
                     ret += s;
@@ -258,6 +265,7 @@ pub(crate) fn op_concat(args: &[DataValue]) -> Result<DataValue> {
     }
 }
 
+/// Append an element to the end of a list.
 pub(crate) fn op_append(args: &[DataValue]) -> Result<DataValue> {
     match arg(args, 0)? {
         DataValue::List(l) => {
@@ -278,6 +286,7 @@ pub(crate) fn op_append(args: &[DataValue]) -> Result<DataValue> {
     }
 }
 
+/// Prepend an element to the beginning of a list.
 pub(crate) fn op_prepend(args: &[DataValue]) -> Result<DataValue> {
     match arg(args, 0)? {
         DataValue::List(pl) => {
@@ -298,294 +307,7 @@ pub(crate) fn op_prepend(args: &[DataValue]) -> Result<DataValue> {
     }
 }
 
-pub(crate) fn op_union(args: &[DataValue]) -> Result<DataValue> {
-    let mut ret = BTreeSet::new();
-    for arg in args {
-        match arg {
-            DataValue::List(l) => {
-                ret.extend(l.iter().cloned());
-            }
-            DataValue::Set(s) => {
-                ret.extend(s.iter().cloned());
-            }
-            _ => {
-                return TypeMismatchSnafu {
-                    op: "union",
-                    expected: "lists",
-                }
-                .fail();
-            }
-        }
-    }
-    Ok(DataValue::List(ret.into_iter().collect()))
-}
-
-pub(crate) fn op_difference(args: &[DataValue]) -> Result<DataValue> {
-    let mut start: BTreeSet<_> = match arg(args, 0)? {
-        DataValue::List(l) => l.iter().cloned().collect(),
-        DataValue::Set(s) => s.iter().cloned().collect(),
-        _ => {
-            return TypeMismatchSnafu {
-                op: "difference",
-                expected: "lists",
-            }
-            .fail();
-        }
-    };
-    for arg in args.get(1..).unwrap_or_default() {
-        match arg {
-            DataValue::List(l) => {
-                for el in l {
-                    start.remove(el);
-                }
-            }
-            DataValue::Set(s) => {
-                for el in s {
-                    start.remove(el);
-                }
-            }
-            _ => {
-                return TypeMismatchSnafu {
-                    op: "difference",
-                    expected: "lists",
-                }
-                .fail();
-            }
-        }
-    }
-    Ok(DataValue::List(start.into_iter().collect()))
-}
-
-pub(crate) fn op_intersection(args: &[DataValue]) -> Result<DataValue> {
-    let mut start: BTreeSet<_> = match arg(args, 0)? {
-        DataValue::List(l) => l.iter().cloned().collect(),
-        DataValue::Set(s) => s.iter().cloned().collect(),
-        _ => {
-            return TypeMismatchSnafu {
-                op: "intersection",
-                expected: "lists",
-            }
-            .fail();
-        }
-    };
-    for arg in args.get(1..).unwrap_or_default() {
-        match arg {
-            DataValue::List(l) => {
-                let other: BTreeSet<_> = l.iter().cloned().collect();
-                start = start.intersection(&other).cloned().collect();
-            }
-            DataValue::Set(s) => start = start.intersection(s).cloned().collect(),
-            _ => {
-                return TypeMismatchSnafu {
-                    op: "intersection",
-                    expected: "lists",
-                }
-                .fail();
-            }
-        }
-    }
-    Ok(DataValue::List(start.into_iter().collect()))
-}
-
-pub(crate) fn op_length(args: &[DataValue]) -> Result<DataValue> {
-    Ok(DataValue::from(match arg(args, 0)? {
-        DataValue::Set(s) => {
-            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
-            let len = s.len() as i64;
-            len
-        }
-        DataValue::List(l) => {
-            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
-            let len = l.len() as i64;
-            len
-        }
-        DataValue::Str(s) => {
-            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
-            let len = s.chars().count() as i64;
-            len
-        }
-        DataValue::Bytes(b) => {
-            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
-            let len = b.len() as i64;
-            len
-        }
-        DataValue::Vec(v) => {
-            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
-            let len = v.len() as i64;
-            len
-        }
-        _ => {
-            return TypeMismatchSnafu {
-                op: "length",
-                expected: "lists",
-            }
-            .fail();
-        }
-    }))
-}
-
-pub(crate) fn op_first(args: &[DataValue]) -> Result<DataValue> {
-    Ok(arg(args, 0)?
-        .get_slice()
-        .ok_or_else(|| {
-            TypeMismatchSnafu {
-                op: "first",
-                expected: "lists",
-            }
-            .build()
-        })?
-        .first()
-        .cloned()
-        .unwrap_or(DataValue::Null))
-}
-
-pub(crate) fn op_last(args: &[DataValue]) -> Result<DataValue> {
-    Ok(arg(args, 0)?
-        .get_slice()
-        .ok_or_else(|| {
-            TypeMismatchSnafu {
-                op: "last",
-                expected: "lists",
-            }
-            .build()
-        })?
-        .last()
-        .cloned()
-        .unwrap_or(DataValue::Null))
-}
-
-pub(crate) fn op_sorted(args: &[DataValue]) -> Result<DataValue> {
-    let mut a = arg(args, 0)?
-        .get_slice()
-        .ok_or_else(|| {
-            TypeMismatchSnafu {
-                op: "sort",
-                expected: "lists",
-            }
-            .build()
-        })?
-        .to_vec();
-    a.sort();
-    Ok(DataValue::List(a))
-}
-
-pub(crate) fn op_reverse(args: &[DataValue]) -> Result<DataValue> {
-    let mut a = arg(args, 0)?
-        .get_slice()
-        .ok_or_else(|| {
-            TypeMismatchSnafu {
-                op: "reverse",
-                expected: "lists",
-            }
-            .build()
-        })?
-        .to_vec();
-    a.reverse();
-    Ok(DataValue::List(a))
-}
-
-pub(crate) fn op_chunks(args: &[DataValue]) -> Result<DataValue> {
-    let a = arg(args, 0)?.get_slice().ok_or_else(|| {
-        TypeMismatchSnafu {
-            op: "chunks",
-            expected: "a list as first argument",
-        }
-        .build()
-    })?;
-    let n = arg(args, 1)?.get_int().ok_or_else(|| {
-        TypeMismatchSnafu {
-            op: "chunks",
-            expected: "an integer as second argument",
-        }
-        .build()
-    })?;
-    snafu::ensure!(
-        n > 0,
-        InvalidValueSnafu {
-            message: "second argument to 'chunks' must be positive"
-        }
-    );
-    let n = usize::try_from(n).map_err(|_e| {
-        InvalidValueSnafu {
-            message: "second argument to 'chunks' out of range",
-        }
-        .build()
-    })?;
-    let res = a
-        .chunks(n)
-        .map(|el| DataValue::List(el.to_vec()))
-        .collect_vec();
-    Ok(DataValue::List(res))
-}
-
-pub(crate) fn op_chunks_exact(args: &[DataValue]) -> Result<DataValue> {
-    let a = arg(args, 0)?.get_slice().ok_or_else(|| {
-        TypeMismatchSnafu {
-            op: "chunks_exact",
-            expected: "a list as first argument",
-        }
-        .build()
-    })?;
-    let n = arg(args, 1)?.get_int().ok_or_else(|| {
-        TypeMismatchSnafu {
-            op: "chunks_exact",
-            expected: "an integer as second argument",
-        }
-        .build()
-    })?;
-    snafu::ensure!(
-        n > 0,
-        InvalidValueSnafu {
-            message: "second argument to 'chunks_exact' must be positive"
-        }
-    );
-    let n = usize::try_from(n).map_err(|_e| {
-        InvalidValueSnafu {
-            message: "second argument to 'chunks_exact' out of range",
-        }
-        .build()
-    })?;
-    let res = a
-        .chunks_exact(n)
-        .map(|el| DataValue::List(el.to_vec()))
-        .collect_vec();
-    Ok(DataValue::List(res))
-}
-
-pub(crate) fn op_windows(args: &[DataValue]) -> Result<DataValue> {
-    let a = arg(args, 0)?.get_slice().ok_or_else(|| {
-        TypeMismatchSnafu {
-            op: "windows",
-            expected: "a list as first argument",
-        }
-        .build()
-    })?;
-    let n = arg(args, 1)?.get_int().ok_or_else(|| {
-        TypeMismatchSnafu {
-            op: "windows",
-            expected: "an integer as second argument",
-        }
-        .build()
-    })?;
-    snafu::ensure!(
-        n > 0,
-        InvalidValueSnafu {
-            message: "second argument to 'windows' must be positive"
-        }
-    );
-    let n = usize::try_from(n).map_err(|_e| {
-        InvalidValueSnafu {
-            message: "second argument to 'windows' out of range",
-        }
-        .build()
-    })?;
-    let res = a
-        .windows(n)
-        .map(|el| DataValue::List(el.to_vec()))
-        .collect_vec();
-    Ok(DataValue::List(res))
-}
-
+/// Get element with fallback default on error.
 pub(crate) fn op_get(args: &[DataValue]) -> Result<DataValue> {
     match get_impl(args) {
         Ok(res) => Ok(res),
@@ -599,132 +321,10 @@ pub(crate) fn op_get(args: &[DataValue]) -> Result<DataValue> {
     }
 }
 
+/// Get element, returning `Null` on any error (missing key, out of bounds, etc.).
 pub(crate) fn op_maybe_get(args: &[DataValue]) -> Result<DataValue> {
     match get_impl(args) {
         Ok(res) => Ok(res),
         Err(_) => Ok(DataValue::Null),
-    }
-}
-
-pub(crate) fn op_slice(args: &[DataValue]) -> Result<DataValue> {
-    let l = arg(args, 0)?.get_slice().ok_or_else(|| {
-        TypeMismatchSnafu {
-            op: "slice",
-            expected: "a list as first argument",
-        }
-        .build()
-    })?;
-    let m = arg(args, 1)?.get_int().ok_or_else(|| {
-        TypeMismatchSnafu {
-            op: "slice",
-            expected: "an integer as second argument",
-        }
-        .build()
-    })?;
-    let n = arg(args, 2)?.get_int().ok_or_else(|| {
-        TypeMismatchSnafu {
-            op: "slice",
-            expected: "an integer as third argument",
-        }
-        .build()
-    })?;
-    let m = get_index(m, l.len(), false)?;
-    let n = get_index(n, l.len(), true)?;
-    Ok(DataValue::List(
-        l.get(m..n)
-            .ok_or_else(|| {
-                IndexOutOfBoundsSnafu {
-                    index: i64::try_from(n).unwrap_or(i64::MAX),
-                }
-                .build()
-            })?
-            .to_vec(),
-    ))
-}
-
-pub(crate) fn op_int_range(args: &[DataValue]) -> Result<DataValue> {
-    let [start, end] = match args.len() {
-        1 => {
-            let end = arg(args, 0)?.get_int().ok_or_else(|| {
-                TypeMismatchSnafu {
-                    op: "int_range",
-                    expected: "an integer for end",
-                }
-                .build()
-            })?;
-            [0, end]
-        }
-        2 => {
-            let start = arg(args, 0)?.get_int().ok_or_else(|| {
-                TypeMismatchSnafu {
-                    op: "int_range",
-                    expected: "an integer for start",
-                }
-                .build()
-            })?;
-            let end = arg(args, 1)?.get_int().ok_or_else(|| {
-                TypeMismatchSnafu {
-                    op: "int_range",
-                    expected: "an integer for end",
-                }
-                .build()
-            })?;
-            [start, end]
-        }
-        3 => {
-            let start = arg(args, 0)?.get_int().ok_or_else(|| {
-                TypeMismatchSnafu {
-                    op: "int_range",
-                    expected: "an integer for start",
-                }
-                .build()
-            })?;
-            let end = arg(args, 1)?.get_int().ok_or_else(|| {
-                TypeMismatchSnafu {
-                    op: "int_range",
-                    expected: "an integer for end",
-                }
-                .build()
-            })?;
-            let step = arg(args, 2)?.get_int().ok_or_else(|| {
-                TypeMismatchSnafu {
-                    op: "int_range",
-                    expected: "an integer for step",
-                }
-                .build()
-            })?;
-            let mut current = start;
-            let mut result = vec![];
-            if step > 0 {
-                while current < end {
-                    result.push(DataValue::from(current));
-                    current += step;
-                }
-            } else {
-                while current > end {
-                    result.push(DataValue::from(current));
-                    current += step;
-                }
-            }
-            return Ok(DataValue::List(result));
-        }
-        _ => {
-            return TypeMismatchSnafu {
-                op: "int_range",
-                expected: "1 to 3 argument",
-            }
-            .fail();
-        }
-    };
-    Ok(DataValue::List((start..end).map(DataValue::from).collect()))
-}
-
-pub(crate) fn op_assert(args: &[DataValue]) -> Result<DataValue> {
-    match arg(args, 0)? {
-        DataValue::Bool(true) => Ok(DataValue::from(true)),
-        _ => AssertionFailedSnafu {
-            message: format!("{args:?}"),
-        }
-        .fail(),
     }
 }

--- a/crates/krites/src/data/functions/collections.rs
+++ b/crates/krites/src/data/functions/collections.rs
@@ -1,0 +1,442 @@
+//! Collection, set, range, and assertion functions.
+#![expect(clippy::as_conversions, reason = "collection functions require i64/usize casts — engine-internal")]
+#![expect(clippy::mutable_key_type, reason = "DataValue contains interior-mutable Regex; BTreeSet usage is engine-internal")]
+use std::collections::BTreeSet;
+
+use itertools::Itertools;
+
+use super::arg;
+use crate::data::error::*;
+type Result<T> = DataResult<T>;
+use crate::data::value::DataValue;
+
+use super::aggregate::get_index;
+
+/// Set union of one or more lists.
+///
+/// # Contract
+/// All arguments must be lists or sets. Returns a list of unique elements
+/// in sorted order.
+pub(crate) fn op_union(args: &[DataValue]) -> Result<DataValue> {
+    let mut ret = BTreeSet::new();
+    for arg in args {
+        match arg {
+            DataValue::List(l) => {
+                ret.extend(l.iter().cloned());
+            }
+            DataValue::Set(s) => {
+                ret.extend(s.iter().cloned());
+            }
+            _ => {
+                return TypeMismatchSnafu {
+                    op: "union",
+                    expected: "lists",
+                }
+                .fail();
+            }
+        }
+    }
+    Ok(DataValue::List(ret.into_iter().collect()))
+}
+
+/// Set difference: first list minus elements in subsequent lists.
+pub(crate) fn op_difference(args: &[DataValue]) -> Result<DataValue> {
+    let mut start: BTreeSet<_> = match arg(args, 0)? {
+        DataValue::List(l) => l.iter().cloned().collect(),
+        DataValue::Set(s) => s.iter().cloned().collect(),
+        _ => {
+            return TypeMismatchSnafu {
+                op: "difference",
+                expected: "lists",
+            }
+            .fail();
+        }
+    };
+    for arg in args.get(1..).unwrap_or_default() {
+        match arg {
+            DataValue::List(l) => {
+                for el in l {
+                    start.remove(el);
+                }
+            }
+            DataValue::Set(s) => {
+                for el in s {
+                    start.remove(el);
+                }
+            }
+            _ => {
+                return TypeMismatchSnafu {
+                    op: "difference",
+                    expected: "lists",
+                }
+                .fail();
+            }
+        }
+    }
+    Ok(DataValue::List(start.into_iter().collect()))
+}
+
+/// Set intersection of one or more lists.
+pub(crate) fn op_intersection(args: &[DataValue]) -> Result<DataValue> {
+    let mut start: BTreeSet<_> = match arg(args, 0)? {
+        DataValue::List(l) => l.iter().cloned().collect(),
+        DataValue::Set(s) => s.iter().cloned().collect(),
+        _ => {
+            return TypeMismatchSnafu {
+                op: "intersection",
+                expected: "lists",
+            }
+            .fail();
+        }
+    };
+    for arg in args.get(1..).unwrap_or_default() {
+        match arg {
+            DataValue::List(l) => {
+                let other: BTreeSet<_> = l.iter().cloned().collect();
+                start = start.intersection(&other).cloned().collect();
+            }
+            DataValue::Set(s) => start = start.intersection(s).cloned().collect(),
+            _ => {
+                return TypeMismatchSnafu {
+                    op: "intersection",
+                    expected: "lists",
+                }
+                .fail();
+            }
+        }
+    }
+    Ok(DataValue::List(start.into_iter().collect()))
+}
+
+/// Length of a list, set, string, byte sequence, or vector.
+pub(crate) fn op_length(args: &[DataValue]) -> Result<DataValue> {
+    Ok(DataValue::from(match arg(args, 0)? {
+        DataValue::Set(s) => {
+            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
+            let len = s.len() as i64;
+            len
+        }
+        DataValue::List(l) => {
+            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
+            let len = l.len() as i64;
+            len
+        }
+        DataValue::Str(s) => {
+            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
+            let len = s.chars().count() as i64;
+            len
+        }
+        DataValue::Bytes(b) => {
+            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
+            let len = b.len() as i64;
+            len
+        }
+        DataValue::Vec(v) => {
+            #[expect(clippy::cast_possible_wrap, reason = "length fits i64")]
+            let len = v.len() as i64;
+            len
+        }
+        _ => {
+            return TypeMismatchSnafu {
+                op: "length",
+                expected: "lists",
+            }
+            .fail();
+        }
+    }))
+}
+
+/// First element of a list, or `Null` if empty.
+pub(crate) fn op_first(args: &[DataValue]) -> Result<DataValue> {
+    Ok(arg(args, 0)?
+        .get_slice()
+        .ok_or_else(|| {
+            TypeMismatchSnafu {
+                op: "first",
+                expected: "lists",
+            }
+            .build()
+        })?
+        .first()
+        .cloned()
+        .unwrap_or(DataValue::Null))
+}
+
+/// Last element of a list, or `Null` if empty.
+pub(crate) fn op_last(args: &[DataValue]) -> Result<DataValue> {
+    Ok(arg(args, 0)?
+        .get_slice()
+        .ok_or_else(|| {
+            TypeMismatchSnafu {
+                op: "last",
+                expected: "lists",
+            }
+            .build()
+        })?
+        .last()
+        .cloned()
+        .unwrap_or(DataValue::Null))
+}
+
+/// Return a sorted copy of a list.
+pub(crate) fn op_sorted(args: &[DataValue]) -> Result<DataValue> {
+    let mut a = arg(args, 0)?
+        .get_slice()
+        .ok_or_else(|| {
+            TypeMismatchSnafu {
+                op: "sort",
+                expected: "lists",
+            }
+            .build()
+        })?
+        .to_vec();
+    a.sort();
+    Ok(DataValue::List(a))
+}
+
+/// Return a reversed copy of a list.
+pub(crate) fn op_reverse(args: &[DataValue]) -> Result<DataValue> {
+    let mut a = arg(args, 0)?
+        .get_slice()
+        .ok_or_else(|| {
+            TypeMismatchSnafu {
+                op: "reverse",
+                expected: "lists",
+            }
+            .build()
+        })?
+        .to_vec();
+    a.reverse();
+    Ok(DataValue::List(a))
+}
+
+/// Split a list into chunks of size `n` (last chunk may be shorter).
+pub(crate) fn op_chunks(args: &[DataValue]) -> Result<DataValue> {
+    let a = arg(args, 0)?.get_slice().ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "chunks",
+            expected: "a list as first argument",
+        }
+        .build()
+    })?;
+    let n = arg(args, 1)?.get_int().ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "chunks",
+            expected: "an integer as second argument",
+        }
+        .build()
+    })?;
+    snafu::ensure!(
+        n > 0,
+        InvalidValueSnafu {
+            message: "second argument to 'chunks' must be positive"
+        }
+    );
+    let n = usize::try_from(n).map_err(|_e| {
+        InvalidValueSnafu {
+            message: "second argument to 'chunks' out of range",
+        }
+        .build()
+    })?;
+    let res = a
+        .chunks(n)
+        .map(|el| DataValue::List(el.to_vec()))
+        .collect_vec();
+    Ok(DataValue::List(res))
+}
+
+/// Split a list into exact chunks of size `n` (remainder discarded).
+pub(crate) fn op_chunks_exact(args: &[DataValue]) -> Result<DataValue> {
+    let a = arg(args, 0)?.get_slice().ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "chunks_exact",
+            expected: "a list as first argument",
+        }
+        .build()
+    })?;
+    let n = arg(args, 1)?.get_int().ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "chunks_exact",
+            expected: "an integer as second argument",
+        }
+        .build()
+    })?;
+    snafu::ensure!(
+        n > 0,
+        InvalidValueSnafu {
+            message: "second argument to 'chunks_exact' must be positive"
+        }
+    );
+    let n = usize::try_from(n).map_err(|_e| {
+        InvalidValueSnafu {
+            message: "second argument to 'chunks_exact' out of range",
+        }
+        .build()
+    })?;
+    let res = a
+        .chunks_exact(n)
+        .map(|el| DataValue::List(el.to_vec()))
+        .collect_vec();
+    Ok(DataValue::List(res))
+}
+
+/// Sliding windows of size `n` over a list.
+pub(crate) fn op_windows(args: &[DataValue]) -> Result<DataValue> {
+    let a = arg(args, 0)?.get_slice().ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "windows",
+            expected: "a list as first argument",
+        }
+        .build()
+    })?;
+    let n = arg(args, 1)?.get_int().ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "windows",
+            expected: "an integer as second argument",
+        }
+        .build()
+    })?;
+    snafu::ensure!(
+        n > 0,
+        InvalidValueSnafu {
+            message: "second argument to 'windows' must be positive"
+        }
+    );
+    let n = usize::try_from(n).map_err(|_e| {
+        InvalidValueSnafu {
+            message: "second argument to 'windows' out of range",
+        }
+        .build()
+    })?;
+    let res = a
+        .windows(n)
+        .map(|el| DataValue::List(el.to_vec()))
+        .collect_vec();
+    Ok(DataValue::List(res))
+}
+
+/// Extract a sub-list from index `m` (inclusive) to `n` (exclusive).
+pub(crate) fn op_slice(args: &[DataValue]) -> Result<DataValue> {
+    let l = arg(args, 0)?.get_slice().ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "slice",
+            expected: "a list as first argument",
+        }
+        .build()
+    })?;
+    let m = arg(args, 1)?.get_int().ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "slice",
+            expected: "an integer as second argument",
+        }
+        .build()
+    })?;
+    let n = arg(args, 2)?.get_int().ok_or_else(|| {
+        TypeMismatchSnafu {
+            op: "slice",
+            expected: "an integer as third argument",
+        }
+        .build()
+    })?;
+    let m = get_index(m, l.len(), false)?;
+    let n = get_index(n, l.len(), true)?;
+    Ok(DataValue::List(
+        l.get(m..n)
+            .ok_or_else(|| {
+                IndexOutOfBoundsSnafu {
+                    index: i64::try_from(n).unwrap_or(i64::MAX),
+                }
+                .build()
+            })?
+            .to_vec(),
+    ))
+}
+
+/// Generate a list of integers. Supports 1-3 arguments: `(end)`, `(start, end)`, `(start, end, step)`.
+pub(crate) fn op_int_range(args: &[DataValue]) -> Result<DataValue> {
+    let [start, end] = match args.len() {
+        1 => {
+            let end = arg(args, 0)?.get_int().ok_or_else(|| {
+                TypeMismatchSnafu {
+                    op: "int_range",
+                    expected: "an integer for end",
+                }
+                .build()
+            })?;
+            [0, end]
+        }
+        2 => {
+            let start = arg(args, 0)?.get_int().ok_or_else(|| {
+                TypeMismatchSnafu {
+                    op: "int_range",
+                    expected: "an integer for start",
+                }
+                .build()
+            })?;
+            let end = arg(args, 1)?.get_int().ok_or_else(|| {
+                TypeMismatchSnafu {
+                    op: "int_range",
+                    expected: "an integer for end",
+                }
+                .build()
+            })?;
+            [start, end]
+        }
+        3 => {
+            let start = arg(args, 0)?.get_int().ok_or_else(|| {
+                TypeMismatchSnafu {
+                    op: "int_range",
+                    expected: "an integer for start",
+                }
+                .build()
+            })?;
+            let end = arg(args, 1)?.get_int().ok_or_else(|| {
+                TypeMismatchSnafu {
+                    op: "int_range",
+                    expected: "an integer for end",
+                }
+                .build()
+            })?;
+            let step = arg(args, 2)?.get_int().ok_or_else(|| {
+                TypeMismatchSnafu {
+                    op: "int_range",
+                    expected: "an integer for step",
+                }
+                .build()
+            })?;
+            let mut current = start;
+            let mut result = vec![];
+            if step > 0 {
+                while current < end {
+                    result.push(DataValue::from(current));
+                    current += step;
+                }
+            } else {
+                while current > end {
+                    result.push(DataValue::from(current));
+                    current += step;
+                }
+            }
+            return Ok(DataValue::List(result));
+        }
+        _ => {
+            return TypeMismatchSnafu {
+                op: "int_range",
+                expected: "1 to 3 argument",
+            }
+            .fail();
+        }
+    };
+    Ok(DataValue::List((start..end).map(DataValue::from).collect()))
+}
+
+/// Assert that the first argument is `true`. Returns an error otherwise.
+pub(crate) fn op_assert(args: &[DataValue]) -> Result<DataValue> {
+    match arg(args, 0)? {
+        DataValue::Bool(true) => Ok(DataValue::from(true)),
+        _ => AssertionFailedSnafu {
+            message: format!("{args:?}"),
+        }
+        .fail(),
+    }
+}

--- a/crates/krites/src/data/functions/mod.rs
+++ b/crates/krites/src/data/functions/mod.rs
@@ -8,6 +8,7 @@ use crate::data::value::DataValue;
 
 mod aggregate;
 mod bits;
+mod collections;
 mod math;
 mod string;
 mod temporal;
@@ -32,6 +33,7 @@ pub(crate) fn arg(args: &[DataValue], idx: usize) -> Result<&DataValue> {
 
 pub(crate) use aggregate::*;
 pub(crate) use bits::*;
+pub(crate) use collections::*;
 pub(crate) use math::*;
 pub(crate) use string::*;
 pub(crate) use temporal::*;

--- a/crates/krites/src/data/mod.rs
+++ b/crates/krites/src/data/mod.rs
@@ -1,4 +1,9 @@
 //! Core data types for the Datalog engine.
+//!
+//! This module defines the value representation ([`value::DataValue`]),
+//! expression evaluation ([`expr`]), scalar functions ([`functions`]),
+//! aggregation operators ([`aggr`]), relation metadata ([`relation`]),
+//! binary key encoding ([`memcmp`]), and the Datalog program AST ([`program`]).
 #![expect(clippy::wildcard_imports, reason = "error selectors and re-exports used pervasively across data module")]
 pub(crate) mod aggr;
 pub(crate) mod error;

--- a/crates/krites/src/data/relation.rs
+++ b/crates/krites/src/data/relation.rs
@@ -22,6 +22,7 @@ use serde_json::json;
 
 use super::error::*;
 use crate::data::expr::Expr;
+use crate::data::json::JsonValue;
 use crate::data::value::Num;
 use crate::data::value::{DataValue, JsonData, UuidWrapper, Validity, ValidityTs, Vector};
 
@@ -499,14 +500,16 @@ impl NullableColType {
                 DataValue::List(l) => {
                     let mut arr = Vec::with_capacity(l.len());
                     for el in l {
-                        arr.push(self.coerce(el, cur_vld)?);
+                        let coerced = self.coerce(el, cur_vld)?;
+                        arr.push(JsonValue::try_from(coerced).unwrap_or(JsonValue::Null));
                     }
                     arr.into()
                 }
                 DataValue::Set(l) => {
                     let mut arr = Vec::with_capacity(l.len());
                     for el in l {
-                        arr.push(self.coerce(el, cur_vld)?);
+                        let coerced = self.coerce(el, cur_vld)?;
+                        arr.push(JsonValue::try_from(coerced).unwrap_or(JsonValue::Null));
                     }
                     arr.into()
                 }

--- a/crates/krites/src/data/tests/json.rs
+++ b/crates/krites/src/data/tests/json.rs
@@ -27,9 +27,9 @@ fn special_float_json_serialization() {
     let dv_neg_infinity = DataValue::from(f64::NEG_INFINITY);
     let dv_nan = DataValue::from(f64::NAN);
 
-    let jv_infinity: JsonValue = dv_infinity.into();
-    let jv_neg_infinity: JsonValue = dv_neg_infinity.into();
-    let jv_nan: JsonValue = dv_nan.into();
+    let jv_infinity = JsonValue::try_from(dv_infinity).expect("non-Bot converts");
+    let jv_neg_infinity = JsonValue::try_from(dv_neg_infinity).expect("non-Bot converts");
+    let jv_nan = JsonValue::try_from(dv_nan).expect("non-Bot converts");
 
     // JsonValue serializes special floats as string constants
     assert_eq!(
@@ -47,4 +47,10 @@ fn special_float_json_serialization() {
         "null",
         "JsonValue NaN should serialize to null"
     );
+}
+
+#[test]
+fn bot_to_json_returns_error() {
+    let result = JsonValue::try_from(DataValue::Bot);
+    assert!(result.is_err(), "Bot should not convert to JSON");
 }

--- a/crates/krites/src/data/value.rs
+++ b/crates/krites/src/data/value.rs
@@ -32,7 +32,11 @@ use uuid::Uuid;
 use crate::data::json::JsonValue;
 use crate::data::relation::VecElementType;
 
-#[derive(Clone, Hash, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+/// Newtype wrapper around [`Uuid`] providing custom `Ord` for memcmp-compatible key ordering.
+///
+/// UUID fields are compared in (time_hi, time_mid, time_low, rest) order so that
+/// v1 UUIDs sort chronologically in the storage layer.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct UuidWrapper(pub Uuid);
 
 impl PartialOrd<Self> for UuidWrapper {
@@ -52,9 +56,19 @@ impl Ord for UuidWrapper {
     }
 }
 
-/// A Regex in the database. Used internally in functions.
+/// Compiled regex carried as a transient value inside the engine.
+///
+/// `RegexWrapper` is **not** serializable: it exists only during expression
+/// evaluation (e.g., `regex_matches`). `Hash`, `Eq`, and `Ord` compare the
+/// source pattern string, not compiled state.
 #[derive(Clone)]
 pub struct RegexWrapper(pub Regex);
+
+impl Debug for RegexWrapper {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Regex({:?})", self.0.as_str())
+    }
+}
 
 impl Hash for RegexWrapper {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -104,20 +118,27 @@ impl PartialOrd for RegexWrapper {
     }
 }
 
-/// Timestamp part of validity
+/// Microsecond timestamp for time-travel validity, sorted **descending**.
+///
+/// Wraps `Reverse<i64>` so that the natural `Ord` puts newer timestamps first,
+/// which is required by the key-scan logic in `check_key_for_validity`.
 #[derive(
     Copy, Clone, Eq, PartialEq, Ord, PartialOrd, serde::Deserialize, serde::Serialize, Hash, Debug,
 )]
 pub struct ValidityTs(pub Reverse<i64>);
 
-/// Validity for time travel
+/// Validity marker attached to stored tuples for time-travel queries.
+///
+/// Each stored fact carries a `(timestamp, is_assert)` pair. Assertions add the
+/// fact at a point in time; retractions remove it. Both fields sort descending so
+/// that the storage scan finds the most recent state first.
 #[derive(
-    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, serde::Deserialize, serde::Serialize, Hash,
+    Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, serde::Deserialize, serde::Serialize, Hash,
 )]
 pub struct Validity {
-    /// Timestamp, sorted descendingly
+    /// Microsecond timestamp, sorted descending (newest first).
     pub timestamp: ValidityTs,
-    /// Whether this validity is an assertion, sorted descendingly
+    /// `true` = assertion, `false` = retraction; sorted descending.
     pub is_assert: Reverse<bool>,
 }
 
@@ -130,42 +151,63 @@ impl From<(i64, bool)> for Validity {
     }
 }
 
-/// A Value in the database
+/// The core value type for every datum in the Datalog engine.
+///
+/// `DataValue` appears in tuples, expressions, function arguments, and storage
+/// keys. Variant ordering defines the memcmp sort order used by the storage
+/// layer (Null < Bool < Num < Str < ... < Bot).
+///
+/// # Internal-only variants
+///
+/// `Regex`, `Set`, `Validity`, and `Bot` are engine-internal: they never appear
+/// in user-facing query results. `Bot` is the bottom sentinel used as the
+/// upper-bound key in range scans.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize, Hash)]
 #[non_exhaustive]
 pub enum DataValue {
-    /// null
+    /// The null (absent) value. Sorts before all other variants.
     Null,
-    /// boolean
+    /// Boolean truth value.
     Bool(bool),
-    /// number, may be int or float
+    /// Numeric value — integer or float (see [`Num`]).
     Num(Num),
-    /// string
+    /// UTF-8 string, stored inline via [`CompactString`].
     Str(CompactString),
-    /// bytes
+    /// Raw byte sequence, serialized via `serde_bytes`.
     #[serde(with = "serde_bytes")]
     Bytes(Vec<u8>),
-    /// UUID
+    /// UUID value with chronological sort order (see [`UuidWrapper`]).
     Uuid(UuidWrapper),
-    /// Regex, used internally only
+    /// Compiled regex — transient, not serializable. Engine-internal.
     Regex(RegexWrapper),
-    /// list
+    /// Ordered sequence of values.
     List(Vec<DataValue>),
-    /// set, used internally only
+    /// Deduplicated ordered set. Engine-internal; coerced to `List` at output.
     Set(BTreeSet<DataValue>),
-    /// Array, mainly for proximity search
+    /// Typed floating-point vector for proximity search (HNSW).
     Vec(Vector),
-    /// Json
+    /// Arbitrary JSON value (objects, arrays, etc.).
     Json(JsonData),
-    /// validity,
+    /// Timestamp + assertion flag for time-travel queries. Engine-internal.
     Validity(Validity),
-    /// bottom type, used internally only
+    /// Bottom sentinel — sorts after everything. Used as upper key bound. Engine-internal.
     Bot,
 }
 
-/// Wrapper for JsonValue
+/// Wrapper around [`JsonValue`] that provides `Ord` and `Hash` (via string representation).
+///
+/// JSON objects and arrays are stored as opaque blobs in the Datalog engine.
+/// Ordering and hashing use the JSON serialized form, which is sufficient for
+/// key deduplication but **not** semantically meaningful (different key orders
+/// in objects compare differently).
 #[derive(Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct JsonData(pub JsonValue);
+
+impl Debug for JsonData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JsonData({})", self.0)
+    }
+}
 
 impl PartialOrd<Self> for JsonData {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -193,13 +235,17 @@ impl Hash for JsonData {
     }
 }
 
-/// Vector of floating numbers
+/// Typed dense vector of floating-point numbers, used for HNSW proximity search.
+///
+/// Supports both single- and double-precision representations. Distance
+/// functions (`l2_dist`, `ip_dist`, `cos_dist`) operate on vectors of the
+/// same element type.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum Vector {
-    /// 32-bit float array
+    /// Single-precision (32-bit) float array.
     F32(Array1<f32>),
-    /// 64-bit float array
+    /// Double-precision (64-bit) float array.
     F64(Array1<f64>),
 }
 
@@ -479,13 +525,17 @@ impl From<bool> for DataValue {
     }
 }
 
-/// Representing a number
+/// Numeric value: either an exact integer or an IEEE 754 double.
+///
+/// Mixed-type arithmetic promotes `Int` to `Float`. The custom `Ord`
+/// implementation sorts `Int(n)` before `Float(n)` when the float
+/// representation is identical, preserving type distinction in key ordering.
 #[derive(Copy, Clone, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub enum Num {
-    /// intger number
+    /// Exact integer value.
     Int(i64),
-    /// float number
+    /// IEEE 754 double-precision floating-point value.
     Float(f64),
 }
 
@@ -520,6 +570,7 @@ impl Num {
             }
         }
     }
+    /// Convert to f64, promoting integers via `as` cast (precision loss above 2^53).
     pub(crate) fn get_float(&self) -> f64 {
         match self {
             #[expect(
@@ -689,6 +740,7 @@ impl DataValue {
             _ => None,
         }
     }
+    /// Returns the integer value if non-negative, converting whole floats.
     pub(crate) fn get_non_neg_int(&self) -> Option<u64> {
         match self {
             DataValue::Num(n) => n.get_int().and_then(|i| u64::try_from(i).ok()),
@@ -709,9 +761,11 @@ impl DataValue {
             _ => None,
         }
     }
+    /// Construct a `DataValue::Uuid` from a raw [`Uuid`].
     pub(crate) fn uuid(uuid: Uuid) -> Self {
         Self::Uuid(UuidWrapper(uuid))
     }
+    /// Extract UUID, also parsing from `Str` if the string is a valid UUID.
     pub(crate) fn get_uuid(&self) -> Option<Uuid> {
         match self {
             DataValue::Uuid(UuidWrapper(uuid)) => Some(*uuid),
@@ -721,4 +775,5 @@ impl DataValue {
     }
 }
 
+/// Largest valid Unicode code point — used as the suffix for prefix-scan upper bounds.
 pub(crate) const LARGEST_UTF_CHAR: char = '\u{10ffff}';

--- a/crates/krites/src/runtime/db.rs
+++ b/crates/krites/src/runtime/db.rs
@@ -166,7 +166,11 @@ impl NamedRows {
         let rows = self
             .rows
             .into_iter()
-            .map(|row| row.into_iter().map(JsonValue::from).collect::<JsonValue>())
+            .map(|row| {
+                row.into_iter()
+                    .map(|v| JsonValue::try_from(v).unwrap_or(JsonValue::Null))
+                    .collect::<JsonValue>()
+            })
             .collect::<JsonValue>();
         json!({
             "headers": self.headers,


### PR DESCRIPTION
## Summary

- **Panic elimination**: Replace `panic!("found bottom")` in `From<DataValue> for JsonValue` with `TryFrom` returning `DataValueToJsonError` — the only non-library panic in `data/`
- **Split monolith**: `functions/aggregate.rs` (730 LOC) split into `aggregate.rs` (330) + `collections.rs` (442) — set ops, range, slice, assertion moved out
- **Derives**: Add `Debug` to `UuidWrapper`, `RegexWrapper`, `JsonData`, `Validity`
- **Documentation**: All `DataValue` variants, `Num`, `Vector`, `ValidityTs`, `Validity`, `JsonData`, `UuidWrapper`, `RegexWrapper`, aggregation trait contracts (`NormalAggrObj`, `MeetAggrObj`), module-level doc for `data/`
- **Clippy fixes**: `Default::default()` -> `String::new()`, unused lint expect, doc backticks
- **New test**: `bot_to_json_returns_error` verifies `TryFrom` rejects `Bot`

## Scope

`crates/krites/src/data/` only, plus one caller update in `runtime/db.rs`.

## Test plan

- [x] `cargo check -p krites`
- [x] `cargo test -p krites` (329 tests pass)
- [x] `cargo test -p episteme`
- [x] `cargo test -p mneme`
- [x] `cargo clippy -p krites` (0 new warnings in data/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)