### PR TITLE
fix(episteme): validate extractions, surface errors, remove hardcoded constants (#3303, #3304, #3305, #3307)

### DIFF
--- a/crates/episteme/src/causal.rs
+++ b/crates/episteme/src/causal.rs
@@ -244,6 +244,11 @@ impl CausalStore {
 /// Each entry is (`keyword`, `relation_type`, `confidence`). The keyword
 /// is matched case-insensitively against the combined session text.
 /// Confidence reflects the extraction heuristic quality for that cue.
+///
+/// WHY not in taxis config: these are domain knowledge (linguistic patterns),
+/// not behavioral tuning. The mapping from word to relation type is structural,
+/// not something an operator would adjust per-deployment. If language-specific
+/// packs are added later, this table should move to a domain pack.
 const CAUSAL_CUES: &[(&str, CausalRelationType, f64)] = &[
     ("because", CausalRelationType::Caused, 0.6),
     ("caused by", CausalRelationType::Caused, 0.75),

--- a/crates/episteme/src/conflict.rs
+++ b/crates/episteme/src/conflict.rs
@@ -437,6 +437,16 @@ pub(crate) fn classify_against_candidates(
             if classification != ConflictClassification::Unrelated {
                 return Ok(Some((classification, idx)));
             }
+        } else {
+            // WHY: a systematically misbehaving LLM would silently cause all conflicts
+            // to be classified as Unrelated without this warning.
+            let snippet_len = response.len().min(200);
+            tracing::warn!(
+                response_snippet = &response[..snippet_len],
+                existing_content = %candidate.existing_content,
+                new_content = %fact.content,
+                "conflict classification response did not match any known class, falling back to Unrelated"
+            );
         }
     }
 

--- a/crates/episteme/src/consolidation/engine.rs
+++ b/crates/episteme/src/consolidation/engine.rs
@@ -19,8 +19,23 @@ use crate::knowledge::{EpistemicTier, FactAccess, FactLifecycle, FactProvenance,
 use crate::knowledge_store::KnowledgeStore;
 
 /// Convert a non-negative `i64` from a Datalog row to `usize`.
+///
+/// Negative values indicate data corruption in the knowledge store (counts
+/// should never be negative). When detected, a warning is logged with the
+/// raw value and the function returns 0 for operational continuity.
 fn i64_as_usize(v: i64) -> usize {
-    v.try_into().unwrap_or(0)
+    match v.try_into() {
+        Ok(n) => n,
+        Err(_) => {
+            // WHY: negative counts are a data corruption indicator — surface it
+            // via logging rather than silently defaulting.
+            tracing::warn!(
+                raw_value = v,
+                "negative i64 encountered where usize expected — possible data corruption, defaulting to 0"
+            );
+            0
+        }
+    }
 }
 
 impl KnowledgeStore {

--- a/crates/episteme/src/extract/engine.rs
+++ b/crates/episteme/src/extract/engine.rs
@@ -5,7 +5,7 @@
         reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
     )
 )]
-use snafu::ResultExt;
+use snafu::IntoError;
 use tracing::instrument;
 
 #[cfg(feature = "mneme-engine")]
@@ -119,7 +119,8 @@ Rules:
 
     /// Parse a JSON extraction response from the LLM.
     ///
-    /// Strips markdown code fences if present.
+    /// Strips markdown code fences if present. On parse failure, includes the
+    /// first 500 characters of the raw response for debugging.
     #[instrument(skip(self, response))]
     #[expect(
         clippy::unused_self,
@@ -127,7 +128,12 @@ Rules:
     )]
     pub(crate) fn parse_response(&self, response: &str) -> Result<Extraction, ExtractionError> {
         let trimmed = strip_code_fences(response);
-        serde_json::from_str(trimmed).context(ParseResponseSnafu)
+        serde_json::from_str(trimmed).map_err(|source| {
+            // WHY: include response text so operators can diagnose malformed LLM output
+            // without correlating with provider logs.
+            let response_snippet: String = response.chars().take(500).collect();
+            ParseResponseSnafu { response_snippet }.into_error(source)
+        })
     }
 
     /// Run extraction end-to-end: build prompt, call provider, parse response.
