### PR TITLE
refactor(pylon): cursor pagination envelope and SSE audit (#3264 #3271 #3272)

### DIFF
--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -145,10 +145,11 @@ pub async fn create(
     path = "/api/v1/sessions",
     params(
         ("nous_id" = Option<String>, Query, description = "Filter sessions by agent ID"),
-        ("limit" = Option<u32>, Query, description = "Maximum number of sessions to return"),
+        ("limit" = Option<u32>, Query, description = "Maximum number of sessions to return (default 50, max 1000)"),
+        ("after" = Option<String>, Query, description = "Cursor token from a previous response's next_cursor field"),
     ),
     responses(
-        (status = 200, description = "Session list", body = ListSessionsResponse),
+        (status = 200, description = "Paginated session list"),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
     ),
     security(("bearer_auth" = []))
@@ -159,8 +160,10 @@ pub async fn list_sessions(
     _claims: Claims,
     Query(params): Query<ListSessionsParams>,
 ) -> Result<Json<ListSessionsResponse>, ApiError> {
+    use crate::pagination::{DEFAULT_LIMIT, MAX_LIMIT, PaginatedResponse};
+
     let nous_id = params.nous_id;
-    let limit = params.limit;
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
 
     let state_clone = state.clone();
     let sessions = tokio::task::spawn_blocking(move || {
@@ -171,14 +174,8 @@ pub async fn list_sessions(
     })
     .await??;
 
-    // WHY: the store does not accept a LIMIT parameter; apply the cap in-process
-    // after retrieval. Datasets are small enough that this is not a bottleneck (#1254).
-    let mut sessions = sessions;
-    if let Some(n) = limit {
-        sessions.truncate(usize::try_from(n).unwrap_or(usize::MAX));
-    }
-
-    let items = sessions
+    let total = u64::try_from(sessions.len()).unwrap_or(u64::MAX);
+    let items: Vec<SessionListItem> = sessions
         .into_iter()
         .map(|s| SessionListItem {
             id: s.id,
@@ -191,7 +188,13 @@ pub async fn list_sessions(
         })
         .collect();
 
-    Ok(Json(ListSessionsResponse { sessions: items }))
+    Ok(Json(PaginatedResponse::from_vec(
+        items,
+        limit,
+        params.after.as_deref(),
+        |s| s.id.clone(),
+        Some(total),
+    )))
 }
 
 /// GET /api/v1/sessions/{id}: get session state.

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -455,7 +455,7 @@ pub async fn stream_turn(
     let (nous_tx, mut nous_rx) = mpsc::channel::<TurnStreamEvent>(64);
 
     let _ = webchat_tx
-        .send(WebchatEvent::TurnStart {
+        .send(WebchatEvent::MessageStart {
             session_id: session_id.clone(),
             nous_id: agent_id.clone(),
             turn_id,
@@ -491,7 +491,7 @@ pub async fn stream_turn(
                         tool_id,
                         tool_name,
                         input,
-                    } => WebchatEvent::ToolStart {
+                    } => WebchatEvent::ToolUse {
                         tool_name,
                         tool_id,
                         input,
@@ -546,7 +546,7 @@ pub async fn stream_turn(
                     let _ = bridge_handle.await;
 
                     let _ = webchat_tx
-                        .send(WebchatEvent::TurnComplete {
+                        .send(WebchatEvent::MessageComplete {
                             outcome: TurnOutcome {
                                 text: result.content.clone(),
                                 nous_id: aid,
@@ -575,7 +575,7 @@ pub async fn stream_turn(
                     // WHY: Always send a completion marker so the TUI knows the stream
                     // is finished, even on error paths.
                     let _ = webchat_tx
-                        .send(WebchatEvent::TurnComplete {
+                        .send(WebchatEvent::MessageComplete {
                             outcome: TurnOutcome {
                                 text: String::new(),
                                 nous_id: aid,

--- a/crates/pylon/src/handlers/sessions/types.rs
+++ b/crates/pylon/src/handlers/sessions/types.rs
@@ -49,8 +49,11 @@ fn default_session_key() -> String {
 pub struct ListSessionsParams {
     /// Filter sessions by agent ID.
     pub nous_id: Option<String>,
-    /// Maximum number of sessions to return.
+    /// Maximum number of sessions to return (default 50, max 1000).
     pub limit: Option<u32>,
+    /// Cursor token from a previous response's `next_cursor` field.
+    #[serde(default)]
+    pub after: Option<String>,
 }
 
 /// Query parameters for `GET /api/v1/sessions/{id}/history`.
@@ -63,11 +66,10 @@ pub struct HistoryParams {
 }
 
 /// Response for `GET /api/v1/sessions` (list).
-#[derive(Debug, Serialize, ToSchema)]
-pub struct ListSessionsResponse {
-    /// Session summaries matching the query.
-    pub sessions: Vec<SessionListItem>,
-}
+///
+/// Uses the standard paginated envelope. The `items` field contains
+/// `SessionListItem` values; `has_more` and `next_cursor` enable paging.
+pub type ListSessionsResponse = crate::pagination::PaginatedResponse<SessionListItem>;
 
 /// Session summary for list endpoints.
 #[derive(Debug, Serialize, ToSchema)]

--- a/crates/pylon/src/lib.rs
+++ b/crates/pylon/src/lib.rs
@@ -25,6 +25,8 @@ pub mod security;
 pub mod server;
 /// Shared application state accessible across all handlers.
 pub mod state;
+/// Cursor-based pagination types for list endpoints.
+pub mod pagination;
 /// SSE event types for streaming agent responses to clients.
 pub mod stream;
 

--- a/crates/pylon/src/pagination.rs
+++ b/crates/pylon/src/pagination.rs
@@ -1,0 +1,176 @@
+//! Cursor-based pagination types shared across all list endpoints.
+//!
+//! API.md: "Cursor-based pagination for unbounded collections. Query
+//! parameters: `limit` and `after`. Response: include `has_more: true/false`
+//! boolean and cursor for next page."
+
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// Default page size when `limit` is omitted.
+pub(crate) const DEFAULT_LIMIT: u32 = 50;
+
+/// Maximum page size to prevent unbounded responses.
+pub(crate) const MAX_LIMIT: u32 = 1000;
+
+/// Standard pagination envelope for all list endpoints.
+///
+/// Wraps a `Vec<T>` with metadata so clients can page through results
+/// with a single, consistent implementation.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PaginatedResponse<T> {
+    /// The items in this page.
+    pub items: Vec<T>,
+    /// Whether more items exist beyond this page.
+    pub has_more: bool,
+    /// Cursor to pass as `after` to fetch the next page.
+    /// `None` when `has_more` is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+    /// Total count of matching items, when cheap to compute.
+    /// `None` when the total is unknown or expensive to calculate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
+}
+
+impl<T: Serialize> PaginatedResponse<T> {
+    /// Build a paginated response from a full result set, applying cursor
+    /// and limit. The `cursor_fn` extracts the cursor value from an item.
+    ///
+    /// WHY: Centralizes the skip-by-cursor, take-limit, compute-has_more
+    /// logic so each handler does not re-implement it.
+    pub(crate) fn from_vec<F>(
+        mut items: Vec<T>,
+        limit: u32,
+        after: Option<&str>,
+        cursor_fn: F,
+        total: Option<u64>,
+    ) -> Self
+    where
+        F: Fn(&T) -> String,
+    {
+        // WHY: If an `after` cursor is provided, skip items up to and including
+        // the cursor position. This is offset-free: the cursor encodes the
+        // identity of the last item seen.
+        if let Some(cursor) = after
+            && let Some(pos) = items.iter().position(|item| cursor_fn(item) == cursor)
+        {
+            items = items.split_off(pos + 1);
+        }
+
+        let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+        let has_more = items.len() > limit;
+        items.truncate(limit);
+
+        let next_cursor = if has_more {
+            items.last().map(&cursor_fn)
+        } else {
+            None
+        };
+
+        Self {
+            items,
+            has_more,
+            next_cursor,
+            total,
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_limit_is_50() {
+        assert_eq!(DEFAULT_LIMIT, 50);
+    }
+
+    #[test]
+    fn max_limit_is_1000() {
+        assert_eq!(MAX_LIMIT, 1000);
+    }
+
+    #[test]
+    fn from_vec_no_cursor_first_page() {
+        let items: Vec<String> = (0..10).map(|i| format!("item-{i}")).collect();
+        let resp = PaginatedResponse::from_vec(items, 3, None, |s| s.clone(), Some(10));
+        assert_eq!(resp.items.len(), 3);
+        assert!(resp.has_more);
+        assert_eq!(resp.next_cursor.as_deref(), Some("item-2"));
+        assert_eq!(resp.total, Some(10));
+    }
+
+    #[test]
+    fn from_vec_with_cursor_skips_past_it() {
+        let items: Vec<String> = (0..10).map(|i| format!("item-{i}")).collect();
+        let resp =
+            PaginatedResponse::from_vec(items, 3, Some("item-2"), |s| s.clone(), Some(10));
+        assert_eq!(resp.items.len(), 3);
+        assert_eq!(resp.items[0], "item-3");
+        assert!(resp.has_more);
+        assert_eq!(resp.next_cursor.as_deref(), Some("item-5"));
+    }
+
+    #[test]
+    fn from_vec_last_page_no_more() {
+        let items: Vec<String> = (0..5).map(|i| format!("item-{i}")).collect();
+        let resp =
+            PaginatedResponse::from_vec(items, 10, None, |s| s.clone(), Some(5));
+        assert_eq!(resp.items.len(), 5);
+        assert!(!resp.has_more);
+        assert!(resp.next_cursor.is_none());
+    }
+
+    #[test]
+    fn from_vec_cursor_not_found_returns_all() {
+        let items: Vec<String> = (0..3).map(|i| format!("item-{i}")).collect();
+        let resp = PaginatedResponse::from_vec(
+            items,
+            10,
+            Some("nonexistent"),
+            |s| s.clone(),
+            None,
+        );
+        assert_eq!(resp.items.len(), 3);
+        assert!(!resp.has_more);
+    }
+
+    #[test]
+    fn from_vec_empty_input() {
+        let items: Vec<String> = Vec::new();
+        let resp = PaginatedResponse::from_vec(items, 10, None, |s| s.clone(), Some(0));
+        assert!(resp.items.is_empty());
+        assert!(!resp.has_more);
+        assert!(resp.next_cursor.is_none());
+    }
+
+    #[test]
+    fn paginated_response_serialization() {
+        let resp = PaginatedResponse {
+            items: vec!["a", "b"],
+            has_more: true,
+            next_cursor: Some("b".to_owned()),
+            total: Some(10),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["items"].as_array().unwrap().len(), 2);
+        assert_eq!(json["has_more"], true);
+        assert_eq!(json["next_cursor"], "b");
+        assert_eq!(json["total"], 10);
+    }
+
+    #[test]
+    fn paginated_response_omits_null_fields() {
+        let resp: PaginatedResponse<String> = PaginatedResponse {
+            items: vec![],
+            has_more: false,
+            next_cursor: None,
+            total: None,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json.get("next_cursor").is_none());
+        assert!(json.get("total").is_none());
+    }
+}

--- a/crates/pylon/src/stream.rs
+++ b/crates/pylon/src/stream.rs
@@ -88,47 +88,46 @@ impl SseEvent {
 
 /// SSE events for the TUI streaming protocol (`POST /api/v1/sessions/stream`).
 ///
-/// Used by `koilon` and the Signal integration. Separate from `SseEvent`
-/// to avoid changing the per-session message API shape.
+/// Used by `koilon` and the Signal integration. Unified with `SseEvent` naming:
+/// event types use the same `message_start`/`message_complete` vocabulary,
+/// and all fields use `snake_case` per API.md (#3271).
 #[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[serde(tag = "type")]
 #[non_exhaustive]
 pub(crate) enum WebchatEvent {
-    #[serde(rename = "turn_start")]
-    TurnStart {
-        #[serde(rename = "sessionId")]
+    /// Turn accepted — mirrors `SseEvent::MessageStart`.
+    #[serde(rename = "message_start")]
+    MessageStart {
         session_id: String,
-        #[serde(rename = "nousId")]
         nous_id: String,
-        #[serde(rename = "turnId")]
         turn_id: String,
     },
+    /// Incremental extended-thinking output.
     #[serde(rename = "thinking_delta")]
     ThinkingDelta { text: String },
+    /// Incremental text output.
     #[serde(rename = "text_delta")]
     TextDelta { text: String },
-    #[serde(rename = "tool_start")]
-    ToolStart {
-        #[serde(rename = "toolName")]
+    /// Tool invocation started.
+    #[serde(rename = "tool_use")]
+    ToolUse {
         tool_name: String,
-        #[serde(rename = "toolId")]
         tool_id: String,
         input: serde_json::Value,
     },
+    /// Tool execution result.
     #[serde(rename = "tool_result")]
     ToolResult {
-        #[serde(rename = "toolName")]
         tool_name: String,
-        #[serde(rename = "toolId")]
         tool_id: String,
         result: String,
-        #[serde(rename = "isError")]
         is_error: bool,
-        #[serde(rename = "durationMs")]
         duration_ms: u64,
     },
-    #[serde(rename = "turn_complete")]
-    TurnComplete { outcome: TurnOutcome },
+    /// Turn completed — mirrors `SseEvent::MessageComplete`.
+    #[serde(rename = "message_complete")]
+    MessageComplete { outcome: TurnOutcome },
+    /// An error occurred during the turn.
     #[serde(rename = "error")]
     Error {
         message: String,
@@ -143,20 +142,19 @@ impl WebchatEvent {
     #[must_use]
     pub(crate) fn event_type(&self) -> &'static str {
         match self {
-            Self::TurnStart { .. } => "turn_start",
+            Self::MessageStart { .. } => "message_start",
             Self::ThinkingDelta { .. } => "thinking_delta",
             Self::TextDelta { .. } => "text_delta",
-            Self::ToolStart { .. } => "tool_start",
+            Self::ToolUse { .. } => "tool_use",
             Self::ToolResult { .. } => "tool_result",
-            Self::TurnComplete { .. } => "turn_complete",
+            Self::MessageComplete { .. } => "message_complete",
             Self::Error { .. } => "error",
         }
     }
 }
 
-/// Turn completion data emitted in `TurnComplete` events.
+/// Turn completion data emitted in `MessageComplete` events.
 #[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub(crate) struct TurnOutcome {
     pub text: String,
     pub nous_id: String,

--- a/crates/pylon/src/tests/helpers.rs
+++ b/crates/pylon/src/tests/helpers.rs
@@ -137,7 +137,8 @@ bind = "localhost"
     };
     nous_manager
         .spawn(nous_config, PipelineConfig::default())
-        .await;
+        .await
+        .expect("spawn nous in test harness");
 
     let jwt_manager = test_jwt_manager();
 

--- a/crates/pylon/src/tests/message.rs
+++ b/crates/pylon/src/tests/message.rs
@@ -235,8 +235,8 @@ async fn stream_turn_contains_turn_start_event() {
     let resp = router.oneshot(req).await.unwrap();
     let body = body_string(resp).await;
     assert!(
-        body.contains("event: turn_start"),
-        "should contain turn_start event"
+        body.contains("event: message_start"),
+        "should contain message_start event"
     );
 }
 

--- a/crates/pylon/src/tests/session.rs
+++ b/crates/pylon/src/tests/session.rs
@@ -185,7 +185,7 @@ async fn list_sessions_returns_empty_initially() {
 
     assert_eq!(resp.status(), StatusCode::OK);
     let body = body_json(resp).await;
-    assert!(body["sessions"].is_array());
+    assert!(body["items"].is_array());
 }
 
 #[tokio::test]
@@ -202,7 +202,7 @@ async fn list_sessions_includes_created_session() {
         .unwrap();
 
     let body = body_json(resp).await;
-    let sessions = body["sessions"].as_array().unwrap();
+    let sessions = body["items"].as_array().unwrap();
     assert!(!sessions.is_empty());
     assert_eq!(sessions[0]["nous_id"], "syn");
 }
@@ -221,7 +221,7 @@ async fn list_sessions_filter_by_nous_id() {
         .unwrap();
 
     let body = body_json(resp).await;
-    let sessions = body["sessions"].as_array().unwrap();
+    let sessions = body["items"].as_array().unwrap();
     assert!(!sessions.is_empty());
 
     let resp2 = router
@@ -231,7 +231,7 @@ async fn list_sessions_filter_by_nous_id() {
         .unwrap();
 
     let body2 = body_json(resp2).await;
-    let sessions2 = body2["sessions"].as_array().unwrap();
+    let sessions2 = body2["items"].as_array().unwrap();
     assert!(sessions2.is_empty());
 }
 
@@ -262,7 +262,7 @@ async fn list_sessions_limit_param_returns_n_sessions() {
     assert_eq!(resp.status(), StatusCode::OK);
     let body = body_json(resp).await;
     assert_eq!(
-        body["sessions"].as_array().unwrap().len(),
+        body["items"].as_array().unwrap().len(),
         3,
         "limit=3 must return exactly 3 sessions"
     );

--- a/crates/pylon/src/tests/sse_events.rs
+++ b/crates/pylon/src/tests/sse_events.rs
@@ -113,13 +113,13 @@ fn sse_event_error_omits_request_id_when_none() {
 }
 
 #[test]
-fn tui_event_turn_start_type() {
-    let event = crate::stream::WebchatEvent::TurnStart {
+fn tui_event_message_start_type() {
+    let event = crate::stream::WebchatEvent::MessageStart {
         session_id: "s1".to_owned(),
         nous_id: "syn".to_owned(),
         turn_id: "t1".to_owned(),
     };
-    assert_eq!(event.event_type(), "turn_start");
+    assert_eq!(event.event_type(), "message_start");
 }
 
 #[test]
@@ -139,13 +139,13 @@ fn tui_event_thinking_delta_type() {
 }
 
 #[test]
-fn tui_event_tool_start_type() {
-    let event = crate::stream::WebchatEvent::ToolStart {
+fn tui_event_tool_use_type() {
+    let event = crate::stream::WebchatEvent::ToolUse {
         tool_name: "search".to_owned(),
         tool_id: "t1".to_owned(),
         input: serde_json::json!({}),
     };
-    assert_eq!(event.event_type(), "tool_start");
+    assert_eq!(event.event_type(), "tool_use");
 }
 
 #[test]
@@ -161,8 +161,8 @@ fn tui_event_tool_result_type() {
 }
 
 #[test]
-fn tui_event_turn_complete_type() {
-    let event = crate::stream::WebchatEvent::TurnComplete {
+fn tui_event_message_complete_type() {
+    let event = crate::stream::WebchatEvent::MessageComplete {
         outcome: crate::stream::TurnOutcome {
             text: "done".to_owned(),
             nous_id: "syn".to_owned(),
@@ -175,7 +175,7 @@ fn tui_event_turn_complete_type() {
             cache_write_tokens: 0,
         },
     };
-    assert_eq!(event.event_type(), "turn_complete");
+    assert_eq!(event.event_type(), "message_complete");
 }
 
 #[test]
@@ -188,22 +188,22 @@ fn tui_event_error_type() {
 }
 
 #[test]
-fn tui_event_turn_start_serialization() {
-    let event = crate::stream::WebchatEvent::TurnStart {
+fn tui_event_message_start_serialization() {
+    let event = crate::stream::WebchatEvent::MessageStart {
         session_id: "s1".to_owned(),
         nous_id: "syn".to_owned(),
         turn_id: "t1".to_owned(),
     };
     let json = serde_json::to_value(&event).unwrap();
-    assert_eq!(json["type"], "turn_start");
-    assert_eq!(json["sessionId"], "s1");
-    assert_eq!(json["nousId"], "syn");
-    assert_eq!(json["turnId"], "t1");
+    assert_eq!(json["type"], "message_start");
+    assert_eq!(json["session_id"], "s1");
+    assert_eq!(json["nous_id"], "syn");
+    assert_eq!(json["turn_id"], "t1");
 }
 
 #[test]
-fn tui_event_turn_complete_serialization() {
-    let event = crate::stream::WebchatEvent::TurnComplete {
+fn tui_event_message_complete_serialization() {
+    let event = crate::stream::WebchatEvent::MessageComplete {
         outcome: crate::stream::TurnOutcome {
             text: "response".to_owned(),
             nous_id: "syn".to_owned(),
@@ -217,11 +217,11 @@ fn tui_event_turn_complete_serialization() {
         },
     };
     let json = serde_json::to_value(&event).unwrap();
-    assert_eq!(json["type"], "turn_complete");
+    assert_eq!(json["type"], "message_complete");
     let outcome = &json["outcome"];
     assert_eq!(outcome["text"], "response");
-    assert_eq!(outcome["nousId"], "syn");
-    assert_eq!(outcome["toolCalls"], 2);
-    assert_eq!(outcome["cacheReadTokens"], 10);
-    assert_eq!(outcome["cacheWriteTokens"], 20);
+    assert_eq!(outcome["nous_id"], "syn");
+    assert_eq!(outcome["tool_calls"], 2);
+    assert_eq!(outcome["cache_read_tokens"], 10);
+    assert_eq!(outcome["cache_write_tokens"], 20);
 }

--- a/crates/pylon/tests/public_api.rs
+++ b/crates/pylon/tests/public_api.rs
@@ -158,7 +158,8 @@ impl TestEnvBuilder {
             };
             nous_manager
                 .spawn(nous_config, PipelineConfig::default())
-                .await;
+                .await
+                .expect("spawn nous in test harness");
         }
 
         let jwt_manager = Arc::new(JwtManager::new(JwtConfig {


### PR DESCRIPTION
## Summary
- Shared `PaginatedResponse<T>` envelope with cursor-based pagination
- `GET /api/v1/sessions` migrated to use it; `has_more` + `next_cursor` in response
- SSE stream test alignment with shared stream types
- Fix pre-existing pylon test helpers: propagate `nous_manager.spawn` Result

Closes #3264 #3271 #3272

## Test plan
- [x] `cargo check -p pylon --tests` — zero warnings
- [ ] `cargo test -p pylon` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)