### PR TITLE
refactor: extract shared test fixtures across workspace (#3342, #3344, #3345, #3346)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "koina",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "koina",
  "organon",
@@ -1931,7 +1931,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "eidos"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "serde",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "eidos",
  "fjall",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -2822,7 +2822,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "dokimion",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "fd-lock",
  "futures",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "dianoia",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "episteme",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "energeia",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "jiff",
  "snafu",
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "poiesis-core",
  "rust_xlsxwriter",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "poiesis-core",
  "ppt-rs",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "krilla",
  "poiesis-core",
@@ -5289,7 +5289,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -6621,7 +6621,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "compact_str",
@@ -6876,7 +6876,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -6989,7 +6989,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -7101,14 +7101,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/eidos/Cargo.toml
+++ b/crates/eidos/Cargo.toml
@@ -13,6 +13,9 @@ workspace = true
 [features]
 test-core = []
 test-full = []
+# WHY: exposes test_fixtures module with Fact/Entity/Relationship builders
+# for downstream crates. Not compiled in production builds.
+test-support = []
 
 [dependencies]
 jiff = { workspace = true, features = ["serde"] }

--- a/crates/eidos/src/lib.rs
+++ b/crates/eidos/src/lib.rs
@@ -9,6 +9,10 @@
 pub mod id;
 /// Knowledge graph domain types: facts, entities, relationships, embeddings.
 pub mod knowledge;
+/// Shared test data builders for `Fact`, `Entity`, and `Relationship`.
+#[cfg(any(test, feature = "test-support"))]
+#[expect(clippy::expect_used, reason = "test fixture builders — panics are intentional")]
+pub mod test_fixtures;
 /// Training data capture types.
 pub mod training;
 

--- a/crates/eidos/src/test_fixtures.rs
+++ b/crates/eidos/src/test_fixtures.rs
@@ -1,0 +1,80 @@
+//! Shared test data builders for knowledge domain types.
+//!
+//! Provides builder functions for `Fact`, `Entity`, and `Relationship` that
+//! eliminate the 30+ field manual constructions scattered across the workspace.
+//! Import via `eidos::test_fixtures` from downstream crates.
+//!
+//! Gated behind the `test-support` feature so production builds never compile
+//! this module.
+
+use crate::id::{EntityId, FactId};
+use crate::knowledge::{
+    Entity, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
+    Relationship, far_future, parse_timestamp,
+};
+
+/// Parse an ISO 8601 timestamp for test data. Panics on invalid input.
+pub fn test_ts(s: &str) -> jiff::Timestamp {
+    parse_timestamp(s).expect("valid test timestamp in test helper")
+}
+
+/// Build a minimal `Fact` with sensible test defaults.
+///
+/// Fields can be mutated after construction for test-specific overrides:
+/// ```ignore
+/// let mut f = make_fact("f1", "syn", "Rust is fast");
+/// f.provenance.confidence = 0.5;
+/// ```
+pub fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
+    Fact {
+        id: FactId::new(id).expect("valid test id"),
+        nous_id: nous_id.to_owned(),
+        content: content.to_owned(),
+        fact_type: String::new(),
+        temporal: FactTemporal {
+            valid_from: test_ts("2026-01-01"),
+            valid_to: far_future(),
+            recorded_at: test_ts("2026-03-01T00:00:00Z"),
+        },
+        provenance: FactProvenance {
+            confidence: 0.9,
+            tier: EpistemicTier::Inferred,
+            source_session_id: None,
+            stability_hours: 720.0,
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
+        scope: None,
+    }
+}
+
+/// Build a minimal `Entity` with sensible test defaults.
+pub fn make_entity(id: &str, name: &str, entity_type: &str) -> Entity {
+    Entity {
+        id: EntityId::new(id).expect("valid test id"),
+        name: name.to_owned(),
+        entity_type: entity_type.to_owned(),
+        aliases: vec![],
+        created_at: test_ts("2026-03-01T00:00:00Z"),
+        updated_at: test_ts("2026-03-01T00:00:00Z"),
+    }
+}
+
+/// Build a minimal `Relationship` with sensible test defaults.
+pub fn make_relationship(src: &str, dst: &str, relation: &str, weight: f64) -> Relationship {
+    Relationship {
+        src: EntityId::new(src).expect("valid test id"),
+        dst: EntityId::new(dst).expect("valid test id"),
+        relation: relation.to_owned(),
+        weight,
+        created_at: test_ts("2026-03-01T00:00:00Z"),
+    }
+}

--- a/crates/episteme/Cargo.toml
+++ b/crates/episteme/Cargo.toml
@@ -59,6 +59,7 @@ hf-hub = { version = "0.5", optional = true, default-features = false, features 
 
 [dev-dependencies]
 criterion = { workspace = true }
+eidos = { path = "../eidos", features = ["test-support"] }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -841,52 +841,8 @@ mod tests {
         reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
     )]
 
-    use super::super::{KnowledgeConfig, KnowledgeStore};
-    use crate::knowledge::{
-        EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal, ForgetReason,
-    };
-
-    const DIM: usize = 4;
-
-    fn make_store() -> std::sync::Arc<KnowledgeStore> {
-        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() })
-            .expect("open_mem")
-    }
-
-    fn test_ts(s: &str) -> jiff::Timestamp {
-        crate::knowledge::parse_timestamp(s).expect("valid test timestamp in test helper")
-    }
-
-    fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
-        Fact {
-            id: crate::id::FactId::new(id).expect("valid test id"),
-            nous_id: nous_id.to_owned(),
-            content: content.to_owned(),
-            fact_type: String::new(),
-            temporal: FactTemporal {
-                valid_from: test_ts("2026-01-01"),
-                valid_to: crate::knowledge::far_future(),
-                recorded_at: test_ts("2026-03-01T00:00:00Z"),
-            },
-            provenance: FactProvenance {
-                confidence: 0.9,
-                tier: EpistemicTier::Inferred,
-                source_session_id: None,
-                stability_hours: 720.0,
-            },
-            lifecycle: FactLifecycle {
-                superseded_by: None,
-                is_forgotten: false,
-                forgotten_at: None,
-                forget_reason: None,
-            },
-            access: FactAccess {
-                access_count: 0,
-                last_accessed_at: None,
-            },
-            scope: None,
-        }
-    }
+    use crate::knowledge::ForgetReason;
+    use crate::test_fixtures::{make_fact, make_store};
 
     // ── Insertion ──────────────────────────────────────────────────────────────
 

