### PR TITLE
fix(pylon): health timeout, 204 responses, SSE correlation, error fidelity (#3277, #3279, #3281, #3282, #3283)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "koina",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "koina",
  "organon",
@@ -1931,7 +1931,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "eidos"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "serde",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "eidos",
  "fjall",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -2822,7 +2822,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "dokimion",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "fd-lock",
  "futures",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "dianoia",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "episteme",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "energeia",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "snafu",
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "poiesis-core",
  "rust_xlsxwriter",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "poiesis-core",
  "ppt-rs",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "krilla",
  "poiesis-core",
@@ -5289,7 +5289,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -6621,7 +6621,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "compact_str",
@@ -6876,7 +6876,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -6989,7 +6989,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -7101,14 +7101,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/graphe/src/error.rs
+++ b/crates/graphe/src/error.rs
@@ -305,5 +305,77 @@ pub enum Error {
     },
 }
 
+impl Error {
+    /// Whether this error is a `SQLite` UNIQUE constraint violation.
+    ///
+    /// Uses the typed `rusqlite::ErrorCode::ConstraintViolation` rather than
+    /// string matching on the error message, which is fragile across `SQLite`
+    /// versions and rusqlite wrappers (#3282).
+    #[cfg(feature = "sqlite")]
+    #[must_use]
+    pub fn is_unique_constraint_violation(&self) -> bool {
+        match self {
+            Self::Database { source, .. } => matches!(
+                source,
+                rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error {
+                        code: rusqlite::ErrorCode::ConstraintViolation,
+                        extended_code: 2067, // SQLITE_CONSTRAINT_UNIQUE
+                    },
+                    _,
+                )
+            ),
+            _ => false,
+        }
+    }
+}
+
 /// Result alias using mneme's [`Error`] type.
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+#[cfg(feature = "sqlite")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unique_constraint_violation_detected() {
+        let sqlite_err = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::ConstraintViolation,
+                extended_code: 2067,
+            },
+            Some("UNIQUE constraint failed: sessions.nous_id, sessions.session_key".to_owned()),
+        );
+        let err = Error::Database {
+            source: sqlite_err,
+            location: snafu::location!(),
+        };
+        assert!(err.is_unique_constraint_violation());
+    }
+
+    #[test]
+    fn non_unique_constraint_not_detected() {
+        let sqlite_err = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DatabaseBusy,
+                extended_code: 5,
+            },
+            Some("database is locked".to_owned()),
+        );
+        let err = Error::Database {
+            source: sqlite_err,
+            location: snafu::location!(),
+        };
+        assert!(!err.is_unique_constraint_violation());
+    }
+
+    #[test]
+    fn non_database_error_not_detected() {
+        let err = Error::SessionNotFound {
+            id: "test".to_owned(),
+            location: snafu::location!(),
+        };
+        assert!(!err.is_unique_constraint_violation());
+    }
+}

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -204,30 +204,44 @@ impl IntoResponse for ApiError {
     }
 }
 
-/// Convert a crate error into an [`ApiError`], with a catch-all mapping to [`InternalSnafu`].
+/// Convert a crate error into an [`ApiError`] with explicit match arms for
+/// every known variant, plus a `#[non_exhaustive]` catch-all that logs the
+/// full error (including source chain) at `error` level.
 ///
