### PR TITLE
fix: audit expect() calls — add missing annotations, fix misleading messages (#3231)

### DIFF
--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -276,6 +276,10 @@ fn process_agent(
     Ok((unique.len(), agent_deduped))
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "ID construction from fixed-format strings (migrated-<16-hex>) is infallible against non-empty/<=256 validation"
+)]
 fn import_fact(
     agent_id: &str,
     record: &MemoryRecord,
@@ -287,7 +291,7 @@ fn import_fact(
     let valid_from = parse_timestamp(&record.created_at).unwrap_or(now);
 
     let fact = Fact {
-        id: FactId::new(&fact_id).expect("ULID fact_id is always valid"),
+        id: FactId::new(&fact_id).expect("migrated-<hash> is non-empty and under 256 bytes"),
         nous_id: agent_id.to_owned(),
         content: record.content.clone(),
         fact_type: String::new(),
@@ -320,7 +324,7 @@ fn import_fact(
     if let Ok(embedding) = embedder.embed(&record.content) {
         let chunk = EmbeddedChunk {
             id: EmbeddingId::new(&format!("emb-{fact_id}"))
-                .expect("emb- prefix + ULID is always valid"),
+                .expect("emb-migrated-<hash> is non-empty and under 256 bytes"),
             content: record.content.clone(),
             source_type: "fact".to_owned(),
             source_id: fact_id,

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -93,6 +93,10 @@ pub enum ServerError {
 /// until the OS delivers a shutdown signal; dropping it at that point skips the
 /// SIGHUP-handler drain and `shutdown_readonly` call, which may leave actor tasks
 /// running until the runtime exits.
+#[expect(
+    clippy::expect_used,
+    reason = "startup-time invariants: default nous spawn and signal handlers are not recoverable errors"
+)]
 pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
     let oikos = Oikos::from_root(&config.instance_path);
     oikos.validate().context(ValidationSnafu)?;

--- a/crates/theatron/koilon/src/main.rs
+++ b/crates/theatron/koilon/src/main.rs
@@ -25,6 +25,10 @@ struct Cli {
 }
 
 #[tokio::main]
+#[expect(
+    clippy::expect_used,
+    reason = "ring crypto provider installation fails only if called twice, which is a programming error"
+)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     rustls::crypto::ring::default_provider()
         .install_default()


### PR DESCRIPTION
## Summary

- Audited all production `expect()` calls across the workspace (excluding `krites` and test code)
- **Finding: all expect() calls are genuine invariants.** No lazy error handling was found masquerading as invariants.
- Three sites were missing `#[expect(clippy::expect_used)]` annotations; two had misleading messages

### Changes

- **`crates/aletheia/src/migrate_memory.rs`**: Added `#[expect]` annotation to `import_fact()`. Fixed messages from "ULID fact_id is always valid" to "migrated-<hash> is non-empty and under 256 bytes" — these are SHA-256 hash-based IDs, not ULIDs, and the validation is non-empty + max-length
- **`crates/pylon/src/server.rs`**: Added `#[expect]` annotation to `run()` for the startup-time `expect("default nous spawn")` and signal handler installs
- **`crates/theatron/koilon/src/main.rs`**: Added `#[expect]` annotation to `main()` for `ring::default_provider().install_default()` which only fails if called twice

### Audit categories (all verified as genuine invariants)

| Category | Count | Examples |
|----------|-------|---------|
| Metric registration (LazyLock) | ~35 | All metrics crates — panics only on duplicate name (programmer error) |
| Static regex compilation | ~20 | hermeneus, koina, energeia, pylon — compile-time literals |
| Signal handler installation | ~6 | pylon, aletheia — infallible on supported platforms |
| Mutex poisoning | ~5 | hermeneus concurrency — no Result to propagate |
| Data structure invariants | ~5 | ViewStack never-empty, typed state machines |
| Bounded timestamp arithmetic | ~5 | energeia, graphe — days-from-now subtraction |
| Infallible serialization | ~3 | OpenAPI JSON, prometheus encoding |
| ID construction from known formats | ~3 | koina ULID/UUID, migrate_memory hashes |
| Startup-time initialization | ~3 | TLS, nous spawn, crypto provider |

## Test plan

- [x] `cargo check --workspace` passes
- [x] All existing tests pass (no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)