### PR TITLE
docs: replace spatial references with direct element naming (#3297)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -112,7 +112,7 @@ cargo bench -p aletheia-symbolon --bench jwt -- --quick
    ```
 
 5. Verify with `cargo bench -p aletheia-<crate> --bench <name> -- --quick`.
-6. Add a row to the coverage table above.
+6. Add a row to the Coverage table.
 
 ## Baselines and regressions
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -284,7 +284,7 @@ id = "main"
 default = true
 ```
 
-> **Manual alternative:** Steps 1–3 above apply to both first-time manual setups and adding agents to an existing instance. If you used the init wizard, only step 3 may be needed to add additional agents.
+> **Manual alternative:** Steps 1–3 in [Manual: add an additional agent](#manual-add-an-additional-agent) apply to both first-time manual setups and adding agents to an existing instance. If you used the init wizard, only step 3 may be needed to add additional agents.
 
 ---
 

--- a/docs/FJALL-EVALUATION.md
+++ b/docs/FJALL-EVALUATION.md
@@ -56,7 +56,7 @@ fjall declares `#![deny(unsafe_code)]` in `src/lib.rs`. The codebase contains fi
 
 - `src/lib.rs:74` -- the `#![deny(unsafe_code)]` lint gate itself
 - `src/meta_keyspace.rs:177` -- `#[expect(unsafe_code, clippy::indexing_slicing)]` with one `unsafe` block calling `Slice::builder_unzeroed`. This is uninitialized buffer allocation with a known size; the pattern is a standard optimization for buffer-building in I/O code.
-- `src/journal/entry.rs:199` -- `#[warn(unsafe_code)]` with one `unsafe { Slice::builder_unzeroed(value_len) }` call. Same pattern as above.
+- `src/journal/entry.rs:199` -- `#[warn(unsafe_code)]` with one `unsafe { Slice::builder_unzeroed(value_len) }` call. Same pattern as the `src/meta_keyspace.rs` entry.
 
 All three `unsafe` call sites are `Slice::builder_unzeroed`, an uninitialized-allocation helper from `byteview`. The scope is narrow, the rationale is I/O performance, and all three are annotated with lint attributes.
 

--- a/docs/HOT-RELOAD.md
+++ b/docs/HOT-RELOAD.md
@@ -256,7 +256,7 @@ const RESTART_PREFIXES: &[&str] = &[
 
 ### Match Status: ✅ CONSISTENT
 
-All fields marked as **Cold** in this document match the `RESTART_PREFIXES` in `reload.rs`:
+All fields marked as **Cold** in HOT-RELOAD.md match the `RESTART_PREFIXES` in `reload.rs`:
 
 | Prefix in Code | Document Status | Notes |
 |----------------|-----------------|-------|

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -123,7 +123,7 @@ In a second terminal:
 aletheia health
 ```
 
-Expected output: status `healthy` with your agent listed. If you see `degraded`, your API key wasn't found -- see Troubleshooting below.
+Expected output: status `healthy` with your agent listed. If you see `degraded`, your API key wasn't found -- see [Troubleshooting](#troubleshooting).
 
 ```bash
 aletheia status
@@ -154,7 +154,7 @@ curl -s http://localhost:18789/api/v1/sessions \
   -H "X-Requested-With: aletheia" \
   -d '{"nous_id": "pronoea"}' | jq .
 
-# Send a message (replace SESSION_ID with the id from above)
+# Send a message (replace SESSION_ID with the id from the session creation response)
 curl -N http://localhost:18789/api/v1/sessions/SESSION_ID/messages \
   -H "Content-Type: application/json" \
   -H "X-Requested-With: aletheia" \

--- a/docs/benchmarks/memory-benchmarks.md
+++ b/docs/benchmarks/memory-benchmarks.md
@@ -197,7 +197,7 @@ Key log lines to watch:
 
 ## Metrics to capture
 
-Record the following for each run and add to the Results table below:
+Record the following for each run and add to the Results table:
 
 | Metric | Description |
 |---|---|
@@ -273,7 +273,7 @@ Per-category breakdown (Hindsight / GPT-4 + mem):
 
 ## Results
 
-*Not yet collected — see Prerequisites above.*
+*Not yet collected — see [Prerequisites](#prerequisites).*
 
 When results are available, record them here:
 
@@ -293,7 +293,7 @@ When results are available, record them here:
 
 ## Analysis guidance
 
-When results land, compare against the SOTA table above and analyze:
+When results land, compare against the [Published SOTA baselines](#published-sota-baselines) table and analyze:
 
 **Strengths to look for:**
 - `single-session-user` and `single-session-assistant` EM above 70%: basic

--- a/docs/constants-audit.md
+++ b/docs/constants-audit.md
@@ -250,7 +250,7 @@ Research depth ALL variant array, handoff filenames (`.continue-here.json`, `.co
 
 Scaffold template content (SOUL, IDENTITY, AGENTS, etc.), single-agent sandbox TOML template, binary name, REPL banner/help text, academic API constants.
 
-### agora — 8 constants (all parameterized, see above)
+### agora — 8 constants (all parameterized, see the Summary section)
 
 ### poiesis/text — 9 constants (all invariant)
 

--- a/standards/QA.md
+++ b/standards/QA.md
@@ -73,7 +73,7 @@ Each audit summary record includes category scores (see [Training data output](#
 
 **Gate** means a repo scoring below the minimum on a gated category blocks the next release. Non-gated categories are tracked and trended but do not block.
 
-**How scores map to grades.** Scores derive from the violation density (violations per 1K lines) and severity distribution within each category. The grading function lives in basanos and is the single source of truth. Do not hardcode grade thresholds in this document — reference the implementation.
+**How scores map to grades.** Scores derive from the violation density (violations per 1K lines) and severity distribution within each category. The grading function lives in basanos and is the single source of truth. Do not hardcode grade thresholds in QA.md — reference the implementation.
 
 WHY: Hardcoded thresholds in prose diverge from the code that actually computes them. The table above defines policy (what the minimums are); the code defines mechanics (how a score becomes a grade).
 


### PR DESCRIPTION
Fixes #3297. Replaces 'the table below' etc. with direct element references.