### PR TITLE
docs: add ARCHITECTURE-QUICK.md — compact crate reference for agent cold-start (#3354)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ Shell: [standards/SHELL.md](standards/SHELL.md)
 
 ## Structure
 
-[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md): crate workspace, module map, dependency graph, trait boundaries.
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md): crate workspace, module map, dependency graph, trait boundaries.  
+[docs/ARCHITECTURE-QUICK.md](docs/ARCHITECTURE-QUICK.md): one-page crate reference for cold-start.
 
 ### Config
 

--- a/docs/ARCHITECTURE-QUICK.md
+++ b/docs/ARCHITECTURE-QUICK.md
@@ -1,0 +1,38 @@
+# Aletheia Architecture Quick Reference
+
+## Types & domain
+- **koina** — core types, errors, tracing, system abstractions
+- **eidos** — shared knowledge types
+- **mneme** — facade re-exporting memory sub-crates
+
+## Storage
+- **graphe** — SQLite session/message store
+- **krites** — embedded Datalog engine
+- **episteme** — knowledge pipeline: extraction, recall, embeddings
+
+## Runtime
+- **hermeneus** — LLM client: streaming, retries, health tracking
+- **organon** — tool registry, sandbox, 38 built-in tools
+- **melete** — context distillation / summarization
+- **thesauros** — domain pack loader
+- **nous** — agent runtime: actor model, turn pipeline
+
+## HTTP
+- **symbolon** — auth: JWT, API keys, OAuth, RBAC
+- **pylon** — Axum HTTP gateway: SSE, auth, rate limits
+- **diaporeia** — MCP server for external AI agents
+
+## CLI & desktop
+- **aletheia** — binary: CLI, server startup, wiring
+- **theatron** — UI umbrella: skene, koilon (TUI), proskenion (desktop)
+- **dianoia** — planning: multi-phase state machine
+- **agora** — channel registry: Signal, etc.
+
+## Ops & misc
+- **taxis** — config cascade: TOML, oikos, hot-reload
+- **daemon** — background tasks: cron, maintenance, watchdog
+- **eval** — behavioral eval: scenario-based API testing
+- **energeia** — dispatch orchestration
+- **poiesis** — document rendering: PDF, ODT, XLSX, ODS, PPTX
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for full details.


### PR DESCRIPTION
## Summary
- New docs/ARCHITECTURE-QUICK.md: ~209 words, grouped by layer (types → storage → runtime → HTTP → CLI → desktop → ops), one line per crate.

Closes #3354

🤖 Kimi okabe (v1.30.0)