### PR TITLE
docs: replace banned words with direct alternatives (#3298)

### DIFF
--- a/crates/daemon/src/prosoche.rs
+++ b/crates/daemon/src/prosoche.rs
@@ -416,7 +416,7 @@ pub(crate) fn parse_vmrss(contents: &str) -> std::io::Result<u64> {
 
 /// Number of recent facts to sample per consistency check.
 ///
-/// Kept small to ensure the check is lightweight. Each sampled fact triggers
+/// Kept small so the check is lightweight. Each sampled fact triggers
 /// one additional Datalog query for entity-path verification.
 #[cfg(feature = "knowledge-store")]
 const ANOMALY_SAMPLE_SIZE: usize = 15;

--- a/crates/energeia/src/qa/corrective.rs
+++ b/crates/energeia/src/qa/corrective.rs
@@ -68,7 +68,7 @@ pub fn derive_failure_type(qa_result: &QaResult) -> String {
 
 /// Determine the blast radius for a corrective prompt.
 ///
-/// Prefers files specifically mentioned in mechanical issues. Falls back to
+/// Prefers files mentioned in mechanical issues. Falls back to
 /// the original prompt's blast radius.
 fn extract_corrective_blast_radius(qa_result: &QaResult, original: &PromptSpec) -> Vec<String> {
     let mut files_from_issues: Vec<String> = qa_result

--- a/crates/graphe/src/store/fjall_store.rs
+++ b/crates/graphe/src/store/fjall_store.rs
@@ -100,7 +100,7 @@ pub struct SessionStore {
     /// WHY: fjall's `SingleWriterTxDatabase` serialises writers internally,
     /// but the graphe API takes `&self` (shared ref) for all write methods —
     /// matching the `SQLite` backend where `Connection` uses interior mutability.
-    /// We use a `Mutex<()>` to ensure only one logical "graphe write" runs at
+    /// We use a `Mutex<()>` so only one logical "graphe write" runs at
     /// a time, mirroring the serial-write contract of `SingleWriterTxDatabase`.
     write_lock: Mutex<()>,
     /// Kept alive to auto-delete the temp directory when the store is dropped.

--- a/crates/krites/src/fixed_rule/algos/yen.rs
+++ b/crates/krites/src/fixed_rule/algos/yen.rs
@@ -3,7 +3,7 @@
 //! Finds the k shortest simple (loopless) paths between a source and target
 //! node.  Works by iteratively finding spur paths from each node on the
 //! previous shortest path, with appropriate edge and node exclusions to
-//! ensure new paths are discovered.
+//! so new paths are discovered.
 //!
 //! Reference: Yen, J.Y. (1971). "Finding the K Shortest Loopless Paths in
 //! a Network." *Management Science*, 17(11), 712--716.

--- a/crates/krites/src/query/stored/validation.rs
+++ b/crates/krites/src/query/stored/validation.rs
@@ -1,4 +1,4 @@
-//! Stored relation validation: ensure constraints and removal operations.
+//! Stored relation validation: verify constraints and removal operations.
 //! SessionTx methods for stored relation mutation and FTS/HNSW/LSH index maintenance.
 //! Stored relation access operators.
 #![expect(

--- a/crates/krites/src/runtime/hnsw/atomic_save.rs
+++ b/crates/krites/src/runtime/hnsw/atomic_save.rs
@@ -31,8 +31,8 @@ fn save_err(reason: String) -> crate::error::InternalError {
 /// Atomically write `data` to `target_path`.
 ///
 /// 1. Write to a temporary file in the same directory as `target_path`.
-/// 2. `fsync` the temporary file to ensure data is on disk.
-/// 3. `fsync` on Unix platforms to ensure directory entry is durable.
+/// 2. `fsync` the temporary file to guarantee data is on disk.
+/// 3. `fsync` on Unix platforms to guarantee the directory entry is durable.
 /// 4. Atomically rename the temp file to `target_path`.
 ///
 /// If any step fails, the temp file is cleaned up and `target_path` is

--- a/crates/melete/src/dream/mod.rs
+++ b/crates/melete/src/dream/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Background process that periodically consolidates session transcripts INTO
 //! the knowledge graph. Uses a triple-gate system (time → sessions → lock) to
-//! ensure consolidation runs infrequently, only when meaningful new data exists,
+//! so consolidation runs infrequently, only when meaningful new data exists,
 //! and never concurrently.
 //!
 //! Gate ORDER matters: each subsequent gate is more expensive.

--- a/crates/nous/src/compact/full.rs
+++ b/crates/nous/src/compact/full.rs
@@ -3,7 +3,7 @@
 //! Triggers when token usage exceeds a configurable threshold of the context
 //! window. Replaces history with a summary plus the last N turns. After
 //! compaction, critical files (recently modified or referenced) are re-injected
-//! to ensure the agent retains context about files it's actively editing.
+//! so the agent retains context about files it's actively editing.
 
 use tracing::debug;
 

--- a/crates/nous/src/finalize.rs
+++ b/crates/nous/src/finalize.rs
@@ -70,7 +70,7 @@ pub struct FinalizeResult {
 /// # Session guarantee
 ///
 /// The nous actor creates sessions in memory (not in `SQLite`). Before
-/// appending messages we ensure the session record exists in the store,
+/// appending messages we verify the session record exists in the store,
 /// avoiding a FOREIGN KEY constraint violation on the `messages` table.
 // NOTE(#940): 120 lines: sequential persistence pipeline: persist assistant message,
 // store tool results, update session, emit events. One cohesive commit sequence.

--- a/crates/nous/src/working_state.rs
+++ b/crates/nous/src/working_state.rs
@@ -94,7 +94,7 @@ pub(crate) struct CacheSafeParams {
 impl CacheSafeParams {
     /// Create cache-safe params with deterministically sorted tools.
     ///
-    /// Tools are sorted by name to ensure identical cache keys regardless
+    /// Tools are sorted by name to guarantee identical cache keys regardless
     /// of registration order.
     #[cfg_attr(
         not(test),

--- a/crates/poiesis/text/src/pdf.rs
+++ b/crates/poiesis/text/src/pdf.rs
@@ -40,7 +40,7 @@ const USABLE_W: f32 = PAGE_W - 2.0 * MARGIN_X;
 #[derive(Debug, Snafu)]
 pub enum PdfError {
     /// No usable system font was found. Install a font (e.g. `liberation-sans-fonts`
-    /// or `google-noto-sans-fonts`) and ensure it is readable.
+    /// or `google-noto-sans-fonts`) and verify it is readable.
     #[snafu(display("no usable system font found for PDF rendering"))]
     NoFont,
 

--- a/crates/symbolon/src/store/fjall_store.rs
+++ b/crates/symbolon/src/store/fjall_store.rs
@@ -97,7 +97,7 @@ pub(crate) struct AuthStore {
     /// WHY: `SingleWriterTxDatabase` serialises writers internally, but the
     /// symbolon API takes `&self` for all write methods (matching the `SQLite`
     /// backend where `Connection` uses interior mutability). We use a `Mutex<()>`
-    /// to ensure only one write runs at a time, matching that serial contract.
+    /// so only one write runs at a time, matching that serial contract.
     write_lock: Mutex<()>,
     /// Kept alive to auto-delete the temp directory when the store is dropped.
     ///

--- a/crates/theatron/proskenion/src/components/chat/mod.rs
+++ b/crates/theatron/proskenion/src/components/chat/mod.rs
@@ -484,7 +484,7 @@ impl ChatStateManager {
     }
 
     /// Force-flush all buffered text. Call this on a timer tick (100ms)
-    /// from the Dioxus coroutine to ensure text is never stuck in the
+    /// from the Dioxus coroutine so text is never stuck in the
     /// buffer longer than the debounce interval.
     #[must_use]
     pub(crate) fn tick(&mut self, state: &mut ChatState) -> bool {

--- a/crates/theatron/proskenion/src/state/events.rs
+++ b/crates/theatron/proskenion/src/state/events.rs
@@ -66,7 +66,7 @@ impl Default for EventState {
 }
 
 /// SSE connection lifecycle state, separate from the server connection
-/// (P604). This tracks specifically whether we are receiving SSE events.
+/// (P604). This tracks whether we are receiving SSE events.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SseConnectionState {

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -289,7 +289,7 @@ fuser -k 18789/tcp    # kill the process on that port
 
 The default auth mode from the init wizard is `none` (no bearer token). When `gateway.auth.mode = "none"`, the role assigned to all requests is controlled by `gateway.auth.none_role`. The compiled default is `"admin"`, which permits all operations. If you explicitly set `none_role` to `"readonly"`, only dashboard reads will work -- sessions, messages, and config changes will be rejected.
 
-Fix: ensure your config has:
+Fix: verify your config has:
 
 ```toml
 [gateway.auth]

--- a/docs/benchmarks/memory-benchmarks.md
+++ b/docs/benchmarks/memory-benchmarks.md
@@ -300,7 +300,7 @@ When results land, compare against the SOTA table above and analyze:
   factual recall is working
 - `temporal-reasoning` above 60%: Bayesian surprise and staleness features
   (#2848, #2852) are contributing
-- F1 notably above EM: the model is producing correct-content answers that
+- F1 above EM: the model is producing correct-content answers that
   fail normalized exact match — consider relaxing the scorer or accepting
   contains as partial credit
 

--- a/planning/research/browser-automation.md
+++ b/planning/research/browser-automation.md
@@ -375,7 +375,7 @@ Connection pooling for browser instances across sessions. Only justified if brow
 
 ## Gotchas
 
-1. **Chrome binary availability.** Headless Chrome must be installed on the host or auto-downloaded via `chromiumoxide_fetcher`. The feature flag approach means builds without `browser` have zero Chrome dependency, but deployments that enable it must ensure Chrome is present. Document the requirement and provide a Nix flake overlay.
+1. **Chrome binary availability.** Headless Chrome must be installed on the host or auto-downloaded via `chromiumoxide_fetcher`. The feature flag approach means builds without `browser` have zero Chrome dependency, but deployments that enable it must verify Chrome is present. Document the requirement and provide a Nix flake overlay.
 
 2. **Landlock + Chrome sandbox conflict.** Chrome's internal sandbox uses user namespaces and seccomp-bpf. Running Chrome under Landlock with `--no-sandbox` disables Chrome's own sandbox, relying on Landlock for isolation instead. This is safe (Landlock is stricter) but non-obvious. Document the security rationale.
 

--- a/standards/AGENT-DOCS.md
+++ b/standards/AGENT-DOCS.md
@@ -127,14 +127,14 @@ Research shows agent performance degrades when context files exceed ~500 words i
 General prompt voice rules (positive over negative, WHY on every rule, dial back aggressive emphasis) apply here too -- see [PROMPTING.md § Voice](PROMPTING.md#voice). The following are specific to context files:
 
 - **Direct and terse** -- every word costs tokens in always-loaded files; context files compete for attention more than one-shot prompts
-- **Concrete over abstract** -- "run `kanon gate`" not "ensure CI passes" because agents cannot act on vague instructions without additional lookup
+- **Concrete over abstract** -- "run `kanon gate`" not "verify CI passes" because agents cannot act on vague instructions without additional lookup
 - **Imperative mood** -- "add tests for new public functions" not "tests should be added" because imperative framing maps directly to agent actions
 
 ---
 
 ## Anti-patterns
 
-- **Codebase overviews** -- agents navigate codebases well without guidance. Over 90% of files with overviews showed no measurable navigation improvement.
+- **Codebase overviews** -- agents explore codebases well without guidance. Over 90% of files with overviews showed no measurable navigation improvement.
 - **LLM-generated content** -- ETH Zurich research shows LLM-generated context files reduce success rates by 3% while increasing cost 20%+. Manually craft every line.
 - **Linter-enforceable rules** -- use actual linters and hooks. Asking an agent to check formatting wastes context on something a tool does better.
 - **README duplication** -- if it's in the README, package.json, or config files, agents already find it.

--- a/standards/ARCHITECTURE.md
+++ b/standards/ARCHITECTURE.md
@@ -158,7 +158,7 @@ Run `cargo tree -f '{p} {f}'` to display each package with its resolved features
 # Show all packages and their resolved features
 cargo tree -f '{p} {f}'
 
-# Show the feature graph specifically
+# Show the feature graph
 cargo tree -e features
 
 # Check a specific feature's activation path

--- a/standards/PYTHON.md
+++ b/standards/PYTHON.md
@@ -550,7 +550,7 @@ Include an empty `py.typed` file in the package root. WHY: tells mypy and pyrigh
 
 ### Module size
 
-Split modules when they exceed ~300 lines. A module with 800 lines of mixed concerns is hard to navigate and harder to test in isolation. Group by domain concept, not by implementation pattern (don't create `utils.py`, `helpers.py`, or `misc.py`).
+Split modules when they exceed ~300 lines. A module with 800 lines of mixed concerns is hard to follow and harder to test in isolation. Group by domain concept, not by implementation pattern (don't create `utils.py`, `helpers.py`, or `misc.py`).
 
 - WHY: a `utils.py` file is a gravity well. Every unrelated function lands there. It grows unbounded, has no cohesion, and becomes a dependency bottleneck that everything imports.
 

--- a/standards/RESTIC.md
+++ b/standards/RESTIC.md
@@ -283,7 +283,7 @@ ps aux | grep restic
 restic unlock
 ```
 
-**Prevention**: Use `trap EXIT` in scripts to ensure cleanup on interruption.
+**Prevention**: Use `trap EXIT` in scripts to run cleanup on interruption.
 
 ### Permission denied on restore
 

--- a/standards/SQL.md
+++ b/standards/SQL.md
@@ -696,7 +696,7 @@ Defense: use STRICT tables (see § SQLite > STRICT tables). With STRICT, SQLite 
 
 Rule: use `CAST()` for portable code. Use `::` only in PostgreSQL-specific contexts.
 
-For JSON casting specifically:
+For JSON casting:
 - PostgreSQL: `value::jsonb` or `CAST(value AS jsonb)` -- both work, `::` is idiomatic
 - SQLite: no JSON cast -- use `json()` to validate and minify, `json_valid()` to check
 


### PR DESCRIPTION
Fixes #3298. Replaces ensure/notably/navigate/specifically with direct alternatives.