### PR TITLE
refactor: organon unsafe docs and energeia quality sweep

### DIFF
--- a/crates/energeia/src/dag.rs
+++ b/crates/energeia/src/dag.rs
@@ -350,7 +350,7 @@ pub fn compute_frontier(dag: &PromptDag) -> Vec<Vec<u32>> {
             .collect();
 
         if group.is_empty() {
-            // SAFETY: No progress means a cycle exists. Break rather than loop
+            // INVARIANT: No progress means a cycle exists. Break rather than loop
             // forever — validate() should have caught this beforehand.
             break;
         }

--- a/crates/energeia/src/qa/mechanical.rs
+++ b/crates/energeia/src/qa/mechanical.rs
@@ -40,6 +40,7 @@ const ANTI_PATTERNS: &[(&str, &str)] = &[
 ///
 /// Checks blast radius compliance and scans for anti-patterns. These checks
 /// incur no LLM cost and run on the diff text alone.
+#[must_use]
 pub fn mechanical_check(diff: &str, prompt: &PromptSpec) -> Vec<MechanicalIssue> {
     let mut issues = Vec::new();
 
@@ -173,6 +174,7 @@ pub async fn lint_check(working_dir: &Path) -> Vec<MechanicalIssue> {
 ///
 /// Parses `+++ b/path` lines which give the destination path and handle
 /// renames correctly.
+#[must_use]
 pub fn parse_changed_files(diff: &str) -> Vec<String> {
     let mut files = Vec::new();
 

--- a/crates/energeia/src/qa/semantic.rs
+++ b/crates/energeia/src/qa/semantic.rs
@@ -51,6 +51,7 @@ const SEMANTIC_KEYWORDS: &[&str] = &[
 /// - Contains semantic keyword → `CriterionType::Semantic`
 /// - If both match, mechanical takes precedence (cheaper to verify)
 /// - Default (no keyword match) → `CriterionType::Semantic`
+#[must_use]
 pub fn classify_criteria(criteria: &[String]) -> Vec<(String, CriterionType)> {
     criteria
         .iter()
@@ -138,6 +139,7 @@ const OUTPUT_SCHEMA: &str = r#"{
 /// The prompt includes the task description, numbered criteria, the PR diff
 /// (truncated at 100K chars to stay within context limits), few-shot examples,
 /// and the expected output schema.
+#[must_use]
 pub fn build_qa_prompt(
     description: &str,
     criteria: &[(String, CriterionType)],
@@ -217,6 +219,7 @@ struct QaCriterionResult {
 ///
 /// This function is infallible: unparseable responses produce criteria marked
 /// as failed with explanatory evidence.
+#[must_use]
 pub fn parse_qa_response(raw: &str, criteria: &[(String, CriterionType)]) -> Vec<CriterionResult> {
     // NOTE: Try direct JSON parse.
     if let Ok(response) = serde_json::from_str::<QaResponse>(raw) {


### PR DESCRIPTION
## Summary

- **Organon (#3240):** Audited all 4 `unsafe` blocks in `crates/organon/src/`. All already have thorough `// SAFETY:` comments documenting invariants. None can be eliminated (inherently unsafe APIs: `unshare_unsafe`, inline asm syscall, `pre_exec`).
- **Energeia (#3241):** Quality sweep of the dispatch execution bridge crate:
  - Fixed misused `// SAFETY:` comment to `// INVARIANT:` in `dag.rs` frontier computation (not an unsafe block)
  - Added `#[must_use]` to 5 pure public functions in `qa/mechanical.rs` and `qa/semantic.rs`
  - Clippy: zero warnings (was already clean)
  - unwrap/expect: all production uses already annotated with `#[expect(clippy::expect_used, reason = "...")]`
  - Doc comments: `#![deny(missing_docs)]` enforced crate-wide, all public types documented
  - async-trait: already removed per #3197

## Test plan

- [x] `cargo check -p organon -p energeia` passes
- [x] `cargo clippy -p organon -p energeia` zero warnings
- [x] No behavioral changes — only annotations and comment fixes

Closes #3240, closes #3241