@@ -207,10 +213,38 @@ Rules:
         let boost = turn_type.confidence_boost() + correction.confidence_boost;
         let mut filtered_count = 0;
 
+        // WHY: check for LLM confidence inflation before filtering individual facts,
+        // so the warning fires even if some facts are later filtered for other reasons.
+        let confidence_tuples: Vec<(f64,)> =
+            extraction.facts.iter().map(|f| (f.confidence,)).collect();
+        if refinement::has_confidence_inflation(&confidence_tuples) {
+            tracing::warn!(
+                total_facts = extraction.facts.len(),
+                "confidence inflation detected: >80% of extracted facts have confidence >= 0.95"
+            );
+        }
+
         extraction.facts = extraction
             .facts
             .into_iter()
             .filter_map(|mut fact| {
+                // WHY: reject facts with empty triple fields before any other processing —
+                // a fact with no subject, predicate, or object has zero semantic value.
+                if !refinement::validate_triple_fields(
+                    &fact.subject,
+                    &fact.predicate,
+                    &fact.object,
+                ) {
+                    filtered_count += 1;
+                    tracing::debug!(
+                        subject = %fact.subject,
+                        predicate = %fact.predicate,
+                        object = %fact.object,
+                        "fact rejected: empty subject, predicate, or object"
+                    );
+                    return None;
+                }
+
                 let fact_content = format!("{} {} {}", fact.subject, fact.predicate, fact.object);
                 let classified_type = refinement::classify_fact(&fact_content);
                 fact.fact_type = Some(classified_type.as_str().to_owned());
@@ -313,6 +347,14 @@ Rules:
         };
 
         for entity in entities {
+            // WHY: reject entities with empty names — they cannot be referenced or queried.
+            if entity.name.trim().is_empty() {
+                tracing::debug!(
+                    entity_type = %entity.entity_type,
+                    "entity rejected: empty name"
+                );
+                continue;
+            }
             let id = crate::id::EntityId::new(slugify(&entity.name)).map_err(|e| {
                 PersistSnafu {
                     message: e.to_string(),
@@ -410,6 +452,21 @@ Rules:
         }
 
         for (i, fact) in facts.iter().enumerate() {
+            // WHY: guard against empty triple fields reaching the knowledge store —
+            // the extraction pipeline should have caught these, but persist is the
+            // last line of defense.
+            if fact.subject.trim().is_empty()
+                || fact.predicate.trim().is_empty()
+                || fact.object.trim().is_empty()
+            {
+                tracing::debug!(
+                    subject = %fact.subject,
+                    predicate = %fact.predicate,
+                    object = %fact.object,
+                    "fact skipped during persist: empty subject, predicate, or object"
+                );
+                continue;
+            }
             let content = format!("{} {} {}", fact.subject, fact.predicate, fact.object);
             let id = crate::id::FactId::new(format!(
                 "{}-{}-{i}",

--- a/crates/episteme/src/extract/error.rs
+++ b/crates/episteme/src/extract/error.rs
@@ -10,9 +10,13 @@ use snafu::Snafu;
 )]
 pub enum ExtractionError {
     /// The LLM response could not be parsed as valid extraction JSON.
-    #[snafu(display("failed to parse extraction response"))]
+    ///
+    /// Includes a truncated snippet of the raw response for debugging.
+    #[snafu(display("failed to parse extraction response: {response_snippet}"))]
     ParseResponse {
         source: serde_json::Error,
+        /// First 500 characters of the raw LLM response that failed to parse.
+        response_snippet: String,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/episteme/src/extract/refinement.rs
+++ b/crates/episteme/src/extract/refinement.rs
@@ -434,6 +434,8 @@ pub enum FilterReason {
     Trivial,
     /// Duplicate of an earlier fact in the same batch.
     Duplicate,
+    /// One or more triple fields (subject, predicate, object) are empty or whitespace-only.
+    EmptyField,
 }
 
 impl std::fmt::Display for FilterReason {
@@ -444,6 +446,7 @@ impl std::fmt::Display for FilterReason {
             Self::TooLong => f.write_str("too_long"),
             Self::Trivial => f.write_str("trivial"),
             Self::Duplicate => f.write_str("duplicate"),
+            Self::EmptyField => f.write_str("empty_field"),
         }
     }
 }
@@ -502,6 +505,30 @@ pub(crate) fn filter_fact(content: &str, confidence: f64) -> FilterResult {
         passed: true,
         reason: None,
     }
+}
+
+/// Validate that all triple fields (subject, predicate, object) are non-empty.
+///
+/// Returns `true` if all fields contain at least one non-whitespace character.
+/// Empty or whitespace-only fields have no semantic value and must be rejected
+/// before insertion into the knowledge store.
+#[must_use]
+pub(crate) fn validate_triple_fields(subject: &str, predicate: &str, object: &str) -> bool {
+    !subject.trim().is_empty() && !predicate.trim().is_empty() && !object.trim().is_empty()
+}
+
+/// Check a batch of facts for confidence inflation.
+///
+/// Returns `true` if more than 80% of facts have confidence >= 0.95,
+/// which indicates the LLM is over-assigning high confidence scores.
+#[must_use]
+pub(crate) fn has_confidence_inflation(facts: &[(f64,)]) -> bool {
+    if facts.is_empty() {
+        return false;
+    }
+    let high_count = facts.iter().filter(|(c,)| *c >= 0.95).count();
+    // WHY: integer multiply avoids float division for threshold comparison.
+    high_count * 100 > facts.len() * 80
 }
 
 const TRIVIAL_PATTERNS: &[&str] = &[

--- a/crates/episteme/src/extract/refinement_tests.rs
+++ b/crates/episteme/src/extract/refinement_tests.rs
@@ -628,3 +628,97 @@ fn full_pipeline_tool_heavy_turn() {
         "full pipeline tool heavy turn: expected to contain value"
     );
 }
+
+// --- #3303: Empty field validation ---
+
+#[test]
+fn validate_triple_fields_all_populated() {
+    assert!(
+        validate_triple_fields("Alice", "uses", "Rust"),
+        "all non-empty fields should pass validation"
+    );
+}
+
+#[test]
+fn validate_triple_fields_empty_subject() {
+    assert!(
+        !validate_triple_fields("", "uses", "Rust"),
+        "empty subject should fail validation"
+    );
+}
+
+#[test]
+fn validate_triple_fields_empty_predicate() {
+    assert!(
+        !validate_triple_fields("Alice", "", "Rust"),
+        "empty predicate should fail validation"
+    );
+}
+
+#[test]
+fn validate_triple_fields_empty_object() {
+    assert!(
+        !validate_triple_fields("Alice", "uses", ""),
+        "empty object should fail validation"
+    );
+}
+
+#[test]
+fn validate_triple_fields_whitespace_only() {
+    assert!(
+        !validate_triple_fields("  ", "uses", "Rust"),
+        "whitespace-only subject should fail validation"
+    );
+    assert!(
+        !validate_triple_fields("Alice", "  \t  ", "Rust"),
+        "whitespace-only predicate should fail validation"
+    );
+    assert!(
+        !validate_triple_fields("Alice", "uses", "  \n  "),
+        "whitespace-only object should fail validation"
+    );
+}
+
+#[test]
+fn validate_triple_fields_all_empty() {
+    assert!(
+        !validate_triple_fields("", "", ""),
+        "all empty fields should fail validation"
+    );
+}
+
+#[test]
+fn confidence_inflation_detected() {
+    let facts: Vec<(f64,)> = vec![(0.96,), (0.97,), (0.98,), (0.99,), (0.95,)];
+    assert!(
+        has_confidence_inflation(&facts),
+        "100% at >=0.95 should trigger inflation warning"
+    );
+}
+
+#[test]
+fn confidence_inflation_not_triggered_below_threshold() {
+    let facts: Vec<(f64,)> = vec![(0.95,), (0.80,), (0.70,), (0.60,), (0.95,)];
+    assert!(
+        !has_confidence_inflation(&facts),
+        "40% at >=0.95 should not trigger inflation warning"
+    );
+}
+
+#[test]
+fn confidence_inflation_empty_batch() {
+    let facts: Vec<(f64,)> = vec![];
+    assert!(
+        !has_confidence_inflation(&facts),
+        "empty batch should not trigger inflation warning"
+    );
+}
+
+#[test]
+fn filter_reason_empty_field_display() {
+    assert_eq!(
+        FilterReason::EmptyField.to_string(),
+        "empty_field",
+        "EmptyField filter reason display"
+    );
+}

--- a/crates/episteme/src/extract/tests/utilities.rs
+++ b/crates/episteme/src/extract/tests/utilities.rs
@@ -125,12 +125,52 @@ fn parse_response_truncated_json() {
     let truncated = r#"{"entities": [{"name": "Alice""#;
     let result = engine.parse_response(truncated);
     assert!(result.is_err(), "truncated JSON must return error");
+    let err = result.expect_err("truncated JSON should produce parse error");
     assert!(
-        matches!(
-            result.expect_err("truncated JSON should produce parse error"),
-            ExtractionError::ParseResponse { .. }
-        ),
+        matches!(&err, ExtractionError::ParseResponse { .. }),
         "truncated JSON should yield ParseResponse error variant"
+    );
+    // #3305: parse error must include response snippet for debugging
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("Alice"),
+        "parse error should include the raw response snippet: {err_msg}"
+    );
+}
+
+#[test]
+fn parse_response_error_snippet_truncated_at_500_chars() {
+    let engine = ExtractionEngine::new(ExtractionConfig::default());
+    // WHY: use ASCII to guarantee exact 500-char truncation (no multi-byte boundary issues).
+    let long_response = "x".repeat(1000);
+    let result = engine.parse_response(&long_response);
+    assert!(result.is_err(), "non-JSON string must return error");
+    let err = result.expect_err("non-JSON string should produce parse error");
+    if let ExtractionError::ParseResponse {
+        response_snippet, ..
+    } = &err
+    {
+        assert_eq!(
+            response_snippet.len(),
+            500,
+            "response snippet should be truncated to 500 chars for ASCII input"
+        );
+    } else {
+        panic!("expected ParseResponse variant");
+    }
+}
+
+#[test]
+fn parse_response_error_snippet_short_response_included_fully() {
+    let engine = ExtractionEngine::new(ExtractionConfig::default());
+    let short = "not json at all";
+    let result = engine.parse_response(short);
+    assert!(result.is_err(), "non-JSON string must return error");
+    let err = result.expect_err("non-JSON string should produce parse error");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("not json at all"),
+        "short responses should be included fully in error: {err_msg}"
     );
 }
 
@@ -416,6 +456,99 @@ fn slugify_nfc_normalization_preserves_ascii() {
         utils::slugify("Data Processor"),
         "data-processor",
         "plain ASCII should not be altered by NFC normalization"
+    );
+}
+
+#[cfg(feature = "mneme-engine")]
+#[test]
+fn persist_skips_empty_entity_name() {
+    let store = crate::knowledge_store::KnowledgeStore::open_mem()
+        .expect("in-memory knowledge store should open successfully");
+    let engine = ExtractionEngine::new(ExtractionConfig::default());
+
+    let extraction = Extraction {
+        entities: vec![
+            ExtractedEntity {
+                name: String::new(),
+                entity_type: "person".to_owned(),
+                description: "No name".to_owned(),
+            },
+            ExtractedEntity {
+                name: "   ".to_owned(),
+                entity_type: "person".to_owned(),
+                description: "Whitespace name".to_owned(),
+            },
+            ExtractedEntity {
+                name: "ValidEntity".to_owned(),
+                entity_type: "concept".to_owned(),
+                description: "Has a real name".to_owned(),
+            },
+        ],
+        relationships: vec![],
+        facts: vec![],
+    };
+
+    let result = engine
+        .persist(&extraction, &store, "session:test", "syn")
+        .expect("persist should succeed, skipping empty-name entities");
+    assert_eq!(
+        result.entities_inserted, 1,
+        "only the entity with a valid name should be inserted"
+    );
+}
+
+#[cfg(feature = "mneme-engine")]
+#[test]
+fn persist_skips_empty_fact_fields() {
+    let store = crate::knowledge_store::KnowledgeStore::open_mem()
+        .expect("in-memory knowledge store should open successfully");
+    let engine = ExtractionEngine::new(ExtractionConfig::default());
+
+    let extraction = Extraction {
+        entities: vec![],
+        relationships: vec![],
+        facts: vec![
+            ExtractedFact {
+                subject: String::new(),
+                predicate: "uses".to_owned(),
+                object: "Rust".to_owned(),
+                confidence: 0.9,
+                is_correction: false,
+                fact_type: None,
+            },
+            ExtractedFact {
+                subject: "Alice".to_owned(),
+                predicate: "   ".to_owned(),
+                object: "Rust".to_owned(),
+                confidence: 0.9,
+                is_correction: false,
+                fact_type: None,
+            },
+            ExtractedFact {
+                subject: "Alice".to_owned(),
+                predicate: "uses".to_owned(),
+                object: String::new(),
+                confidence: 0.9,
+                is_correction: false,
+                fact_type: None,
+            },
+            ExtractedFact {
+                subject: "Alice".to_owned(),
+                predicate: "uses".to_owned(),
+                object: "Rust".to_owned(),
+                confidence: 0.9,
+                is_correction: false,
+                fact_type: None,
+            },
+        ],
+    };
+
+    let result = engine
+        .persist(&extraction, &store, "session:test", "syn")
+        .expect("persist should succeed, skipping facts with empty fields");
+    assert_eq!(
+        result.facts_inserted, 1,
+        "only the fact with all non-empty fields should be inserted"
     );
 }
 

--- a/crates/episteme/src/extract/utils.rs
+++ b/crates/episteme/src/extract/utils.rs
@@ -1,10 +1,25 @@
 /// Strip markdown code fences from an LLM response.
+///
+/// If the response starts with a code fence but the closing fence is missing,
+/// the opening fence marker is still stripped and a warning is logged. Without
+/// this, the fence marker would be included in the JSON string, causing a parse
+/// error with no clear root cause.
 pub(super) fn strip_code_fences(s: &str) -> &str {
     let trimmed = s.trim();
     if let Some(rest) = trimmed.strip_prefix("```json") {
-        rest.strip_suffix("```").unwrap_or(rest).trim()
+        if let Some(stripped) = rest.strip_suffix("```") {
+            stripped.trim()
+        } else {
+            tracing::warn!("LLM response has opening ```json fence but no closing ```, stripping opening fence only");
+            rest.trim()
+        }
     } else if let Some(rest) = trimmed.strip_prefix("```") {
-        rest.strip_suffix("```").unwrap_or(rest).trim()
+        if let Some(stripped) = rest.strip_suffix("```") {
+            stripped.trim()
+        } else {
+            tracing::warn!("LLM response has opening ``` fence but no closing ```, stripping opening fence only");
+            rest.trim()
+        }
     } else {
         trimmed
     }

--- a/crates/episteme/src/skill.rs
+++ b/crates/episteme/src/skill.rs
@@ -9,17 +9,30 @@
 use serde::{Deserialize, Serialize};
 
 /// Decay score thresholds for skill lifecycle management.
+///
+/// These are compile-time defaults. Callers should prefer the values from
+/// `taxis::config::KnowledgeConfig::skill_decay_*` fields when available.
 #[cfg(any(feature = "mneme-engine", test))]
 pub(crate) mod decay {
     /// Skills below this score are flagged for review.
+    ///
+    /// Callers should prefer `taxis::config::KnowledgeConfig::skill_decay_needs_review_threshold`.
     pub(crate) const NEEDS_REVIEW_THRESHOLD: f64 = 0.3;
     /// Skills below this score are auto-retired.
+    ///
+    /// Callers should prefer `taxis::config::KnowledgeConfig::skill_decay_retire_threshold`.
     pub(crate) const RETIRE_THRESHOLD: f64 = 0.08;
     /// Default days of inactivity before decay reaches review threshold for low-usage skills.
+    ///
+    /// Callers should prefer `taxis::config::KnowledgeConfig::skill_decay_stale_days`.
     pub(crate) const DEFAULT_STALE_DAYS: u32 = 28;
     /// Usage count above which a skill is considered "high-usage" and decays 3× slower.
+    ///
+    /// Callers should prefer `taxis::config::KnowledgeConfig::skill_decay_high_usage_threshold`.
     pub(crate) const HIGH_USAGE_THRESHOLD: u32 = 10;
     /// Multiplier applied to decay half-life for high-usage skills.
+    ///
+    /// Callers should prefer `taxis::config::KnowledgeConfig::skill_decay_high_usage_factor`.
     pub(crate) const HIGH_USAGE_DECAY_FACTOR: f64 = 3.0;
 }
 

--- a/crates/taxis/src/config/behavior.rs
+++ b/crates/taxis/src/config/behavior.rs
@@ -235,6 +235,27 @@ pub struct KnowledgeConfig {
     /// Default maximum cache entries for side-query. Default: 64.
     /// Mirrors `episteme::side_query::DEFAULT_CACHE_CAPACITY`.
     pub side_query_cache_capacity: usize,
+    /// Decay score below which a skill is flagged for review. Default: 0.3.
+    /// Mirrors `episteme::skill::decay::NEEDS_REVIEW_THRESHOLD`.
+    pub skill_decay_needs_review_threshold: f64,
+    /// Decay score below which a skill is auto-retired. Default: 0.08.
+    /// Mirrors `episteme::skill::decay::RETIRE_THRESHOLD`.
+    pub skill_decay_retire_threshold: f64,
+    /// Days of inactivity before decay reaches review threshold (low-usage skills). Default: 28.
+    /// Mirrors `episteme::skill::decay::DEFAULT_STALE_DAYS`.
+    pub skill_decay_stale_days: u32,
+    /// Usage count above which a skill decays slower. Default: 10.
+    /// Mirrors `episteme::skill::decay::HIGH_USAGE_THRESHOLD`.
+    pub skill_decay_high_usage_threshold: u32,
+    /// Multiplier applied to decay half-life for high-usage skills. Default: 3.0.
+    /// Mirrors `episteme::skill::decay::HIGH_USAGE_DECAY_FACTOR`.
+    pub skill_decay_high_usage_factor: f64,
+    /// Surprise threshold (nats) for episode boundary detection. Default: 2.0.
+    /// Mirrors `episteme::surprise::DEFAULT_THRESHOLD`.
+    pub surprise_threshold: f64,
+    /// EMA alpha for surprise baseline adaptation. Default: 0.3.
+    /// Mirrors `episteme::surprise::DEFAULT_EMA_ALPHA`.
+    pub surprise_ema_alpha: f64,
 }
 
 impl Default for KnowledgeConfig {
@@ -257,6 +278,13 @@ impl Default for KnowledgeConfig {
             side_query_max_results: 5,
             side_query_cache_ttl_secs: 300,
             side_query_cache_capacity: 64,
+            skill_decay_needs_review_threshold: 0.3,
+            skill_decay_retire_threshold: 0.08,
+            skill_decay_stale_days: 28,
+            skill_decay_high_usage_threshold: 10,
+            skill_decay_high_usage_factor: 3.0,
+            surprise_threshold: 2.0,
+            surprise_ema_alpha: 0.3,
         }
     }
 }


### PR DESCRIPTION
## Summary

- **#3303**: Reject extracted facts with empty/whitespace subject, predicate, or object at both the refinement pipeline and persist layers. Add confidence inflation detection (warn when >80% of facts have confidence >= 0.95). Reject entities with empty names during persist.
- **#3304**: Migrate skill decay (5 constants) and surprise (2 constants) defaults to `taxis::KnowledgeConfig`. Document causal cue patterns as domain knowledge (not behavioral tuning — stays compile-time).
- **#3305**: Include first 500 chars of raw LLM response in `ParseResponse` error. Log warn on unrecognized conflict classification responses. Log warn on unclosed code fences.
- **#3307**: Log warning with raw value when `i64_as_usize` encounters a negative count (data corruption indicator). Still defaults to 0 for operational continuity.

## Test plan

- [x] `cargo check -p episteme` — zero errors
- [x] `cargo test -p episteme` — 877 tests pass (including 11 new tests)
- [x] `cargo clippy -p episteme` — zero warnings
- [x] `cargo check -p taxis` / `cargo clippy -p taxis` — zero errors/warnings
- [x] Proptest regression (unicode char boundary) fixed with `chars().take(500)` instead of byte slicing