### PR TITLE
fix(organon): char-boundary truncation and structured store errors (#3335, #3286)

### DIFF
--- a/crates/nous/src/adapters.rs
+++ b/crates/nous/src/adapters.rs
@@ -31,7 +31,7 @@ use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 
 use mneme::store::SessionStore;
-use organon::error::{StoreError, StoreSnafu};
+use organon::error::{BackendSnafu, StoreError};
 use organon::types::{BlackboardEntry, BlackboardStore, NoteEntry, NoteStore};
 
 /// Acquire the store lock from a synchronous trait method inside an async context.
@@ -56,7 +56,7 @@ where
 }
 
 fn store_err(e: impl std::fmt::Display) -> StoreError {
-    StoreSnafu {
+    BackendSnafu {
         message: e.to_string(),
     }
     .build()

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -53,7 +53,14 @@ pub(crate) const MAX_PATTERN_LENGTH: usize = 1000;
 
 fn truncate_output(mut output: String) -> String {
     if output.len() > MAX_OUTPUT_BYTES {
-        output.truncate(MAX_OUTPUT_BYTES);
+        // WHY: Truncating at an arbitrary byte position can split a multi-byte
+        // UTF-8 character, producing invalid UTF-8. Walk backwards to the
+        // nearest char boundary before truncating. Closes #3335.
+        let mut end = MAX_OUTPUT_BYTES;
+        while end > 0 && !output.is_char_boundary(end) {
+            end -= 1;
+        }
+        output.truncate(end);
         output.push_str("\n[output truncated]");
     }
     output

--- a/crates/organon/src/builtins/filesystem_tests.rs
+++ b/crates/organon/src/builtins/filesystem_tests.rs
@@ -744,6 +744,47 @@ fn test_truncate_output_exactly_at_limit_unchanged() {
 }
 
 #[test]
+fn test_truncate_output_multibyte_at_boundary_produces_valid_utf8() {
+    // WHY: If MAX_OUTPUT_BYTES falls in the middle of a multi-byte character,
+    // naive truncation produces invalid UTF-8. This test places a 4-byte emoji
+    // exactly at the truncation boundary to verify char-boundary-aware
+    // truncation. Closes #3335.
+    let emoji = "\u{1F600}"; // 4 bytes
+    let padding_len = MAX_OUTPUT_BYTES - 2; // 2 bytes short of limit
+    let mut input = "x".repeat(padding_len);
+    input.push_str(emoji); // total = padding_len + 4 > MAX_OUTPUT_BYTES
+    assert!(
+        input.len() > MAX_OUTPUT_BYTES,
+        "test input should exceed limit"
+    );
+
+    let result = truncate_output(input);
+
+    // The result must be valid UTF-8 (it's a String, so this is guaranteed
+    // at the type level, but verify the emoji was cleanly removed rather than
+    // partially included).
+    assert!(
+        result.ends_with("[output truncated]"),
+        "should end with truncation marker"
+    );
+    assert!(
+        !result.contains(emoji),
+        "emoji spanning the boundary should be removed entirely"
+    );
+    // Verify no partial bytes leaked: the text portion before the marker
+    // should be valid on its own.
+    let text_part = result.trim_end_matches("\n[output truncated]");
+    assert!(
+        text_part.len() <= MAX_OUTPUT_BYTES,
+        "text portion should not exceed limit"
+    );
+    assert!(
+        text_part.len() >= padding_len,
+        "text portion should retain the padding"
+    );
+}
+
+#[test]
 fn test_grep_def_has_pattern_as_required() {
     let mut reg = crate::registry::ToolRegistry::new();
     register(&mut reg).expect("register");

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -667,7 +667,14 @@ impl ToolExecutor for ExecExecutor {
             let code = status.code().unwrap_or(-1);
             let mut output = format!("exit={code}\n{stdout}\n{stderr}");
             if output.len() > MAX_OUTPUT_BYTES {
-                output.truncate(MAX_OUTPUT_BYTES);
+                // WHY: Truncating at an arbitrary byte position can split a multi-byte
+                // UTF-8 character, producing invalid UTF-8. Walk backwards to the
+                // nearest char boundary before truncating. Closes #3335.
+                let mut end = MAX_OUTPUT_BYTES;
+                while end > 0 && !output.is_char_boundary(end) {
+                    end -= 1;
+                }
+                output.truncate(end);
                 output.push_str("\n[output truncated]");
             }
 

--- a/crates/organon/src/error.rs
+++ b/crates/organon/src/error.rs
@@ -61,20 +61,43 @@ pub type Result<T> = std::result::Result<T, Error>; // kanon:ignore RUST/pub-vis
 
 /// Error from store operations (`NoteStore` / `BlackboardStore` adapters).
 ///
-/// Uses a message string so implementations can convert any underlying error
-/// without introducing crate-level type dependencies on adapters.
+/// WHY: Structured variants preserve failure mode (not-found vs conflict vs I/O)
+/// so callers can pattern-match on specific failures without string-parsing.
+/// Decoupled from backend types to avoid circular dependencies. Closes #3286.
+///
+/// Variant names are prefixed with `Store` to avoid snafu context-selector
+/// collisions with `PlanningAdapterError` variants in the same module.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 #[non_exhaustive]
 #[expect(
     missing_docs,
-    reason = "snafu error variant fields (message) are self-documenting via display format"
+    reason = "snafu error variant fields (entity, id, context, source, message) are self-documenting via display format"
 )]
 pub enum StoreError {
     // kanon:ignore RUST/pub-visibility
-    /// A store operation failed.
-    #[snafu(display("{message}"))]
-    Store { message: String },
+    /// The requested entity was not found.
+    #[snafu(display("{entity} not found: {id}"))]
+    StoreNotFound { entity: String, id: String },
+
+    /// A conflicting entry already exists.
+    #[snafu(display("{entity} conflict: {id}"))]
+    StoreConflict { entity: String, id: String },
+
+    /// An I/O error occurred during a store operation.
+    #[snafu(display("store I/O error: {context}"))]
+    StoreIo {
+        context: String,
+        source: std::io::Error,
+    },
+
+    /// Serialization or deserialization failed.
+    #[snafu(display("store serialization error"))]
+    StoreSerialization { source: serde_json::Error },
+
+    /// A backend-specific error that doesn't fit other variants.
+    #[snafu(display("store backend error: {message}"))]
+    Backend { message: String },
 }
 
 /// Typed errors for `PlanningService` adapter implementations.


### PR DESCRIPTION
## Summary

- **#3335**: `truncate_output` in `filesystem.rs` and the inline truncation in `workspace.rs` now walk backwards to the nearest `is_char_boundary()` position before calling `String::truncate`, preventing split multi-byte UTF-8 characters from corrupting output sent to the LLM. Test added with a 4-byte emoji at the boundary.
- **#3286**: Replaced `StoreError::Store { message: String }` catch-all with five structured variants (`StoreNotFound`, `StoreConflict`, `StoreIo`, `StoreSerialization`, `Backend`), preserving source chains where applicable. Updated the `nous` adapter to use `BackendSnafu`.

## Test plan

- [x] `cargo test -p organon` -- 402 tests pass, including new `test_truncate_output_multibyte_at_boundary_produces_valid_utf8`
- [x] `cargo clippy -p organon -p nous` -- zero warnings
- [x] `cargo clippy --workspace` -- no new warnings (only pre-existing krites/pylon warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)