### PR TITLE
fix(energeia): re-enable QA eval, DRY store scans, fix blast radius validation (#3326, #3327, #3328)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "koina",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "koina",
  "organon",
@@ -1931,7 +1931,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "eidos"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "serde",
@@ -1962,10 +1962,11 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "eidos",
  "fjall",
+ "hermeneus",
  "jiff",
  "koina",
  "parking_lot",
@@ -2028,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2709,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -2822,7 +2823,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -3286,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "dokimion",
@@ -3525,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -3559,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3640,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -3970,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "fd-lock",
  "futures",
@@ -4063,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -4199,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "dianoia",
@@ -4395,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "episteme",
@@ -4506,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "energeia",
@@ -4861,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "snafu",
@@ -4869,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "poiesis-core",
  "rust_xlsxwriter",
@@ -4879,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "poiesis-core",
  "ppt-rs",
@@ -4888,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "krilla",
  "poiesis-core",
@@ -5289,7 +5290,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -6621,7 +6622,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "compact_str",
@@ -6876,7 +6877,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -6989,7 +6990,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -7101,14 +7102,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/energeia/CLAUDE.md
+++ b/crates/energeia/CLAUDE.md
@@ -44,5 +44,5 @@ Dispatch orchestration: actualization of plans into execution. Absorbs kanon's p
 
 ## Dependencies
 
-Uses: koina, eidos, jiff, serde, snafu, tokio (hermeneus pending compilation fix)
+Uses: koina, eidos, hermeneus, jiff, serde, snafu, tokio
 Used by: aletheia (binary, behind `energeia` feature flag)

--- a/crates/energeia/Cargo.toml
+++ b/crates/energeia/Cargo.toml
@@ -18,12 +18,9 @@ storage-fjall = ["dep:fjall"]
 [dependencies]
 koina = { path = "../koina" }
 eidos = { path = "../eidos" }
+hermeneus = { path = "../hermeneus" }
 prometheus = { workspace = true }
 regex = { workspace = true }
-# WHY: hermeneus has pre-existing compilation errors on main (kanon lint pass
-# introduced unwrap_or_default on non-Default types). Add dependency once
-# hermeneus compiles again; implementations will need it for LLM evaluation.
-# hermeneus = { path = "../hermeneus" }
 fjall = { version = "3", optional = true }
 jiff = { workspace = true, features = ["serde"] }
 parking_lot = { version = "0.12", default-features = false }

--- a/crates/energeia/src/error.rs
+++ b/crates/energeia/src/error.rs
@@ -90,8 +90,6 @@ pub enum Error {
     },
 
     /// LLM provider error during dispatch operations.
-    // NOTE: will wrap hermeneus::error::Error as `source` once
-    // hermeneus compiles on main. For now, carries the error as a string.
     #[snafu(display("LLM error: {detail}"))]
     Llm {
         detail: String,

--- a/crates/energeia/src/orchestrator/orchestrator_tests.rs
+++ b/crates/energeia/src/orchestrator/orchestrator_tests.rs
@@ -46,6 +46,7 @@ impl QaGate for MockQaGate {
                 mechanical_issues: vec![],
                 cost_usd: 0.0,
                 evaluated_at: Timestamp::now(),
+                semantic_evaluated: false,
             })
         })
     }

--- a/crates/energeia/src/qa/corrective.rs
+++ b/crates/energeia/src/qa/corrective.rs
@@ -127,6 +127,7 @@ mod tests {
             mechanical_issues: vec![],
             cost_usd: 0.03,
             evaluated_at: Timestamp::now(),
+            semantic_evaluated: true,
         }
     }
 

