### PR TITLE
security(krites): audit unsafe blocks with SAFETY documentation (#3220)

### DIFF
--- a/crates/krites/src/data/functions/vector.rs
+++ b/crates/krites/src/data/functions/vector.rs
@@ -1,10 +1,7 @@
 //! Vector creation and distance operations.
-#![expect(unsafe_code, reason = "base64-decoded vectors require unsafe reinterpret via ArrayView1::from_shape_ptr")]
-#![expect(clippy::as_conversions, reason = "vector operations require pointer and numeric casts — engine-internal")]
-#![expect(clippy::cast_ptr_alignment, reason = "global allocator guarantees alignment; debug_assert verifies")]
-#![expect(clippy::ptr_as_ptr, reason = "pointer casts required for byte-to-float reinterpretation")]
+#![expect(clippy::as_conversions, reason = "vector operations require numeric casts (f64 → f32) for element conversion")]
+#![expect(clippy::map_err_ignore, reason = "bytemuck PodCastError detail is not useful to the caller; the message describes the failure")]
 #![expect(clippy::too_many_lines, reason = "op_vec handles multiple input types and vector element types")]
-use std::mem;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
@@ -142,64 +139,26 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
             })?;
             match t {
                 VecElementType::F32 => {
-                    let f32_count = bytes.len() / mem::size_of::<f32>();
-                    debug_assert_eq!(
-                        bytes.as_ptr().addr() % mem::align_of::<f32>(),
-                        0,
-                        "Vec<u8> buffer must be aligned for f32 reinterpretation"
-                    );
-                    // SAFETY: `bytes` is a Vec<u8> produced by base64-decoding a
-                    // serialised f32 vector (written by `Vector::serialize`). Three
-                    // invariants hold:
-                    // (1) Alignment: the global allocator guarantees the buffer is
-                    //     aligned to at least max_align_t (≥ 16 B), which is larger
-                    //     than align_of::<f32>() (4 B); the debug_assert above
-                    //     verifies this at runtime in debug builds.
-                    // (2) Length: `f32_count` is `bytes.len() / size_of::<f32>()`, so
-                    //     the pointer covers exactly `f32_count` fully-initialised f32
-                    //     elements within the live `bytes` allocation.
-                    // (3) Lifetime: `arr` is immediately converted to an owned array
-                    //     via `to_owned()` before `bytes` is dropped, so the view
-                    //     never outlives the backing buffer.
-                    // Violating any of these would cause UB: misaligned read,
-                    // out-of-bounds access, or dangling pointer respectively.
-                    let arr = unsafe {
-                        ndarray::ArrayView1::from_shape_ptr(
-                            ndarray::Dim([f32_count]),
-                            bytes.as_ptr() as *const f32,
-                        )
-                    };
-                    Ok(DataValue::Vec(Vector::F32(arr.to_owned())))
+                    let floats: &[f32] = bytemuck::try_cast_slice(&bytes).map_err(|_| {
+                        EncodingFailedSnafu {
+                            message: "f32 vector data is not properly aligned or sized",
+                        }
+                        .build()
+                    })?;
+                    Ok(DataValue::Vec(Vector::F32(ndarray::Array1::from(
+                        floats.to_vec(),
+                    ))))
                 }
                 VecElementType::F64 => {
-                    let f64_count = bytes.len() / mem::size_of::<f64>();
-                    debug_assert_eq!(
-                        bytes.as_ptr().addr() % mem::align_of::<f64>(),
-                        0,
-                        "Vec<u8> buffer must be aligned for f64 reinterpretation"
-                    );
-                    // SAFETY: `bytes` is a Vec<u8> produced by base64-decoding a
-                    // serialised f64 vector (written by `Vector::serialize`). Three
-                    // invariants hold:
-                    // (1) Alignment: the global allocator guarantees the buffer is
-                    //     aligned to at least max_align_t (≥ 16 B), which is larger
-                    //     than align_of::<f64>() (8 B); the debug_assert above
-                    //     verifies this at runtime in debug builds.
-                    // (2) Length: `f64_count` is `bytes.len() / size_of::<f64>()`, so
-                    //     the pointer covers exactly `f64_count` fully-initialised f64
-                    //     elements within the live `bytes` allocation.
-                    // (3) Lifetime: `arr` is immediately converted to an owned array
-                    //     via `to_owned()` before `bytes` is dropped, so the view
-                    //     never outlives the backing buffer.
-                    // Violating any of these would cause UB: misaligned read,
-                    // out-of-bounds access, or dangling pointer respectively.
-                    let arr = unsafe {
-                        ndarray::ArrayView1::from_shape_ptr(
-                            ndarray::Dim([f64_count]),
-                            bytes.as_ptr() as *const f64,
-                        )
-                    };
-                    Ok(DataValue::Vec(Vector::F64(arr.to_owned())))
+                    let floats: &[f64] = bytemuck::try_cast_slice(&bytes).map_err(|_| {
+                        EncodingFailedSnafu {
+                            message: "f64 vector data is not properly aligned or sized",
+                        }
+                        .build()
+                    })?;
+                    Ok(DataValue::Vec(Vector::F64(ndarray::Array1::from(
+                        floats.to_vec(),
+                    ))))
                 }
             }
         }

