### PR TITLE
docs(mneme): fix consumer list in crate documentation (#3308)

### DIFF
--- a/crates/mneme/CLAUDE.md
+++ b/crates/mneme/CLAUDE.md
@@ -64,4 +64,4 @@ Mneme itself has no logic. All changes go to the sub-crates:
 ## Dependencies
 
 Uses: eidos, graphe, episteme, krites
-Used by: nous, pylon, melete, aletheia (binary)
+Used by: nous, pylon, aletheia, diaporeia, integration-tests

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -5,9 +5,9 @@
 //! sub-crates: graphe (session persistence), episteme (knowledge pipeline),
 //! eidos (types), and krites (Datalog engine).
 //!
-//! Only types that downstream consumers (nous, pylon, aletheia, melete, daemon,
-//! diaporeia, integration-tests) actually import are surfaced here. Internal
-//! types remain accessible through the sub-crates directly.
+//! Only types that downstream consumers (nous, pylon, aletheia, diaporeia,
+//! integration-tests) actually import are surfaced here. Internal types remain
+//! accessible through the sub-crates directly.
 
 // ── Types (eidos) ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #3308. Corrects the 'Used by' section to list actual consumers.