### PR TITLE
refactor(deps): migrate from deprecated serde_yaml to serde_yml (#3394)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "snafu",
  "tempfile",
  "tokio",
@@ -3757,6 +3757,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4527,7 +4537,6 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
- "serde_yaml",
  "snafu",
  "taxis",
  "tempfile",
@@ -6493,16 +6502,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -7824,12 +7835,6 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ snafu = "0.8"
 # Serialization
 serde = { version = "1", default-features = false, features = ["derive", "std"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
-serde_yaml = { version = "0.9", default-features = false }
+serde_yml = { version = "0.0.12", default-features = false }
 toml = "1.1"
 
 # HTTP

--- a/crates/energeia/Cargo.toml
+++ b/crates/energeia/Cargo.toml
@@ -27,7 +27,7 @@ parking_lot = { version = "0.12", default-features = false }
 rmp-serde = "1.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+serde_yml = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true, features = ["process", "io-util"] }
 tokio-util = { workspace = true }

--- a/crates/energeia/src/prompt.rs
+++ b/crates/energeia/src/prompt.rs
@@ -118,7 +118,7 @@ fn parse_prompt_str(raw: &str, path: &Path) -> Result<PromptSpec> {
     )]
     let body = after_open[body_start..].trim_start_matches('\n').to_owned();
 
-    let fm: Frontmatter = serde_yaml::from_str(yaml_str).map_err(|e| {
+    let fm: Frontmatter = serde_yml::from_str(yaml_str).map_err(|e| {
         FrontmatterParseSnafu {
             path: path.to_owned(),
             detail: format!("YAML parse error: {e}"),

--- a/crates/energeia/tests/public_api.rs
+++ b/crates/energeia/tests/public_api.rs
@@ -62,7 +62,7 @@ project: yaml-test
 dag_ref: prompts/dag.yaml
 max_parallel: 4
 ";
-    let spec: DispatchSpec = serde_yaml::from_str(yaml).expect("deserialize from yaml");
+    let spec: DispatchSpec = serde_yml::from_str(yaml).expect("deserialize from yaml");
 
     assert_eq!(spec.prompt_numbers, vec![1, 2]);
     assert_eq!(spec.project, "yaml-test");

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -36,7 +36,6 @@ prometheus = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
## Summary
- Replace `serde_yaml` (deprecated) with `serde_yml` (active fork, drop-in API).

Closes #3394

🤖 Kimi okabe (v1.30.0)