### PR TITLE
fix(hermeneus,melete): bound subprocess output, fix flush sections, cross-platform locks (#3324, #3325, #3333, #3334)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "koina",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "koina",
  "organon",
@@ -1931,7 +1931,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "eidos"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "serde",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "eidos",
  "fjall",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -2822,7 +2822,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "dokimion",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -3970,13 +3970,14 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "fd-lock",
  "futures",
  "hermeneus",
  "jiff",
  "koina",
+ "libc",
  "prometheus",
  "serde",
  "serde_json",
@@ -4063,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -4199,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "dianoia",
@@ -4395,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "episteme",
@@ -4506,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "energeia",
@@ -4861,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "snafu",
@@ -4869,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "poiesis-core",
  "rust_xlsxwriter",
@@ -4879,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "poiesis-core",
  "ppt-rs",
@@ -4888,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "krilla",
  "poiesis-core",
@@ -5289,7 +5290,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -6621,7 +6622,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "compact_str",
@@ -6876,7 +6877,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -6989,7 +6990,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -7101,14 +7102,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,8 @@ regex = { version = "1", default-features = false, features = ["std", "perf", "u
 # Database
 rusqlite = { version = "0.38", features = ["bundled"] }
 
-# FFI
+# FFI / System
+libc = { version = "0.2", default-features = false }
 rustix = { version = "1", default-features = false, features = [
     "fs",
     "mm",

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -299,7 +299,8 @@ impl AnthropicProvider {
 
         let request = &self.maybe_prepend_oauth_identity(request);
         let attribution = self.compute_attribution(request);
-        let wire = WireRequest::from_request(request, Some(true), attribution.as_deref());
+        let wire = WireRequest::from_request(request, Some(true), attribution.as_deref())
+            .context(error::ParseResponseSnafu)?;
         let body = serde_json::to_string(&wire).context(error::ParseResponseSnafu)?;
 
         let mut last_error = None;
@@ -729,7 +730,8 @@ impl AnthropicProvider {
         // models are available. This matches what Claude Code itself sends.
         let request = &self.maybe_prepend_oauth_identity(request);
         let attribution = self.compute_attribution(request);
-        let wire = WireRequest::from_request(request, None, attribution.as_deref());
+        let wire = WireRequest::from_request(request, None, attribution.as_deref())
+            .context(error::ParseResponseSnafu)?;
         let body = serde_json::to_string(&wire).context(error::ParseResponseSnafu)?;
 
         let mut last_error = None;

--- a/crates/hermeneus/src/anthropic/wire/mod.rs
+++ b/crates/hermeneus/src/anthropic/wire/mod.rs
@@ -47,34 +47,34 @@ pub(super) fn compute_turn_cache_indices(messages: &[&crate::types::Message]) ->
 ///
 /// For `Content::Text`, wraps as a single-element block array.
 /// For `Content::Blocks`, clones and injects `cache_control` on the final block.
-pub(super) fn content_with_cache_control(content: &Content) -> serde_json::Value {
+///
+/// # Errors
+///
+/// Returns `serde_json::Error` if any content block fails to serialize.
+/// WHY: Silent `unwrap_or_default()` or `filter_map(ok())` would produce
+/// `Value::Null` or silently drop blocks, corrupting the API request.
+pub(super) fn content_with_cache_control(
+    content: &Content,
+) -> Result<serde_json::Value, serde_json::Error> {
     let cc = serde_json::json!({"type": "ephemeral"});
 
     match content {
-        Content::Text(text) => {
-            serde_json::json!([{
-                "type": "text",
-                "text": text,
-                "cache_control": cc
-            }])
-        }
+        Content::Text(text) => Ok(serde_json::json!([{
+            "type": "text",
+            "text": text,
+            "cache_control": cc
+        }])),
         Content::Blocks(blocks) => {
             let mut arr: Vec<serde_json::Value> = blocks
                 .iter()
-                .filter_map(|b| {
-                    serde_json::to_value(b)
-                        .inspect_err(|e| {
-                            tracing::warn!(error = %e, "content block serialization failed, dropping block");
-                        })
-                        .ok()
-                })
-                .collect();
+                .map(serde_json::to_value)
+                .collect::<Result<Vec<_>, _>>()?;
             if let Some(last) = arr.last_mut()
                 && let Some(obj) = last.as_object_mut()
             {
                 obj.insert(String::from("cache_control"), cc);
             }
-            serde_json::Value::Array(arr)
+            Ok(serde_json::Value::Array(arr))
         }
     }
 }

--- a/crates/hermeneus/src/anthropic/wire/request.rs
+++ b/crates/hermeneus/src/anthropic/wire/request.rs
@@ -101,11 +101,16 @@ impl<'a> WireRequest<'a> {
     /// prompt. When present, the system prompt is always sent as an array of
     /// text blocks (matching CC format). The attribution block intentionally
     /// omits `cache_control` since it contains a per-conversation fingerprint.
+    ///
+    /// # Errors
+    ///
+    /// Returns `serde_json::Error` if any content block fails to serialize
+    /// during cache control injection.
     pub(crate) fn from_request(
         req: &'a CompletionRequest,
         stream: Option<bool>,
         attribution: Option<&str>,
-    ) -> Self {
+    ) -> Result<Self, serde_json::Error> {
         // WHY: Anthropic API requires system prompt as a top-level field, not in messages.
         let system_text = req.system.clone().or_else(|| {
             let system_texts: Vec<&str> = req
@@ -177,16 +182,16 @@ impl<'a> WireRequest<'a> {
             .enumerate()
             .map(|(i, m)| {
                 let content = if cached_indices.contains(&i) {
-                    WireContent::WithCacheControl(content_with_cache_control(&m.content))
+                    WireContent::WithCacheControl(content_with_cache_control(&m.content)?)
                 } else {
                     WireContent::Borrowed(&m.content)
                 };
-                WireMessage {
+                Ok(WireMessage {
                     role: m.role.as_str(),
                     content,
-                }
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, serde_json::Error>>()?;
 
         let user_tool_count = req.tools.len();
         let mut tools: Vec<WireToolEntry<'a>> = req
@@ -230,7 +235,7 @@ impl<'a> WireRequest<'a> {
 
         let stop_sequences: Vec<&str> = req.stop_sequences.iter().map(String::as_str).collect();
 
-        Self {
+        Ok(Self {
             model: &req.model,
             max_tokens: req.max_tokens,
             messages,
@@ -243,7 +248,7 @@ impl<'a> WireRequest<'a> {
             tool_choice: req.tool_choice.as_ref(),
             metadata: req.metadata.as_ref(),
             citations: req.citations.as_ref(),
-        }
+        })
     }
 }
 

--- a/crates/hermeneus/src/anthropic/wire/tests.rs
+++ b/crates/hermeneus/src/anthropic/wire/tests.rs
@@ -101,7 +101,7 @@ fn wire_request_extracts_system_prompt() {
         stop_sequences: vec![],
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     assert_eq!(
         wire.system,
         Some(serde_json::Value::String("You are helpful.".to_owned()))
@@ -132,7 +132,7 @@ fn wire_request_extracts_system_from_messages() {
         stop_sequences: vec![],
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     assert_eq!(
         wire.system,
         Some(serde_json::Value::String("Be concise.".to_owned()))
@@ -160,7 +160,7 @@ fn wire_request_serializes_thinking_config() {
         stop_sequences: vec![],
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let thinking = json.get("thinking").unwrap();
     assert_eq!(thinking["type"], "enabled");
@@ -194,7 +194,7 @@ fn wire_request_serializes_tools() {
         stop_sequences: vec![],
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let tools = json["tools"].as_array().unwrap();
     assert_eq!(tools.len(), 1);
@@ -258,7 +258,7 @@ fn wire_request_cache_system_serializes_as_array() {
         cache_system: true,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let system = json["system"].as_array().unwrap();
     assert_eq!(system.len(), 1);
@@ -293,7 +293,7 @@ fn wire_request_cache_tools_on_last_tool() {
         cache_tools: true,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let tools = json["tools"].as_array().unwrap();
     assert!(tools[0].get("cache_control").is_none());
@@ -312,7 +312,7 @@ fn wire_request_tool_choice_auto() {
         tool_choice: Some(crate::types::ToolChoice::Auto),
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     assert_eq!(json["tool_choice"]["type"], "auto");
 }
@@ -331,7 +331,7 @@ fn wire_request_tool_choice_specific_tool() {
         }),
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     assert_eq!(json["tool_choice"]["type"], "tool");
     assert_eq!(json["tool_choice"]["name"], "exec");
@@ -348,7 +348,7 @@ fn wire_request_tool_choice_none_omitted() {
         max_tokens: 1024,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     assert!(json.get("tool_choice").is_none());
 }
@@ -367,7 +367,7 @@ fn wire_request_metadata_serialized() {
         }),
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     assert_eq!(json["metadata"]["user_id"], "nous:syn:main");
 }
@@ -384,7 +384,7 @@ fn wire_request_citations_serialized() {
         citations: Some(crate::types::CitationConfig { enabled: true }),
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     assert_eq!(json["citations"]["enabled"], true);
 }
@@ -463,7 +463,7 @@ fn wire_request_mixed_user_and_server_tools() {
         }],
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let tools = json["tools"].as_array().unwrap();
     assert_eq!(tools.len(), 2);
@@ -563,7 +563,7 @@ fn wire_request_cache_tools_only_on_user_tools() {
         cache_tools: true,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let tools = json["tools"].as_array().unwrap();
     assert_eq!(tools[0]["cache_control"]["type"], "ephemeral");

--- a/crates/hermeneus/src/anthropic/wire/tests_extended.rs
+++ b/crates/hermeneus/src/anthropic/wire/tests_extended.rs
@@ -97,7 +97,7 @@ fn wire_request_code_execution_server_tool() {
         }],
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let tools = json["tools"].as_array().unwrap();
     assert_eq!(tools.len(), 1, "should have one server tool");
@@ -123,7 +123,7 @@ fn wire_request_no_cache_system_is_string() {
         max_tokens: 1024,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     assert!(
         json["system"].is_string(),
@@ -154,7 +154,7 @@ fn cache_turns_marks_text_content_as_blocks() {
         cache_turns: true,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let msgs = json["messages"].as_array().unwrap();
     let first_content = &msgs[0]["content"];
@@ -192,7 +192,7 @@ fn cache_turns_disabled_leaves_content_unchanged() {
         cache_turns: false,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let msgs = json["messages"].as_array().unwrap();
     for msg in msgs {
@@ -215,7 +215,7 @@ fn cache_turns_single_message_no_breakpoints() {
         cache_turns: true,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let msgs = json["messages"].as_array().unwrap();
     assert!(
@@ -262,7 +262,7 @@ fn cache_turns_multi_turn_marks_recent_user_messages() {
         cache_turns: true,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let msgs = json["messages"].as_array().unwrap();
 
@@ -318,7 +318,7 @@ fn cache_turns_with_block_content() {
         cache_turns: true,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let msgs = json["messages"].as_array().unwrap();
 
@@ -356,7 +356,7 @@ fn cache_turns_never_marks_current_message() {
         cache_turns: true,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let msgs = json["messages"].as_array().unwrap();
     assert!(
@@ -560,7 +560,7 @@ fn wire_usage_cache_tokens_parsed() {
 #[test]
 fn content_with_cache_control_text() {
     let content = Content::Text("hello".to_owned());
-    let value = content_with_cache_control(&content);
+    let value = content_with_cache_control(&content).unwrap();
     let arr = value.as_array().unwrap();
     assert_eq!(arr.len(), 1, "text content should produce single block");
     assert_eq!(arr[0]["type"], "text", "block type should be text");
@@ -583,7 +583,7 @@ fn content_with_cache_control_blocks() {
             citations: None,
         },
     ]);
-    let value = content_with_cache_control(&content);
+    let value = content_with_cache_control(&content).unwrap();
     let arr = value.as_array().unwrap();
     assert_eq!(arr.len(), 2, "blocks content should preserve block count");
     assert!(
@@ -627,7 +627,7 @@ fn cache_turns_combined_with_system_and_tools() {
         cache_turns: true,
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     assert_eq!(
         json["system"][0]["cache_control"]["type"], "ephemeral",
@@ -690,7 +690,7 @@ fn wire_request_disable_passthrough_serialized() {
         }],
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let tools = json["tools"].as_array().unwrap();
     assert_eq!(
@@ -716,7 +716,7 @@ fn wire_request_disable_passthrough_none_omitted() {
         }],
         ..Default::default()
     };
-    let wire = WireRequest::from_request(&req, None, None);
+    let wire = WireRequest::from_request(&req, None, None).unwrap();
     let json = serde_json::to_value(&wire).unwrap();
     let tools = json["tools"].as_array().unwrap();
     assert!(

--- a/crates/hermeneus/src/cc/process.rs
+++ b/crates/hermeneus/src/cc/process.rs
@@ -16,6 +16,26 @@ use crate::error::{self, Result};
 
 use super::parse::{self, CcEvent};
 
+/// Maximum total bytes of collected stream deltas before aborting.
+///
+/// WHY: Unbounded delta collection is an OOM risk if CC outputs unexpectedly
+/// large content (e.g., tool dumps a huge file, runaway LLM response).
+/// 10 MB is generous for any legitimate completion while preventing OOM.
+const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024; // 10 MB
+
+/// Maximum total number of stream delta lines before aborting.
+///
+/// WHY: Secondary guard alongside byte limit. A runaway subprocess could
+/// emit many small lines that individually pass no single-line check.
+const MAX_OUTPUT_LINES: usize = 100_000;
+
+/// Maximum length of a system prompt passed to the CC subprocess.
+///
+/// WHY: The system prompt is passed as a command-line argument. An
+/// excessively large prompt could exhaust argument space or cause the
+/// subprocess to consume excessive memory during parsing.
+const MAX_SYSTEM_PROMPT_BYTES: usize = 100 * 1024; // 100 KB
+
 /// Extract the OAuth access token from the raw JSON content of a CC credentials file.
 ///
 /// Separated from I/O so it can be unit-tested without touching the real filesystem
@@ -127,6 +147,15 @@ pub(crate) async fn run_completion(
         .env_remove("CLAUDE_CODE_OAUTH_TOKEN");
 
     if let Some(sys) = system_prompt {
+        if sys.len() > MAX_SYSTEM_PROMPT_BYTES {
+            return Err(error::ApiRequestSnafu {
+                message: format!(
+                    "system prompt exceeds maximum size ({} bytes > {MAX_SYSTEM_PROMPT_BYTES} byte limit)",
+                    sys.len(),
+                ),
+            }
+            .build());
+        }
         cmd.arg("--system-prompt").arg(sys);
     }
 
@@ -234,6 +263,7 @@ where
     let mut lines = reader.lines();
 
     let mut stream_deltas = Vec::new();
+    let mut total_bytes: usize = 0;
     let mut result_text = String::new();
     let mut is_error = false;
     let mut usage = None;
@@ -255,6 +285,23 @@ where
         match event {
             CcEvent::Assistant { message } => {
                 if !message.text.is_empty() {
+                    total_bytes = total_bytes.saturating_add(message.text.len());
+                    if total_bytes > MAX_OUTPUT_BYTES {
+                        return Err(error::ApiRequestSnafu {
+                            message: format!(
+                                "CC subprocess output exceeds {MAX_OUTPUT_BYTES} byte limit (collected {total_bytes} bytes)"
+                            ),
+                        }
+                        .build());
+                    }
+                    if stream_deltas.len() >= MAX_OUTPUT_LINES {
+                        return Err(error::ApiRequestSnafu {
+                            message: format!(
+                                "CC subprocess output exceeds {MAX_OUTPUT_LINES} line limit"
+                            ),
+                        }
+                        .build());
+                    }
                     stream_deltas.push(message.text);
                 }
             }
@@ -349,6 +396,15 @@ pub(crate) async fn run_streaming(
     }
 
     if let Some(sys) = system_prompt {
+        if sys.len() > MAX_SYSTEM_PROMPT_BYTES {
+            return Err(error::ApiRequestSnafu {
+                message: format!(
+                    "system prompt exceeds maximum size ({} bytes > {MAX_SYSTEM_PROMPT_BYTES} byte limit)",
+                    sys.len(),
+                ),
+            }
+            .build());
+        }
         cmd.arg("--system-prompt").arg(sys);
     }
 
@@ -426,6 +482,7 @@ where
     let mut lines = reader.lines();
 
     let mut stream_deltas = Vec::new();
+    let mut total_bytes: usize = 0;
     let mut result_text = String::new();
     let mut is_error = false;
     let mut usage = None;
@@ -447,6 +504,23 @@ where
         match event {
             CcEvent::Assistant { message } => {
                 if !message.text.is_empty() {
+                    total_bytes = total_bytes.saturating_add(message.text.len());
+                    if total_bytes > MAX_OUTPUT_BYTES {
+                        return Err(error::ApiRequestSnafu {
+                            message: format!(
+                                "CC subprocess output exceeds {MAX_OUTPUT_BYTES} byte limit (collected {total_bytes} bytes)"
+                            ),
+                        }
+                        .build());
+                    }
+                    if stream_deltas.len() >= MAX_OUTPUT_LINES {
+                        return Err(error::ApiRequestSnafu {
+                            message: format!(
+                                "CC subprocess output exceeds {MAX_OUTPUT_LINES} line limit"
+                            ),
+                        }
+                        .build());
+                    }
                     on_delta(&message.text);
                     stream_deltas.push(message.text);
                 }

--- a/crates/hermeneus/src/cc/process_tests.rs
+++ b/crates/hermeneus/src/cc/process_tests.rs
@@ -467,3 +467,107 @@ async fn run_streaming_timeout_returns_error() {
     );
     let _ = fs::remove_file(&script);
 }
+
+// ── output size limits (#3324) ───────────────────────────────────────────
+
+#[tokio::test]
+async fn read_stream_rejects_oversized_output_by_bytes() {
+    // WHY: A CC subprocess that outputs more than MAX_OUTPUT_BYTES must be
+    // rejected with a clear error, not allowed to grow unbounded to OOM.
+    let big_text = "x".repeat(MAX_OUTPUT_BYTES + 1);
+    let event = format!(
+        r#"{{"type":"assistant","message":{{"type":"text","text":"{}"}}}}"#,
+        big_text
+    );
+    let buf = stream_buf(&[&event]);
+    let err = read_stream(buf.as_slice()).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("byte limit"),
+        "error should mention byte limit, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn read_stream_with_callback_rejects_oversized_output() {
+    // WHY: The streaming variant must enforce the same size limits.
+    let big_text = "x".repeat(MAX_OUTPUT_BYTES + 1);
+    let event = format!(
+        r#"{{"type":"assistant","message":{{"type":"text","text":"{}"}}}}"#,
+        big_text
+    );
+    let buf = stream_buf(&[&event]);
+    let mut on_delta = |_: &str| {};
+    let err = read_stream_with_callback(buf.as_slice(), &mut on_delta)
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("byte limit"),
+        "error should mention byte limit, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn read_stream_accepts_output_within_limits() {
+    // WHY: Output within the byte limit must succeed normally.
+    let text = "x".repeat(1000);
+    let event = format!(
+        r#"{{"type":"assistant","message":{{"type":"text","text":"{}"}}}}"#,
+        text
+    );
+    let result_event = format!(
+        r#"{{"type":"result","subtype":"success","result":"{}","is_error":false}}"#,
+        text
+    );
+    let buf = stream_buf(&[&event, &result_event]);
+    let output = read_stream(buf.as_slice()).await.unwrap();
+    assert_eq!(output.result_text, text);
+}
+
+#[tokio::test]
+async fn run_completion_rejects_oversized_system_prompt() {
+    // WHY: A system prompt exceeding MAX_SYSTEM_PROMPT_BYTES must be
+    // rejected before spawning the subprocess.
+    let big_prompt = "x".repeat(MAX_SYSTEM_PROMPT_BYTES + 1);
+    let binary = PathBuf::from("/bin/echo"); // won't be reached
+    let err = run_completion(
+        &binary,
+        "test-model",
+        Some(&big_prompt),
+        "hello",
+        1024,
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("system prompt exceeds maximum size"),
+        "error should mention system prompt size, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn run_streaming_rejects_oversized_system_prompt() {
+    // WHY: The streaming variant must enforce the same system prompt limit.
+    let big_prompt = "x".repeat(MAX_SYSTEM_PROMPT_BYTES + 1);
+    let binary = PathBuf::from("/bin/echo");
+    let mut on_delta = |_: &str| {};
+    let err = run_streaming(
+        &binary,
+        "test-model",
+        Some(&big_prompt),
+        "hello",
+        1024,
+        Duration::from_secs(5),
+        &mut on_delta,
+    )
+    .await
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("system prompt exceeds maximum size"),
+        "error should mention system prompt size, got: {msg}"
+    );
+}

--- a/crates/melete/Cargo.toml
+++ b/crates/melete/Cargo.toml
@@ -27,6 +27,9 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 jiff = { workspace = true }
 
+[target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 hermeneus = { path = "../hermeneus", features = ["test-utils"] }
 tempfile = { workspace = true }

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -628,12 +628,16 @@ fn extract_summary_text(content: &[hermeneus::types::ContentBlock]) -> String {
 
 /// Parse a distillation summary into structured memory items.
 ///
-/// Extracts key decisions, corrections, and task context from the markdown
-/// sections of the summary, populating a [`MemoryFlush`] for the caller to
-/// persist to long-term storage.
+/// Extracts all 7 standard section types from the markdown summary,
+/// populating a [`MemoryFlush`] for the caller to persist to long-term
+/// storage. Key Decisions and Corrections get their own dedicated fields;
+/// all other sections (Summary, Task Context, Completed Work, Current State,
+/// Open Threads) are stored as facts to prevent information loss across
+/// distillation boundaries.
 fn parse_summary_to_flush(summary: &str, timestamp: &str) -> MemoryFlush {
     let mut decisions: Vec<FlushItem> = Vec::new();
     let mut corrections: Vec<FlushItem> = Vec::new();
+    let mut facts: Vec<FlushItem> = Vec::new();
     let mut task_state: Option<String> = None;
     let mut current_section = "";
     let mut section_lines: Vec<&str> = Vec::new();
@@ -646,6 +650,7 @@ fn parse_summary_to_flush(summary: &str, timestamp: &str) -> MemoryFlush {
                 timestamp,
                 &mut decisions,
                 &mut corrections,
+                &mut facts,
                 &mut task_state,
             );
             current_section = heading.trim();
@@ -660,24 +665,42 @@ fn parse_summary_to_flush(summary: &str, timestamp: &str) -> MemoryFlush {
         timestamp,
         &mut decisions,
         &mut corrections,
+        &mut facts,
         &mut task_state,
     );
 
     MemoryFlush {
         decisions,
         corrections,
-        facts: vec![],
+        facts,
         task_state,
     }
 }
 
+/// Extract bullet items from section content lines.
+///
+/// Strips leading `-` markers and trims whitespace. Skips empty lines.
+fn extract_bullet_items<'a>(content: &[&'a str]) -> Vec<&'a str> {
+    content
+        .iter()
+        .copied()
+        .map(|l| l.trim_start_matches('-').trim())
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
 /// Process one markdown section of a distillation summary into flush items.
+///
+/// WHY: All 7 standard sections are extracted. Previously only 3 were handled,
+/// permanently losing Completed Work, Current State, Open Threads, and Summary
+/// across distillation boundaries.
 fn collect_flush_section(
     section: &str,
     lines: &[&str],
     timestamp: &str,
     decisions: &mut Vec<FlushItem>,
     corrections: &mut Vec<FlushItem>,
+    facts: &mut Vec<FlushItem>,
     task_state: &mut Option<String>,
 ) {
     let content: Vec<&str> = lines
@@ -690,34 +713,69 @@ fn collect_flush_section(
     }
     match section {
         "Key Decisions" => {
-            for &line in &content {
-                let text = line.trim_start_matches('-').trim();
-                if !text.is_empty() {
-                    decisions.push(FlushItem {
-                        content: text.to_owned(),
-                        timestamp: timestamp.to_owned(),
-                        source: FlushSource::Extracted,
-                    });
-                }
+            for text in extract_bullet_items(&content) {
+                decisions.push(FlushItem {
+                    content: text.to_owned(),
+                    timestamp: timestamp.to_owned(),
+                    source: FlushSource::Extracted,
+                });
             }
         }
         "Corrections" => {
-            for &line in &content {
-                let text = line.trim_start_matches('-').trim();
-                if !text.is_empty() {
-                    corrections.push(FlushItem {
-                        content: text.to_owned(),
-                        timestamp: timestamp.to_owned(),
-                        source: FlushSource::Extracted,
-                    });
-                }
+            for text in extract_bullet_items(&content) {
+                corrections.push(FlushItem {
+                    content: text.to_owned(),
+                    timestamp: timestamp.to_owned(),
+                    source: FlushSource::Extracted,
+                });
             }
         }
         "Task Context" => {
             *task_state = Some(content.join("\n"));
         }
+        "Summary" => {
+            // WHY: The one-sentence overview is a high-level fact for recall.
+            let text = content.join(" ");
+            facts.push(FlushItem {
+                content: format!("[Summary] {text}"),
+                timestamp: timestamp.to_owned(),
+                source: FlushSource::Extracted,
+            });
+        }
+        "Completed Work" => {
+            // WHY: Each completed work item becomes a fact so future sessions
+            // know what was already done without re-discovering from narrative.
+            for text in extract_bullet_items(&content) {
+                facts.push(FlushItem {
+                    content: format!("[Completed] {text}"),
+                    timestamp: timestamp.to_owned(),
+                    source: FlushSource::Extracted,
+                });
+            }
+        }
+        "Current State" => {
+            // WHY: Task status snapshot persists as a fact so future sessions
+            // can resume without rediscovering where things stand.
+            let text = content.join("\n");
+            facts.push(FlushItem {
+                content: format!("[State] {text}"),
+                timestamp: timestamp.to_owned(),
+                source: FlushSource::Extracted,
+            });
+        }
+        "Open Threads" => {
+            // WHY: Unfinished items persist as facts so future sessions can
+            // resume them instead of losing deferred work.
+            for text in extract_bullet_items(&content) {
+                facts.push(FlushItem {
+                    content: format!("[Open] {text}"),
+                    timestamp: timestamp.to_owned(),
+                    source: FlushSource::Extracted,
+                });
+            }
+        }
         _ => {
-            // NOTE: unrecognized sections are not extracted
+            // NOTE: unrecognized/custom sections are not extracted
         }
     }
 }

--- a/crates/melete/src/distill_tests/extraction_integration/context_parse.rs
+++ b/crates/melete/src/distill_tests/extraction_integration/context_parse.rs
@@ -349,3 +349,170 @@ fn parse_summary_flush_source_is_extracted() {
         "extracted decision source should be FlushSource::Extracted"
     );
 }
+
+// ── flush extraction for all 7 sections (#3333) ─────────────────────────
+
+#[test]
+fn parse_summary_extracts_summary_section_as_fact() {
+    let summary = "\
+## Summary
+Fixed login bug in auth module.
+
+## Key Decisions
+- Use null check.
+";
+    let flush = parse_summary_to_flush(summary, "2026-04-15T00:00:00Z");
+    assert!(
+        flush.facts.iter().any(|f| f.content.contains("[Summary]")),
+        "Summary section should be extracted as a fact with [Summary] prefix"
+    );
+    assert!(
+        flush.facts.iter().any(|f| f.content.contains("login bug")),
+        "Summary fact should contain the summary text"
+    );
+}
+
+#[test]
+fn parse_summary_extracts_completed_work_items_as_facts() {
+    let summary = "\
+## Summary
+Auth work.
+
+## Completed Work
+- Fixed null check on line 42 of src/auth/login.rs
+- Added regression test for the fix
+";
+    let flush = parse_summary_to_flush(summary, "2026-04-15T00:00:00Z");
+    let completed_facts: Vec<_> = flush
+        .facts
+        .iter()
+        .filter(|f| f.content.starts_with("[Completed]"))
+        .collect();
+    assert_eq!(
+        completed_facts.len(),
+        2,
+        "should extract 2 Completed Work items as facts"
+    );
+    assert!(
+        completed_facts.iter().any(|f| f.content.contains("null check")),
+        "first completed work fact should mention null check"
+    );
+    assert!(
+        completed_facts.iter().any(|f| f.content.contains("regression test")),
+        "second completed work fact should mention regression test"
+    );
+}
+
+#[test]
+fn parse_summary_extracts_current_state_as_fact() {
+    let summary = "\
+## Summary
+Auth work.
+
+## Current State
+Bug is fixed, test passes. Awaiting code review.
+";
+    let flush = parse_summary_to_flush(summary, "2026-04-15T00:00:00Z");
+    let state_facts: Vec<_> = flush
+        .facts
+        .iter()
+        .filter(|f| f.content.starts_with("[State]"))
+        .collect();
+    assert_eq!(
+        state_facts.len(),
+        1,
+        "Current State section should produce exactly 1 state fact"
+    );
+    assert!(
+        state_facts[0].content.contains("Bug is fixed"),
+        "state fact should contain the current state text"
+    );
+}
+
+#[test]
+fn parse_summary_extracts_open_threads_as_facts() {
+    let summary = "\
+## Summary
+Auth work.
+
+## Open Threads
+- Investigate performance regression in session handler
+- Update documentation for new auth flow
+";
+    let flush = parse_summary_to_flush(summary, "2026-04-15T00:00:00Z");
+    let open_facts: Vec<_> = flush
+        .facts
+        .iter()
+        .filter(|f| f.content.starts_with("[Open]"))
+        .collect();
+    assert_eq!(
+        open_facts.len(),
+        2,
+        "should extract 2 Open Threads items as facts"
+    );
+    assert!(
+        open_facts.iter().any(|f| f.content.contains("performance regression")),
+        "first open thread fact should mention performance regression"
+    );
+}
+
+#[test]
+fn parse_summary_extracts_all_seven_sections() {
+    // WHY: End-to-end test that all 7 section types produce output.
+    let flush = parse_summary_to_flush(MOCK_SUMMARY, "2026-04-15T00:00:00Z");
+
+    // Decisions from "Key Decisions"
+    assert!(
+        !flush.decisions.is_empty(),
+        "Key Decisions section should produce decision items"
+    );
+
+    // Corrections from "Corrections"
+    assert!(
+        !flush.corrections.is_empty(),
+        "Corrections section should produce correction items"
+    );
+
+    // Task state from "Task Context"
+    assert!(
+        flush.task_state.is_some(),
+        "Task Context section should populate task_state"
+    );
+
+    // Facts from Summary, Completed Work, Current State, Open Threads
+    assert!(
+        flush.facts.iter().any(|f| f.content.starts_with("[Summary]")),
+        "Summary section should produce a [Summary] fact"
+    );
+    assert!(
+        flush.facts.iter().any(|f| f.content.starts_with("[Completed]")),
+        "Completed Work section should produce [Completed] facts"
+    );
+    assert!(
+        flush.facts.iter().any(|f| f.content.starts_with("[State]")),
+        "Current State section should produce a [State] fact"
+    );
+    // NOTE: MOCK_SUMMARY has "- None" for Open Threads, which produces a fact
+    assert!(
+        flush.facts.iter().any(|f| f.content.starts_with("[Open]")),
+        "Open Threads section should produce [Open] facts"
+    );
+}
+
+#[test]
+fn parse_summary_empty_sections_produce_no_facts() {
+    let summary = "\
+## Summary
+
+## Completed Work
+
+## Current State
+
+## Open Threads
+";
+    let flush = parse_summary_to_flush(summary, "2026-04-15T00:00:00Z");
+    assert!(
+        flush.facts.is_empty(),
+        "empty sections should produce no facts"
+    );
+}

--- a/crates/melete/src/dream/lock.rs
+++ b/crates/melete/src/dream/lock.rs
@@ -235,16 +235,53 @@ fn read_pid(path: &Path) -> Option<u32> {
 }
 
 /// Check whether a PID corresponds to a running process.
+///
+/// Uses `/proc/{pid}` on Linux and `kill(pid, 0)` on other Unix platforms
+/// (macOS, BSDs). The `kill(pid, 0)` syscall sends no signal but checks
+/// whether the process exists and is reachable.
+///
+/// WHY: The previous non-Linux fallback always returned `true`, which meant
+/// a stale lock from a crashed process would block consolidation for the
+/// full mtime stale threshold (up to 24 hours). Using `kill(pid, 0)` allows
+/// immediate reclamation on macOS and other Unix platforms.
 fn is_pid_alive(pid: u32) -> bool {
     #[cfg(target_os = "linux")]
     {
         std::path::Path::new(&format!("/proc/{pid}")).exists()
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(all(unix, not(target_os = "linux")))]
     {
-        // NOTE: conservative fallback; rely on mtime stale threshold for non-Linux.
+        // WHY: kill(pid, 0) checks process existence without sending a signal.
+        // Returns 0 if the process exists, -1 with ESRCH if it does not.
+        // EPERM (no permission to signal) still means the process exists.
+        #[expect(
+            clippy::as_conversions,
+            reason = "u32→i32: PIDs are always positive and fit in i32 on Unix"
+        )]
+        let pid_i32 = pid as i32;
+        // SAFETY: kill(pid, 0) is safe — signal 0 performs a permission check
+        // without delivering any signal. This is the standard Unix idiom for
+        // process existence checks.
+        let ret = unsafe { libc::kill(pid_i32, 0) };
+        if ret == 0 {
+            return true;
+        }
+        // WHY: EPERM means the process exists but we lack permission to signal it.
+        // ESRCH means no process with this PID exists.
+        let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+        errno == libc::EPERM
+    }
+    // NOTE: Non-Unix platforms (e.g., Windows) cannot check PID liveness.
+    // Return false so stale locks are reclaimed via mtime threshold rather than
+    // blocking consolidation indefinitely.
+    #[cfg(not(unix))]
+    {
         let _ = pid;
-        true
+        tracing::warn!(
+            pid,
+            "PID liveness check unavailable on this platform; assuming dead"
+        );
+        false
     }
 }
 
@@ -402,42 +439,57 @@ mod tests {
         // NOTE: write a fake PID that is very unlikely to be alive.
         write_file(&lock_path, b"4294967295").unwrap_or_default();
 
-        // NOTE: on Linux, PID 4294967295 (u32::MAX) is not alive, so lock is reclaimable.
-        #[cfg(target_os = "linux")]
+        // WHY (#3334): On all Unix platforms (Linux via /proc, macOS/BSD via
+        // kill(pid, 0)), PID 4294967295 (u32::MAX) should be detected as dead
+        // and the lock should be reclaimable without waiting for mtime stale.
+        #[cfg(unix)]
         {
             let acquired =
                 try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS).unwrap();
             assert!(
                 acquired.is_some(),
-                "lock with dead PID should be reclaimable"
+                "lock with dead PID should be reclaimable on Unix"
             );
             if let Some(lock) = acquired {
                 lock.mark_complete().unwrap_or_default();
             }
         }
 
-        // NOTE: on non-Linux, PIDs are conservatively treated as alive.
-        // Set mtime to 2 hours ago for stale detection fallback.
-        #[cfg(not(target_os = "linux"))]
+        // NOTE: on non-Unix, dead PIDs return false from is_pid_alive, so
+        // the lock is also reclaimable.
+        #[cfg(not(unix))]
         {
-            let past = std::time::SystemTime::now() - std::time::Duration::from_secs(7_200);
-            let times = std::fs::FileTimes::new().set_modified(past);
-            let file = std::fs::File::options()
-                .write(true)
-                .open(&lock_path)
-                .unwrap();
-            file.set_times(times).unwrap_or_default();
-            drop(file);
             let acquired =
                 try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS).unwrap();
             assert!(
                 acquired.is_some(),
-                "stale lock with old mtime should be reclaimable"
+                "lock with dead PID should be reclaimable on non-Unix"
             );
             if let Some(lock) = acquired {
                 lock.mark_complete().unwrap_or_default();
             }
         }
+    }
+
+    #[test]
+    fn is_pid_alive_detects_current_process() {
+        // WHY: The current process PID must always be detected as alive.
+        // This validates the cross-platform PID detection works correctly.
+        assert!(
+            is_pid_alive(std::process::id()),
+            "current process PID should be detected as alive"
+        );
+    }
+
+    #[test]
+    fn is_pid_alive_detects_dead_pid() {
+        // WHY (#3334): A PID that does not correspond to any running process
+        // must return false so stale locks are reclaimable.
+        // PID u32::MAX is extremely unlikely to be in use.
+        assert!(
+            !is_pid_alive(u32::MAX),
+            "u32::MAX PID should be detected as dead"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#3324 (hermeneus)**: CC subprocess output capped at 10MB / 100K lines with clear error messages; system prompt validated at 100KB max before spawning
- **#3325 (hermeneus)**: `content_with_cache_control` and `WireRequest::from_request` now return `Result` — serialization errors propagate instead of silently producing `Value::Null` or dropping blocks
- **#3333 (melete)**: `parse_summary_to_flush` extracts all 7 distillation sections — Summary, Completed Work, Current State, and Open Threads now persist as tagged facts (`[Summary]`, `[Completed]`, `[State]`, `[Open]`) instead of being silently discarded
- **#3334 (melete)**: `is_pid_alive` uses `libc::kill(pid, 0)` on non-Linux Unix (macOS, BSDs); non-Unix platforms return `false` (assume dead) so stale locks are reclaimable immediately

## Test plan

- [x] `cargo test -p hermeneus` — 271 tests pass (includes new: oversized output, oversized system prompt, within-limits output)
- [x] `cargo test -p melete` — 220 tests pass (includes new: all 7 section extraction, empty sections, current/dead PID detection)
- [x] `cargo clippy -p hermeneus -p melete` — zero warnings
- [x] `cargo clippy --workspace` — no new warnings (pre-existing in krites/pylon only)

Closes #3324, #3325, #3333, #3334