### PR TITLE
fix(skene): add streaming timeout and structured server errors (#3317, #3318)

### DIFF
--- a/crates/theatron/skene/src/api/client.rs
+++ b/crates/theatron/skene/src/api/client.rs
@@ -917,7 +917,12 @@ impl ApiClient {
         } else {
             format!("{} {}", status.as_u16(), reason)
         };
-        ServerSnafu { operation, message }.fail()
+        ServerSnafu {
+            operation,
+            status: status.as_u16(),
+            message,
+        }
+        .fail()
     }
 
     /// The shared HTTP client, pre-configured with auth and default headers.

--- a/crates/theatron/skene/src/api/error.rs
+++ b/crates/theatron/skene/src/api/error.rs
@@ -22,10 +22,12 @@ pub enum ApiError {
     },
 
     /// Non-2xx HTTP response. Message is extracted from the server body when possible.
-    #[snafu(display("{operation}: {message}"))]
+    #[snafu(display("{operation}: {status} {message}"))]
     Server {
         /// Which API call failed.
         operation: &'static str,
+        /// HTTP status code from the response.
+        status: u16,
         /// Human-readable error from the server.
         message: String,
     },

--- a/crates/theatron/skene/src/api/streaming.rs
+++ b/crates/theatron/skene/src/api/streaming.rs
@@ -15,6 +15,11 @@ use crate::events::StreamEvent;
 use crate::id::{NousId, PlanId, SessionId, ToolId, TurnId};
 use crate::sse::SseStream;
 
+/// If no streaming event is received within this window, the connection is
+/// treated as hung. Matches the SSE connection's `READ_TIMEOUT` in `sse.rs`
+/// for a consistent timeout policy across both connection types.
+const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
+
 /// Streams a turn response from POST /api/v1/sessions/stream.
 /// Returns a channel that yields parsed `StreamEvents`.
 ///
@@ -86,7 +91,26 @@ pub fn stream_message(
 
             let mut es = SseStream::new(resp.bytes_stream());
 
-            while let Some(event) = es.next().await {
+            loop {
+                let maybe_event = tokio::time::timeout(READ_TIMEOUT, es.next()).await;
+                let event = match maybe_event {
+                    Ok(Some(event)) => event,
+                    Ok(None) => break,
+                    Err(_elapsed) => {
+                        // WHY: No event received within READ_TIMEOUT. A healthy
+                        // server sends data more frequently than this window, so
+                        // silence here indicates a hung or dropped connection.
+                        tracing::warn!(
+                            timeout_secs = READ_TIMEOUT.as_secs(),
+                            "stream read timeout — treating as error"
+                        );
+                        let _ = tx
+                            .send(StreamEvent::Error("stream timeout".to_string()))
+                            .await;
+                        break;
+                    }
+                };
+
                 if let Some(parsed) = parse_stream_event(&event.event, &event.data) {
                     let is_terminal = matches!(
                         &parsed,


### PR DESCRIPTION
## Summary

- **#3317**: Streaming event loop (`streaming.rs`) now wraps `es.next().await` in `tokio::time::timeout(45s)`, matching the SSE connection's existing timeout policy. On timeout, sends `StreamEvent::Error("stream timeout")` so consumers detect hung connections.
- **#3318**: `ApiError::Server` gains a `status: u16` field. The `check_status()` method populates it from the HTTP response. Display format updated to include the status code. No downstream breakage — koilon and proskenion don't pattern-match on `Server` fields.

## Test plan

- [x] `cargo test -p skene` — 100 tests pass
- [x] `cargo clippy -p skene -- -D warnings` — zero warnings
- [x] `cargo check -p koilon` — downstream compiles clean
- [ ] Manual: verify timeout fires on simulated hung stream (drop server mid-turn)
- [ ] Manual: verify `ApiError::Server` display includes status code

Generated with [Claude Code](https://claude.com/claude-code)