### PR TITLE
docs: add CRATE-INDEX.toml for machine-readable crate discovery (#3350)

### DIFF
--- a/CRATE-INDEX.toml
+++ b/CRATE-INDEX.toml
@@ -1,0 +1,239 @@
+[crates.agora]
+path = "crates/agora"
+layer = "runtime"
+purpose = "Channel registry and provider implementations (Signal)"
+depends_on = ["koina", "taxis"]
+used_by = ["aletheia"]
+features = { "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.aletheia]
+path = "crates/aletheia"
+layer = "cli"
+purpose = "Aletheia cognitive agent runtime"
+depends_on = ["agora", "dianoia", "diaporeia", "dokimion", "energeia", "hermeneus", "koilon", "koina", "mneme", "nous", "oikonomos", "organon", "pylon", "symbolon", "taxis", "thesauros"]
+used_by = []
+features = { "cc-provider" = "Claude Code subprocess provider", "default" = "tui + recall + storage-fjall + embed-candle + cc-provider", "embed-candle" = "local ML embeddings via candle", "energeia" = "dispatch orchestration", "keyring" = "OS keyring via symbolon", "mcp" = "MCP server interface via diaporeia", "migrate-qdrant" = "Qdrant migration tool", "recall" = "knowledge store with vector search", "storage-fjall" = "fjall storage backend", "test-core" = "test tier with core features", "test-full" = "full test tier", "tls" = "TLS support via pylon", "tui" = "terminal UI via koilon" }
+
+[crates.dianoia]
+path = "crates/dianoia"
+layer = "runtime"
+purpose = "Planning and project orchestration — multi-phase state machine with workspace persistence"
+depends_on = ["koina"]
+used_by = ["aletheia", "nous"]
+features = { "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.diaporeia]
+path = "crates/diaporeia"
+layer = "http"
+purpose = "MCP server interface — the passage through for external AI agents"
+depends_on = ["koina", "mneme", "nous", "organon", "symbolon", "taxis"]
+used_by = ["aletheia"]
+features = { "default" = "knowledge-store enabled", "knowledge-store" = "gates NousManager knowledge store signature", "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.dokimion]
+path = "crates/eval"
+layer = "ops"
+purpose = "Behavioral eval framework — scenario-based API testing against a live instance"
+depends_on = ["koina"]
+used_by = ["aletheia"]
+features = { "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.eidos]
+path = "crates/eidos"
+layer = "types"
+purpose = "Shared knowledge types for the Aletheia memory layer"
+depends_on = []
+used_by = ["energeia", "episteme", "graphe", "krites", "mneme", "nous", "taxis"]
+features = { "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures", "test-support" = "exposes test_fixtures module with builders" }
+
+[crates.energeia]
+path = "crates/energeia"
+layer = "runtime"
+purpose = "Dispatch orchestration — actualization of plans into execution"
+depends_on = ["eidos", "hermeneus", "koina"]
+used_by = ["aletheia", "organon"]
+features = { "storage-fjall" = "fjall storage backend", "test-core" = "test tier with storage-fjall", "test-full" = "full test tier fixtures" }
+
+[crates.episteme]
+path = "crates/episteme"
+layer = "engine"
+purpose = "Knowledge pipeline for Aletheia"
+depends_on = ["eidos", "graphe", "koina", "krites"]
+used_by = ["mneme", "nous", "oikonomos"]
+features = { "default" = "graph algorithm support", "embed-candle" = "local ML embeddings via candle", "graph-algo" = "graph algorithm support", "mneme-engine" = "enables Datalog knowledge store and query builder", "storage-fjall" = "fjall-backed knowledge store", "test-core" = "test tier with mneme-engine", "test-full" = "full test tier with candle embeddings", "test-support" = "test helpers and fixtures" }
+
+[crates.graphe]
+path = "crates/graphe"
+layer = "storage"
+purpose = "Session persistence layer for Aletheia"
+depends_on = ["eidos", "koina"]
+used_by = ["episteme", "mneme"]
+features = { "default" = "fjall backend (pure Rust, zero C dependency)", "fjall" = "fjall LSM-tree backend", "mneme-engine" = "gates error variants for tokio::task::JoinError", "sqlite" = "SQLite backend for migration parity", "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.hermeneus]
+path = "crates/hermeneus"
+layer = "engine"
+purpose = "LLM provider abstraction and Anthropic streaming client"
+depends_on = ["koina"]
+used_by = ["aletheia", "energeia", "melete", "nous", "organon", "pylon"]
+features = { "cc-provider" = "Claude Code subprocess provider", "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures", "test-support" = "mock LLM provider for tests", "test-utils" = "mock LLM provider (legacy alias)" }
+
+[crates.integration-tests]
+path = "crates/integration-tests"
+layer = "ops"
+purpose = "Cross-crate integration test suite exercising multi-crate pipelines end-to-end"
+depends_on = []
+used_by = []
+features = { "default" = "sqlite-tests + knowledge-store", "engine-tests" = "mneme engine tests", "knowledge-store" = "knowledge store integration tests", "sqlite-tests" = "SQLite-backed tests", "test-core" = "test tier with engine-tests", "test-full" = "full test tier fixtures" }
+
+[crates.koilon]
+path = "crates/theatron/koilon"
+layer = "cli"
+purpose = "Terminal dashboard for the Aletheia distributed cognition system"
+depends_on = ["koina", "skene"]
+used_by = ["aletheia"]
+features = { "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.koina]
+path = "crates/koina"
+layer = "types"
+purpose = "Core types, errors, and tracing for Aletheia"
+depends_on = []
+used_by = ["agora", "aletheia", "dianoia", "diaporeia", "dokimion", "energeia", "episteme", "graphe", "hermeneus", "koilon", "melete", "nous", "oikonomos", "organon", "pylon", "skene", "symbolon", "taxis", "thesauros"]
+features = { "fjall" = "fjall KV storage backend support", "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures", "test-support" = "test helpers and fixtures" }
+
+[crates.krites]
+path = "crates/krites"
+layer = "engine"
+purpose = "Embedded Datalog engine with HNSW and graph support for Aletheia"
+depends_on = ["eidos"]
+used_by = ["episteme", "mneme"]
+features = { "default" = "graph algorithm support", "graph-algo" = "graph algorithm support", "storage-fjall" = "fjall storage backend", "test-core" = "test tier with fjall backend", "test-full" = "full test tier fixtures" }
+
+[crates.melete]
+path = "crates/melete"
+layer = "runtime"
+purpose = "Context distillation engine — compresses conversation history"
+depends_on = ["hermeneus", "koina"]
+used_by = ["nous"]
+features = { "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.mneme]
+path = "crates/mneme"
+layer = "storage"
+purpose = "Session store and memory engine for Aletheia"
+depends_on = ["eidos", "episteme", "graphe", "krites"]
+used_by = ["aletheia", "diaporeia", "nous", "pylon"]
+features = { "default" = "fjall + graph-algo + mneme-engine", "embed-candle" = "local ML embeddings via candle", "fjall" = "fjall session backend", "graph-algo" = "graph algorithm support via episteme", "mneme-engine" = "Datalog knowledge store and typed query builder", "sqlite" = "SQLite session backend", "storage-fjall" = "fjall-backed knowledge store", "test-core" = "test tier with storage-fjall", "test-full" = "full test tier with candle embeddings", "test-support" = "test helpers and fixtures" }
+
+[crates.nous]
+path = "crates/nous"
+layer = "runtime"
+purpose = "Agent session pipeline — bootstrap, routing, tool execution"
+depends_on = ["dianoia", "eidos", "episteme", "hermeneus", "koina", "melete", "mneme", "organon", "taxis", "thesauros"]
+used_by = ["aletheia", "diaporeia", "pylon"]
+features = { "knowledge-store" = "enables mneme knowledge store", "test-core" = "test tier with knowledge-store", "test-full" = "full test tier fixtures", "test-support" = "mock search and test helpers" }
+
+[crates.oikonomos]
+path = "crates/daemon"
+layer = "ops"
+purpose = "Per-nous background task runner, cron scheduling, maintenance services, prosoche attention, watchdog"
+depends_on = ["episteme", "koina"]
+used_by = ["aletheia"]
+features = { "default" = "fjall backend", "fjall" = "fjall task-state backend", "knowledge-store" = "anomaly detection via episteme knowledge store", "sqlite" = "SQLite task-state backend", "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.organon]
+path = "crates/organon"
+layer = "tool"
+purpose = "Tool registry, definitions, and built-in tool executors"
+depends_on = ["energeia", "hermeneus", "koina", "taxis"]
+used_by = ["aletheia", "diaporeia", "nous", "pylon", "thesauros"]
+features = { "computer-use" = "screen capture and Landlock sandbox tools", "energeia" = "energeia subsystem tool integrations", "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures", "test-support" = "mock executor and spec helpers" }
+
+[crates.poiesis-core]
+path = "crates/poiesis/core"
+layer = "types"
+purpose = "Format-agnostic document model and Renderer trait for poiesis"
+depends_on = []
+used_by = ["poiesis-sheet", "poiesis-slides", "poiesis-text"]
+features = {}
+
+[crates.poiesis-sheet]
+path = "crates/poiesis/sheet"
+layer = "tool"
+purpose = "XLSX and ODS spreadsheet rendering backends for poiesis"
+depends_on = ["poiesis-core"]
+used_by = []
+features = { "default" = "xlsx + ods", "ods" = "ODS backend via spreadsheet-ods", "xlsx" = "XLSX backend via rust_xlsxwriter" }
+
+[crates.poiesis-slides]
+path = "crates/poiesis/slides"
+layer = "tool"
+purpose = "PPTX presentation rendering backend for poiesis"
+depends_on = ["poiesis-core"]
+used_by = []
+features = { "default" = "pptx", "pptx" = "PPTX backend via ppt-rs" }
+
+[crates.poiesis-text]
+path = "crates/poiesis/text"
+layer = "tool"
+purpose = "PDF and ODT document rendering backends for poiesis"
+depends_on = ["poiesis-core"]
+used_by = []
+features = { "default" = "pdf + odt", "odt" = "ODT backend via zip", "pdf" = "PDF backend via krilla" }
+
+[crates.proskenion]
+path = "crates/theatron/proskenion"
+layer = "desktop"
+purpose = "Dioxus desktop UI for the Aletheia distributed cognition system"
+depends_on = ["skene"]
+used_by = []
+features = {}
+
+[crates.pylon]
+path = "crates/pylon"
+layer = "http"
+purpose = "Axum HTTP gateway for Aletheia"
+depends_on = ["hermeneus", "koina", "mneme", "nous", "organon", "symbolon", "taxis"]
+used_by = ["aletheia"]
+features = { "knowledge-store" = "enables nous knowledge store", "test-core" = "test tier with knowledge-store", "test-full" = "full test tier fixtures", "tls" = "TLS support via axum-server" }
+
+[crates.skene]
+path = "crates/theatron/skene"
+layer = "desktop"
+purpose = "Shared API client, types, SSE, and streaming infrastructure for Aletheia UIs"
+depends_on = ["koina"]
+used_by = ["koilon", "proskenion", "theatron"]
+features = { "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.symbolon]
+path = "crates/symbolon"
+layer = "ops"
+purpose = "Authentication and authorization for Aletheia"
+depends_on = ["koina"]
+used_by = ["aletheia", "diaporeia", "pylon"]
+features = { "default" = "fjall backend", "fjall" = "fjall credential storage backend", "keyring" = "OS keyring integration", "sqlite" = "SQLite credential storage backend", "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures", "test-support" = "test helpers and fixtures" }
+
+[crates.taxis]
+path = "crates/taxis"
+layer = "types"
+purpose = "Configuration cascade and path resolution for Aletheia"
+depends_on = ["eidos", "koina"]
+used_by = ["agora", "aletheia", "diaporeia", "nous", "organon", "pylon"]
+features = { "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }
+
+[crates.theatron]
+path = "crates/theatron"
+layer = "desktop"
+purpose = "Thin facade re-exporting skene types for external consumers"
+depends_on = ["skene"]
+used_by = []
+features = {}
+
+[crates.thesauros]
+path = "crates/thesauros"
+layer = "storage"
+purpose = "Domain pack loader — external knowledge, tools, and config overlays"
+depends_on = ["koina", "organon"]
+used_by = ["aletheia", "nous"]
+features = { "test-core" = "test tier fixtures", "test-full" = "full test tier fixtures" }


### PR DESCRIPTION
## Summary
- New root CRATE-INDEX.toml — 239 lines — with every workspace crate entry: path, layer, purpose, depends_on, used_by, features.

Closes #3350

🤖 Kimi okabe (v1.30.0)