### PR TITLE
fix: surface silent failures in hermeneus, agora, nous, and pylon

### DIFF
--- a/crates/agora/src/listener.rs
+++ b/crates/agora/src/listener.rs
@@ -279,7 +279,11 @@ mod tests {
         );
 
         let mut handles = JoinSet::new();
-        handles.spawn(async { handle.await.ok(); });
+        handles.spawn(async move {
+            if let Err(e) = handle.await {
+                tracing::warn!(error = %e, "spawned task failed");
+            }
+        });
         let listener = ChannelListener::from_parts(rx, handles);
         listener.stop();
     }
@@ -301,7 +305,11 @@ mod tests {
 
         {
             let mut handles = JoinSet::new();
-            handles.spawn(async { handle.await.ok(); });
+            handles.spawn(async move {
+                if let Err(e) = handle.await {
+                    tracing::warn!(error = %e, "spawned task failed");
+                }
+            });
             let _listener = ChannelListener::from_parts(rx, handles);
         }
 
@@ -325,7 +333,11 @@ mod tests {
         );
 
         let mut join_set = JoinSet::new();
-        join_set.spawn(async { handle.await.ok(); });
+        join_set.spawn(async move {
+            if let Err(e) = handle.await {
+                tracing::warn!(error = %e, "spawned task failed");
+            }
+        });
         let listener = ChannelListener::from_parts(rx, join_set);
         let (_rx, mut handles) = listener.into_receiver();
 

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -291,7 +291,7 @@ fn import_fact(
     let valid_from = parse_timestamp(&record.created_at).unwrap_or(now);
 
     let fact = Fact {
-        id: FactId::new(&fact_id).expect("migrated-<hash> is non-empty and under 256 bytes"),
+        id: FactId::new(&fact_id).expect("fact_id is `migrated-{hash}` which is non-empty and under MAX_ID_LEN"),
         nous_id: agent_id.to_owned(),
         content: record.content.clone(),
         fact_type: String::new(),
@@ -324,7 +324,7 @@ fn import_fact(
     if let Ok(embedding) = embedder.embed(&record.content) {
         let chunk = EmbeddedChunk {
             id: EmbeddingId::new(&format!("emb-{fact_id}"))
-                .expect("emb-migrated-<hash> is non-empty and under 256 bytes"),
+                .expect("`emb-{fact_id}` is non-empty and under MAX_ID_LEN"),
             content: record.content.clone(),
             source_type: "fact".to_owned(),
             source_id: fact_id,

--- a/crates/hermeneus/src/anthropic/error.rs
+++ b/crates/hermeneus/src/anthropic/error.rs
@@ -28,7 +28,13 @@ pub(crate) async fn map_error_response(
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
 
-    let body = response.text().await.unwrap_or_default();
+    let body = match response.text().await {
+        Ok(text) => text,
+        Err(e) => {
+            warn!(error = %e, "failed to read error response body");
+            String::new()
+        }
+    };
 
     warn!(
         status,

--- a/crates/hermeneus/src/anthropic/wire/mod.rs
+++ b/crates/hermeneus/src/anthropic/wire/mod.rs
@@ -61,7 +61,13 @@ pub(super) fn content_with_cache_control(content: &Content) -> serde_json::Value
         Content::Blocks(blocks) => {
             let mut arr: Vec<serde_json::Value> = blocks
                 .iter()
-                .map(|b| serde_json::to_value(b).unwrap_or_default())
+                .filter_map(|b| {
+                    serde_json::to_value(b)
+                        .inspect_err(|e| {
+                            tracing::warn!(error = %e, "content block serialization failed, dropping block");
+                        })
+                        .ok()
+                })
                 .collect();
             if let Some(last) = arr.last_mut()
                 && let Some(obj) = last.as_object_mut()

--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -345,6 +345,7 @@ async fn run_extraction(
                     }
                     Err(e) => {
                         warn!(nous_id = %nous_id, error = %e, "extraction persist failed");
+                        crate::metrics::record_background_failure(nous_id, "extraction_persist");
                     }
                 }
             }
@@ -361,6 +362,7 @@ async fn run_extraction(
         }
         Err(e) => {
             warn!(nous_id = %nous_id, error = %e, "extraction failed");
+            crate::metrics::record_background_failure(nous_id, "extraction");
         }
     }
 }
@@ -501,6 +503,7 @@ async fn run_skill_extraction(
                 error = %e,
                 "skill extraction failed"
             );
+            crate::metrics::record_background_failure(nous_id, "skill_extraction");
         }
     }
 }
@@ -514,6 +517,13 @@ async fn run_background_distillation(
     config: crate::distillation::DistillTriggerConfig,
 ) {
     let Some(provider) = providers.find_provider(&config.model) else {
+        warn!(
+            nous_id = %nous_id,
+            session_id = %session_id,
+            model = %config.model,
+            "distillation aborted: no provider for configured model"
+        );
+        crate::metrics::record_background_failure(&nous_id, "distillation");
         return;
     };
 
@@ -521,13 +531,20 @@ async fn run_background_distillation(
     let (history, session) = {
         let s = store.lock().await;
         let Ok(Some(session)) = s.find_session_by_id(&session_id) else {
+            warn!(
+                nous_id = %nous_id,
+                session_id = %session_id,
+                "distillation aborted: session not found"
+            );
+            crate::metrics::record_background_failure(&nous_id, "distillation");
             return;
         };
         match s.get_history(&session_id, None) {
             Ok(h) if !h.is_empty() => (h, session),
             Ok(_) => return,
             Err(e) => {
-                warn!(error = %e, "failed to load history for distillation");
+                warn!(nous_id = %nous_id, error = %e, "failed to load history for distillation");
+                crate::metrics::record_background_failure(&nous_id, "distillation");
                 return;
             }
         }
@@ -554,14 +571,16 @@ async fn run_background_distillation(
     {
         Ok(r) => r,
         Err(e) => {
-            warn!(error = %e, "distillation LLM call failed");
+            warn!(nous_id = %nous_id, session_id = %session_id, error = %e, "distillation LLM call failed");
+            crate::metrics::record_background_failure(&nous_id, "distillation");
             return;
         }
     };
 
     let s = store.lock().await;
     if let Err(e) = crate::distillation::apply_distillation(&s, &session_id, &result, &history) {
-        warn!(error = %e, "failed to apply distillation");
+        warn!(nous_id = %nous_id, session_id = %session_id, error = %e, "failed to apply distillation");
+        crate::metrics::record_background_failure(&nous_id, "distillation");
         return;
     }
 

--- a/crates/pylon/src/openapi.rs
+++ b/crates/pylon/src/openapi.rs
@@ -77,13 +77,13 @@ use koina::http::CONTENT_TYPE_JSON;
 )]
 pub(crate) struct ApiDoc;
 
-/// Override the hardcoded OpenAPI `info.version` with the crate version
+/// Override the hardcoded `OpenAPI` `info.version` with the crate version
 /// from `Cargo.toml` so the spec tracks releases automatically.
 struct VersionFromCrate;
 
 impl utoipa::Modify for VersionFromCrate {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
-        openapi.info.version = env!("CARGO_PKG_VERSION").to_owned();
+        env!("CARGO_PKG_VERSION").clone_into(&mut openapi.info.version);
     }
 }
 

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -27,12 +27,6 @@ use crate::security::SecurityConfig;
 use crate::state::AppState;
 
 /// Build the Axum router with all routes and middleware.
-// NOTE(#940): 130 lines: route and middleware layer assembly where ordering matters.
-// Extraction would obscure the middleware stack ordering that is critical for correctness.
-#[expect(
-    clippy::too_many_lines,
-    reason = "router construction requires assembling all routes and ordered middleware layers; extraction would obscure the stack ordering"
-)]
 pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
     build_router_with(state, security, None)
 }

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -73,6 +73,12 @@ pub enum ServerError {
     Validation {
         source: taxis::error::Error,
     },
+
+    /// Default nous agent failed to spawn during startup.
+    #[snafu(display("default nous spawn failed: {source}"))]
+    NousSpawn {
+        source: nous::error::Error,
+    },
 }
 
 /// Start the HTTP gateway and block until shutdown.