--- a/crates/episteme/src/knowledge_store/tests/entities.rs
+++ b/crates/episteme/src/knowledge_store/tests/entities.rs
@@ -6,74 +6,8 @@
 
 use std::sync::Arc;
 
-use super::super::*;
-use crate::knowledge::{
-    Entity, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
-    Relationship,
-};
-
-const DIM: usize = 4;
-
-fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
-}
-
-fn test_ts(s: &str) -> jiff::Timestamp {
-    crate::knowledge::parse_timestamp(s).expect("valid test timestamp in test helper")
-}
-
-fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
-    Fact {
-        id: crate::id::FactId::new(id).expect("valid test id"),
-        nous_id: nous_id.to_owned(),
-        content: content.to_owned(),
-        fact_type: String::new(),
-        temporal: FactTemporal {
-            valid_from: test_ts("2026-01-01"),
-            valid_to: crate::knowledge::far_future(),
-            recorded_at: test_ts("2026-03-01T00:00:00Z"),
-        },
-        provenance: FactProvenance {
-            confidence: 0.9,
-            tier: EpistemicTier::Inferred,
-            source_session_id: None,
-            stability_hours: 720.0,
-        },
-        lifecycle: FactLifecycle {
-            superseded_by: None,
-            is_forgotten: false,
-            forgotten_at: None,
-            forget_reason: None,
-        },
-        access: FactAccess {
-            access_count: 0,
-            last_accessed_at: None,
-        },
-        scope: None,
-    }
-}
-
-fn make_entity(id: &str, name: &str, entity_type: &str) -> Entity {
-    Entity {
-        id: crate::id::EntityId::new(id).expect("valid test id"),
-        name: name.to_owned(),
-        entity_type: entity_type.to_owned(),
-        aliases: vec![],
-        created_at: test_ts("2026-03-01T00:00:00Z"),
-        updated_at: test_ts("2026-03-01T00:00:00Z"),
-    }
-}
-
-fn make_relationship(src: &str, dst: &str, relation: &str, weight: f64) -> Relationship {
-    Relationship {
-        src: crate::id::EntityId::new(src).expect("valid test id"),
-        dst: crate::id::EntityId::new(dst).expect("valid test id"),
-        relation: relation.to_owned(),
-        weight,
-        created_at: test_ts("2026-03-01T00:00:00Z"),
-    }
-}
-
+use crate::knowledge::Entity;
+use crate::test_fixtures::{make_entity, make_fact, make_relationship, make_store};
 #[test]
 fn insert_entity_and_query_neighborhood() {
     let store = make_store();

--- a/crates/episteme/src/knowledge_store/tests/facts/crud.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/crud.rs
@@ -6,54 +6,10 @@
 )]
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use super::super::super::*;
-use crate::knowledge::{
-    EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal, ForgetReason,
-};
-
-const DIM: usize = 4;
-
-fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
-}
-
-fn test_ts(s: &str) -> jiff::Timestamp {
-    crate::knowledge::parse_timestamp(s).expect("valid test timestamp in test helper")
-}
-
-fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
-    Fact {
-        id: crate::id::FactId::new(id).expect("valid test id"),
-        nous_id: nous_id.to_owned(),
-        content: content.to_owned(),
-        fact_type: String::new(),
-        temporal: FactTemporal {
-            valid_from: test_ts("2026-01-01"),
-            valid_to: crate::knowledge::far_future(),
-            recorded_at: test_ts("2026-03-01T00:00:00Z"),
-        },
-        provenance: FactProvenance {
-            confidence: 0.9,
-            tier: EpistemicTier::Inferred,
-            source_session_id: None,
-            stability_hours: 720.0,
-        },
-        lifecycle: FactLifecycle {
-            superseded_by: None,
-            is_forgotten: false,
-            forgotten_at: None,
-            forget_reason: None,
-        },
-        access: FactAccess {
-            access_count: 0,
-            last_accessed_at: None,
-        },
-        scope: None,
-    }
-}
-
+use crate::knowledge::ForgetReason;
+use crate::test_fixtures::{make_fact, make_store};
 #[test]
 fn query_timeout_returns_typed_error() {
     let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");

--- a/crates/episteme/src/knowledge_store/tests/facts/queries.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/queries.rs
@@ -7,54 +7,9 @@
 )]
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
-use super::super::super::*;
-use crate::knowledge::{
-    EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
-};
-
-const DIM: usize = 4;
-
-fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
-}
-
-fn test_ts(s: &str) -> jiff::Timestamp {
-    crate::knowledge::parse_timestamp(s).expect("valid test timestamp in test helper")
-}
-
-fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
-    Fact {
-        id: crate::id::FactId::new(id).expect("valid test id"),
-        nous_id: nous_id.to_owned(),
-        content: content.to_owned(),
-        fact_type: String::new(),
-        temporal: FactTemporal {
-            valid_from: test_ts("2026-01-01"),
-            valid_to: crate::knowledge::far_future(),
-            recorded_at: test_ts("2026-03-01T00:00:00Z"),
-        },
-        provenance: FactProvenance {
-            confidence: 0.9,
-            tier: EpistemicTier::Inferred,
-            source_session_id: None,
-            stability_hours: 720.0,
-        },
-        lifecycle: FactLifecycle {
-            superseded_by: None,
-            is_forgotten: false,
-            forgotten_at: None,
-            forget_reason: None,
-        },
-        access: FactAccess {
-            access_count: 0,
-            last_accessed_at: None,
-        },
-        scope: None,
-    }
-}
-
+use crate::knowledge_store::QueryResult;
+use crate::test_fixtures::{make_fact, make_store};
 #[test]
 fn query_facts_excludes_expired() {
     let store = make_store();

--- a/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
@@ -9,52 +9,10 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use super::super::super::*;
 use crate::knowledge::{
     EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal, ForgetReason,
 };
-
-const DIM: usize = 4;
-
-fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
-}
-
-fn test_ts(s: &str) -> jiff::Timestamp {
-    crate::knowledge::parse_timestamp(s).expect("valid test timestamp in test helper")
-}
-
-fn make_fact(id: &str, nous_id: &str, content: &str) -> crate::knowledge::Fact {
-    crate::knowledge::Fact {
-        id: crate::id::FactId::new(id).expect("valid test id"),
-        nous_id: nous_id.to_owned(),
-        content: content.to_owned(),
-        fact_type: String::new(),
-        temporal: FactTemporal {
-            valid_from: test_ts("2026-01-01"),
-            valid_to: crate::knowledge::far_future(),
-            recorded_at: test_ts("2026-03-01T00:00:00Z"),
-        },
-        provenance: FactProvenance {
-            confidence: 0.9,
-            tier: EpistemicTier::Inferred,
-            source_session_id: None,
-            stability_hours: 720.0,
-        },
-        lifecycle: FactLifecycle {
-            superseded_by: None,
-            is_forgotten: false,
-            forgotten_at: None,
-            forget_reason: None,
-        },
-        access: FactAccess {
-            access_count: 0,
-            last_accessed_at: None,
-        },
-        scope: None,
-    }
-}
-
+use crate::test_fixtures::{make_fact, make_store};
 #[test]
 fn run_script_read_only_basic() {
     let store = make_store();

--- a/crates/episteme/src/knowledge_store/tests/proptests.rs
+++ b/crates/episteme/src/knowledge_store/tests/proptests.rs
@@ -7,75 +7,9 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use crate::knowledge_store::KnowledgeStore;
+use crate::test_fixtures::{make_entity, make_fact, make_relationship, make_store};
 use proptest::prelude::*;
-
-use super::super::*;
-use crate::knowledge::{
-    Entity, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
-    Relationship,
-};
-
-const DIM: usize = 4;
-
-fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
-}
-
-fn test_ts(s: &str) -> jiff::Timestamp {
-    crate::knowledge::parse_timestamp(s).expect("valid test timestamp in test helper")
-}
-
-fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
-    Fact {
-        id: crate::id::FactId::new(id).expect("valid test id"),
-        nous_id: nous_id.to_owned(),
-        content: content.to_owned(),
-        fact_type: String::new(),
-        temporal: FactTemporal {
-            valid_from: test_ts("2026-01-01"),
-            valid_to: crate::knowledge::far_future(),
-            recorded_at: test_ts("2026-03-01T00:00:00Z"),
-        },
-        provenance: FactProvenance {
-            confidence: 0.9,
-            tier: EpistemicTier::Inferred,
-            source_session_id: None,
-            stability_hours: 720.0,
-        },
-        lifecycle: FactLifecycle {
-            superseded_by: None,
-            is_forgotten: false,
-            forgotten_at: None,
-            forget_reason: None,
-        },
-        access: FactAccess {
-            access_count: 0,
-            last_accessed_at: None,
-        },
-        scope: None,
-    }
-}
-
-fn make_entity(id: &str, name: &str, entity_type: &str) -> Entity {
-    Entity {
-        id: crate::id::EntityId::new(id).expect("valid test id"),
-        name: name.to_owned(),
-        entity_type: entity_type.to_owned(),
-        aliases: vec![],
-        created_at: test_ts("2026-03-01T00:00:00Z"),
-        updated_at: test_ts("2026-03-01T00:00:00Z"),
-    }
-}
-
-fn make_relationship(src: &str, dst: &str, relation: &str, weight: f64) -> Relationship {
-    Relationship {
-        src: crate::id::EntityId::new(src).expect("valid test id"),
-        dst: crate::id::EntityId::new(dst).expect("valid test id"),
-        relation: relation.to_owned(),
-        weight,
-        created_at: test_ts("2026-03-01T00:00:00Z"),
-    }
-}
 
 proptest! {
     #[test]
@@ -232,20 +166,15 @@ proptest! {
 
 mod merge {
     use std::collections::BTreeMap;
-    use std::sync::Arc;
 
     use proptest::prelude::*;
 
-    use super::super::super::{KnowledgeConfig, KnowledgeStore};
+    use super::super::super::KnowledgeStore;
     use crate::engine::DataValue;
     use crate::id::EntityId;
     use crate::knowledge::{Entity, Relationship};
+    use crate::test_fixtures::make_store;
     const RELATION_TYPES: &[&str] = &["KNOWS", "WORKS_AT", "DEPENDS_ON", "USES", "PART_OF"];
-
-    fn make_store() -> Arc<KnowledgeStore> {
-        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() })
-            .expect("in-memory store should always open")
-    }
 
     fn count_entities(store: &KnowledgeStore) -> usize {
         store

--- a/crates/episteme/src/knowledge_store/tests/search.rs
+++ b/crates/episteme/src/knowledge_store/tests/search.rs
@@ -5,54 +5,8 @@
     reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
 )]
 
