### PR TITLE
fix: zombie actor cleanup and stale architecture docs (#3248, #3244)

### DIFF
--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -7,7 +7,7 @@ use snafu::prelude::*;
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, info, warn};
+use tracing::{Instrument, error, info, warn};
 
 use agora::types::ChannelProvider;
 use hermeneus::provider::ProviderRegistry;
@@ -586,7 +586,7 @@ impl RuntimeBuilder {
                     hooks: nous::config::HookConfig::default(),
                     behavior: resolved.behavior,
                 };
-                nous_manager
+                if let Err(e) = nous_manager
                     .spawn(
                         nous_config,
                         PipelineConfig {
@@ -595,7 +595,14 @@ impl RuntimeBuilder {
                             ..PipelineConfig::default()
                         },
                     )
-                    .await;
+                    .await
+                {
+                    error!(
+                        agent = %agent_def.id,
+                        error = %e,
+                        "failed to spawn agent — skipping"
+                    );
+                }
             }
             info!(count = nous_manager.count(), "nous actors spawned");
         }

--- a/crates/integration-tests/tests/domain_packs.rs
+++ b/crates/integration-tests/tests/domain_packs.rs
@@ -180,7 +180,7 @@ priority = "important"
         },
         ..NousConfig::default()
     };
-    let handle = manager.spawn(config, PipelineConfig::default()).await;
+    let handle = manager.spawn(config, PipelineConfig::default()).await.expect("spawn");
 
     handle.send_turn("main", "Hello").await.expect("turn");
 

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -9,7 +9,7 @@ use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use hermeneus::provider::ProviderRegistry;
 use mneme::embedding::EmbeddingProvider;
@@ -31,7 +31,7 @@ mod background;
 mod spawn;
 mod turn;
 
-pub(crate) use spawn::spawn;
+pub(crate) use spawn::{spawn, validate_workspace};
 
 /// Default bounded channel capacity for the actor inbox.
 pub const DEFAULT_INBOX_CAPACITY: usize = 32;
