### PR TITLE
fix: systemd readiness probe and OpenAPI version tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Register in `crates/organon/src/builtins/mod.rs` via `register_all()`.
 | GET | `/api/v1/knowledge/search` | Full-text search (query: `q`, `nous_id`, `limit`) |
 | GET | `/api/v1/knowledge/timeline` | Fact activity timeline |
 
-> **Note:** The OpenAPI spec version at `/api/docs/openapi.json` is fixed at `"1.0.0"` and does not track the release version.
+> **Note:** The OpenAPI spec version at `/api/docs/openapi.json` tracks `CARGO_PKG_VERSION` automatically.
 
 ## Scripts
 

--- a/crates/pylon/src/openapi.rs
+++ b/crates/pylon/src/openapi.rs
@@ -73,9 +73,19 @@ use koina::http::CONTENT_TYPE_JSON;
         crate::stream::SseEvent,
         crate::stream::UsageData,
     )),
-    modifiers(&SecurityAddon),
+    modifiers(&VersionFromCrate, &SecurityAddon),
 )]
 pub(crate) struct ApiDoc;
+
+/// Override the hardcoded OpenAPI `info.version` with the crate version
+/// from `Cargo.toml` so the spec tracks releases automatically.
+struct VersionFromCrate;
+
+impl utoipa::Modify for VersionFromCrate {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.info.version = env!("CARGO_PKG_VERSION").to_owned();
+    }
+}
 
 struct SecurityAddon;
 
@@ -118,6 +128,16 @@ mod tests {
             .to_json()
             .expect("OpenAPI spec serialization must not fail");
         assert!(!json.is_empty());
+    }
+
+    #[test]
+    fn openapi_spec_version_tracks_crate_version() {
+        let spec = ApiDoc::openapi();
+        assert_eq!(
+            spec.info.version,
+            env!("CARGO_PKG_VERSION"),
+            "OpenAPI spec version must match CARGO_PKG_VERSION"
+        );
     }
 
     #[test]

--- a/instance.example/services/aletheia.service
+++ b/instance.example/services/aletheia.service
@@ -4,7 +4,11 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=simple
+# WHY: Type=exec waits for the exec() call to succeed before marking the
+# service as started, catching binary-not-found immediately. The ExecStartPost
+# readiness probe then polls the health endpoint so dependents and `systemctl
+# start` only return once the HTTP gateway is actually accepting connections.
+Type=exec
 Environment=RUST_BACKTRACE=1
 # WARNING: Do not put secrets (API keys, tokens) directly in this file.
 # Use the EnvironmentFile below instead. Unit files are world-readable.
@@ -13,6 +17,16 @@ Environment=RUST_BACKTRACE=1
 EnvironmentFile=-%h/aletheia/instance/config/env  # CUSTOMIZE: path to your instance config/env
 # %h expands to the user's home directory at runtime.
 ExecStart=%h/.local/bin/aletheia -r %h/aletheia/instance  # CUSTOMIZE: binary and instance paths
+# Readiness probe: poll the health endpoint until the gateway is listening.
+# Retries every 0.5s for up to 15s (30 attempts). Adjust URL if using a
+# non-default port or bind address.
+ExecStartPost=/bin/sh -c '\
+  url="${ALETHEIA_HEALTH_URL:-http://localhost:18789/api/health}"; \
+  i=0; while [ "$i" -lt 30 ]; do \
+    if curl -sf --max-time 2 "$url" >/dev/null 2>&1; then exit 0; fi; \
+    sleep 0.5; i=$((i+1)); \
+  done; \
+  echo "aletheia health endpoint not reachable after 15s" >&2; exit 1'
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
## Summary

- **#3235:** systemd service used `Type=simple`, marking service active before the HTTP gateway was listening. Changed to `Type=exec` with an `ExecStartPost` readiness probe that polls `/api/health` for up to 15s (30 x 0.5s retries). Dependents and `systemctl start` now block until the gateway is actually accepting connections.
- **#3246:** OpenAPI spec version was hardcoded at `"1.0.0"`. Added a `VersionFromCrate` utoipa `Modify` implementation that injects `env!("CARGO_PKG_VERSION")` at spec generation time, so the version tracks releases automatically.
- Updated CLAUDE.md note to reflect the version now tracks automatically.

## Test plan

- [x] `cargo check -p pylon -p aletheia` passes
- [x] `cargo test -p pylon -- openapi` passes (7 tests including new `openapi_spec_version_tracks_crate_version`)
- [ ] Deploy to menos and verify `systemctl --user start aletheia` blocks until health endpoint responds
- [ ] Verify `/api/docs/openapi.json` reports version `0.17.0` instead of `1.0.0`

Closes #3235, closes #3246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)