-use std::sync::Arc;
-
-use super::super::*;
-use crate::knowledge::{
-    EmbeddedChunk, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
-};
-
-const DIM: usize = 4;
-
-fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
-}
-
-fn test_ts(s: &str) -> jiff::Timestamp {
-    crate::knowledge::parse_timestamp(s).expect("valid test timestamp in test helper")
-}
-
-fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
-    Fact {
-        id: crate::id::FactId::new(id).expect("valid test id"),
-        nous_id: nous_id.to_owned(),
-        content: content.to_owned(),
-        fact_type: String::new(),
-        temporal: FactTemporal {
-            valid_from: test_ts("2026-01-01"),
-            valid_to: crate::knowledge::far_future(),
-            recorded_at: test_ts("2026-03-01T00:00:00Z"),
-        },
-        provenance: FactProvenance {
-            confidence: 0.9,
-            tier: EpistemicTier::Inferred,
-            source_session_id: None,
-            stability_hours: 720.0,
-        },
-        lifecycle: FactLifecycle {
-            superseded_by: None,
-            is_forgotten: false,
-            forgotten_at: None,
-            forget_reason: None,
-        },
-        access: FactAccess {
-            access_count: 0,
-            last_accessed_at: None,
-        },
-        scope: None,
-    }
-}
-
+use crate::knowledge::EmbeddedChunk;
+use crate::test_fixtures::{make_fact, make_store, test_ts};
 fn make_embedding(id: &str, content: &str, source_id: &str, nous_id: &str) -> EmbeddedChunk {
     EmbeddedChunk {
         id: crate::id::EmbeddingId::new(id).expect("valid test id"),
@@ -160,52 +114,12 @@ async fn search_vectors_async_works() {
 }
 
 mod correctness {
-    use super::super::super::*;
-    use crate::knowledge::{
-        EmbeddedChunk, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance,
-        FactTemporal, ForgetReason,
-    };
+    use crate::knowledge::{EmbeddedChunk, ForgetReason};
+    use crate::test_fixtures::{make_store, test_ts};
 
-    const DIM: usize = 4;
-
-    fn make_store() -> std::sync::Arc<KnowledgeStore> {
-        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() })
-            .expect("open in-memory store")
-    }
-
-    fn ts(s: &str) -> jiff::Timestamp {
-        crate::knowledge::parse_timestamp(s).expect("valid test timestamp")
-    }
-
-    fn fact(id: &str, content: &str) -> Fact {
-        Fact {
-            id: crate::id::FactId::new(id).expect("valid test id"),
-            nous_id: "test-nous".to_owned(),
-            content: content.to_owned(),
-            fact_type: String::new(),
-            temporal: FactTemporal {
-                valid_from: ts("2026-01-01"),
-                valid_to: crate::knowledge::far_future(),
-                recorded_at: ts("2026-03-01T00:00:00Z"),
-            },
-            provenance: FactProvenance {
-                confidence: 0.9,
-                tier: EpistemicTier::Inferred,
-                source_session_id: None,
-                stability_hours: 720.0,
-            },
-            lifecycle: FactLifecycle {
-                superseded_by: None,
-                is_forgotten: false,
-                forgotten_at: None,
-                forget_reason: None,
-            },
-            access: FactAccess {
-                access_count: 0,
-                last_accessed_at: None,
-            },
-            scope: None,
-        }
+    /// Shorthand: build a fact with a fixed nous_id for correctness tests.
+    fn fact(id: &str, content: &str) -> crate::knowledge::Fact {
+        crate::test_fixtures::make_fact(id, "test-nous", content)
     }
 
     fn embedding(id: &str, source_id: &str, vec: Vec<f32>) -> EmbeddedChunk {
@@ -216,7 +130,7 @@ mod correctness {
             source_id: source_id.to_owned(),
             nous_id: "test-nous".to_owned(),
             embedding: vec,
-            created_at: ts("2026-03-01T00:00:00Z"),
+            created_at: test_ts("2026-03-01T00:00:00Z"),
         }
     }
 
@@ -279,7 +193,7 @@ mod correctness {
             nous_id: "test-nous".to_owned(),
             // WHY: Wrong: 6 values instead of DIM=4
             embedding: vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
-            created_at: ts("2026-03-01T00:00:00Z"),
+            created_at: test_ts("2026-03-01T00:00:00Z"),
         };
 
         let err = store
@@ -311,7 +225,7 @@ mod correctness {
             source_id: "dim-ok".to_owned(),
             nous_id: "test-nous".to_owned(),
             embedding: vec![0.5, 0.5, 0.5, 0.5],
-            created_at: ts("2026-03-01T00:00:00Z"),
+            created_at: test_ts("2026-03-01T00:00:00Z"),
         };
         store
             .insert_embedding(&correct)

--- a/crates/episteme/src/knowledge_store/tests/skills.rs
+++ b/crates/episteme/src/knowledge_store/tests/skills.rs
@@ -4,54 +4,10 @@
     reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
 )]
 
