### PR TITLE
fix(proskenion): connection timeout, paginated history, consolidated state, auth warning (#3319, #3320, #3321, #3323)

### DIFF
--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "compact_str",
  "jiff",
@@ -4209,7 +4209,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "compact_str",

--- a/crates/theatron/proskenion/src/components/chat/mod.rs
+++ b/crates/theatron/proskenion/src/components/chat/mod.rs
@@ -132,6 +132,66 @@ impl Default for ChatState {
     }
 }
 
+impl ChatState {
+    /// Project legacy messages into the render-ready `ChatMessage` model.
+    ///
+    /// WHY: Centralizes the legacy-to-render projection so it is defined once
+    /// and shared by all consumers (chat view, command palette export, etc.).
+    /// This eliminates the duplicate projection that was previously inlined
+    /// in each call site (#3323).
+    ///
+    /// `limit` controls how many of the most recent messages to include.
+    /// Pass `None` to include all messages.
+    #[must_use]
+    pub(crate) fn project_messages(
+        &self,
+        limit: Option<usize>,
+    ) -> Vec<crate::state::chat::ChatMessage> {
+        use crate::state::chat::{ChatMessage as RenderMessage, Role};
+
+        let now_ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| {
+                #[expect(clippy::as_conversions, reason = "epoch seconds fit in i64 until year 292B")]
+                let secs = d.as_secs() as i64;
+                secs
+            })
+            .unwrap_or(0);
+
+        let skip_count = match limit {
+            Some(lim) => self.messages.len().saturating_sub(lim),
+            None => 0,
+        };
+
+        self.messages
+            .iter()
+            .enumerate()
+            .skip(skip_count)
+            .map(|(i, m)| RenderMessage {
+                #[expect(clippy::as_conversions, reason = "message index to u64 id")]
+                id: i as u64 + 1,
+                role: match m.role {
+                    MessageRole::User => Role::User,
+                    MessageRole::Assistant => Role::Assistant,
+                },
+                content: m.content.clone(),
+                timestamp: {
+                    #[expect(clippy::as_conversions, reason = "message offset to i64 for timestamp spacing")]
+                    let offset = (self.messages.len() - 1 - i) as i64 * 30;
+                    now_ts - offset
+                },
+                agent_id: self.agent_id.clone(),
+                tool_calls: m.tool_calls,
+                thinking_content: None,
+                is_streaming: false,
+                model: m.model.clone(),
+                input_tokens: m.input_tokens,
+                output_tokens: m.output_tokens,
+            })
+            .collect()
+    }
+}
+
 /// Manages `ChatState` transitions in response to `StreamEvent`s.
 ///
 /// Encapsulates the debounce buffer and flush logic. In a Dioxus component,

--- a/crates/theatron/proskenion/src/components/command_palette.rs
+++ b/crates/theatron/proskenion/src/components/command_palette.rs
@@ -9,7 +9,7 @@ use dioxus::prelude::*;
 use crate::app::Route;
 use crate::components::chat::ChatState;
 use crate::services::export::messages_to_markdown;
-use crate::state::chat::{ChatMessage, Role};
+use crate::state::chat::ChatMessage;
 use crate::state::commands::{CommandCategory, CommandStore};
 use crate::state::toasts::{Severity, ToastStore};
 
@@ -121,32 +121,10 @@ fn dispatch_command(
                 return;
             };
 
