### PR TITLE
refactor(deps): unify sha2 to 0.11 across workspace (#3443)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,12 +1241,6 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -1539,6 +1539,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,8 +1836,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -2836,7 +2845,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "snafu",
  "tokio",
  "tower 0.5.3",
@@ -2882,6 +2891,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4621,7 +4639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
  "password-hash 0.4.2",
  "sha2 0.10.9",
 ]
@@ -4633,7 +4651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -6886,7 +6904,7 @@ dependencies = [
  "blake3",
  "criterion",
  "fjall",
- "hmac",
+ "hmac 0.13.0",
  "jiff",
  "keyring",
  "koina",
@@ -6897,7 +6915,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "snafu",
  "subtle",
  "tempfile",
@@ -8948,7 +8966,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "sha1",
  "time",
@@ -8971,7 +8989,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "getrandom 0.3.4",
- "hmac",
+ "hmac 0.12.1",
  "indexmap 2.14.0",
  "lzma-rs",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,8 +190,8 @@ rustls = { version = "0.23", default-features = false, features = [
 ] }
 
 # Cryptography (RustCrypto)
-hmac = { version = "0.12", default-features = false }
-sha2 = { version = "0.10", default-features = false }
+hmac = { version = "0.13", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 aes-gcm = "0.10"
 chacha20poly1305 = "0.10"
 rcgen = "0.14"

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -75,7 +75,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 qdrant-client = { version = "1", optional = true }
 rand = { workspace = true }
-sha2 = "0.11"
+sha2 = { workspace = true }
 anyhow = "1"
 snafu = { workspace = true }
 rcgen = { workspace = true }

--- a/crates/graphe/Cargo.toml
+++ b/crates/graphe/Cargo.toml
@@ -30,7 +30,7 @@ prometheus = { workspace = true }
 rusqlite = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = { version = "0.11", optional = true }
+sha2 = { workspace = true, optional = true }
 snafu = { workspace = true }
 tempfile = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/krites/Cargo.toml
+++ b/crates/krites/Cargo.toml
@@ -45,7 +45,7 @@ itertools = { version = "0.14.0", default-features = false, features = ["use_std
 rustc-hash = { version = "2.1.2", default-features = false, features = ["std"] }
 twox-hash = "2.1"
 regex = { workspace = true }
-sha2 = { version = "0.11", default-features = false }
+sha2 = { workspace = true, default-features = false }
 either = { version = "1", default-features = false }
 rand = { workspace = true }
 base64 = { workspace = true }

--- a/crates/symbolon/src/jwt.rs
+++ b/crates/symbolon/src/jwt.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 use tracing::instrument;
 


### PR DESCRIPTION
## Summary
- Bump workspace sha2 0.10 → 0.11; every direct sha2=0.11 in crate manifests now inherits from workspace.
- `cargo check --workspace` clean.

Closes #3443

🤖 Kimi okabe (v1.30.0)