@@ -243,10 +243,9 @@ impl NousActor {
         reason = "actor run loop: sequential select! branches; splitting would obscure the event-driven structure"
     )]
     pub async fn run(mut self) {
-        if let Err(e) = spawn::validate_workspace(&self.services.oikos, &self.id).await {
-            error!(error = %e, "workspace validation failed, shutting down");
-            return;
-        }
+        // NOTE: Workspace validation (SOUL.md, directory existence) is performed
+        // by NousManager::spawn_inner before the actor is created, preventing
+        // zombie ActorEntry creation on validation failure (#3248).
 
         self.runtime.started_at = Instant::now();
         info!(lifecycle = %self.channel.status, "actor started");

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -140,6 +140,7 @@ impl NousManager {
     /// Spawn a new nous actor and return its handle.
     ///
     /// If an actor with the same id already exists, the old actor is shut down first.
+    /// Returns an error if workspace validation fails (e.g., missing SOUL.md).
     ///
     /// # Cancel safety
     ///
@@ -150,7 +151,7 @@ impl NousManager {
         &mut self,
         config: NousConfig,
         pipeline_config: PipelineConfig,
-    ) -> NousHandle {
+    ) -> crate::error::Result<NousHandle> {
         let id = config.id.to_string();
 
         if let Some(old) = self.actors.remove(&id) {
@@ -170,12 +171,20 @@ impl NousManager {
     }
 
     /// Internal spawn that does not check for existing actors.
+    ///
+    /// Validates the workspace before creating the actor. Returns an error if
+    /// validation fails (e.g., missing SOUL.md), preventing zombie entries (#3248).
     async fn spawn_inner(
         &mut self,
         config: NousConfig,
         pipeline_config: PipelineConfig,
-    ) -> NousHandle {
+    ) -> crate::error::Result<NousHandle> {
         let id = config.id.to_string();
+
+        // WHY: Validate before creating the actor so a validation failure (e.g.,
+        // missing SOUL.md) never produces a zombie ActorEntry that delays restart
+        // for the full health-check backoff cycle (#3248).
+        actor::validate_workspace(&self.oikos, &id).await?;
 
         let extra_bootstrap = {
             let estimator = CharEstimator::new(u64::from(config.generation.chars_per_token));
@@ -232,7 +241,7 @@ impl NousManager {
                 active_turn,
             },
         );
-        handle
+        Ok(handle)
     }
 
     /// Look up a handle by nous id.
@@ -404,23 +413,33 @@ impl NousManager {
             }
         }
 
-        let handle = self
+        match self
             .spawn_inner(config.clone(), pipeline_config.clone())
-            .await;
+            .await
+        {
+            Ok(handle) => {
+                if let Some(entry) = self.actors.get_mut(id) {
+                    entry.restart_count = restart_count + 1;
+                    entry.last_restart = Some(std::time::Instant::now());
+                    entry.consecutive_misses = 0;
+                }
 
-        if let Some(entry) = self.actors.get_mut(id) {
-            entry.restart_count = restart_count + 1;
-            entry.last_restart = Some(std::time::Instant::now());
-            entry.consecutive_misses = 0;
+                info!(
+                    nous_id = %id,
+                    restart_count = prev_restart_count + 1,
+                    "actor restarted successfully"
+                );
+
+                drop(handle);
+            }
+            Err(e) => {
+                error!(
+                    nous_id = %id,
+                    error = %e,
+                    "failed to restart actor — workspace validation failed"
+                );
+            }
         }
-
-        info!(
-            nous_id = %id,
-            restart_count = prev_restart_count + 1,
-            "actor restarted successfully"
-        );
-
-        drop(handle);
     }
 
     /// Spawn a background task that runs `health_cycle` on an interval.

--- a/crates/nous/src/manager_tests.rs
+++ b/crates/nous/src/manager_tests.rs
@@ -77,7 +77,7 @@ async fn spawn_returns_handle() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
     assert_eq!(handle.id(), "syn", "spawned handle should have syn id");
     assert_eq!(mgr.count(), 1, "manager should have one actor after spawn");
 
@@ -89,7 +89,7 @@ async fn get_finds_spawned_actor() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
 
     let handle = mgr.get("syn").expect("found");
     assert_eq!(handle.id(), "syn", "retrieved handle should have syn id");
@@ -112,7 +112,7 @@ async fn get_config_returns_stored_config() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
 
     let config = mgr.get_config("syn").expect("config");
     assert_eq!(config.id.as_ref(), "syn", "config id should match");
@@ -139,9 +139,9 @@ async fn configs_returns_all() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
     mgr.spawn(demiurge_config(), PipelineConfig::default())
-        .await;
+        .await.expect("spawn");
 
     let configs = mgr.configs();
     assert_eq!(configs.len(), 2, "should have two configs");
@@ -158,9 +158,9 @@ async fn list_returns_all_statuses() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
     mgr.spawn(demiurge_config(), PipelineConfig::default())
-        .await;
+        .await.expect("spawn");
 
     let statuses = mgr.list().await;
     assert_eq!(statuses.len(), 2, "should list two actors");
@@ -180,10 +180,10 @@ async fn shutdown_all_stops_all_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle1 = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    let handle1 = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
     let handle2 = mgr
         .spawn(demiurge_config(), PipelineConfig::default())
-        .await;
+        .await.expect("spawn");
 
     mgr.shutdown_all().await;
 
@@ -207,9 +207,9 @@ async fn spawn_multiple_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
     mgr.spawn(demiurge_config(), PipelineConfig::default())
-        .await;
+        .await.expect("spawn");
 
     assert_eq!(mgr.count(), 2, "manager should have two actors");
 
@@ -229,8 +229,8 @@ async fn spawn_replaces_existing_actor() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let old_handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
-    let new_handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    let old_handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    let new_handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
 
     assert_eq!(mgr.count(), 1, "re-spawn should replace, not add");
 
@@ -250,7 +250,7 @@ async fn manager_turn_through_handle() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
     let result = handle.send_turn("main", "Hello").await.expect("turn");
     assert_eq!(result.content, "Hello!", "turn should return mock response");
 
@@ -263,10 +263,10 @@ async fn drain_stops_all_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle1 = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    let handle1 = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
     let handle2 = mgr
         .spawn(demiurge_config(), PipelineConfig::default())
-        .await;
+        .await.expect("spawn");
 
     // WHY: drain() takes &self: no mutable access needed.
     mgr.drain(Duration::from_secs(5)).await;
@@ -287,7 +287,7 @@ async fn cancel_token_propagates_to_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
 
     // WHY: Cancel via manager's root token directly (as drain() would do internally).
     mgr.cancel.cancel();
@@ -311,9 +311,9 @@ async fn drain_timeout_does_not_panic() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
     mgr.spawn(demiurge_config(), PipelineConfig::default())
-        .await;
+        .await.expect("spawn");
 
     // NOTE: 1-nanosecond timeout: drain will warn but must not panic.
     mgr.drain(Duration::from_nanos(1)).await;
@@ -324,7 +324,7 @@ async fn check_health_reports_alive_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
 
     let health = mgr.check_health().await;
     assert_eq!(health.len(), 1, "health map should have one entry");
@@ -343,7 +343,7 @@ async fn check_health_detects_dead_actor() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
 
     handle.shutdown().await.expect("shutdown");
     // kanon:ignore TESTING/sleep-in-test reason = "waiting for actor task to fully stop before health check; real async shutdown cannot use pause+advance"
@@ -362,7 +362,7 @@ async fn check_health_busy_actor_reports_alive() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await;
+    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
 
     // NOTE: Simulate: actor is mid-turn (flag set) but its inbox is closed (ping fails).
     mgr.actors

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -120,9 +120,12 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         taxis::config::NousBehaviorConfig::default(),
     );
     let nous_config = NousConfig::default();
+    // WHY: Test/dev server: validation failure for the default nous config
+    // is a startup error, not a recoverable condition.
     nous_manager
         .spawn(nous_config, PipelineConfig::default())
-        .await;
+        .await
+        .expect("default nous spawn");
 
     let aletheia_config = taxis::loader::load_config(&oikos).unwrap_or_else(|e| {
         tracing::warn!("failed to load config, using defaults: {e}");

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,13 +188,6 @@ Imports flow downward only. Lower-layer crates must not depend on higher layers.
 | `ChannelProvider` | agora | Send/receive on a messaging channel |
 | `LlmProvider` | hermeneus | LLM API calls |
 
-### Planned crates
-
-| Crate | Domain | Milestone |
-|-------|--------|-----------|
-| `prostheke` | WASM plugin host (wasmtime) | M5 |
-| `autarkeia` | Agent export/import | M5 |
-
 ---
 
 ## Adding components


### PR DESCRIPTION
## Summary

- **#3248**: Move workspace validation (`validate_workspace`) from `NousActor::run()` to `NousManager::spawn_inner()`, executing it *before* the actor is created. If validation fails (e.g., missing SOUL.md), no `ActorEntry` is created, eliminating the zombie entry that previously caused 90s restart delays through the health-check backoff cycle.
- **#3244**: Remove the "Planned crates" section from `docs/ARCHITECTURE.md` — `prostheke` and `autarkeia` don't exist in the workspace and were confusing agents and contributors.

## Changes

- `crates/nous/src/manager.rs`: `spawn` and `spawn_inner` now return `Result<NousHandle>`. `spawn_inner` validates workspace before creating the actor. `restart_actor` handles validation failure gracefully.
- `crates/nous/src/actor/mod.rs`: Remove `validate_workspace` call from `NousActor::run()`, re-export `validate_workspace` for use by manager.
- `crates/aletheia/src/runtime/mod.rs`: Handle spawn `Result` — log error and skip agent on validation failure.
- `crates/pylon/src/server.rs`: Handle spawn `Result` — expect in dev/test server context.
- `crates/integration-tests/tests/domain_packs.rs`: Handle spawn `Result` in test.
- `crates/nous/src/manager_tests.rs`: All 22 `.spawn().await` calls updated to `.expect("spawn")`.
- `docs/ARCHITECTURE.md`: Remove planned crates section (prostheke, autarkeia).

## Test plan

- [x] `cargo check -p nous` passes (zero warnings)
- [x] `cargo check --workspace` passes (only pre-existing diaporeia warning)
- [ ] `cargo test -p nous` — manager tests exercise the updated `spawn` signature
- [ ] `cargo test -p integration-tests` — domain_packs test exercises the updated signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)