### PR TITLE
fix: token refresh error handling, restart backoff reset, atomic deploy

### DIFF
--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -297,6 +297,10 @@ impl NousManager {
 
     /// Run one health-check cycle: ping all actors, track misses, restart dead ones.
     ///
+    /// Also proactively decays `restart_count` for actors that have been stable
+    /// longer than `manager_restart_decay_window_secs`, so the next crash after
+    /// a long period of uptime starts from a fresh backoff.
+    ///
     /// Call this periodically from a background task.
     ///
     /// # Cancel safety
@@ -307,11 +311,29 @@ impl NousManager {
     /// poller task that never races with a cancellation signal).
     pub async fn health_cycle(&mut self) {
         let health = self.check_health().await;
+        let restart_decay_window =
+            Duration::from_secs(self.nous_behavior.manager_restart_decay_window_secs);
 
         let mut to_restart: Vec<String> = Vec::new();
 
         for (id, actor_health) in &health {
             if let Some(entry) = self.actors.get_mut(id) {
+                // WHY: proactively decay restart_count during stable operation so
+                // that a crash after long uptime starts from a fresh backoff, not
+                // the penalty accumulated from prior rapid-fire failures.
+                if entry.restart_count > 0 {
+                    let stable_since = entry.last_restart.unwrap_or(entry.last_start);
+                    if stable_since.elapsed() >= restart_decay_window {
+                        debug!(
+                            nous_id = %id,
+                            old_restart_count = entry.restart_count,
+                            "restart_count decayed to 0 after stable operation"
+                        );
+                        entry.restart_count = 0;
+                        entry.last_restart = None;
+                    }
+                }
+
                 if actor_health.alive {
                     entry.consecutive_misses = 0;
                 } else {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -157,9 +157,15 @@ check_health() {
     while (( elapsed < HEALTH_TIMEOUT )); do
         if health_response=$(curl -sf --max-time 5 "$HEALTH_URL" 2>/dev/null); then
             local status
-            status=$(echo "$health_response" | jq -r '.status // empty' 2>/dev/null) || true  # NOTE: intentional - failure is non-fatal here
+            if ! status=$(echo "$health_response" | jq -r '.status // empty' 2>&1); then
+                log_warn "jq failed parsing health status: ${status}"
+                status=""
+            fi
             local version
-            version=$(echo "$health_response" | jq -r '.version // empty' 2>/dev/null) || true  # NOTE: intentional - failure is non-fatal here
+            if ! version=$(echo "$health_response" | jq -r '.version // empty' 2>&1); then
+                log_warn "jq failed parsing health version: ${version}"
+                version=""
+            fi
 
             # Post-deploy requires "healthy". Rollback passes "allow_degraded"
             # because partial recovery is better than a crash loop.
@@ -219,8 +225,12 @@ do_rollback() {
         systemctl --user stop "$SERVICE"
     fi
 
-    # Restore binary
-    cp -- "$backup" "$BINARY_DST"
+    # Restore binary (atomic: write to temp on same filesystem, then rename)
+    local rollback_tmp
+    rollback_tmp=$(mktemp -p "$(dirname "$BINARY_DST")" aletheia.rollback.XXXXXXXXXX) \
+        || die "Failed to create temp file for rollback (mktemp failed)"
+    cp -- "$backup" "$rollback_tmp"
+    mv -- "$rollback_tmp" "$BINARY_DST"
     log "Restored binary from $backup"
 
     # Restart service
@@ -252,14 +262,15 @@ refresh_token() {
         return 0
     fi
 
-    local token
-    if ! token=$(jq -r '.claudeAiOauth.accessToken // empty' "$cred_file" 2>/dev/null); then
-        log_warn "token refresh failed: jq returned empty"
+    local token jq_err
+    if ! jq_err=$(jq -r '.claudeAiOauth.accessToken // empty' "$cred_file" 2>&1); then
+        log_warn "token refresh failed: jq error: ${jq_err}"
         return 1
     fi
+    token="$jq_err"
 
     if [[ -z "$token" ]]; then
-        log_warn "token refresh failed: jq returned empty"
+        log_warn "token refresh failed: accessToken field is empty or missing"
         return 1
     fi
 
@@ -316,7 +327,12 @@ download_binary() {
             --output "$tmp_bin" \
             --clobber 2>/dev/null; then
             chmod +x -- "$tmp_bin"
-            cp -- "$tmp_bin" "$BINARY_SRC"
+            # Atomic: write to temp on same filesystem, then rename
+            local gh_tmp
+            gh_tmp=$(mktemp -p "$(dirname "$BINARY_SRC")" aletheia.dl.XXXXXXXXXX) \
+                || { log "WARNING: mktemp failed for gh download"; return 1; }
+            cp -- "$tmp_bin" "$gh_tmp"
+            mv -- "$gh_tmp" "$BINARY_SRC"
             log "Downloaded binary via gh: ${BINARY_SRC}"
             return 0
         fi
@@ -326,7 +342,12 @@ download_binary() {
     local url="https://github.com/${repo}/releases/download/${version}/${asset_name}"
     if curl -fsSL --max-time 120 --output "$tmp_bin" -- "$url" 2>/dev/null; then
         chmod +x -- "$tmp_bin"
-        cp -- "$tmp_bin" "$BINARY_SRC"
+        # Atomic: write to temp on same filesystem, then rename
+        local curl_tmp
+        curl_tmp=$(mktemp -p "$(dirname "$BINARY_SRC")" aletheia.dl.XXXXXXXXXX) \
+            || { log "WARNING: mktemp failed for curl download"; return 1; }
+        cp -- "$tmp_bin" "$curl_tmp"
+        mv -- "$curl_tmp" "$BINARY_SRC"
         log "Downloaded binary via curl: ${BINARY_SRC}"
         return 0
     fi

--- a/scripts/health-monitor.sh
+++ b/scripts/health-monitor.sh
@@ -48,8 +48,14 @@ health=$(curl -sf --max-time 5 "$HEALTH_URL" 2>/dev/null) || {
     exit 1
 }
 
-status=$(echo "$health" | jq -r '.status // empty' 2>/dev/null)
-version=$(echo "$health" | jq -r '.version // empty' 2>/dev/null)
+if ! status=$(echo "$health" | jq -r '.status // empty' 2>&1); then
+    log_warn "jq failed parsing health status: ${status}"
+    status=""
+fi
+if ! version=$(echo "$health" | jq -r '.version // empty' 2>&1); then
+    log_warn "jq failed parsing health version: ${version}"
+    version=""
+fi
 
 if [[ -z "$status" ]]; then
     log_warn "health response missing status field; raw: ${health:0:200}"
@@ -65,8 +71,10 @@ log_ok "healthy v$version"
 
 # 3. Token expiry check
 if [[ -f "$CRED_FILE" ]]; then
-    remaining=$(jq -r '(.claudeAiOauth.expiresAt // 0) / 1000 | (. - now) / 60 | floor' "$CRED_FILE" 2>/dev/null || echo "unknown")
-    if [[ -z "$remaining" ]]; then
+    if ! remaining=$(jq -r '(.claudeAiOauth.expiresAt // 0) / 1000 | (. - now) / 60 | floor' "$CRED_FILE" 2>&1); then
+        log_warn "jq failed parsing credential expiry: ${remaining}"
+        remaining="unknown"
+    elif [[ -z "$remaining" ]]; then
         remaining="unknown"
         log_warn "jq returned empty output parsing credential file"
     fi


### PR DESCRIPTION
## Summary

- **#3232 (symbolon/shell):** Surface jq parse errors as warnings in `deploy.sh` and `health-monitor.sh` instead of silently swallowing them with `2>/dev/null`. All jq calls now redirect stderr to stdout so failures are visible in deploy and health logs.
- **#3233 (nous):** Proactively decay `restart_count` to 0 during `health_cycle` when the actor has been stable longer than `manager_restart_decay_window_secs` (default 1 hour). Previously the counter only decayed reactively inside `restart_actor`, so a crash after long uptime could briefly see a stale penalty before the decay check fired.
- **#3234 (scripts):** Use atomic write-to-temp + rename for binary deploy in rollback and download paths. The main deploy path already used this pattern; `do_rollback` and `download_binary` used bare `cp` which can leave a partial binary on crash.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test -p symbolon -p nous` passes (all tests green)
- [x] `shellcheck scripts/deploy.sh scripts/health-monitor.sh` passes (zero warnings)
- [ ] Manual: deploy with `--rollback` to verify atomic restore path
- [ ] Manual: trigger health check with invalid JSON to verify jq error surfacing

Closes #3232, #3233, #3234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)