-            let messages: Vec<ChatMessage> = {
-                use crate::components::chat::MessageRole;
-                let state = legacy_state.read();
-                state
-                    .messages
-                    .iter()
-                    .enumerate()
-                    .map(|(i, m)| ChatMessage {
-                        #[expect(clippy::as_conversions, reason = "message index to u64 id")]
-                        id: i as u64 + 1,
-                        role: match m.role {
-                            MessageRole::User => Role::User,
-                            MessageRole::Assistant => Role::Assistant,
-                        },
-                        content: m.content.clone(),
-                        timestamp: 0,
-                        agent_id: None,
-                        tool_calls: 0,
-                        thinking_content: None,
-                        is_streaming: false,
-                        model: None,
-                        input_tokens: 0,
-                        output_tokens: 0,
-                    })
-                    .collect()
-            };
+            // WHY: Use the centralized projection method instead of
+            // duplicating the legacy-to-render mapping here (#3323).
+            let messages: Vec<ChatMessage> =
+                legacy_state.read().project_messages(None);
 
             if messages.is_empty() {
                 if let Some(mut toast_store) = try_consume_context::<Signal<ToastStore>>() {

--- a/crates/theatron/proskenion/src/services/config.rs
+++ b/crates/theatron/proskenion/src/services/config.rs
@@ -3,8 +3,11 @@
 //! Loads on startup and saves after each successful connection so the user
 //! does not have to re-enter the server URL on every launch.
 //!
-//! NOTE: Auth tokens are currently stored in plaintext. Future versions should
-//! integrate with the OS keyring (libsecret, Keychain, Credential Manager).
+//! SECURITY: Auth tokens are stored in plaintext in the config file. The file
+//! is written with 0600 (owner-only) permissions, but any process running as
+//! the same user can read it. Full OS keyring integration (libsecret on Linux,
+//! Keychain on macOS) is tracked as future work. Do not copy this file or
+//! commit it to version control.
 
 use std::io::Write;
 use std::path::PathBuf;
@@ -153,14 +156,49 @@ pub(crate) fn save(config: &ConnectionConfig) -> Result<(), ConfigError> {
 ///
 /// Logs a warning if loading fails. Suitable for startup where a missing
 /// or corrupt config file should not prevent the app from launching.
+///
+/// Emits a `tracing::warn!` if an auth token is present, since it is stored
+/// in plaintext (see module-level SECURITY note).
 #[must_use]
 pub(crate) fn load_or_default() -> ConnectionConfig {
-    match load() {
+    let config = match load() {
         Ok(config) => config,
         Err(e) => {
             tracing::warn!("failed to load config, using defaults: {e}");
-            ConnectionConfig::default()
+            return ConnectionConfig::default();
         }
+    };
+
+    if config.auth_token.is_some() {
+        tracing::warn!(
+            "auth token loaded from plaintext config file (~/.config/aletheia/desktop.toml). \
+             OS keyring integration is not yet implemented. The file is 0600 but any \
+             same-user process can read it."
+        );
+        // Verify the config file has correct permissions (0600).
+        warn_if_permissions_loose();
+    }
+
+    config
+}
+
+/// Check that the config file has restrictive permissions (0600) and warn if not.
+fn warn_if_permissions_loose() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Ok(path) = config_path() else { return };
+    let Ok(metadata) = std::fs::metadata(&path) else {
+        return;
+    };
+    let mode = metadata.permissions().mode() & 0o777;
+    if mode != 0o600 {
+        tracing::warn!(
+            path = %path.display(),
+            mode = format!("{mode:04o}"),
+            "config file has loose permissions (expected 0600). \
+             Run: chmod 600 {}",
+            path.display(),
+        );
     }
 }
 
@@ -243,6 +281,7 @@ mod tests {
             server_url: "https://pylon.example.com:8443".to_string(),
             auth_token: Some("tok_abc123".to_string()),
             auto_reconnect: false,
+            ..ConnectionConfig::default()
         };
 
         let desktop = DesktopConfig {
@@ -270,6 +309,7 @@ mod tests {
             server_url: "http://10.0.0.1:3000".to_string(),
             auth_token: Some("my-token".to_string()),
             auto_reconnect: true,
+            ..ConnectionConfig::default()
         };
 
         let desktop = DesktopConfig {

--- a/crates/theatron/proskenion/src/services/connection.rs
+++ b/crates/theatron/proskenion/src/services/connection.rs
@@ -57,6 +57,13 @@ pub enum ConnectionError {
         status: u16,
     },
 
+    /// Connection attempt exceeded the configured timeout.
+    #[snafu(display("connection timed out after {timeout_secs}s"))]
+    Timeout {
+        /// Configured timeout in seconds.
+        timeout_secs: u64,
+    },
+
     /// Auth token contains non-ASCII characters.
     #[snafu(display("invalid auth token: contains non-ASCII characters"))]
     InvalidToken,
@@ -190,7 +197,12 @@ impl ConnectionService {
         let _ = self.tx.send(state);
     }
 
-    /// Run the connection loop until cancelled.
+    /// Run the connection loop until cancelled or timed out.
+    ///
+    /// The overall connection phase (all retries combined) is bounded by
+    /// `ConnectionConfig::connect_timeout_secs` (default 30s). If the
+    /// deadline elapses without a successful health check, the service
+    /// emits `ConnectionState::TimedOut` so the UI can offer a retry button.
     ///
     /// This is designed to be spawned as a background task:
     /// ```ignore
@@ -212,8 +224,10 @@ impl ConnectionService {
             }
         };
 
-        // Initial connection attempt.
+        // Initial connection attempt with overall timeout.
         self.emit(ConnectionState::Connecting);
+        let deadline = tokio::time::sleep(self.config.connect_timeout());
+        tokio::pin!(deadline);
         let mut attempt: u32 = 0;
 
         loop {
@@ -223,7 +237,23 @@ impl ConnectionService {
 
             attempt = attempt.saturating_add(1);
 
-            match client.health().await {
+            // Race the health check against cancellation and the overall deadline.
+            let health_result = tokio::select! {
+                biased;
+                _ = self.cancel.cancelled() => return,
+                _ = &mut deadline => {
+                    tracing::warn!(
+                        timeout_secs = self.config.connect_timeout_secs,
+                        attempts = attempt,
+                        "connection timed out"
+                    );
+                    self.emit(ConnectionState::TimedOut);
+                    return;
+                }
+                result = client.health() => result,
+            };
+
+            match health_result {
                 Ok(()) => {
                     tracing::info!(base_url = client.base_url(), "connected to pylon");
                     self.emit(ConnectionState::Connected);
@@ -241,6 +271,15 @@ impl ConnectionService {
                     tokio::select! {
                         biased;
                         _ = self.cancel.cancelled() => return,
+                        _ = &mut deadline => {
+                            tracing::warn!(
+                                timeout_secs = self.config.connect_timeout_secs,
+                                attempts = attempt,
+                                "connection timed out during backoff"
+                            );
+                            self.emit(ConnectionState::TimedOut);
+                            return;
+                        }
                         // NOTE: backoff elapsed, retry connection
                         _ = tokio::time::sleep(delay) => {}
                     }

--- a/crates/theatron/proskenion/src/state/chat.rs
+++ b/crates/theatron/proskenion/src/state/chat.rs
@@ -1,6 +1,6 @@
 //! Chat session and message state for the desktop chat view.
 
-use skene::id::{NousId, SessionId};
+use skene::id::NousId;
 
 /// Role of a chat message sender.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,40 +40,6 @@ pub struct ChatMessage {
     pub input_tokens: u32,
     /// Output tokens produced.
     pub output_tokens: u32,
-}
-
-/// A chat session: one conversation with an agent.
-#[derive(Debug, Clone)]
-pub struct ChatSession {
-    /// Session identifier.
-    #[expect(dead_code, reason = "public API")]
-    pub id: SessionId,
-    /// Agent this session belongs to.
-    #[expect(dead_code, reason = "public API")]
-    pub agent_id: NousId,
-    /// Ordered message history (oldest first).
-    #[expect(dead_code, reason = "public API")]
-    pub messages: Vec<ChatMessage>,
-    /// Current scroll position (pixel offset from top of content).
-    #[expect(dead_code, reason = "public API")]
-    pub scroll_position: f64,
-    /// Whether older messages exist on the server.
-    #[expect(dead_code, reason = "public API")]
-    pub has_more_history: bool,
-    #[expect(dead_code, reason = "public API")]
-    next_id: u64,
-}
-
-
-/// Store managing all chat sessions.
-#[derive(Debug, Clone, Default)]
-pub struct ChatStore {
-    /// Currently active session ID.
-    #[expect(dead_code, reason = "public API")]
-    pub active_session: Option<SessionId>,
-    /// All loaded sessions keyed by ID.
-    #[expect(dead_code, reason = "public API")]
-    pub sessions: std::collections::HashMap<SessionId, ChatSession>,
 }
 
 /// Format a Unix timestamp as a relative time string.

--- a/crates/theatron/proskenion/src/state/connection.rs
+++ b/crates/theatron/proskenion/src/state/connection.rs
@@ -35,6 +35,8 @@ pub enum ConnectionState {
         /// Consecutive reconnection failures (1-indexed).
         attempt: u32,
     },
+    /// Connection attempt exceeded the configured timeout.
+    TimedOut,
     /// Permanently failed: requires user intervention (e.g. bad URL, auth
     /// rejected, max retries exceeded).
     Failed {
@@ -67,6 +69,7 @@ impl ConnectionState {
             Self::Connecting => "connecting",
             Self::Connected => "connected",
             Self::Reconnecting { .. } => "reconnecting",
+            Self::TimedOut => "timed out",
             Self::Failed { .. } => "failed",
         }
     }
@@ -86,14 +89,23 @@ pub struct ConnectionConfig {
     pub server_url: String,
     /// Optional authentication token. Injected as `Authorization: Bearer <token>`.
     ///
-    /// NOTE: Stored in plaintext in the config file for v1. Future versions
-    /// should integrate with the OS keyring (e.g. libsecret on Linux,
-    /// Keychain on macOS) for secure token storage.
+    /// SECURITY: Stored in plaintext in the config file (`~/.config/aletheia/desktop.toml`).
+    /// The file is written with 0600 permissions (owner-only), but any process running
+    /// as the same user can read it. Full OS keyring integration (libsecret on Linux,
+    /// Keychain on macOS) is tracked as future work. Do not copy this file or commit
+    /// it to version control.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_token: Option<String>,
     /// Whether to automatically reconnect on connection loss.
     #[serde(default = "default_auto_reconnect")]
     pub auto_reconnect: bool,
+    /// Maximum time in seconds to wait for a connection attempt before timing out.
+    #[serde(default = "default_connect_timeout_secs")]
+    pub connect_timeout_secs: u64,
+}
+
+fn default_connect_timeout_secs() -> u64 {
+    DEFAULT_CONNECT_TIMEOUT.as_secs()
 }
 
 fn default_auto_reconnect() -> bool {
@@ -106,9 +118,22 @@ impl Default for ConnectionConfig {
             server_url: "http://localhost:3000".to_string(),
             auth_token: None,
             auto_reconnect: true,
+            connect_timeout_secs: DEFAULT_CONNECT_TIMEOUT.as_secs(),
         }
     }
 }
+
+/// Returns the configured connect timeout as a [`Duration`].
+impl ConnectionConfig {
+    /// Connection timeout as a [`Duration`].
+    #[must_use]
+    pub(crate) fn connect_timeout(&self) -> Duration {
+        Duration::from_secs(self.connect_timeout_secs)
+    }
+}
+
+/// Default timeout for an individual connection attempt.
+pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Initial backoff delay after a connection failure.
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
@@ -146,6 +171,7 @@ mod tests {
         assert!(!ConnectionState::Disconnected.is_connected());
         assert!(!ConnectionState::Connecting.is_connected());
         assert!(!ConnectionState::Reconnecting { attempt: 1 }.is_connected());
+        assert!(!ConnectionState::TimedOut.is_connected());
         assert!(
             !ConnectionState::Failed {
                 reason: "bad".into()
@@ -160,6 +186,7 @@ mod tests {
         assert!(ConnectionState::Connecting.needs_connect_view());
         assert!(!ConnectionState::Connected.needs_connect_view());
         assert!(ConnectionState::Reconnecting { attempt: 1 }.needs_connect_view());
+        assert!(ConnectionState::TimedOut.needs_connect_view());
         assert!(
             ConnectionState::Failed {
                 reason: "err".into()
@@ -177,6 +204,7 @@ mod tests {
             ConnectionState::Reconnecting { attempt: 3 }.label(),
             "reconnecting"
         );
+        assert_eq!(ConnectionState::TimedOut.label(), "timed out");
         assert_eq!(
             ConnectionState::Failed { reason: "x".into() }.label(),
             "failed"
@@ -213,6 +241,16 @@ mod tests {
         assert_eq!(cfg.server_url, "http://localhost:3000");
         assert!(cfg.auth_token.is_none());
         assert!(cfg.auto_reconnect);
+        assert_eq!(cfg.connect_timeout_secs, 30);
+    }
+
+    #[test]
+    fn connection_config_connect_timeout() {
+        let cfg = ConnectionConfig {
+            connect_timeout_secs: 60,
+            ..ConnectionConfig::default()
+        };
+        assert_eq!(cfg.connect_timeout(), Duration::from_secs(60));
     }
 
     #[test]
@@ -221,12 +259,14 @@ mod tests {
             server_url: "https://example.com:8080".to_string(),
             auth_token: Some("secret-token".to_string()),
             auto_reconnect: false,
+            connect_timeout_secs: 45,
         };
         let serialized = toml::to_string(&cfg).unwrap();
         let deserialized: ConnectionConfig = toml::from_str(&serialized).unwrap();
         assert_eq!(deserialized.server_url, cfg.server_url);
         assert_eq!(deserialized.auth_token, cfg.auth_token);
         assert_eq!(deserialized.auto_reconnect, cfg.auto_reconnect);
+        assert_eq!(deserialized.connect_timeout_secs, cfg.connect_timeout_secs);
     }
 
     #[test]
@@ -241,5 +281,19 @@ mod tests {
         let toml_str = r#"server_url = "http://localhost:3000""#;
         let cfg: ConnectionConfig = toml::from_str(toml_str).unwrap();
         assert!(cfg.auto_reconnect);
+    }
+
+    #[test]
+    fn connection_config_toml_defaults_connect_timeout() {
+        let toml_str = r#"server_url = "http://localhost:3000""#;
+        let cfg: ConnectionConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.connect_timeout_secs, DEFAULT_CONNECT_TIMEOUT.as_secs());
+    }
+
+    #[test]
+    fn connection_state_timed_out() {
+        assert!(ConnectionState::TimedOut.needs_connect_view());
+        assert!(!ConnectionState::TimedOut.is_connected());
+        assert!(!ConnectionState::TimedOut.is_disconnected());
     }
 }

--- a/crates/theatron/proskenion/src/views/chat.rs
+++ b/crates/theatron/proskenion/src/views/chat.rs
@@ -27,7 +27,7 @@ use crate::components::tool_panel::ToolPanel;
 use crate::services::file_watcher::{self, FileChangeTracker};
 use crate::state::agents::AgentStore;
 use crate::state::app::TabBar;
-use crate::state::chat::{ChatMessage, ChatStore, Role};
+use crate::state::chat::ChatMessage;
 use crate::state::commands::CommandStore;
 use crate::state::connection::ConnectionConfig;
 use crate::state::input::InputState;
@@ -38,11 +38,16 @@ use crate::state::view_preservation::{PreservedViewState, ViewKey, ViewPreservat
 /// Estimated message height in pixels for virtual scroll calculations.
 const ESTIMATED_MSG_HEIGHT: f64 = 80.0;
 
+/// Number of messages to load initially and per pagination chunk.
+const PAGE_SIZE: usize = 100;
+
+/// Scroll threshold in pixels from the top to trigger loading older messages.
+const LOAD_MORE_THRESHOLD: f64 = 200.0;
+
 /// Chat view with virtualized scrolling, markdown rendering, and agent switching.
 #[component]
 pub(crate) fn Chat() -> Element {
     let mut legacy_state = use_signal(ChatState::default);
-    let _store = use_signal(ChatStore::default);
     let mut input_state = use_signal(InputState::default);
     let mut cancel_token = use_signal(CancellationToken::new);
     let mut palette_open = use_signal(|| false);
@@ -60,6 +65,11 @@ pub(crate) fn Chat() -> Element {
     // WHY: Ticking signal drives elapsed-time re-renders every second
     // during streaming without polling the DOM.
     let mut elapsed_tick = use_signal(|| 0u64);
+
+    // WHY: Paginate message history so only the most recent PAGE_SIZE
+    // messages are projected into ChatMessage structs. Scrolling up past
+    // the LOAD_MORE_THRESHOLD loads the next page (#3321).
+    let mut loaded_page_count = use_signal(|| 1_usize);
 
     // Virtual scroll state
     let mut scroll_top = use_signal(|| 0.0_f64);
@@ -105,49 +115,14 @@ pub(crate) fn Chat() -> Element {
         }
     });
 
-    // Bridge: sync legacy ChatState messages into the new ChatStore model.
-    // WHY: The existing ChatStateManager + streaming pipeline writes to
-    // ChatState.messages (Vec<LegacyChatMessage>). Rather than rewriting
-    // the entire streaming pipeline, we project legacy messages into
-    // ChatMessage for rendering.
-    let messages: Vec<ChatMessage> = {
-        let state = legacy_state.read();
-        let now_ts = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| {
-                #[expect(clippy::as_conversions, reason = "epoch seconds fit in i64 until year 292B")]
-                let secs = d.as_secs() as i64;
-                secs
-            })
-            .unwrap_or(0);
-
-        state
-            .messages
-            .iter()
-            .enumerate()
-            .map(|(i, m)| ChatMessage {
-                #[expect(clippy::as_conversions, reason = "message index to u64 id")]
-                id: i as u64 + 1,
-                role: match m.role {
-                    MessageRole::User => Role::User,
-                    MessageRole::Assistant => Role::Assistant,
-                },
-                content: m.content.clone(),
-                timestamp: {
-                    #[expect(clippy::as_conversions, reason = "message offset to i64 for timestamp spacing")]
-                    let offset = (state.messages.len() - 1 - i) as i64 * 30;
-                    now_ts - offset
-                },
-                agent_id: state.agent_id.clone(),
-                tool_calls: m.tool_calls,
-                thinking_content: None,
-                is_streaming: false,
-                model: m.model.clone(),
-                input_tokens: m.input_tokens,
-                output_tokens: m.output_tokens,
-            })
-            .collect()
-    };
+    // WHY: Use the centralized projection method to convert legacy ChatState
+    // messages into render-ready ChatMessage structs. Only the most recent
+    // loaded_page_count * PAGE_SIZE messages are projected (#3321, #3323).
+    let total_message_count = legacy_state.read().messages.len();
+    let loaded_limit = loaded_page_count() * PAGE_SIZE;
+    let has_more_history = total_message_count > loaded_limit;
+    let messages: Vec<ChatMessage> =
+        legacy_state.read().project_messages(Some(loaded_limit));
 
     // Virtual scroll: compute visible range using shared utility.
     let total_messages = messages.len();
@@ -483,6 +458,11 @@ pub(crate) fn Chat() -> Element {
                                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(cleaned) {
                                     if let Some(top) = parsed.get("top").and_then(|v| v.as_f64()) {
                                         scroll_top.set(top);
+                                        // WHY: Load older messages when the user scrolls
+                                        // near the top of the viewport (#3321).
+                                        if top < LOAD_MORE_THRESHOLD && has_more_history {
+                                            loaded_page_count.set(loaded_page_count() + 1);
+                                        }
                                     }
                                     if let Some(h) = parsed.get("height").and_then(|v| v.as_f64()) {
                                         if h > 0.0 {
@@ -498,6 +478,23 @@ pub(crate) fn Chat() -> Element {
                     // Virtual scroll spacer (top)
                     div {
                         style: "height: {pad_top}px;",
+                    }
+
+                    // "Load more" indicator when older messages exist
+                    if has_more_history {
+                        div {
+                            style: "\
+                                text-align: center; \
+                                padding: var(--space-2); \
+                                color: var(--text-muted); \
+                                font-size: var(--text-xs); \
+                                cursor: pointer;\
+                            ",
+                            onclick: move |_| {
+                                loaded_page_count.set(loaded_page_count() + 1);
+                            },
+                            "Scroll up or click to load older messages ({total_message_count} total)"
+                        }
                     }
 
                     // Visible messages

--- a/crates/theatron/proskenion/src/views/connect.rs
+++ b/crates/theatron/proskenion/src/views/connect.rs
@@ -105,6 +105,8 @@ pub(crate) fn ConnectView(
             .clone()
             .unwrap_or_default()
     });
+    // WHY: Hold the cancel token so the user can abort a connection attempt.
+    let mut active_cancel = use_signal(|| None::<CancellationToken>);
 
     // WHY: Run auto-discovery once on first render when the URL is the compiled
     // default. If a server is found, update the URL input so the user does not
@@ -135,17 +137,24 @@ pub(crate) fn ConnectView(
         ConnectionState::Reconnecting { attempt } => {
             format!("Reconnecting (attempt {attempt})...")
         }
+        ConnectionState::TimedOut => "Connection timed out".to_string(),
         ConnectionState::Failed { reason } => format!("Failed: {reason}"),
     };
 
     let status_color = match &*connection_state.read() {
         ConnectionState::Connected => "var(--status-success)",
-        ConnectionState::Failed { .. } => "var(--status-error)",
+        ConnectionState::Failed { .. } | ConnectionState::TimedOut => "var(--status-error)",
         ConnectionState::Reconnecting { .. } | ConnectionState::Connecting => "var(--status-warning)",
         ConnectionState::Disconnected => "var(--text-muted)",
     };
 
     let on_connect = move |_| {
+        // WHY: Cancel any previously running connection attempt so we do not
+        // leak background tasks when the user clicks Connect multiple times.
+        if let Some(prev) = active_cancel.read().as_ref() {
+            prev.cancel();
+        }
+
         let url = url_input.read().clone();
         let token = token_input.read().clone();
         let token_opt = if token.is_empty() { None } else { Some(token) };
@@ -154,6 +163,7 @@ pub(crate) fn ConnectView(
             server_url: url,
             auth_token: token_opt,
             auto_reconnect: true,
+            ..ConnectionConfig::default()
         };
 
         // WHY: Persist config to disk so settings survive app restarts.
@@ -167,6 +177,7 @@ pub(crate) fn ConnectView(
         // NOTE: Set up channel for background to UI communication.
         let (tx, mut rx) = mpsc::unbounded_channel::<ConnectionState>();
         let cancel = CancellationToken::new();
+        active_cancel.set(Some(cancel.clone()));
         let svc = ConnectionService::new(new_config, cancel, tx);
 
         // WHY: Spawn the connection service on the tokio runtime so it runs
@@ -184,6 +195,14 @@ pub(crate) fn ConnectView(
                 state_signal.set(new_state);
             }
         });
+    };
+
+    // WHY: Allow the user to abort a connection attempt that is taking too long.
+    let on_cancel = move |_| {
+        if let Some(cancel) = active_cancel.read().as_ref() {
+            cancel.cancel();
+        }
+        connection_state.set(ConnectionState::Disconnected);
     };
 
     rsx! {
@@ -219,13 +238,50 @@ pub(crate) fn ConnectView(
                             token_input.set(evt.value().clone());
                         },
                     }
+                    if !token_input.read().is_empty() {
+                        div {
+                            style: "\
+                                font-size: var(--text-xs); \
+                                color: var(--status-warning); \
+                                margin-top: var(--space-1); \
+                                line-height: 1.4;\
+                            ",
+                            "Token will be stored in plaintext (~/.config/aletheia/desktop.toml, mode 0600). \
+                             OS keyring integration is planned but not yet implemented."
+                        }
+                    }
                 }
 
-                button {
-                    style: if is_connecting { "{BUTTON_DISABLED_STYLE}" } else { "{BUTTON_STYLE}" },
-                    disabled: is_connecting,
-                    onclick: on_connect,
-                    if is_connecting { "Connecting..." } else { "Connect" }
+                if is_connecting {
+                    button {
+                        style: "{BUTTON_DISABLED_STYLE}",
+                        disabled: true,
+                        "Connecting..."
+                    }
+                    button {
+                        style: "\
+                            background: transparent; \
+                            color: var(--status-error); \
+                            border: 1px solid var(--status-error); \
+                            border-radius: var(--radius-md); \
+                            padding: var(--space-2); \
+                            font-size: var(--text-sm); \
+                            cursor: pointer; \
+                            transition: background-color var(--transition-quick);\
+                        ",
+                        onclick: on_cancel,
+                        "Cancel"
+                    }
+                } else {
+                    button {
+                        style: "{BUTTON_STYLE}",
+                        onclick: on_connect,
+                        if matches!(*connection_state.read(), ConnectionState::TimedOut) {
+                            "Retry"
+                        } else {
+                            "Connect"
+                        }
+                    }
                 }
 
                 div {

--- a/crates/theatron/proskenion/src/views/settings/servers.rs
+++ b/crates/theatron/proskenion/src/views/settings/servers.rs
@@ -29,6 +29,7 @@ async fn probe_health(url: &str, token: Option<&str>) -> ServerHealth {
         server_url: url.to_string(),
         auth_token: token.map(str::to_string),
         auto_reconnect: false,
+        ..ConnectionConfig::default()
     };
     match PylonClient::new(&config) {
         Ok(client) => match client.health().await {

--- a/crates/theatron/proskenion/src/views/settings/wizard.rs
+++ b/crates/theatron/proskenion/src/views/settings/wizard.rs
@@ -126,6 +126,7 @@ pub(crate) fn SetupWizard() -> Element {
                                             server_url: data.server_url.clone(),
                                             auth_token: token,
                                             auto_reconnect: true,
+                                            ..ConnectionConfig::default()
                                         };
                                         connection_config.set(new_config.clone());
                                         if let Err(e) = config::save(&new_config) {


### PR DESCRIPTION
## Summary

- **#3320 Connection timeout**: `ConnectionService::run()` enforces a configurable deadline (default 30s) across all connection retries. New `TimedOut` state variant with retry button. Cancel button lets user abort in-progress attempts.
- **#3321 Paginated chat history**: Chat view loads most recent 100 messages initially, lazy-loads older pages on scroll-up (< 200px threshold) or click. Total message count displayed.
- **#3323 Consolidated state model**: Centralized `ChatState::project_messages()` method eliminates duplicate legacy-to-render projections in chat view and command palette. Removed dead `ChatStore`/`ChatSession` types.
- **#3319 Auth token warning**: Startup log warning when token loaded from plaintext config. Inline warning in connect view. Permission verification on config file. Documentation updated.

## Test plan

- [x] `cargo check` passes (proskenion crate)
- [x] `cargo clippy` -- zero new warnings (88 pre-existing)
- [x] `cargo test` -- 503 tests pass, 0 failures
- [ ] Manual: connect to unreachable server, verify timeout after 30s shows "Connection timed out" with Retry button
- [ ] Manual: connect with Cancel button visible during connection attempt
- [ ] Manual: open chat with 200+ messages, verify only recent 100 rendered initially
- [ ] Manual: scroll up to trigger lazy load of older messages
- [ ] Manual: enter auth token in connect view, verify warning text appears
- [ ] Manual: check startup logs for plaintext token warning when token configured

Closes #3319, #3320, #3321, #3323

Generated with [Claude Code](https://claude.com/claude-code)