-use std::sync::Arc;
-
-use super::super::*;
 use crate::knowledge::{
     EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
 };
-
-const DIM: usize = 4;
-
-fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
-}
-
-fn test_ts(s: &str) -> jiff::Timestamp {
-    crate::knowledge::parse_timestamp(s).expect("valid test timestamp in test helper")
-}
-
-fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
-    Fact {
-        id: crate::id::FactId::new(id).expect("valid test id"),
-        nous_id: nous_id.to_owned(),
-        content: content.to_owned(),
-        fact_type: String::new(),
-        temporal: FactTemporal {
-            valid_from: test_ts("2026-01-01"),
-            valid_to: crate::knowledge::far_future(),
-            recorded_at: test_ts("2026-03-01T00:00:00Z"),
-        },
-        provenance: FactProvenance {
-            confidence: 0.9,
-            tier: EpistemicTier::Inferred,
-            source_session_id: None,
-            stability_hours: 720.0,
-        },
-        lifecycle: FactLifecycle {
-            superseded_by: None,
-            is_forgotten: false,
-            forgotten_at: None,
-            forget_reason: None,
-        },
-        access: FactAccess {
-            access_count: 0,
-            last_accessed_at: None,
-        },
-        scope: None,
-    }
-}
-
+use crate::test_fixtures::{make_fact, make_store, test_ts};
 fn make_skill_fact(id: &str, nous_id: &str, skill_name: &str, domain_tags: &[&str]) -> Fact {
     let content = serde_json::to_string(&crate::skill::SkillContent {
         name: skill_name.to_owned(),

--- a/crates/episteme/src/knowledge_store/tests/temporal.rs
+++ b/crates/episteme/src/knowledge_store/tests/temporal.rs
@@ -4,54 +4,11 @@
     reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
 )]
 
-use std::sync::Arc;
-
-use super::super::*;
 use crate::knowledge::{
     EmbeddedChunk, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
 };
-
-const DIM: usize = 4;
-
-fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() }).expect("open_mem")
-}
-
-fn test_ts(s: &str) -> jiff::Timestamp {
-    crate::knowledge::parse_timestamp(s).expect("valid test timestamp in test helper")
-}
-
-fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
-    Fact {
-        id: crate::id::FactId::new(id).expect("valid test id"),
-        nous_id: nous_id.to_owned(),
-        content: content.to_owned(),
-        fact_type: String::new(),
-        temporal: FactTemporal {
-            valid_from: test_ts("2026-01-01"),
-            valid_to: crate::knowledge::far_future(),
-            recorded_at: test_ts("2026-03-01T00:00:00Z"),
-        },
-        provenance: FactProvenance {
-            confidence: 0.9,
-            tier: EpistemicTier::Inferred,
-            source_session_id: None,
-            stability_hours: 720.0,
-        },
-        lifecycle: FactLifecycle {
-            superseded_by: None,
-            is_forgotten: false,
-            forgotten_at: None,
-            forget_reason: None,
-        },
-        access: FactAccess {
-            access_count: 0,
-            last_accessed_at: None,
-        },
-        scope: None,
-    }
-}
-
+use crate::knowledge_store::HybridQuery;
+use crate::test_fixtures::{make_fact, make_store, test_ts};
 fn make_temporal_fact(
     id: &str,
     nous_id: &str,

--- a/crates/episteme/src/lib.rs
+++ b/crates/episteme/src/lib.rs
@@ -79,6 +79,10 @@ pub mod rule_proposals;
 /// Bayesian surprise for episode boundary detection (EM-LLM, arXiv 2407.09450).
 pub mod surprise;
 
+/// Shared test fixtures for knowledge store tests (DRY helpers).
+#[cfg(all(test, feature = "mneme-engine"))]
+pub(crate) mod test_fixtures;
+
 #[cfg(test)]
 mod phase_f_integration_tests;
 #[cfg(test)]

--- a/crates/episteme/src/test_fixtures.rs
+++ b/crates/episteme/src/test_fixtures.rs
@@ -1,0 +1,21 @@
+//! Shared test fixtures for episteme knowledge store tests.
+//!
+//! Re-exports the common type builders from `eidos::test_fixtures` and adds
+//! episteme-specific helpers (`make_store`) for knowledge store tests.
+
+use std::sync::Arc;
+
+use crate::knowledge_store::{KnowledgeConfig, KnowledgeStore};
+
+// Re-export type builders from eidos so test modules can import everything
+// from a single location.
+pub(crate) use eidos::test_fixtures::{make_entity, make_fact, make_relationship, test_ts};
+
+/// Default embedding dimension for test stores (small to keep tests fast).
+pub(crate) const DIM: usize = 4;
+
+/// Open an in-memory `KnowledgeStore` with test defaults.
+pub(crate) fn make_store() -> Arc<KnowledgeStore> {
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() })
+        .expect("open in-memory knowledge store for test")
+}

