### PR TITLE
security(diaporeia): add MCP auth layer and rate limit resource reads (#3226, #3227)

### DIFF
--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -7,7 +7,10 @@ use snafu::prelude::*;
 use tracing::{info, warn};
 
 use koina::system::{Environment, RealSystem};
+#[cfg(not(feature = "mcp"))]
 use pylon::router::build_router;
+#[cfg(feature = "mcp")]
+use pylon::router::build_router_with;
 use taxis::loader::load_config;
 use taxis::oikos::Oikos;
 
@@ -91,7 +94,9 @@ pub(crate) async fn run(args: Args) -> Result<()> {
         });
         let mcp_router = diaporeia::transport::streamable_http_router(diaporeia_state);
         info!("diaporeia MCP server mounted at /mcp");
-        build_router(runtime.state.clone(), &security).merge(mcp_router)
+        // WHY: merge MCP routes BEFORE pylon's middleware layers so they get
+        // the full security stack (rate limiting, CSRF, metrics) (#3226).
+        build_router_with(runtime.state.clone(), &security, Some(mcp_router))
     };
 
     #[cfg(not(feature = "mcp"))]

--- a/crates/diaporeia/src/server.rs
+++ b/crates/diaporeia/src/server.rs
@@ -75,6 +75,7 @@ impl rmcp::handler::server::ServerHandler for DiaporeiaServer {
         _params: Option<rmcp::model::PaginatedRequestParams>,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<ListResourceTemplatesResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Cheap)?;
         let mut templates: Vec<ResourceTemplate> = resources::nous::resource_templates();
         templates.extend(resources::config::resource_templates());
         Ok(ListResourceTemplatesResult {
@@ -89,6 +90,7 @@ impl rmcp::handler::server::ServerHandler for DiaporeiaServer {
         _params: Option<rmcp::model::PaginatedRequestParams>,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<ListResourcesResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Cheap)?;
         // NOTE: static resources only: dynamic listing deferred
         Ok(ListResourcesResult {
             resources: vec![],

--- a/crates/diaporeia/tests/public_api.rs
+++ b/crates/diaporeia/tests/public_api.rs
@@ -572,7 +572,7 @@ async fn router_allows_unauthenticated_requests_in_none_mode() {
 
     // WHY: auth_mode = "none" injects anonymous claims and passes through.
     // Without an `Accept: text/event-stream` header, the downstream MCP
-    // service returns 406 Not Acceptable for GET requests. The 406 proves the
+    // service returns 400 Bad Request for GET requests. The 400 proves the
     // middleware passed the request through — a 401 would indicate rejection.
     let response = router
         .oneshot(
@@ -587,9 +587,9 @@ async fn router_allows_unauthenticated_requests_in_none_mode() {
 
     assert_eq!(
         response.status(),
-        StatusCode::NOT_ACCEPTABLE,
+        StatusCode::BAD_REQUEST,
         "auth_mode=none must pass the request through to the MCP service, \
-         which returns 406 for GET without an event-stream Accept header"
+         which returns 400 for GET without an event-stream Accept header"
     );
 }
 
@@ -673,7 +673,7 @@ async fn router_auth_rejection_precedes_method_handling() {
 #[tokio::test(flavor = "multi_thread")]
 async fn router_valid_token_passes_auth_layer_and_reaches_mcp_service() {
     // WHY: a validly-signed Bearer token must clear the auth middleware and
-    // reach the downstream MCP service. The service then rejects with 406
+    // reach the downstream MCP service. The service then rejects with 400
     // (missing Accept: text/event-stream + application/json) — proving the
     // request got past auth but failed at protocol negotiation.
     let (state, jwt, _tmp) = StateBuilder::new().auth_mode("token").build();
@@ -694,9 +694,9 @@ async fn router_valid_token_passes_auth_layer_and_reaches_mcp_service() {
 
     assert_eq!(
         response.status(),
-        StatusCode::NOT_ACCEPTABLE,
+        StatusCode::BAD_REQUEST,
         "valid Bearer token must clear auth and reach the MCP service, \
-         which rejects empty POSTs with 406 for missing Accept header"
+         which rejects empty POSTs with 400 for missing Accept header"
     );
 }
 
@@ -766,7 +766,7 @@ async fn router_in_none_mode_ignores_authorization_header_when_present() {
     // entirely and inject anonymous claims, regardless of what the client
     // sends in the Authorization header. A malformed Bearer value would fail
     // in token mode but must be ignored here — the request still reaches the
-    // downstream service, which returns 406 for a GET without the expected
+    // downstream service, which returns 400 for a GET without the expected
     // event-stream Accept header.
     let (state, _jwt, _tmp) = StateBuilder::new().auth_mode("none").build();
     let router = streamable_http_router(state);
@@ -785,8 +785,8 @@ async fn router_in_none_mode_ignores_authorization_header_when_present() {
 
     assert_eq!(
         response.status(),
-        StatusCode::NOT_ACCEPTABLE,
+        StatusCode::BAD_REQUEST,
         "auth_mode=none must ignore Authorization and pass through to the \
-         MCP service (which returns 406 for GET without Accept: text/event-stream)"
+         MCP service (which returns 400 for GET without Accept: text/event-stream)"
     );
 }

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -34,7 +34,30 @@ use crate::state::AppState;
     reason = "router construction requires assembling all routes and ordered middleware layers; extraction would obscure the stack ordering"
 )]
 pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
+    build_router_with(state, security, None)
+}
+
+/// Build the Axum router with all routes, middleware, and optional extra routes.
+///
+/// Extra routes (e.g. diaporeia's MCP router) are merged BEFORE middleware
+/// layers are applied. This ensures global layers (rate limiting, CSRF,
+/// metrics, error enrichment, etc.) wrap all routes including external ones.
+// NOTE(#940): 130+ lines: route and middleware layer assembly where ordering matters.
+// Extraction would obscure the middleware stack ordering that is critical for correctness.
+#[expect(
+    clippy::too_many_lines,
+    reason = "router construction requires assembling all routes and ordered middleware layers; extraction would obscure the stack ordering"
+)]
+pub fn build_router_with(
+    state: Arc<AppState>,
+    security: &SecurityConfig,
+    extra: Option<Router>,
+) -> Router {
     crate::metrics::init();
+
+    // WHY: Extract shutdown token before state is moved into the router.
+    // The user_rate_limiter cleanup task needs it after .with_state() consumes the Arc.
+    let shutdown = state.shutdown.clone();
 
     let v1 = Router::new()
         .route(
@@ -106,9 +129,22 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
 
     router = router.fallback(fallback_handler);
 
+    // WHY: Bind state before merging extra routes. This converts
+    // Router<Arc<AppState>> to Router<()> so the extra Router<()> from
+    // diaporeia can be merged. All subsequent middleware layers are
+    // tower-level (not Axum state extractors), so they work on Router<()>.
+    let mut router = router.with_state(state);
+
+    // WHY: Extra routes are merged BEFORE middleware layers so they benefit from
+    // the same global protections (rate limiting, CSRF, compression, tracing,
+    // metrics, error enrichment) as pylon's own routes (#3226).
+    if let Some(extra) = extra {
+        router = router.merge(extra);
+    }
+
     if security.rate_limit.per_user.enabled {
         let user_limiter = Arc::new(UserRateLimiter::new(security.rate_limit.per_user.clone()));
-        spawn_stale_cleanup(Arc::clone(&user_limiter), state.shutdown.clone());
+        spawn_stale_cleanup(Arc::clone(&user_limiter), shutdown.clone());
         router = router
             .layer(axum::middleware::from_fn(per_user_rate_limit))
             .layer(axum::Extension(user_limiter));
@@ -178,9 +214,7 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
     router = router.layer(build_cors_layer(security));
 
     // WARNING: Outermost layer: must wrap all other layers so headers apply to every response.
-    router = apply_security_headers(router, security);
-
-    router.with_state(state)
+    apply_security_headers(router, security)
 }
 
 /// Fallback handler for unmatched routes.
@@ -264,10 +298,7 @@ fn build_cors_layer(security: &SecurityConfig) -> CorsLayer {
 }
 
 /// Apply standard security response headers.
-fn apply_security_headers(
-    router: Router<Arc<AppState>>,
-    security: &SecurityConfig,
-) -> Router<Arc<AppState>> {
+fn apply_security_headers(router: Router, security: &SecurityConfig) -> Router {
     let mut r = router
         .layer(SetResponseHeaderLayer::overriding(
             HeaderName::from_static("x-frame-options"),


### PR DESCRIPTION
## Summary

- **#3226**: MCP routes were merged into pylon's router after middleware layers were applied, bypassing global rate limiting, CSRF, metrics, and error enrichment. Refactored `build_router` into `build_router_with` that accepts an optional extra Router merged before layers are applied, so MCP routes get the full pylon security stack.
- **#3227**: Added `rate_limiter.check(Tier::Cheap)` to `list_resources` and `list_resource_templates` in `DiaporeiaServer`, matching the pattern already used on `read_resource` and all tool calls.
- Fixed 3 pre-existing test failures where rmcp 1.4 returns 400 instead of 406 for protocol-level rejections.

## Test plan

- [x] `cargo check -p diaporeia` passes
- [x] `cargo test -p diaporeia` passes (69 tests: 42 unit + 27 integration)
- [x] `cargo check -p pylon` passes
- [x] `cargo test -p pylon` passes (399 tests)
- [x] `cargo check -p aletheia --features mcp` passes (no warnings)
- [x] `cargo check -p aletheia` passes (without mcp feature, no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)