### PR TITLE
refactor: extract shared fjall patterns, standardize snafu context (#3242, #3341, #3343)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,6 +3564,7 @@ version = "0.18.0"
 dependencies = [
  "compact_str",
  "criterion",
+ "fjall",
  "jiff",
  "rand 0.9.4",
  "regex",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 # WHY: fjall is the new default backend -- pure Rust, zero C dependency.
 # sqlite is preserved for backward compatibility during the Wave 4 migration window.
 default = ["fjall"]
-fjall = ["dep:fjall"]
+fjall = ["dep:fjall", "koina/fjall"]
 sqlite = ["dep:rusqlite"]
 # WHY: gates anomaly detection (prosoche memory consistency checks) on the
 # heavy CozoDB-backed KnowledgeStore from episteme. Not all daemon users need it.

--- a/crates/daemon/src/state/fjall_store.rs
+++ b/crates/daemon/src/state/fjall_store.rs
@@ -13,10 +13,13 @@
 use std::path::Path;
 
 use fjall::{KeyspaceCreateOptions, Readable as _, SingleWriterTxDatabase};
-use snafu::{IntoError as _, ResultExt as _};
+use snafu::ResultExt as _;
 
 use crate::error::{self, Result};
 use crate::state::TaskState;
+
+/// Partition name for task state records.
+const PARTITION: &str = "ops:tasks";
 
 /// Fjall-backed store for task execution state.
 ///
@@ -25,9 +28,6 @@ use crate::state::TaskState;
 pub(crate) struct TaskStateStore {
     db: SingleWriterTxDatabase,
 }
-
-/// Partition name for task state records.
-const PARTITION: &str = "ops:tasks";
 
 #[cfg_attr(
     not(test),
@@ -46,30 +46,14 @@ impl TaskStateStore {
     /// Returns `Storage` if the fjall keyspace cannot be opened or the
     /// `ops:tasks` partition cannot be initialised.
     pub(crate) fn open(path: &Path) -> Result<Self> {
-        std::fs::create_dir_all(path).map_err(|e| {
-            crate::error::MaintenanceIoSnafu {
-                context: format!("creating task-state directory: {}", path.display()),
-            }
-            .into_error(e)
-        })?;
-
-        let db = SingleWriterTxDatabase::builder(path).open().map_err(|e| {
+        let fdb = koina::fjall::FjallDb::open(path, &[PARTITION]).map_err(|e| {
             error::StorageSnafu {
-                message: format!("fjall open task-state store: {e}"),
+                message: e.to_string(),
             }
             .build()
         })?;
 
-        // Eagerly open the partition so it exists before any read/write.
-        db.keyspace(PARTITION, KeyspaceCreateOptions::default)
-            .map_err(|e| {
-                error::StorageSnafu {
-                    message: format!("fjall open partition {PARTITION}: {e}"),
-                }
-                .build()
-            })?;
-
-        Ok(Self { db })
+        Ok(Self { db: fdb.db })
     }
 
     /// Load all persisted task states.

--- a/crates/graphe/Cargo.toml
+++ b/crates/graphe/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 # WHY: fjall is the new default backend — pure Rust, zero C dependency.
 # sqlite is preserved for backward compatibility and migration parity.
 default = ["fjall"]
-fjall = ["dep:fjall", "dep:tempfile"]
+fjall = ["dep:fjall", "dep:tempfile", "koina/fjall"]
 sqlite = ["dep:rusqlite", "dep:sha2"]
 # WHY: gates error variants that reference tokio::task::JoinError; no runtime dep.
 mneme-engine = ["dep:tokio"]

--- a/crates/graphe/src/store/fjall_store.rs
+++ b/crates/graphe/src/store/fjall_store.rs
@@ -34,9 +34,8 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use fjall::{KeyspaceCreateOptions, SingleWriterTxDatabase};
-use jiff::Zoned;
 use serde::{Deserialize, Serialize};
-use snafu::{IntoError as _, ResultExt};
+use snafu::ResultExt;
 use tracing::{debug, info, instrument, warn};
 
 use crate::error::{self, Result};
@@ -70,7 +69,7 @@ fn encode_u64(v: u64) -> [u8; 8] {
 
 /// ISO 8601 timestamp string for "now".
 fn now_iso() -> String {
-    Zoned::now().strftime("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
+    koina::fjall::now_iso()
 }
 
 // ── Distillation record (fjall-internal, not a public type) ────────────────
@@ -88,6 +87,17 @@ struct DistillationRecord {
 
 // ── SessionStore ───────────────────────────────────────────────────────────
 
+/// Partitions used by the graphe session store.
+const PARTITIONS: &[&str] = &[
+    "sessions",
+    "messages",
+    "usage",
+    "distillations",
+    "notes",
+    "blackboard",
+    "counters",
+];
+
 /// Fjall-backed session store.
 ///
 /// Open with [`SessionStore::open`] for persistent storage or
@@ -95,19 +105,9 @@ struct DistillationRecord {
 /// `TempDir` that is cleaned up on drop).
 pub struct SessionStore {
     db: Arc<SingleWriterTxDatabase>,
-    /// Shared write mutex.
-    ///
-    /// WHY: fjall's `SingleWriterTxDatabase` serialises writers internally,
-    /// but the graphe API takes `&self` (shared ref) for all write methods —
-    /// matching the `SQLite` backend where `Connection` uses interior mutability.
-    /// We use a `Mutex<()>` so only one logical "graphe write" runs at
-    /// a time, mirroring the serial-write contract of `SingleWriterTxDatabase`.
+    /// Shared write mutex — see [`koina::fjall::FjallDb::write_lock`].
     write_lock: Mutex<()>,
     /// Kept alive to auto-delete the temp directory when the store is dropped.
-    ///
-    /// WHY: The leading `_` makes Rust suppress `dead_code` warnings for a field
-    /// that is intentionally unused for its value but needed for its `Drop` side
-    /// effect (deleting the temp directory when `SessionStore` is dropped).
     _temp_dir: Option<tempfile::TempDir>,
 }
 
@@ -119,18 +119,9 @@ impl SessionStore {
     #[instrument(skip(path))]
     pub fn open(path: &Path) -> Result<Self> {
         info!(path = %path.display(), "Opening fjall session store");
-        std::fs::create_dir_all(path).map_err(|e| {
-            error::IoSnafu {
-                path: path.to_path_buf(),
-            }
-            .into_error(e)
-        })?;
-
-        let db = SingleWriterTxDatabase::builder(path)
-            .open()
-            .map_err(|e| error::StorageSnafu { message: format!("fjall open: {e}") }.build())?;
-
-        Self::init(db, None)
+        let fdb = koina::fjall::FjallDb::open(path, PARTITIONS)
+            .map_err(|e| error::StorageSnafu { message: e.to_string() }.build())?;
+        Ok(Self::from_fjall_db(fdb))
     }
 
     /// Open an ephemeral session store backed by a `TempDir` (for testing).
@@ -143,36 +134,17 @@ impl SessionStore {
     /// created.
     #[instrument]
     pub fn open_in_memory() -> Result<Self> {
-        let dir = tempfile::TempDir::new().map_err(|e| {
-            error::IoSnafu {
-                path: std::path::PathBuf::from("<tempdir>"),
-            }
-            .into_error(e)
-        })?;
-
-        let db = SingleWriterTxDatabase::builder(dir.path())
-            .open()
-            .map_err(|e| error::StorageSnafu { message: format!("fjall open temp: {e}") }.build())?;
-
-        Self::init(db, Some(dir))
+        let fdb = koina::fjall::FjallDb::open_temp(PARTITIONS)
+            .map_err(|e| error::StorageSnafu { message: e.to_string() }.build())?;
+        Ok(Self::from_fjall_db(fdb))
     }
 
-    fn init(db: SingleWriterTxDatabase, temp_dir: Option<tempfile::TempDir>) -> Result<Self> {
-        // Open all partitions eagerly so they exist before any read/write.
-        for name in &["sessions", "messages", "usage", "distillations", "notes", "blackboard", "counters"] {
-            db.keyspace(name, KeyspaceCreateOptions::default)
-                .map_err(|e| {
-                    error::StorageSnafu {
-                        message: format!("fjall open partition {name}: {e}"),
-                    }
-                    .build()
-                })?;
+    fn from_fjall_db(fdb: koina::fjall::FjallDb) -> Self {
+        Self {
+            db: Arc::new(fdb.db),
+            write_lock: fdb.write_lock,
+            _temp_dir: fdb._temp_dir,
         }
-        Ok(Self {
-            db: Arc::new(db),
-            write_lock: Mutex::new(()),
-            _temp_dir: temp_dir,
-        })
     }
 
     // ── Partition helpers ─────────────────────────────────────────────────

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -12,11 +12,14 @@ workspace = true
 
 [features]
 default = []
+fjall = ["dep:fjall", "dep:tempfile"]
 test-core = []
 test-full = []
 test-support = []
 
 [dependencies]
+fjall = { version = "3", default-features = false, optional = true }
+tempfile = { workspace = true, optional = true }
 compact_str = { workspace = true }
 jiff = { workspace = true }
 rustix = { workspace = true, features = ["fs"] }

--- a/crates/koina/src/fjall.rs
+++ b/crates/koina/src/fjall.rs
@@ -1,0 +1,207 @@
+//! Shared fjall storage helpers for Aletheia crates.
+//!
+//! Four crates (graphe, symbolon, daemon, energeia) use fjall as an LSM-tree
+//! storage backend. This module extracts the common initialization patterns so
+//! each crate only contains domain-specific logic.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use koina::fjall::FjallDb;
+//!
+//! // Persistent store
+//! let db = FjallDb::open(path, &["sessions", "messages"])?;
+//!
+//! // Ephemeral store (tests)
+//! let db = FjallDb::open_temp(&["sessions", "messages"])?;
+//! ```
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use fjall::{KeyspaceCreateOptions, SingleWriterTxDatabase};
+
+/// A fjall database handle with a write-serialization mutex and optional temp
+/// directory for ephemeral (test) stores.
+///
+/// The `_temp_dir` field's `Drop` implementation deletes the temporary directory
+/// when the store is dropped. The leading underscore suppresses `dead_code`
+/// warnings since the field is only needed for its `Drop` side effect.
+pub struct FjallDb {
+    /// The underlying fjall database.
+    pub db: SingleWriterTxDatabase,
+    /// Shared write mutex.
+    ///
+    /// WHY: `SingleWriterTxDatabase` serialises writers internally, but many
+    /// Aletheia stores expose `&self` write methods (matching the `SQLite` backends
+    /// that use interior mutability). This mutex ensures only one logical write
+    /// runs at a time, matching that serial contract.
+    pub write_lock: Mutex<()>,
+    /// Kept alive to auto-delete the temp directory when the store is dropped.
+    ///
+    /// WHY: the leading underscore signals that the field is unused for its value
+    /// but needed for its `Drop` side effect. Clippy flags this as
+    /// `pub_underscore_fields`, but consumers destructure `FjallDb` and need
+    /// access to transfer ownership of the temp directory into their own struct.
+    #[expect(
+        clippy::pub_underscore_fields,
+        reason = "consumers destructure FjallDb and transfer ownership of the TempDir guard"
+    )]
+    pub _temp_dir: Option<tempfile::TempDir>,
+}
+
+impl FjallDb {
+    /// Open (or create) a persistent fjall database at `path`, eagerly creating
+    /// all named partitions.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` error message if directory creation, database open, or
+    /// partition initialization fails. Callers should map this into their
+    /// crate-specific error type.
+    pub fn open(path: &Path, partitions: &[&str]) -> Result<Self, FjallOpenError> {
+        std::fs::create_dir_all(path).map_err(|source| FjallOpenError::CreateDir {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+        let db = SingleWriterTxDatabase::builder(path)
+            .open()
+            .map_err(|e| FjallOpenError::Open(format!("fjall open: {e}")))?;
+
+        for name in partitions {
+            db.keyspace(name, KeyspaceCreateOptions::default)
+                .map_err(|e| {
+                    FjallOpenError::Open(format!("fjall open partition {name}: {e}"))
+                })?;
+        }
+
+        Ok(Self {
+            db,
+            write_lock: Mutex::new(()),
+            _temp_dir: None,
+        })
+    }
+
+    /// Open an ephemeral fjall database backed by a `TempDir`, eagerly creating
+    /// all named partitions.
+    ///
+    /// The directory and all data are deleted when the returned `FjallDb` is
+    /// dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` error message if temp-dir creation, database open, or
+    /// partition initialization fails.
+    pub fn open_temp(partitions: &[&str]) -> Result<Self, FjallOpenError> {
+        let dir =
+            tempfile::TempDir::new().map_err(|source| FjallOpenError::TempDir { source })?;
+
+        let db = SingleWriterTxDatabase::builder(dir.path())
+            .open()
+            .map_err(|e| FjallOpenError::Open(format!("fjall open temp: {e}")))?;
+
+        for name in partitions {
+            db.keyspace(name, KeyspaceCreateOptions::default)
+                .map_err(|e| {
+                    FjallOpenError::Open(format!("fjall open partition {name}: {e}"))
+                })?;
+        }
+
+        Ok(Self {
+            db,
+            write_lock: Mutex::new(()),
+            _temp_dir: Some(dir),
+        })
+    }
+}
+
+/// Errors from [`FjallDb::open`] and [`FjallDb::open_temp`].
+///
+/// Callers map these into their crate-specific error type.
+#[derive(Debug)]
+pub enum FjallOpenError {
+    /// Failed to create the store directory.
+    CreateDir {
+        /// The path that could not be created.
+        path: std::path::PathBuf,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+    /// Failed to create a temporary directory.
+    TempDir {
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+    /// Failed to open the fjall database or a partition.
+    Open(String),
+}
+
+impl std::fmt::Display for FjallOpenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CreateDir { path, source } => {
+                write!(f, "failed to create directory {}: {source}", path.display())
+            }
+            Self::TempDir { source } => write!(f, "failed to create temp directory: {source}"),
+            Self::Open(msg) => f.write_str(msg),
+        }
+    }
+}
+
+impl std::error::Error for FjallOpenError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CreateDir { source, .. } | Self::TempDir { source } => Some(source),
+            Self::Open(_) => None,
+        }
+    }
+}
+
+/// ISO 8601 timestamp string for "now" using jiff.
+///
+/// Shared across fjall-backed stores that need consistent timestamp formatting.
+pub fn now_iso() -> String {
+    jiff::Zoned::now()
+        .strftime("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string()
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_temp_creates_partitions() {
+        let db = FjallDb::open_temp(&["p1", "p2"]).unwrap();
+        // Verify partitions exist by opening them again (idempotent).
+        let ks = db
+            .db
+            .keyspace("p1", KeyspaceCreateOptions::default)
+            .unwrap();
+        ks.insert("test-key", b"test-val").unwrap();
+    }
+
+    #[test]
+    fn open_persistent_creates_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("subdir").join("db");
+        let db = FjallDb::open(&db_path, &["data"]).unwrap();
+        assert!(db_path.exists());
+        let ks = db
+            .db
+            .keyspace("data", KeyspaceCreateOptions::default)
+            .unwrap();
+        ks.insert("k", b"v").unwrap();
+    }
+
+    #[test]
+    fn now_iso_format() {
+        let ts = now_iso();
+        // Must match ISO 8601 with 3-digit milliseconds and Z suffix.
+        assert!(ts.ends_with('Z'), "timestamp must end with Z: {ts}");
+        assert!(ts.contains('T'), "timestamp must contain T separator: {ts}");
+        assert_eq!(ts.len(), 24, "expected 24-char ISO timestamp: {ts}");
+    }
+}

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -7,6 +7,9 @@
 
 /// Setup-time cleanup registration via RAII guards ([`cleanup::CleanupGuard`], [`cleanup::CleanupRegistry`]).
 pub mod cleanup;
+/// Shared fjall storage helpers: database open, temp stores, timestamp formatting.
+#[cfg(feature = "fjall")]
+pub mod fjall;
 /// Credential provider trait for dynamic API key resolution.
 pub mod credential;
 /// Shared configuration defaults (token budgets, timeouts, iteration limits).

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 # WHY: fjall is the new default backend — pure Rust, zero C dependency.
 # sqlite is preserved for backward compatibility and migration parity.
 default = ["fjall"]
-fjall = ["dep:fjall", "dep:jiff", "dep:tempfile"]
+fjall = ["dep:fjall", "dep:jiff", "dep:tempfile", "koina/fjall"]
 sqlite = ["dep:rusqlite"]
 keyring = ["dep:keyring"]
 test-support = []

--- a/crates/symbolon/src/store/fjall_store.rs
+++ b/crates/symbolon/src/store/fjall_store.rs
@@ -28,9 +28,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use fjall::{KeyspaceCreateOptions, SingleWriterTxDatabase};
-use jiff::Zoned;
 use serde::{Deserialize, Serialize};
-use snafu::IntoError as _;
 use tracing::{info, instrument, warn};
 
 use crate::error::{self, Result};
@@ -67,7 +65,7 @@ struct ApiKeyEntry {
 
 /// ISO 8601 timestamp string for "now".
 fn now_iso() -> String {
-    Zoned::now().strftime("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
+    koina::fjall::now_iso()
 }
 
 fn decode_role(role_str: &str) -> Role {
@@ -86,23 +84,18 @@ fn storage_err(message: impl Into<String>) -> crate::error::Error {
 
 // ── AuthStore ─────────────────────────────────────────────────────────────────
 
+/// Partitions used by the symbolon auth store.
+const PARTITIONS: &[&str] = &["users", "api_keys", "revoked_tokens"];
+
 /// Auth store backed by `fjall` (pure-Rust LSM-tree).
 ///
 /// Open with [`AuthStore::open`] for persistent storage or
 /// [`AuthStore::open_in_memory`] for ephemeral storage (test-only).
 pub(crate) struct AuthStore {
     db: Arc<SingleWriterTxDatabase>,
-    /// Shared write mutex.
-    ///
-    /// WHY: `SingleWriterTxDatabase` serialises writers internally, but the
-    /// symbolon API takes `&self` for all write methods (matching the `SQLite`
-    /// backend where `Connection` uses interior mutability). We use a `Mutex<()>`
-    /// so only one write runs at a time, matching that serial contract.
+    /// Shared write mutex — see [`koina::fjall::FjallDb::write_lock`].
     write_lock: Mutex<()>,
     /// Kept alive to auto-delete the temp directory when the store is dropped.
-    ///
-    /// WHY: the leading `_` suppresses `dead_code` — this field is only needed
-    /// for its `Drop` side effect (deleting the temp directory).
     _temp_dir: Option<tempfile::TempDir>,
 }
 
@@ -111,18 +104,9 @@ impl AuthStore {
     #[instrument(skip(path))]
     pub(crate) fn open(path: &Path) -> Result<Self> {
         info!(path = %path.display(), "Opening fjall auth store");
-        std::fs::create_dir_all(path).map_err(|e| {
-            error::IoSnafu {
-                path: path.to_path_buf(),
-            }
-            .into_error(e)
-        })?;
-
-        let db = SingleWriterTxDatabase::builder(path)
-            .open()
-            .map_err(|e| storage_err(format!("fjall open: {e}")))?;
-
-        Self::init(db, None)
+        let fdb = koina::fjall::FjallDb::open(path, PARTITIONS)
+            .map_err(|e| storage_err(e.to_string()))?;
+        Ok(Self::from_fjall_db(fdb))
     }
 
     /// Open an ephemeral auth store backed by a `TempDir` (for testing).
@@ -130,31 +114,17 @@ impl AuthStore {
     /// The directory and all data are deleted when the returned store is dropped.
     #[instrument]
     pub(crate) fn open_in_memory() -> Result<Self> {
-        let dir = tempfile::TempDir::new().map_err(|e| {
-            error::IoSnafu {
-                path: std::path::PathBuf::from("<tempdir>"),
-            }
-            .into_error(e)
-        })?;
-
-        let db = SingleWriterTxDatabase::builder(dir.path())
-            .open()
-            .map_err(|e| storage_err(format!("fjall open temp: {e}")))?;
-
-        Self::init(db, Some(dir))
+        let fdb = koina::fjall::FjallDb::open_temp(PARTITIONS)
+            .map_err(|e| storage_err(e.to_string()))?;
+        Ok(Self::from_fjall_db(fdb))
     }
 
-    fn init(db: SingleWriterTxDatabase, temp_dir: Option<tempfile::TempDir>) -> Result<Self> {
-        // Open all partitions eagerly so they exist before any read/write.
-        for name in &["users", "api_keys", "revoked_tokens"] {
-            db.keyspace(name, KeyspaceCreateOptions::default)
-                .map_err(|e| storage_err(format!("fjall open partition {name}: {e}")))?;
+    fn from_fjall_db(fdb: koina::fjall::FjallDb) -> Self {
+        Self {
+            db: Arc::new(fdb.db),
+            write_lock: fdb.write_lock,
+            _temp_dir: fdb._temp_dir,
         }
-        Ok(Self {
-            db: Arc::new(db),
-            write_lock: Mutex::new(()),
-            _temp_dir: temp_dir,
-        })
     }
 
     // ── Partition helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Extract `koina::fjall::FjallDb` with `open()` / `open_temp()` that consolidates the duplicated fjall store initialization across graphe, symbolon, daemon, and energeia (~67 lines net reduction)
- Extract `koina::fjall::now_iso()` shared timestamp helper, replacing identical copies in graphe and symbolon
- Eliminate all `.map_err(|e| Snafu.into_error(e))` patterns in fjall stores — the shared builder returns typed `FjallOpenError` that callers map to crate-specific errors

Remaining `into_error()` calls in the codebase are legitimate: test error construction or match-arm re-wrapping where `.context()` does not apply (no `Result` to chain on).

No behavioral change — pure structural DRY consolidation.

Closes #3242, closes #3341, closes #3343.

## Test plan

- [x] `cargo check --workspace` — clean compile
- [x] `cargo clippy --workspace` — zero new warnings (krites/pylon pre-existing only)
- [x] `cargo test -p koina --features fjall` — 214 passed
- [x] `cargo test -p graphe` — 27 passed
- [x] `cargo test -p symbolon` — 17 passed
- [x] `cargo test -p oikonomos` — 61 passed
- [x] `cargo test -p energeia` — 62 passed

Gate-Passed: kanon 0.1.0