### PR TITLE
fix(nous): harden health, eviction, logging, and streaming (#3249, #3253, #3254, #3256, #3284, #3285)

### DIFF
--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -96,18 +96,26 @@ impl NousActor {
             return;
         }
 
+        let cancel = self.channel.cancel.child_token();
         self.runtime.background_tasks.spawn(
             async move {
-                run_extraction(
-                    &config,
-                    providers,
-                    &nous_id,
-                    &user,
-                    &assistant,
-                    #[cfg(feature = "knowledge-store")]
-                    knowledge_store.as_ref(),
-                )
-                .await;
+                // WHY: background tasks respect the actor's cancellation token so
+                // they exit promptly during shutdown instead of running until the
+                // drain timeout expires. (#3256)
+                tokio::select! {
+                    () = cancel.cancelled() => {
+                        info!(nous_id = %nous_id, task_type = "extraction", "background task cancelled during shutdown");
+                    }
+                    () = run_extraction(
+                        &config,
+                        providers,
+                        &nous_id,
+                        &user,
+                        &assistant,
+                        #[cfg(feature = "knowledge-store")]
+                        knowledge_store.as_ref(),
+                    ) => {}
+                }
             }
             .instrument(span),
         );
@@ -192,19 +200,24 @@ impl NousActor {
             return;
         }
 
+        let cancel = self.channel.cancel.child_token();
         self.runtime.background_tasks.spawn(
             async move {
-                run_skill_extraction(
-                    &model,
-                    providers,
-                    &nous_id,
-                    &candidate_id,
-                    &tool_calls,
-                    &tracker,
-                    #[cfg(feature = "knowledge-store")]
-                    knowledge_store.as_ref(),
-                )
-                .await;
+                tokio::select! {
+                    () = cancel.cancelled() => {
+                        info!(nous_id = %nous_id, task_type = "skill_extraction", "background task cancelled during shutdown");
+                    }
+                    () = run_skill_extraction(
+                        &model,
+                        providers,
+                        &nous_id,
+                        &candidate_id,
+                        &tool_calls,
+                        &tracker,
+                        #[cfg(feature = "knowledge-store")]
+                        knowledge_store.as_ref(),
+                    ) => {}
+                }
             }
             .instrument(span),
         );
@@ -285,12 +298,18 @@ impl NousActor {
         }
 
         let flag = Arc::clone(&self.runtime.distillation_in_progress);
+        let cancel = self.channel.cancel.child_token();
         self.runtime.background_tasks.spawn(
             async move {
                 // WHY: drop guard ensures the flag is cleared even if the task panics,
                 // preventing distillation from being permanently blocked (#2155)
                 let _guard = DistillationFlagGuard(Arc::clone(&flag));
-                run_background_distillation(store, providers, session_id, nous_id, config).await;
+                tokio::select! {
+                    () = cancel.cancelled() => {
+                        info!(nous_id = %nous_id, task_type = "distillation", "background task cancelled during shutdown");
+                    }
+                    () = run_background_distillation(store, providers, session_id, nous_id.clone(), config) => {}
+                }
                 // NOTE: guard Drop handles flag.store(false) for both normal and panic paths
             }
             .instrument(span),

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::time::{Duration, Instant};
 
 use tokio::sync::Mutex;
@@ -90,6 +90,11 @@ pub(crate) struct ActorRuntime {
     /// distinguish a busy actor from an unresponsive one without queuing
     /// through the inbox.
     active_turn: Arc<AtomicBool>,
+    /// Monotonic timestamp (millis since `started_at`) when the current turn began.
+    /// 0 when idle. Shared with the manager so the health check can detect stuck
+    /// turns (active for longer than `stuck_turn_timeout_secs`) even when
+    /// `active_turn` is true, preventing the flag from masking a hung pipeline. (#3254)
+    turn_started_at_ms: Arc<AtomicU64>,
     /// Guards against concurrent distillation when two turns finish close together.
     /// WHY: Background distillation is async; a second turn can finish while the
     /// first turn's distillation task is still running, triggering a duplicate.
@@ -159,6 +164,7 @@ impl NousActor {
         tool_services: Option<Arc<ToolServices>>,
         extra_bootstrap: Vec<BootstrapSection>,
         active_turn: Arc<AtomicBool>,
+        turn_started_at_ms: Arc<AtomicU64>,
         nous_behavior: taxis::config::NousBehaviorConfig,
     ) -> Self {
         #[cfg(feature = "knowledge-store")]
@@ -209,6 +215,7 @@ impl NousActor {
             runtime: ActorRuntime {
                 background_tasks: JoinSet::new(),
                 active_turn,
+                turn_started_at_ms,
                 distillation_in_progress: Arc::new(AtomicBool::new(false)),
                 pipeline_panic_count: 0,
                 pipeline_panic_timestamps: Vec::new(),

--- a/crates/nous/src/actor/spawn.rs
+++ b/crates/nous/src/actor/spawn.rs
@@ -1,7 +1,7 @@
 //! Actor spawning and workspace validation.
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -52,12 +52,13 @@ pub(crate) fn spawn(
     cross_rx: Option<mpsc::Receiver<CrossNousEnvelope>>,
     cancel: CancellationToken,
     nous_behavior: taxis::config::NousBehaviorConfig,
-) -> (NousHandle, tokio::task::JoinHandle<()>, Arc<AtomicBool>) {
+) -> (NousHandle, tokio::task::JoinHandle<()>, Arc<AtomicBool>, Arc<AtomicU64>) {
     let (tx, rx) = mpsc::channel(DEFAULT_INBOX_CAPACITY);
     let id = config.id.to_string();
     let handle = NousHandle::new(id.clone(), tx);
 
     let active_turn = Arc::new(AtomicBool::new(false));
+    let turn_started_at_ms = Arc::new(AtomicU64::new(0));
 
     let actor = NousActor::new(
         id.clone(),
@@ -77,13 +78,14 @@ pub(crate) fn spawn(
         tool_services,
         extra_bootstrap,
         Arc::clone(&active_turn),
+        Arc::clone(&turn_started_at_ms),
         nous_behavior,
     );
 
     let span = tracing::info_span!("nous_actor", nous.id = %id);
     let join_handle = tokio::spawn(async move { actor.run().await }.instrument(span));
 
-    (handle, join_handle, active_turn)
+    (handle, join_handle, active_turn, turn_started_at_ms)
 }
 
 /// Parameters for daemon-initiated child agent spawning.
@@ -124,7 +126,7 @@ pub struct DaemonSpawnParams {
 /// parent's runtime services. This public function wraps the internal `spawn`
 /// with a parameter struct and cancellation token from the coordinator.
 ///
-/// Returns the same triple as internal spawn: `(NousHandle, JoinHandle, active_turn)`.
+/// Returns the same tuple as internal spawn: `(NousHandle, JoinHandle, active_turn, turn_started_at_ms)`.
 #[expect(
     dead_code,
     reason = "daemon coordinator wiring not yet connected; public API for child agent spawning"
@@ -132,7 +134,7 @@ pub struct DaemonSpawnParams {
 pub fn spawn_for_daemon(
     params: DaemonSpawnParams,
     cancel: CancellationToken,
-) -> (NousHandle, tokio::task::JoinHandle<()>, Arc<AtomicBool>) {
+) -> (NousHandle, tokio::task::JoinHandle<()>, Arc<AtomicBool>, Arc<AtomicU64>) {
     spawn(
         params.config,
         params.pipeline_config,

--- a/crates/nous/src/actor/tests.rs
+++ b/crates/nous/src/actor/tests.rs
@@ -54,7 +54,7 @@ fn spawn_test_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile::Tem
     let config = test_config();
     let pipeline_config = PipelineConfig::default();
 
-    let (handle, join, _active_turn) = spawn(
+    let (handle, join, _active_turn, _turn_started_at_ms) = spawn(
         config,
         pipeline_config,
         providers,
@@ -357,7 +357,7 @@ fn spawn_panicking_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile
     let config = test_config();
     let pipeline_config = PipelineConfig::default();
 
-    let (handle, join, _active_turn) = spawn(
+    let (handle, join, _active_turn, _turn_started_at_ms) = spawn(
         config,
         pipeline_config,
         providers,
@@ -529,7 +529,7 @@ fn spawn_test_actor_with_store(
     let config = test_config();
     let pipeline_config = PipelineConfig::default();
 
-    let (handle, join, _active_turn) = spawn(
+    let (handle, join, _active_turn, _turn_started_at_ms) = spawn(
         config,
         pipeline_config,
         providers,
@@ -567,6 +567,7 @@ fn make_test_actor(
     let config = test_config();
     let (tx, rx) = mpsc::channel(DEFAULT_INBOX_CAPACITY);
     let active_turn = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let turn_started_at_ms = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let actor = NousActor::new(
         "test-agent".to_owned(),
         config,
@@ -585,6 +586,7 @@ fn make_test_actor(
         None,
         Vec::new(),
         active_turn,
+        turn_started_at_ms,
         taxis::config::NousBehaviorConfig::default(),
     );
     (actor, tx, dir)

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -40,6 +40,16 @@ impl NousActor {
         self.channel.status = NousLifecycle::Active;
         self.active_session = Some(session_key.to_owned());
         self.runtime.active_turn.store(true, Ordering::Release);
+        // WHY: record when the turn started so the health check can detect turns
+        // stuck longer than `stuck_turn_timeout_secs`, even when active_turn is
+        // true. Uses millis-since-started_at to avoid wrapping issues. (#3254)
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::as_conversions,
+            reason = "u128→u64: actor uptime in ms won't exceed u64::MAX"
+        )]
+        let elapsed_ms = self.runtime.started_at.elapsed().as_millis() as u64; // kanon:ignore RUST/as-cast
+        self.runtime.turn_started_at_ms.store(elapsed_ms, Ordering::Release);
     }
 
     /// Finalize turn: update session tokens, check drift, spawn side-effects, reset state.
@@ -73,6 +83,7 @@ impl NousActor {
             self.channel.status = NousLifecycle::Idle;
         }
         self.runtime.active_turn.store(false, Ordering::Release);
+        self.runtime.turn_started_at_ms.store(0, Ordering::Release);
     }
 
     /// Extract quality metrics from a turn result and feed them to the

--- a/crates/nous/src/execute/dispatch.rs
+++ b/crates/nous/src/execute/dispatch.rs
@@ -3,7 +3,7 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use tokio::sync::mpsc;
 
@@ -262,10 +262,23 @@ pub(super) async fn dispatch_tools(
 
         let content = truncate_tool_result(content, max_tool_result_bytes);
 
-        debug!(
-            tool = tool_name.as_str(),
-            duration_ms, is_error, "tool executed"
-        );
+        // WHY: tool failures must be visible at production log levels so operators
+        // can detect systematic tool problems (DNS, permissions, etc.) without
+        // enabling debug-level tracing. (#3284)
+        if is_error {
+            warn!(
+                tool = tool_name.as_str(),
+                tool_id = tool_id.as_str(),
+                duration_ms,
+                "tool execution failed"
+            );
+            crate::metrics::record_tool_failure(tool_ctx.nous_id.as_ref(), tool_name);
+        } else {
+            debug!(
+                tool = tool_name.as_str(),
+                duration_ms, "tool executed"
+            );
+        }
 
         all_tool_calls.push(ToolCall {
             id: tool_id.clone(),
@@ -312,6 +325,10 @@ pub(super) async fn dispatch_tools(
     clippy::too_many_arguments,
     reason = "streaming dispatch inherently needs context, detector, channel, and limit"
 )]
+#[expect(
+    clippy::too_many_lines,
+    reason = "streaming dispatch: sequential tool execution with error handling and event logging; splitting would scatter the per-tool lifecycle"
+)]
 pub(super) async fn dispatch_tools_streaming(
     tool_uses: &[(String, String, serde_json::Value)],
     tools: &ToolRegistry,
@@ -333,11 +350,37 @@ pub(super) async fn dispatch_tools_streaming(
             .build()
         })?;
 
-        let _ = stream_tx.try_send(TurnStreamEvent::ToolStart {
+        // WHY: distinguish buffer-full (performance problem, warn) from receiver-
+        // disconnected (expected client close, debug). Silent drops violate the
+        // streaming observability contract. (#3285)
+        if let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolStart {
             tool_id: tool_id.clone(),
             tool_name: tool_name.clone(),
             input: tool_input.clone(),
-        });
+        }) {
+            match e {
+                tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                    warn!(
+                        tool = tool_name.as_str(),
+                        "streaming event dropped: channel buffer full — client cannot keep up"
+                    );
+                    crate::metrics::record_stream_event_dropped(
+                        tool_ctx.nous_id.as_ref(),
+                        "buffer_full",
+                    );
+                }
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                    debug!(
+                        tool = tool_name.as_str(),
+                        "streaming event dropped: receiver disconnected"
+                    );
+                    crate::metrics::record_stream_event_dropped(
+                        tool_ctx.nous_id.as_ref(),
+                        "disconnected",
+                    );
+                }
+            }
+        }
 
         let start = std::time::Instant::now();
         let result = tools
@@ -366,18 +409,51 @@ pub(super) async fn dispatch_tools_streaming(
         let content = truncate_tool_result(content, max_tool_result_bytes);
         let result_summary = content.text_summary();
 
-        debug!(
-            tool = tool_name.as_str(),
-            duration_ms, is_error, "tool executed"
-        );
+        if is_error {
+            warn!(
+                tool = tool_name.as_str(),
+                tool_id = tool_id.as_str(),
+                duration_ms,
+                "tool execution failed"
+            );
+            crate::metrics::record_tool_failure(tool_ctx.nous_id.as_ref(), tool_name);
+        } else {
+            debug!(
+                tool = tool_name.as_str(),
+                duration_ms, "tool executed"
+            );
+        }
 
-        let _ = stream_tx.try_send(TurnStreamEvent::ToolResult {
+        if let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolResult {
             tool_id: tool_id.clone(),
             tool_name: tool_name.clone(),
             result: result_summary.clone(),
             is_error,
             duration_ms,
-        });
+        }) {
+            match e {
+                tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                    warn!(
+                        tool = tool_name.as_str(),
+                        "streaming result dropped: channel buffer full — client cannot keep up"
+                    );
+                    crate::metrics::record_stream_event_dropped(
+                        tool_ctx.nous_id.as_ref(),
+                        "buffer_full",
+                    );
+                }
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                    debug!(
+                        tool = tool_name.as_str(),
+                        "streaming result dropped: receiver disconnected"
+                    );
+                    crate::metrics::record_stream_event_dropped(
+                        tool_ctx.nous_id.as_ref(),
+                        "disconnected",
+                    );
+                }
+            }
+        }
 
         all_tool_calls.push(ToolCall {
             id: tool_id.clone(),

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 // WHY: lock held only during synchronous .take() on Option<JoinHandle>: no await while locked
 use std::sync::Mutex; // kanon:ignore RUST/std-mutex-in-async
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use tokio::sync::Mutex as TokioMutex;
@@ -50,6 +50,10 @@ struct ActorEntry {
     /// Readable without queuing through the inbox: used by `check_health` to
     /// distinguish a busy (healthy) actor from an unresponsive (dead) one.
     active_turn: Arc<AtomicBool>,
+    /// Monotonic timestamp (millis since actor start) when the current turn began.
+    /// 0 when idle. Used by `check_health` to detect stuck turns that have been
+    /// active longer than `stuck_turn_timeout_secs`. (#3254)
+    turn_started_at_ms: Arc<AtomicU64>,
 }
 
 
@@ -208,7 +212,7 @@ impl NousManager {
         };
 
         let child_cancel = self.cancel.child_token();
-        let (handle, join_handle, active_turn) = actor::spawn(
+        let (handle, join_handle, active_turn, turn_started_at_ms) = actor::spawn(
             config.clone(),
             pipeline_config.clone(),
             Arc::clone(&self.providers),
@@ -239,6 +243,7 @@ impl NousManager {
                 last_start: std::time::Instant::now(),
                 last_restart: None,
                 active_turn,
+                turn_started_at_ms,
             },
         );
         Ok(handle)
@@ -279,12 +284,47 @@ impl NousManager {
     pub async fn check_health(&self) -> BTreeMap<String, ActorHealth> {
         let mut results = BTreeMap::new();
         let ping_timeout = Duration::from_secs(self.nous_behavior.manager_ping_timeout_secs);
+        let stuck_timeout_ms = self.nous_behavior.stuck_turn_timeout_secs * 1_000;
         for (id, entry) in &self.actors {
             let ping_result = entry.handle.ping(ping_timeout).await;
+            let is_active = entry.active_turn.load(Ordering::Acquire);
             // WHY: An actor processing a long turn cannot dequeue Ping messages
             // until the turn completes. Treat active_turn=true as a liveness
             // signal so busy actors are not incorrectly declared dead.
-            let alive = ping_result.is_ok() || entry.active_turn.load(Ordering::Acquire);
+            // However, if the turn has been active longer than `stuck_turn_timeout_secs`,
+            // the actor is considered stuck and NOT alive. This prevents a hung
+            // pipeline from masking a dead actor indefinitely. (#3254)
+            let alive = if ping_result.is_ok() {
+                true
+            } else if is_active {
+                let turn_start = entry.turn_started_at_ms.load(Ordering::Acquire);
+                if turn_start == 0 {
+                    // active_turn is true but timestamp is 0: inconsistent state.
+                    // Treat as alive to avoid false restarts.
+                    true
+                } else {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        clippy::as_conversions,
+                        reason = "u128→u64: actor uptime in ms won't exceed u64::MAX"
+                    )]
+                    let now_ms = entry.last_start.elapsed().as_millis() as u64; // kanon:ignore RUST/as-cast
+                    let turn_duration_ms = now_ms.saturating_sub(turn_start);
+                    if turn_duration_ms > stuck_timeout_ms {
+                        warn!(
+                            nous_id = %id,
+                            turn_duration_secs = turn_duration_ms / 1_000,
+                            stuck_turn_timeout_secs = self.nous_behavior.stuck_turn_timeout_secs,
+                            "turn exceeded stuck timeout — declaring actor dead despite active_turn flag"
+                        );
+                        false
+                    } else {
+                        true
+                    }
+                }
+            } else {
+                false
+            };
 
             let (panic_count, uptime) = if let Ok(status) = entry.handle.status().await {
                 (status.panic_count, status.uptime)

--- a/crates/nous/src/manager_tests.rs
+++ b/crates/nous/src/manager_tests.rs
@@ -365,11 +365,16 @@ async fn check_health_busy_actor_reports_alive() {
     mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
 
     // NOTE: Simulate: actor is mid-turn (flag set) but its inbox is closed (ping fails).
-    mgr.actors
-        .get("syn")
-        .expect("actor registered")
-        .active_turn
-        .store(true, std::sync::atomic::Ordering::Release);
+    let entry = mgr.actors.get("syn").expect("actor registered");
+    entry.active_turn.store(true, std::sync::atomic::Ordering::Release);
+    // WHY: set a recent turn_started_at_ms so stuck-turn detection doesn't trigger
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "u128→u64: test uptime in ms won't exceed u64::MAX"
+    )]
+    let now_ms = entry.last_start.elapsed().as_millis() as u64; // kanon:ignore RUST/as-cast
+    entry.turn_started_at_ms.store(now_ms, std::sync::atomic::Ordering::Release);
 
     let handle = mgr.actors.get("syn").expect("entry").handle.clone();
     handle.shutdown().await.expect("shutdown sent");

--- a/crates/nous/src/metrics.rs
+++ b/crates/nous/src/metrics.rs
@@ -68,6 +68,28 @@ static BACKGROUND_TASK_FAILURES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|
     .expect("metric registration") // kanon:ignore RUST/expect
 });
 
+static TOOL_FAILURES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "aletheia_tool_failures_total",
+            "Total tool execution failures by tool name"
+        ),
+        &["nous_id", "tool_name"]
+    )
+    .expect("metric registration") // kanon:ignore RUST/expect
+});
+
+static STREAM_EVENTS_DROPPED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "aletheia_stream_events_dropped_total",
+            "Total streaming events dropped due to full channel or disconnected receiver"
+        ),
+        &["nous_id", "reason"]
+    )
+    .expect("metric registration") // kanon:ignore RUST/expect
+});
+
 static CACHE_CREATION_TOKENS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(
         Opts::new(
@@ -94,6 +116,8 @@ pub(crate) fn init() {
     LazyLock::force(&CACHE_READ_TOKENS_TOTAL);
     LazyLock::force(&CACHE_CREATION_TOKENS_TOTAL);
     LazyLock::force(&BACKGROUND_TASK_FAILURES_TOTAL);
+    LazyLock::force(&TOOL_FAILURES_TOTAL);
+    LazyLock::force(&STREAM_EVENTS_DROPPED_TOTAL);
 }
 
 /// Record a completed pipeline stage.
@@ -112,6 +136,26 @@ pub(crate) fn record_turn(nous_id: &str) {
 pub(crate) fn record_error(nous_id: &str, stage: &str, error_type: &str) {
     PIPELINE_ERRORS_TOTAL
         .with_label_values(&[nous_id, stage, error_type])
+        .inc();
+}
+
+/// Record a tool execution failure.
+///
+/// WHY: Tool failures at warn level need a metrics counter so operators can
+/// set alerts on systematic tool problems. Closes #3284.
+pub(crate) fn record_tool_failure(nous_id: &str, tool_name: &str) {
+    TOOL_FAILURES_TOTAL
+        .with_label_values(&[nous_id, tool_name])
+        .inc();
+}
+
+/// Record a dropped streaming event.
+///
+/// WHY: Silently dropped streaming events are invisible contract violations.
+/// This counter surfaces the drop rate for alerting. Closes #3285.
+pub(crate) fn record_stream_event_dropped(nous_id: &str, reason: &str) {
+    STREAM_EVENTS_DROPPED_TOTAL
+        .with_label_values(&[nous_id, reason])
         .inc();
 }
 

--- a/crates/nous/src/session.rs
+++ b/crates/nous/src/session.rs
@@ -63,6 +63,10 @@ impl SessionState {
     pub fn next_turn(&mut self) -> u64 {
         self.turn += 1;
         self.turn_id = Ulid::new();
+        // WHY: update last_accessed so LRU eviction correctly keeps active sessions
+        // over idle ones. Without this, eviction is effectively creation-time ordering
+        // because Instant::now() is only set in new(). (#3253)
+        self.last_accessed = Instant::now();
         self.turn
     }
 

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -155,7 +155,7 @@ impl SpawnService for SpawnServiceImpl {
 
                 // WHY: ephemeral actors get their own cancellation token: short-lived, no shared parent
                 let ephemeral_cancel = CancellationToken::new();
-                let (handle, join_handle, _active_turn) = actor::spawn(
+                let (handle, join_handle, _active_turn, _turn_started_at_ms) = actor::spawn(
                     config,
                     pipeline_config,
                     providers,

--- a/crates/taxis/src/config/behavior.rs
+++ b/crates/taxis/src/config/behavior.rs
@@ -145,6 +145,13 @@ pub struct NousBehaviorConfig {
     /// Timeout in seconds for health-ping responses. Default: 5.
     /// Mirrors `nous::manager::DEFAULT_PING_TIMEOUT`.
     pub manager_ping_timeout_secs: u64,
+    /// Maximum seconds a turn may be active before the health check considers
+    /// the actor stuck. An `active_turn` flag alone cannot distinguish a legitimately
+    /// busy actor from one hung on an infinite loop or deadlock. Default: 600 (10 min).
+    /// WHY: Without a timeout, a stuck `active_turn` flag prevents the health check
+    /// from ever restarting the actor, making a single hung pipeline permanently
+    /// block all subsequent messages. (#3254)
+    pub stuck_turn_timeout_secs: u64,
     /// Number of recent tool calls scanned for loop detection. Default: 50.
     /// Mirrors `nous::pipeline::DEFAULT_LOOP_WINDOW`.
     pub loop_detection_window: usize,
@@ -173,6 +180,7 @@ impl Default for NousBehaviorConfig {
             manager_restart_decay_window_secs: 3_600,
             manager_health_interval_secs: 30,
             manager_ping_timeout_secs: 5,
+            stuck_turn_timeout_secs: 600,
             loop_detection_window: 50,
             cycle_detection_max_len: 10,
             self_audit_event_threshold: 50,

--- a/crates/taxis/src/config/config_tests.rs
+++ b/crates/taxis/src/config/config_tests.rs
@@ -852,6 +852,8 @@ fn deployment_defaults_match_original_constants() {
     assert_eq!(nb.manager_health_interval_secs, 30, "manager_health_interval_secs");
     // nous::manager::DEFAULT_PING_TIMEOUT = 5s
     assert_eq!(nb.manager_ping_timeout_secs, 5, "manager_ping_timeout_secs");
+    // nous::manager: stuck turn detection timeout = 600s
+    assert_eq!(nb.stuck_turn_timeout_secs, 600, "stuck_turn_timeout_secs");
     // nous::pipeline::DEFAULT_LOOP_WINDOW = 50
     assert_eq!(nb.loop_detection_window, 50, "loop_detection_window");
     // nous::pipeline::CYCLE_DETECTION_MAX_LEN = 10


### PR DESCRIPTION
## Summary

- **#3249**: Verified background task panics are already separated from pipeline panics; `record_background_panic` does not trigger degraded mode
- **#3253**: Session eviction fixed to be truly LRU — `last_accessed` is now updated on every `next_turn()` call, not just at creation
- **#3254**: Health check hardened with `turn_started_at_ms` (`AtomicU64` timestamp); stuck turns exceeding `stuck_turn_timeout_secs` (default 600s) are detected even when `active_turn` flag is true
- **#3256**: Background tasks (extraction, distillation, skill analysis) now respect the actor's `CancellationToken` via `tokio::select!`, enabling prompt shutdown
- **#3284**: Tool execution failures logged at `warn!` (was `debug!`) with structured fields; new `aletheia_tool_failures_total` Prometheus counter
- **#3285**: Streaming `try_send` failures now log at `warn!` (buffer full) or `debug!` (disconnected); new `aletheia_stream_events_dropped_total` counter

## Test plan

- [x] `cargo check -p nous` — zero errors
- [x] `cargo test -p nous` — 769 unit + 7 integration tests pass
- [x] `cargo test -p taxis` — 282 tests pass (new `stuck_turn_timeout_secs` default verified)
- [x] `cargo clippy -p nous -p taxis` — zero warnings from changed code
- [x] `cargo clippy --workspace` — no new warnings introduced
- [x] Existing `check_health_busy_actor_reports_alive` test updated for new timestamp field

🤖 Generated with [Claude Code](https://claude.com/claude-code)