### PR TITLE
security(diaporeia): auth warnings, RBAC enforcement, streaming docs (#3336, #3337, #3251)

### DIFF
--- a/crates/diaporeia/src/error.rs
+++ b/crates/diaporeia/src/error.rs
@@ -66,6 +66,14 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Caller lacks the required role for this operation.
+    #[snafu(display("unauthorized: {message}"))]
+    Unauthorized {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Result alias using diaporeia's [`Error`] type.
@@ -82,6 +90,11 @@ impl From<Error> for rmcp::ErrorData {
             // NOTE: client provided an invalid agent or session ID: include what wasn't found
             Error::NousNotFound { .. } | Error::SessionNotFound { .. } => {
                 rmcp::ErrorData::invalid_params(message, None)
+            }
+            // WHY: authorization failures return a clear message so clients can
+            // distinguish access-denied from invalid-params.
+            Error::Unauthorized { .. } => {
+                rmcp::ErrorData::new(rmcp::model::ErrorCode(-32001), message, None)
             }
             // WHY: server-side failures expose only a sanitized message, never internal details
             Error::Pipeline { .. }
@@ -198,5 +211,20 @@ mod tests {
             mcp.message.contains("syn"),
             "message must identify the missing agent"
         );
+    }
+
+    #[test]
+    fn unauthorized_maps_to_custom_error_code() {
+        let err = UnauthorizedSnafu {
+            message: "session_create requires operator role or above".to_string(),
+        }
+        .build();
+        let mcp: rmcp::ErrorData = err.into();
+        assert_eq!(
+            mcp.code,
+            rmcp::model::ErrorCode(-32001),
+            "unauthorized must use custom error code -32001"
+        );
+        assert!(mcp.message.contains("operator"));
     }
 }

--- a/crates/diaporeia/src/server.rs
+++ b/crates/diaporeia/src/server.rs
@@ -12,6 +12,9 @@ use rmcp::model::{
 };
 use rmcp::tool_handler;
 
+use symbolon::types::Role;
+
+use crate::error::UnauthorizedSnafu;
 use crate::rate_limit::{RateLimiter, Tier};
 use crate::resources;
 use crate::state::DiaporeiaState;
@@ -48,6 +51,77 @@ impl DiaporeiaServer {
             tool_router: Self::tool_router(),
         }
     }
+
+    /// Check that the caller has at least `minimum` role for a resource operation.
+    ///
+    /// Extracts the role from auth state: uses the configured `none_role` in
+    /// auth-disabled mode, otherwise validates the JWT via `jwt_manager`.
+    async fn require_resource_role(
+        &self,
+        context: &rmcp::service::RequestContext<rmcp::RoleServer>,
+        minimum: Role,
+        operation: &str,
+    ) -> Result<(), rmcp::ErrorData> {
+        let role = self.resolve_caller_role(context).await;
+        match role {
+            Some(r) if r >= minimum => Ok(()),
+            Some(r) => {
+                tracing::warn!(
+                    caller_role = %r,
+                    required_role = %minimum,
+                    operation,
+                    "MCP resource RBAC denied",
+                );
+                Err(UnauthorizedSnafu {
+                    message: format!("{operation} requires {minimum} role or above"),
+                }
+                .build()
+                .into())
+            }
+            None => {
+                tracing::warn!(operation, "MCP resource RBAC denied: no role resolved");
+                Err(UnauthorizedSnafu {
+                    message: format!("{operation} requires {minimum} role or above"),
+                }
+                .build()
+                .into())
+            }
+        }
+    }
+
+    /// Resolve the caller's role from the request context.
+    ///
+    /// Logic mirrors `tools::extract_role` but lives on the server struct
+    /// so resource handlers can use it without depending on the tools module.
+    async fn resolve_caller_role(
+        &self,
+        context: &rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Option<Role> {
+        let config = self.state.config.read().await;
+
+        if config.gateway.auth.mode == "none" {
+            return config
+                .gateway
+                .auth
+                .none_role
+                .parse::<Role>()
+                .ok()
+                .or(Some(Role::Admin));
+        }
+
+        let parts = context.extensions.get::<http::request::Parts>()?;
+        let header = parts
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())?;
+        let token = header.strip_prefix(koina::http::BEARER_PREFIX)?;
+
+        if let Some(ref jwt) = self.state.jwt_manager {
+            return jwt.validate(token).ok().map(|claims| claims.role);
+        }
+
+        None
+    }
 }
 
 // NOTE: type alias required by rmcp: get_info must return this exact name