--- a/crates/krites/src/data/memcmp.rs
+++ b/crates/krites/src/data/memcmp.rs
@@ -1,5 +1,5 @@
 //! Memory-comparable encoding for composite keys.
-#![expect(unsafe_code, reason = "memcmp decoding uses ptr::read for zero-copy numeric deserialization")]
+#![expect(unsafe_code, reason = "memcmp decoding uses from_utf8_unchecked for strings known to be valid UTF-8 from encoding")]
 #![expect(clippy::indexing_slicing, reason = "memcmp encoding indices are structurally bounded by length prefix parsing")]
 #![expect(clippy::as_conversions, reason = "binary encoding requires byte-level numeric casts")]
 #![expect(clippy::unreadable_literal, reason = "bit flag constants (0b00010000) are clearer without separators")]

--- a/crates/krites/src/data/relation.rs
+++ b/crates/krites/src/data/relation.rs
@@ -1,9 +1,5 @@
 //! Relation metadata and schema definitions.
-#![expect(unsafe_code, reason = "relation accessors use ptr::read for zero-copy column type deserialization")]
 #![expect(clippy::as_conversions, reason = "relation metadata requires numeric casts for column indices")]
-#![expect(clippy::cast_ptr_alignment, reason = "relation byte buffers are allocator-aligned; deserialization requires reinterpret casts")]
-#![expect(clippy::ptr_as_ptr, reason = "relation byte deserialization requires pointer type casts")]
-#![expect(clippy::unsafe_derive_deserialize, reason = "NullableColType derives Deserialize with unsafe accessors — audited")]
 #![expect(clippy::too_many_lines, reason = "ensure_compatible handles all DataValue variant combinations")]
 #![expect(clippy::uninlined_format_args, reason = "format args style is consistent within relation coercion code")]
 #![expect(clippy::semicolon_if_nothing_returned, reason = "Display write calls — semicolon not needed")]
@@ -11,7 +7,6 @@
 #![expect(clippy::redundant_else, reason = "else after return keeps error path visually grouped with the check")]
 use std::cmp::Reverse;
 use std::fmt::{Display, Formatter};