--- a/crates/energeia/src/qa/mechanical.rs
+++ b/crates/energeia/src/qa/mechanical.rs
@@ -197,6 +197,11 @@ pub fn parse_changed_files(diff: &str) -> Vec<String> {
 // ---------------------------------------------------------------------------
 
 /// Verify all changed files fall within the declared blast radius.
+///
+/// Uses component-based path matching instead of string prefix matching
+/// to prevent path tricks. For example, `src/lib` as a blast radius does
+/// not match `src/library/mod.rs` because `library` is a different path
+/// component than `lib`.
 fn check_blast_radius(
     changed_files: &[String],
     blast_radius: &[String],
@@ -207,13 +212,17 @@ fn check_blast_radius(
     }
 
     for file in changed_files {
+        let file_path = Path::new(file);
         let within_scope = blast_radius.iter().any(|allowed| {
-            // WHY: A blast radius entry ending with `/` is a directory prefix.
-            // Anything under that path is allowed. Otherwise, exact match only.
+            // WHY: A blast radius entry ending with `/` is a directory scope.
+            // Anything under that directory is allowed. Otherwise, exact file
+            // match only. We use component-based matching so that `src/lib/`
+            // does not match `src/library/mod.rs`.
             if allowed.ends_with('/') {
-                file.starts_with(allowed.as_str())
+                let dir_path = Path::new(allowed.trim_end_matches('/'));
+                path_is_under(file_path, dir_path)
             } else {
-                file == allowed
+                file_path == Path::new(allowed)
             }
         });
 
@@ -225,6 +234,25 @@ fn check_blast_radius(
             });
         }
     }
+}
+
+/// Check if `child` is under `parent` using component-based matching.
+///
+/// Returns `true` if every component of `parent` matches the corresponding
+/// leading component of `child`. This prevents false positives from string
+/// prefix matching (e.g., `src/lib` would NOT match `src/library/mod.rs`).
+fn path_is_under(child: &Path, parent: &Path) -> bool {
+    let parent_components: Vec<_> = parent.components().collect();
+    let child_components: Vec<_> = child.components().collect();
+
+    if parent_components.len() > child_components.len() {
+        return false;
+    }
+
+    parent_components
+        .iter()
+        .zip(child_components.iter())
+        .all(|(p, c)| p == c)
 }
 
 // ---------------------------------------------------------------------------