@@ -74,9 +148,16 @@ impl rmcp::handler::server::ServerHandler for DiaporeiaServer {
     async fn list_resource_templates(
         &self,
         _params: Option<rmcp::model::PaginatedRequestParams>,
-        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<ListResourceTemplatesResult, rmcp::ErrorData> {
         self.rate_limiter.check(Tier::Cheap)?;
+
+        // WHY(#3337): resource templates reveal what internal state is
+        // accessible. Restrict to Operator+ so Readonly users cannot
+        // discover agent workspace files or config structure.
+        self.require_resource_role(&context, Role::Operator, "list_resource_templates")
+            .await?;
+
         let mut templates: Vec<ResourceTemplate> = resources::nous::resource_templates();
         templates.extend(resources::config::resource_templates());
         Ok(ListResourceTemplatesResult {
@@ -89,9 +170,13 @@ impl rmcp::handler::server::ServerHandler for DiaporeiaServer {
     async fn list_resources(
         &self,
         _params: Option<rmcp::model::PaginatedRequestParams>,
-        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<ListResourcesResult, rmcp::ErrorData> {
         self.rate_limiter.check(Tier::Cheap)?;
+
+        self.require_resource_role(&context, Role::Operator, "list_resources")
+            .await?;
+
         // NOTE: static resources only: dynamic listing deferred
         Ok(ListResourcesResult {
             resources: vec![],
@@ -103,10 +188,16 @@ impl rmcp::handler::server::ServerHandler for DiaporeiaServer {
     async fn read_resource(
         &self,
         params: ReadResourceRequestParams,
-        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<ReadResourceResult, rmcp::ErrorData> {
         self.rate_limiter.check(Tier::Cheap)?;
         let uri = params.uri.as_str();
+
+        // WHY(#3337): all MCP resources expose internal state (agent workspace
+        // files, runtime config). Require Operator+ to prevent Readonly users
+        // from enumerating agents, config, or knowledge.
+        self.require_resource_role(&context, Role::Operator, uri)
+            .await?;
 
         let contents = if uri.starts_with("aletheia://nous/") {
             resources::nous::read_resource(&self.state, &params)?

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -15,15 +15,20 @@ use koina::http::BEARER_PREFIX;
 use koina::id::SessionId;
 use symbolon::types::Role;
 
-use crate::error::{NousNotFoundSnafu, PipelineSnafu, SerializationSnafu, SessionStoreSnafu};
+use crate::error::{
+    NousNotFoundSnafu, PipelineSnafu, SerializationSnafu, SessionStoreSnafu, UnauthorizedSnafu,
+};
 use crate::rate_limit::Tier;
 use crate::server::DiaporeiaServer;
 
 /// Extract role from request context by validating the Bearer token.
 ///
-/// Returns `None` if auth info is unavailable or token is invalid.
+/// When a `JwtManager` is available, validates the signature before
+/// extracting claims (closes the payload-only decode bypass from #3337).
 /// In single-operator mode (`auth.mode = "none"`), returns the configured
 /// `none_role` (defaults to admin).
+///
+/// Returns `None` only when auth info is unavailable or the token is invalid.
 async fn extract_role(
     server: &DiaporeiaServer,
     context: &RequestContext<rmcp::RoleServer>,
@@ -50,14 +55,22 @@ async fn extract_role(
 
     let token = header.strip_prefix(BEARER_PREFIX)?;
 
+    // WHY(#3337): When jwt_manager is available, validate the signature
+    // instead of just decoding the payload. This prevents role spoofing
+    // on direct MCP connections that bypass the gateway.
+    if let Some(ref jwt) = server.state.jwt_manager {
+        return jwt.validate(token).ok().map(|claims| claims.role);
+    }
+
+    // Fallback: decode-only when no jwt_manager (should not happen when
+    // auth_mode != "none", but handle gracefully).
     parse_role_from_token(token)
 }
 
 /// Parse role from a JWT token payload without signature verification.
 ///
-/// This is a best-effort parse to extract the role claim. Full validation
-/// is handled at the gateway layer; by the time the request reaches the
-/// MCP tool, the token has already been validated.
+/// Only used as a fallback when no `JwtManager` is available. Prefer
+/// signature-verified extraction via `extract_role`.
 fn parse_role_from_token(token: &str) -> Option<Role> {
     let mut parts = token.split('.');
     let _header = parts.next()?;
@@ -95,6 +108,43 @@ async fn is_operator_or_above(
     }
 }
 
+/// Require at least the given role, returning an MCP error if insufficient.
+///
+/// Used by tools and resources that need RBAC enforcement beyond the
+/// operator-or-above check (e.g. session creation, config access).
+async fn require_role(
+    server: &DiaporeiaServer,
+    context: &RequestContext<rmcp::RoleServer>,
+    minimum: Role,
+    operation: &str,
+) -> Result<(), rmcp::ErrorData> {
+    let role = extract_role(server, context).await;
+    match role {
+        Some(r) if r >= minimum => Ok(()),
+        Some(r) => {
+            tracing::warn!(
+                caller_role = %r,
+                required_role = %minimum,
+                operation,
+                "MCP RBAC denied",
+            );
+            Err(UnauthorizedSnafu {
+                message: format!("{operation} requires {minimum} role or above"),
+            }
+            .build()
+            .into())
+        }
+        None => {
+            tracing::warn!(operation, "MCP RBAC denied: no role resolved");
+            Err(UnauthorizedSnafu {
+                message: format!("{operation} requires {minimum} role or above"),
+            }
+            .build()
+            .into())
+        }
+    }
+}
+
 /// Register all tools on the server via the `#[tool_router]` macro.
 ///
 /// This generates the `DiaporeiaServer::tool_router()` associated function
@@ -102,12 +152,16 @@ async fn is_operator_or_above(
 #[tool_router(vis = "pub(crate)")]
 impl DiaporeiaServer {
     /// Create a new session for a nous agent. Returns session metadata as JSON.
+    ///
+    /// Requires `Operator` role or above (#3337).
     #[tool(description = "Create a new session for a nous agent")]
     async fn session_create(
         &self,
         Parameters(params): Parameters<params::SessionCreateParams>,
+        context: RequestContext<rmcp::RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         self.rate_limiter.check(Tier::Expensive)?;
+        require_role(self, &context, Role::Operator, "session_create").await?;
         let session_key = params.session_key.as_deref().unwrap_or("main");
         // WHY: SessionId (UUID v4) is the canonical format. ULID here caused
         // 'invalid SessionId' when nous parsed the stored ID back (#2349).
@@ -176,12 +230,32 @@ impl DiaporeiaServer {
     ///
     /// Uses streaming execution so long-running turns emit events progressively
     /// instead of blocking until the full turn completes (avoids transport timeout).
-    #[tool(description = "Send a message to a nous agent session and get the response")]
+    ///
+    /// # Streaming limitation (#3251)
+    ///
+    /// The MCP protocol's `tools/call` is a request-response RPC: the client
+    /// sends one request and receives one response. There is no MCP-level
+    /// primitive for streaming partial tool results back to the caller.
+    ///
+    /// Internally, `send_turn_streaming` is used so the nous actor pipeline
+    /// does not block on long turns (preventing transport timeout). However,
+    /// stream events are drained and discarded because MCP has no server-push
+    /// channel for tool execution. The client sees only the final result.
+    ///
+    /// To get token-level streaming, use the HTTP API's SSE endpoint at
+    /// `POST /api/v1/sessions/{id}/messages` instead.
+    ///
+    /// Requires `Operator` role or above (#3337).
+    #[tool(description = "Send a message to a nous agent session and get the response. \
+        Note: response is not streamed — the full result is returned after the turn completes. \
+        For streaming, use the HTTP SSE endpoint.")]
     async fn session_message(
         &self,
         Parameters(params): Parameters<params::SessionMessageParams>,
+        context: RequestContext<rmcp::RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         self.rate_limiter.check(Tier::Expensive)?;
+        require_role(self, &context, Role::Operator, "session_message").await?;
         let handle = self
             .state
             .nous_manager
@@ -405,12 +479,16 @@ impl DiaporeiaServer {
     }
 
     /// Semantic search across the knowledge graph.
+    ///
+    /// Requires `Operator` role or above (#3337).
     #[tool(description = "Semantic search across the knowledge graph")]
     async fn knowledge_search(
         &self,
         Parameters(_params): Parameters<params::KnowledgeSearchParams>,
+        context: RequestContext<rmcp::RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         self.rate_limiter.check(Tier::Expensive)?;
+        require_role(self, &context, Role::Operator, "knowledge_search").await?;
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             "Knowledge search is not available in this configuration. \
              The server must be built with the 'recall' feature enabled \
@@ -420,9 +498,15 @@ impl DiaporeiaServer {
     }
 
     /// Get the runtime configuration with sensitive fields redacted.
+    ///
+    /// Requires `Operator` role or above (#3337).
     #[tool(description = "Get the runtime configuration with sensitive fields redacted")]
-    async fn config_get(&self) -> Result<CallToolResult, rmcp::ErrorData> {
+    async fn config_get(
+        &self,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
         self.rate_limiter.check(Tier::Cheap)?;
+        require_role(self, &context, Role::Operator, "config_get").await?;
         let config = self.state.config.read().await;
 
         let redacted = serde_json::json!({

--- a/crates/diaporeia/src/transport.rs
+++ b/crates/diaporeia/src/transport.rs
@@ -17,7 +17,42 @@ use crate::state::DiaporeiaState;
 /// Mount this into the main application router to expose MCP at `/mcp`.
 /// The auth middleware validates Bearer JWT tokens (or passes through
 /// anonymous claims when `auth_mode == "none"`).
+///
+/// # Security warnings
+///
+/// Logs a `WARN` when `auth_mode == "none"` (all connections receive the
+/// configured `none_role` without any credential check). Escalates to
+/// `ERROR` when the bind address is not loopback, because the MCP server
+/// is reachable from the network with no authentication.
 pub fn streamable_http_router(state: Arc<DiaporeiaState>) -> axum::Router {
+    if state.auth_mode == "none" {
+        // WHY: silent auth bypass is a security anti-pattern. Make the
+        // operator decision visible in logs so it's never accidental.
+        //
+        // NOTE: try_read() avoids panicking when called within a tokio
+        // runtime (integration tests). If the lock is held, default to
+        // "localhost" which is the safe default — the warning is about
+        // network exposure, so false-safe is acceptable.
+        let bind = state.config.try_read().map_or_else(
+            |_| "localhost".to_owned(),
+            |cfg| cfg.gateway.bind.clone(),
+        );
+        let is_loopback = bind == "localhost" || bind == "127.0.0.1" || bind == "::1";
+
+        if is_loopback {
+            tracing::warn!(
+                "MCP authentication disabled — all connections have {} access",
+                state.none_role,
+            );
+        } else {
+            tracing::error!(
+                bind = %bind,
+                "MCP exposed on network with no authentication — all connections have {} access",
+                state.none_role,
+            );
+        }
+    }
+
     let auth_state = Arc::clone(&state);
     let service = StreamableHttpService::new(
         move || Ok(DiaporeiaServer::with_state(Arc::clone(&state))),

--- a/instance.example/config/aletheia.toml
+++ b/instance.example/config/aletheia.toml
@@ -17,6 +17,11 @@ bind = "lan"              # lan | localhost | auto
 
 [gateway.auth]
 mode = "token"            # token | none
+# SECURITY: mode = "none" disables ALL authentication on both the HTTP API
+# and MCP server. Every connection receives the role specified by noneRole
+# (defaults to "admin"). Only use for single-operator localhost deployments.
+# When bind != "localhost", the server logs an ERROR at startup.
+# noneRole = "admin"      # readonly | agent | operator | admin
 
 # [gateway.tls]
 # enabled = true


### PR DESCRIPTION
## Summary

- **#3336**: `auth_mode=none` now emits a prominent `WARN` at startup (loopback) or `ERROR` (network-bound) with the assigned role. Example config documents security implications.
- **#3337**: Per-tool and per-resource RBAC enforcement. `session_create`, `session_message`, `config_get`, `knowledge_search`, and all resource handlers now require Operator+. JWT role extraction validates signatures via `JwtManager` instead of decode-only payload parsing (prevents role spoofing on direct MCP connections).
- **#3251**: `session_message` streaming limitation documented in code and tool description. MCP `tools/call` is inherently request-response; clients are directed to the HTTP SSE endpoint for token-level streaming.

## Changes

| File | Change |
|------|--------|
| `src/transport.rs` | Startup auth warning (WARN loopback, ERROR network) |
| `src/error.rs` | `Unauthorized` variant with custom MCP error code -32001 |
| `src/tools/mod.rs` | `require_role()` helper, RBAC on 4 tools, JWT signature validation, streaming docs |
| `src/server.rs` | `require_resource_role()` + `resolve_caller_role()` on resource handlers |
| `instance.example/config/aletheia.toml` | Security documentation for `mode = "none"` |

## Test plan

- [x] `cargo test -p diaporeia` — 70 tests pass (43 unit + 27 integration)
- [x] `cargo clippy -p diaporeia --no-deps -- -D warnings` — zero warnings
- [x] `cargo check -p aletheia` — binary crate compiles clean
- [x] Existing integration tests for auth_mode=none still pass (transport layer unchanged)
- [x] New `unauthorized_maps_to_custom_error_code` test verifies error mapping

Generated with [Claude Code](https://claude.com/claude-code)