### PR TITLE
security(pylon): IP-based rate limiting and agent-scoped tool listing (#3228, #3229)

### DIFF
--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -85,6 +85,10 @@ pub async fn get_status(
 
 /// GET /api/v1/nous/{id}/tools: list tools available to a nous.
 ///
+/// Returns only the tools that the requesting agent is permitted to use,
+/// filtered by the agent's `tool_allowlist` from its `NousConfig`. When no
+/// allowlist is configured, all registered tools are returned (#3229).
+///
 /// # Cancel safety
 ///
 /// Cancel-safe. Axum handler; cancellation drops the future with no
@@ -105,13 +109,27 @@ pub async fn tools(
     _claims: Claims,
     Path(id): Path<String>,
 ) -> Result<Json<ToolsResponse>, ApiError> {
-    if state.nous_manager.get_config(&id).is_none() {
-        return Err(NousNotFoundSnafu { id }.build());
-    }
+    let config = state
+        .nous_manager
+        .get_config(&id)
+        .ok_or_else(|| NousNotFoundSnafu { id }.build())?;
 
     let defs = state.tool_registry.definitions();
+
+    // WHY: Without filtering, the API returns the global tool registry
+    // regardless of which agent is requesting. Agents with a `tool_allowlist`
+    // (e.g. role-restricted sub-agents) should only see their permitted tools.
+    // This matches the execution-layer enforcement in `execute/mod.rs` (#3229).
     let tools = defs
         .into_iter()
+        .filter(|d| {
+            config
+                .tool_allowlist
+                .as_ref()
+                .is_none_or(|allowlist| {
+                    allowlist.iter().any(|a| a == d.name.as_str())
+                })
+        })
         .map(|d| ToolSummary {
             name: d.name.as_str().to_owned(),
             description: d.description.clone(),

--- a/crates/pylon/src/middleware/mod.rs
+++ b/crates/pylon/src/middleware/mod.rs
@@ -443,4 +443,76 @@ mod tests {
         assert_eq!(evicted, 0, "recent entries should not be evicted");
         assert_eq!(limiter.tracked_users(), 1, "active user should remain");
     }
+
+    #[test]
+    fn ip_ceiling_limits_aggregate_traffic_from_one_ip() {
+        // WHY: Verifies that multiple tokens from the same IP cannot bypass
+        // the per-user rate limit. The IP ceiling is 5x the per-user burst
+        // (IP_CEILING_BURST_MULTIPLIER = 5), so 5 different users can each
+        // make 1 request, but 6 total from the same IP hits the ceiling (#3228).
+        let config = PerUserRateLimitConfig {
+            default_rpm: 60,
+            default_burst: 1,
+            ..PerUserRateLimitConfig::default()
+        };
+        let limiter = UserRateLimiter::new(config);
+
+        // 5 distinct users, 1 request each = 5 total from same IP (at ceiling).
+        for i in 0..5 {
+            let user = format!("user-{i}");
+            assert!(
+                limiter.check(&user, EndpointCategory::General).is_none(),
+                "user {i} should be allowed (within per-user burst)"
+            );
+            assert!(
+                limiter.check_ip("192.168.1.100", EndpointCategory::General).is_none(),
+                "IP should be allowed for user {i} (within IP ceiling burst)"
+            );
+        }
+
+        // 6th user from same IP: per-user bucket allows it, but IP ceiling rejects.
+        assert!(
+            limiter.check("user-5", EndpointCategory::General).is_none(),
+            "user-5 per-user bucket should allow (first request)"
+        );
+        assert!(
+            limiter.check_ip("192.168.1.100", EndpointCategory::General).is_some(),
+            "IP ceiling should reject the 6th request from the same IP"
+        );
+    }
+
+    #[test]
+    fn ip_ceiling_tracks_separately_from_user_state() {
+        let config = PerUserRateLimitConfig {
+            stale_after_secs: 600,
+            ..PerUserRateLimitConfig::default()
+        };
+        let limiter = UserRateLimiter::new(config);
+
+        limiter.check("alice", EndpointCategory::General);
+        limiter.check_ip("192.168.1.100", EndpointCategory::General);
+
+        assert_eq!(limiter.tracked_users(), 1, "should track 1 user");
+        assert_eq!(limiter.tracked_ips(), 1, "should track 1 IP");
+    }
+
+    #[test]
+    fn cleanup_stale_evicts_ip_entries() {
+        let config = PerUserRateLimitConfig {
+            stale_after_secs: 0,
+            ..PerUserRateLimitConfig::default()
+        };
+        let limiter = UserRateLimiter::new(config);
+
+        limiter.check("alice", EndpointCategory::General);
+        limiter.check_ip("192.168.1.100", EndpointCategory::General);
+        assert_eq!(limiter.tracked_users(), 1);
+        assert_eq!(limiter.tracked_ips(), 1);
+
+        std::thread::sleep(Duration::from_millis(10));
+        let evicted = limiter.cleanup_stale();
+        assert_eq!(evicted, 2, "both user and IP entries should be evicted");
+        assert_eq!(limiter.tracked_users(), 0);
+        assert_eq!(limiter.tracked_ips(), 0);
+    }
 }

--- a/crates/pylon/src/middleware/user_rate_limiter.rs
+++ b/crates/pylon/src/middleware/user_rate_limiter.rs
@@ -109,14 +109,34 @@ struct UserBuckets {
     last_access: Instant,
 }
 
+/// Burst multiplier for the per-IP rate limit ceiling.
+///
+/// WHY: The per-IP ceiling must be more generous than the per-user limit to
+/// accommodate multiple legitimate users behind a shared IP (NAT, corporate
+/// proxy). A 5x multiplier means up to 5 distinct users behind one IP can
+/// each burst at their per-user rate before the IP ceiling kicks in. Beyond
+/// that, token-multiplied abuse is throttled (#3228).
+const IP_CEILING_BURST_MULTIPLIER: u32 = 5;
+
 /// Per-user token-bucket rate limiter with endpoint-category differentiation.
 ///
 /// Each authenticated user gets separate token buckets for general, LLM, and
-/// tool endpoints. Uses `std::sync::Mutex` (not tokio): the critical section
+/// tool endpoints. Additionally enforces a per-IP ceiling so that a single
+/// IP address cannot bypass limits by creating multiple bearer tokens (#3228).
+/// The per-IP ceiling uses the same RPM but a higher burst allowance
+/// ([`IP_CEILING_BURST_MULTIPLIER`] x per-user burst) to accommodate
+/// multiple legitimate users behind a shared IP.
+///
+/// Uses `std::sync::Mutex` (not tokio): the critical section
 /// is short and contains no `.await` points.
 pub struct UserRateLimiter {
     config: PerUserRateLimitConfig,
+    /// Per-user (token-keyed) rate limit state.
     state: Mutex<HashMap<String, UserBuckets>>,
+    /// Per-IP rate limit ceiling. Checked alongside the per-user bucket so
+    /// that a single IP cannot exceed the configured limit regardless of how
+    /// many bearer tokens it presents (#3228).
+    ip_state: Mutex<HashMap<String, UserBuckets>>,
 }
 
 impl UserRateLimiter {
@@ -124,6 +144,7 @@ impl UserRateLimiter {
         Self {
             config,
             state: Mutex::new(HashMap::new()),
+            ip_state: Mutex::new(HashMap::new()),
         }
     }
 
@@ -155,25 +176,93 @@ impl UserRateLimiter {
         bucket.try_acquire(now).err()
     }
 
+    /// Check the per-IP rate limit ceiling.
+    ///
+    /// WHY: A client can obtain N bearer tokens and get N x the per-user rate
+    /// limit from a single IP. This per-IP ceiling ensures one IP address
+    /// cannot exceed the configured rate regardless of token count (#3228).
+    /// The ceiling uses `IP_CEILING_BURST_MULTIPLIER` x the per-user burst
+    /// so multiple legitimate users behind a shared IP are not penalized.
+    ///
+    /// Returns `None` if allowed, or `Some(retry_after_secs)` if rate limited.
+    pub(crate) fn check_ip(&self, ip: &str, category: EndpointCategory) -> Option<u64> {
+        let m = IP_CEILING_BURST_MULTIPLIER;
+        let now = Instant::now();
+        let mut state = self
+            .ip_state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let buckets = state.entry(ip.to_owned()).or_insert_with(|| UserBuckets {
+            general: TokenBucket::new(
+                self.config.default_rpm.saturating_mul(m),
+                self.config.default_burst.saturating_mul(m),
+            ),
+            llm: TokenBucket::new(
+                self.config.llm_rpm.saturating_mul(m),
+                self.config.llm_burst.saturating_mul(m),
+            ),
+            tool: TokenBucket::new(
+                self.config.tool_rpm.saturating_mul(m),
+                self.config.tool_burst.saturating_mul(m),
+            ),
+            last_access: now,
+        });
+
+        buckets.last_access = now;
+
+        let bucket = match category {
+            EndpointCategory::General => &mut buckets.general,
+            EndpointCategory::Llm => &mut buckets.llm,
+            EndpointCategory::Tool => &mut buckets.tool,
+        };
+
+        bucket.try_acquire(now).err()
+    }
+
     /// Remove entries for users who haven't made requests within the stale
     /// threshold. Returns the number of entries evicted.
     pub(crate) fn cleanup_stale(&self) -> usize {
         let now = Instant::now();
         let stale_threshold = Duration::from_secs(self.config.stale_after_secs);
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        let before = state.len();
-        state.retain(|_, buckets| now.duration_since(buckets.last_access) < stale_threshold);
-        before - state.len()
+        let evicted_users = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let before = state.len();
+            state.retain(|_, buckets| now.duration_since(buckets.last_access) < stale_threshold);
+            before - state.len()
+        };
+
+        let evicted_ips = {
+            let mut ip_state = self
+                .ip_state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let before = ip_state.len();
+            ip_state
+                .retain(|_, buckets| now.duration_since(buckets.last_access) < stale_threshold);
+            before - ip_state.len()
+        };
+
+        evicted_users + evicted_ips
     }
 
     /// Number of tracked users (for diagnostics).
     #[cfg(test)]
     pub(crate) fn tracked_users(&self) -> usize {
         self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+
+    /// Number of tracked IPs (for diagnostics).
+    #[cfg(test)]
+    pub(crate) fn tracked_ips(&self) -> usize {
+        self.ip_state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .len()
@@ -206,10 +295,11 @@ fn extract_user_key(request: &Request, trust_proxy: bool) -> String {
 
 /// Middleware that enforces per-user rate limiting with endpoint categories.
 ///
-/// Reads the `Arc<UserRateLimiter>` from request extensions. Keys on client
-/// IP address (verified claims are unavailable at the middleware layer).
-/// Returns 429 with `Retry-After` header when the client has exceeded the
-/// configured limit for the endpoint category.
+/// Reads the `Arc<UserRateLimiter>` from request extensions. Keys on both
+/// bearer token hash (per-user) and client IP (per-IP ceiling). The per-IP
+/// check prevents a single IP from bypassing limits by creating multiple
+/// bearer tokens (#3228). Returns 429 with `Retry-After` header when the
+/// client has exceeded the configured limit for the endpoint category.
 ///
 /// # Cancel safety
 ///
@@ -227,7 +317,22 @@ pub async fn per_user_rate_limit(request: Request, next: Next) -> Response {
     };
 
     let user = extract_user_key(&request, trust_proxy);
+    let ip = extract_client_key(&request, trust_proxy);
     let category = EndpointCategory::from_path(request.uri().path());
+
+    // WHY: Check per-IP ceiling first. A client opening N sessions (N bearer
+    // tokens) from one IP would get N x the per-user limit without this
+    // check. The IP ceiling ensures aggregate traffic from one address stays
+    // within bounds regardless of token count (#3228).
+    if let Some(retry_after_secs) = limiter.check_ip(&ip, category) {
+        debug!(
+            ip = %ip,
+            category = ?category,
+            retry_after_secs,
+            "per-IP rate limit ceiling exceeded"
+        );
+        return rate_limit_response(retry_after_secs, category);
+    }
 
     if let Some(retry_after_secs) = limiter.check(&user, category) {
         debug!(
@@ -236,32 +341,37 @@ pub async fn per_user_rate_limit(request: Request, next: Next) -> Response {
             retry_after_secs,
             "per-user rate limit exceeded"
         );
-        let mut response = (
-            StatusCode::TOO_MANY_REQUESTS,
-            axum::Json(ErrorResponse {
-                error: ErrorBody {
-                    code: "rate_limited".to_owned(),
-                    message: format!(
-                        "per-user rate limit exceeded, retry after {retry_after_secs}s"
-                    ),
-                    request_id: None,
-                    details: Some(serde_json::json!({
-                        "retry_after_secs": retry_after_secs,
-                        "category": format!("{category:?}").to_lowercase(),
-                    })),
-                },
-            }),
-        )
-            .into_response();
-        if let Ok(value) = axum::http::HeaderValue::from_str(&retry_after_secs.to_string()) {
-            response
-                .headers_mut()
-                .insert(axum::http::header::RETRY_AFTER, value);
-        }
-        return response;
+        return rate_limit_response(retry_after_secs, category);
     }
 
     next.run(request).await
+}
+
+/// Build a 429 Too Many Requests response with `Retry-After` header.
+fn rate_limit_response(retry_after_secs: u64, category: EndpointCategory) -> Response {
+    let mut response = (
+        StatusCode::TOO_MANY_REQUESTS,
+        axum::Json(ErrorResponse {
+            error: ErrorBody {
+                code: "rate_limited".to_owned(),
+                message: format!(
+                    "per-user rate limit exceeded, retry after {retry_after_secs}s"
+                ),
+                request_id: None,
+                details: Some(serde_json::json!({
+                    "retry_after_secs": retry_after_secs,
+                    "category": format!("{category:?}").to_lowercase(),
+                })),
+            },
+        }),
+    )
+        .into_response();
+    if let Ok(value) = axum::http::HeaderValue::from_str(&retry_after_secs.to_string()) {
+        response
+            .headers_mut()
+            .insert(axum::http::header::RETRY_AFTER, value);
+    }
+    response
 }
 
 /// Spawn a background task that periodically cleans up stale user rate limit


### PR DESCRIPTION
## Summary

- **#3228**: Add per-IP rate limit ceiling to `UserRateLimiter` alongside the per-user (bearer token) buckets. A single IP can no longer bypass rate limits by creating N bearer tokens for N x the limit. The IP ceiling uses a 5x burst multiplier over per-user config to accommodate legitimate shared-IP scenarios (NAT, corporate proxy).
- **#3229**: Filter the `GET /api/v1/nous/{id}/tools` endpoint by the requesting agent's `tool_allowlist` from `NousConfig`. Previously returned the global tool registry regardless of agent. Now matches the execution-layer enforcement already in `execute/mod.rs`.
- Extract `rate_limit_response()` helper to deduplicate 429 response construction.
- 3 new unit tests for IP ceiling behavior, IP state tracking, and IP stale cleanup.

## Test plan

- [x] `cargo check -p pylon` passes
- [x] `cargo clippy -p pylon` zero warnings
- [x] `cargo test -p pylon` — 365 unit + 34 integration tests pass (3 new tests)
- [ ] Verify IP ceiling triggers correctly under multi-token attack (manual or integration test with real TCP)
- [ ] Verify agents with `tool_allowlist` see only their permitted tools via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)