@@ -83,6 +89,7 @@ pub enum ServerError {
 /// Returns [`ServerError::SessionStore`] if the session database cannot be opened.
 /// Returns [`ServerError::Bind`] if the server cannot bind to the configured address.
 /// Returns [`ServerError::Serve`] if the HTTP server encounters a fatal I/O error.
+/// Returns [`ServerError::NousSpawn`] if the default nous agent fails to spawn.
 /// Returns [`ServerError::TlsConfig`] if TLS is enabled but certs cannot be loaded.
 /// Returns [`ServerError::TlsNotCompiled`] if TLS is enabled but the feature is absent.
 ///
@@ -124,12 +131,10 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         taxis::config::NousBehaviorConfig::default(),
     );
     let nous_config = NousConfig::default();
-    // WHY: Test/dev server: validation failure for the default nous config
-    // is a startup error, not a recoverable condition.
     nous_manager
         .spawn(nous_config, PipelineConfig::default())
         .await
-        .expect("default nous spawn");
+        .context(NousSpawnSnafu)?;
 
     let aletheia_config = taxis::loader::load_config(&oikos).unwrap_or_else(|e| {
         tracing::warn!("failed to load config, using defaults: {e}");


### PR DESCRIPTION
## Summary

- **#3291** hermeneus JSON block serialization: `unwrap_or_default()` replaced with `filter_map` + warn logging — failed blocks are now dropped with a visible warning instead of silently producing empty objects
- **#3288** hermeneus HTTP response body read: `unwrap_or_default()` replaced with explicit match — transport errors now logged at warn instead of silently returning empty string
- **#3289** agora listener tests: `.await.ok()` on spawned task handles replaced with explicit `if let Err(e)` + warn logging — panics in spawned tasks are now visible
- **#3287** nous background tasks: added `record_background_failure` metric calls to all error paths in extraction, skill extraction, and distillation — failures now surface via `aletheia_background_task_failures_total` Prometheus counter with specific `task_type` labels
- **#3231** pylon server: replaced `expect()` on nous spawn with proper `NousSpawn` snafu error variant and `?` propagation; fixed pre-existing clippy warnings in pylon (unfulfilled lint expectation, doc_markdown, assigning_clones); fixed misleading expect messages in migrate_memory

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace` passes (only pre-existing krites/diaporeia warnings remain)
- [x] `cargo test -p hermeneus -p agora -p nous -p pylon` — all 34+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)