### PR TITLE
fix: deploy smoke test ordering, migration guard, parameterize constants (#3250, #3252, #3257)

### DIFF
--- a/crates/taxis/src/config/agents.rs
+++ b/crates/taxis/src/config/agents.rs
@@ -401,6 +401,11 @@ pub struct AgentBehaviorDefaults {
     /// Mirrors `nous::uncertainty::MAX_CALIBRATION_POINTS`.
     pub uncertainty_max_calibration_points: usize,
 
+    // --- Manifest ---
+    /// Maximum memory entries in a single manifest for side-query pre-filtering. Default: 200.
+    /// Mirrors `episteme::manifest::MAX_MEMORY_ENTRIES`.
+    pub manifest_max_entries: usize,
+
     // --- Skills ---
     /// Maximum number of skills loadable per agent. Default: 5.
     pub skills_max_skills: usize,
@@ -588,6 +593,8 @@ impl Default for AgentBehaviorDefaults {
             drift_min_samples: 8,
             // Uncertainty
             uncertainty_max_calibration_points: 1_000,
+            // Manifest
+            manifest_max_entries: 200,
             // Skills
             skills_max_skills: 5,
             skills_max_context_chars: 200,

--- a/crates/taxis/src/config/behavior.rs
+++ b/crates/taxis/src/config/behavior.rs
@@ -226,6 +226,9 @@ pub struct KnowledgeConfig {
     /// Maximum length for context summaries. Default: 100.
     /// Mirrors `episteme::instinct::MAX_CONTEXT_SUMMARY_LEN`.
     pub instinct_max_context_summary_len: usize,
+    /// Maximum byte length for fact content strings. Default: 102400 (100 KiB).
+    /// Mirrors `eidos::knowledge::fact::MAX_CONTENT_LENGTH`.
+    pub max_content_length: usize,
     /// Default maximum entries returned by a single side-query. Default: 5.
     /// Mirrors `episteme::side_query::DEFAULT_MAX_RESULTS`.
     pub side_query_max_results: usize,
@@ -248,6 +251,7 @@ impl Default for KnowledgeConfig {
             decay_max_reinforcement_bonus: 1.0,
             decay_cross_agent_bonus_per_agent: 0.15,
             decay_max_cross_agent_multiplier: 1.75,
+            max_content_length: 102_400,
             extraction_confidence_threshold: 0.3,
             extraction_min_fact_length: 10,
             extraction_max_fact_length: 500,

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -276,6 +276,9 @@ pub struct CredentialConfig {
     /// Override path to the Claude Code credentials file.
     /// Defaults to `~/.claude/.credentials.json`.
     pub claude_code_credentials: Option<String>,
+    /// Refresh when token has less than this many seconds remaining. Default: 3600 (1 hour).
+    /// Mirrors `symbolon::credential::REFRESH_THRESHOLD_SECS`.
+    pub refresh_threshold_secs: u64,
     /// Circuit breaker settings for OAuth token refresh.
     pub circuit_breaker: CircuitBreakerSettings,
 }
@@ -285,6 +288,7 @@ impl Default for CredentialConfig {
         Self {
             source: "auto".to_owned(),
             claude_code_credentials: None,
+            refresh_threshold_secs: 3_600,
             circuit_breaker: CircuitBreakerSettings::default(),
         }
     }

--- a/crates/taxis/src/registry.rs
+++ b/crates/taxis/src/registry.rs
@@ -961,6 +961,57 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Maximum downtime tolerance analysis",
             direction_hint: TuningDirection::Contextual,
         },
+
+        // ===================================================================
+        // Knowledge — content limits
+        // ===================================================================
+        ParameterSpec {
+            key: "knowledge.maxContentLength",
+            section: "knowledge",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Int(102_400),
+            bounds: Some((1_024.0, 10_485_760.0)),
+            hot_reloadable: true,
+            description: "Maximum byte length for fact content strings",
+            affects: "knowledge_storage_capacity",
+            outcome_signal: "content_truncation_rate",
+            evidence_required: "Fact content length distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // Manifest — memory entries
+        // ===================================================================
+        ParameterSpec {
+            key: "agents.defaults.behavior.manifestMaxEntries",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::PerAgent,
+            default: ParameterValue::Int(200),
+            bounds: Some((10.0, 10_000.0)),
+            hot_reloadable: true,
+            description: "Maximum memory entries in a single manifest for side-query pre-filtering",
+            affects: "recall_quality",
+            outcome_signal: "side_query_recall_precision",
+            evidence_required: "Manifest size vs. recall precision analysis",
+            direction_hint: TuningDirection::Contextual,
+        },
+
+        // ===================================================================
+        // Credential — refresh threshold
+        // ===================================================================
+        ParameterSpec {
+            key: "credential.refreshThresholdSecs",
+            section: "credential",
+            tier: ParameterTier::Deployment,
+            default: ParameterValue::Duration(3_600),
+            bounds: Some((60.0, 86_400.0)),
+            hot_reloadable: true,
+            description: "Refresh token when less than this many seconds remain before expiry",
+            affects: "credential_management",
+            outcome_signal: "token_refresh_failure_rate",
+            evidence_required: "Token expiry distribution and refresh success rates",
+            direction_hint: TuningDirection::Contextual,
+        },
     ]
 }
 

--- a/instance.example/config/aletheia.toml
+++ b/instance.example/config/aletheia.toml
@@ -114,6 +114,7 @@ workspace = "nous/main"
 # [credential]
 # source = "auto"
 # claudeCodeCredentials = "~/.claude/.credentials.json"  # override default path
+# refreshThresholdSecs = 3600  # refresh token when less than N seconds remain
 
 # --- Cost tracking ---
 # [pricing."claude-sonnet-4-6"]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -193,9 +193,11 @@ check_health() {
 smoke_test() {
     local binary_path="${1:-$BINARY_DST}"
     log "Running smoke test (check-config) against ${binary_path}..."
-    if "$binary_path" -r "$INSTANCE_ROOT" check-config; then
+    local smoke_output
+    if smoke_output=$("$binary_path" -r "$INSTANCE_ROOT" check-config 2>&1); then
         log "Smoke test passed"
     else
+        log_error "Smoke test output: ${smoke_output}"
         die "Smoke test failed — config is invalid, deploy aborted"
     fi
 }
@@ -420,6 +422,7 @@ fi
 if [[ "$DRY_RUN" == true ]]; then
     log "[dry-run] Would copy ${BINARY_SRC} to temp location, validate, then atomic move to ${BINARY_DST}"
     log "[dry-run] Would run smoke test (check-config) against temp binary"
+    log "[dry-run] Would preserve previous binary at ${BINARY_DST}.prev"
 else
     mkdir -p "$(dirname "$BINARY_DST")"
 
@@ -434,6 +437,12 @@ else
     if ! smoke_test "$BINARY_TMP"; then
         rm -f -- "$BINARY_TMP"
         die "Smoke test failed — production binary unchanged"
+    fi
+
+    # Preserve previous binary for manual rollback
+    if [[ -f "$BINARY_DST" ]]; then
+        cp -- "$BINARY_DST" "${BINARY_DST}.prev"
+        log "Previous binary preserved at ${BINARY_DST}.prev"
     fi
 
     # Atomic move to production location


### PR DESCRIPTION
## Summary

- **#3250** (deploy.sh): Capture smoke test error output on failure and log it. Preserve previous binary as `aletheia.prev` before atomic swap for manual rollback. Deploy sequence was already correct (smoke before swap) from prior work; this adds the missing `.prev` preservation and error logging.
- **#3252** (graphe): `SchemaTooNew` runtime guard already fully implemented in `run_migrations` with test coverage. Binary refuses to start when DB schema is newer than code expects. No additional changes needed.
- **#3257** (taxis): Parameterize three missed Phase 05c constants with appropriate config tiers and `ParameterSpec` registry entries:
  - `MAX_CONTENT_LENGTH` (102400) -> `knowledge.maxContentLength` (deployment-tunable)
  - `MAX_MEMORY_ENTRIES` (200) -> `agents.defaults.behavior.manifestMaxEntries` (per-agent-tunable)
  - `REFRESH_THRESHOLD_SECS` (3600) -> `credential.refreshThresholdSecs` (deployment-tunable)

All defaults match current hardcoded values -- zero behavioral change.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace` -- zero new warnings
- [x] `cargo test -p taxis` -- 282 tests pass (including registry tests)
- [x] `cargo test -p graphe` -- 27 tests pass (including `schema_too_new_returns_error`)
- [x] `cargo test -p eidos` -- 49 tests pass
- [x] `cargo test -p episteme` -- 34 tests pass
- [x] `cargo test -p symbolon` -- 17 tests pass
- [ ] Manual: `scripts/deploy.sh --dry-run` shows `.prev` preservation message
- [ ] Manual: deploy with intentionally broken config shows smoke test output in log

Closes #3250, closes #3252, closes #3257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)