--- a/crates/graphe/src/backup_tests.rs
+++ b/crates/graphe/src/backup_tests.rs
@@ -5,12 +5,8 @@
 )]
 use super::*;
 use crate::migration;
-use crate::store::SessionStore;
+use crate::test_fixtures::test_store;
 use crate::types::Role;
-
-fn test_store() -> SessionStore {
-    SessionStore::open_in_memory().expect("open in-memory session store")
-}
 
 #[test]
 fn json_export_produces_valid_files() {

--- a/crates/graphe/src/export_tests.rs
+++ b/crates/graphe/src/export_tests.rs
@@ -4,12 +4,8 @@
     reason = "test assertions"
 )]
 use super::*;
-use crate::store::SessionStore;
+use crate::test_fixtures::test_store;
 use crate::types::Role;
-
-fn test_store() -> SessionStore {
-    SessionStore::open_in_memory().expect("open in-memory store")
-}
 
 #[test]
 fn binary_path_detection() {

--- a/crates/graphe/src/import_tests/validation.rs
+++ b/crates/graphe/src/import_tests/validation.rs
@@ -10,12 +10,8 @@ use std::collections::HashMap;
 use super::super::*;
 use crate::export::{ExportOptions, export_agent};
 use crate::portability::*;
-use crate::store::SessionStore;
+use crate::test_fixtures::test_store;
 use crate::types::Role;
-
-fn test_store() -> SessionStore {
-    SessionStore::open_in_memory().expect("open in-memory store")
-}
 
 fn counter_id_gen() -> Box<dyn Fn() -> String> {
     let counter = std::sync::atomic::AtomicU64::new(1);

--- a/crates/graphe/src/import_tests/workspace_files.rs
+++ b/crates/graphe/src/import_tests/workspace_files.rs
@@ -9,12 +9,8 @@ use std::collections::HashMap;
 use super::super::*;
 use crate::export::{ExportOptions, export_agent};
 use crate::portability::*;
-use crate::store::SessionStore;
+use crate::test_fixtures::test_store;
 use crate::types::Role;
-
-fn test_store() -> SessionStore {
-    SessionStore::open_in_memory().expect("open in-memory store")
-}
 
 fn counter_id_gen() -> Box<dyn Fn() -> String> {
     let counter = std::sync::atomic::AtomicU64::new(1);

--- a/crates/graphe/src/lib.rs
+++ b/crates/graphe/src/lib.rs
@@ -45,6 +45,10 @@ pub mod store;
 /// Core types for sessions, messages, usage records, and agent notes.
 pub mod types;
 
+/// Shared test fixtures for session store tests (DRY helpers).
+#[cfg(all(test, any(feature = "sqlite", feature = "fjall")))]
+pub(crate) mod test_fixtures;
+
 #[cfg(all(test, feature = "sqlite"))]
 mod assertions {
     use super::store::SessionStore;

--- a/crates/graphe/src/store/fjall_store_tests.rs
+++ b/crates/graphe/src/store/fjall_store_tests.rs
@@ -1,12 +1,8 @@
 #![expect(clippy::expect_used, reason = "test assertions")]
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 
-use super::SessionStore;
+use crate::test_fixtures::test_store;
 use crate::types::{Role, SessionStatus};
-
-fn test_store() -> SessionStore {
-    SessionStore::open_in_memory().expect("open fjall in-memory store")
-}
 
 #[test]
 fn create_and_find_session() {

--- a/crates/graphe/src/store/tests/advanced.rs
+++ b/crates/graphe/src/store/tests/advanced.rs
@@ -4,12 +4,8 @@
     clippy::indexing_slicing,
     reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
 )]
-use super::super::SessionStore;
+use crate::test_fixtures::test_store;
 use crate::types::{Role, SessionStatus, UsageRecord};
-
-fn test_store() -> SessionStore {
-    SessionStore::open_in_memory().expect("open in-memory store")
-}
 
 #[test]
 fn get_history_empty_session() {

--- a/crates/graphe/src/store/tests/blackboard.rs
+++ b/crates/graphe/src/store/tests/blackboard.rs
@@ -1,11 +1,7 @@
 //! Tests for blackboard CRUD and expiry.
 #![expect(clippy::expect_used, reason = "test assertions")]
-use super::super::SessionStore;
+use crate::test_fixtures::test_store;
 use crate::types::Role;
-
-fn test_store() -> SessionStore {
-    SessionStore::open_in_memory().expect("open in-memory store")
-}
 
 #[test]
 fn blackboard_crud() {

--- a/crates/graphe/src/store/tests/edge_cases.rs
+++ b/crates/graphe/src/store/tests/edge_cases.rs
@@ -4,12 +4,8 @@
     clippy::indexing_slicing,
     reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
 )]
-use super::super::SessionStore;
+use crate::test_fixtures::test_store;
 use crate::types::Role;
-
-fn test_store() -> SessionStore {
-    SessionStore::open_in_memory().expect("open in-memory store")
-}
 
 #[test]
 fn history_empty_session() {

--- a/crates/graphe/src/store/tests/session_crud.rs
+++ b/crates/graphe/src/store/tests/session_crud.rs
@@ -9,12 +9,8 @@
     clippy::similar_names,
     reason = "seq_a1/seq_b1/seq_a2/seq_b2 mirror paired-session assertions"
 )]
-use super::super::SessionStore;
+use crate::test_fixtures::test_store;
 use crate::types::{Role, SessionStatus, SessionType, UsageRecord};
-
-fn test_store() -> SessionStore {
-    SessionStore::open_in_memory().expect("open in-memory store")
-}
 
 #[test]
 fn create_and_find_session() {

--- a/crates/graphe/src/test_fixtures.rs
+++ b/crates/graphe/src/test_fixtures.rs
@@ -1,0 +1,12 @@
+//! Shared test fixtures for graphe session store tests.
+//!
+//! Centralises the `test_store` helper that was duplicated across every
+//! test module in `store/tests/`, `backup_tests`, `export_tests`, and
+//! `import_tests/`.
+
+use crate::store::SessionStore;
+
+/// Open an in-memory `SessionStore` for use in tests.
+pub(crate) fn test_store() -> SessionStore {
+    SessionStore::open_in_memory().expect("open in-memory session store for test")
+}


### PR DESCRIPTION
## Summary
- Extract shared test fixtures from 18 test files across 3 crates (eidos, episteme, graphe), eliminating ~500 lines of duplicated helper code
- Create `eidos::test_fixtures` module with `make_fact`, `make_entity`, `make_relationship`, `test_ts` builders behind `test-support` feature gate
- Create `episteme::test_fixtures` module re-exporting eidos builders plus `make_store` for KnowledgeStore setup
- Create `graphe::test_fixtures` module with `test_store` for SessionStore setup

## Test plan
- [x] `cargo test -p episteme --features mneme-engine` -- 1090 passed
- [x] `cargo test -p graphe --features sqlite` -- 274 passed
- [x] `cargo test -p eidos` -- 173 passed
- [x] `cargo test --workspace --exclude integration-tests` -- all pass (pre-existing krites failure unrelated)
- [x] `cargo clippy --workspace` -- zero new warnings

Closes #3342, #3344, #3345, #3346

🤖 Generated with [Claude Code](https://claude.com/claude-code)