@@ -403,6 +431,83 @@ diff --git a/src/lib.rs b/src/lib.rs
 
         assert!(
             !issues
+                .iter()
+                .any(|i| i.kind == MechanicalIssueKind::BlastRadiusViolation)
+        );
+    }
+
+    #[test]
+    fn blast_radius_prefix_similar_names_rejected() {
+        // WHY: `src/lib/` should NOT match `src/library/mod.rs` — these are
+        // different path components. String prefix matching would incorrectly
+        // allow this.
+        let diff = "+++ b/src/library/mod.rs\n@@ -1 +1,2 @@\n+new line\n";
+        let prompt = stub_prompt(vec!["src/lib/".to_owned()]);
+
+        let issues = mechanical_check(diff, &prompt);
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.kind == MechanicalIssueKind::BlastRadiusViolation)
+        );
+    }
+
+    #[test]
+    fn blast_radius_parent_child_directory() {
+        // WHY: Changes in `src/foo/bar.rs` should be allowed when
+        // `src/foo/` is in the blast radius.
+        let diff = "+++ b/src/foo/bar.rs\n@@ -1 +1,2 @@\n+new line\n";
+        let prompt = stub_prompt(vec!["src/foo/".to_owned()]);
+
+        let issues = mechanical_check(diff, &prompt);
+
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.kind == MechanicalIssueKind::BlastRadiusViolation)
+        );
+    }
+
+    #[test]
+    fn blast_radius_sibling_directories_rejected() {
+        // WHY: `src/foo/` should not match `src/bar/baz.rs`.
+        let diff = "+++ b/src/bar/baz.rs\n@@ -1 +1,2 @@\n+new line\n";
+        let prompt = stub_prompt(vec!["src/foo/".to_owned()]);
+
+        let issues = mechanical_check(diff, &prompt);
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.kind == MechanicalIssueKind::BlastRadiusViolation)
+        );
+    }
+
+    #[test]
+    fn blast_radius_same_file_allowed() {
+        let diff = "+++ b/src/lib.rs\n@@ -1 +1,2 @@\n+new line\n";
+        let prompt = stub_prompt(vec!["src/lib.rs".to_owned()]);
+
+        let issues = mechanical_check(diff, &prompt);
+
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.kind == MechanicalIssueKind::BlastRadiusViolation)
+        );
+    }
+
+    #[test]
+    fn blast_radius_file_does_not_match_prefix_similar_file() {
+        // WHY: `src/lib.rs` as exact match should not match `src/lib_utils.rs`.
+        let diff = "+++ b/src/lib_utils.rs\n@@ -1 +1,2 @@\n+new line\n";
+        let prompt = stub_prompt(vec!["src/lib.rs".to_owned()]);
+
+        let issues = mechanical_check(diff, &prompt);
+
+        assert!(
+            issues
                 .iter()
                 .any(|i| i.kind == MechanicalIssueKind::BlastRadiusViolation)
         );

--- a/crates/energeia/src/qa/mod.rs
+++ b/crates/energeia/src/qa/mod.rs
@@ -4,17 +4,23 @@
 //! 1. Run mechanical pre-screening (blast radius, anti-patterns)
 //! 2. Classify acceptance criteria (mechanical vs semantic)
 //! 3. Auto-pass mechanical criteria if no mechanical issues found
-//! 4. Run LLM evaluation on semantic criteria via hermeneus
+//! 4. Run LLM evaluation on semantic criteria via hermeneus (when provider available)
 //! 5. Determine verdict: Pass / Partial / Fail
 //! 6. Capture training data as a lesson
 //! 7. If Partial/Fail, generate corrective prompt
 //!
 //! The [`QaGate`] trait separates mechanical pre-screening (fast, no LLM cost)
 //! from semantic evaluation (uses hermeneus for LLM-based assessment).
+//!
+//! When no LLM provider is available, [`run_qa`] degrades gracefully to
+//! mechanical-only evaluation and sets `semantic_evaluated = false` on the
+//! result so the operator knows the gate is incomplete.
 
 use std::future::Future;
 use std::pin::Pin;
 
+use hermeneus::provider::LlmProvider;
+use hermeneus::types::{CompletionRequest, Content, ContentBlock, Message, Role};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -130,17 +136,26 @@ impl PromptSpec {
 /// * `diff` - The unified diff of the PR
 /// * `prompt` - The prompt specification with criteria and blast radius
 /// * `pr_number` - The pull request number
+/// * `llm` - Optional LLM provider for semantic evaluation. When `None`,
+///   semantic criteria are skipped with a warning and the verdict reflects
+///   mechanical checks only.
 ///
-/// # LLM evaluation
+/// # Semantic evaluation
 ///
-/// Semantic criteria evaluation requires hermeneus, which is currently disabled
-/// due to compilation errors. When hermeneus is unavailable, semantic criteria
-/// are marked as failed with explanatory evidence. The mechanical checks, verdict
-/// logic, and corrective generation all work without hermeneus.
-pub fn run_qa(diff: &str, prompt: &PromptSpec, pr_number: u64) -> QaResult {
+/// When an LLM provider is supplied, semantic criteria are evaluated via
+/// hermeneus. When unavailable (`None`), the verdict indicates that
+/// semantic evaluation was not included so the operator knows the gate
+/// is mechanical-only.
+pub async fn run_qa(
+    diff: &str,
+    prompt: &PromptSpec,
+    pr_number: u64,
+    llm: Option<&dyn LlmProvider>,
+) -> QaResult {
     tracing::info!(
         prompt_number = prompt.prompt_number,
         pr_number,
+        semantic_eval = llm.is_some(),
         "starting QA evaluation"
     );
 
@@ -180,42 +195,14 @@ pub fn run_qa(diff: &str, prompt: &PromptSpec, pr_number: u64) -> QaResult {
         .cloned()
         .collect();
 
-    let (semantic_results, cost_usd) =
-        if verdict::has_critical_mechanical_issues(&mechanical_issues) {
-            tracing::info!("skipping LLM evaluation due to critical mechanical issues");
-            let results = semantic_criteria
-                .iter()
-                .map(|(text, ct)| CriterionResult {
-                    criterion: text.clone(),
-                    classification: *ct,
-                    passed: false,
-                    evidence: "skipped: critical mechanical issues prevent evaluation".to_owned(),
-                })
-                .collect();
-            (results, 0.0)
-        } else if semantic_criteria.is_empty() {
-            (Vec::new(), 0.0)
-        } else {
-            // WHY: hermeneus is temporarily disabled due to compilation errors.
-            // Build the evaluation prompt so the infrastructure is ready, but
-            // mark criteria as unevaluated until hermeneus is restored.
-            let _qa_prompt =
-                semantic::build_qa_prompt(&prompt.description, &semantic_criteria, diff);
-
-            tracing::warn!("hermeneus unavailable — semantic criteria marked as unevaluated");
-
-            let results = semantic_criteria
-                .iter()
-                .map(|(text, ct)| CriterionResult {
-                    criterion: text.clone(),
-                    classification: *ct,
-                    passed: false,
-                    evidence: "LLM evaluation unavailable — hermeneus pending compilation fix"
-                        .to_owned(),
-                })
-                .collect();
-            (results, 0.0)
-        };
+    let (semantic_results, cost_usd, semantic_evaluated) = evaluate_semantic_criteria(
+        &semantic_criteria,
+        &mechanical_issues,
+        &prompt.description,
+        diff,
+        llm,
+    )
+    .await;
 
     // NOTE: Step 5 — combine results and determine verdict.
     let mut all_results = mechanical_results;
@@ -231,15 +218,105 @@ pub fn run_qa(diff: &str, prompt: &PromptSpec, pr_number: u64) -> QaResult {
         mechanical_issues,
         cost_usd,
         evaluated_at: Timestamp::now(),
+        semantic_evaluated,
     };
 
     tracing::info!(
         verdict = %qa_result.verdict,
         cost_usd = qa_result.cost_usd,
+        semantic_evaluated = qa_result.semantic_evaluated,
         "QA evaluation complete"
     );
 
     qa_result
+}
+
+/// Evaluate semantic criteria via LLM or degrade gracefully.
+///
+/// Returns `(results, cost_usd, semantic_evaluated)`.
+async fn evaluate_semantic_criteria(
+    criteria: &[(String, CriterionType)],
+    mechanical_issues: &[MechanicalIssue],
+    description: &str,
+    diff: &str,
+    llm: Option<&dyn LlmProvider>,
+) -> (Vec<CriterionResult>, f64, bool) {
+    if verdict::has_critical_mechanical_issues(mechanical_issues) {
+        tracing::info!("skipping LLM evaluation due to critical mechanical issues");
+        let results = criteria
+            .iter()
+            .map(|(text, ct)| CriterionResult {
+                criterion: text.clone(),
+                classification: *ct,
+                passed: false,
+                evidence: "skipped: critical mechanical issues prevent evaluation".to_owned(),
+            })
+            .collect();
+        return (results, 0.0, false);
+    }
+
+    if criteria.is_empty() {
+        return (Vec::new(), 0.0, true);
+    }
+
+    let Some(provider) = llm else {
+        tracing::warn!("no LLM provider — semantic criteria skipped (mechanical-only gate)");
+        let results = criteria
+            .iter()
+            .map(|(text, ct)| CriterionResult {
+                criterion: text.clone(),
+                classification: *ct,
+                passed: false,
+                evidence: "no LLM provider available — semantic evaluation skipped".to_owned(),
+            })
+            .collect();
+        return (results, 0.0, false);
+    };
+
+    // NOTE: Build the QA prompt and send it to the LLM via hermeneus.
+    let qa_prompt_text = semantic::build_qa_prompt(description, criteria, diff);
+
+    let request = CompletionRequest {
+        model: String::new(), // WHY: empty string lets the provider use its default model
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text(qa_prompt_text),
+        }],
+        ..CompletionRequest::default()
+    };
+
+    match provider.complete(&request).await {
+        Ok(response) => {
+            let response_text: String = response
+                .content
+                .iter()
+                .filter_map(|block| match block {
+                    ContentBlock::Text { text, .. } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            let results = semantic::parse_qa_response(&response_text, criteria);
+            // WHY: Cost estimation requires model pricing data which lives in
+            // hermeneus::models. The provider returns raw token counts; callers
+            // with pricing context can compute cost from response.usage. We
+            // report 0.0 here and let the orchestrator handle cost attribution.
+            (results, 0.0, true)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "LLM evaluation failed — semantic criteria marked as unevaluated");
+            let results = criteria
+                .iter()
+                .map(|(text, ct)| CriterionResult {
+                    criterion: text.clone(),
+                    classification: *ct,
+                    passed: false,
+                    evidence: format!("LLM evaluation failed: {e}"),
+                })
+                .collect();
+            (results, 0.0, false)
+        }
+    }
 }
 
 /// Record a QA evaluation result as a lesson in the store.
@@ -320,8 +397,8 @@ mod tests {
         assert_eq!(deserialized.blast_radius.len(), 1);
     }
 
-    #[test]
-    fn run_qa_all_mechanical_pass() {
+    #[tokio::test]
+    async fn run_qa_all_mechanical_pass() {
         let prompt = PromptSpec {
             prompt_number: 1,
             description: "add endpoint".to_owned(),
@@ -333,17 +410,18 @@ mod tests {
         };
         let diff = "+++ b/src/lib.rs\n@@ -1 +1,2 @@\n+pub fn foo() {}\n";
 
-        let result = run_qa(diff, &prompt, 42);
+        let result = run_qa(diff, &prompt, 42, None).await;
 
-        // NOTE: No mechanical issues → mechanical criteria auto-pass.
-        // But hermeneus is unavailable, so there should be no semantic criteria
-        // to fail (these are all mechanical keywords).
+        // NOTE: No mechanical issues, all criteria are mechanical keywords
+        // so they auto-pass. semantic_evaluated is true because there are no
+        // semantic criteria to evaluate (vacuously complete).
         assert_eq!(result.verdict, QaVerdict::Pass);
         assert!(result.mechanical_issues.is_empty());
+        assert!(result.semantic_evaluated);
     }
 
-    #[test]
-    fn run_qa_blast_radius_violation_fails() {
+    #[tokio::test]
+    async fn run_qa_blast_radius_violation_fails() {
         let prompt = PromptSpec {
             prompt_number: 1,
             description: "scoped change".to_owned(),
@@ -352,14 +430,14 @@ mod tests {
         };
         let diff = "+++ b/src/outside/file.rs\n@@ -1 +1,2 @@\n+new line\n";
 
-        let result = run_qa(diff, &prompt, 42);
+        let result = run_qa(diff, &prompt, 42, None).await;
 
         assert_eq!(result.verdict, QaVerdict::Fail);
         assert!(!result.mechanical_issues.is_empty());
     }
 
-    #[test]
-    fn run_qa_captures_anti_patterns() {
+    #[tokio::test]
+    async fn run_qa_captures_anti_patterns() {
         let prompt = PromptSpec {
             prompt_number: 1,
             description: "test".to_owned(),
@@ -368,7 +446,7 @@ mod tests {
         };
         let diff = "+++ b/src/lib.rs\n@@ -1 +1,2 @@\n+    let x = foo.unwrap();\n";
 
-        let result = run_qa(diff, &prompt, 42);
+        let result = run_qa(diff, &prompt, 42, None).await;
 
         assert!(
             result
@@ -378,8 +456,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_qa_skips_llm_on_mechanical_failure() {
+    #[tokio::test]
+    async fn run_qa_skips_llm_on_mechanical_failure() {
         let prompt = PromptSpec {
             prompt_number: 1,
             description: "test".to_owned(),
@@ -388,14 +466,34 @@ mod tests {
         };
         let diff = "+++ b/src/outside/file.rs\n@@ -1 +1,2 @@\n+new line\n";
 
-        let result = run_qa(diff, &prompt, 42);
+        let result = run_qa(diff, &prompt, 42, None).await;
 
-        // WHY: Blast radius violation → skip LLM → semantic criteria skipped.
+        // WHY: Blast radius violation -> skip LLM -> semantic criteria skipped.
         assert_eq!(result.verdict, QaVerdict::Fail);
         assert!(result.cost_usd < f64::EPSILON);
+        assert!(!result.semantic_evaluated);
         assert!(result.criteria_results.iter().any(|cr| {
             cr.evidence
                 .contains("critical mechanical issues prevent evaluation")
+        }));
+    }
+
+    #[tokio::test]
+    async fn run_qa_indicates_no_semantic_eval_without_llm() {
+        let prompt = PromptSpec {
+            prompt_number: 1,
+            description: "test".to_owned(),
+            acceptance_criteria: vec!["Implements feature correctly".to_owned()],
+            blast_radius: vec![],
+        };
+        let diff = "+++ b/src/lib.rs\n@@ -1 +1,2 @@\n+pub fn foo() {}\n";
+
+        let result = run_qa(diff, &prompt, 42, None).await;
+
+        // WHY: No LLM provider -> semantic criteria fail with clear evidence.
+        assert!(!result.semantic_evaluated);
+        assert!(result.criteria_results.iter().any(|cr| {
+            cr.evidence.contains("no LLM provider available")
         }));
     }
 }

--- a/crates/energeia/src/store/queries.rs
+++ b/crates/energeia/src/store/queries.rs
@@ -23,6 +23,51 @@ pub(crate) fn deserialize_value<T: serde::de::DeserializeOwned>(value: &[u8]) ->
     })
 }
 
+// ---------------------------------------------------------------------------
+// Generic prefix scan
+// ---------------------------------------------------------------------------
+
+/// Scan a fjall keyspace by prefix, deserializing each value and collecting
+/// results that pass an optional filter.
+///
+/// # Arguments
+///
+/// * `keyspace` — the fjall keyspace to scan
+/// * `prefix` — key prefix bytes to scan
+/// * `context` — human-readable context for error messages (e.g. "session prefix scan")
+/// * `limit` — maximum number of results to return (`usize::MAX` for no limit)
+/// * `filter` — predicate applied after deserialization; returning `false` skips the record
+#[cfg(feature = "storage-fjall")]
+fn prefix_scan<T: serde::de::DeserializeOwned>(
+    keyspace: &fjall::Keyspace,
+    prefix: &[u8],
+    context: &str,
+    limit: usize,
+    filter: impl Fn(&T) -> bool,
+) -> Result<Vec<T>> {
+    let mut results = Vec::new();
+    for guard in keyspace.prefix(prefix) {
+        if results.len() >= limit {
+            break;
+        }
+        let (_key, value) = guard.into_inner().map_err(|e| {
+            error::StoreSnafu {
+                message: format!("{context}: {e}"),
+            }
+            .build()
+        })?;
+        let record = deserialize_value::<T>(&value)?;
+        if filter(&record) {
+            results.push(record);
+        }
+    }
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Query functions
+// ---------------------------------------------------------------------------
+
 /// Collect all sessions for a given dispatch via prefix scan.
 #[cfg(feature = "storage-fjall")]
 pub(crate) fn list_sessions_for_dispatch(
@@ -30,17 +75,7 @@ pub(crate) fn list_sessions_for_dispatch(
     dispatch_id: &crate::store::records::DispatchId,
 ) -> Result<Vec<SessionRecord>> {
     let prefix = schema::session_prefix_for_dispatch(dispatch_id);
-    let mut results = Vec::new();
-    for guard in keyspace.prefix(prefix.as_bytes()) {
-        let (_key, value) = guard.into_inner().map_err(|e| {
-            error::StoreSnafu {
-                message: format!("session prefix scan: {e}"),
-            }
-            .build()
-        })?;
-        results.push(deserialize_value::<SessionRecord>(&value)?);
-    }
-    Ok(results)
+    prefix_scan(keyspace, prefix.as_bytes(), "session prefix scan", usize::MAX, |_: &SessionRecord| true)
 }
 
 /// Query lessons with optional source filter, returning up to `limit` results.
@@ -63,29 +98,15 @@ pub(crate) fn query_lessons(
         None => schema::lesson_prefix().as_bytes(),
     };
 
-    let mut results = Vec::new();
-    for guard in keyspace.prefix(prefix_bytes) {
-        if results.len() >= limit {
-            break;
-        }
-        let (_key, value) = guard.into_inner().map_err(|e| {
-            error::StoreSnafu {
-                message: format!("lesson prefix scan: {e}"),
-            }
-            .build()
-        })?;
-        let record = deserialize_value::<LessonRecord>(&value)?;
-
+    prefix_scan(keyspace, prefix_bytes, "lesson prefix scan", limit, |record: &LessonRecord| {
         if category.is_some_and(|cat| record.category != cat) {
-            continue;
+            return false;
         }
         if project.is_some_and(|proj| record.project.as_deref() != Some(proj)) {
-            continue;
+            return false;
         }
-
-        results.push(record);
-    }
-    Ok(results)
+        true
+    })
 }
 
 /// Query observations with optional project filter and day window.
@@ -113,30 +134,15 @@ pub(crate) fn query_observations(
         cutoff.as_millisecond()
     });
 
-    let mut results = Vec::new();
-    for guard in keyspace.prefix(prefix_bytes) {
-        if results.len() >= limit {
-            break;
-        }
-        let (_key, value) = guard.into_inner().map_err(|e| {
-            error::StoreSnafu {
-                message: format!("observation prefix scan: {e}"),
-            }
-            .build()
-        })?;
-        let record = deserialize_value::<ObservationRecord>(&value)?;
-
+    prefix_scan(keyspace, prefix_bytes, "observation prefix scan", limit, |record: &ObservationRecord| {
         if cutoff_ms.is_some_and(|cutoff| record.created_at.as_millisecond() < cutoff) {
-            continue;
+            return false;
         }
-
         if project.is_some_and(|proj| record.project != proj) {
-            continue;
+            return false;
         }
-
-        results.push(record);
-    }
-    Ok(results)
+        true
+    })
 }
 
 /// Collect all dispatch records via prefix scan.
@@ -149,20 +155,7 @@ pub(crate) fn list_dispatches(
     limit: usize,
 ) -> Result<Vec<crate::store::records::DispatchRecord>> {
     let prefix_bytes = schema::dispatch_prefix().as_bytes();
-    let mut results = Vec::new();
-    for guard in keyspace.prefix(prefix_bytes) {
-        if results.len() >= limit {
-            break;
-        }
-        let (_key, value) = guard.into_inner().map_err(|e| {
-            error::StoreSnafu {
-                message: format!("dispatch prefix scan: {e}"),
-            }
-            .build()
-        })?;
-        results.push(deserialize_value::<DispatchRecord>(&value)?);
-    }
-    Ok(results)
+    prefix_scan(keyspace, prefix_bytes, "dispatch prefix scan", limit, |_: &DispatchRecord| true)
 }
 
 /// Collect all session records across all dispatches via prefix scan.
@@ -175,20 +168,7 @@ pub(crate) fn list_all_sessions(
     limit: usize,
 ) -> Result<Vec<SessionRecord>> {
     let prefix_bytes = schema::session_prefix().as_bytes();
-    let mut results = Vec::new();
-    for guard in keyspace.prefix(prefix_bytes) {
-        if results.len() >= limit {
-            break;
-        }
-        let (_key, value) = guard.into_inner().map_err(|e| {
-            error::StoreSnafu {
-                message: format!("session prefix scan: {e}"),
-            }
-            .build()
-        })?;
-        results.push(deserialize_value::<SessionRecord>(&value)?);
-    }
-    Ok(results)
+    prefix_scan(keyspace, prefix_bytes, "session prefix scan", limit, |_: &SessionRecord| true)
 }
 
 /// Collect all CI validation records across all sessions via prefix scan.
@@ -200,20 +180,7 @@ pub(crate) fn list_all_ci_validations(
     limit: usize,
 ) -> Result<Vec<CiValidationRecord>> {
     let prefix_bytes = schema::ci_validation_prefix().as_bytes();
-    let mut results = Vec::new();
-    for guard in keyspace.prefix(prefix_bytes) {
-        if results.len() >= limit {
-            break;
-        }
-        let (_key, value) = guard.into_inner().map_err(|e| {
-            error::StoreSnafu {
-                message: format!("ci_validation prefix scan: {e}"),
-            }
-            .build()
-        })?;
-        results.push(deserialize_value::<CiValidationRecord>(&value)?);
-    }
-    Ok(results)
+    prefix_scan(keyspace, prefix_bytes, "ci_validation prefix scan", limit, |_: &CiValidationRecord| true)
 }
 
 /// Collect CI validations for a given session via prefix scan.
@@ -223,15 +190,5 @@ pub(crate) fn list_ci_validations_for_session(
     session_id: &crate::store::records::SessionId,
 ) -> Result<Vec<CiValidationRecord>> {
     let prefix = schema::ci_validation_prefix_for_session(session_id);
-    let mut results = Vec::new();
-    for guard in keyspace.prefix(prefix.as_bytes()) {
-        let (_key, value) = guard.into_inner().map_err(|e| {
-            error::StoreSnafu {
-                message: format!("ci_validation prefix scan: {e}"),
-            }
-            .build()
-        })?;
-        results.push(deserialize_value::<CiValidationRecord>(&value)?);
-    }
-    Ok(results)
+    prefix_scan(keyspace, prefix.as_bytes(), "ci_validation prefix scan", usize::MAX, |_: &CiValidationRecord| true)
 }

--- a/crates/energeia/src/types.rs
+++ b/crates/energeia/src/types.rs
@@ -175,9 +175,17 @@ pub struct QaResult {
     pub cost_usd: f64,
     /// Timestamp when the evaluation completed.
     pub evaluated_at: Timestamp,
+    /// Whether semantic (LLM-based) evaluation was included in this result.
+    ///
+    /// When `false`, the verdict reflects mechanical checks only and the
+    /// operator should be aware that semantic criteria were not evaluated.
+    pub semantic_evaluated: bool,
 }
 
 /// Raw deserialization type for [`QaResult`].
+///
+/// The `semantic_evaluated` field defaults to `false` for backward
+/// compatibility with serialized results that predate this field.
 #[derive(Debug, Clone, Deserialize)]
 struct QaResultRaw {
     prompt_number: u32,
@@ -187,6 +195,8 @@ struct QaResultRaw {
     mechanical_issues: Vec<MechanicalIssue>,
     cost_usd: f64,
     evaluated_at: Timestamp,
+    #[serde(default)]
+    semantic_evaluated: bool,
 }
 
 impl From<QaResultRaw> for QaResult {
@@ -199,6 +209,7 @@ impl From<QaResultRaw> for QaResult {
             mechanical_issues: raw.mechanical_issues,
             cost_usd: raw.cost_usd,
             evaluated_at: raw.evaluated_at,
+            semantic_evaluated: raw.semantic_evaluated,
         }
     }
 }
@@ -217,6 +228,7 @@ impl QaResult {
         mechanical_issues: Vec<MechanicalIssue>,
         cost_usd: f64,
         evaluated_at: Timestamp,
+        semantic_evaluated: bool,
     ) -> Self {
         Self {
             prompt_number,
@@ -226,6 +238,7 @@ impl QaResult {
             mechanical_issues,
             cost_usd,
             evaluated_at,
+            semantic_evaluated,
         }
     }
 }
@@ -397,10 +410,12 @@ mod tests {
             mechanical_issues: vec![],
             cost_usd: 0.03,
             evaluated_at: Timestamp::now(),
+            semantic_evaluated: true,
         };
         let json = serde_json::to_string(&result).unwrap();
         let deserialized: QaResult = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.verdict, QaVerdict::Pass);
+        assert!(deserialized.semantic_evaluated);
         assert_eq!(deserialized.criteria_results.len(), 1);
     }
 

--- a/crates/organon/src/builtins/energeia/qa.rs
+++ b/crates/organon/src/builtins/energeia/qa.rs
@@ -109,7 +109,10 @@ impl ToolExecutor for DokimasiaExecutor {
             // access which is outside this tool's scope. Callers may pass a diff
             // via a future `diff` field extension. Mechanical checks on an empty
             // diff produce no findings.
-            let qa_result = run_qa("", &qa_prompt, pr_number);
+            // WHY: No LLM provider available in the tool context — runs
+            // mechanical-only evaluation. Semantic evaluation requires the
+            // orchestrator which has access to hermeneus providers.
+            let qa_result = run_qa("", &qa_prompt, pr_number, None).await;
 
             Ok(to_json_text(&qa_result))
         })

--- a/crates/organon/tests/energeia_tools.rs
+++ b/crates/organon/tests/energeia_tools.rs
@@ -47,6 +47,7 @@ impl QaGate for AlwaysPassQaGate {
                 vec![],
                 0.0,
                 jiff::Timestamp::now(),
+                false,
             ))
         })
     }


### PR DESCRIPTION
## Summary

- **#3326**: Restore hermeneus dependency (now compiles on main). `run_qa` accepts an optional `LlmProvider` for semantic evaluation via hermeneus. Degrades gracefully to mechanical-only with `semantic_evaluated = false` on the `QaResult` so operators know the gate is incomplete. Removes stale comments and dead code around the disabled dependency.
- **#3327**: Extract `prefix_scan<T>` generic helper in `store/queries.rs`. All 7 query functions now delegate to the shared helper, eliminating 6 copies of identical iteration/map_err/deserialize/push boilerplate. Error context preserved per query via the `context` parameter.
- **#3328**: Replace string prefix matching in `check_blast_radius` with component-based path matching via `path_is_under()`. `src/lib/` no longer falsely matches `src/library/mod.rs`. Added 5 tests covering same-file, parent/child directory, sibling directories, and prefix-similar names.

## Test plan

- [x] `cargo test -p energeia` -- 390 tests pass
- [x] `cargo test -p energeia --features test-core` -- 445 tests pass (fjall store tests exercise refactored queries)
- [x] `cargo clippy -p energeia` -- zero warnings
- [x] `cargo clippy --workspace` -- no new warnings (pre-existing in hermeneus, krites, pylon)
- [x] `cargo check -p organon` -- compiles clean (updated `QaResult::new` call and `run_qa` usage)

Closes #3326, closes #3327, closes #3328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)