-/// WHY: three downstream crate errors (mneme, hermeneus, nous) share the same
-/// pattern — match specific variants, fall through to `InternalSnafu`. This
-/// macro eliminates the repeated catch-all and `From` boilerplate.
+/// WHY: every known variant gets an explicit match arm so the HTTP status code
+/// is semantically correct (transient -> 503, permanent -> 500, client fault
+/// -> 4xx). The catch-all exists only because downstream enums are
+/// `#[non_exhaustive]` — if a new variant is added, it triggers the catch-all
+/// which logs the full error with `tracing::error!`, making the gap immediately
+/// visible in monitoring without silently erasing the error type (#3283).
 macro_rules! impl_from_error {
     ($error_mod:path, |$err:ident| { $($arms:tt)* }) => {
         impl From<$error_mod> for ApiError {
             fn from($err: $error_mod) -> Self {
-                // WHY: `#[allow]` rather than `#[expect]` because each macro
-                // invocation has different match coverage — for some error
-                // types every variant is matched (catch-all unreachable), for
-                // others the catch-all is genuinely needed. `#[expect]`
-                // would fire `unfulfilled_lint_expectations` on the cases
-                // where the lint doesn't fire.
                 #[allow(clippy::enum_glob_use, reason = "scoped to From impl body for concise match arms")]
                 use $error_mod::*;
                 match $err {
                     $($arms)*
-                    #[allow(unreachable_patterns, reason = "catch-all after explicit arms")]
-                    _ => InternalSnafu {
-                        message: $err.to_string(),
+                    // WHY: `#[non_exhaustive]` requires a catch-all. Unlike the
+                    // previous version that silently converted to `Internal` via
+                    // `.to_string()`, this logs the full error at error level so
+                    // new unclassified variants are immediately visible (#3283).
+                    // WHY `#[allow]` not `#[expect]`: this arm is unreachable when
+                    // all current variants are matched, but becomes reachable when
+                    // a downstream crate adds a new variant. `#[expect]` would
+                    // fire `unfulfilled_lint_expectations` in the common case.
+                    #[allow(unreachable_patterns, reason = "required by #[non_exhaustive]; triggers on new unhandled variants")]
+                    _ => {
+                        tracing::error!(
+                            error = %$err,
+                            error_debug = ?$err,
+                            "unclassified error variant — add an explicit match arm"
+                        );
+                        InternalSnafu {
+                            message: $err.to_string(),
+                        }
+                        .build()
                     }
-                    .build(),
                 }
             }
         }
@@ -248,10 +262,63 @@ impl_from_error!(mneme::error::Error, |err| {
     | EmptyEntityName { .. }
     | InvalidWeight { .. }
     | EmptyEmbedding { .. }
-    | EmptyEmbeddingContent { .. } => BadRequestSnafu {
+    | EmptyEmbeddingContent { .. }
+    | AdmissionRejected { .. }
+    | InvalidId { .. } => BadRequestSnafu {
         message: err.to_string(),
     }
     .build(),
+    // WHY: database and storage errors are transient infrastructure failures.
+    // 503 tells clients the server is alive but the store is temporarily
+    // unavailable, so they know to retry.
+    Database { .. }
+    | DatabaseDegraded { .. }
+    | DatabaseCorrupt { .. } => {
+        tracing::error!(error = %err, "mneme storage error");
+        ServiceUnavailableSnafu {
+            message: format!("storage error: {err}"),
+        }
+        .build()
+    }
+    Migration { .. } | ChecksumMismatch { .. } | SchemaTooNew { .. } => {
+        tracing::error!(error = %err, "mneme schema error");
+        InternalSnafu {
+            message: format!("schema error: {err}"),
+        }
+        .build()
+    }
+    UnsupportedVersion { .. } | UnsafePath { .. } | InvalidBackupPath { .. } | BackupPathTraversal { .. } => {
+        BadRequestSnafu {
+            message: err.to_string(),
+        }
+        .build()
+    }
+    EngineInit { .. } | EngineQuery { .. } | SchemaVersion { .. } | Conversion { .. } => {
+        tracing::error!(error = %err, "mneme engine error");
+        InternalSnafu {
+            message: format!("engine error: {err}"),
+        }
+        .build()
+    }
+    QueryTimeout { .. } => ServiceUnavailableSnafu {
+        message: format!("query timed out: {err}"),
+    }
+    .build(),
+    Join { .. } => InternalSnafu {
+        message: format!("task join failed: {err}"),
+    }
+    .build(),
+    EmbeddingDimensionMismatch { .. } => BadRequestSnafu {
+        message: err.to_string(),
+    }
+    .build(),
+    SessionCreate { .. } | Storage { .. } | StoredJson { .. } | Io { .. } => {
+        tracing::error!(error = %err, "mneme internal error");
+        InternalSnafu {
+            message: err.to_string(),
+        }
+        .build()
+    }
 });
 
 impl_from_error!(hermeneus::error::Error, |err| {
@@ -280,6 +347,42 @@ impl_from_error!(hermeneus::error::Error, |err| {
         message,
         ..
     } => ServiceUnavailableSnafu { message }.build(),
+    // WHY: 5xx from the upstream provider is a transient condition. 503 tells
+    // the client to retry.
+    ApiError {
+        status: 500..=599,
+        message,
+        ..
+    } => ServiceUnavailableSnafu {
+        message: format!("provider error: {message}"),
+    }
+    .build(),
+    // WHY: 4xx from upstream is the caller's fault (bad model, too many tokens, etc.)
+    ApiError { status, ref message, .. } => {
+        tracing::error!(error = %err, "hermeneus API error");
+        InternalSnafu {
+            message: format!("provider API error ({status}): {message}"),
+        }
+        .build()
+    }
+    // WHY: Parse errors indicate the provider returned unexpected data — not retryable.
+    ParseResponse { .. } => {
+        tracing::error!(error = %err, "hermeneus parse response error");
+        InternalSnafu {
+            message: format!("provider response parse failed: {err}"),
+        }
+        .build()
+    }
+    UnsupportedModel { model, .. } => BadRequestSnafu {
+        message: format!("model '{model}' is not supported by this provider"),
+    }
+    .build(),
+    // WHY: network-level request failures (timeout, connection refused, etc.)
+    // are transient — 503 so clients know to retry.
+    ApiRequest { .. } => ServiceUnavailableSnafu {
+        message: format!("provider request failed: {err}"),
+    }
+    .build(),
 });
 
 impl_from_error!(nous::error::Error, |err| {
@@ -299,11 +402,99 @@ impl_from_error!(nous::error::Error, |err| {
     PipelineStage { stage, message, .. } if stage == "execute" && message.contains("unavailable") => {
         ServiceUnavailableSnafu { message }.build()
     }
+    PipelineStage { ref stage, ref message, .. } => {
+        tracing::error!(error = %err, "pipeline stage error");
+        InternalSnafu {
+            message: format!("pipeline stage '{stage}' failed: {message}"),
+        }
+        .build()
+    }
     ServiceDegraded { nous_id, panic_count, .. } => ServiceUnavailableSnafu {
         message: format!("agent '{nous_id}' is degraded after {panic_count} panics"),
     }
     .build(),
     Llm { source, .. } => Self::from(source),
+    // WHY: transient failures (actor channels, recall, stores) map to 503
+    // so clients know the server is alive but temporarily unable to process.
+    ActorSend { .. } | ActorRecv { .. } => ServiceUnavailableSnafu {
+        message: format!("agent actor unavailable: {err}"),
+    }
+    .build(),
+    AskTimeout { nous_id, timeout_secs, .. } => ServiceUnavailableSnafu {
+        message: format!("cross-agent ask to '{nous_id}' timed out after {timeout_secs}s"),
+    }
+    .build(),
+    InboxFull { nous_id, .. } => ServiceUnavailableSnafu {
+        message: format!("agent '{nous_id}' is overloaded"),
+    }
+    .build(),
+    RecallEmbedding { .. } | RecallSearch { .. } => ServiceUnavailableSnafu {
+        message: format!("recall service unavailable: {err}"),
+    }
+    .build(),
+    Store { .. } => ServiceUnavailableSnafu {
+        message: format!("session store unavailable: {err}"),
+    }
+    .build(),
+    CompetenceStore { .. } | UncertaintyStore { .. } => ServiceUnavailableSnafu {
+        message: format!("store unavailable: {err}"),
+    }
+    .build(),
+    // WHY: permanent configuration/validation errors — cannot succeed on retry.
+    Config { message, .. } => InternalSnafu {
+        message: format!("configuration error: {message}"),
+    }
+    .build(),
+    WorkspaceValidation { nous_id, message, .. } => InternalSnafu {
+        message: format!("agent '{nous_id}' workspace invalid: {message}"),
+    }
+    .build(),
+    ContextAssembly { message, .. } => InternalSnafu {
+        message: format!("context assembly failed: {message}"),
+    }
+    .build(),
+    ContextAssemblyIo { file, .. } => InternalSnafu {
+        message: format!("context assembly failed: file '{file}' unreadable"),
+    }
+    .build(),
+    LoopDetected { iterations, pattern, .. } => InternalSnafu {
+        message: format!("loop detected after {iterations} iterations: {pattern}"),
+    }
+    .build(),
+    AskCycleDetected { chain, .. } => InternalSnafu {
+        message: format!("ask cycle detected: {chain}"),
+    }
+    .build(),
+    DeliveryFailed { nous_id, .. } => ServiceUnavailableSnafu {
+        message: format!("delivery to '{nous_id}' failed"),
+    }
+    .build(),
+    ReplyNotFound { .. } => InternalSnafu {
+        message: format!("reply channel not found: {err}"),
+    }
+    .build(),
+    MutexPoisoned { .. } => InternalSnafu {
+        message: format!("internal lock poisoned: {err}"),
+    }
+    .build(),
+    PipelinePanic { .. } => InternalSnafu {
+        message: "pipeline encountered an unexpected internal error".to_owned(),
+    }
+    .build(),
+    Distillation { .. } => {
+        tracing::error!(error = %err, "distillation failed");
+        InternalSnafu {
+            message: format!("distillation failed: {err}"),
+        }
+        .build()
+    }
+    SelfAudit { .. } | RoleContract { .. } => {
+        tracing::error!(error = %err, "self-monitoring error");
+        InternalSnafu {
+            message: format!("self-monitoring error: {err}"),
+        }
+        .build()
+    }
 });
 
 impl From<tokio::task::JoinError> for ApiError {

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -1,5 +1,7 @@
 //! Health check endpoint.
 
+use std::time::Duration;
+
 use koina::system::{Environment, RealSystem};
 use axum::Json;
 use axum::extract::State;
@@ -9,6 +11,12 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::state::HealthState;
+
+/// Per-check timeout: individual health checks that exceed this are reported as "timeout".
+const CHECK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Overall endpoint timeout: the health response is always returned within this bound.
+const OVERALL_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// GET /api/health: liveness + readiness check.
 ///
@@ -27,69 +35,53 @@ use crate::state::HealthState;
 pub async fn check(State(state): State<HealthState>) -> impl IntoResponse {
     let uptime = state.start_time.elapsed().as_secs();
 
-    let mut checks = Vec::new();
+    // WHY: Run all health checks concurrently with individual timeouts so a
+    // single hanging check (e.g., provider connection) cannot block the entire
+    // endpoint. The overall timeout guarantees a response even if multiple
+    // checks hang simultaneously (#3277).
+    let checks = tokio::time::timeout(OVERALL_TIMEOUT, async {
+        // Read config once before spawning concurrent checks.
+        let api_limits = &state.config.read().await.api_limits;
+        let clock_skew_leeway = api_limits.clock_skew_leeway_secs;
+        let expiry_warning_threshold = api_limits.expiry_warning_threshold_secs;
 
-    let store_ok = state.session_store.lock().await.ping().is_ok();
-    checks.push(HealthCheck {
-        name: "session_store",
-        status: if store_ok { "pass" } else { "fail" },
-        message: if store_ok {
-            None
-        } else {
-            Some("session store unavailable".to_owned())
-        },
+        let (store_check, actor_check, config_check, storage_check) = tokio::join!(
+            timed_check("session_store", check_session_store(&state)),
+            timed_check("nous_actors", check_nous_actors(&state)),
+            timed_check("config_readable", check_config_readable(&state)),
+            timed_check("storage_writable", check_storage_writable(&state)),
+        );
+
+        // These are synchronous / cheap — no timeout needed.
+        let provider_check = check_provider_availability(&state);
+        let credential_check =
+            check_credential_validity(&state, clock_skew_leeway, expiry_warning_threshold);
+
+        vec![
+            store_check,
+            provider_check,
+            actor_check,
+            check_provider_reachability(&state),
+            config_check,
+            credential_check,
+            storage_check,
+        ]
+    })
+    .await
+    .unwrap_or_else(|_| {
+        vec![HealthCheck {
+            name: "overall",
+            status: "fail",
+            message: Some("health check timed out".to_owned()),
+        }]
     });
 
-    let has_providers = !state.provider_registry.providers().is_empty();
-    checks.push(HealthCheck {
-        name: "providers",
-        status: if has_providers { "pass" } else { "warn" },
-        message: if has_providers {
-            None
-        } else {
-            Some("no LLM providers registered".to_owned())
-        },
-    });
-
-    let actor_health = state.nous_manager.check_health().await;
-    let any_dead = actor_health.values().any(|h| !h.alive);
-    checks.push(HealthCheck {
-        name: "nous_actors",
-        status: if actor_health.is_empty() || any_dead {
-            "fail"
-        } else {
-            "pass"
-        },
-        message: if actor_health.is_empty() {
-            Some("no nous actors registered".to_owned())
-        } else if any_dead {
-            let dead: Vec<_> = actor_health
-                .iter()
-                .filter(|(_, h)| !h.alive)
-                .map(|(id, _)| id.as_str())
-                .collect();
-            Some(format!("actors not responding: {}", dead.join(", ")))
-        } else {
-            None
-        },
-    });
-
-    // Check provider reachability via health tracker
-    checks.push(check_provider_reachability(&state));
-
-    // Check config readability
-    checks.push(check_config_readable(&state).await);
-
-    // Check credential validity
-    let api_limits = &state.config.read().await.api_limits;
-    let clock_skew_leeway = api_limits.clock_skew_leeway_secs;
-    let expiry_warning_threshold = api_limits.expiry_warning_threshold_secs;
-    checks.push(check_credential_validity(&state, clock_skew_leeway, expiry_warning_threshold));
-
-    // Check storage writability
-    checks.push(check_storage_writable(&state).await);
-
-    let status = if checks.iter().any(|c| c.status == "fail") {
+    // WHY: "timeout" is treated as "fail" for aggregate status because
+    // a timed-out check means we cannot confirm the subsystem is healthy.
+    let status = if checks
+        .iter()
+        .any(|c| c.status == "fail" || c.status == "timeout")
+    {
         "unhealthy"
     } else if checks.iter().any(|c| c.status == "warn") {
         "degraded"
@@ -113,6 +105,76 @@ pub async fn check(State(state): State<HealthState>) -> impl IntoResponse {
             data_dir: state.oikos.data().to_string_lossy().into_owned(),
         }),
     )
+}
+
+/// Run a health check with a per-check timeout. If the check exceeds
+/// [`CHECK_TIMEOUT`], a "timeout" status is returned instead of blocking.
+async fn timed_check(
+    name: &'static str,
+    future: impl std::future::Future<Output = HealthCheck>,
+) -> HealthCheck {
+    match tokio::time::timeout(CHECK_TIMEOUT, future).await {
+        Ok(check) => check,
+        Err(_elapsed) => HealthCheck {
+            name,
+            status: "timeout",
+            message: Some(format!("{name} check timed out after {}s", CHECK_TIMEOUT.as_secs())),
+        },
+    }
+}
+
+/// Check session store connectivity.
+async fn check_session_store(state: &HealthState) -> HealthCheck {
+    let store_ok = state.session_store.lock().await.ping().is_ok();
+    HealthCheck {
+        name: "session_store",
+        status: if store_ok { "pass" } else { "fail" },
+        message: if store_ok {
+            None
+        } else {
+            Some("session store unavailable".to_owned())
+        },
+    }
+}
+
+/// Check whether any LLM providers are registered.
+fn check_provider_availability(state: &HealthState) -> HealthCheck {
+    let has_providers = !state.provider_registry.providers().is_empty();
+    HealthCheck {
+        name: "providers",
+        status: if has_providers { "pass" } else { "warn" },
+        message: if has_providers {
+            None
+        } else {
+            Some("no LLM providers registered".to_owned())
+        },
+    }
+}
+
+/// Check nous actor liveness.
+async fn check_nous_actors(state: &HealthState) -> HealthCheck {
+    let actor_health = state.nous_manager.check_health().await;
+    let any_dead = actor_health.values().any(|h| !h.alive);
+    HealthCheck {
+        name: "nous_actors",
+        status: if actor_health.is_empty() || any_dead {
+            "fail"
+        } else {
+            "pass"
+        },
+        message: if actor_health.is_empty() {
+            Some("no nous actors registered".to_owned())
+        } else if any_dead {
+            let dead: Vec<_> = actor_health
+                .iter()
+                .filter(|(_, h)| !h.alive)
+                .map(|(id, _)| id.as_str())
+                .collect();
+            Some(format!("actors not responding: {}", dead.join(", ")))
+        } else {
+            None
+        },
+    }
 }
 
 /// Check LLM provider connectivity by querying the provider registry health.
@@ -481,7 +543,7 @@ pub struct HealthCheck {
     /// Subsystem name (e.g. `"session_store"`, `"providers"`).
     #[schema(value_type = String)]
     pub name: &'static str,
-    /// Check outcome: `"pass"`, `"warn"`, or `"fail"`.
+    /// Check outcome: `"pass"`, `"warn"`, `"fail"`, or `"timeout"`.
     #[schema(value_type = String)]
     pub status: &'static str,
     /// Diagnostic message when status is not `"pass"`.
@@ -637,6 +699,62 @@ mod tests {
             "healthy"
         };
         assert_eq!(status, "healthy");
+    }
+
+    #[test]
+    fn aggregate_status_unhealthy_when_any_check_times_out() {
+        let checks = [
+            HealthCheck {
+                name: "a",
+                status: "pass",
+                message: None,
+            },
+            HealthCheck {
+                name: "b",
+                status: "timeout",
+                message: Some("check timed out after 5s".to_owned()),
+            },
+        ];
+        // WHY: "timeout" is treated as "fail" for aggregate status because
+        // a timed-out check means we cannot confirm the subsystem is healthy.
+        let status = if checks.iter().any(|c| c.status == "fail" || c.status == "timeout") {
+            "unhealthy"
+        } else if checks.iter().any(|c| c.status == "warn") {
+            "degraded"
+        } else {
+            "healthy"
+        };
+        assert_eq!(status, "unhealthy");
+    }
+
+    #[tokio::test]
+    async fn timed_check_returns_timeout_on_slow_future() {
+        let check = timed_check("slow_check", async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            HealthCheck {
+                name: "slow_check",
+                status: "pass",
+                message: None,
+            }
+        })
+        .await;
+        assert_eq!(check.status, "timeout");
+        assert_eq!(check.name, "slow_check");
+        assert!(check.message.unwrap().contains("timed out"));
+    }
+
+    #[tokio::test]
+    async fn timed_check_returns_result_on_fast_future() {
+        let check = timed_check("fast_check", async {
+            HealthCheck {
+                name: "fast_check",
+                status: "pass",
+                message: None,
+            }
+        })
+        .await;
+        assert_eq!(check.status, "pass");
+        assert_eq!(check.name, "fast_check");
     }
 
     #[test]

--- a/crates/pylon/src/handlers/knowledge/mutation.rs
+++ b/crates/pylon/src/handlers/knowledge/mutation.rs
@@ -2,6 +2,7 @@
 
 use axum::Json;
 use axum::extract::{Path, State};
+use axum::http::StatusCode;
 
 use symbolon::types::Role;
 
@@ -22,7 +23,7 @@ use super::{ForgetRequest, UpdateConfidenceRequest};
         content_type = "application/json"
     ),
     responses(
-        (status = 200, description = "Fact marked forgotten"),
+        (status = 204, description = "Fact marked forgotten"),
         (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
     ),
     security(("bearer_auth" = []))
@@ -37,7 +38,7 @@ pub async fn forget_fact(
     claims: Claims,
     Path(id): Path<String>,
     Json(body): Json<ForgetRequest>,
-) -> Result<Json<serde_json::Value>, ApiError> {
+) -> Result<StatusCode, ApiError> {
     require_role(&claims, Role::Operator)?;
     #[cfg(feature = "knowledge-store")]
     if let Some(ref store) = state.knowledge_store {
@@ -52,7 +53,7 @@ pub async fn forget_fact(
         return match store.forget_fact_async(fact_id, reason).await {
             Ok(_) => {
                 tracing::info!(fact_id = %id, "fact forgotten");
-                Ok(Json(serde_json::json!({ "status": "forgotten", "id": id })))
+                Ok(StatusCode::NO_CONTENT)
             }
             Err(mneme::error::Error::FactNotFound { .. }) => Err(ApiError::NotFound {
                 path: format!("fact/{id}"),
@@ -79,7 +80,7 @@ pub async fn forget_fact(
     path = "/api/v1/knowledge/facts/{id}/restore",
     params(("id" = String, Path, description = "Fact ID")),
     responses(
-        (status = 200, description = "Fact restored"),
+        (status = 204, description = "Fact restored"),
         (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
     ),
     security(("bearer_auth" = []))
@@ -93,7 +94,7 @@ pub async fn restore_fact(
     State(state): State<KnowledgeState>,
     claims: Claims,
     Path(id): Path<String>,
-) -> Result<Json<serde_json::Value>, ApiError> {
+) -> Result<StatusCode, ApiError> {
     require_role(&claims, Role::Operator)?;
     #[cfg(feature = "knowledge-store")]
     if let Some(ref store) = state.knowledge_store {
@@ -104,7 +105,7 @@ pub async fn restore_fact(
         return match store.unforget_fact_async(fact_id).await {
             Ok(_) => {
                 tracing::info!(fact_id = %id, "fact restored");
-                Ok(Json(serde_json::json!({ "status": "restored", "id": id })))
+                Ok(StatusCode::NO_CONTENT)
             }
             Err(mneme::error::Error::FactNotFound { .. }) => Err(ApiError::NotFound {
                 path: format!("fact/{id}"),

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -548,11 +548,11 @@ pub(crate) async fn resolve_session(
 
 /// Returns `true` when a mneme error is a `SQLite` UNIQUE constraint violation.
 ///
-/// `SQLite` always includes "UNIQUE constraint failed" in the error message for
-/// constraint violations. We match on the string because pylon does not take a
-/// direct rusqlite dependency: the type lives inside mneme's `Database` variant.
+/// WHY: Uses the typed `rusqlite::ErrorCode::ConstraintViolation` via
+/// `mneme::error::Error::is_unique_constraint_violation()` instead of
+/// string matching on the error message, which is fragile (#3282).
 fn is_unique_constraint_violation(err: &mneme::error::Error) -> bool {
-    err.to_string().contains("UNIQUE constraint failed")
+    err.is_unique_constraint_violation()
 }
 
 pub(crate) async fn find_session(

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -238,6 +238,7 @@ pub async fn send_message(
     let idem_key = idempotency_key.clone();
     let idem_cache = Arc::clone(&state.idempotency_cache);
 
+    let request_id_str = request_id.0.clone();
     let turn_span = tracing::info_span!(
         "send_turn",
         session.id = %session_id,
@@ -302,6 +303,7 @@ pub async fn send_message(
                         .send(SseEvent::Error {
                             code: err_code,
                             message: err_message,
+                            request_id: Some(request_id_str.clone()),
                         })
                         .await;
                     // WHY: Always send a completion marker so the client knows the
@@ -432,6 +434,7 @@ pub async fn stream_turn(
 
     let session_id = resolve_session(&state, &agent_id, &session_key, model.as_deref()).await?;
 
+    let webchat_request_id = request_id.0.clone();
     let turn_id = koina::ulid::Ulid::new().to_string();
     let (webchat_tx, webchat_rx) = mpsc::channel::<WebchatEvent>(32);
     let (nous_tx, mut nous_rx) = mpsc::channel::<TurnStreamEvent>(64);
@@ -551,6 +554,7 @@ pub async fn stream_turn(
                     let _ = webchat_tx
                         .send(WebchatEvent::Error {
                             message: err_message,
+                            request_id: Some(webchat_request_id.clone()),
                         })
                         .await;
                     // WHY: Always send a completion marker so the TUI knows the stream

--- a/crates/pylon/src/handlers/sessions/streaming_tests.rs
+++ b/crates/pylon/src/handlers/sessions/streaming_tests.rs
@@ -354,6 +354,7 @@ fn sse_event_error_serializes_correctly() {
     let event = SseEvent::Error {
         code: "turn_failed".to_owned(),
         message: "something broke".to_owned(),
+        request_id: Some("req-abc".to_owned()),
     };
     let result = sse_event_to_axum(event).expect("infallible");
     drop(result);

--- a/crates/pylon/src/stream.rs
+++ b/crates/pylon/src/stream.rs
@@ -52,7 +52,13 @@ pub(crate) enum SseEvent {
 
     /// An error occurred during the turn.
     #[serde(rename = "error")]
-    Error { code: String, message: String },
+    Error {
+        code: String,
+        message: String,
+        /// Per-request correlation ID for cross-system error tracing.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+    },
 }
 
 /// Token usage summary sent with `message_complete`.
@@ -124,7 +130,12 @@ pub(crate) enum WebchatEvent {
     #[serde(rename = "turn_complete")]
     TurnComplete { outcome: TurnOutcome },
     #[serde(rename = "error")]
-    Error { message: String },
+    Error {
+        message: String,
+        /// Per-request correlation ID for cross-system error tracing.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+    },
 }
 
 impl WebchatEvent {

--- a/crates/pylon/src/tests/sse_events.rs
+++ b/crates/pylon/src/tests/sse_events.rs
@@ -56,6 +56,7 @@ fn sse_event_type_error() {
     let event = crate::stream::SseEvent::Error {
         code: "test".to_owned(),
         message: "err".to_owned(),
+        request_id: None,
     };
     assert_eq!(event.event_type(), "error");
 }
@@ -91,11 +92,24 @@ fn sse_event_error_serialization() {
     let event = crate::stream::SseEvent::Error {
         code: "turn_failed".to_owned(),
         message: "provider error".to_owned(),
+        request_id: Some("req-123".to_owned()),
     };
     let json = serde_json::to_value(&event).unwrap();
     assert_eq!(json["type"], "error");
     assert_eq!(json["code"], "turn_failed");
     assert_eq!(json["message"], "provider error");
+    assert_eq!(json["request_id"], "req-123");
+}
+
+#[test]
+fn sse_event_error_omits_request_id_when_none() {
+    let event = crate::stream::SseEvent::Error {
+        code: "test".to_owned(),
+        message: "err".to_owned(),
+        request_id: None,
+    };
+    let json = serde_json::to_value(&event).unwrap();
+    assert!(json.get("request_id").is_none(), "request_id should be omitted when None");
 }
 
 #[test]
@@ -168,6 +182,7 @@ fn tui_event_turn_complete_type() {
 fn tui_event_error_type() {
     let event = crate::stream::WebchatEvent::Error {
         message: "fail".to_owned(),
+        request_id: None,
     };
     assert_eq!(event.event_type(), "error");
 }


### PR DESCRIPTION
## Summary

- **#3277**: Health endpoint runs all checks concurrently with per-check (5s) and overall (10s) timeouts; timed-out checks report `"timeout"` status
- **#3279**: `forget_fact` and `restore_fact` return 204 No Content instead of 200 with body
- **#3281**: SSE error events (`SseEvent::Error` and `WebchatEvent::Error`) now include `request_id` for cross-system correlation
- **#3282**: UNIQUE constraint detection uses `rusqlite::ErrorCode::ConstraintViolation` (extended code 2067) via new `graphe::error::Error::is_unique_constraint_violation()` instead of string matching
- **#3283**: `impl_from_error!` macro: exhaustive match arms for all mneme/hermeneus/nous error variants (transient -> 503, permanent -> 500, client fault -> 4xx); `#[non_exhaustive]` catch-all logs full `Debug` + `Display` at error level instead of silently erasing to `.to_string()`

## Test plan

- [x] `cargo check -p pylon` — zero errors
- [x] `cargo test -p pylon` — 404 tests pass (370 unit + 34 integration)
- [x] `cargo clippy -p pylon` — zero new warnings (pre-existing `server.rs` lint expectation only)
- [x] `cargo test -p graphe --features sqlite -- error::tests` — 3 new tests pass
- [x] New tests: `timed_check_returns_timeout_on_slow_future`, `timed_check_returns_result_on_fast_future`, `aggregate_status_unhealthy_when_any_check_times_out`
- [x] New tests: `sse_event_error_omits_request_id_when_none`, updated `sse_event_error_serialization` validates `request_id` field
- [x] New tests: `unique_constraint_violation_detected`, `non_unique_constraint_not_detected`, `non_database_error_not_detected`

Closes #3277, #3279, #3281, #3282, #3283

🤖 Generated with [Claude Code](https://claude.com/claude-code)