-use std::mem;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
@@ -304,68 +299,20 @@ impl NullableColType {
                     let bytes = STANDARD.decode(s).map_err(|_| make_err())?;
                     match eltype {
                         VecElementType::F32 => {
-                            let f32_count = bytes.len() / mem::size_of::<f32>();
-                            if f32_count != *len {
+                            let floats: &[f32] =
+                                bytemuck::try_cast_slice(&bytes).map_err(|_| make_err())?;
+                            if floats.len() != *len {
                                 return Err(make_err());
                             }
-                            debug_assert_eq!(
-                                bytes.as_ptr().addr() % mem::align_of::<f32>(),
-                                0,
-                                "Vec<u8> buffer must be aligned for f32 reinterpretation"
-                            );
-                            // SAFETY: `bytes` is a Vec<u8> produced by base64-decoding a
-                            // serialised f32 vector. Three invariants hold:
-                            // (1) Alignment: the global allocator guarantees the buffer is
-                            //     aligned to at least max_align_t (≥ 16 B), which is larger
-                            //     than align_of::<f32>() (4 B); the debug_assert above
-                            //     verifies this at runtime in debug builds.
-                            // (2) Length: the length check above ensures `f32_count == *len`,
-                            //     so the pointer covers exactly `f32_count` initialised f32
-                            //     elements within the live `bytes` allocation.
-                            // (3) Lifetime: `arr` is immediately converted to an owned array
-                            //     via `to_owned()` before `bytes` is dropped, so the view
-                            //     never outlives the backing buffer.
-                            // Violating any of these would cause UB: misaligned read,
-                            // out-of-bounds access, or dangling pointer respectively.
-                            let arr = unsafe {
-                                ndarray::ArrayView1::from_shape_ptr(
-                                    ndarray::Dim([f32_count]),
-                                    bytes.as_ptr() as *const f32,
-                                )
-                            };
-                            DataValue::Vec(Vector::F32(arr.to_owned()))
+                            DataValue::Vec(Vector::F32(ndarray::Array1::from(floats.to_vec())))
                         }
                         VecElementType::F64 => {
-                            let f64_count = bytes.len() / mem::size_of::<f64>();
-                            if f64_count != *len {
+                            let floats: &[f64] =
+                                bytemuck::try_cast_slice(&bytes).map_err(|_| make_err())?;
+                            if floats.len() != *len {
                                 return Err(make_err());
                             }
-                            debug_assert_eq!(
-                                bytes.as_ptr().addr() % mem::align_of::<f64>(),
-                                0,
-                                "Vec<u8> buffer must be aligned for f64 reinterpretation"
-                            );
-                            // SAFETY: `bytes` is a Vec<u8> produced by base64-decoding a
-                            // serialised f64 vector. Three invariants hold:
-                            // (1) Alignment: the global allocator guarantees the buffer is
-                            //     aligned to at least max_align_t (≥ 16 B), which is larger
-                            //     than align_of::<f64>() (8 B); the debug_assert above
-                            //     verifies this at runtime in debug builds.
-                            // (2) Length: the length check above ensures `f64_count == *len`,
-                            //     so the pointer covers exactly `f64_count` initialised f64
-                            //     elements within the live `bytes` allocation.
-                            // (3) Lifetime: `arr` is immediately converted to an owned array
-                            //     via `to_owned()` before `bytes` is dropped, so the view
-                            //     never outlives the backing buffer.
-                            // Violating any of these would cause UB: misaligned read,
-                            // out-of-bounds access, or dangling pointer respectively.
-                            let arr = unsafe {
-                                ndarray::ArrayView1::from_shape_ptr(
-                                    ndarray::Dim([f64_count]),
-                                    bytes.as_ptr() as *const f64,
-                                )
-                            };
-                            DataValue::Vec(Vector::F64(arr.to_owned()))
+                            DataValue::Vec(Vector::F64(ndarray::Array1::from(floats.to_vec())))
                         }
                     }
                 }
@@ -501,7 +448,7 @@ impl NullableColType {
                     let mut arr = Vec::with_capacity(l.len());
                     for el in l {
                         let coerced = self.coerce(el, cur_vld)?;
-                        arr.push(JsonValue::try_from(coerced).unwrap_or(JsonValue::Null));
+                        arr.push(JsonValue::from(coerced));
                     }
                     arr.into()
                 }
@@ -509,7 +456,7 @@ impl NullableColType {
                     let mut arr = Vec::with_capacity(l.len());
                     for el in l {
                         let coerced = self.coerce(el, cur_vld)?;
-                        arr.push(JsonValue::try_from(coerced).unwrap_or(JsonValue::Null));
+                        arr.push(JsonValue::from(coerced));
                     }
                     arr.into()
                 }

--- a/crates/krites/src/data/value.rs
+++ b/crates/krites/src/data/value.rs
@@ -1,8 +1,5 @@
 //! Core value type for the Datalog engine.
-#![expect(unsafe_code, reason = "DataValue layout requires unsafe for Ord impl and raw pointer access")]
 #![expect(clippy::as_conversions, reason = "DataValue numeric conversions require i64/f64/pointer casts")]
-#![expect(clippy::ptr_as_ptr, reason = "DataValue union layout requires raw pointer casts for zero-copy access")]
-#![expect(clippy::unsafe_derive_deserialize, reason = "DataValue derives Deserialize with manual Ord — unsafe is audited")]
 #![expect(clippy::semicolon_if_nothing_returned, reason = "hash/display impls — semicolon not needed before closing brace")]
 #![expect(clippy::explicit_iter_loop, reason = "explicit .iter() in DataValue collection processing")]
 #![expect(clippy::needless_continue, reason = "explicit continue in sort comparison arms aids readability")]
@@ -162,6 +159,10 @@ impl From<(i64, bool)> for Validity {
 /// `Regex`, `Set`, `Validity`, and `Bot` are engine-internal: they never appear
 /// in user-facing query results. `Bot` is the bottom sentinel used as the
 /// upper-bound key in range scans.
+#[expect(
+    clippy::unsafe_derive_deserialize,
+    reason = "DataValue has no unsafe code; clippy false positive from Vector serde impl in same module"
+)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize, Hash)]
 #[non_exhaustive]
 pub enum DataValue {
@@ -270,23 +271,13 @@ impl serde::Serialize for Vector {
             Vector::F32(a) => {
                 state.serialize_element(&0u8)?;
                 let arr = a.as_slice().unwrap_or(&[]);
-                let len = std::mem::size_of_val(arr);
-                let ptr = arr.as_ptr() as *const u8;
-                // SAFETY: `ptr` comes from a valid &[f32] allocation. Reinterpreting as
-                // &[u8] is safe because u8 has alignment 1 (always satisfied) and `len`
-                // is exactly `size_of_val(arr)`: the true byte length of the slice.
-                let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+                let bytes: &[u8] = bytemuck::cast_slice(arr);
                 state.serialize_element(&VecBytes(bytes))?;
             }
             Vector::F64(a) => {
                 state.serialize_element(&1u8)?;
                 let arr = a.as_slice().unwrap_or(&[]);
-                let len = std::mem::size_of_val(arr);
-                let ptr = arr.as_ptr() as *const u8;
-                // SAFETY: `ptr` comes from a valid &[f64] allocation. Reinterpreting as
-                // &[u8] is safe because u8 has alignment 1 (always satisfied) and `len`
-                // is exactly `size_of_val(arr)`: the true byte length of the slice.
-                let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+                let bytes: &[u8] = bytemuck::cast_slice(arr);
                 state.serialize_element(&VecBytes(bytes))?;
             }
         }
@@ -323,34 +314,14 @@ impl<'de> Visitor<'de> for VectorVisitor {
             .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
         match tag {
             0u8 => {
-                let len = bytes.len() / std::mem::size_of::<f32>();
-                let mut v = vec![];
-                v.reserve_exact(len);
-                let ptr = v.as_mut_ptr() as *mut u8;
-                // SAFETY: `v` has capacity for `len` f32 values, which is exactly
-                // `bytes.len()` bytes. `copy_nonoverlapping` writes into the reserved
-                // (but not yet initialized) capacity. After the copy every element is
-                // initialised, so `set_len(len)` is sound.
-                unsafe {
-                    std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
-                    v.set_len(len);
-                }
-                Ok(Vector::F32(Array1::from(v)))
+                let floats: &[f32] = bytemuck::try_cast_slice(bytes)
+                    .map_err(|e| serde::de::Error::custom(format!("f32 cast: {e}")))?;
+                Ok(Vector::F32(Array1::from(floats.to_vec())))
             }
             1u8 => {
-                let len = bytes.len() / std::mem::size_of::<f64>();
-                let mut v = vec![];
-                v.reserve_exact(len);
-                let ptr = v.as_mut_ptr() as *mut u8;
-                // SAFETY: `v` has capacity for `len` f64 values, which is exactly
-                // `bytes.len()` bytes. `copy_nonoverlapping` writes into the reserved
-                // (but not yet initialized) capacity. After the copy every element is
-                // initialised, so `set_len(len)` is sound.
-                unsafe {
-                    std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
-                    v.set_len(len);
-                }
-                Ok(Vector::F64(Array1::from(v)))
+                let floats: &[f64] = bytemuck::try_cast_slice(bytes)
+                    .map_err(|e| serde::de::Error::custom(format!("f64 cast: {e}")))?;
+                Ok(Vector::F64(Array1::from(floats.to_vec())))
             }
             _ => Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Unsigned(u64::from(tag)),

--- a/crates/krites/src/runtime/hnsw/mmap_storage.rs
+++ b/crates/krites/src/runtime/hnsw/mmap_storage.rs
@@ -29,14 +29,12 @@ use crate::error::InternalResult as Result;
 use crate::runtime::error::InvalidOperationSnafu;
 
 /// Borrow the raw fd from a `std::fs::File` as a `rustix::fd::BorrowedFd`.
-///
-/// # Safety
-///
-/// The returned `BorrowedFd` must not outlive the `File`.
 #[cfg(unix)]
 fn borrow_fd(file: &File) -> rustix::fd::BorrowedFd<'_> {
     use std::os::unix::io::AsRawFd;
-    // SAFETY: the file is open and we borrow for the lifetime of `file`.
+    // SAFETY: `file` is an open `std::fs::File`, so `as_raw_fd()` returns a
+    // valid fd. The returned `BorrowedFd` borrows `file` (via the `'_` lifetime
+    // tied to the function parameter), preventing use-after-close.
     unsafe { rustix::fd::BorrowedFd::borrow_raw(file.as_raw_fd()) }
 }
 
@@ -378,13 +376,9 @@ impl MmapVectorStorage {
         let stride = self.dim * std::mem::size_of::<f32>();
         let offset = index * stride;
         let bytes = &self.as_bytes()[offset..offset + stride];
-        // SAFETY: stride is always a multiple of 4 (dim * sizeof(f32)).
-        // File data is written from f32 slices so alignment is preserved.
-        let (prefix, floats, suffix) = unsafe { bytes.align_to::<f32>() };
-        debug_assert!(
-            prefix.is_empty() && suffix.is_empty(),
-            "vector data must be f32-aligned"
-        );
+        // bytemuck verifies alignment and size at runtime; mmap data written
+        // from f32 slices is always properly aligned.
+        let floats: &[f32] = bytemuck::cast_slice(bytes);
         Some(floats)
     }
 
@@ -409,9 +403,7 @@ impl MmapVectorStorage {
         }
 
         let stride = self.dim * std::mem::size_of::<f32>();
-        // SAFETY: f32 slice → u8 slice of same memory, stride = dim * 4.
-        let bytes: &[u8] =
-            unsafe { std::slice::from_raw_parts(vector.as_ptr().cast::<u8>(), stride) };
+        let bytes: &[u8] = bytemuck::cast_slice(vector);
 
         #[cfg(unix)]
         {


### PR DESCRIPTION
## Summary

- Audit all unsafe blocks in `crates/krites/src/` — eliminated 11 unnecessary unsafe usages by replacing raw pointer reinterpretation with `bytemuck` (already a dependency)
- 9 unsafe blocks + 4 unsafe impls remain, all inherent to mmap FFI or fjall Sync guarantees, each with a SAFETY comment documenting the soundness invariant
- Fixed pre-existing clippy warnings (unnecessary_fallible_conversions, unfulfilled lint expectations) to achieve zero clippy warnings

### Eliminated unsafe (11 total)
| File | Count | Replacement |
|------|-------|-------------|
| `data/value.rs` | 4 | `bytemuck::cast_slice` / `try_cast_slice` for f32/f64 serde |
| `data/relation.rs` | 2 | `bytemuck::try_cast_slice` for base64-decoded vectors |
| `data/functions/vector.rs` | 2 | `bytemuck::try_cast_slice` for base64-decoded vectors |
| `runtime/hnsw/mmap_storage.rs` | 2 | `bytemuck::cast_slice` for push/get |
| Stale lint expects | 5 | Removed `unsafe_code`, `ptr_as_ptr`, `cast_ptr_alignment` |

### Remaining unsafe (13 total, all documented)
| File | Count | Justification |
|------|-------|---------------|
| `storage/fjall_backend.rs` | 2 impls | fjall types lack native `Sync`; extensive soundness argument |
| `runtime/hnsw/mmap_storage.rs` | 2 impls + 7 blocks | mmap FFI via rustix (munmap, mmap, madvise, msync, from_raw_parts, borrow_raw) |
| `data/memcmp.rs` | 2 blocks | `from_utf8_unchecked` on encoding-guaranteed UTF-8 strings |

## Test plan

- [x] `cargo check -p krites` passes
- [x] `cargo clippy -p krites` — zero warnings
- [x] `cargo test -p krites` — 289 passed, 21 pre-existing HNSW failures unchanged
- [x] All remaining unsafe blocks have SAFETY comments
- [x] All unsafe Sync/Send impls verified sound with documented invariants


🤖 Generated with [Claude Code](https://claude.com/claude-code)