### PR TITLE
ci: add Rust PR workflow, enable cargo-audit/deny enforcement, fix deny.toml (#3469 #3377 #3375)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,21 @@
+# cargo-audit configuration.
+#
+# WHY: cargo-audit does not read deny.toml. This file mirrors the advisory
+# ignore list in deny.toml so both tools stay in sync. When adding or
+# removing an ignore here, update deny.toml's [[advisories.ignore]]
+# entries to match (and vice versa). See standards/CI.md § Vulnerability
+# scanning for policy.
+
+[advisories]
+ignore = [
+    # yaml-rust unmaintained — transitive via syntect/aletheia-tui, no safe upgrade
+    "RUSTSEC-2024-0320",
+    # bincode unmaintained — transitive via syntect/aletheia-tui, no safe upgrade
+    "RUSTSEC-2025-0141",
+    # paste unmaintained — transitive via tokenizers; no safe upgrade
+    "RUSTSEC-2024-0436",
+    # rustls-pemfile unmaintained — transitive via tonic/qdrant-client; tracked in follow-up issue
+    "RUSTSEC-2025-0134",
+    # rand 0.8.5 unsound with custom logger using rand::rng() — transitive via tonic/qdrant-client; tracked in follow-up issue
+    "RUSTSEC-2026-0097",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+# WHY: Run the full Rust gate on every PR — format, type check, clippy (zero
+# warnings), and the workspace test suite. These are the commands CLAUDE.md
+# lists under "Before submitting"; until this workflow existed, nothing on CI
+# enforced them. Scoped to ubuntu-latest for now; macOS lives behind issue
+# #3390 and slots in as another matrix entry when unblocked.
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# PROJECT: explicit top-level default deny; job-level permissions grant only what's needed
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  # WHY: workspace MSRV is 1.94 (Cargo.toml workspace.package.rust-version).
+  # The stable toolchain is used everywhere; MSRV is enforced by the compiler.
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false # PROJECT: security hardening — never expose token to steps
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          components: rustfmt
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+  check-clippy-test:
+    # WHY: single job on ubuntu runs check, clippy, and test sharing one
+    # target/ cache. Splitting them across jobs would rebuild the workspace
+    # 3× and burn ~30 min of runner time per PR. Structure is a matrix so
+    # macOS (#3390) slots in when unblocked without restructuring.
+    name: ${{ matrix.name }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: check + clippy + test
+            os: ubuntu-latest
+            features: test-core
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # WHY: one cache per OS so macOS (when added) doesn't clobber Linux.
+          key: ${{ matrix.os }}-${{ matrix.features }}
+
+      - name: cargo check --workspace --features ${{ matrix.features }}
+        run: cargo check --workspace --features ${{ matrix.features }} --all-targets
+
+      - name: cargo clippy --workspace --features ${{ matrix.features }} -- -D warnings
+        # WHY: RUSTFLAGS already sets -D warnings, but pass it to clippy
+        # explicitly too so the intent is local to the step.
+        run: cargo clippy --workspace --features ${{ matrix.features }} --all-targets -- -D warnings
+
+      - name: cargo test --workspace --features ${{ matrix.features }}
+        run: cargo test --workspace --features ${{ matrix.features }} --no-fail-fast

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,72 @@
+# WHY: Block merges on known vulnerabilities and license/source/ban
+# violations. Runs `cargo audit` (RustSec DB) and `cargo deny check`
+# (licenses, sources, bans, advisories) on every PR and daily against main
+# so newly-published CVEs against existing deps are caught even when no PR
+# is open. See standards/CI.md § Vulnerability scanning.
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # NOTE: Daily at 05:00 CST (11:00 UTC), avoids overlap with CodeQL
+    # (Wednesday 08:00 CST) and Fuzz (Saturday 04:00 CST).
+    - cron: "0 11 * * *"
+  workflow_dispatch:
+
+# PROJECT: explicit top-level default deny; job-level permissions grant only what's needed
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-deny:
+    # WHY: checks licenses, banned crates (openssl-sys), source registries,
+    # and the RustSec advisory DB using deny.toml's ignore list. Any
+    # finding fails the job — suppressions require a deny.toml entry with
+    # a WHY comment, not silent --ignore flags.
+    name: cargo deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false # PROJECT: security hardening — never expose token to steps
+      - uses: EmbarkStudios/cargo-deny-action@30f817c6f72275c6d54dc744fbca09ebc958599f # v2.0.14
+        with:
+          command: check
+          # WHY: run every check explicitly so a schema regression in one
+          # section can't silently disable the others.
+          arguments: --all-features advisories licenses bans sources
+
+  cargo-audit:
+    # WHY: cargo-deny's advisories check overlaps but uses a different code
+    # path; running cargo-audit independently protects against bugs or
+    # config drift disabling one of the two. See standards/CI.md.
+    name: cargo audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cargo-audit
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version ^0.22
+      - name: cargo audit
+        # WHY: -D unmaintained,unsound,yanked escalates those categories
+        # to errors (default is warning only). Suppressions go through
+        # .cargo/audit.toml, which mirrors deny.toml's [[advisories.ignore]]
+        # entries — no silent --ignore flags here.
+        run: cargo audit --deny unmaintained --deny unsound --deny yanked

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,10 @@ tui/target/
 fuzz/target/
 fuzz/artifacts/
 fuzz/Cargo.lock
-.cargo/
+.cargo/*
+# Keep cargo-audit config under version control so CI and local runs share the same
+# advisory-ignore list (mirrors deny.toml's [[advisories.ignore]]).
+!.cargo/audit.toml
 
 # === Model caches ===
 .fastembed_cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -6203,9 +6203,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,14 @@ reason = "bincode unmaintained — transitive via syntect/aletheia-tui, no safe 
 id = "RUSTSEC-2024-0436"
 reason = "paste unmaintained, transitive via tokenizers; no safe upgrade"
 
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0134"
+reason = "rustls-pemfile unmaintained — transitive via tonic 0.12/qdrant-client 1.17; tracked in follow-up issue to upgrade qdrant-client when its tonic upgrades"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0097"
+reason = "rand 0.8.5 unsound only when a custom logger calls rand::rng() — we don't; transitive via tonic 0.12/qdrant-client 1.17 and rust_decimal/spreadsheet-ods; tracked in follow-up issue"
+
 [licenses]
 allow = [
     "MIT",
@@ -32,9 +40,7 @@ allow = [
     "0BSD",
     "MPL-2.0",              # option-ext, smartstring
     "LGPL-3.0-or-later",    # priority-queue
-    "CDLA-Permissive-2.0",  # webpki-roots, webpki-root-certs,
-,
-
+    "CDLA-Permissive-2.0",  # webpki-roots, webpki-root-certs
 ]
 confidence-threshold = 0.8
 
@@ -133,7 +139,7 @@ skip = [
     # WHY: some deps have not yet migrated to rand 0.10 (e.g., rmcp uses 0.10,
     # while older audio/crypto crates still pull rand 0.9).
     # Blocked until all transitive deps migrate to rand 0.10.
-    { name = "rand", version = "=0.9.2" },
+    { name = "rand", version = "=0.9.4" },
 
     # WHY: password-hash pins rand_core 0.6; rand 0.9 chain uses rand_core 0.9.
     # Canonical: rand_core 0.10 (rand 0.10). Blocked on rand ecosystem upgrade.
@@ -159,9 +165,8 @@ skip = [
     { name = "toml", version = "=0.8.23" },
     { name = "toml_datetime", version = "=0.6.11" },
 
-    # WHY: cron crate pins winnow 0.6; toml_edit pins winnow 0.7.
-    # Canonical: winnow 1.0 (toml 1.x). Blocked until cron and toml_edit update.
-    { name = "winnow", version = "=0.6.26" },
+    # WHY: toml_edit pins winnow 0.7.
+    # Canonical: winnow 1.0 (toml 1.x). Blocked until toml_edit updates.
     { name = "winnow", version = "=0.7.15" },
 ]
 


### PR DESCRIPTION
## Summary

Bundles three CI gaps into one PR. Before this change nothing on CI ran `cargo test`, `cargo clippy`, or `cargo build` on PRs, `cargo-audit`/`cargo-deny` weren't wired up at all, and `deny.toml` had a parse error that silently disabled every cargo-deny check.

- **#3469** — new `.github/workflows/ci.yml` runs `cargo fmt --check`, `cargo check --workspace --features test-core`, `cargo clippy --workspace --features test-core -- -D warnings`, and `cargo test --workspace --features test-core` on every PR. Structured as a matrix on `ubuntu-latest` so macOS (#3390) slots in as another matrix entry without restructuring.
- **#3377** — new `.github/workflows/security.yml` runs `cargo deny check` (advisories, licenses, bans, sources) and `cargo audit --deny unmaintained --deny unsound --deny yanked` on every PR, on pushes to `main`, and daily at 05:00 CST. Both tools share an advisory-ignore list: `deny.toml` is canonical, `.cargo/audit.toml` mirrors it (cargo-audit does not read deny.toml).
- **#3375** — `deny.toml` `[licenses].allow` had a stray `,` after `CDLA-Permissive-2.0` followed by a bare `,` on its own line. cargo-deny bailed with `expected a value, found a comma` and silently disabled every check. Fixed, plus:
  - Updated `rustls-webpki` 0.103.10 -> 0.103.12 (RUSTSEC-2026-0098 / -2026-0099 — name-constraint handling in rustls-webpki).
  - Updated `fastrand` 2.4.0 -> 2.4.1 (yanked).
  - Added ignore entries for RUSTSEC-2025-0134 (`rustls-pemfile` unmaintained) and RUSTSEC-2026-0097 (`rand` 0.8 unsound with a custom-logger `rand::rng()` — we don't use one). Both are transitive via tonic 0.12 / qdrant-client 1.17; follow-up issue filed for the qdrant-client upgrade.
  - Refreshed stale skips: `rand =0.9.2` -> `=0.9.4`, dropped `winnow =0.6.26` (no longer in the lockfile).

## Local verification

```
$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok

$ cargo audit --deny unmaintained --deny unsound --deny yanked
(exit 0)
```

## Known follow-ups (filed separately)

- `cargo fmt --check` will fail on `main` today — pre-existing violations across ~386 files. Fixing inline would balloon this PR from ~200 lines to ~5,900 lines and bury the CI changes. Filed as a separate issue; the follow-up PR will be a pure `cargo fmt --all` run.
- qdrant-client upgrade to drop the tonic-0.12 chain (unpins `rustls-pemfile` and `rand` 0.8).
- `cargo clippy --workspace --features test-core -- -D warnings` may surface pedantic warnings that haven't been gated before; findings will be tracked in a follow-up issue if any appear on the first PR run.

## Test plan

- [ ] New `CI` workflow runs on this PR and surfaces any fmt/clippy/test gaps vs. current `main`.
- [ ] New `Security` workflow runs cargo-deny and cargo-audit to completion on this PR.
- [ ] On merge, scheduled Security run fires daily at 05:00 CST against `main`.
- [ ] When `cargo fmt --check` fails on `main` (expected), the follow-up fmt-only PR unblocks.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>