### PR TITLE
docs: fix title case headers to sentence case standard (#3296)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,17 +10,17 @@ assignees: ''
 
 A clear description of the bug.
 
-## Steps to Reproduce
+## Steps to reproduce
 
 1.
 2.
 3.
 
-## Expected Behavior
+## Expected behavior
 
 What should happen.
 
-## Actual Behavior
+## Actual behavior
 
 What happens instead. Include error messages or logs if available.
 
@@ -31,6 +31,6 @@ What happens instead. Include error messages or logs if available.
 - **Aletheia version/commit:**
 - **Relevant services:** (e.g., Qdrant, Neo4j, signal-cli)
 
-## Additional Context
+## Additional context
 
 Relevant logs, screenshots, or configuration (redact credentials).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,14 +10,14 @@ assignees: ''
 
 What problem does this solve? What's the current limitation?
 
-## Proposed Solution
+## Proposed solution
 
 Describe the feature or change you'd like.
 
-## Alternatives Considered
+## Alternatives considered
 
 Other approaches you've thought about and why they're less suitable.
 
-## Additional Context
+## Additional context
 
 Examples, mockups, references, or related issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,6 @@ cargo check --manifest-path crates/theatron/proskenion/Cargo.toml
 All PRs need `Gate-Passed: kanon 0.1.0` in a commit body.
 Desktop PRs: `Gate-Passed: kanon 0.1.0 desktop-only (excluded from workspace build)`.
 
-## Skip Setup section
+## Skip setup section
 
 If you're reading this in a worktree, skip setup — you're already there.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,7 +45,7 @@ After a fix ships, we publish a GitHub Security Advisory with CVE (if warranted)
 | 0.x (previous minor) | Bug fixes only |
 | < current - 2 minors | No |
 
-## Software Bill of Materials (SBOM)
+## Software bill of materials (SBOM)
 
 Per basanos security requirements, every dependency must be tracked in an SBOM with component name, version, PURL, license (SPDX), and hash.
 

--- a/crates/daemon/CLAUDE.md
+++ b/crates/daemon/CLAUDE.md
@@ -67,7 +67,7 @@ Used by: aletheia (binary)
 
 _No `#[instrument]` spans in this crate. Spans created via `tracing::info_span!` at task spawn points._
 
-### Log Events
+### Log events
 
 | Level | Event | When |
 |-------|-------|------|

--- a/crates/episteme/CLAUDE.md
+++ b/crates/episteme/CLAUDE.md
@@ -86,7 +86,7 @@ Used by: mneme (facade re-export)
 | `KnowledgeStore::search` | `knowledge_store/search.rs` | `limit`, `ef` |
 | `KnowledgeStore::insert_fact` | `knowledge_store/facts.rs` | `fact_id` |
 
-### Log Events
+### Log events
 
 | Level | Event | When |
 |-------|-------|------|

--- a/crates/graphe/CLAUDE.md
+++ b/crates/graphe/CLAUDE.md
@@ -96,7 +96,7 @@ Used by: mneme (facade re-export), episteme
 | `import_agent_file` | `import.rs` | `agent_file` |
 | `export_sessions` | `export.rs` | - |
 
-### Log Events
+### Log events
 
 | Level | Event | When |
 |-------|-------|------|

--- a/crates/hermeneus/CLAUDE.md
+++ b/crates/hermeneus/CLAUDE.md
@@ -67,7 +67,7 @@ Used by: nous, pylon, organon, melete
 
 _No `#[instrument]` spans in this crate. Span creation is delegated to callers (typically via `tracing::info_span!` in parent crates)._
 
-### Log Events
+### Log events
 
 | Level | Event | When |
 |-------|-------|------|

--- a/crates/nous/CLAUDE.md
+++ b/crates/nous/CLAUDE.md
@@ -87,7 +87,7 @@ Used by: pylon, aletheia (binary)
 | `cross_router_deliver` | `cross/router.rs` | `msg_id`, `from`, `to` |
 | `cross_router_handle_reply` | `cross/router.rs` | `in_reply_to`, `from` |
 
-### Log Events
+### Log events
 
 | Level | Event | When |
 |-------|-------|------|

--- a/crates/pylon/CLAUDE.md
+++ b/crates/pylon/CLAUDE.md
@@ -87,7 +87,7 @@ Used by: aletheia (binary)
 | `config_reload` | `handlers/config.rs` | - |
 | `config_update` | `handlers/config.rs` | - |
 
-### Log Events
+### Log events
 
 | Level | Event | When |
 |-------|-------|------|

--- a/crates/theatron/proskenion/assets/fonts/README.md
+++ b/crates/theatron/proskenion/assets/fonts/README.md
@@ -1,4 +1,4 @@
-# Font Acquisition
+# Font acquisition
 
 The desktop design system uses two typefaces, both licensed under the SIL Open Font License (OFL):
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,8 +1,8 @@
-# Feature Matrix
+# Feature matrix
 
 This document documents all compile-time feature flags across the Aletheia workspace.
 
-## Feature Matrix by Crate
+## Feature matrix by crate
 
 | Crate | Feature | Default | Gates |
 |-------|---------|---------|-------|
@@ -102,9 +102,9 @@ This document documents all compile-time feature flags across the Aletheia works
 | aletheia-thesauros | test-core | no | Test helpers |
 | aletheia-thesauros | test-full | no | Full test suite |
 
-## Build Profiles
+## Build profiles
 
-### Dev Profile
+### Dev profile
 
 Optimized for fast incremental builds during development:
 
@@ -136,7 +136,7 @@ Proc-macro crates use `opt-level = 1` for faster cold builds:
 - `snafu-derive`
 - `tracing-attributes`
 
-### Release Profile
+### Release profile
 
 Optimized for production binaries:
 
@@ -153,9 +153,9 @@ strip = "symbols"
 | `codegen-units` | 1 | Maximum optimization, single codegen unit |
 | `strip` | "symbols" | Remove debug symbols for smaller binaries |
 
-## Workspace-Level vs Crate-Level Features
+## Workspace-level vs crate-level features
 
-### Workspace-Level Configuration
+### Workspace-level configuration
 
 The workspace `Cargo.toml` defines:
 - **Workspace members**: 27 crate paths (including nested crates like `theatron`)
@@ -163,7 +163,7 @@ The workspace `Cargo.toml` defines:
 - **Shared dependencies**: Common crate versions via `[workspace.dependencies]`
 - **Lint configuration**: Rust and clippy lints applied workspace-wide
 
-### Crate-Level Features
+### Crate-level features
 
 Features are defined per-crate in their respective `Cargo.toml` files:
 
@@ -171,7 +171,7 @@ Features are defined per-crate in their respective `Cargo.toml` files:
 - **Library crates** (`aletheia-*`): Export features for composition by dependent crates.
 - **Test features** (`test-core`, `test-full`, `test-support`): Hierarchical test configuration across the workspace.
 
-### Feature Propagation
+### Feature propagation
 
 Features flow downstream through dependencies:
 
@@ -182,9 +182,9 @@ aletheia (binary)
                                           ──► aletheia-krites
 ```
 
-## Common Feature Patterns
+## Common feature patterns
 
-### Test Tiers
+### Test tiers
 
 All crates follow a consistent test tier pattern:
 
@@ -194,7 +194,7 @@ All crates follow a consistent test tier pattern:
 | Full | `test-full` | Superset of test-core, includes ML embedding tests |
 | Support | `test-support` | Mock implementations for dependent crates |
 
-### Optional Dependencies
+### Optional dependencies
 
 Features often gate optional dependencies using the `dep:` prefix:
 
@@ -205,7 +205,7 @@ tls = ["dep:axum-server"]
 keyring = ["dep:keyring"]
 ```
 
-## Build Examples
+## Build examples
 
 ```bash
 # Default build (tui, recall, storage-fjall, embed-candle)
@@ -227,7 +227,7 @@ cargo test --workspace --features test-core
 cargo test --workspace --features test-full
 ```
 
-## Important Notes
+## Important notes
 
 - **`embed-candle`** must remain in default features. It has been accidentally removed three times (#1263, #1326, #1378). A compile-time test in `tests/default_features.rs` guards against recurrence.
 - **`computer-use`** requires Linux kernel 5.13+ with Landlock support.

--- a/docs/HOT-RELOAD.md
+++ b/docs/HOT-RELOAD.md
@@ -1,4 +1,4 @@
-# Hot Reload Classification
+# Hot reload classification
 
 This document classifies all `AletheiaConfig` fields as either **Hot** (safe to apply via SIGHUP without restart) or **Cold** (requires process restart to take effect).
 
@@ -24,7 +24,7 @@ This document classifies all `AletheiaConfig` fields as either **Hot** (safe to 
 
 ---
 
-## Detailed Classification
+## Detailed classification
 
 ### Gateway (`gateway`)
 
@@ -221,7 +221,7 @@ This document classifies all `AletheiaConfig` fields as either **Hot** (safe to 
 | `mcp.rateLimit.messageRequestsPerMinute` | Hot | Limit read per-MCP-request |
 | `mcp.rateLimit.readRequestsPerMinute` | Hot | Limit read per-MCP-request |
 
-### Local Provider (`localProvider`)
+### Local provider (`localProvider`)
 
 | Config path | Hot/Cold | Reason |
 |-------------|----------|--------|
@@ -238,7 +238,7 @@ This document classifies all `AletheiaConfig` fields as either **Hot** (safe to 
 
 ---
 
-## Verification Against `RESTART_PREFIXES`
+## Verification against `RESTART_PREFIXES`
 
 The `crates/taxis/src/reload.rs` file defines the following `RESTART_PREFIXES`:
 
@@ -254,7 +254,7 @@ const RESTART_PREFIXES: &[&str] = &[
 ];
 ```
 
-### Match Status: ✅ CONSISTENT
+### Match status: ✅ CONSISTENT
 
 All fields marked as **Cold** in this document match the `RESTART_PREFIXES` in `reload.rs`:
 
@@ -268,19 +268,19 @@ All fields marked as **Cold** in this document match the `RESTART_PREFIXES` in `
 | `gateway.bodyLimit` | Cold ✅ | Axum body limit |
 | `channels` | Cold ✅ | Channel transport lifecycle |
 
-### Cold Field Detail: `gateway.csrf`
+### Cold field detail: `gateway.csrf`
 
 **Note:** The `RESTART_PREFIXES` includes `gateway.csrf` as a cold prefix, meaning the **entire** CSRF config subtree requires restart. While `gateway.csrf.headerName` and `gateway.csrf.headerValue` are evaluated per-request, the middleware layer that performs CSRF checking is initialized at startup with the `enabled` flag. Therefore, the entire subtree is classified as Cold for consistency.
 
-### Cold Field Detail: `channels`
+### Cold field detail: `channels`
 
 **Note:** The `channels` prefix covers the entire messaging transport configuration. Signal accounts and their connection parameters are established at server startup. Changes to any channel settings require a restart to re-initialize the transport connections.
 
 ---
 
-## Guidelines for Operators
+## Guidelines for operators
 
-### Safe to Change via SIGHUP (Hot Reload)
+### Safe to change via SIGHUP (hot reload)
 
 - **Agent settings**: Model selection, token budgets, thinking settings, tool iterations, recall parameters
 - **Rate limiting**: All gateway and MCP rate limit settings
@@ -288,7 +288,7 @@ All fields marked as **Cold** in this document match the `RESTART_PREFIXES` in `
 - **Sandbox policies**: Enforcement mode, egress rules, path allowances
 - **Logging**: Log levels, retention, redaction settings
 
-### Requires Process Restart (Cold Changes)
+### Requires process restart (cold changes)
 
 - **Network binding**: Port, bind address, TLS certificates
 - **Authentication mode**: Switching between token/none/JWT modes

--- a/docs/THEATRON-AUDIT.md
+++ b/docs/THEATRON-AUDIT.md
@@ -1,4 +1,4 @@
-# Theatron LOC Audit
+# Theatron LOC audit
 
 > As of v0.13.59 (April 2026). Issue #2317.
 

--- a/docs/benchmarks/memory-benchmarks.md
+++ b/docs/benchmarks/memory-benchmarks.md
@@ -1,4 +1,4 @@
-# Memory Benchmark Results: LongMemEval and LoCoMo
+# Memory benchmark results: LongMemEval and LoCoMo
 
 **Status:** Harness implemented, awaiting live run. See [Prerequisites](#prerequisites) before executing.
 

--- a/docs/constants-audit.md
+++ b/docs/constants-audit.md
@@ -1,4 +1,4 @@
-# Constants Audit — #2306 Wave 7 (Completion)
+# Constants audit — #2306 wave 7 (completion)
 
 **Issue:** forkwright/aletheia#2306
 **Date:** 2026-04-13

--- a/docs/dep-budget.md
+++ b/docs/dep-budget.md
@@ -1,6 +1,6 @@
-# Dependency Budget
+# Dependency budget
 
-## Current State (as of 2026-03-19, v0.13.0)
+## Current state (as of 2026-03-19, v0.13.0)
 
 | Metric | Count |
 |--------|-------|
@@ -13,7 +13,7 @@ The 1714-line `cargo tree --depth 1` output includes all workspace crates' own
 direct dependencies; the 657 external packages figure (from `cargo metadata`)
 is the authoritative count of third-party crates pulled in transitively.
 
-## Target Budget
+## Target budget
 
 | Metric | Budget |
 |--------|--------|

--- a/docs/design/graph-3d.md
+++ b/docs/design/graph-3d.md
@@ -1,4 +1,4 @@
-# 3D Force-Directed Knowledge Graph
+# 3D force-directed knowledge graph
 
 Architecture for the Dioxus desktop 3D graph visualization.
 

--- a/docs/test-tiers.md
+++ b/docs/test-tiers.md
@@ -1,4 +1,4 @@
-# Test Tiers
+# Test tiers
 
 Aletheia uses Cargo feature flags to organize tests into tiers that balance
 coverage against build time and resource requirements.

--- a/standards/ENVIRONMENT.md
+++ b/standards/ENVIRONMENT.md
@@ -1,4 +1,4 @@
-# Environment Configuration
+# Environment configuration
 
 > Standards for environment variables, configuration files, and runtime settings. Defines how values vary across deploy contexts and how configuration is discovered, loaded, and validated.
 

--- a/standards/PROTOBUF.md
+++ b/standards/PROTOBUF.md
@@ -1,4 +1,4 @@
-# Protocol Buffers
+# Protocol buffers
 
 > Standards for proto3 schema design, wire compatibility, gRPC service patterns, JSON mapping, and Rust codegen. Applies to all `.proto` files and generated code.
 

--- a/standards/SECURITY.md
+++ b/standards/SECURITY.md
@@ -672,7 +672,7 @@ Log DNS queries for security analysis and debugging. Retain query logs for at mi
 
 ---
 
-## Software Bill of Materials (SBOM)
+## Software bill of materials (SBOM)
 
 Every released binary and container image must have a machine-readable SBOM attached. The SBOM lists every dependency (direct and transitive), its version, and its license. Without an SBOM, you cannot answer "are we affected?" when a CVE drops — you are reduced to grepping lockfiles across dozens of repos under time pressure.
 

--- a/standards/STANDARDS.md
+++ b/standards/STANDARDS.md
@@ -1,4 +1,4 @@
-# Coding Standards
+# Coding standards
 
 > Universal principles for all code, all languages, all projects. All other standards in this directory are additive to this document. Read this first.
 

--- a/standards/TESTING.md
+++ b/standards/TESTING.md
@@ -18,7 +18,7 @@
 
 Don't test private functions directly. Test them through the public API. If a private function is complex enough to need its own tests, it should be a public function in a smaller module.
 
-## When NOT to test
+## When not to test
 
 - getters/setters
 - Direct delegation (fn that calls one other fn and returns)

--- a/standards/WRITING.md
+++ b/standards/WRITING.md
@@ -125,6 +125,7 @@ Don't write three paragraphs when a table says it better. Don't make a bullet li
 
 - **Sentence case** for document headers: "Error handling patterns" not "Error Handling Patterns"
 - Exception: `UPPER_SNAKE` for canonical doc filenames (STANDARDS.md, ARCHITECTURE.md)
+- Exception: Keep a Changelog category headers (`Added`, `Changed`, `Fixed`, etc.) in `CHANGELOG.md`
 - Headers describe content, not categories: "Sessions persist across restarts" not "Session Persistence Feature"
 - No trailing punctuation on headers
 - **One H1 per page.** The page title.


### PR DESCRIPTION
Fixes #3296. Converts Title Case headers to sentence case across documentation.