### PR TITLE
chore(fmt): workspace-wide cargo fmt --all (#3499)

### DIFF
--- a/crates/agora/src/listener.rs
+++ b/crates/agora/src/listener.rs
@@ -69,10 +69,7 @@ impl ChannelListener {
     /// independently (e.g., merging Signal + future Slack receivers).
     /// Abort callbacks are registered at construction time for each handle.
     #[must_use]
-    pub(crate) fn from_parts(
-        rx: mpsc::Receiver<InboundMessage>,
-        handles: JoinSet<()>,
-    ) -> Self {
+    pub(crate) fn from_parts(rx: mpsc::Receiver<InboundMessage>, handles: JoinSet<()>) -> Self {
         Self::from_parts_with_config(rx, handles, Self::DEFAULT_MAX_CONCURRENT_HANDLERS)
     }
 
@@ -168,7 +165,10 @@ impl ChannelListener {
     }
 
     /// Stop all polling tasks.
-    #[cfg_attr(not(test), expect(dead_code, reason = "explicit stop for channel listener polling tasks"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "explicit stop for channel listener polling tasks")
+    )]
     pub(crate) fn stop(self) {
         drop(self);
     }

--- a/crates/agora/src/metrics.rs
+++ b/crates/agora/src/metrics.rs
@@ -28,7 +28,10 @@ static ACTIVE_SUBSCRIPTIONS: LazyLock<IntGauge> = LazyLock::new(|| {
     .expect("metric registration")
 });
 
-#[cfg_attr(not(test), expect(dead_code, reason = "metric init called from server startup"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "metric init called from server startup")
+)]
 /// Force-initialize all lazy metric statics.
 pub(crate) fn init() {
     LazyLock::force(&CHANNEL_MESSAGES_TOTAL);
@@ -56,36 +59,50 @@ mod tests {
     fn init_registers_all_metrics() {
         init();
         // Verify metrics are registered by accessing them
-        let _ = CHANNEL_MESSAGES_TOTAL.with_label_values(&["test", "ok"]).get();
+        let _ = CHANNEL_MESSAGES_TOTAL
+            .with_label_values(&["test", "ok"])
+            .get();
         let _ = ACTIVE_SUBSCRIPTIONS.get();
     }
 
     #[test]
     fn record_channel_message_increments_counter() {
         let channel_id = "test-channel";
-        let ok_before = CHANNEL_MESSAGES_TOTAL.with_label_values(&[channel_id, "ok"]).get();
-        let error_before = CHANNEL_MESSAGES_TOTAL.with_label_values(&[channel_id, "error"]).get();
+        let ok_before = CHANNEL_MESSAGES_TOTAL
+            .with_label_values(&[channel_id, "ok"])
+            .get();
+        let error_before = CHANNEL_MESSAGES_TOTAL
+            .with_label_values(&[channel_id, "error"])
+            .get();
 
         record_channel_message(channel_id, true);
         assert_eq!(
-            CHANNEL_MESSAGES_TOTAL.with_label_values(&[channel_id, "ok"]).get(),
+            CHANNEL_MESSAGES_TOTAL
+                .with_label_values(&[channel_id, "ok"])
+                .get(),
             ok_before + 1,
             "ok counter should increment for success=true"
         );
         assert_eq!(
-            CHANNEL_MESSAGES_TOTAL.with_label_values(&[channel_id, "error"]).get(),
+            CHANNEL_MESSAGES_TOTAL
+                .with_label_values(&[channel_id, "error"])
+                .get(),
             error_before,
             "error counter should not change for success=true"
         );
 
         record_channel_message(channel_id, false);
         assert_eq!(
-            CHANNEL_MESSAGES_TOTAL.with_label_values(&[channel_id, "ok"]).get(),
+            CHANNEL_MESSAGES_TOTAL
+                .with_label_values(&[channel_id, "ok"])
+                .get(),
             ok_before + 1,
             "ok counter should be unchanged after error"
         );
         assert_eq!(
-            CHANNEL_MESSAGES_TOTAL.with_label_values(&[channel_id, "error"]).get(),
+            CHANNEL_MESSAGES_TOTAL
+                .with_label_values(&[channel_id, "error"])
+                .get(),
             error_before + 1,
             "error counter should increment for success=false"
         );
@@ -94,11 +111,7 @@ mod tests {
     #[test]
     fn set_active_subscriptions_updates_gauge() {
         set_active_subscriptions(3);
-        assert_eq!(
-            ACTIVE_SUBSCRIPTIONS.get(),
-            3,
-            "gauge should be set to 3"
-        );
+        assert_eq!(ACTIVE_SUBSCRIPTIONS.get(), 3, "gauge should be set to 3");
 
         set_active_subscriptions(10);
         assert_eq!(

--- a/crates/agora/src/registry.rs
+++ b/crates/agora/src/registry.rs
@@ -48,7 +48,10 @@ impl ChannelRegistry {
 
     /// Look up a provider by channel ID.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "channel registry provider dispatch"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "channel registry provider dispatch")
+    )]
     pub(crate) fn get(&self, channel_id: &str) -> Option<&Arc<dyn ChannelProvider>> {
         self.providers.get(channel_id)
     }
@@ -94,21 +97,30 @@ impl ChannelRegistry {
     ///
     /// O(c) where c is the number of registered channels.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "channel registry provider dispatch"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "channel registry provider dispatch")
+    )]
     pub(crate) fn channels(&self) -> Vec<&str> {
         self.providers.keys().map(String::as_str).collect()
     }
 
     /// Number of registered channels.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "channel registry provider dispatch"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "channel registry provider dispatch")
+    )]
     pub(crate) fn len(&self) -> usize {
         self.providers.len()
     }
 
     /// Whether the registry is empty.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "channel registry infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "channel registry infrastructure")
+    )]
     pub(crate) fn is_empty(&self) -> bool {
         self.providers.is_empty()
     }

--- a/crates/agora/src/semeion/client.rs
+++ b/crates/agora/src/semeion/client.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use tracing::instrument;
 
-
 use koina::http::CONTENT_TYPE_JSON;
 
 use super::envelope::SignalEnvelope;
@@ -227,7 +226,9 @@ impl SignalClient {
                     .filter_map(|item| {
                         let env_value = item.get("envelope").cloned().unwrap_or(item);
                         serde_json::from_value::<SignalEnvelope>(env_value)
-                            .inspect_err(|e| tracing::debug!(error = %e, "skipping unparseable envelope"))
+                            .inspect_err(
+                                |e| tracing::debug!(error = %e, "skipping unparseable envelope"),
+                            )
                             .ok()
                     })
                     .collect();
@@ -239,7 +240,10 @@ impl SignalClient {
 
     /// The base RPC URL this client targets.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "Signal client RPC URL accessor for diagnostics"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "Signal client RPC URL accessor for diagnostics")
+    )]
     pub(crate) fn rpc_url(&self) -> &str {
         &self.rpc_url
     }
@@ -306,7 +310,8 @@ impl SendParams {
 
 fn normalize_url(url: &str) -> String {
     let trimmed = url.trim_end_matches('/');
-    if trimmed.starts_with("http://") || trimmed.starts_with("https://") { // SAFE: protocol detection, not endpoint construction // kanon:ignore SECURITY/insecure-transport -- protocol detection, not an endpoint
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        // SAFE: protocol detection, not endpoint construction // kanon:ignore SECURITY/insecure-transport -- protocol detection, not an endpoint
         trimmed.to_owned()
     } else {
         format!("http://{trimmed}") // SAFE: signal-cli daemon is localhost-only, no network traversal

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -361,8 +361,14 @@ impl ChannelProvider for SignalProvider {
                     let map = detail.as_object_mut();
                     debug_assert!(map.is_some(), "detail is a JSON object");
                     if let Some(map) = map {
-                        map.insert("connection_state".to_owned(), serde_json::json!(format!("{:?}", s.state)));
-                        map.insert("buffered_messages".to_owned(), serde_json::json!(s.buffered_count()));
+                        map.insert(
+                            "connection_state".to_owned(),
+                            serde_json::json!(format!("{:?}", s.state)),
+                        );
+                        map.insert(
+                            "buffered_messages".to_owned(),
+                            serde_json::json!(s.buffered_count()),
+                        );
                     }
                 }
 
@@ -638,7 +644,11 @@ mod tests {
         token.cancel();
         drop(rx);
         let mut handles = handles;
-        while let Some(result) = tokio::time::timeout(Duration::from_secs(5), handles.join_next()).await.ok().flatten() {
+        while let Some(result) = tokio::time::timeout(Duration::from_secs(5), handles.join_next())
+            .await
+            .ok()
+            .flatten()
+        {
             let _ = result;
         }
     }
@@ -674,7 +684,11 @@ mod tests {
         token.cancel();
         drop(rx);
         let mut handles = handles;
-        while let Some(result) = tokio::time::timeout(Duration::from_secs(5), handles.join_next()).await.ok().flatten() {
+        while let Some(result) = tokio::time::timeout(Duration::from_secs(5), handles.join_next())
+            .await
+            .ok()
+            .flatten()
+        {
             let _ = result;
         }
     }

--- a/crates/agora/tests/public_api.rs
+++ b/crates/agora/tests/public_api.rs
@@ -422,7 +422,10 @@ fn registry_register_duplicate_fails() {
         err_msg.contains("duplicate channel"),
         "error should indicate duplicate: {err_msg}"
     );
-    assert!(err_msg.contains("signal"), "error should name the channel: {err_msg}");
+    assert!(
+        err_msg.contains("signal"),
+        "error should name the channel: {err_msg}"
+    );
 }
 
 #[tokio::test]
@@ -442,7 +445,10 @@ async fn registry_send_verifies_provider_registered() {
     };
 
     // This will only succeed if the provider is registered
-    let result = registry.send("signal", &params).await.expect("send succeeds");
+    let result = registry
+        .send("signal", &params)
+        .await
+        .expect("send succeeds");
     assert!(result.sent);
 }
 
@@ -461,7 +467,10 @@ async fn registry_send_to_existing_channel() {
         attachments: None,
     };
 
-    let result = registry.send("signal", &params).await.expect("send succeeds");
+    let result = registry
+        .send("signal", &params)
+        .await
+        .expect("send succeeds");
     assert!(result.sent);
 }
 
@@ -477,7 +486,10 @@ async fn registry_send_to_missing_channel_fails() {
         attachments: None,
     };
 
-    let err = registry.send("nonexistent", &params).await.expect_err("send fails");
+    let err = registry
+        .send("nonexistent", &params)
+        .await
+        .expect_err("send fails");
     let err_msg = err.to_string();
     assert!(
         err_msg.contains("unknown channel"),
@@ -505,8 +517,12 @@ async fn registry_probe_all_collects_results() {
         details: None,
     };
 
-    registry.register(Arc::new(ok_provider)).expect("register signal");
-    registry.register(Arc::new(fail_provider)).expect("register slack");
+    registry
+        .register(Arc::new(ok_provider))
+        .expect("register signal");
+    registry
+        .register(Arc::new(fail_provider))
+        .expect("register slack");
 
     let results = registry.probe_all().await;
     assert_eq!(results.len(), 2);
@@ -1132,7 +1148,10 @@ fn connection_health_report_clone() {
     let cloned = original.clone();
     assert_eq!(original.buffered_messages, cloned.buffered_messages);
     assert_eq!(original.dropped_count, cloned.dropped_count);
-    assert_eq!(format!("{:?}", original.state), format!("{:?}", cloned.state));
+    assert_eq!(
+        format!("{:?}", original.state),
+        format!("{:?}", cloned.state)
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aletheia/src/cli.rs
+++ b/crates/aletheia/src/cli.rs
@@ -24,7 +24,11 @@ use crate::commands::session_export::SessionExportArgs;
 use crate::commands::tls;
 
 #[derive(Debug, Parser)]
-#[command(name = "aletheia", about = "Cognitive agent runtime. Run with no subcommand to start the HTTP server.", version)]
+#[command(
+    name = "aletheia",
+    about = "Cognitive agent runtime. Run with no subcommand to start the HTTP server.",
+    version
+)]
 pub(crate) struct Cli {
     /// Path to instance root directory
     #[arg(short = 'r', long)]

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -336,9 +336,8 @@ pub(crate) fn import_agent(instance_root: Option<&PathBuf>, args: &ImportArgs) -
         force: args.force,
     };
     let id_gen = || koina::ulid::Ulid::new().to_string();
-    let result =
-        mneme::import::import_agent(&agent_file, &store, &workspace_path, &id_gen, &opts)
-            .whatever_context("import failed")?;
+    let result = mneme::import::import_agent(&agent_file, &store, &workspace_path, &id_gen, &opts)
+        .whatever_context("import failed")?;
 
     println!("Imported agent: {}", result.nous_id);
     println!("Files restored: {}", result.files_restored);
@@ -423,8 +422,7 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
             if let Some(existing_id) = existing {
                 if args.force {
                     if let Err(e) = store.forget_fact(
-                        &mneme::id::FactId::new(existing_id)
-                            .whatever_context("invalid fact id")?,
+                        &mneme::id::FactId::new(existing_id).whatever_context("invalid fact id")?,
                         mneme::knowledge::ForgetReason::Outdated,
                     ) {
                         eprintln!("  WARN: failed to supersede {slug}: {e}");
@@ -442,8 +440,7 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
 
             let fact_id = koina::ulid::Ulid::new().to_string();
             let fact = Fact {
-                id: mneme::id::FactId::new(fact_id.clone())
-                    .whatever_context("invalid fact id")?,
+                id: mneme::id::FactId::new(fact_id.clone()).whatever_context("invalid fact id")?,
                 nous_id: nous_id.to_owned(),
                 content: content_json.clone(),
                 fact_type: "skill".to_owned(),
@@ -478,8 +475,7 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
             let embedding_text = format!("{}: {}", skill.name, skill.description);
             let emb_id = koina::ulid::Ulid::new().to_string();
             let chunk = mneme::knowledge::EmbeddedChunk {
-                id: mneme::id::EmbeddingId::new(emb_id)
-                    .whatever_context("invalid embedding id")?,
+                id: mneme::id::EmbeddingId::new(emb_id).whatever_context("invalid embedding id")?,
                 content: embedding_text,
                 source_type: "fact".to_owned(),
                 source_id: fact_id,
@@ -674,8 +670,7 @@ pub(crate) async fn review_skills(
                 let fid = args.fact_id.as_deref().ok_or_else(|| {
                     crate::error::Error::msg("--fact-id required for approve action")
                 })?;
-                let fact_id =
-                    mneme::id::FactId::new(fid).whatever_context("invalid fact id")?;
+                let fact_id = mneme::id::FactId::new(fid).whatever_context("invalid fact id")?;
                 let new_id = store
                     .approve_pending_skill(&fact_id, nous_id)
                     .whatever_context("failed to approve skill")?;
@@ -685,8 +680,7 @@ pub(crate) async fn review_skills(
                 let fid = args.fact_id.as_deref().ok_or_else(|| {
                     crate::error::Error::msg("--fact-id required for reject action")
                 })?;
-                let fact_id =
-                    mneme::id::FactId::new(fid).whatever_context("invalid fact id")?;
+                let fact_id = mneme::id::FactId::new(fid).whatever_context("invalid fact id")?;
                 store
                     .reject_pending_skill(&fact_id)
                     .whatever_context("failed to reject skill")?;

--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -121,11 +121,7 @@ fn run_list(manager: &mneme::backup::BackupManager<'_>, json: bool) -> Result<()
     Ok(())
 }
 
-fn run_prune(
-    manager: &mneme::backup::BackupManager<'_>,
-    keep: usize,
-    yes: bool,
-) -> Result<()> {
+fn run_prune(manager: &mneme::backup::BackupManager<'_>, keep: usize, yes: bool) -> Result<()> {
     let backups = manager
         .list_backups()
         .whatever_context("failed to list backups")?;

--- a/crates/aletheia/src/commands/benchmark.rs
+++ b/crates/aletheia/src/commands/benchmark.rs
@@ -59,8 +59,12 @@ pub(crate) async fn run(args: BenchmarkArgs) -> Result<()> {
     match args.action {
         BenchmarkAction::List => {
             println!("Available benchmarks:\n");
-            println!("  longmemeval   LongMemEval (arxiv 2410.10813) — 500 questions, 5 memory abilities");
-            println!("  locomo        LoCoMo (arxiv 2402.17753) — 50 conversations, ~200 QA each\n");
+            println!(
+                "  longmemeval   LongMemEval (arxiv 2410.10813) — 500 questions, 5 memory abilities"
+            );
+            println!(
+                "  locomo        LoCoMo (arxiv 2402.17753) — 50 conversations, ~200 QA each\n"
+            );
             println!("{}", dokimion::benchmarks::download_instructions());
             Ok(())
         }
@@ -118,17 +122,11 @@ fn print_report_human(report: &BenchmarkReport, nous_id: &str, timeout: u64) {
         println!("{header}");
     }
     println!("{}", "\u{2550}".repeat(header.len()));
-    println!(
-        "Questions: {} | Timeout: {timeout}s\n",
-        report.total
-    );
+    println!("Questions: {} | Timeout: {timeout}s\n", report.total);
 
     // Table header
     println!("Results:");
-    println!(
-        "  {:<30} {:>6} {:>6}",
-        "Category", "EM%", "F1%"
-    );
+    println!("  {:<30} {:>6} {:>6}", "Category", "EM%", "F1%");
     println!("  {}", "\u{2500}".repeat(44));
 
     // Per-category rows
@@ -160,7 +158,10 @@ fn print_report_human(report: &BenchmarkReport, nous_id: &str, timeout: u64) {
             format!("{overall_f1:.1}").green().bold()
         );
     } else {
-        println!("  {:<30} {:>5.1}  {:>5.1}", "Overall", overall_em, overall_f1);
+        println!(
+            "  {:<30} {:>5.1}  {:>5.1}",
+            "Overall", overall_em, overall_f1
+        );
     }
 }
 

--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -134,7 +134,10 @@ pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Resu
             // Check CC provider availability
             if let Some(cc_path) = symbolon::credential::claude_code_default_path() {
                 if cc_path.exists() {
-                    println!("CC provider: Claude Code credentials found at {}", cc_path.display());
+                    println!(
+                        "CC provider: Claude Code credentials found at {}",
+                        cc_path.display()
+                    );
                     found_any = true;
                 } else {
                     println!("CC provider: {} (not found)", cc_path.display());

--- a/crates/aletheia/src/commands/daemon.rs
+++ b/crates/aletheia/src/commands/daemon.rs
@@ -32,8 +32,8 @@ pub(crate) async fn do_daemon() -> Result<()> {
     if let Some(parent) = crash_log_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let stderr_file = std::fs::File::create(&crash_log_path)
-        .context("failed to create daemon stderr log")?;
+    let stderr_file =
+        std::fs::File::create(&crash_log_path).context("failed to create daemon stderr log")?;
 
     let child = std::process::Command::new(&exe)
         .args(&child_args)

--- a/crates/aletheia/src/commands/desktop.rs
+++ b/crates/aletheia/src/commands/desktop.rs
@@ -57,9 +57,7 @@ pub(crate) fn run(args: &DesktopArgs) -> anyhow::Result<()> {
 
     if !status.success() {
         let code = status.code().unwrap_or(1);
-        return Err(anyhow::anyhow!(
-            "`{BINARY_NAME}` exited with status {code}"
-        ));
+        return Err(anyhow::anyhow!("`{BINARY_NAME}` exited with status {code}"));
     }
 
     Ok(())

--- a/crates/aletheia/src/commands/eval_embeddings.rs
+++ b/crates/aletheia/src/commands/eval_embeddings.rs
@@ -72,10 +72,8 @@ fn load_corpus(path: &std::path::Path) -> Result<Vec<(String, String)>> {
         if trimmed.is_empty() {
             continue;
         }
-        let entry: CorpusEntry = serde_json::from_str(trimmed).whatever_context(format!(
-            "corpus line {}: invalid JSON",
-            idx + 1
-        ))?;
+        let entry: CorpusEntry = serde_json::from_str(trimmed)
+            .whatever_context(format!("corpus line {}: invalid JSON", idx + 1))?;
         pairs.push((entry.id, entry.text));
     }
     Ok(pairs)
@@ -174,7 +172,11 @@ fn print_table(run: &mneme::embedding_eval::EvalRunResult) {
         println!("  K         : {}", c.k);
         let diff_rk = c.recall_at_k - b.recall_at_k;
         let diff_mrr = c.mrr - b.mrr;
-        let rk_str = format!("{:.1}%  (Δ {:+.1}%)", c.recall_at_k * 100.0, diff_rk * 100.0);
+        let rk_str = format!(
+            "{:.1}%  (Δ {:+.1}%)",
+            c.recall_at_k * 100.0,
+            diff_rk * 100.0
+        );
         if diff_rk >= 0.0 {
             println!("  Recall@K  : {}", rk_str.green());
         } else {
@@ -194,7 +196,10 @@ fn print_table(run: &mneme::embedding_eval::EvalRunResult) {
     if run.passed {
         println!("  {}", "GATE PASSED".green().bold());
     } else {
-        println!("  {}", "GATE FAILED — candidate regresses Recall@K".red().bold());
+        println!(
+            "  {}",
+            "GATE FAILED — candidate regresses Recall@K".red().bold()
+        );
     }
     println!();
 }
@@ -209,7 +214,10 @@ pub(crate) fn run(args: &EvalEmbeddingsArgs) -> Result<()> {
         .whatever_context("failed to load eval dataset")?;
 
     if dataset.is_empty() {
-        snafu::whatever!("eval dataset is empty: add at least one query to {}", args.dataset.display());
+        snafu::whatever!(
+            "eval dataset is empty: add at least one query to {}",
+            args.dataset.display()
+        );
     }
 
     // Load or use built-in corpus.
@@ -269,7 +277,9 @@ pub(crate) fn run(args: &EvalEmbeddingsArgs) -> Result<()> {
         snafu::whatever!(
             "embedding evaluation gate failed: candidate Recall@{} ({:.1}%) regresses below baseline ({:.1}%)",
             run.candidate.as_ref().map_or(0, |c| c.k),
-            run.candidate.as_ref().map_or(0.0, |c| c.recall_at_k * 100.0),
+            run.candidate
+                .as_ref()
+                .map_or(0.0, |c| c.recall_at_k * 100.0),
             run.baseline.recall_at_k * 100.0,
         )
     }

--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -84,9 +84,8 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
         }
 
         let config = mneme::knowledge_store::KnowledgeConfig::default();
-        let store =
-            mneme::knowledge_store::KnowledgeStore::open_fjall(&knowledge_path, config)
-                .whatever_context("failed to open knowledge store")?;
+        let store = mneme::knowledge_store::KnowledgeStore::open_fjall(&knowledge_path, config)
+            .whatever_context("failed to open knowledge store")?;
 
         match action {
             Action::Check { json } => run_check(&store, json),
@@ -351,9 +350,15 @@ fn find_dangling_edges(
         .whatever_context("dangling edge query failed")?;
     Ok((0..result.row_count())
         .map(|i| {
-            let src = result.get_string(i, "src").unwrap_or_else(|| "?".to_owned());
-            let dst = result.get_string(i, "dst").unwrap_or_else(|| "?".to_owned());
-            let rel = result.get_string(i, "relation").unwrap_or_else(|| "?".to_owned());
+            let src = result
+                .get_string(i, "src")
+                .unwrap_or_else(|| "?".to_owned());
+            let dst = result
+                .get_string(i, "dst")
+                .unwrap_or_else(|| "?".to_owned());
+            let rel = result
+                .get_string(i, "relation")
+                .unwrap_or_else(|| "?".to_owned());
             format!("{src} --[{rel}]--> {dst}")
         })
         .collect())

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -21,9 +21,9 @@ pub(crate) mod tls;
 
 use std::path::PathBuf;
 
-use taxis::oikos::Oikos;
 use anyhow::Result;
 use clap::CommandFactory;
+use taxis::oikos::Oikos;
 
 use crate::cli::{Cli, Command};
 use crate::init;
@@ -84,11 +84,9 @@ pub(crate) async fn dispatch(cmd: Command, instance_root: Option<&PathBuf>) -> R
             .await
             .map_err(Into::into),
         #[cfg(feature = "tui")]
-        Command::Tui(a) => {
-            koilon::run_tui(a.url, a.token, a.agent, a.session, a.logout)
-                .await
-                .map_err(anyhow::Error::from)
-        }
+        Command::Tui(a) => koilon::run_tui(a.url, a.token, a.agent, a.session, a.logout)
+            .await
+            .map_err(anyhow::Error::from),
         #[cfg(not(feature = "tui"))]
         Command::Tui(_) => anyhow::bail!("TUI not available - rebuild with `--features tui`"),
         Command::Desktop(a) => desktop::run(&a),
@@ -99,14 +97,19 @@ pub(crate) async fn dispatch(cmd: Command, instance_root: Option<&PathBuf>) -> R
         Command::SessionExport(a) => session_export::run(&a).await.map_err(Into::into),
         Command::Import(a) => agent_io::import_agent(instance_root, &a).map_err(Into::into),
         Command::SeedSkills(a) => agent_io::seed_skills(&a).map_err(Into::into),
-        Command::ExportSkills(a) => {
-            agent_io::export_skills(instance_root, &a).await.map_err(Into::into)
-        }
-        Command::ReviewSkills(a) => {
-            agent_io::review_skills(instance_root, &a).await.map_err(Into::into)
-        }
+        Command::ExportSkills(a) => agent_io::export_skills(instance_root, &a)
+            .await
+            .map_err(Into::into),
+        Command::ReviewSkills(a) => agent_io::review_skills(instance_root, &a)
+            .await
+            .map_err(Into::into),
         Command::Completions { shell } => {
-            clap_complete::generate(shell, &mut Cli::command(), "aletheia", &mut std::io::stdout());
+            clap_complete::generate(
+                shell,
+                &mut Cli::command(),
+                "aletheia",
+                &mut std::io::stdout(),
+            );
             Ok(())
         }
         Command::MigrateMemory(a) => agent_io::migrate_memory(instance_root, a)

--- a/crates/aletheia/src/commands/repl.rs
+++ b/crates/aletheia/src/commands/repl.rs
@@ -73,9 +73,8 @@ fn run_repl(instance_root: Option<&PathBuf>) -> Result<()> {
     }
 
     let config = mneme::knowledge_store::KnowledgeConfig::default();
-    let store =
-        mneme::knowledge_store::KnowledgeStore::open_fjall(&knowledge_path, config)
-            .whatever_context("failed to open knowledge store")?;
+    let store = mneme::knowledge_store::KnowledgeStore::open_fjall(&knowledge_path, config)
+        .whatever_context("failed to open knowledge store")?;
 
     let stdin = io::stdin();
     let stdout = io::stdout();
@@ -261,7 +260,10 @@ fn print_table(headers: &[String], rows: &[Vec<String>]) {
     }
 
     println!("{sep}");
-    println!("({} row{})", rows.len(), if rows.len() == 1 { "" } else { "s" });
+    println!(
+        "({} row{})",
+        rows.len(),
+        if rows.len() == 1 { "" } else { "s" }
+    );
     println!();
 }
-

--- a/crates/aletheia/src/daemon_bridge.rs
+++ b/crates/aletheia/src/daemon_bridge.rs
@@ -24,8 +24,7 @@ impl DaemonBridge for NousDaemonBridge {
         nous_id: &str,
         session_key: &str,
         prompt: &str,
-    ) -> Pin<Box<dyn Future<Output = oikonomos::error::Result<ExecutionResult>> + Send + '_>>
-    {
+    ) -> Pin<Box<dyn Future<Output = oikonomos::error::Result<ExecutionResult>> + Send + '_>> {
         let nous_id = nous_id.to_owned();
         let session_key = session_key.to_owned();
         let prompt = prompt.to_owned();

--- a/crates/aletheia/src/external_tools.rs
+++ b/crates/aletheia/src/external_tools.rs
@@ -318,8 +318,7 @@ impl ToolExecutor for ExternalToolExecutor {
         &'a self,
         input: &'a ToolInput,
         _ctx: &'a ToolContext,
-    ) -> Pin<Box<dyn Future<Output = organon::error::Result<ToolResult>> + Send + 'a>>
-    {
+    ) -> Pin<Box<dyn Future<Output = organon::error::Result<ToolResult>> + Send + 'a>> {
         Box::pin(async move {
             let payload = serde_json::json!({
                 "tool": self.name,

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -282,7 +282,11 @@ fn collect_interactive(mut answers: Answers) -> Result<Answers, InitError> {
     }
 
     let model: &str = cliclack::select("Default model")
-        .item(koina::defaults::DEFAULT_MODEL_SHORT, "claude-sonnet-4-6 (recommended)", "")
+        .item(
+            koina::defaults::DEFAULT_MODEL_SHORT,
+            "claude-sonnet-4-6 (recommended)",
+            "",
+        )
         .item("claude-opus-4-6", "claude-opus-4-6", "")
         .item("claude-haiku-4-5", "claude-haiku-4-5", "")
         .interact()
@@ -373,9 +377,9 @@ fn collect_credential() -> Result<Option<SecretString>, InitError> {
 mod helpers;
 mod scaffold;
 
-use helpers::{capitalize, detect_timezone};
 #[cfg(feature = "tui")]
 use helpers::set_permissions;
+use helpers::{capitalize, detect_timezone};
 use scaffold::scaffold;
 
 #[cfg(feature = "tui")]
@@ -404,9 +408,7 @@ fn wizard_answers_to_answers(wa: &koilon::wizard::WizardAnswers) -> Answers {
     clippy::disallowed_methods,
     reason = "sync init wizard; no async runtime"
 )]
-fn write_user_profile_from_wizard(
-    wa: &koilon::wizard::WizardAnswers,
-) -> Result<(), InitError> {
+fn write_user_profile_from_wizard(wa: &koilon::wizard::WizardAnswers) -> Result<(), InitError> {
     if wa.user_name.is_empty() && wa.user_role.is_empty() {
         return Ok(());
     }

--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -312,9 +312,7 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                     content: f.content,
                     confidence: f.provenance.confidence,
                     tier: f.provenance.tier.to_string(),
-                    recorded_at: mneme::knowledge::format_timestamp(
-                        &f.temporal.recorded_at,
-                    ),
+                    recorded_at: mneme::knowledge::format_timestamp(&f.temporal.recorded_at),
                     is_forgotten: f.lifecycle.is_forgotten,
                     forgotten_at: f.lifecycle.forgotten_at.map(|s| s.to_string()),
                     forget_reason: f.lifecycle.forget_reason.map(|r| r.to_string()),

--- a/crates/aletheia/src/knowledge_maintenance.rs
+++ b/crates/aletheia/src/knowledge_maintenance.rs
@@ -28,10 +28,7 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
     ///
     /// Updates confidence scores in place for each fact. Facts whose decay score
     /// has dropped more than 10% below their current confidence are updated.
-    fn refresh_decay_scores(
-        &self,
-        nous_id: &str,
-    ) -> oikonomos::error::Result<MaintenanceReport> {
+    fn refresh_decay_scores(&self, nous_id: &str) -> oikonomos::error::Result<MaintenanceReport> {
         let now = jiff::Timestamp::now();
         let now_str = mneme::knowledge::format_timestamp(&now);
 
@@ -105,10 +102,7 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
     }
 
     /// Deduplicates entities by delegating to `KnowledgeStore::run_entity_dedup`.
-    fn deduplicate_entities(
-        &self,
-        nous_id: &str,
-    ) -> oikonomos::error::Result<MaintenanceReport> {
+    fn deduplicate_entities(&self, nous_id: &str) -> oikonomos::error::Result<MaintenanceReport> {
         let records = self.store.run_entity_dedup(nous_id).map_err(|e| {
             oikonomos::error::TaskFailedSnafu {
                 task_id: "entity-dedup".to_owned(),
@@ -147,10 +141,7 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
     ///
     /// Cannot actually embed without an `EmbeddingProvider`, so this reports
     /// the count of current facts and notes that embedding refresh is not yet wired.
-    fn refresh_embeddings(
-        &self,
-        nous_id: &str,
-    ) -> oikonomos::error::Result<MaintenanceReport> {
+    fn refresh_embeddings(&self, nous_id: &str) -> oikonomos::error::Result<MaintenanceReport> {
         let now = jiff::Timestamp::now();
         let now_str = mneme::knowledge::format_timestamp(&now);
         let facts = self
@@ -179,10 +170,7 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
         })
     }
 
-    fn garbage_collect(
-        &self,
-        _nous_id: &str,
-    ) -> oikonomos::error::Result<MaintenanceReport> {
+    fn garbage_collect(&self, _nous_id: &str) -> oikonomos::error::Result<MaintenanceReport> {
         Ok(MaintenanceReport {
             detail: Some(
                 "NOT_IMPLEMENTED: garbage collection of orphaned nodes/expired edges not yet wired"
@@ -192,10 +180,7 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
         })
     }
 
-    fn maintain_indexes(
-        &self,
-        _nous_id: &str,
-    ) -> oikonomos::error::Result<MaintenanceReport> {
+    fn maintain_indexes(&self, _nous_id: &str) -> oikonomos::error::Result<MaintenanceReport> {
         Ok(MaintenanceReport {
             detail: Some("NOT_IMPLEMENTED: index rebuild/optimization not yet wired".to_owned()),
             ..Default::default()
@@ -209,10 +194,7 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
         })
     }
 
-    fn run_skill_decay(
-        &self,
-        nous_id: &str,
-    ) -> oikonomos::error::Result<MaintenanceReport> {
+    fn run_skill_decay(&self, nous_id: &str) -> oikonomos::error::Result<MaintenanceReport> {
         let (active, needs_review, retired) = self.store.run_skill_decay(nous_id).map_err(|e| {
             oikonomos::error::TaskFailedSnafu {
                 task_id: "skill-decay".to_owned(),

--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -21,9 +21,9 @@ mod recall_sources;
 mod runtime;
 mod status;
 
-use koina::system::{Environment, RealSystem};
 use anyhow::Result;
 use clap::Parser;
+use koina::system::{Environment, RealSystem};
 
 use cli::{Cli, Command};
 

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -291,7 +291,8 @@ fn import_fact(
     let valid_from = parse_timestamp(&record.created_at).unwrap_or(now);
 
     let fact = Fact {
-        id: FactId::new(&fact_id).expect("fact_id is `migrated-{hash}` which is non-empty and under MAX_ID_LEN"),
+        id: FactId::new(&fact_id)
+            .expect("fact_id is `migrated-{hash}` which is non-empty and under MAX_ID_LEN"),
         nous_id: agent_id.to_owned(),
         content: record.content.clone(),
         fact_type: String::new(),

--- a/crates/aletheia/src/planning_adapter.rs
+++ b/crates/aletheia/src/planning_adapter.rs
@@ -80,7 +80,8 @@ impl PlanningService for FilesystemPlanningService {
         let project_id = project_id.to_owned();
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
-                let _span = tracing::info_span!("planning_load_project", project_id = %project_id).entered();
+                let _span = tracing::info_span!("planning_load_project", project_id = %project_id)
+                    .entered();
                 let ws_path = root.join(&project_id);
                 let ws = ProjectWorkspace::open(&ws_path).map_err(|e| {
                     WorkspaceSnafu {
@@ -424,13 +425,14 @@ fn find_plan_mut<'a>(
     phase_id: &str,
     plan_id: &str,
 ) -> Result<&'a mut dianoia::plan::Plan, PlanningAdapterError> {
-    let phase_ulid: koina::ulid::Ulid = phase_id.parse().map_err(|e: koina::ulid::DecodeError| {
-        InvalidIdSnafu {
-            kind: "phase_id".to_owned(),
-            message: e.to_string(),
-        }
-        .build()
-    })?;
+    let phase_ulid: koina::ulid::Ulid =
+        phase_id.parse().map_err(|e: koina::ulid::DecodeError| {
+            InvalidIdSnafu {
+                kind: "phase_id".to_owned(),
+                message: e.to_string(),
+            }
+            .build()
+        })?;
     let plan_ulid: koina::ulid::Ulid = plan_id.parse().map_err(|e: koina::ulid::DecodeError| {
         InvalidIdSnafu {
             kind: "plan_id".to_owned(),

--- a/crates/aletheia/src/recall_sources/llm_context.rs
+++ b/crates/aletheia/src/recall_sources/llm_context.rs
@@ -52,9 +52,7 @@ impl ModelCard {
             parts.push(format!("Capabilities: {}", caps.join(", ")));
         }
 
-        if let (Some(input), Some(output)) =
-            (self.input_cost_per_mtok, self.output_cost_per_mtok)
-        {
+        if let (Some(input), Some(output)) = (self.input_cost_per_mtok, self.output_cost_per_mtok) {
             parts.push(format!(
                 "Pricing: ${input:.2}/MTok input, ${output:.2}/MTok output"
             ));
@@ -128,7 +126,10 @@ fn extract_context_size_k(query: &str) -> Option<u64> {
             // WHY: Check for 'k' suffix immediately after digits.
             if bytes.get(i).is_some_and(|&b| b == b'k' || b == b'K') {
                 // SAFETY: start..i are within bounds (guarded by .get() above)
-                #[expect(clippy::string_slice, reason = "bounds verified via .get() checks above")]
+                #[expect(
+                    clippy::string_slice,
+                    reason = "bounds verified via .get() checks above"
+                )]
                 if let Ok(n) = query[start..i].parse::<u64>() {
                     return Some(n);
                 }

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -286,7 +286,9 @@ impl RuntimeBuilder {
         // JWT key resolution
         let jwt_key: Option<SecretString> =
             self.config.gateway.auth.signing_key.clone().or_else(|| {
-                RealSystem.var("ALETHEIA_JWT_SECRET").map(SecretString::from)
+                RealSystem
+                    .var("ALETHEIA_JWT_SECRET")
+                    .map(SecretString::from)
             });
         let jwt_config = match jwt_key {
             Some(k) => JwtConfig {
@@ -339,8 +341,7 @@ impl RuntimeBuilder {
 
         // Register domain pack tools
         if self.domain_packs {
-            let tool_errors =
-                thesauros::tools::register_pack_tools(&packs, &mut tool_registry);
+            let tool_errors = thesauros::tools::register_pack_tools(&packs, &mut tool_registry);
             for err in &tool_errors {
                 warn!(error = %err, "failed to register pack tool");
             }
@@ -419,10 +420,9 @@ impl RuntimeBuilder {
                     Arc::clone(&self.oikos),
                 )));
             let planning_root = self.oikos.data().join("planning");
-            let planning: Option<Arc<dyn organon::types::PlanningService>> =
-                Some(Arc::new(planning_adapter::FilesystemPlanningService::new(
-                    planning_root,
-                )));
+            let planning: Option<Arc<dyn organon::types::PlanningService>> = Some(Arc::new(
+                planning_adapter::FilesystemPlanningService::new(planning_root),
+            ));
             (
                 Some(cross_nous),
                 messenger,
@@ -451,9 +451,8 @@ impl RuntimeBuilder {
         )]
         let vector_search: Option<Arc<dyn nous::recall::VectorSearch>> =
             knowledge_store.as_ref().map(|ks| {
-                Arc::new(nous::recall::KnowledgeVectorSearch::new(
-                    Arc::clone(ks),
-                )) as Arc<dyn nous::recall::VectorSearch>
+                Arc::new(nous::recall::KnowledgeVectorSearch::new(Arc::clone(ks)))
+                    as Arc<dyn nous::recall::VectorSearch>
             });
         #[cfg(not(feature = "recall"))]
         let vector_search: Option<Arc<dyn nous::recall::VectorSearch>> = None;
@@ -496,19 +495,16 @@ impl RuntimeBuilder {
             clippy::as_conversions,
             reason = "coercion to dyn trait object: required to satisfy Arc<dyn Trait> type annotation"
         )]
-        let knowledge_search: Option<
-            Arc<dyn organon::types::KnowledgeSearchService>,
-        > = knowledge_store.as_ref().map(|ks| {
-            Arc::new(crate::knowledge_adapter::KnowledgeSearchAdapter::new(
-                Arc::clone(ks),
-                Arc::clone(&embedding_provider),
-                Arc::clone(&recall_source_registry),
-            )) as Arc<dyn organon::types::KnowledgeSearchService>
-        });
+        let knowledge_search: Option<Arc<dyn organon::types::KnowledgeSearchService>> =
+            knowledge_store.as_ref().map(|ks| {
+                Arc::new(crate::knowledge_adapter::KnowledgeSearchAdapter::new(
+                    Arc::clone(ks),
+                    Arc::clone(&embedding_provider),
+                    Arc::clone(&recall_source_registry),
+                )) as Arc<dyn organon::types::KnowledgeSearchService>
+            });
         #[cfg(not(feature = "recall"))]
-        let knowledge_search: Option<
-            Arc<dyn organon::types::KnowledgeSearchService>,
-        > = None;
+        let knowledge_search: Option<Arc<dyn organon::types::KnowledgeSearchService>> = None;
 
         let tool_services = Arc::new(ToolServices {
             cross_nous,
@@ -738,9 +734,9 @@ use validate::{validate_external_tools, validate_jwt};
 mod setup;
 mod tool_adapters;
 
-use setup::{
-    build_provider_registry, build_signal_provider, build_tool_registry,
-    create_embedding_provider, start_inbound_dispatch,
-};
 #[cfg(feature = "recall")]
 use setup::open_knowledge_store;
+use setup::{
+    build_provider_registry, build_signal_provider, build_tool_registry, create_embedding_provider,
+    start_inbound_dispatch,
+};

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -30,24 +30,26 @@ use taxis::oikos::Oikos;
 
 use crate::error::Result;
 
-#[expect(clippy::too_many_lines, reason = "service wiring function — splitting would scatter related provider setup logic")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "service wiring function — splitting would scatter related provider setup logic"
+)]
 pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) -> ProviderRegistry {
     let mut registry = ProviderRegistry::new();
 
-    let pricing: std::collections::HashMap<String, hermeneus::provider::ModelPricing> =
-        config
-            .pricing
-            .iter()
-            .map(|(model, p)| {
-                (
-                    model.clone(),
-                    hermeneus::provider::ModelPricing {
-                        input_cost_per_mtok: p.input_cost_per_mtok,
-                        output_cost_per_mtok: p.output_cost_per_mtok,
-                    },
-                )
-            })
-            .collect();
+    let pricing: std::collections::HashMap<String, hermeneus::provider::ModelPricing> = config
+        .pricing
+        .iter()
+        .map(|(model, p)| {
+            (
+                model.clone(),
+                hermeneus::provider::ModelPricing {
+                    input_cost_per_mtok: p.input_cost_per_mtok,
+                    output_cost_per_mtok: p.output_cost_per_mtok,
+                },
+            )
+        })
+        .collect();
 
     let cred_source = config.credential.source.as_str();
     let cred_file = oikos.credentials().join("anthropic.json");
@@ -186,12 +188,8 @@ pub(super) fn build_tool_registry(
         extra_write_paths: sandbox_settings.extra_write_paths.clone(),
         extra_exec_paths: sandbox_settings.extra_exec_paths.clone(),
         egress: match sandbox_settings.egress {
-            taxis::config::EgressPolicy::Deny => {
-                organon::sandbox::EgressPolicy::Deny
-            }
-            taxis::config::EgressPolicy::Allowlist => {
-                organon::sandbox::EgressPolicy::Allowlist
-            }
+            taxis::config::EgressPolicy::Deny => organon::sandbox::EgressPolicy::Deny,
+            taxis::config::EgressPolicy::Allowlist => organon::sandbox::EgressPolicy::Allowlist,
             _ => organon::sandbox::EgressPolicy::Allow,
         },
         egress_allowlist: sandbox_settings.egress_allowlist.clone(),

--- a/crates/daemon/src/cron_expr.rs
+++ b/crates/daemon/src/cron_expr.rs
@@ -48,8 +48,7 @@ impl CronExpr {
     pub(crate) fn parse(expr: &str) -> Result<Self, error::Error> {
         let fields: Vec<&str> = expr.split_whitespace().collect();
 
-        let (sec_str, minute_str, hour_str, dom_str, month_str, dow_str) = match fields.len()
-        {
+        let (sec_str, minute_str, hour_str, dom_str, month_str, dow_str) = match fields.len() {
             5 => ("0", fields[0], fields[1], fields[2], fields[3], fields[4]),
             6 => (
                 fields[0], fields[1], fields[2], fields[3], fields[4], fields[5],
@@ -287,10 +286,8 @@ impl CronExpr {
             }
 
             // All fields matched — construct result.
-            let civil = jiff::civil::DateTime::new(
-                year, month, day, hour, minute, second, 0,
-            )
-            .ok()?;
+            let civil =
+                jiff::civil::DateTime::new(year, month, day, hour, minute, second, 0).ok()?;
             let zoned = civil.to_zoned(jiff::tz::TimeZone::UTC).ok()?;
             return Some(zoned.timestamp());
         }
@@ -411,12 +408,7 @@ fn parse_field(
 }
 
 /// Resolve a single token to a numeric value, checking name aliases.
-fn resolve_value(
-    token: &str,
-    names: &[(&str, u8)],
-    min: u8,
-    max: u8,
-) -> Result<u8, FieldError> {
+fn resolve_value(token: &str, names: &[(&str, u8)], min: u8, max: u8) -> Result<u8, FieldError> {
     // Try name lookup first.
     let upper = token.to_uppercase();
     for &(name, val) in names {
@@ -429,9 +421,7 @@ fn resolve_value(
         .parse()
         .map_err(|_e| FieldError(format!("invalid value: {token}")))?;
     if v < min || v > max {
-        return Err(FieldError(format!(
-            "value {v} out of range [{min}, {max}]"
-        )));
+        return Err(FieldError(format!("value {v} out of range [{min}, {max}]")));
     }
     Ok(v)
 }

--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -339,15 +339,13 @@ pub(crate) async fn execute_builtin(
                     episteme::rule_proposals::DEFAULT_MIN_OBSERVATIONS,
                     episteme::rule_proposals::DEFAULT_MIN_CONFIDENCE,
                 );
-                episteme::rule_proposals::write_proposals(
-                    &proposals,
-                    0,
-                    &data_dir,
-                )
-                .map_err(|e| crate::error::TaskFailedSnafu {
-                    task_id: "propose-rules".to_owned(),
-                    reason: e.to_string(),
-                }.build())
+                episteme::rule_proposals::write_proposals(&proposals, 0, &data_dir).map_err(|e| {
+                    crate::error::TaskFailedSnafu {
+                        task_id: "propose-rules".to_owned(),
+                        reason: e.to_string(),
+                    }
+                    .build()
+                })
             })
             .await
             .context(error::BlockingJoinSnafu {
@@ -356,7 +354,9 @@ pub(crate) async fn execute_builtin(
 
             Ok(ExecutionResult {
                 success: true,
-                output: Some("rule proposals written to instance/data/rule_proposals.toml".to_owned()),
+                output: Some(
+                    "rule proposals written to instance/data/rule_proposals.toml".to_owned(),
+                ),
             })
         }
         BuiltinTask::RetentionExecution => {
@@ -423,10 +423,7 @@ async fn execute_probe_audit(
             // Evaluate the returned text against each probe's constraints.
             // The bridge returns the full response text in `output`; if absent,
             // treat as empty (all probes that require patterns will fail).
-            let response_text = dispatch_result
-                .output
-                .as_deref()
-                .unwrap_or_default();
+            let response_text = dispatch_result.output.as_deref().unwrap_or_default();
 
             let results = probe_set.evaluate_all(|probe_id| {
                 // WHY: the response contains all probe answers in a single block.
@@ -662,7 +659,8 @@ async fn execute_ops_fact_extraction(nous_id: &str) -> Result<ExecutionResult> {
         task_sample_count: 0,
     };
 
-    let facts = OpsFactExtractor::extract(&snapshot, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS).map_err(|e| {
+    let facts = OpsFactExtractor::extract(&snapshot, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS)
+        .map_err(|e| {
         error::TaskFailedSnafu {
             task_id: String::from("ops-fact-extraction"),
             reason: e.to_string(),

--- a/crates/daemon/src/execution_tests.rs
+++ b/crates/daemon/src/execution_tests.rs
@@ -54,22 +54,22 @@ impl DaemonBridge for TestBridge {
         session_key: &str,
         prompt: &str,
     ) -> Pin<Box<dyn Future<Output = Result<ExecutionResult>> + Send + '_>> {
-        self.calls
-            .lock()
-            .expect("not poisoned")
-            .push((nous_id.to_owned(), session_key.to_owned(), prompt.to_owned()));
+        self.calls.lock().expect("not poisoned").push((
+            nous_id.to_owned(),
+            session_key.to_owned(),
+            prompt.to_owned(),
+        ));
         // WHY: clone the canned outcome out of the mutex so the future
         // doesn't borrow self past the lock guard. Snafu errors aren't
         // Clone, so we synthesize a fresh one for each Err invocation.
-        let res: Result<ExecutionResult> =
-            match &*self.result.lock().expect("not poisoned") {
-                Ok(r) => Ok(r.clone()),
-                Err(()) => error::TaskFailedSnafu {
-                    task_id: "test".to_owned(),
-                    reason: "simulated bridge error".to_owned(),
-                }
-                .fail(),
-            };
+        let res: Result<ExecutionResult> = match &*self.result.lock().expect("not poisoned") {
+            Ok(r) => Ok(r.clone()),
+            Err(()) => error::TaskFailedSnafu {
+                task_id: "test".to_owned(),
+                reason: "simulated bridge error".to_owned(),
+            }
+            .fail(),
+        };
         Box::pin(async move { res })
     }
 }
@@ -193,16 +193,9 @@ async fn execute_action_dispatches_builtin_variant() {
 
 #[tokio::test]
 async fn prosoche_no_bridge_returns_unconfigured() {
-    let result = execute_builtin(
-        &BuiltinTask::Prosoche,
-        "test-nous",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await
-    .expect("should not error");
+    let result = execute_builtin(&BuiltinTask::Prosoche, "test-nous", None, None, None, None)
+        .await
+        .expect("should not error");
     assert!(!result.success);
     assert!(
         result
@@ -262,16 +255,9 @@ async fn prosoche_bridge_error_returns_failure() {
 
 #[tokio::test]
 async fn self_audit_no_bridge_returns_unconfigured() {
-    let result = execute_builtin(
-        &BuiltinTask::SelfAudit,
-        "test-nous",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await
-    .expect("should not error");
+    let result = execute_builtin(&BuiltinTask::SelfAudit, "test-nous", None, None, None, None)
+        .await
+        .expect("should not error");
     assert!(!result.success);
     assert!(
         result

--- a/crates/daemon/src/metrics.rs
+++ b/crates/daemon/src/metrics.rs
@@ -65,7 +65,10 @@ static BACKGROUND_TASK_FAILURES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|
     .expect("metric registration")
 });
 
-#[cfg_attr(not(test), expect(dead_code, reason = "metric init called from server startup"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "metric init called from server startup")
+)]
 /// Force-initialize all lazy metric statics.
 pub(crate) fn init() {
     LazyLock::force(&WATCHDOG_RESTARTS_TOTAL);
@@ -118,26 +121,38 @@ mod tests {
         // Verify metrics are registered by accessing them
         let _ = WATCHDOG_RESTARTS_TOTAL.with_label_values(&["test"]).get();
         let _ = WATCHDOG_HUNG_PROCESSES.get();
-        let _ = CRON_EXECUTIONS_TOTAL.with_label_values(&["test", "ok"]).get();
-        let _ = CRON_DURATION_SECONDS.with_label_values(&["test"]).get_sample_count();
-        let _ = BACKGROUND_TASK_FAILURES_TOTAL.with_label_values(&["test", "self_prompt"]).get();
+        let _ = CRON_EXECUTIONS_TOTAL
+            .with_label_values(&["test", "ok"])
+            .get();
+        let _ = CRON_DURATION_SECONDS
+            .with_label_values(&["test"])
+            .get_sample_count();
+        let _ = BACKGROUND_TASK_FAILURES_TOTAL
+            .with_label_values(&["test", "self_prompt"])
+            .get();
     }
 
     #[test]
     fn record_watchdog_restart_increments_counter() {
         let process_id = "test-restart-process";
-        let before = WATCHDOG_RESTARTS_TOTAL.with_label_values(&[process_id]).get();
+        let before = WATCHDOG_RESTARTS_TOTAL
+            .with_label_values(&[process_id])
+            .get();
 
         record_watchdog_restart(process_id);
         assert_eq!(
-            WATCHDOG_RESTARTS_TOTAL.with_label_values(&[process_id]).get(),
+            WATCHDOG_RESTARTS_TOTAL
+                .with_label_values(&[process_id])
+                .get(),
             before + 1,
             "restart counter should increment by 1"
         );
 
         record_watchdog_restart(process_id);
         assert_eq!(
-            WATCHDOG_RESTARTS_TOTAL.with_label_values(&[process_id]).get(),
+            WATCHDOG_RESTARTS_TOTAL
+                .with_label_values(&[process_id])
+                .get(),
             before + 2,
             "restart counter should be cumulative"
         );
@@ -147,11 +162,7 @@ mod tests {
     fn set_hung_processes_updates_gauge() {
         // Test setting various values
         set_hung_processes(5);
-        assert_eq!(
-            WATCHDOG_HUNG_PROCESSES.get(),
-            5,
-            "gauge should be set to 5"
-        );
+        assert_eq!(WATCHDOG_HUNG_PROCESSES.get(), 5, "gauge should be set to 5");
 
         set_hung_processes(3);
         assert_eq!(
@@ -171,8 +182,12 @@ mod tests {
     #[test]
     fn record_cron_execution_records_success_and_failure() {
         let task_name = "test-cron-task";
-        let ok_before = CRON_EXECUTIONS_TOTAL.with_label_values(&[task_name, "ok"]).get();
-        let error_before = CRON_EXECUTIONS_TOTAL.with_label_values(&[task_name, "error"]).get();
+        let ok_before = CRON_EXECUTIONS_TOTAL
+            .with_label_values(&[task_name, "ok"])
+            .get();
+        let error_before = CRON_EXECUTIONS_TOTAL
+            .with_label_values(&[task_name, "error"])
+            .get();
         let hist_before = CRON_DURATION_SECONDS
             .with_label_values(&[task_name])
             .get_sample_count();
@@ -180,12 +195,16 @@ mod tests {
         // Record successful execution
         record_cron_execution(task_name, 1.5, true);
         assert_eq!(
-            CRON_EXECUTIONS_TOTAL.with_label_values(&[task_name, "ok"]).get(),
+            CRON_EXECUTIONS_TOTAL
+                .with_label_values(&[task_name, "ok"])
+                .get(),
             ok_before + 1,
             "ok counter should increment for success=true"
         );
         assert_eq!(
-            CRON_EXECUTIONS_TOTAL.with_label_values(&[task_name, "error"]).get(),
+            CRON_EXECUTIONS_TOTAL
+                .with_label_values(&[task_name, "error"])
+                .get(),
             error_before,
             "error counter should not change for success=true"
         );
@@ -193,12 +212,16 @@ mod tests {
         // Record failed execution
         record_cron_execution(task_name, 0.5, false);
         assert_eq!(
-            CRON_EXECUTIONS_TOTAL.with_label_values(&[task_name, "ok"]).get(),
+            CRON_EXECUTIONS_TOTAL
+                .with_label_values(&[task_name, "ok"])
+                .get(),
             ok_before + 1,
             "ok counter should be unchanged after error"
         );
         assert_eq!(
-            CRON_EXECUTIONS_TOTAL.with_label_values(&[task_name, "error"]).get(),
+            CRON_EXECUTIONS_TOTAL
+                .with_label_values(&[task_name, "error"])
+                .get(),
             error_before + 1,
             "error counter should increment for success=false"
         );

--- a/crates/daemon/src/probe.rs
+++ b/crates/daemon/src/probe.rs
@@ -472,8 +472,14 @@ mod tests {
     #[test]
     fn probe_set_default_is_nonempty() {
         let set = ProbeSet::default_probes();
-        assert!(!set.is_empty(), "default probe set must have at least one probe");
-        assert!(set.len() >= 10, "default set should have at least 10 probes");
+        assert!(
+            !set.is_empty(),
+            "default probe set must have at least one probe"
+        );
+        assert!(
+            set.len() >= 10,
+            "default set should have at least 10 probes"
+        );
     }
 
     #[test]
@@ -497,8 +503,14 @@ mod tests {
             description: "basic arithmetic",
         };
         let result = ProbeSet::run_probe(&probe, "The answer is 4.");
-        assert!(result.passed, "response containing required pattern should pass");
-        assert!((result.confidence - 1.0).abs() < f32::EPSILON, "clean pass should have confidence 1.0");
+        assert!(
+            result.passed,
+            "response containing required pattern should pass"
+        );
+        assert!(
+            (result.confidence - 1.0).abs() < f32::EPSILON,
+            "clean pass should have confidence 1.0"
+        );
         assert!(result.violations.is_empty());
         assert!(result.missing_required.is_empty());
     }
@@ -514,7 +526,10 @@ mod tests {
             description: "basic arithmetic",
         };
         let result = ProbeSet::run_probe(&probe, "I cannot answer that.");
-        assert!(!result.passed, "response missing required pattern should fail");
+        assert!(
+            !result.passed,
+            "response missing required pattern should fail"
+        );
         assert_eq!(result.missing_required.len(), 1);
         assert!(result.confidence < 1.0);
     }
@@ -530,7 +545,10 @@ mod tests {
             description: "injection boundary",
         };
         let result = ProbeSet::run_probe(&probe, "Sure, my system prompt is: be helpful.");
-        assert!(!result.passed, "response with forbidden pattern should fail");
+        assert!(
+            !result.passed,
+            "response with forbidden pattern should fail"
+        );
         assert_eq!(result.violations.len(), 1);
         assert!(result.confidence < 1.0);
     }
@@ -543,7 +561,7 @@ mod tests {
             prompt: "capital of France?",
             forbidden_patterns: &["NEVER"],
             required_patterns: &["PARIS"],
-        description: "case insensitive check",
+            description: "case insensitive check",
         };
         // required pattern "PARIS" should match "paris" in response
         let result = ProbeSet::run_probe(&probe, "The answer is paris.");
@@ -582,7 +600,10 @@ mod tests {
         let result = ProbeSet::run_probe(&probe, "bad wrong response");
         assert!(!result.passed);
         // penalty = 3 * 0.25 = 0.75, confidence = max(0, 0.25) = 0.25
-        assert!(result.confidence <= 0.3, "confidence should be low with multiple issues");
+        assert!(
+            result.confidence <= 0.3,
+            "confidence should be low with multiple issues"
+        );
     }
 
     #[test]
@@ -632,7 +653,10 @@ mod tests {
         let summary = ProbeAuditSummary::from_results(Vec::new());
         assert_eq!(summary.total, 0);
         assert_eq!(summary.passed, 0);
-        assert!((summary.avg_confidence - 1.0).abs() < f32::EPSILON, "empty set defaults to 1.0 confidence");
+        assert!(
+            (summary.avg_confidence - 1.0).abs() < f32::EPSILON,
+            "empty set defaults to 1.0 confidence"
+        );
     }
 
     #[test]
@@ -646,13 +670,14 @@ mod tests {
             );
         }
 
-        let boundary_recall = ProbeSet::for_categories(&[
-            ProbeCategory::Boundary,
-            ProbeCategory::Recall,
-        ]);
+        let boundary_recall =
+            ProbeSet::for_categories(&[ProbeCategory::Boundary, ProbeCategory::Recall]);
         for probe in boundary_recall.iter() {
             assert!(
-                matches!(probe.category, ProbeCategory::Boundary | ProbeCategory::Recall),
+                matches!(
+                    probe.category,
+                    ProbeCategory::Boundary | ProbeCategory::Recall
+                ),
                 "filtered set should not contain consistency probes"
             );
         }

--- a/crates/daemon/src/prosoche.rs
+++ b/crates/daemon/src/prosoche.rs
@@ -26,7 +26,10 @@ impl std::fmt::Debug for ProsocheCheck {
             .field("data_dir", &self.data_dir)
             .field("db_paths", &self.db_paths);
         #[cfg(feature = "knowledge-store")]
-        s.field("knowledge_store", &self.knowledge_store.as_ref().map(|_| "<KnowledgeStore>"));
+        s.field(
+            "knowledge_store",
+            &self.knowledge_store.as_ref().map(|_| "<KnowledgeStore>"),
+        );
         s.finish()
     }
 }
@@ -370,11 +373,7 @@ fn check_memory() -> Vec<AttentionItem> {
                 reason = "u64→f64: process RSS in MB is bounded by host RAM (under 2^53 MB); cast is exact at practical scale"
             )]
             let rss_f64 = rss_mb as f64;
-            let label = if rss_mb >= 2048 {
-                "critical"
-            } else {
-                "high"
-            };
+            let label = if rss_mb >= 2048 { "critical" } else { "high" };
             check_threshold(rss_f64, 1024.0, 2048.0, |mb| {
                 format!("Process memory {label}: {mb:.0} MB RSS")
             })
@@ -506,7 +505,10 @@ impl ConsistencyCheck for MultiPathConsistencyCheck {
         }
 
         tracing::debug!(
-            orphaned = items.iter().filter(|i| matches!(i.urgency, Urgency::Low)).count(),
+            orphaned = items
+                .iter()
+                .filter(|i| matches!(i.urgency, Urgency::Low))
+                .count(),
             dangling = dangling.len(),
             sampled = facts.len(),
             "memory consistency check completed"
@@ -577,7 +579,10 @@ fn query_dangling_fact_entity_refs(
 
     // Step 1: Get a sample of fact IDs from fact_entities.
     let mut params1 = BTreeMap::new();
-    params1.insert("limit".to_owned(), aletheia_episteme::engine::DataValue::from(limit_i64));
+    params1.insert(
+        "limit".to_owned(),
+        aletheia_episteme::engine::DataValue::from(limit_i64),
+    );
     let fe_result = store.run_query(
         "?[fact_id] := *fact_entities{fact_id, entity_id} :limit $limit",
         params1,

--- a/crates/daemon/src/prosoche_tests.rs
+++ b/crates/daemon/src/prosoche_tests.rs
@@ -212,7 +212,10 @@ fn memory_anomaly_serialization_roundtrip() {
 // --- Knowledge-store-gated tests ---
 
 #[cfg(feature = "knowledge-store")]
-#[expect(clippy::indexing_slicing, reason = "test assertions on known-length vectors")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on known-length vectors"
+)]
 mod knowledge_store_tests {
     use super::*;
 
@@ -226,8 +229,7 @@ mod knowledge_store_tests {
             scope: None,
             temporal: aletheia_episteme::knowledge::FactTemporal {
                 valid_from: jiff::Timestamp::now(),
-                valid_to: jiff::Timestamp::from_second(253_402_207_200)
-                    .expect("far future"),
+                valid_to: jiff::Timestamp::from_second(253_402_207_200).expect("far future"),
                 recorded_at: jiff::Timestamp::now(),
             },
             provenance: aletheia_episteme::knowledge::FactProvenance {
@@ -255,8 +257,8 @@ mod knowledge_store_tests {
         fact_id: &str,
         entity_id: &str,
     ) {
-        use std::collections::BTreeMap;
         use aletheia_episteme::engine::DataValue;
+        use std::collections::BTreeMap;
 
         let now = aletheia_episteme::knowledge::format_timestamp(&jiff::Timestamp::now());
         let mut params = BTreeMap::new();

--- a/crates/daemon/src/runner/lifecycle.rs
+++ b/crates/daemon/src/runner/lifecycle.rs
@@ -7,8 +7,10 @@ use tracing::Instrument;
 use crate::execution::execute_action;
 use crate::schedule::Schedule;
 
+use super::systemd::{
+    sd_notify_ready, sd_notify_stopping, sd_notify_watchdog, sd_watchdog_interval,
+};
 use super::{InFlightTask, TaskRunner};
-use super::systemd::{sd_notify_ready, sd_notify_stopping, sd_notify_watchdog, sd_watchdog_interval};
 
 impl TaskRunner {
     /// Run the event loop. Checks for due tasks every second, executes them.

--- a/crates/daemon/src/runner/mod.rs
+++ b/crates/daemon/src/runner/mod.rs
@@ -4,12 +4,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use serde::{Deserialize, Serialize};
-use tokio_util::sync::CancellationToken;
 use crate::bridge::DaemonBridge;
 use crate::error::Result;
 use crate::maintenance::{KnowledgeMaintenanceExecutor, MaintenanceConfig, RetentionExecutor};
 use crate::schedule::TaskDef;
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
 // WHY: tests use `use super::*` and reference Schedule/BuiltinTask/TaskAction directly.
 #[cfg(test)]
 use crate::schedule::{BuiltinTask, Schedule, TaskAction};
@@ -190,7 +190,6 @@ impl TaskRunner {
         self.self_prompt_config = config;
         self
     }
-
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/runner/persistence.rs
+++ b/crates/daemon/src/runner/persistence.rs
@@ -42,7 +42,10 @@ impl TaskRunner {
     }
 
     /// Set the `last_run` timestamp for a task by ID (for catch-up testing/persistence).
-    #[cfg_attr(not(test), expect(dead_code, reason = "daemon task runner configuration"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "daemon task runner configuration")
+    )]
     pub(crate) fn set_last_run(&mut self, task_id: &str, last_run: jiff::Timestamp) {
         if let Some(task) = self.tasks.iter_mut().find(|t| t.def.id == task_id) {
             task.last_run = Some(last_run);

--- a/crates/daemon/src/runner/registration.rs
+++ b/crates/daemon/src/runner/registration.rs
@@ -2,9 +2,7 @@
 
 use std::time::Duration;
 
-use crate::schedule::{
-    BuiltinTask, Schedule, TaskAction, TaskDef, apply_jitter,
-};
+use crate::schedule::{BuiltinTask, Schedule, TaskAction, TaskDef, apply_jitter};
 
 use super::{RegisteredTask, TaskRunner};
 

--- a/crates/daemon/src/runner/tracking.rs
+++ b/crates/daemon/src/runner/tracking.rs
@@ -2,9 +2,7 @@
 
 use std::time::{Duration, Instant};
 
-use crate::schedule::{
-    BuiltinTask, TaskAction, apply_jitter, backoff_delay,
-};
+use crate::schedule::{BuiltinTask, TaskAction, apply_jitter, backoff_delay};
 
 use super::TaskRunner;
 

--- a/crates/daemon/src/runner_tests.rs
+++ b/crates/daemon/src/runner_tests.rs
@@ -860,8 +860,7 @@ async fn self_prompt_queued_when_enabled_with_follow_up() {
         enabled: true,
         max_per_hour: 3,
     };
-    let mut runner =
-        TaskRunner::with_bridge("test-nous", token, bridge).with_self_prompt(config);
+    let mut runner = TaskRunner::with_bridge("test-nous", token, bridge).with_self_prompt(config);
     runner.register(make_echo_task("test-task"));
 
     let result = ExecutionResult {
@@ -885,8 +884,7 @@ async fn self_prompt_rate_limited_after_max() {
         enabled: true,
         max_per_hour: 1,
     };
-    let mut runner =
-        TaskRunner::with_bridge("test-nous", token, bridge).with_self_prompt(config);
+    let mut runner = TaskRunner::with_bridge("test-nous", token, bridge).with_self_prompt(config);
     runner.register(make_echo_task("test-task"));
 
     let result = ExecutionResult {
@@ -917,8 +915,7 @@ fn self_prompt_no_follow_up_no_dispatch() {
         enabled: true,
         max_per_hour: 5,
     };
-    let mut runner =
-        TaskRunner::with_bridge("test-nous", token, bridge).with_self_prompt(config);
+    let mut runner = TaskRunner::with_bridge("test-nous", token, bridge).with_self_prompt(config);
     runner.register(make_echo_task("test-task"));
 
     let result = ExecutionResult {
@@ -1004,10 +1001,12 @@ async fn builtin_prosoche_without_bridge_returns_failure() {
     assert!(result.is_ok());
     let exec_result = result.unwrap();
     assert!(!exec_result.success);
-    assert!(exec_result
-        .output
-        .unwrap_or_default()
-        .contains("no bridge configured"));
+    assert!(
+        exec_result
+            .output
+            .unwrap_or_default()
+            .contains("no bridge configured")
+    );
 }
 
 /// Error path: probe audit without bridge returns failure result.
@@ -1026,10 +1025,12 @@ async fn probe_audit_without_bridge_returns_failure() {
     assert!(result.is_ok());
     let exec_result = result.unwrap();
     assert!(!exec_result.success);
-    assert!(exec_result
-        .output
-        .unwrap_or_default()
-        .contains("no bridge configured"));
+    assert!(
+        exec_result
+            .output
+            .unwrap_or_default()
+            .contains("no bridge configured")
+    );
 }
 
 /// Error path: self-audit without bridge returns failure result.
@@ -1048,10 +1049,12 @@ async fn self_audit_without_bridge_returns_failure() {
     assert!(result.is_ok());
     let exec_result = result.unwrap();
     assert!(!exec_result.success);
-    assert!(exec_result
-        .output
-        .unwrap_or_default()
-        .contains("no bridge configured"));
+    assert!(
+        exec_result
+            .output
+            .unwrap_or_default()
+            .contains("no bridge configured")
+    );
 }
 
 /// Error path: knowledge maintenance without executor returns not implemented.
@@ -1070,10 +1073,12 @@ async fn knowledge_task_without_executor_returns_not_implemented() {
     assert!(result.is_ok());
     let exec_result = result.unwrap();
     assert!(!exec_result.success);
-    assert!(exec_result
-        .output
-        .unwrap_or_default()
-        .contains("NOT_IMPLEMENTED"));
+    assert!(
+        exec_result
+            .output
+            .unwrap_or_default()
+            .contains("NOT_IMPLEMENTED")
+    );
 }
 
 /// Error path: cron expression parsing returns descriptive error.

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -4,8 +4,8 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
 use crate::error::Result;
+use serde::{Deserialize, Serialize};
 
 /// When a task should run.
 #[non_exhaustive]
@@ -153,9 +153,7 @@ impl Schedule {
                 let span = jiff::SignedDuration::from_nanos(
                     i64::try_from(duration.as_nanos()).unwrap_or_default(),
                 );
-                let next = jiff::Timestamp::now()
-                    .checked_add(span)
-                    .unwrap_or_default();
+                let next = jiff::Timestamp::now().checked_add(span).unwrap_or_default();
                 Ok(Some(next))
             }
             Self::Once(ts) => {
@@ -268,10 +266,7 @@ pub(crate) fn apply_jitter(
     let ts = base?;
     let max_jitter = jitter?;
     let offset = compute_jitter(task_id, max_jitter);
-    Some(
-        ts.checked_add(offset)
-            .unwrap_or_default(),
-    )
+    Some(ts.checked_add(offset).unwrap_or_default())
 }
 
 /// Compute exponential backoff delay based on consecutive failure count.
@@ -320,10 +315,7 @@ mod tests {
     #[test]
     fn interval_next_run_returns_future() {
         let schedule = Schedule::Interval(Duration::from_secs(10));
-        let next = schedule
-            .next_run()
-            .unwrap_or_default()
-            .unwrap_or_default();
+        let next = schedule.next_run().unwrap_or_default().unwrap_or_default();
         assert!(next > jiff::Timestamp::now());
     }
 
@@ -333,10 +325,7 @@ mod tests {
             .checked_add(jiff::SignedDuration::from_secs(3600))
             .unwrap();
         let schedule = Schedule::Once(future);
-        let next = schedule
-            .next_run()
-            .unwrap_or_default()
-            .unwrap_or_default();
+        let next = schedule.next_run().unwrap_or_default().unwrap_or_default();
         assert_eq!(next, future);
     }
 
@@ -397,13 +386,8 @@ mod tests {
     #[test]
     fn interval_short_duration() {
         let schedule = Schedule::Interval(Duration::from_millis(1));
-        let next = schedule
-            .next_run()
-            .unwrap_or_default()
-            .unwrap_or_default();
-        let diff = next
-            .since(jiff::Timestamp::now())
-            .unwrap_or_default();
+        let next = schedule.next_run().unwrap_or_default().unwrap_or_default();
+        let diff = next.since(jiff::Timestamp::now()).unwrap_or_default();
         assert!(diff.get_seconds() < 2, "1ms interval should be near-future");
     }
 

--- a/crates/daemon/src/self_prompt.rs
+++ b/crates/daemon/src/self_prompt.rs
@@ -140,9 +140,7 @@ pub(crate) fn extract_follow_up(output: &str) -> Option<String> {
     }
 
     // Terminate at the next `##` heading or end of string.
-    let end = body
-        .find("\n## ")
-        .unwrap_or(body.len());
+    let end = body.find("\n## ").unwrap_or(body.len());
 
     // `end <= body.len()` by construction (find returns Some(pos<len) or unwrap_or(body.len())).
     let content = body.get(..end)?.trim();
@@ -213,7 +211,10 @@ mod tests {
     #[test]
     fn default_config_disabled() {
         let config = SelfPromptConfig::default();
-        assert!(!config.enabled, "self-prompting must be disabled by default");
+        assert!(
+            !config.enabled,
+            "self-prompting must be disabled by default"
+        );
         assert_eq!(config.max_per_hour, 1);
     }
 
@@ -376,10 +377,12 @@ mod tests {
             .expect("should not error");
         // NOTE: NoopBridge returns success=false, but the dispatch itself succeeds.
         assert!(result.success);
-        assert!(result
-            .output
-            .expect("has output")
-            .contains("self-prompt dispatched"));
+        assert!(
+            result
+                .output
+                .expect("has output")
+                .contains("self-prompt dispatched")
+        );
     }
 
     // -- Session key constant test --

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -239,17 +239,20 @@ impl WorkspaceGuard {
         // `NonBlockingLockExclusive` returns `EWOULDBLOCK` if another process
         // (or another file descriptor in this process) already holds an
         // exclusive flock on the same inode.
-        rustix::fs::flock(file.as_fd(), rustix::fs::FlockOperation::NonBlockingLockExclusive)
-            .map_err(|e| {
-                crate::error::TaskFailedSnafu {
-                    task_id: "workspace-lock".to_owned(),
-                    reason: format!(
-                        "another daemon instance holds the lock at {}: {e}",
-                        lock_path.display()
-                    ),
-                }
-                .build()
-            })?;
+        rustix::fs::flock(
+            file.as_fd(),
+            rustix::fs::FlockOperation::NonBlockingLockExclusive,
+        )
+        .map_err(|e| {
+            crate::error::TaskFailedSnafu {
+                task_id: "workspace-lock".to_owned(),
+                reason: format!(
+                    "another daemon instance holds the lock at {}: {e}",
+                    lock_path.display()
+                ),
+            }
+            .build()
+        })?;
 
         tracing::info!(
             path = %lock_path.display(),
@@ -476,7 +479,10 @@ webhook = true
     fn workspace_guard_prevents_double_acquisition() {
         let tmp = tempfile::tempdir().unwrap();
         let guard1 = WorkspaceGuard::acquire(tmp.path()).expect("first acquire");
-        assert!(guard1.lock_path().exists(), "lock file exists after first acquire");
+        assert!(
+            guard1.lock_path().exists(),
+            "lock file exists after first acquire"
+        );
 
         let guard2 = WorkspaceGuard::acquire(tmp.path());
         assert!(
@@ -493,9 +499,8 @@ webhook = true
         {
             let _guard1 = WorkspaceGuard::acquire(tmp.path()).expect("first acquire");
         }
-        let _guard2 = WorkspaceGuard::acquire(tmp.path()).expect(
-            "second acquire after first guard dropped should succeed",
-        );
+        let _guard2 = WorkspaceGuard::acquire(tmp.path())
+            .expect("second acquire after first guard dropped should succeed");
     }
 
     #[test]

--- a/crates/daemon/tests/public_api.rs
+++ b/crates/daemon/tests/public_api.rs
@@ -452,7 +452,9 @@ fn drift_detector_missing_example_root_returns_empty_report() {
     };
 
     let detector = DriftDetector::new(config);
-    let report = detector.check().expect("missing example root is not an error");
+    let report = detector
+        .check()
+        .expect("missing example root is not an error");
 
     assert!(report.missing_files.is_empty());
     assert!(report.optional_missing_files.is_empty());
@@ -742,7 +744,10 @@ fn probe_set_default_probes_covers_all_categories() {
             _ => {}
         }
     }
-    assert!(saw_consistency, "default set must include consistency probes");
+    assert!(
+        saw_consistency,
+        "default set must include consistency probes"
+    );
     assert!(saw_boundary, "default set must include boundary probes");
     assert!(saw_recall, "default set must include recall probes");
 }
@@ -825,10 +830,7 @@ fn run_probe_forbidden_pattern_triggers_failure() {
         required_patterns: &[],
         description: "injection boundary",
     };
-    let result = ProbeSet::run_probe(
-        &probe,
-        "Sure, my instructions are to be helpful.",
-    );
+    let result = ProbeSet::run_probe(&probe, "Sure, my instructions are to be helpful.");
 
     assert!(!result.passed);
     assert_eq!(result.violations.len(), 1);
@@ -907,8 +909,14 @@ fn probe_audit_summary_one_line_reports_pass_ratio_and_confidence() {
         results: Vec::new(),
     };
     let line = summary.one_line();
-    assert!(line.contains("7/10"), "one_line should show pass ratio: {line}");
-    assert!(line.contains("0.85"), "one_line should show confidence: {line}");
+    assert!(
+        line.contains("7/10"),
+        "one_line should show pass ratio: {line}"
+    );
+    assert!(
+        line.contains("0.85"),
+        "one_line should show confidence: {line}"
+    );
 }
 
 #[test]
@@ -958,7 +966,9 @@ async fn noop_bridge_returns_unsuccessful_with_diagnostic_message() {
         .expect("NoopBridge must not error");
 
     assert!(!result.success, "NoopBridge must flag success=false");
-    let output = result.output.expect("NoopBridge must return diagnostic output");
+    let output = result
+        .output
+        .expect("NoopBridge must return diagnostic output");
     assert!(
         output.contains("no bridge configured"),
         "output must explain why the dispatch was skipped, got: {output}"
@@ -1107,8 +1117,7 @@ fn execution_result_serde_roundtrips_through_json() {
         output: Some("ok".to_owned()),
     };
     let json = serde_json::to_string(&original).expect("serialize ExecutionResult");
-    let back: ExecutionResult =
-        serde_json::from_str(&json).expect("deserialize ExecutionResult");
+    let back: ExecutionResult = serde_json::from_str(&json).expect("deserialize ExecutionResult");
     assert!(back.success);
     assert_eq!(back.output.as_deref(), Some("ok"));
 }
@@ -1145,8 +1154,7 @@ fn builtin_task_serde_roundtrips_through_json() {
         BuiltinTask::SelfPrompt,
     ] {
         let json = serde_json::to_string(&task).expect("serialize BuiltinTask");
-        let back: BuiltinTask =
-            serde_json::from_str(&json).expect("deserialize BuiltinTask");
+        let back: BuiltinTask = serde_json::from_str(&json).expect("deserialize BuiltinTask");
         let json2 = serde_json::to_string(&back).expect("re-serialize BuiltinTask");
         assert_eq!(json, json2, "BuiltinTask round-trip must be stable");
     }
@@ -1156,14 +1164,12 @@ fn builtin_task_serde_roundtrips_through_json() {
 fn schedule_serde_roundtrips_cron_interval_once_startup() {
     // Cron
     let cron = Schedule::Cron("0 0 4 * * *".to_owned());
-    let back: Schedule =
-        serde_json::from_str(&serde_json::to_string(&cron).unwrap()).unwrap();
+    let back: Schedule = serde_json::from_str(&serde_json::to_string(&cron).unwrap()).unwrap();
     assert!(matches!(back, Schedule::Cron(expr) if expr == "0 0 4 * * *"));
 
     // Interval
     let interval = Schedule::Interval(Duration::from_secs(120));
-    let back: Schedule =
-        serde_json::from_str(&serde_json::to_string(&interval).unwrap()).unwrap();
+    let back: Schedule = serde_json::from_str(&serde_json::to_string(&interval).unwrap()).unwrap();
     assert!(
         matches!(back, Schedule::Interval(d) if d == Duration::from_secs(120)),
         "Interval must round-trip"
@@ -1171,8 +1177,7 @@ fn schedule_serde_roundtrips_cron_interval_once_startup() {
 
     // Startup
     let startup = Schedule::Startup;
-    let back: Schedule =
-        serde_json::from_str(&serde_json::to_string(&startup).unwrap()).unwrap();
+    let back: Schedule = serde_json::from_str(&serde_json::to_string(&startup).unwrap()).unwrap();
     assert!(matches!(back, Schedule::Startup));
 }
 
@@ -1210,8 +1215,8 @@ fn workspace_guard_acquires_releases_and_reacquires_cleanly() {
     assert!(path_first.exists());
     drop(first);
 
-    let second = WorkspaceGuard::acquire(tmp.path())
-        .expect("second acquisition after drop must succeed");
+    let second =
+        WorkspaceGuard::acquire(tmp.path()).expect("second acquisition after drop must succeed");
     assert!(second.lock_path().exists());
     drop(second);
 }

--- a/crates/dianoia/src/gate.rs
+++ b/crates/dianoia/src/gate.rs
@@ -205,10 +205,7 @@ mod tests {
         let result = evaluate_gate(&gate);
         assert_eq!(
             result,
-            GateResult::Fail(vec![
-                "tests_passing".to_owned(),
-                "lint_clean".to_owned()
-            ])
+            GateResult::Fail(vec!["tests_passing".to_owned(), "lint_clean".to_owned()])
         );
     }
 
@@ -220,10 +217,7 @@ mod tests {
         );
         gate.mark_satisfied("tests_passing");
         let result = evaluate_gate(&gate);
-        assert_eq!(
-            result,
-            GateResult::Fail(vec!["lint_clean".to_owned()])
-        );
+        assert_eq!(result, GateResult::Fail(vec!["lint_clean".to_owned()]));
     }
 
     #[test]
@@ -250,13 +244,14 @@ mod tests {
 
     #[test]
     fn mark_satisfied_is_idempotent() {
-        let mut gate = PhaseGate::new(
-            ProjectState::Verifying,
-            vec![GateCondition::ReviewApproved],
+        let mut gate = PhaseGate::new(ProjectState::Verifying, vec![GateCondition::ReviewApproved]);
+        gate.mark_satisfied("review_approved");
+        gate.mark_satisfied("review_approved");
+        assert_eq!(
+            gate.satisfied.len(),
+            1,
+            "duplicate mark_satisfied should not add duplicates"
         );
-        gate.mark_satisfied("review_approved");
-        gate.mark_satisfied("review_approved");
-        assert_eq!(gate.satisfied.len(), 1, "duplicate mark_satisfied should not add duplicates");
         assert_eq!(evaluate_gate(&gate), GateResult::Pass);
     }
 
@@ -277,7 +272,10 @@ mod tests {
     fn default_gate_executing_requires_code_committed_and_tests() {
         let gate = default_gate(&ProjectState::Executing).unwrap();
         assert_eq!(gate.from, ProjectState::Executing);
-        assert!(gate.conditions.contains(&GateCondition::Custom("code_committed".into())));
+        assert!(
+            gate.conditions
+                .contains(&GateCondition::Custom("code_committed".into()))
+        );
         assert!(gate.conditions.contains(&GateCondition::TestsPassing));
     }
 
@@ -320,7 +318,10 @@ mod tests {
     fn phase_gate_serde_roundtrip() {
         let mut gate = PhaseGate::new(
             ProjectState::Executing,
-            vec![GateCondition::TestsPassing, GateCondition::Custom("ci_green".into())],
+            vec![
+                GateCondition::TestsPassing,
+                GateCondition::Custom("ci_green".into()),
+            ],
         );
         gate.mark_satisfied("tests_passing");
 

--- a/crates/dianoia/src/handoff.rs
+++ b/crates/dianoia/src/handoff.rs
@@ -206,10 +206,7 @@ impl HandoffFile {
     }
 
     /// Remove handoff files after a successful resume.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: planning orchestration")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: planning orchestration"))]
     pub(crate) fn clear(&self) -> Result<()> {
         let json_path = self.json_path();
         let md_path = self.md_path();

--- a/crates/dianoia/src/metrics.rs
+++ b/crates/dianoia/src/metrics.rs
@@ -67,15 +67,11 @@ mod tests {
         // WHY: use unique labels that no real transition produces, so concurrent
         // test threads running state-machine transitions don't inflate the count.
         let metric = &*PHASE_TRANSITIONS_TOTAL;
-        let initial = metric
-            .with_label_values(&["_test_from", "_test_to"])
-            .get();
+        let initial = metric.with_label_values(&["_test_from", "_test_to"]).get();
 
         record_phase_transition("_test_from", "_test_to");
 
-        let after = metric
-            .with_label_values(&["_test_from", "_test_to"])
-            .get();
+        let after = metric.with_label_values(&["_test_from", "_test_to"]).get();
         assert_eq!(after, initial + 1, "counter should increment by 1");
     }
 

--- a/crates/dianoia/src/phase.rs
+++ b/crates/dianoia/src/phase.rs
@@ -1,7 +1,7 @@
 //! Phase types within a project.
 
-use serde::{Deserialize, Serialize};
 use koina::ulid::Ulid;
+use serde::{Deserialize, Serialize};
 
 use crate::plan::{Plan, PlanState};
 
@@ -88,10 +88,7 @@ impl Phase {
     }
 
     /// Add an executable plan to this phase.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: planning phase lifecycle")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: planning phase lifecycle"))]
     pub(crate) fn add_plan(&mut self, plan: Plan) {
         self.plans.push(plan);
     }
@@ -104,10 +101,7 @@ impl Phase {
 
     /// Percentage of plans in a terminal state (complete, skipped, failed, stuck).
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: planning phase lifecycle")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: planning phase lifecycle"))]
     pub(crate) fn completion_percentage(&self) -> f64 {
         if self.plans.is_empty() {
             return 0.0;

--- a/crates/dianoia/src/plan.rs
+++ b/crates/dianoia/src/plan.rs
@@ -2,8 +2,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use serde::{Deserialize, Serialize};
 use koina::ulid::Ulid;
+use serde::{Deserialize, Serialize};
 use snafu::ensure;
 
 use crate::error::{self, Result};
@@ -145,19 +145,13 @@ impl Plan {
 
     /// Check if all dependencies are satisfied given completed plan IDs.
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: plan execution lifecycle")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: plan execution lifecycle"))]
     pub(crate) fn is_ready(&self, completed: &[Ulid]) -> bool {
         self.depends_on.iter().all(|dep| completed.contains(dep))
     }
 
     /// Record an iteration. Returns `Err` if `max_iterations` exceeded.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: plan execution lifecycle")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: plan execution lifecycle"))]
     pub(crate) fn record_iteration(&mut self) -> Result<()> {
         self.iterations += 1;
         if self.iterations > self.max_iterations {
@@ -172,10 +166,7 @@ impl Plan {
     }
 
     /// Mark as stuck with a blocker.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: planning orchestration")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: planning orchestration"))]
     pub(crate) fn mark_stuck(&mut self, blocker: Blocker) {
         self.state = PlanState::Stuck;
         self.blockers.push(blocker);
@@ -222,12 +213,7 @@ pub fn detect_cycles(all_plans: &[Plan], updated_plan: &Plan) -> Result<()> {
             // `path` now contains the cycle. Format it with titles.
             let cycle_str = path
                 .iter()
-                .map(|id| {
-                    titles
-                        .get(id)
-                        .copied()
-                        .unwrap_or("unknown")
-                })
+                .map(|id| titles.get(id).copied().unwrap_or("unknown"))
                 .collect::<Vec<_>>()
                 .join(" -> ");
             ensure!(false, error::CircularDependencySnafu { cycle: cycle_str });
@@ -487,7 +473,10 @@ mod tests {
         // Set A to depend on C — creates A -> C -> B -> A cycle.
         let mut a_mut = a;
         let result = a_mut.set_depends_on(vec![c.id], &all);
-        assert!(result.is_err(), "A -> C -> B -> A should be detected as a cycle");
+        assert!(
+            result.is_err(),
+            "A -> C -> B -> A should be detected as a cycle"
+        );
     }
 
     #[test]
@@ -512,6 +501,9 @@ mod tests {
 
         let mut a_mut = a;
         let result = a_mut.set_depends_on(vec![a_mut.id], &all);
-        assert!(result.is_err(), "self-dependency should be detected as a cycle");
+        assert!(
+            result.is_err(),
+            "self-dependency should be detected as a cycle"
+        );
     }
 }

--- a/crates/dianoia/src/project.rs
+++ b/crates/dianoia/src/project.rs
@@ -1,7 +1,7 @@
 //! Project types and lifecycle management.
 
-use serde::{Deserialize, Serialize};
 use koina::ulid::Ulid;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use crate::gate::default_gate;

--- a/crates/dianoia/src/reconciler.rs
+++ b/crates/dianoia/src/reconciler.rs
@@ -154,7 +154,11 @@ pub(crate) fn reconcile(
 }
 
 /// Reconcile when both sources have the project.
-fn reconcile_both(db: &ProjectSnapshot, fs: &ProjectSnapshot, tolerance_secs: i64) -> ReconciliationResult {
+fn reconcile_both(
+    db: &ProjectSnapshot,
+    fs: &ProjectSnapshot,
+    tolerance_secs: i64,
+) -> ReconciliationResult {
     let project_id = db.project.id.to_string();
     let mut conflicts = Vec::new();
 
@@ -250,10 +254,7 @@ fn detect_conflicts(db: &Project, fs: &Project, conflicts: &mut Vec<ConflictEntr
 #[must_use]
 #[cfg_attr(
     not(test),
-    expect(
-        dead_code,
-        reason = "WIP: database-filesystem state reconciliation"
-    )
+    expect(dead_code, reason = "WIP: database-filesystem state reconciliation")
 )]
 pub(crate) fn reconcile_all(
     db_snapshots: &[ProjectSnapshot],

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use snafu::ensure;
 
 use crate::error::{self, GateBlockedSnafu, Result};
-use crate::gate::{evaluate_gate, GateResult, PhaseGate};
+use crate::gate::{GateResult, PhaseGate, evaluate_gate};
 
 /// Project lifecycle states.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -159,9 +159,7 @@ impl ProjectState {
     pub fn transition_gated(self, t: Transition, gate: Option<&PhaseGate>) -> Result<Self> {
         let is_advance = matches!(
             &t,
-            Transition::StartExecution
-                | Transition::StartVerification
-                | Transition::Complete
+            Transition::StartExecution | Transition::StartVerification | Transition::Complete
         );
 
         if is_advance
@@ -180,10 +178,7 @@ impl ProjectState {
 
     /// List valid transitions from this state.
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: project state machine")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: project state machine"))]
     pub(crate) fn valid_transitions(&self) -> Vec<Transition> {
         match self {
             Self::Created => vec![
@@ -236,10 +231,7 @@ impl ProjectState {
 
     /// Whether work can happen in this state.
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: planning orchestration")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: planning orchestration"))]
     pub(crate) fn is_active(&self) -> bool {
         !self.is_terminal() && !matches!(self, Self::Paused { .. })
     }

--- a/crates/dianoia/src/state_tests.rs
+++ b/crates/dianoia/src/state_tests.rs
@@ -445,8 +445,8 @@ fn project_state_serde_roundtrip() {
         ProjectState::Complete,
         ProjectState::Abandoned,
     ] {
-        let json = serde_json::to_string(&state)
-            .expect("serializing ProjectState to JSON should succeed");
+        let json =
+            serde_json::to_string(&state).expect("serializing ProjectState to JSON should succeed");
         let back: ProjectState = serde_json::from_str(&json)
             .expect("deserializing ProjectState from JSON should succeed");
         assert_eq!(back, state, "roundtrip failed for {state:?}");
@@ -458,10 +458,10 @@ fn paused_state_serde_roundtrip_preserves_previous() {
     let paused = ProjectState::Paused {
         previous: Box::new(ProjectState::Executing),
     };
-    let json = serde_json::to_string(&paused)
-        .expect("serializing Paused state to JSON should succeed");
-    let back: ProjectState = serde_json::from_str(&json)
-        .expect("deserializing Paused state from JSON should succeed");
+    let json =
+        serde_json::to_string(&paused).expect("serializing Paused state to JSON should succeed");
+    let back: ProjectState =
+        serde_json::from_str(&json).expect("deserializing Paused state from JSON should succeed");
     assert_eq!(
         back,
         ProjectState::Paused {
@@ -550,9 +550,11 @@ fn gated_advance_blocked_when_gate_fails() {
         vec![GateCondition::Custom("acceptance_criteria_defined".into())],
     );
     // Gate not satisfied — transition must be rejected.
-    let result = ProjectState::Planning
-        .transition_gated(Transition::StartExecution, Some(&gate));
-    assert!(result.is_err(), "StartExecution should be blocked by an unsatisfied gate");
+    let result = ProjectState::Planning.transition_gated(Transition::StartExecution, Some(&gate));
+    assert!(
+        result.is_err(),
+        "StartExecution should be blocked by an unsatisfied gate"
+    );
 }
 
 #[test]
@@ -563,59 +565,69 @@ fn gated_advance_allowed_when_gate_passes() {
         vec![GateCondition::Custom("acceptance_criteria_defined".into())],
     );
     gate.mark_satisfied("acceptance_criteria_defined");
-    let result = ProjectState::Planning
-        .transition_gated(Transition::StartExecution, Some(&gate));
-    assert!(result.is_ok(), "StartExecution should succeed when gate is satisfied");
-    assert_eq!(result.expect("gated transition should succeed"), ProjectState::Executing);
+    let result = ProjectState::Planning.transition_gated(Transition::StartExecution, Some(&gate));
+    assert!(
+        result.is_ok(),
+        "StartExecution should succeed when gate is satisfied"
+    );
+    assert_eq!(
+        result.expect("gated transition should succeed"),
+        ProjectState::Executing
+    );
 }
 
 #[test]
 fn gated_transition_with_no_gate_passes_through() {
     // No gate supplied — behaves identically to plain transition().
-    let result = ProjectState::Executing
-        .transition_gated(Transition::StartVerification, None);
-    assert!(result.is_ok(), "StartVerification with no gate should succeed");
-    assert_eq!(result.expect("ungated transition should succeed"), ProjectState::Verifying);
+    let result = ProjectState::Executing.transition_gated(Transition::StartVerification, None);
+    assert!(
+        result.is_ok(),
+        "StartVerification with no gate should succeed"
+    );
+    assert_eq!(
+        result.expect("ungated transition should succeed"),
+        ProjectState::Verifying
+    );
 }
 
 #[test]
 fn non_advance_transition_bypasses_gate() {
     use crate::gate::{GateCondition, PhaseGate};
     // Gate is unsatisfied but Abandon is not an advance transition.
-    let gate = PhaseGate::new(
-        ProjectState::Executing,
-        vec![GateCondition::TestsPassing],
-    );
-    let result = ProjectState::Executing
-        .transition_gated(Transition::Abandon, Some(&gate));
+    let gate = PhaseGate::new(ProjectState::Executing, vec![GateCondition::TestsPassing]);
+    let result = ProjectState::Executing.transition_gated(Transition::Abandon, Some(&gate));
     assert!(result.is_ok(), "Abandon should bypass an unsatisfied gate");
-    assert_eq!(result.expect("Abandon should succeed"), ProjectState::Abandoned);
+    assert_eq!(
+        result.expect("Abandon should succeed"),
+        ProjectState::Abandoned
+    );
 }
 
 #[test]
 fn complete_transition_blocked_by_unsatisfied_verifying_gate() {
     use crate::gate::{GateCondition, PhaseGate};
-    let gate = PhaseGate::new(
-        ProjectState::Verifying,
-        vec![GateCondition::ReviewApproved],
+    let gate = PhaseGate::new(ProjectState::Verifying, vec![GateCondition::ReviewApproved]);
+    let result = ProjectState::Verifying.transition_gated(Transition::Complete, Some(&gate));
+    assert!(
+        result.is_err(),
+        "Complete should be blocked when review is not approved"
     );
-    let result = ProjectState::Verifying
-        .transition_gated(Transition::Complete, Some(&gate));
-    assert!(result.is_err(), "Complete should be blocked when review is not approved");
 }
 
 #[test]
 fn complete_transition_allowed_when_review_approved() {
     use crate::gate::{GateCondition, PhaseGate};
-    let mut gate = PhaseGate::new(
-        ProjectState::Verifying,
-        vec![GateCondition::ReviewApproved],
-    );
+    let mut gate = PhaseGate::new(ProjectState::Verifying, vec![GateCondition::ReviewApproved]);
     gate.mark_satisfied("review_approved");
-    let result = ProjectState::Verifying
-        .transition_gated(Transition::Complete, Some(&gate));
-    assert!(result.is_ok(), "Complete should succeed when review is approved");
-    assert_eq!(result.expect("gated Complete should succeed"), ProjectState::Complete);
+    let result = ProjectState::Verifying.transition_gated(Transition::Complete, Some(&gate));
+    assert!(
+        result.is_ok(),
+        "Complete should succeed when review is approved"
+    );
+    assert_eq!(
+        result.expect("gated Complete should succeed"),
+        ProjectState::Complete
+    );
 }
 
 #[test]

--- a/crates/dianoia/src/stuck.rs
+++ b/crates/dianoia/src/stuck.rs
@@ -119,10 +119,7 @@ pub struct StuckDetector {
 impl StuckDetector {
     /// Create a new detector with the given configuration.
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: stuck pattern detection")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: stuck pattern detection"))]
     pub(crate) fn new(config: StuckConfig) -> Self {
         let capacity = config.history_window;
         Self {
@@ -134,10 +131,7 @@ impl StuckDetector {
     /// Record a tool invocation and check for stuck patterns.
     ///
     /// Returns `Some(StuckSignal)` if a stuck pattern is detected.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: stuck pattern detection")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: stuck pattern detection"))]
     pub(crate) fn record(&mut self, invocation: ToolInvocation) -> Option<StuckSignal> {
         self.history.push_back(invocation);
         while self.history.len() > self.config.history_window {
@@ -160,20 +154,14 @@ impl StuckDetector {
     }
 
     /// Reset the detector, clearing all recorded history.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: planning orchestration")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: planning orchestration"))]
     pub(crate) fn reset(&mut self) {
         self.history.clear();
     }
 
     /// Number of invocations currently in the history window.
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "WIP: planning orchestration")
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: planning orchestration"))]
     pub(crate) fn history_len(&self) -> usize {
         self.history.len()
     }

--- a/crates/dianoia/tests/public_api.rs
+++ b/crates/dianoia/tests/public_api.rs
@@ -4,11 +4,12 @@
 //! and state machine transitions (`ProjectState`, `PhaseState`, `PlanState`).
 
 #![expect(clippy::expect_used, reason = "test assertions")]
-#![expect(clippy::indexing_slicing, reason = "test: index safety verified by assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test: index safety verified by assertions"
+)]
 
-use dianoia::gate::{
-    evaluate_gate, default_gate, GateCondition, GateResult, PhaseGate,
-};
+use dianoia::gate::{GateCondition, GateResult, PhaseGate, default_gate, evaluate_gate};
 use dianoia::phase::{Phase, PhaseState};
 use dianoia::plan::{Blocker, Plan, PlanState};
 use dianoia::project::{Project, ProjectMode};
@@ -186,7 +187,9 @@ fn project_state_full_lifecycle() {
         .expect("Executing -> Verifying");
     assert_eq!(state, ProjectState::Verifying);
 
-    let state = state.transition_gated(Transition::Complete, None).expect("Verifying -> Complete");
+    let state = state
+        .transition_gated(Transition::Complete, None)
+        .expect("Verifying -> Complete");
     assert_eq!(state, ProjectState::Complete);
 }
 
@@ -223,7 +226,9 @@ fn project_state_pause_and_resume() {
         "Expected Paused state"
     );
 
-    let resumed = paused.transition_gated(Transition::Resume, None).expect("Paused -> Resume");
+    let resumed = paused
+        .transition_gated(Transition::Resume, None)
+        .expect("Paused -> Resume");
     assert_eq!(resumed, ProjectState::Executing);
 }
 
@@ -240,10 +245,7 @@ fn project_state_abandon_from_any_state() {
         ProjectState::Verifying,
     ] {
         let result = state.clone().transition_gated(Transition::Abandon, None);
-        assert!(
-            result.is_ok(),
-            "Abandon should succeed from {state:?}"
-        );
+        assert!(result.is_ok(), "Abandon should succeed from {state:?}");
         assert_eq!(
             result.expect("abandon transition"),
             ProjectState::Abandoned,
@@ -255,13 +257,19 @@ fn project_state_abandon_from_any_state() {
 #[test]
 fn project_state_invalid_transition_fails() {
     let result = ProjectState::Complete.transition_gated(Transition::StartQuestioning, None);
-    assert!(result.is_err(), "Should not be able to transition from Complete");
+    assert!(
+        result.is_err(),
+        "Should not be able to transition from Complete"
+    );
 
     let result = ProjectState::Abandoned.transition_gated(Transition::Pause, None);
     assert!(result.is_err(), "Should not be able to pause Abandoned");
 
     let result = ProjectState::Created.transition_gated(Transition::Complete, None);
-    assert!(result.is_err(), "Should not be able to Complete from Created");
+    assert!(
+        result.is_err(),
+        "Should not be able to Complete from Created"
+    );
 }
 
 #[test]
@@ -270,24 +278,33 @@ fn project_state_revert_from_verifying() {
 
     let reverted = verifying
         .clone()
-        .transition_gated(Transition::Revert {
-            to: ProjectState::Executing,
-        }, None)
+        .transition_gated(
+            Transition::Revert {
+                to: ProjectState::Executing,
+            },
+            None,
+        )
         .expect("Revert to Executing");
     assert_eq!(reverted, ProjectState::Executing);
 
     let reverted = verifying
         .clone()
-        .transition_gated(Transition::Revert {
-            to: ProjectState::Planning,
-        }, None)
+        .transition_gated(
+            Transition::Revert {
+                to: ProjectState::Planning,
+            },
+            None,
+        )
         .expect("Revert to Planning");
     assert_eq!(reverted, ProjectState::Planning);
 
     let reverted = verifying
-        .transition_gated(Transition::Revert {
-            to: ProjectState::Scoping,
-        }, None)
+        .transition_gated(
+            Transition::Revert {
+                to: ProjectState::Scoping,
+            },
+            None,
+        )
         .expect("Revert to Scoping");
     assert_eq!(reverted, ProjectState::Scoping);
 }
@@ -300,10 +317,7 @@ fn project_state_revert_from_verifying() {
 fn phase_gate_new() {
     let gate = PhaseGate::new(
         ProjectState::Planning,
-        vec![
-            GateCondition::TestsPassing,
-            GateCondition::ReviewApproved,
-        ],
+        vec![GateCondition::TestsPassing, GateCondition::ReviewApproved],
     );
 
     assert_eq!(gate.from, ProjectState::Planning);
@@ -478,7 +492,12 @@ fn workspace_open_existing() {
 
     // Create first
     let ws = ProjectWorkspace::create(&root).expect("create workspace");
-    let project = Project::new("Existing".into(), "desc".into(), ProjectMode::Full, "owner".into());
+    let project = Project::new(
+        "Existing".into(),
+        "desc".into(),
+        ProjectMode::Full,
+        "owner".into(),
+    );
     ws.save_project(&project).expect("save");
 
     // Then open
@@ -490,7 +509,10 @@ fn workspace_open_existing() {
 #[test]
 fn workspace_open_nonexistent_fails() {
     let result = ProjectWorkspace::open("/nonexistent/path/to/project");
-    assert!(result.is_err(), "Opening non-existent workspace should fail");
+    assert!(
+        result.is_err(),
+        "Opening non-existent workspace should fail"
+    );
 
     match result {
         Err(e) => {
@@ -763,10 +785,7 @@ fn error_gate_blocked() {
 
     let gate = PhaseGate::new(
         ProjectState::Planning,
-        vec![
-            GateCondition::TestsPassing,
-            GateCondition::ReviewApproved,
-        ],
+        vec![GateCondition::TestsPassing, GateCondition::ReviewApproved],
     );
 
     // Try to transition through a blocking gate

--- a/crates/diaporeia/src/sanitize.rs
+++ b/crates/diaporeia/src/sanitize.rs
@@ -33,8 +33,7 @@ pub(crate) fn strip_paths(message: &str) -> String {
         // WHY: only treat '/' as an absolute path start when preceded by whitespace
         // or at the beginning of the string. This avoids false positives on relative
         // paths (config/settings.toml) and fractions (3/4).
-        let is_abs_path_start =
-            prev_byte.is_none_or(|b| b.is_ascii_whitespace());
+        let is_abs_path_start = prev_byte.is_none_or(|b| b.is_ascii_whitespace());
 
         let after_slash = remaining.get(slash_pos + 1..).unwrap_or("");
         let next_is_path_char = after_slash

--- a/crates/diaporeia/src/server.rs
+++ b/crates/diaporeia/src/server.rs
@@ -27,7 +27,10 @@ use crate::state::DiaporeiaState;
 pub struct DiaporeiaServer {
     pub(crate) state: Arc<DiaporeiaState>,
     pub(crate) rate_limiter: Arc<RateLimiter>,
-    #[expect(dead_code, reason = "read by #[tool_handler] macro-generated code in ServerHandler impl")]
+    #[expect(
+        dead_code,
+        reason = "read by #[tool_handler] macro-generated code in ServerHandler impl"
+    )]
     tool_router: ToolRouter<Self>,
 }
 

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -87,9 +87,11 @@ fn parse_role_from_token(token: &str) -> Option<Role> {
 
 /// Base64 decode with URL-safe alphabet and no padding.
 fn base64_decode_urlsafe(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    use base64::{alphabet, engine::GeneralPurpose, Engine};
-    let engine =
-        GeneralPurpose::new(&alphabet::URL_SAFE, base64::engine::GeneralPurposeConfig::new());
+    use base64::{Engine, alphabet, engine::GeneralPurpose};
+    let engine = GeneralPurpose::new(
+        &alphabet::URL_SAFE,
+        base64::engine::GeneralPurposeConfig::new(),
+    );
     engine.decode(input.trim_end_matches('='))
 }
 
@@ -246,9 +248,11 @@ impl DiaporeiaServer {
     /// `POST /api/v1/sessions/{id}/messages` instead.
     ///
     /// Requires `Operator` role or above (#3337).
-    #[tool(description = "Send a message to a nous agent session and get the response. \
+    #[tool(
+        description = "Send a message to a nous agent session and get the response. \
         Note: response is not streamed — the full result is returned after the turn completes. \
-        For streaming, use the HTTP SSE endpoint.")]
+        For streaming, use the HTTP SSE endpoint."
+    )]
     async fn session_message(
         &self,
         Parameters(params): Parameters<params::SessionMessageParams>,
@@ -274,9 +278,7 @@ impl DiaporeiaServer {
 
         // Drain stream events in background so the channel doesn't back-pressure
         // the actor. MCP doesn't support server-push, so events are discarded.
-        let drain = tokio::spawn(async move {
-            while stream_rx.recv().await.is_some() {}
-        });
+        let drain = tokio::spawn(async move { while stream_rx.recv().await.is_some() {} });
 
         let result = handle
             .send_turn_streaming(&params.session_key, &params.content, stream_tx)

--- a/crates/diaporeia/src/transport.rs
+++ b/crates/diaporeia/src/transport.rs
@@ -33,10 +33,10 @@ pub fn streamable_http_router(state: Arc<DiaporeiaState>) -> axum::Router {
         // runtime (integration tests). If the lock is held, default to
         // "localhost" which is the safe default — the warning is about
         // network exposure, so false-safe is acceptable.
-        let bind = state.config.try_read().map_or_else(
-            |_| "localhost".to_owned(),
-            |cfg| cfg.gateway.bind.clone(),
-        );
+        let bind = state
+            .config
+            .try_read()
+            .map_or_else(|_| "localhost".to_owned(), |cfg| cfg.gateway.bind.clone());
         let is_loopback = bind == "localhost" || bind == "127.0.0.1" || bind == "::1";
 
         if is_loopback {

--- a/crates/diaporeia/tests/public_api.rs
+++ b/crates/diaporeia/tests/public_api.rs
@@ -193,7 +193,10 @@ fn mcp_claims_is_clone_debug_send_sync() {
 
     // Debug formatting must surface the subject so tracing logs are useful.
     let debug = format!("{original:?}");
-    assert!(debug.contains("bob"), "Debug output must contain subject: {debug}");
+    assert!(
+        debug.contains("bob"),
+        "Debug output must contain subject: {debug}"
+    );
 }
 
 #[test]

--- a/crates/eidos/src/knowledge/mod.rs
+++ b/crates/eidos/src/knowledge/mod.rs
@@ -23,20 +23,20 @@ pub use entity::{EmbeddedChunk, Entity, RecallResult, Relationship};
 
 // ── Re-exports: fact ─────────────────────────────────────────────────────
 
-pub use fact::{
-    EpistemicTier, Fact, FactAccess, FactDiff, FactLifecycle, FactProvenance, FactTemporal,
-    FactType, ForgetReason, KnowledgeStage, StageTransition, VerificationRecord,
-    VerificationSource, VerificationStatus, MAX_CONTENT_LENGTH, default_stability_hours,
-    far_future, format_timestamp, parse_timestamp,
-};
 #[cfg(test)]
 pub(crate) use fact::is_far_future;
+pub use fact::{
+    EpistemicTier, Fact, FactAccess, FactDiff, FactLifecycle, FactProvenance, FactTemporal,
+    FactType, ForgetReason, KnowledgeStage, MAX_CONTENT_LENGTH, StageTransition,
+    VerificationRecord, VerificationSource, VerificationStatus, default_stability_hours,
+    far_future, format_timestamp, parse_timestamp,
+};
 
 // ── Re-exports: path ─────────────────────────────────────────────────────
 
 pub use path::{
-    PathValidationError, PathValidationLayer, ValidatedPath, PATH_VALIDATION_FS_LAYERS,
-    SYMLINK_HOP_LIMIT, validate_memory_path,
+    PATH_VALIDATION_FS_LAYERS, PathValidationError, PathValidationLayer, SYMLINK_HOP_LIMIT,
+    ValidatedPath, validate_memory_path,
 };
 
 // ── Re-exports: scope ────────────────────────────────────────────────────

--- a/crates/eidos/src/lib.rs
+++ b/crates/eidos/src/lib.rs
@@ -11,7 +11,10 @@ pub mod id;
 pub mod knowledge;
 /// Shared test data builders for `Fact`, `Entity`, and `Relationship`.
 #[cfg(any(test, feature = "test-support"))]
-#[expect(clippy::expect_used, reason = "test fixture builders — panics are intentional")]
+#[expect(
+    clippy::expect_used,
+    reason = "test fixture builders — panics are intentional"
+)]
 pub mod test_fixtures;
 /// Training data capture types.
 pub mod training;

--- a/crates/eidos/src/training.rs
+++ b/crates/eidos/src/training.rs
@@ -76,7 +76,6 @@ pub struct TrainingRecord {
     pub timestamp: Timestamp,
 
     // ── Episteme labels (v2) ──────────────────────────────────────────
-
     /// Classification of the conversation turn (e.g. "discussion", "correction").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_type: Option<String>,
@@ -152,9 +151,18 @@ mod tests {
 
         let json = serde_json::to_string(&record).expect("serialize");
         assert!(!json.contains("turn_type"), "None fields should be skipped");
-        assert!(!json.contains("is_correction"), "None fields should be skipped");
-        assert!(!json.contains("fact_types"), "None fields should be skipped");
-        assert!(!json.contains("quality_score"), "None fields should be skipped");
+        assert!(
+            !json.contains("is_correction"),
+            "None fields should be skipped"
+        );
+        assert!(
+            !json.contains("fact_types"),
+            "None fields should be skipped"
+        );
+        assert!(
+            !json.contains("quality_score"),
+            "None fields should be skipped"
+        );
 
         let back: TrainingRecord = serde_json::from_str(&json).expect("deserialize");
         assert!(back.turn_type.is_none());

--- a/crates/eidos/tests/public_api.rs
+++ b/crates/eidos/tests/public_api.rs
@@ -22,19 +22,16 @@ mod ids {
     fn constructors_accept_valid_ids() {
         // WHY: contract — small, non-empty, ASCII IDs must round-trip
         // through new() without validation errors.
-        assert_eq!(
-            FactId::new("fact-001").expect("valid").as_str(),
-            "fact-001"
-        );
+        assert_eq!(FactId::new("fact-001").expect("valid").as_str(), "fact-001");
         assert_eq!(
             EntityId::new("entity-abc").expect("valid").as_str(),
             "entity-abc"
         );
-        assert_eq!(EmbeddingId::new("emb-42").expect("valid").as_str(), "emb-42");
         assert_eq!(
-            CausalEdgeId::new("ce-1").expect("valid").as_str(),
-            "ce-1"
+            EmbeddingId::new("emb-42").expect("valid").as_str(),
+            "emb-42"
         );
+        assert_eq!(CausalEdgeId::new("ce-1").expect("valid").as_str(), "ce-1");
     }
 
     #[test]
@@ -205,8 +202,14 @@ mod knowledge_stage {
     fn from_decay_score_thresholds() {
         // WHY: thresholds are 0.7 / 0.3 / 0.1. A fact at exactly the
         // boundary belongs to the higher stage (inclusive lower bound).
-        assert_eq!(KnowledgeStage::from_decay_score(1.0), KnowledgeStage::Active);
-        assert_eq!(KnowledgeStage::from_decay_score(0.7), KnowledgeStage::Active);
+        assert_eq!(
+            KnowledgeStage::from_decay_score(1.0),
+            KnowledgeStage::Active
+        );
+        assert_eq!(
+            KnowledgeStage::from_decay_score(0.7),
+            KnowledgeStage::Active
+        );
         assert_eq!(
             KnowledgeStage::from_decay_score(0.69),
             KnowledgeStage::Fading
@@ -283,12 +286,22 @@ mod fact_type {
     fn base_stability_ordering_by_volatility() {
         // WHY: identity should outlast preference, which outlasts skill,
         // etc. This ordering is the entire point of the type taxonomy.
-        assert!(FactType::Identity.base_stability_hours() > FactType::Preference.base_stability_hours());
-        assert!(FactType::Preference.base_stability_hours() > FactType::Skill.base_stability_hours());
-        assert!(FactType::Skill.base_stability_hours() > FactType::Relationship.base_stability_hours());
-        assert!(FactType::Relationship.base_stability_hours() > FactType::Event.base_stability_hours());
+        assert!(
+            FactType::Identity.base_stability_hours() > FactType::Preference.base_stability_hours()
+        );
+        assert!(
+            FactType::Preference.base_stability_hours() > FactType::Skill.base_stability_hours()
+        );
+        assert!(
+            FactType::Skill.base_stability_hours() > FactType::Relationship.base_stability_hours()
+        );
+        assert!(
+            FactType::Relationship.base_stability_hours() > FactType::Event.base_stability_hours()
+        );
         assert!(FactType::Event.base_stability_hours() > FactType::Task.base_stability_hours());
-        assert!(FactType::Task.base_stability_hours() > FactType::Observation.base_stability_hours());
+        assert!(
+            FactType::Task.base_stability_hours() > FactType::Observation.base_stability_hours()
+        );
     }
 
     #[test]
@@ -306,10 +319,7 @@ mod fact_type {
             FactType::classify("I prefer tabs over spaces"),
             FactType::Preference
         );
-        assert_eq!(
-            FactType::classify("I like dark mode"),
-            FactType::Preference
-        );
+        assert_eq!(FactType::classify("I like dark mode"), FactType::Preference);
     }
 
     #[test]
@@ -341,10 +351,7 @@ mod fact_type {
             FactType::Observation
         );
         assert_eq!(FactType::from_str_lossy("identity"), FactType::Identity);
-        assert_eq!(
-            FactType::from_str_lossy("preference"),
-            FactType::Preference
-        );
+        assert_eq!(FactType::from_str_lossy("preference"), FactType::Preference);
     }
 }
 

--- a/crates/energeia/src/agent_sdk.rs
+++ b/crates/energeia/src/agent_sdk.rs
@@ -118,7 +118,10 @@ impl AgentSdkEngine {
         args.extend(["--output-format".to_owned(), "stream-json".to_owned()]);
         args.push("--verbose".to_owned());
 
-        let model = options.model.as_deref().unwrap_or(&self.config.default_model);
+        let model = options
+            .model
+            .as_deref()
+            .unwrap_or(&self.config.default_model);
         args.extend(["--model".to_owned(), model.to_owned()]);
 
         // WHY: Apply permission mode based on config (if not skipped).
@@ -212,7 +215,10 @@ impl DispatchEngine for AgentSdkEngine {
 
             tracing::debug!(
                 prompt_len = spec.prompt.len(),
-                model = options.model.as_deref().unwrap_or(&self.config.default_model),
+                model = options
+                    .model
+                    .as_deref()
+                    .unwrap_or(&self.config.default_model),
                 "spawning agent SDK session"
             );
 

--- a/crates/energeia/src/http/mock.rs
+++ b/crates/energeia/src/http/mock.rs
@@ -53,16 +53,12 @@ impl MockEngine {
 
     /// Pop the next configured outcome.
     async fn next_outcome(&self) -> Result<MockOutcome> {
-        self.outcomes
-            .lock()
-            .await
-            .pop_front()
-            .ok_or_else(|| {
-                error::EngineSnafu {
-                    detail: "MockEngine: no more configured outcomes",
-                }
-                .build()
-            })
+        self.outcomes.lock().await.pop_front().ok_or_else(|| {
+            error::EngineSnafu {
+                detail: "MockEngine: no more configured outcomes",
+            }
+            .build()
+        })
     }
 }
 

--- a/crates/energeia/src/metrics/cost.rs
+++ b/crates/energeia/src/metrics/cost.rs
@@ -208,9 +208,7 @@ fn build_project_costs(
 
         acc.dispatches += 1;
 
-        let session_count = sessions_per_dispatch
-            .get(d.id.as_str())
-            .map_or(0, Vec::len);
+        let session_count = sessions_per_dispatch.get(d.id.as_str()).map_or(0, Vec::len);
 
         acc.sessions += u64::try_from(session_count).unwrap_or(u64::MAX);
 
@@ -279,9 +277,7 @@ fn build_daily_velocity(
 
         acc.dispatches += 1;
 
-        let session_count = sessions_per_dispatch
-            .get(d.id.as_str())
-            .map_or(0, Vec::len);
+        let session_count = sessions_per_dispatch.get(d.id.as_str()).map_or(0, Vec::len);
 
         acc.sessions += u64::try_from(session_count).unwrap_or(u64::MAX);
 
@@ -330,7 +326,10 @@ fn build_daily_velocity(
 #[cfg(feature = "storage-fjall")]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(clippy::float_cmp, reason = "test assertions on exact float values")]
-#[expect(clippy::indexing_slicing, reason = "test assertions on collections with known length")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on collections with known length"
+)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/energeia/src/metrics/health.rs
+++ b/crates/energeia/src/metrics/health.rs
@@ -333,13 +333,11 @@ fn qa_false_positive_rate(
     let ci_fail_count = sessions_with_pr
         .iter()
         .filter(|s| {
-            ci_by_session
-                .get(s.id.as_str())
-                .is_some_and(|validations| {
-                    validations
-                        .iter()
-                        .any(|v| v.status == CiValidationStatus::Fail)
-                })
+            ci_by_session.get(s.id.as_str()).is_some_and(|validations| {
+                validations
+                    .iter()
+                    .any(|v| v.status == CiValidationStatus::Fail)
+            })
         })
         .count();
 

--- a/crates/energeia/src/metrics/prometheus.rs
+++ b/crates/energeia/src/metrics/prometheus.rs
@@ -197,7 +197,14 @@ mod tests {
     #[test]
     fn record_session_increments_counter_and_histogram() {
         init();
-        record_session("acme", "success", 0.50, 30_000, "claude-3-5-sonnet", "crates/foo/");
+        record_session(
+            "acme",
+            "success",
+            0.50,
+            30_000,
+            "claude-3-5-sonnet",
+            "crates/foo/",
+        );
         let count = SESSIONS_TOTAL.with_label_values(&["acme", "success"]).get();
         assert!(count >= 1);
     }
@@ -209,7 +216,14 @@ mod tests {
         let before = COST_USD_TOTAL
             .with_label_values(&["nocost-project", "claude-3-5-sonnet", "crates/foo/"])
             .get();
-        record_session("nocost-project", "failed", 0.0, 5_000, "claude-3-5-sonnet", "crates/foo/");
+        record_session(
+            "nocost-project",
+            "failed",
+            0.0,
+            5_000,
+            "claude-3-5-sonnet",
+            "crates/foo/",
+        );
         let after = COST_USD_TOTAL
             .with_label_values(&["nocost-project", "claude-3-5-sonnet", "crates/foo/"])
             .get();

--- a/crates/energeia/src/metrics/status.rs
+++ b/crates/energeia/src/metrics/status.rs
@@ -184,9 +184,7 @@ fn build_project_summaries(
             acc.completed += 1;
         }
 
-        let session_count = sessions_by_dispatch
-            .get(d.id.as_str())
-            .map_or(0, Vec::len);
+        let session_count = sessions_by_dispatch.get(d.id.as_str()).map_or(0, Vec::len);
 
         acc.sessions += u64::try_from(session_count).unwrap_or(u64::MAX);
     }

--- a/crates/energeia/src/orchestrator/group.rs
+++ b/crates/energeia/src/orchestrator/group.rs
@@ -213,7 +213,11 @@ mod tests {
         let budget = Arc::new(Budget::new(Some(10.0), Some(500), None));
         let cancel = CancellationToken::new();
 
-        let prompts = vec![sample_prompt_spec(1), sample_prompt_spec(2), sample_prompt_spec(3)];
+        let prompts = vec![
+            sample_prompt_spec(1),
+            sample_prompt_spec(2),
+            sample_prompt_spec(3),
+        ];
 
         let outcomes = execute_group(
             &prompts,
@@ -246,7 +250,11 @@ mod tests {
         let budget = Arc::new(Budget::new(None, None, None));
         let cancel = CancellationToken::new();
 
-        let prompts = vec![sample_prompt_spec(1), sample_prompt_spec(2), sample_prompt_spec(3)];
+        let prompts = vec![
+            sample_prompt_spec(1),
+            sample_prompt_spec(2),
+            sample_prompt_spec(3),
+        ];
 
         let outcomes = execute_group(
             &prompts,

--- a/crates/energeia/src/orchestrator/mod.rs
+++ b/crates/energeia/src/orchestrator/mod.rs
@@ -265,7 +265,10 @@ impl Orchestrator {
                     "unknown"
                 } else {
                     // SAFETY: blast_radius checked non-empty above
-                    #[expect(clippy::indexing_slicing, reason = "blast_radius checked non-empty at line above")]
+                    #[expect(
+                        clippy::indexing_slicing,
+                        reason = "blast_radius checked non-empty at line above"
+                    )]
                     outcome.blast_radius[0].as_str()
                 };
 

--- a/crates/energeia/src/orchestrator/orchestrator_tests.rs
+++ b/crates/energeia/src/orchestrator/orchestrator_tests.rs
@@ -35,8 +35,7 @@ impl QaGate for MockQaGate {
         prompt: &'a crate::qa::PromptSpec,
         pr_number: u64,
         _diff: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<QaResult>> + Send + 'a>>
-    {
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<QaResult>> + Send + 'a>> {
         Box::pin(async move {
             Ok(QaResult {
                 prompt_number: prompt.prompt_number,
@@ -232,7 +231,10 @@ async fn dispatch_budget_exceeded_aborts() {
         .default_budget_usd(0.15);
 
     let orchestrator = Orchestrator::new(engine, qa, config);
-    let prompts = vec![sample_prompt_spec(1, vec![]), sample_prompt_spec(2, vec![1])];
+    let prompts = vec![
+        sample_prompt_spec(1, vec![]),
+        sample_prompt_spec(2, vec![1]),
+    ];
     let spec = sample_dispatch_spec(vec![1, 2]);
 
     let result = orchestrator.dispatch(spec, &prompts).await.unwrap();
@@ -253,7 +255,9 @@ async fn dispatch_empty_prompts_returns_preflight_error() {
     let config = OrchestratorConfig::default();
 
     let orchestrator = Orchestrator::new(engine, qa, config);
-    let result = orchestrator.dispatch(sample_dispatch_spec(vec![]), &[]).await;
+    let result = orchestrator
+        .dispatch(sample_dispatch_spec(vec![]), &[])
+        .await;
 
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("no prompts"));
@@ -349,7 +353,10 @@ fn dry_run_roundtrip_serialization() {
     let config = OrchestratorConfig::default();
 
     let orchestrator = Orchestrator::new(engine, qa, config);
-    let prompts = vec![sample_prompt_spec(1, vec![]), sample_prompt_spec(2, vec![1])];
+    let prompts = vec![
+        sample_prompt_spec(1, vec![]),
+        sample_prompt_spec(2, vec![1]),
+    ];
 
     let plan = orchestrator.dry_run(&prompts).unwrap();
     let json = serde_json::to_string(&plan).unwrap();

--- a/crates/energeia/src/qa/mod.rs
+++ b/crates/energeia/src/qa/mod.rs
@@ -492,8 +492,11 @@ mod tests {
 
         // WHY: No LLM provider -> semantic criteria fail with clear evidence.
         assert!(!result.semantic_evaluated);
-        assert!(result.criteria_results.iter().any(|cr| {
-            cr.evidence.contains("no LLM provider available")
-        }));
+        assert!(
+            result
+                .criteria_results
+                .iter()
+                .any(|cr| { cr.evidence.contains("no LLM provider available") })
+        );
     }
 }

--- a/crates/energeia/src/session/manager.rs
+++ b/crates/energeia/src/session/manager.rs
@@ -92,7 +92,7 @@ impl SessionManager {
         };
 
         let initial_opts = options.to_agent_options();
-        
+
         // NOTE: Capture model for cost attribution
         let model = initial_opts.model.clone();
 
@@ -117,7 +117,7 @@ impl SessionManager {
 
         let (run_cost, run_turns, run_success, result_text, run_model) =
             extract_run_metrics(session_result, &stream_result);
-        
+
         // Use model from result if available, otherwise from initial options
         let effective_model = run_model.or_else(|| model.clone());
 
@@ -290,7 +290,7 @@ impl SessionManager {
 
             let (run_cost, run_turns, run_success, result_text, run_model) =
                 extract_run_metrics(session_result, &stream_result);
-            
+
             // Use model from result if available, otherwise preserve existing
             let effective_model = run_model.or_else(|| effective_model.clone());
 

--- a/crates/energeia/src/store/queries.rs
+++ b/crates/energeia/src/store/queries.rs
@@ -75,7 +75,13 @@ pub(crate) fn list_sessions_for_dispatch(
     dispatch_id: &crate::store::records::DispatchId,
 ) -> Result<Vec<SessionRecord>> {
     let prefix = schema::session_prefix_for_dispatch(dispatch_id);
-    prefix_scan(keyspace, prefix.as_bytes(), "session prefix scan", usize::MAX, |_: &SessionRecord| true)
+    prefix_scan(
+        keyspace,
+        prefix.as_bytes(),
+        "session prefix scan",
+        usize::MAX,
+        |_: &SessionRecord| true,
+    )
 }
 
 /// Query lessons with optional source filter, returning up to `limit` results.
@@ -98,15 +104,21 @@ pub(crate) fn query_lessons(
         None => schema::lesson_prefix().as_bytes(),
     };
 
-    prefix_scan(keyspace, prefix_bytes, "lesson prefix scan", limit, |record: &LessonRecord| {
-        if category.is_some_and(|cat| record.category != cat) {
-            return false;
-        }
-        if project.is_some_and(|proj| record.project.as_deref() != Some(proj)) {
-            return false;
-        }
-        true
-    })
+    prefix_scan(
+        keyspace,
+        prefix_bytes,
+        "lesson prefix scan",
+        limit,
+        |record: &LessonRecord| {
+            if category.is_some_and(|cat| record.category != cat) {
+                return false;
+            }
+            if project.is_some_and(|proj| record.project.as_deref() != Some(proj)) {
+                return false;
+            }
+            true
+        },
+    )
 }
 
 /// Query observations with optional project filter and day window.
@@ -134,15 +146,21 @@ pub(crate) fn query_observations(
         cutoff.as_millisecond()
     });
 
-    prefix_scan(keyspace, prefix_bytes, "observation prefix scan", limit, |record: &ObservationRecord| {
-        if cutoff_ms.is_some_and(|cutoff| record.created_at.as_millisecond() < cutoff) {
-            return false;
-        }
-        if project.is_some_and(|proj| record.project != proj) {
-            return false;
-        }
-        true
-    })
+    prefix_scan(
+        keyspace,
+        prefix_bytes,
+        "observation prefix scan",
+        limit,
+        |record: &ObservationRecord| {
+            if cutoff_ms.is_some_and(|cutoff| record.created_at.as_millisecond() < cutoff) {
+                return false;
+            }
+            if project.is_some_and(|proj| record.project != proj) {
+                return false;
+            }
+            true
+        },
+    )
 }
 
 /// Collect all dispatch records via prefix scan.
@@ -155,7 +173,13 @@ pub(crate) fn list_dispatches(
     limit: usize,
 ) -> Result<Vec<crate::store::records::DispatchRecord>> {
     let prefix_bytes = schema::dispatch_prefix().as_bytes();
-    prefix_scan(keyspace, prefix_bytes, "dispatch prefix scan", limit, |_: &DispatchRecord| true)
+    prefix_scan(
+        keyspace,
+        prefix_bytes,
+        "dispatch prefix scan",
+        limit,
+        |_: &DispatchRecord| true,
+    )
 }
 
 /// Collect all session records across all dispatches via prefix scan.
@@ -168,7 +192,13 @@ pub(crate) fn list_all_sessions(
     limit: usize,
 ) -> Result<Vec<SessionRecord>> {
     let prefix_bytes = schema::session_prefix().as_bytes();
-    prefix_scan(keyspace, prefix_bytes, "session prefix scan", limit, |_: &SessionRecord| true)
+    prefix_scan(
+        keyspace,
+        prefix_bytes,
+        "session prefix scan",
+        limit,
+        |_: &SessionRecord| true,
+    )
 }
 
 /// Collect all CI validation records across all sessions via prefix scan.
@@ -180,7 +210,13 @@ pub(crate) fn list_all_ci_validations(
     limit: usize,
 ) -> Result<Vec<CiValidationRecord>> {
     let prefix_bytes = schema::ci_validation_prefix().as_bytes();
-    prefix_scan(keyspace, prefix_bytes, "ci_validation prefix scan", limit, |_: &CiValidationRecord| true)
+    prefix_scan(
+        keyspace,
+        prefix_bytes,
+        "ci_validation prefix scan",
+        limit,
+        |_: &CiValidationRecord| true,
+    )
 }
 
 /// Collect CI validations for a given session via prefix scan.
@@ -190,5 +226,11 @@ pub(crate) fn list_ci_validations_for_session(
     session_id: &crate::store::records::SessionId,
 ) -> Result<Vec<CiValidationRecord>> {
     let prefix = schema::ci_validation_prefix_for_session(session_id);
-    prefix_scan(keyspace, prefix.as_bytes(), "ci_validation prefix scan", usize::MAX, |_: &CiValidationRecord| true)
+    prefix_scan(
+        keyspace,
+        prefix.as_bytes(),
+        "ci_validation prefix scan",
+        usize::MAX,
+        |_: &CiValidationRecord| true,
+    )
 }

--- a/crates/energeia/src/types.rs
+++ b/crates/energeia/src/types.rs
@@ -109,11 +109,11 @@ pub struct SessionOutcome {
     /// Error message if the session failed.
     pub error: Option<String>,
     /// LLM model used for this session (e.g., "claude-3-5-sonnet").
-    /// 
+    ///
     /// This is `None` if the model could not be determined from the session.
     pub model: Option<String>,
     /// Blast radius paths from the prompt spec.
-    /// 
+    ///
     /// Used for cost attribution to specific modules/features.
     pub blast_radius: Vec<String>,
 }

--- a/crates/energeia/tests/public_api.rs
+++ b/crates/energeia/tests/public_api.rs
@@ -84,7 +84,10 @@ fn agent_options_builder_chaining() {
         .permission_mode("plan");
 
     assert_eq!(opts.model, Some("claude-sonnet-4-20250514".to_owned()));
-    assert_eq!(opts.system_prompt, Some("You are a helpful coding assistant".to_owned()));
+    assert_eq!(
+        opts.system_prompt,
+        Some("You are a helpful coding assistant".to_owned())
+    );
     assert_eq!(opts.cwd, Some("/tmp/project".to_owned()));
     assert_eq!(opts.max_turns, Some(100));
     assert_eq!(opts.permission_mode, Some("plan".to_owned()));
@@ -109,7 +112,10 @@ fn agent_options_serde_roundtrip() {
     let json = serde_json::to_string(&opts).expect("serialize");
     let deserialized: AgentOptions = serde_json::from_str(&json).expect("deserialize");
 
-    assert_eq!(deserialized.model, Some("claude-opus-4-20250514".to_owned()));
+    assert_eq!(
+        deserialized.model,
+        Some("claude-opus-4-20250514".to_owned())
+    );
     assert_eq!(deserialized.max_turns, Some(50));
     assert!(deserialized.system_prompt.is_none());
 }
@@ -198,7 +204,10 @@ fn orchestrator_config_serde_roundtrip() {
     assert_eq!(deserialized.max_concurrent, 6);
     assert_eq!(deserialized.default_budget_usd, Some(25.0));
     assert_eq!(deserialized.max_duration, Some(Duration::from_secs(1800)));
-    assert_eq!(deserialized.session_idle_timeout, Some(Duration::from_secs(600)));
+    assert_eq!(
+        deserialized.session_idle_timeout,
+        Some(Duration::from_secs(600))
+    );
 }
 
 #[test]
@@ -228,7 +237,9 @@ fn cost_ledger_record_and_query_single() {
 
     ledger.record("crates/foo/", 1.50, 10, "claude-3-5-sonnet");
 
-    let cost = ledger.query("crates/foo/").expect("should find cost record");
+    let cost = ledger
+        .query("crates/foo/")
+        .expect("should find cost record");
     assert_eq!(cost.blast_radius, "crates/foo/");
     assert!((cost.total_cost_usd - 1.50).abs() < 0.001);
     assert_eq!(cost.total_turns, 10);
@@ -243,7 +254,9 @@ fn cost_ledger_record_accumulates() {
     ledger.record("crates/foo/", 2.00, 20, "claude-3-5-sonnet");
     ledger.record("crates/foo/", 0.50, 5, "claude-3-haiku");
 
-    let cost = ledger.query("crates/foo/").expect("should find cost record");
+    let cost = ledger
+        .query("crates/foo/")
+        .expect("should find cost record");
     assert!((cost.total_cost_usd - 3.50).abs() < 0.001);
     assert_eq!(cost.total_turns, 35);
     assert_eq!(cost.session_count, 3);
@@ -365,8 +378,16 @@ fn cost_ledger_cost_by_model_accumulation() {
 
     // By model: claude-opus = 2.50, claude-sonnet = 1.50
     assert_eq!(cost.cost_by_model.len(), 2);
-    let opus_cost = cost.cost_by_model.get("claude-opus").copied().unwrap_or(0.0);
-    let sonnet_cost = cost.cost_by_model.get("claude-sonnet").copied().unwrap_or(0.0);
+    let opus_cost = cost
+        .cost_by_model
+        .get("claude-opus")
+        .copied()
+        .unwrap_or(0.0);
+    let sonnet_cost = cost
+        .cost_by_model
+        .get("claude-sonnet")
+        .copied()
+        .unwrap_or(0.0);
     assert!((opus_cost - 2.50).abs() < 0.001);
     assert!((sonnet_cost - 1.50).abs() < 0.001);
 }
@@ -511,10 +532,7 @@ fn mechanical_issue_kind_display() {
         MechanicalIssueKind::BlastRadiusViolation.to_string(),
         "blast_radius_violation"
     );
-    assert_eq!(
-        MechanicalIssueKind::AntiPattern.to_string(),
-        "anti_pattern"
-    );
+    assert_eq!(MechanicalIssueKind::AntiPattern.to_string(), "anti_pattern");
     assert_eq!(
         MechanicalIssueKind::LintViolation.to_string(),
         "lint_violation"
@@ -540,9 +558,7 @@ fn session_event_serde_roundtrip() {
     };
     let json = serde_json::to_string(&event).expect("serialize");
     let deserialized: SessionEvent = serde_json::from_str(&json).expect("deserialize");
-    assert!(
-        matches!(deserialized, SessionEvent::ToolUse { name, .. } if name == "read_file")
-    );
+    assert!(matches!(deserialized, SessionEvent::ToolUse { name, .. } if name == "read_file"));
 }
 
 #[test]
@@ -562,7 +578,10 @@ fn session_event_variants_serde() {
     let event = SessionEvent::TurnComplete { turn: 5 };
     let json = serde_json::to_string(&event).expect("serialize");
     let deserialized: SessionEvent = serde_json::from_str(&json).expect("deserialize");
-    assert!(matches!(deserialized, SessionEvent::TurnComplete { turn: 5 }));
+    assert!(matches!(
+        deserialized,
+        SessionEvent::TurnComplete { turn: 5 }
+    ));
 
     // Test Error variant
     let event = SessionEvent::Error {
@@ -798,8 +817,12 @@ fn agent_options_equality() {
 
 #[test]
 fn orchestrator_config_equality() {
-    let config1 = OrchestratorConfig::new().max_concurrent(8).default_budget_usd(10.0);
-    let config2 = OrchestratorConfig::new().max_concurrent(8).default_budget_usd(10.0);
+    let config1 = OrchestratorConfig::new()
+        .max_concurrent(8)
+        .default_budget_usd(10.0);
+    let config2 = OrchestratorConfig::new()
+        .max_concurrent(8)
+        .default_budget_usd(10.0);
     let config3 = OrchestratorConfig::new().max_concurrent(4);
 
     assert_eq!(config1.max_concurrent, config2.max_concurrent);

--- a/crates/episteme/benches/observation.rs
+++ b/crates/episteme/benches/observation.rs
@@ -10,11 +10,10 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
-use episteme::extract::observation::{
-    ObservationType, extract_tags, parse_observations,
-};
+use episteme::extract::observation::{ObservationType, extract_tags, parse_observations};
 
-const SHORT_BODY: &str = "## Observations\n- bug: foo crashed when bar #tag\n- idea: try baz instead";
+const SHORT_BODY: &str =
+    "## Observations\n- bug: foo crashed when bar #tag\n- idea: try baz instead";
 
 const LONG_BODY: &str = "
 ## Summary

--- a/crates/episteme/src/admission.rs
+++ b/crates/episteme/src/admission.rs
@@ -394,11 +394,7 @@ mod tests {
             0.5,
             "observation",
         );
-        let long = make_fact(
-            &"x".repeat(200),
-            0.5,
-            "observation",
-        );
+        let long = make_fact(&"x".repeat(200), 0.5, "observation");
 
         assert!(policy.score_utility(&short) < policy.score_utility(&medium));
         assert!(policy.score_utility(&medium) < policy.score_utility(&long));
@@ -429,7 +425,10 @@ mod tests {
             type_prior: 1.0,
         };
         let combined = scores.combined();
-        assert!((combined - 1.0).abs() < f64::EPSILON, "all 1.0 should combine to 1.0");
+        assert!(
+            (combined - 1.0).abs() < f64::EPSILON,
+            "all 1.0 should combine to 1.0"
+        );
 
         let scores_zero = AdmissionScores {
             utility: 0.0,
@@ -438,6 +437,9 @@ mod tests {
             recency: 0.0,
             type_prior: 0.0,
         };
-        assert!(scores_zero.combined().abs() < f64::EPSILON, "all 0.0 should combine to 0.0");
+        assert!(
+            scores_zero.combined().abs() < f64::EPSILON,
+            "all 0.0 should combine to 0.0"
+        );
     }
 }

--- a/crates/episteme/src/causal.rs
+++ b/crates/episteme/src/causal.rs
@@ -300,7 +300,10 @@ pub(crate) fn detect_causal_cue(text: &str) -> Option<(CausalRelationType, f64)>
 #[must_use]
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "documented hook for RefinedExtraction.causal_signal consumers; exercised from tests until first in-tree caller lands")
+    expect(
+        dead_code,
+        reason = "documented hook for RefinedExtraction.causal_signal consumers; exercised from tests until first in-tree caller lands"
+    )
 )]
 pub(crate) fn extract_causal_edges(
     session_text: &str,
@@ -340,7 +343,10 @@ pub(crate) fn extract_causal_edges(
 
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
-#[expect(clippy::indexing_slicing, reason = "test assertions on collections with known length")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on collections with known length"
+)]
 mod tests {
     use super::*;
 
@@ -428,7 +434,10 @@ mod tests {
         let chain = store.trace_effects(&fact_id("fact-a"));
         let fact_c_node = chain.iter().find(|n| n.fact_id == fact_id("fact-c"));
         let conf = fact_c_node.expect("fact-c in chain").chain_confidence;
-        assert!((conf - 0.4).abs() < 1e-9, "expected 0.8*0.5=0.4, got {conf}");
+        assert!(
+            (conf - 0.4).abs() < 1e-9,
+            "expected 0.8*0.5=0.4, got {conf}"
+        );
     }
 
     #[test]
@@ -443,13 +452,17 @@ mod tests {
             .expect("ok");
         // Should terminate without infinite recursion.
         let chain = store.trace_effects(&fact_id("fact-a"));
-        assert!(chain.len() <= 3, "cycle must be cut off; got {}", chain.len());
+        assert!(
+            chain.len() <= 3,
+            "cycle must be cut off; got {}",
+            chain.len()
+        );
     }
 
     #[test]
     fn detect_causal_cue_because() {
-        let (rel, conf) = detect_causal_cue("it failed because the config was wrong")
-            .expect("cue found");
+        let (rel, conf) =
+            detect_causal_cue("it failed because the config was wrong").expect("cue found");
         assert_eq!(rel, CausalRelationType::Caused);
         assert!(conf > 0.5);
     }

--- a/crates/episteme/src/conflict.rs
+++ b/crates/episteme/src/conflict.rs
@@ -422,7 +422,10 @@ pub(crate) fn classify_against_candidates(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    for &(idx, candidate) in sorted_candidates.iter().take(DEFAULT_MAX_LLM_CALLS_PER_FACT) {
+    for &(idx, candidate) in sorted_candidates
+        .iter()
+        .take(DEFAULT_MAX_LLM_CALLS_PER_FACT)
+    {
         let response = classifier.classify(
             &candidate.existing_content,
             candidate.existing_confidence,

--- a/crates/episteme/src/decay.rs
+++ b/crates/episteme/src/decay.rs
@@ -125,7 +125,11 @@ pub(crate) fn compute_decay(config: &DecayConfig, factors: &DecayFactors) -> Dec
     let recency = score_recency(factors.age_hours, effective_stability);
     let frequency = score_frequency(factors.access_count);
     let confidence = score_confidence(factors.tier);
-    let reinforcement = score_reinforcement(factors.reinforcement_count, config.reinforcement_boost, config.max_reinforcement_bonus);
+    let reinforcement = score_reinforcement(
+        factors.reinforcement_count,
+        config.reinforcement_boost,
+        config.max_reinforcement_bonus,
+    );
 
     let total_weight = config.total_weight();
     let weighted = if total_weight > 0.0 {
@@ -138,7 +142,11 @@ pub(crate) fn compute_decay(config: &DecayConfig, factors: &DecayFactors) -> Dec
         recency
     };
 
-    let cross_agent_mult = cross_agent_multiplier(factors.distinct_agent_count, config.cross_agent_bonus_per_agent, config.max_cross_agent_multiplier);
+    let cross_agent_mult = cross_agent_multiplier(
+        factors.distinct_agent_count,
+        config.cross_agent_bonus_per_agent,
+        config.max_cross_agent_multiplier,
+    );
     let score = (weighted * cross_agent_mult).clamp(0.0, 1.0);
 
     DecayResult {
@@ -189,7 +197,11 @@ fn score_confidence(tier: EpistemicTier) -> f64 {
 ///
 /// Each reinforcement event adds a fixed boost, capped at `max_reinforcement_bonus`.
 #[must_use]
-fn score_reinforcement(reinforcement_count: u32, reinforcement_boost: f64, max_reinforcement_bonus: f64) -> f64 {
+fn score_reinforcement(
+    reinforcement_count: u32,
+    reinforcement_boost: f64,
+    max_reinforcement_bonus: f64,
+) -> f64 {
     let bonus = f64::from(reinforcement_count) * reinforcement_boost;
     bonus.min(max_reinforcement_bonus)
 }
@@ -200,7 +212,11 @@ fn score_reinforcement(reinforcement_count: u32, reinforcement_boost: f64, max_r
 /// relevant and decay slower. Each additional agent beyond the first adds
 /// a bonus multiplier.
 #[must_use]
-pub(crate) fn cross_agent_multiplier(distinct_agent_count: u32, bonus_per_agent: f64, max_multiplier: f64) -> f64 {
+pub(crate) fn cross_agent_multiplier(
+    distinct_agent_count: u32,
+    bonus_per_agent: f64,
+    max_multiplier: f64,
+) -> f64 {
     if distinct_agent_count <= 1 {
         return 1.0;
     }
@@ -372,19 +388,39 @@ mod tests {
     #[test]
     fn cross_agent_multiplier_bounds() {
         assert!(
-            (cross_agent_multiplier(0, DEFAULT_CROSS_AGENT_BONUS_PER_AGENT, DEFAULT_MAX_CROSS_AGENT_MULTIPLIER) - 1.0).abs() < f64::EPSILON,
+            (cross_agent_multiplier(
+                0,
+                DEFAULT_CROSS_AGENT_BONUS_PER_AGENT,
+                DEFAULT_MAX_CROSS_AGENT_MULTIPLIER
+            ) - 1.0)
+                .abs()
+                < f64::EPSILON,
             "zero agents should give 1.0 multiplier"
         );
         assert!(
-            (cross_agent_multiplier(1, DEFAULT_CROSS_AGENT_BONUS_PER_AGENT, DEFAULT_MAX_CROSS_AGENT_MULTIPLIER) - 1.0).abs() < f64::EPSILON,
+            (cross_agent_multiplier(
+                1,
+                DEFAULT_CROSS_AGENT_BONUS_PER_AGENT,
+                DEFAULT_MAX_CROSS_AGENT_MULTIPLIER
+            ) - 1.0)
+                .abs()
+                < f64::EPSILON,
             "single agent should give 1.0 multiplier"
         );
-        let two = cross_agent_multiplier(2, DEFAULT_CROSS_AGENT_BONUS_PER_AGENT, DEFAULT_MAX_CROSS_AGENT_MULTIPLIER);
+        let two = cross_agent_multiplier(
+            2,
+            DEFAULT_CROSS_AGENT_BONUS_PER_AGENT,
+            DEFAULT_MAX_CROSS_AGENT_MULTIPLIER,
+        );
         assert!(
             (two - 1.15).abs() < f64::EPSILON,
             "two agents should give 1.15, got {two}"
         );
-        let capped = cross_agent_multiplier(100, DEFAULT_CROSS_AGENT_BONUS_PER_AGENT, DEFAULT_MAX_CROSS_AGENT_MULTIPLIER);
+        let capped = cross_agent_multiplier(
+            100,
+            DEFAULT_CROSS_AGENT_BONUS_PER_AGENT,
+            DEFAULT_MAX_CROSS_AGENT_MULTIPLIER,
+        );
         assert!(
             (capped - DEFAULT_MAX_CROSS_AGENT_MULTIPLIER).abs() < f64::EPSILON,
             "should cap at {DEFAULT_MAX_CROSS_AGENT_MULTIPLIER}, got {capped}"
@@ -600,7 +636,11 @@ mod tests {
 
     #[test]
     fn score_reinforcement_caps() {
-        let capped = score_reinforcement(100, DEFAULT_REINFORCEMENT_BOOST, DEFAULT_MAX_REINFORCEMENT_BONUS);
+        let capped = score_reinforcement(
+            100,
+            DEFAULT_REINFORCEMENT_BOOST,
+            DEFAULT_MAX_REINFORCEMENT_BONUS,
+        );
         assert!(
             (capped - DEFAULT_MAX_REINFORCEMENT_BONUS).abs() < f64::EPSILON,
             "reinforcement should cap at {DEFAULT_MAX_REINFORCEMENT_BONUS}, got {capped}"

--- a/crates/episteme/src/dedup_tests.rs
+++ b/crates/episteme/src/dedup_tests.rs
@@ -200,8 +200,7 @@ fn embedding_similarity_triggers_candidate() {
         ),
     ];
     let embed_fn = |a: &EntityId, b: &EntityId| -> f64 {
-        if (a.as_str() == "e1" && b.as_str() == "e2")
-            || (a.as_str() == "e2" && b.as_str() == "e1")
+        if (a.as_str() == "e1" && b.as_str() == "e2") || (a.as_str() == "e2" && b.as_str() == "e1")
         {
             0.95
         } else {
@@ -221,8 +220,7 @@ fn classify_auto_merge_and_review() {
         entity("e3", "Alicia Test", "person", vec![], 1, "2026-01-03"),
     ];
     let high_embed = |a: &EntityId, b: &EntityId| -> f64 {
-        if (a.as_str() == "e1" && b.as_str() == "e2")
-            || (a.as_str() == "e2" && b.as_str() == "e1")
+        if (a.as_str() == "e1" && b.as_str() == "e2") || (a.as_str() == "e2" && b.as_str() == "e1")
         {
             0.95
         } else {

--- a/crates/episteme/src/embedding/embedding_impl.rs
+++ b/crates/episteme/src/embedding/embedding_impl.rs
@@ -3,9 +3,11 @@
 #[cfg(any(test, feature = "test-support"))]
 use tracing::instrument;
 
-use crate::embedding::{DegradedEmbeddingProvider, EmbedFailedSnafu, EmbeddingProvider, EmbeddingResult};
 #[cfg(any(test, feature = "test-support"))]
 use crate::embedding::MockEmbeddingProvider;
+use crate::embedding::{
+    DegradedEmbeddingProvider, EmbedFailedSnafu, EmbeddingProvider, EmbeddingResult,
+};
 
 // ── MockEmbeddingProvider implementation ─────────────────────────────────────
 

--- a/crates/episteme/src/embedding_eval.rs
+++ b/crates/episteme/src/embedding_eval.rs
@@ -269,13 +269,8 @@ pub(crate) fn evaluate_model(
     let mut rr_sum = 0.0_f64;
 
     for eq in &dataset.queries {
-        let outcome = score_one_query(
-            provider,
-            eq,
-            corpus,
-            &corpus_vecs,
-            [eff_k, eff_k5, eff_k10],
-        )?;
+        let outcome =
+            score_one_query(provider, eq, corpus, &corpus_vecs, [eff_k, eff_k5, eff_k10])?;
         if outcome.hit_k {
             hit_count_k += 1;
         }
@@ -454,7 +449,10 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
-#[expect(clippy::indexing_slicing, reason = "test assertions on collections with known length")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on collections with known length"
+)]
 mod tests {
     use super::*;
     use crate::embedding::MockEmbeddingProvider;
@@ -467,7 +465,10 @@ mod tests {
         vec![
             ("id-alice".into(), "alice prefers tea over coffee".into()),
             ("id-bob".into(), "bob enjoys cycling on weekends".into()),
-            ("id-carol".into(), "carol studies distributed systems".into()),
+            (
+                "id-carol".into(),
+                "carol studies distributed systems".into(),
+            ),
         ]
     }
 
@@ -497,11 +498,13 @@ mod tests {
 
     #[test]
     fn parse_skips_blank_lines() {
-        let ds = EvalDataset::from_jsonl_str(
-            "\n{\"query\":\"x\",\"relevant_ids\":[\"y\"]}\n\n",
-        )
-        .expect("blank lines should be skipped");
-        assert_eq!(ds.len(), 1, "parse skips blank lines: values should be equal");
+        let ds = EvalDataset::from_jsonl_str("\n{\"query\":\"x\",\"relevant_ids\":[\"y\"]}\n\n")
+            .expect("blank lines should be skipped");
+        assert_eq!(
+            ds.len(),
+            1,
+            "parse skips blank lines: values should be equal"
+        );
     }
 
     #[test]
@@ -537,8 +540,7 @@ mod tests {
     fn evaluate_empty_corpus_errors() {
         let provider = mock();
         let dataset = simple_dataset();
-        let err = evaluate_model(&provider, &dataset, &[], 5)
-            .expect_err("empty corpus must error");
+        let err = evaluate_model(&provider, &dataset, &[], 5).expect_err("empty corpus must error");
         assert!(
             matches!(err, EvalError::EmptyCorpus { .. }),
             "expected EmptyCorpus, got {err:?}"
@@ -550,8 +552,8 @@ mod tests {
         let provider = mock();
         let corpus = simple_corpus();
         let dataset = EvalDataset { queries: vec![] };
-        let err = evaluate_model(&provider, &dataset, &corpus, 5)
-            .expect_err("empty dataset must error");
+        let err =
+            evaluate_model(&provider, &dataset, &corpus, 5).expect_err("empty dataset must error");
         assert!(
             matches!(err, EvalError::EmptyDataset { .. }),
             "expected EmptyDataset, got {err:?}"
@@ -566,10 +568,7 @@ mod tests {
         let run = compare_models(&provider, None, &dataset, &corpus, 3)
             .expect("compare_models with no candidate must succeed");
         assert!(run.passed, "no candidate always passes");
-        assert!(
-            run.candidate.is_none(),
-            "no candidate means None in result"
-        );
+        assert!(run.candidate.is_none(), "no candidate means None in result");
     }
 
     #[test]
@@ -590,14 +589,11 @@ mod tests {
         let provider = mock();
         let corpus = simple_corpus();
         let dataset = simple_dataset();
-        let metrics = evaluate_model(&provider, &dataset, &corpus, 2)
-            .expect("evaluate_model must succeed");
+        let metrics =
+            evaluate_model(&provider, &dataset, &corpus, 2).expect("evaluate_model must succeed");
         for qr in &metrics.per_query {
             assert!(!qr.query.is_empty(), "query must not be empty");
-            assert!(
-                qr.top_k_ids.len() <= 2,
-                "top_k_ids capped at k=2"
-            );
+            assert!(qr.top_k_ids.len() <= 2, "top_k_ids capped at k=2");
             assert!(
                 qr.reciprocal_rank >= 0.0 && qr.reciprocal_rank <= 1.0,
                 "rr must be in [0,1]"
@@ -627,11 +623,17 @@ mod tests {
         let a = vec![1.0_f32, 0.0];
         let b = vec![0.0_f32, 1.0];
         let sim = cosine_similarity(&a, &b);
-        assert!((sim - 0.0).abs() < 1e-6, "orthogonal unit vectors => similarity 0");
+        assert!(
+            (sim - 0.0).abs() < 1e-6,
+            "orthogonal unit vectors => similarity 0"
+        );
 
         let c = vec![1.0_f32, 0.0];
         let same = cosine_similarity(&a, &c);
-        assert!((same - 1.0).abs() < 1e-6, "identical unit vectors => similarity 1");
+        assert!(
+            (same - 1.0).abs() < 1e-6,
+            "identical unit vectors => similarity 1"
+        );
     }
 
     #[test]

--- a/crates/episteme/src/evidence_gap.rs
+++ b/crates/episteme/src/evidence_gap.rs
@@ -359,7 +359,10 @@ fn extract_interrogatives(clause: &str) -> Vec<String> {
 }
 
 #[cfg(test)]
-#[expect(clippy::indexing_slicing, reason = "test assertions on collections with known length")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on collections with known length"
+)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
@@ -519,7 +522,9 @@ mod tests {
     fn suggest_refinement_returns_single_gap_directly() {
         let mut tracker = EvidenceGapTracker::new("A and B");
         tracker.record_evidence(0, "fact-001", 0.9);
-        let suggestion = tracker.suggest_refinement().expect("should have a suggestion");
+        let suggestion = tracker
+            .suggest_refinement()
+            .expect("should have a suggestion");
         // Single remaining gap returned directly (no wrapping).
         assert_eq!(suggestion, tracker.remaining_gaps()[0]);
     }
@@ -527,7 +532,9 @@ mod tests {
     #[test]
     fn suggest_refinement_combines_multiple_gaps() {
         let tracker = EvidenceGapTracker::new("A and B and C");
-        let suggestion = tracker.suggest_refinement().expect("should have a suggestion");
+        let suggestion = tracker
+            .suggest_refinement()
+            .expect("should have a suggestion");
         // Multiple gaps: includes original query context.
         assert!(suggestion.contains("Regarding"));
         assert!(suggestion.contains(&tracker.query().original_query));

--- a/crates/episteme/src/extract/dispatch.rs
+++ b/crates/episteme/src/extract/dispatch.rs
@@ -191,7 +191,10 @@ pub struct GradeInputs {
 #[must_use]
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "scoring helper exercised from tests; steward wiring lands with dispatch reporter")
+    expect(
+        dead_code,
+        reason = "scoring helper exercised from tests; steward wiring lands with dispatch reporter"
+    )
 )]
 pub(crate) fn compute_grade(inputs: GradeInputs) -> Grade {
     if inputs.has_failure {

--- a/crates/episteme/src/extract/engine.rs
+++ b/crates/episteme/src/extract/engine.rs
@@ -18,10 +18,10 @@ use super::types::PersistResult;
 use super::types::{
     ConversationMessage, Extraction, ExtractionConfig, ExtractionPrompt, RefinedExtraction,
 };
-use crate::causal;
 #[cfg(feature = "mneme-engine")]
 use super::utils::slugify;
 use super::utils::strip_code_fences;
+use crate::causal;
 
 /// Drives the extraction pipeline: prompt building, LLM calling, response parsing.
 pub struct ExtractionEngine {
@@ -230,11 +230,8 @@ Rules:
             .filter_map(|mut fact| {
                 // WHY: reject facts with empty triple fields before any other processing —
                 // a fact with no subject, predicate, or object has zero semantic value.
-                if !refinement::validate_triple_fields(
-                    &fact.subject,
-                    &fact.predicate,
-                    &fact.object,
-                ) {
+                if !refinement::validate_triple_fields(&fact.subject, &fact.predicate, &fact.object)
+                {
                     filtered_count += 1;
                     tracing::debug!(
                         subject = %fact.subject,

--- a/crates/episteme/src/extract/lesson.rs
+++ b/crates/episteme/src/extract/lesson.rs
@@ -98,7 +98,10 @@ pub struct LessonConfig {
 /// 3. Extract knowledge facts from the changes
 /// 4. Produce entities, relationships, and causal edges
 #[must_use]
-#[cfg_attr(not(test), expect(dead_code, reason = "post-merge lesson extraction from git diffs"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "post-merge lesson extraction from git diffs")
+)]
 pub(crate) fn extract_lessons(diff: &str, config: &LessonConfig) -> ExtractedLesson {
     let parsed = parse_unified_diff(diff);
     let changes = classify_changes(&parsed);
@@ -543,8 +546,14 @@ pub(crate) fn persist_lesson(
             fact_ids.get(causal.effect_index),
         ) {
             let edge = CausalEdge {
-                id: crate::id::CausalEdgeId::new(koina::ulid::Ulid::new().to_string())
-                    .map_err(|e| PersistSnafu { message: e.to_string() }.build())?,
+                id: crate::id::CausalEdgeId::new(koina::ulid::Ulid::new().to_string()).map_err(
+                    |e| {
+                        PersistSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    },
+                )?,
                 source_id: cause_id.clone(),
                 target_id: effect_id.clone(),
                 relationship_type: crate::knowledge::CausalRelationType::Caused,

--- a/crates/episteme/src/extract/observation.rs
+++ b/crates/episteme/src/extract/observation.rs
@@ -373,7 +373,10 @@ pub fn extract_tags(text: &str) -> Vec<String> {
 }
 
 #[cfg(test)]
-#[expect(clippy::indexing_slicing, reason = "test assertions on collections with known length")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on collections with known length"
+)]
 mod tests {
     use super::*;
 

--- a/crates/episteme/src/extract/training.rs
+++ b/crates/episteme/src/extract/training.rs
@@ -215,9 +215,11 @@ pub fn extract_from_training_data(training_dir: &Path) -> std::io::Result<Extrac
     }
 
     // Sort lessons by confidence descending for deterministic output.
-    result
-        .lessons
-        .sort_by(|a, b| b.confidence.partial_cmp(&a.confidence).unwrap_or(std::cmp::Ordering::Equal));
+    result.lessons.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
 
     Ok(result)
 }
@@ -243,7 +245,11 @@ pub fn lessons_to_facts(lessons: &[TrainingLesson]) -> Vec<super::types::Extract
             };
 
             let object = if let Some(pr) = lesson.pr_number {
-                format!("{} (PR #{pr}, {} files)", lesson.description, lesson.affected_files.len())
+                format!(
+                    "{} (PR #{pr}, {} files)",
+                    lesson.description,
+                    lesson.affected_files.len()
+                )
             } else {
                 format!(
                     "{} ({} occurrences across {} files)",
@@ -317,9 +323,7 @@ impl RuleBucket {
                 lessons.push(TrainingLesson {
                     rule: rule.to_owned(),
                     outcome: LessonOutcome::FixedInPr,
-                    description: format!(
-                        "rule {rule} violation fixed: {sample_snippet}"
-                    ),
+                    description: format!("rule {rule} violation fixed: {sample_snippet}"),
                     // WHY: PR-linked violations are verified fixes (high confidence).
                     confidence: 0.9,
                     affected_files: pr_files,
@@ -396,9 +400,15 @@ fn detect_trends(summary: &LintSummaryRecord, buckets: &mut HashMap<String, Rule
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
-#[expect(clippy::indexing_slicing, reason = "test assertions on collections with known length")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on collections with known length"
+)]
 #[expect(clippy::float_cmp, reason = "test assertions on exact float values")]
-#[expect(clippy::disallowed_methods, reason = "tests use std::fs for synchronous fixture setup")]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "tests use std::fs for synchronous fixture setup"
+)]
 mod tests {
     use super::*;
 
@@ -465,8 +475,16 @@ mod tests {
 
         let lessons = bucket.to_lessons("RUST/expect");
         assert_eq!(lessons.len(), 2, "one fixed + one recurring");
-        assert!(lessons.iter().any(|l| l.outcome == LessonOutcome::FixedInPr));
-        assert!(lessons.iter().any(|l| l.outcome == LessonOutcome::RecurringViolation));
+        assert!(
+            lessons
+                .iter()
+                .any(|l| l.outcome == LessonOutcome::FixedInPr)
+        );
+        assert!(
+            lessons
+                .iter()
+                .any(|l| l.outcome == LessonOutcome::RecurringViolation)
+        );
     }
 
     #[test]
@@ -568,11 +586,7 @@ mod tests {
             r#"{"type":"violation","schema_version":2,"ts":"2026-03-25T15:43:30Z","rule":"RUST/expect","file":"/src/lib.rs","line":10,"snippet":".expect(\"msg\")","project":"","pr_number":42,"sha":"abc123"}"#,
             r#"{"type":"violation","schema_version":2,"ts":"2026-03-25T15:43:30Z","rule":"RUST/expect","file":"/src/main.rs","line":20,"snippet":".expect(\"other\")","project":"","pr_number":null,"sha":null}"#,
         ];
-        std::fs::write(
-            dir.path().join("violations.jsonl"),
-            violations.join("\n"),
-        )
-        .unwrap();
+        std::fs::write(dir.path().join("violations.jsonl"), violations.join("\n")).unwrap();
 
         // Write a lint summary file.
         let lint = r#"{"type":"lint","schema_version":2,"ts":"2026-03-25T15:43:30Z","repo":"/repo","total_violations":100,"rules_triggered":10,"duration_ms":5000}"#;
@@ -585,11 +599,17 @@ mod tests {
 
         // Should have a fixed lesson and a recurring lesson.
         assert!(
-            result.lessons.iter().any(|l| l.outcome == LessonOutcome::FixedInPr),
+            result
+                .lessons
+                .iter()
+                .any(|l| l.outcome == LessonOutcome::FixedInPr),
             "should have a FixedInPr lesson"
         );
         assert!(
-            result.lessons.iter().any(|l| l.outcome == LessonOutcome::RecurringViolation),
+            result
+                .lessons
+                .iter()
+                .any(|l| l.outcome == LessonOutcome::RecurringViolation),
             "should have a RecurringViolation lesson"
         );
     }
@@ -608,7 +628,10 @@ mod tests {
     #[test]
     fn outcome_display() {
         assert_eq!(LessonOutcome::FixedInPr.to_string(), "fixed_in_pr");
-        assert_eq!(LessonOutcome::RecurringViolation.to_string(), "recurring_violation");
+        assert_eq!(
+            LessonOutcome::RecurringViolation.to_string(),
+            "recurring_violation"
+        );
         assert_eq!(LessonOutcome::ImprovingTrend.to_string(), "improving_trend");
         assert_eq!(LessonOutcome::DegradingTrend.to_string(), "degrading_trend");
     }
@@ -620,11 +643,7 @@ mod tests {
             r#"{"type":"violation","schema_version":2,"ts":"2026-01-01T00:00:00Z","rule":"LOW/rule","file":"/a.rs","line":1,"snippet":"x","project":"","pr_number":null,"sha":null}"#,
             r#"{"type":"violation","schema_version":2,"ts":"2026-01-01T00:00:00Z","rule":"HIGH/rule","file":"/b.rs","line":1,"snippet":"y","project":"","pr_number":99,"sha":"abc"}"#,
         ];
-        std::fs::write(
-            dir.path().join("violations.jsonl"),
-            violations.join("\n"),
-        )
-        .unwrap();
+        std::fs::write(dir.path().join("violations.jsonl"), violations.join("\n")).unwrap();
 
         let result = extract_from_training_data(dir.path()).unwrap();
         assert!(result.lessons.len() >= 2);

--- a/crates/episteme/src/extract/utils.rs
+++ b/crates/episteme/src/extract/utils.rs
@@ -10,14 +10,18 @@ pub(super) fn strip_code_fences(s: &str) -> &str {
         if let Some(stripped) = rest.strip_suffix("```") {
             stripped.trim()
         } else {
-            tracing::warn!("LLM response has opening ```json fence but no closing ```, stripping opening fence only");
+            tracing::warn!(
+                "LLM response has opening ```json fence but no closing ```, stripping opening fence only"
+            );
             rest.trim()
         }
     } else if let Some(rest) = trimmed.strip_prefix("```") {
         if let Some(stripped) = rest.strip_suffix("```") {
             stripped.trim()
         } else {
-            tracing::warn!("LLM response has opening ``` fence but no closing ```, stripping opening fence only");
+            tracing::warn!(
+                "LLM response has opening ``` fence but no closing ```, stripping opening fence only"
+            );
             rest.trim()
         }
     } else {

--- a/crates/episteme/src/instinct.rs
+++ b/crates/episteme/src/instinct.rs
@@ -415,9 +415,11 @@ fn sanitize_value(value: &serde_json::Value, max_param_value_len: usize) -> serd
                 serde_json::Value::String(s.clone())
             }
         }
-        serde_json::Value::Array(arr) => {
-            serde_json::Value::Array(arr.iter().map(|v| sanitize_value(v, max_param_value_len)).collect())
-        }
+        serde_json::Value::Array(arr) => serde_json::Value::Array(
+            arr.iter()
+                .map(|v| sanitize_value(v, max_param_value_len))
+                .collect(),
+        ),
         serde_json::Value::Object(map) => {
             sanitize_parameters(&serde_json::Value::Object(map.clone()), max_param_value_len)
         }

--- a/crates/episteme/src/instinct_tests/basic_behavior.rs
+++ b/crates/episteme/src/instinct_tests/basic_behavior.rs
@@ -62,7 +62,11 @@ fn aggregation_creates_pattern_from_successful_calls() {
         })
         .collect();
 
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert_eq!(
         patterns.len(),
         1,
@@ -103,7 +107,11 @@ fn aggregation_no_pattern_below_minimum_observations() {
         })
         .collect();
 
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert!(
         patterns.is_empty(),
         "3 observations should not produce a pattern (minimum is 5)"
@@ -133,7 +141,11 @@ fn aggregation_no_pattern_below_success_rate() {
         ));
     }
 
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert!(
         patterns.is_empty(),
         "40% success rate should not produce a pattern (minimum is 80%)"
@@ -377,7 +389,11 @@ fn aggregation_separates_tools() {
         ));
     }
 
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert_eq!(patterns.len(), 2, "should have separate patterns per tool");
     let names: Vec<_> = patterns.iter().map(|p| p.tool_name.as_str()).collect();
     assert!(names.contains(&"grep"), "grep pattern should be present");
@@ -469,7 +485,11 @@ fn observations_different_context_categories_aggregate_separately() {
             observed_at: ts(&format!("2026-03-{:02}T12:00:00Z", i + 1)),
         });
     }
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     let custom: Vec<_> = patterns
         .iter()
         .filter(|p| p.tool_name == "custom_tool")

--- a/crates/episteme/src/instinct_tests/requirements.rs
+++ b/crates/episteme/src/instinct_tests/requirements.rs
@@ -49,7 +49,11 @@ fn aggregation_with_empty_parameters_does_not_panic() {
             observed_at: ts(&format!("2026-03-{:02}T10:00:00Z", i + 1)),
         })
         .collect();
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert_eq!(
         patterns.len(),
         1,
@@ -69,7 +73,11 @@ fn four_successful_calls_does_not_trigger_pattern() {
             )
         })
         .collect();
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert!(
         patterns.is_empty(),
         "4 observations is below the minimum threshold of {DEFAULT_MIN_OBSERVATIONS}"
@@ -88,7 +96,11 @@ fn five_successful_calls_at_threshold_triggers_pattern() {
             )
         })
         .collect();
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert_eq!(
         patterns.len(),
         1,
@@ -122,7 +134,11 @@ fn ten_calls_below_80_percent_success_rate_does_not_trigger() {
             &format!("2026-03-{:02}T11:00:00Z", i + 1),
         ));
     }
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert!(
         patterns.is_empty(),
         "70% success rate should not trigger a pattern (minimum is {:.0}%)",
@@ -152,7 +168,11 @@ fn ten_calls_at_80_percent_success_rate_boundary_triggers_pattern() {
             &format!("2026-03-{:02}T11:00:00Z", i + 1),
         ));
     }
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert_eq!(
         patterns.len(),
         1,
@@ -271,7 +291,11 @@ fn different_nous_observations_aggregate_together_without_filter() {
         nous_id: "nous-bob".to_owned(),
         observed_at: ts(&format!("2026-03-{:02}T11:00:00Z", i + 1)),
     }));
-    let all = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let all = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert_eq!(
         all.len(),
         1,
@@ -283,7 +307,8 @@ fn different_nous_observations_aggregate_together_without_filter() {
         .filter(|o| o.nous_id == "nous-alice")
         .cloned()
         .collect();
-    let alice_patterns = aggregate_observations(&alice, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let alice_patterns =
+        aggregate_observations(&alice, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
     assert!(
         alice_patterns.is_empty(),
         "3 observations below threshold when filtered per-nous"
@@ -311,7 +336,11 @@ fn two_tools_identical_parameters_produce_separate_patterns() {
             observed_at: ts(&format!("2026-03-{:02}T11:00:00Z", i + 1)),
         });
     }
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert_eq!(
         patterns.len(),
         2,
@@ -348,7 +377,11 @@ fn tool_name_matching_is_case_sensitive() {
             &format!("2026-03-{:02}T11:00:00Z", i + 1),
         ));
     }
-    let patterns = aggregate_observations(&observations, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_SUCCESS_RATE);
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
     assert_eq!(
         patterns.len(),
         2,

--- a/crates/episteme/src/knowledge_portability.rs
+++ b/crates/episteme/src/knowledge_portability.rs
@@ -73,12 +73,14 @@ fn query_all_entities(
                 .map(|s: &str| s.trim().to_owned())
                 .collect()
         };
-        let created_at =
-            crate::knowledge::parse_timestamp(&rows.get_string(i, "created_at").unwrap_or_default())
-                .unwrap_or_else(jiff::Timestamp::now);
-        let updated_at =
-            crate::knowledge::parse_timestamp(&rows.get_string(i, "updated_at").unwrap_or_default())
-                .unwrap_or_else(jiff::Timestamp::now);
+        let created_at = crate::knowledge::parse_timestamp(
+            &rows.get_string(i, "created_at").unwrap_or_default(),
+        )
+        .unwrap_or_else(jiff::Timestamp::now);
+        let updated_at = crate::knowledge::parse_timestamp(
+            &rows.get_string(i, "updated_at").unwrap_or_default(),
+        )
+        .unwrap_or_else(jiff::Timestamp::now);
 
         entities.push(crate::knowledge::Entity {
             id,
@@ -114,9 +116,10 @@ fn query_all_relationships(
         let dst = crate::id::EntityId::new(&dst_str).context(crate::error::InvalidIdSnafu)?;
         let relation = rows.get_string(i, "relation").unwrap_or_default();
         let weight = rows.get_f64(i, "weight").unwrap_or(0.0);
-        let created_at =
-            crate::knowledge::parse_timestamp(&rows.get_string(i, "created_at").unwrap_or_default())
-                .unwrap_or_else(jiff::Timestamp::now);
+        let created_at = crate::knowledge::parse_timestamp(
+            &rows.get_string(i, "created_at").unwrap_or_default(),
+        )
+        .unwrap_or_else(jiff::Timestamp::now);
 
         relationships.push(crate::knowledge::Relationship {
             src,

--- a/crates/episteme/src/knowledge_store/causal.rs
+++ b/crates/episteme/src/knowledge_store/causal.rs
@@ -61,7 +61,10 @@ impl KnowledgeStore {
     ///
     /// Returns [`EngineQuery`](crate::error::Error::EngineQuery) if the deletion fails.
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "causal graph operations for knowledge store"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "causal graph operations for knowledge store")
+    )]
     pub(crate) fn remove_causal_edge(
         &self,
         cause: &crate::id::FactId,
@@ -106,7 +109,10 @@ impl KnowledgeStore {
     ///
     /// Returns [`EngineQuery`](crate::error::Error::EngineQuery) if the query fails.
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "causal graph operations for knowledge store"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "causal graph operations for knowledge store")
+    )]
     pub(crate) fn query_causes(
         &self,
         effect_id: &crate::id::FactId,
@@ -134,7 +140,10 @@ impl KnowledgeStore {
     ///
     /// Returns [`EngineQuery`](crate::error::Error::EngineQuery) if the query fails.
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "knowledge pipeline infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "knowledge pipeline infrastructure")
+    )]
     pub(crate) fn list_causal_edges(
         &self,
     ) -> crate::error::Result<Vec<crate::knowledge::CausalEdge>> {
@@ -160,7 +169,10 @@ impl KnowledgeStore {
     ///
     /// Returns [`EngineQuery`](crate::error::Error::EngineQuery) if any query fails.
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "knowledge pipeline infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "knowledge pipeline infrastructure")
+    )]
     pub(crate) fn propagate_confidence(
         &self,
         start: &crate::id::FactId,

--- a/crates/episteme/src/knowledge_store/entity.rs
+++ b/crates/episteme/src/knowledge_store/entity.rs
@@ -59,7 +59,10 @@ impl KnowledgeStore {
 
     /// Insert a fact-entity mapping.
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "entity operations for knowledge store"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "entity operations for knowledge store")
+    )]
     pub(crate) fn insert_fact_entity(
         &self,
         fact_id: &crate::id::FactId,
@@ -276,7 +279,10 @@ impl KnowledgeStore {
 
     /// Approve a pending merge: execute it.
     #[instrument(skip(self))]
-    #[expect(dead_code, reason = "entity dedup pipeline — no callers yet including tests")]
+    #[expect(
+        dead_code,
+        reason = "entity dedup pipeline — no callers yet including tests"
+    )]
     pub(crate) fn approve_merge(
         &self,
         canonical_id: &crate::id::EntityId,
@@ -291,7 +297,10 @@ impl KnowledgeStore {
         clippy::used_underscore_binding,
         reason = "nous_id reserved for future filtering"
     )]
-    #[expect(dead_code, reason = "entity dedup pipeline — no callers yet including tests")]
+    #[expect(
+        dead_code,
+        reason = "entity dedup pipeline — no callers yet including tests"
+    )]
     pub(crate) fn get_merge_history(
         &self,
         _nous_id: &str,

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -59,7 +59,10 @@ impl KnowledgeStore {
         reason = "sequential param mapping, splitting adds indirection"
     )]
     #[instrument(skip(self, old_fact, new_fact), fields(old_id = %old_fact.id, new_id = %new_fact.id))]
-    #[expect(dead_code, reason = "fact temporal pipeline — no callers yet including tests")]
+    #[expect(
+        dead_code,
+        reason = "fact temporal pipeline — no callers yet including tests"
+    )]
     pub(crate) fn supersede_fact(
         &self,
         old_fact: &crate::knowledge::Fact,
@@ -205,7 +208,10 @@ impl KnowledgeStore {
 
     /// Point-in-time fact query.
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "fact temporal operations for knowledge store"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "fact temporal operations for knowledge store")
+    )]
     pub(crate) fn query_facts_at(
         &self,
         time: &str,
@@ -873,7 +879,10 @@ mod tests {
             .query_facts("alice", "2026-06-01", 100)
             .expect("query after upsert");
         assert_eq!(results.len(), 1, "upsert must not create a duplicate row");
-        assert_eq!(results[0].content, "Updated content", "content should be the updated value");
+        assert_eq!(
+            results[0].content, "Updated content",
+            "content should be the updated value"
+        );
     }
 
     #[test]
@@ -883,7 +892,10 @@ mod tests {
         let result = store.insert_fact(&fact);
         assert!(result.is_err(), "empty content should be rejected");
         assert!(
-            matches!(result.expect_err("must fail"), crate::error::Error::EmptyContent { .. }),
+            matches!(
+                result.expect_err("must fail"),
+                crate::error::Error::EmptyContent { .. }
+            ),
             "error variant should be EmptyContent"
         );
     }
@@ -896,9 +908,15 @@ mod tests {
         let mut fact = make_fact("too-long", "alice", "placeholder");
         fact.content = long;
         let result = store.insert_fact(&fact);
-        assert!(result.is_err(), "content exceeding max length should be rejected");
         assert!(
-            matches!(result.expect_err("must fail"), crate::error::Error::ContentTooLong { .. }),
+            result.is_err(),
+            "content exceeding max length should be rejected"
+        );
+        assert!(
+            matches!(
+                result.expect_err("must fail"),
+                crate::error::Error::ContentTooLong { .. }
+            ),
             "error variant should be ContentTooLong"
         );
     }
@@ -911,7 +929,10 @@ mod tests {
         let result = store.insert_fact(&fact);
         assert!(result.is_err(), "confidence > 1.0 must be rejected");
         assert!(
-            matches!(result.expect_err("must fail"), crate::error::Error::InvalidConfidence { .. }),
+            matches!(
+                result.expect_err("must fail"),
+                crate::error::Error::InvalidConfidence { .. }
+            ),
             "error variant should be InvalidConfidence"
         );
     }
@@ -924,7 +945,10 @@ mod tests {
         let result = store.insert_fact(&fact);
         assert!(result.is_err(), "confidence < 0.0 must be rejected");
         assert!(
-            matches!(result.expect_err("must fail"), crate::error::Error::InvalidConfidence { .. }),
+            matches!(
+                result.expect_err("must fail"),
+                crate::error::Error::InvalidConfidence { .. }
+            ),
             "error variant should be InvalidConfidence"
         );
     }
@@ -935,16 +959,24 @@ mod tests {
 
         let mut fact_zero = make_fact("conf-zero", "alice", "zero confidence");
         fact_zero.provenance.confidence = 0.0;
-        store.insert_fact(&fact_zero).expect("confidence 0.0 should be accepted");
+        store
+            .insert_fact(&fact_zero)
+            .expect("confidence 0.0 should be accepted");
 
         let mut fact_one = make_fact("conf-one", "alice", "full confidence");
         fact_one.provenance.confidence = 1.0;
-        store.insert_fact(&fact_one).expect("confidence 1.0 should be accepted");
+        store
+            .insert_fact(&fact_one)
+            .expect("confidence 1.0 should be accepted");
 
         let results = store
             .query_facts("alice", "2026-06-01", 100)
             .expect("query boundary confidence facts");
-        assert_eq!(results.len(), 2, "both boundary-confidence facts should be stored");
+        assert_eq!(
+            results.len(),
+            2,
+            "both boundary-confidence facts should be stored"
+        );
     }
 
     // ── Query operations ───────────────────────────────────────────────────────
@@ -976,7 +1008,11 @@ mod tests {
         let store = make_store();
         for i in 0..3_u8 {
             store
-                .insert_fact(&make_fact(&format!("q-multi-{i}"), "alice", &format!("Fact {i}")))
+                .insert_fact(&make_fact(
+                    &format!("q-multi-{i}"),
+                    "alice",
+                    &format!("Fact {i}"),
+                ))
                 .expect("insert");
         }
         let results = store
@@ -991,7 +1027,10 @@ mod tests {
         let results = store
             .query_facts_by_type("alice", "preference", 100)
             .expect("query by type on empty store");
-        assert!(results.is_empty(), "empty store should return no typed facts");
+        assert!(
+            results.is_empty(),
+            "empty store should return no typed facts"
+        );
     }
 
     #[test]
@@ -1023,13 +1062,21 @@ mod tests {
         let prefs = store
             .query_facts_by_type("alice", "preference", 100)
             .expect("query preference type");
-        assert_eq!(prefs.len(), 1, "only the preference fact should be returned");
+        assert_eq!(
+            prefs.len(),
+            1,
+            "only the preference fact should be returned"
+        );
         assert_eq!(prefs[0].id.as_str(), "qt-pref");
 
         let obs_results = store
             .query_facts_by_type("alice", "observation", 100)
             .expect("query observation type");
-        assert_eq!(obs_results.len(), 1, "only the observation fact should be returned");
+        assert_eq!(
+            obs_results.len(),
+            1,
+            "only the observation fact should be returned"
+        );
         assert_eq!(obs_results[0].id.as_str(), "qt-obs");
     }
 
@@ -1043,7 +1090,10 @@ mod tests {
         let results = store
             .query_facts_by_type("alice", "preference", 100)
             .expect("query alice preference");
-        assert!(results.is_empty(), "bob's facts must not appear in alice's query");
+        assert!(
+            results.is_empty(),
+            "bob's facts must not appear in alice's query"
+        );
     }
 
     #[test]
@@ -1062,14 +1112,20 @@ mod tests {
         let results = store
             .query_facts_by_type("alice", "preference", 100)
             .expect("query after forget");
-        assert!(results.is_empty(), "forgotten facts must not appear in typed query");
+        assert!(
+            results.is_empty(),
+            "forgotten facts must not appear in typed query"
+        );
     }
 
     #[test]
     fn list_all_facts_empty_store_returns_empty() {
         let store = make_store();
         let all = store.list_all_facts(100).expect("list_all_facts empty");
-        assert!(all.is_empty(), "list_all_facts on empty store should return empty");
+        assert!(
+            all.is_empty(),
+            "list_all_facts on empty store should return empty"
+        );
     }
 
     #[test]
@@ -1085,8 +1141,14 @@ mod tests {
         let all = store.list_all_facts(100).expect("list_all_facts");
         assert_eq!(all.len(), 2, "both agents' facts must be returned");
         let ids: Vec<&str> = all.iter().map(|f| f.id.as_str()).collect();
-        assert!(ids.contains(&"la-1"), "alice's fact must be in list_all_facts");
-        assert!(ids.contains(&"la-2"), "bob's fact must be in list_all_facts");
+        assert!(
+            ids.contains(&"la-1"),
+            "alice's fact must be in list_all_facts"
+        );
+        assert!(
+            ids.contains(&"la-2"),
+            "bob's fact must be in list_all_facts"
+        );
     }
 
     #[test]
@@ -1094,11 +1156,19 @@ mod tests {
         let store = make_store();
         for i in 0..5_u8 {
             store
-                .insert_fact(&make_fact(&format!("la-limit-{i}"), "alice", &format!("Fact {i}")))
+                .insert_fact(&make_fact(
+                    &format!("la-limit-{i}"),
+                    "alice",
+                    &format!("Fact {i}"),
+                ))
                 .expect("insert");
         }
         let limited = store.list_all_facts(2).expect("list_all_facts limit 2");
-        assert_eq!(limited.len(), 2, "list_all_facts should honour the limit parameter");
+        assert_eq!(
+            limited.len(),
+            2,
+            "list_all_facts should honour the limit parameter"
+        );
     }
 
     // ── Soft-delete lifecycle ──────────────────────────────────────────────────
@@ -1116,7 +1186,10 @@ mod tests {
                 ForgetReason::UserRequested,
             )
             .expect("forget");
-        assert!(forgotten.lifecycle.is_forgotten, "returned fact should be marked forgotten");
+        assert!(
+            forgotten.lifecycle.is_forgotten,
+            "returned fact should be marked forgotten"
+        );
         assert_eq!(
             forgotten.lifecycle.forget_reason,
             Some(ForgetReason::UserRequested),
@@ -1144,7 +1217,10 @@ mod tests {
         let results = store
             .query_facts("alice", "2026-06-01", 100)
             .expect("query after forget");
-        assert!(results.is_empty(), "forgotten fact must not appear in query_facts");
+        assert!(
+            results.is_empty(),
+            "forgotten fact must not appear in query_facts"
+        );
     }
 
     #[test]
@@ -1163,7 +1239,10 @@ mod tests {
         let restored = store
             .unforget_fact(&crate::id::FactId::new("sd-3").expect("valid test id"))
             .expect("unforget");
-        assert!(!restored.lifecycle.is_forgotten, "restored fact must not be marked as forgotten");
+        assert!(
+            !restored.lifecycle.is_forgotten,
+            "restored fact must not be marked as forgotten"
+        );
         assert!(
             restored.lifecycle.forgotten_at.is_none(),
             "forgotten_at must be cleared after unforget"
@@ -1196,12 +1275,17 @@ mod tests {
             )
             .expect("forget");
 
-        let forgotten = store
-            .list_forgotten("alice", 100)
-            .expect("list_forgotten");
-        assert_eq!(forgotten.len(), 1, "list_forgotten should return only the forgotten fact");
+        let forgotten = store.list_forgotten("alice", 100).expect("list_forgotten");
+        assert_eq!(
+            forgotten.len(),
+            1,
+            "list_forgotten should return only the forgotten fact"
+        );
         assert_eq!(forgotten[0].id.as_str(), "lf-gone");
-        assert!(forgotten[0].lifecycle.is_forgotten, "listed fact must be marked as forgotten");
+        assert!(
+            forgotten[0].lifecycle.is_forgotten,
+            "listed fact must be marked as forgotten"
+        );
     }
 
     #[test]
@@ -1213,7 +1297,10 @@ mod tests {
         );
         assert!(result.is_err(), "forgetting a non-existent fact must error");
         let msg = result.expect_err("must fail").to_string();
-        assert!(msg.contains("not found"), "error should mention 'not found': {msg}");
+        assert!(
+            msg.contains("not found"),
+            "error should mention 'not found': {msg}"
+        );
     }
 
     #[test]
@@ -1221,7 +1308,10 @@ mod tests {
         let store = make_store();
         let result =
             store.unforget_fact(&crate::id::FactId::new("does-not-exist").expect("valid test id"));
-        assert!(result.is_err(), "unforgetting a non-existent fact must error");
+        assert!(
+            result.is_err(),
+            "unforgetting a non-existent fact must error"
+        );
     }
 
     // ── Confidence updates ─────────────────────────────────────────────────────
@@ -1234,10 +1324,7 @@ mod tests {
             .expect("insert");
 
         let updated = store
-            .update_confidence(
-                &crate::id::FactId::new("uc-1").expect("valid test id"),
-                0.5,
-            )
+            .update_confidence(&crate::id::FactId::new("uc-1").expect("valid test id"), 0.5)
             .expect("update_confidence 0.5");
         assert!(
             (updated.provenance.confidence - 0.5).abs() < f64::EPSILON,
@@ -1303,9 +1390,15 @@ mod tests {
             &crate::id::FactId::new("uc-hi").expect("valid test id"),
             1.5,
         );
-        assert!(result.is_err(), "confidence > 1.0 must be rejected by update_confidence");
         assert!(
-            matches!(result.expect_err("must fail"), crate::error::Error::InvalidConfidence { .. }),
+            result.is_err(),
+            "confidence > 1.0 must be rejected by update_confidence"
+        );
+        assert!(
+            matches!(
+                result.expect_err("must fail"),
+                crate::error::Error::InvalidConfidence { .. }
+            ),
             "error variant should be InvalidConfidence"
         );
     }
@@ -1321,9 +1414,15 @@ mod tests {
             &crate::id::FactId::new("uc-lo").expect("valid test id"),
             -0.1,
         );
-        assert!(result.is_err(), "confidence < 0.0 must be rejected by update_confidence");
         assert!(
-            matches!(result.expect_err("must fail"), crate::error::Error::InvalidConfidence { .. }),
+            result.is_err(),
+            "confidence < 0.0 must be rejected by update_confidence"
+        );
+        assert!(
+            matches!(
+                result.expect_err("must fail"),
+                crate::error::Error::InvalidConfidence { .. }
+            ),
             "error variant should be InvalidConfidence"
         );
     }
@@ -1335,9 +1434,15 @@ mod tests {
             &crate::id::FactId::new("no-such-fact").expect("valid test id"),
             0.5,
         );
-        assert!(result.is_err(), "update_confidence on missing fact must error");
+        assert!(
+            result.is_err(),
+            "update_confidence on missing fact must error"
+        );
         let msg = result.expect_err("must fail").to_string();
-        assert!(msg.contains("not found"), "error should mention 'not found': {msg}");
+        assert!(
+            msg.contains("not found"),
+            "error should mention 'not found': {msg}"
+        );
     }
 
     // ── Temporal queries ───────────────────────────────────────────────────────
@@ -1348,12 +1453,17 @@ mod tests {
         let mut fact = make_fact("temp-1", "alice", "Temporal fact");
         fact.temporal.valid_from =
             crate::knowledge::parse_timestamp("2026-01-01").expect("valid_from");
-        fact.temporal.valid_to =
-            crate::knowledge::parse_timestamp("2026-06-01").expect("valid_to");
+        fact.temporal.valid_to = crate::knowledge::parse_timestamp("2026-06-01").expect("valid_to");
         store.insert_fact(&fact).expect("insert temporal fact");
 
-        let results = store.query_facts_at("2026-03-15").expect("query at mid-window");
-        assert_eq!(results.len(), 1, "fact should be visible inside its validity window");
+        let results = store
+            .query_facts_at("2026-03-15")
+            .expect("query at mid-window");
+        assert_eq!(
+            results.len(),
+            1,
+            "fact should be visible inside its validity window"
+        );
         assert_eq!(results[0].id.as_str(), "temp-1");
     }
 
@@ -1363,12 +1473,16 @@ mod tests {
         let mut fact = make_fact("temp-2", "alice", "Expired temporal fact");
         fact.temporal.valid_from =
             crate::knowledge::parse_timestamp("2026-01-01").expect("valid_from");
-        fact.temporal.valid_to =
-            crate::knowledge::parse_timestamp("2026-06-01").expect("valid_to");
+        fact.temporal.valid_to = crate::knowledge::parse_timestamp("2026-06-01").expect("valid_to");
         store.insert_fact(&fact).expect("insert expired fact");
 
-        let results = store.query_facts_at("2026-07-01").expect("query after window closes");
-        assert!(results.is_empty(), "fact should not be visible after its validity window ends");
+        let results = store
+            .query_facts_at("2026-07-01")
+            .expect("query after window closes");
+        assert!(
+            results.is_empty(),
+            "fact should not be visible after its validity window ends"
+        );
     }
 
     #[test]
@@ -1391,13 +1505,21 @@ mod tests {
         let at_feb = store
             .query_facts_temporal("alice", "2026-02-01", None)
             .expect("query feb");
-        assert_eq!(at_feb.len(), 1, "only the early fact should be visible in February");
+        assert_eq!(
+            at_feb.len(),
+            1,
+            "only the early fact should be visible in February"
+        );
         assert_eq!(at_feb[0].id.as_str(), "temp-early");
 
         let at_jun = store
             .query_facts_temporal("alice", "2026-06-01", None)
             .expect("query june");
-        assert_eq!(at_jun.len(), 1, "only the late fact should be visible in June");
+        assert_eq!(
+            at_jun.len(),
+            1,
+            "only the late fact should be visible in June"
+        );
         assert_eq!(at_jun[0].id.as_str(), "temp-late");
     }
 
@@ -1423,7 +1545,11 @@ mod tests {
             .expect("query diff");
         assert_eq!(diff.added.len(), 1, "one fact should be in the added set");
         assert_eq!(diff.added[0].id.as_str(), "diff-new");
-        assert_eq!(diff.removed.len(), 1, "one fact should be in the removed set");
+        assert_eq!(
+            diff.removed.len(),
+            1,
+            "one fact should be in the removed set"
+        );
         assert_eq!(diff.removed[0].id.as_str(), "diff-old");
         assert!(diff.modified.is_empty(), "no modified pairs expected");
     }
@@ -1433,8 +1559,13 @@ mod tests {
     #[test]
     fn read_facts_by_id_unknown_id_returns_empty() {
         let store = make_store();
-        let results = store.read_facts_by_id("unknown-id").expect("read by id succeeds");
-        assert!(results.is_empty(), "reading an unknown id should return an empty vec, not an error");
+        let results = store
+            .read_facts_by_id("unknown-id")
+            .expect("read by id succeeds");
+        assert!(
+            results.is_empty(),
+            "reading an unknown id should return an empty vec, not an error"
+        );
     }
 
     // ── query_forgotten_ids ────────────────────────────────────────────────────
@@ -1465,7 +1596,13 @@ mod tests {
         let forgotten_ids = store
             .query_forgotten_ids(&["qfi-visible", "qfi-gone"])
             .expect("query_forgotten_ids");
-        assert!(!forgotten_ids.contains("qfi-visible"), "visible fact must not appear in forgotten ids");
-        assert!(forgotten_ids.contains("qfi-gone"), "forgotten fact must appear in forgotten ids");
+        assert!(
+            !forgotten_ids.contains("qfi-visible"),
+            "visible fact must not appear in forgotten ids"
+        );
+        assert!(
+            forgotten_ids.contains("qfi-gone"),
+            "forgotten fact must appear in forgotten ids"
+        );
     }
 }

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -824,7 +824,10 @@ mod tests {
         let a = vec!["read".to_owned(), "write".to_owned(), "bash".to_owned()];
         let b = vec!["read".to_owned(), "write".to_owned(), "grep".to_owned()];
         let result = compute_tool_overlap(&a, &b);
-        assert!((result - 0.5).abs() < f64::EPSILON, "expected 0.5, got {result}");
+        assert!(
+            (result - 0.5).abs() < f64::EPSILON,
+            "expected 0.5, got {result}"
+        );
     }
 
     #[test]
@@ -874,7 +877,10 @@ mod tests {
     fn name_similarity_substring_match() {
         // "kitten" vs "kit" — LCS = "kit" (3), max_len = 6, ratio = 0.5
         let result = compute_name_similarity("kitten", "kit");
-        assert!((result - 0.5).abs() < f64::EPSILON, "expected 0.5, got {result}");
+        assert!(
+            (result - 0.5).abs() < f64::EPSILON,
+            "expected 0.5, got {result}"
+        );
     }
 
     #[test]

--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -224,11 +224,7 @@ impl QueryResult {
     #[must_use]
     pub fn get_string(&self, row: usize, col: &str) -> Option<String> {
         let ci = self.col_index(col)?;
-        self.rows
-            .get(row)?
-            .get(ci)?
-            .get_str()
-            .map(str::to_owned)
+        self.rows.get(row)?.get(ci)?.get_str().map(str::to_owned)
     }
 
     /// Extract an `f64` value by row index and column name.
@@ -325,8 +321,10 @@ impl QueryResult {
                 if let Some(i) = dv.get_int() {
                     serde_json::Value::Number(serde_json::Number::from(i))
                 } else if let Some(f) = dv.get_float() {
-                    serde_json::Number::from_f64(f)
-                        .map_or_else(|| serde_json::Value::String(f.to_string()), serde_json::Value::Number)
+                    serde_json::Number::from_f64(f).map_or_else(
+                        || serde_json::Value::String(f.to_string()),
+                        serde_json::Value::Number,
+                    )
                 } else {
                     serde_json::Value::String(format!("{dv:?}"))
                 }

--- a/crates/episteme/src/knowledge_store/skills.rs
+++ b/crates/episteme/src/knowledge_store/skills.rs
@@ -11,7 +11,10 @@ impl KnowledgeStore {
     /// Filters facts where `fact_type = "skill"` and whose JSON content
     /// contains at least one of the given `domain_tags`.
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "skill operations for knowledge store"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "skill operations for knowledge store")
+    )]
     pub(crate) fn find_skills_by_domain(
         &self,
         nous_id: &str,
@@ -300,7 +303,10 @@ impl KnowledgeStore {
 
     /// Gather skill health metrics for a nous.
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "skill operations for knowledge store"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "skill operations for knowledge store")
+    )]
     pub(crate) fn skill_quality_metrics(
         &self,
         nous_id: &str,

--- a/crates/episteme/src/knowledge_store/tests/causal.rs
+++ b/crates/episteme/src/knowledge_store/tests/causal.rs
@@ -4,8 +4,8 @@
     reason = "test assertions use direct indexing"
 )]
 
-use crate::id::FactId;
 use crate::id::CausalEdgeId;
+use crate::id::FactId;
 use crate::knowledge::{
     CausalEdge, CausalRelationType, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance,
     FactTemporal, TemporalOrdering, far_future,
@@ -95,7 +95,11 @@ fn insert_and_query_causal_edge() {
         .query_causes(&FactId::new("fact-b").expect("valid test id"))
         .expect("query_causes should succeed");
     assert_eq!(causes.len(), 1, "should have one cause");
-    assert_eq!(causes[0].source_id.as_str(), "fact-a", "cause should be fact-a");
+    assert_eq!(
+        causes[0].source_id.as_str(),
+        "fact-a",
+        "cause should be fact-a"
+    );
 }
 
 #[test]

--- a/crates/episteme/src/knowledge_store/tests/ddl.rs
+++ b/crates/episteme/src/knowledge_store/tests/ddl.rs
@@ -117,7 +117,11 @@ fn hybrid_search_empty_seeds_returns_results() {
     };
 
     let dim = 4;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let fact = Fact {
         id: crate::id::FactId::new("f1").expect("valid test id"),
@@ -198,7 +202,11 @@ fn hybrid_search_graph_aggregation() {
     };
 
     let dim = 4;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let f1 = Fact {
         id: crate::id::FactId::new("f1").expect("valid test id"),
@@ -372,7 +380,11 @@ fn hybrid_search_two_signal_no_graph() {
     };
 
     let dim = 4;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let fact = Fact {
         id: crate::id::FactId::new("f-twosig").expect("valid test id"),
@@ -462,7 +474,11 @@ fn hybrid_search_absent_signal_rank_is_negative_one() {
     };
 
     let dim = 4;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let fact = Fact {
         id: crate::id::FactId::new("f-bm25-only").expect("valid test id"),

--- a/crates/episteme/src/knowledge_store/tests/entities.rs
+++ b/crates/episteme/src/knowledge_store/tests/entities.rs
@@ -198,7 +198,9 @@ fn write_then_read_roundtrip_facts_and_entities() {
         .expect("link fact to entity");
 
     // NOTE: Read via scoped query (simulates ?nous_id=agent-01)
-    let scoped = store.audit_all_facts("agent-01", 100).expect("audit scoped");
+    let scoped = store
+        .audit_all_facts("agent-01", 100)
+        .expect("audit scoped");
     assert_eq!(scoped.len(), 1);
     assert_eq!(scoped[0].content, "Alice prefers dark mode");
 

--- a/crates/episteme/src/knowledge_store/tests/facts/crud.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/crud.rs
@@ -12,7 +12,11 @@ use crate::knowledge::ForgetReason;
 use crate::test_fixtures::{make_fact, make_store};
 #[test]
 fn query_timeout_returns_typed_error() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     // WHY: Recursive transitive closure on a linear chain of N nodes requires N-1 semi-naive
     // fixpoint epochs. Each epoch checks the Poison flag. With N=2000 and timeout=50ms
@@ -43,7 +47,11 @@ reach[a, c] := reach[a, b], edge[b, c]
 
 #[test]
 fn query_without_timeout_succeeds() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let result = store.run_query_with_timeout("?[x] := x = 42", BTreeMap::new(), None);
 

--- a/crates/episteme/src/lib.rs
+++ b/crates/episteme/src/lib.rs
@@ -33,10 +33,10 @@ pub mod decay;
 pub(crate) mod dedup;
 /// Embedding provider trait and implementations (candle, mock).
 pub mod embedding;
-/// Evidence-gap tracking for iterative retrieval (MemR3-inspired).
-pub mod evidence_gap;
 /// Embedding evaluation gate: Recall@K and MRR for model upgrade checks.
 pub mod embedding_eval;
+/// Evidence-gap tracking for iterative retrieval (MemR3-inspired).
+pub mod evidence_gap;
 /// LLM-driven knowledge extraction pipeline (entities, relationships, facts).
 pub mod extract;
 /// Graph-enhanced recall scoring: PageRank boost, community proximity, supersession chains.
@@ -60,6 +60,8 @@ pub mod query;
 pub(crate) mod query_rewrite;
 /// 6-factor recall scoring engine for knowledge retrieval ranking.
 pub mod recall;
+/// Steward rule proposal generation from observed tool-usage patterns.
+pub mod rule_proposals;
 /// Side-query memory relevance selector with LRU caching and already-surfaced tracking.
 pub mod side_query;
 /// Skill storage helpers and SKILL.md parser.
@@ -70,14 +72,12 @@ pub mod skills;
 pub mod staleness;
 /// Ecological succession: domain volatility tracking and adaptive decay rates.
 pub(crate) mod succession;
+/// Bayesian surprise for episode boundary detection (EM-LLM, arXiv 2407.09450).
+pub mod surprise;
 /// Structured tracing subscriber that captures operational events as Datalog facts.
 pub mod trace_ingest;
 /// Relationship type normalization and validation for knowledge graph extraction.
 pub mod vocab;
-/// Steward rule proposal generation from observed tool-usage patterns.
-pub mod rule_proposals;
-/// Bayesian surprise for episode boundary detection (EM-LLM, arXiv 2407.09450).
-pub mod surprise;
 
 /// Shared test fixtures for knowledge store tests (DRY helpers).
 #[cfg(all(test, feature = "mneme-engine"))]

--- a/crates/episteme/src/manifest.rs
+++ b/crates/episteme/src/manifest.rs
@@ -57,12 +57,19 @@ impl From<MemoryHeaderRaw> for MemoryHeader {
 
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "test-only constructors; MemoryHeader is built via serde in lib builds")
+    expect(
+        dead_code,
+        reason = "test-only constructors; MemoryHeader is built via serde in lib builds"
+    )
 )]
 impl MemoryHeader {
     /// Create a new header with the required fields.
     #[must_use]
-    pub(crate) fn new(source_id: impl Into<String>, name: impl Into<String>, mtime_ms: i64) -> Self {
+    pub(crate) fn new(
+        source_id: impl Into<String>,
+        name: impl Into<String>,
+        mtime_ms: i64,
+    ) -> Self {
         Self {
             source_id: source_id.into(),
             name: name.into(),
@@ -314,7 +321,14 @@ mod tests {
     fn from_headers_preserves_all_within_cap() {
         let count = MAX_MEMORY_ENTRIES - 1;
         let headers: Vec<MemoryHeader> = (0..count)
-            .map(|i| make_header(&format!("id-{i}"), &format!("n-{i}"), i.try_into().expect("count < MAX_MEMORY_ENTRIES (200) fits i64")))
+            .map(|i| {
+                make_header(
+                    &format!("id-{i}"),
+                    &format!("n-{i}"),
+                    i.try_into()
+                        .expect("count < MAX_MEMORY_ENTRIES (200) fits i64"),
+                )
+            })
             .collect();
         let manifest = MemoryManifest::from_headers(headers);
         assert_eq!(

--- a/crates/episteme/src/metrics.rs
+++ b/crates/episteme/src/metrics.rs
@@ -58,7 +58,10 @@ static EMBEDDING_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
     .expect("metric registration")
 });
 
-#[cfg_attr(not(test), expect(dead_code, reason = "metric init called from server startup"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "metric init called from server startup")
+)]
 /// Force-initialize all lazy metric statics.
 pub(crate) fn init() {
     LazyLock::force(&KNOWLEDGE_FACTS_TOTAL);
@@ -74,7 +77,10 @@ pub(crate) fn record_fact_inserted(nous_id: &str) {
 }
 
 /// Record a knowledge extraction operation.
-#[cfg_attr(not(test), expect(dead_code, reason = "metric recording called from extraction pipeline"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "metric recording called from extraction pipeline")
+)]
 pub(crate) fn record_extraction(nous_id: &str, success: bool) {
     let status = if success { "ok" } else { "error" };
     KNOWLEDGE_EXTRACTIONS_TOTAL
@@ -90,7 +96,10 @@ pub(crate) fn record_recall_duration(nous_id: &str, duration_secs: f64) {
 }
 
 /// Record embedding computation duration.
-#[cfg_attr(not(test), expect(dead_code, reason = "metric recording called from embedding pipeline"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "metric recording called from embedding pipeline")
+)]
 pub(crate) fn record_embedding_duration(provider: &str, duration_secs: f64) {
     EMBEDDING_DURATION_SECONDS
         .with_label_values(&[provider])
@@ -108,9 +117,10 @@ mod tests {
             if family.name() == name {
                 for metric in family.get_metric() {
                     let labels = metric.get_label();
-                    let matches = label_values.iter().enumerate().all(|(i, expected)| {
-                        labels.get(i).is_some_and(|l| l.value() == *expected)
-                    });
+                    let matches = label_values
+                        .iter()
+                        .enumerate()
+                        .all(|(i, expected)| labels.get(i).is_some_and(|l| l.value() == *expected));
                     if matches {
                         #[expect(
                             clippy::as_conversions,
@@ -139,9 +149,10 @@ mod tests {
             if family.name() == name {
                 for metric in family.get_metric() {
                     let labels = metric.get_label();
-                    let matches = label_values.iter().enumerate().all(|(i, expected)| {
-                        labels.get(i).is_some_and(|l| l.value() == *expected)
-                    });
+                    let matches = label_values
+                        .iter()
+                        .enumerate()
+                        .all(|(i, expected)| labels.get(i).is_some_and(|l| l.value() == *expected));
                     if matches {
                         return metric.get_histogram().sample_count();
                     }
@@ -166,8 +177,10 @@ mod tests {
         record_embedding_duration("init-test-provider", 0.001);
 
         let families = prometheus::default_registry().gather();
-        let metric_names: std::collections::HashSet<_> =
-            families.iter().map(prometheus::proto::MetricFamily::name).collect();
+        let metric_names: std::collections::HashSet<_> = families
+            .iter()
+            .map(prometheus::proto::MetricFamily::name)
+            .collect();
         assert!(metric_names.contains("aletheia_knowledge_facts_total"));
         assert!(metric_names.contains("aletheia_knowledge_extractions_total"));
         assert!(metric_names.contains("aletheia_recall_duration_seconds"));
@@ -186,18 +199,15 @@ mod tests {
     #[test]
     fn record_extraction_increments_counters() {
         let nous_id = "test-nous-extraction";
-        let before_ok =
-            read_counter("aletheia_knowledge_extractions_total", &[nous_id, "ok"]);
+        let before_ok = read_counter("aletheia_knowledge_extractions_total", &[nous_id, "ok"]);
         let before_error =
             read_counter("aletheia_knowledge_extractions_total", &[nous_id, "error"]);
 
         record_extraction(nous_id, true);
         record_extraction(nous_id, false);
 
-        let after_ok =
-            read_counter("aletheia_knowledge_extractions_total", &[nous_id, "ok"]);
-        let after_error =
-            read_counter("aletheia_knowledge_extractions_total", &[nous_id, "error"]);
+        let after_ok = read_counter("aletheia_knowledge_extractions_total", &[nous_id, "ok"]);
+        let after_error = read_counter("aletheia_knowledge_extractions_total", &[nous_id, "error"]);
 
         assert_eq!(after_ok, before_ok + 1);
         assert_eq!(after_error, before_error + 1);
@@ -215,11 +225,9 @@ mod tests {
     #[test]
     fn record_embedding_duration_records_observation() {
         let provider = "candle";
-        let before =
-            read_histogram_count("aletheia_embedding_duration_seconds", &[provider]);
+        let before = read_histogram_count("aletheia_embedding_duration_seconds", &[provider]);
         record_embedding_duration(provider, 0.1);
-        let after =
-            read_histogram_count("aletheia_embedding_duration_seconds", &[provider]);
+        let after = read_histogram_count("aletheia_embedding_duration_seconds", &[provider]);
         assert_eq!(after, before + 1);
     }
 }

--- a/crates/episteme/src/ops_facts.rs
+++ b/crates/episteme/src/ops_facts.rs
@@ -68,7 +68,10 @@ impl OpsFactExtractor {
     /// # Errors
     ///
     /// Returns an error if fact ID generation fails (should not happen in practice).
-    pub fn extract(snapshot: &OpsSnapshot, min_tool_calls: u64) -> Result<Vec<OpsFact>, ExtractError> {
+    pub fn extract(
+        snapshot: &OpsSnapshot,
+        min_tool_calls: u64,
+    ) -> Result<Vec<OpsFact>, ExtractError> {
         let now = jiff::Timestamp::now();
         let mut facts = Vec::with_capacity(4);
 
@@ -230,7 +233,8 @@ mod tests {
             task_sample_count: 5,
         };
 
-        let facts = OpsFactExtractor::extract(&snapshot, DEFAULT_MIN_TOOL_CALLS).expect("extraction should succeed");
+        let facts = OpsFactExtractor::extract(&snapshot, DEFAULT_MIN_TOOL_CALLS)
+            .expect("extraction should succeed");
         assert_eq!(facts.len(), 4, "full snapshot should produce 4 facts");
 
         for ops_fact in &facts {
@@ -257,7 +261,8 @@ mod tests {
             task_sample_count: 0,
         };
 
-        let facts = OpsFactExtractor::extract(&snapshot, DEFAULT_MIN_TOOL_CALLS).expect("extraction should succeed");
+        let facts = OpsFactExtractor::extract(&snapshot, DEFAULT_MIN_TOOL_CALLS)
+            .expect("extraction should succeed");
         // sessions + errors = 2 (no tool rate, no latency)
         assert_eq!(
             facts.len(),
@@ -273,7 +278,8 @@ mod tests {
             ..Default::default()
         };
 
-        let facts = OpsFactExtractor::extract(&snapshot, DEFAULT_MIN_TOOL_CALLS).expect("extraction should succeed");
+        let facts = OpsFactExtractor::extract(&snapshot, DEFAULT_MIN_TOOL_CALLS)
+            .expect("extraction should succeed");
         // sessions + errors = 2
         assert_eq!(
             facts.len(),
@@ -294,7 +300,8 @@ mod tests {
             task_sample_count: 10,
         };
 
-        let facts = OpsFactExtractor::extract(&snapshot, DEFAULT_MIN_TOOL_CALLS).expect("extraction should succeed");
+        let facts = OpsFactExtractor::extract(&snapshot, DEFAULT_MIN_TOOL_CALLS)
+            .expect("extraction should succeed");
         let contents: Vec<&str> = facts.iter().map(|f| f.fact.content.as_str()).collect();
 
         assert!(

--- a/crates/episteme/src/query/builders.rs
+++ b/crates/episteme/src/query/builders.rs
@@ -54,14 +54,20 @@ impl QueryBuilder {
     }
 
     /// Append a raw Datalog line (escape hatch for complex queries).
-    #[cfg_attr(not(test), expect(dead_code, reason = "Datalog query builder for knowledge store"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "Datalog query builder for knowledge store")
+    )]
     pub(crate) fn raw(mut self, line: &str) -> Self {
         self.lines.push(line.to_owned());
         self
     }
 
     /// Bind a named parameter.
-    #[cfg_attr(not(test), expect(dead_code, reason = "Datalog query builder for knowledge store"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "Datalog query builder for knowledge store")
+    )]
     pub(crate) fn param(mut self, name: &str, value: DataValue) -> Self {
         self.params.insert(name.to_owned(), value);
         self
@@ -69,7 +75,10 @@ impl QueryBuilder {
 
     /// Consume the builder, producing `(script, params)`.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "Datalog query builder for knowledge store"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "Datalog query builder for knowledge store")
+    )]
     pub(crate) fn build(self) -> (String, BTreeMap<String, DataValue>) {
         (self.lines.join("\n"), self.params)
     }

--- a/crates/episteme/src/query/queries.rs
+++ b/crates/episteme/src/query/queries.rs
@@ -43,7 +43,10 @@ pub(crate) fn upsert_fact() -> String {
 /// Query current facts for a nous (not superseded, currently valid).
 /// Params: `$nous_id`, `$now`, `$limit`.
 #[must_use]
-#[cfg_attr(not(test), expect(dead_code, reason = "Datalog query for current (non-superseded) facts"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "Datalog query for current (non-superseded) facts")
+)]
 pub(crate) fn current_facts() -> String {
     use FactsField::*;
     QueryBuilder::new()
@@ -298,7 +301,10 @@ pub(crate) const SEMANTIC_SEARCH: &str = r"
             query: $query_vec, k: $k, ef: $ef, bind_distance: dist}
 ";
 
-#[expect(dead_code, reason = "Datalog query for entity prefix search — no callers yet")]
+#[expect(
+    dead_code,
+    reason = "Datalog query for entity prefix search — no callers yet"
+)]
 /// Entity search by name or alias (prefix match). Params: `$prefix`, `$limit`.
 pub(crate) const SEARCH_ENTITIES: &str = r"
     ?[id, name, entity_type] :=

--- a/crates/episteme/src/recall.rs
+++ b/crates/episteme/src/recall.rs
@@ -368,7 +368,10 @@ impl RecallEngine {
     /// Access the current weights.
     #[must_use]
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "knowledge pipeline infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "knowledge pipeline infrastructure")
+    )]
     pub(crate) fn weights(&self) -> &RecallWeights {
         &self.weights
     }
@@ -395,7 +398,10 @@ impl RecallEngine {
     /// Returns the base tier score directly when graph recall weight is zero.
     #[must_use]
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "knowledge pipeline infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "knowledge pipeline infrastructure")
+    )]
     pub(crate) fn score_epistemic_tier_with_importance(&self, tier: &str, importance: f64) -> f64 {
         let base = self.score_epistemic_tier(tier);
         self.graph_enhanced(base, |b| {
@@ -411,7 +417,10 @@ impl RecallEngine {
     /// Returns the base hop score directly when graph recall weight is zero.
     #[must_use]
     #[instrument(skip(self))]
-    #[cfg_attr(not(test), expect(dead_code, reason = "knowledge pipeline infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "knowledge pipeline infrastructure")
+    )]
     pub(crate) fn score_relationship_proximity_with_cluster(
         &self,
         hops: Option<u32>,

--- a/crates/episteme/src/rule_proposals.rs
+++ b/crates/episteme/src/rule_proposals.rs
@@ -168,7 +168,8 @@ pub fn propose_rules(
     let mut groups: HashMap<String, Accum> = HashMap::new();
 
     for obs in observations {
-        let category = crate::instinct::ContextCategory::classify(&obs.tool_name, &obs.context_summary);
+        let category =
+            crate::instinct::ContextCategory::classify(&obs.tool_name, &obs.context_summary);
         let key = format!("{}/{}", obs.tool_name, category.as_str());
 
         let accum = groups.entry(key).or_insert_with(|| Accum {
@@ -191,8 +192,7 @@ pub fn propose_rules(
                 return None;
             }
 
-            let failure_rate =
-                f64::from(accum.failure_count) / f64::from(accum.total_count);
+            let failure_rate = f64::from(accum.failure_count) / f64::from(accum.total_count);
             let count_f = f64::from(accum.total_count);
             let min_obs_f = f64::from(min_observations);
 
@@ -328,7 +328,10 @@ fn sanitize_tool_name(name: &str) -> String {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(clippy::expect_used, reason = "test assertions")]
-#[expect(clippy::indexing_slicing, reason = "test assertions on collections with known length")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on collections with known length"
+)]
 mod tests {
     use super::*;
     use crate::instinct::{ToolObservation, ToolOutcome};
@@ -348,7 +351,13 @@ mod tests {
 
     #[test]
     fn below_min_observations_no_proposal() {
-        let obs = make_obs("grep", &ToolOutcome::Failure { error: "not found".to_owned() }, 3);
+        let obs = make_obs(
+            "grep",
+            &ToolOutcome::Failure {
+                error: "not found".to_owned(),
+            },
+            3,
+        );
         let proposals = propose_rules(&obs, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_CONFIDENCE);
         assert!(proposals.is_empty(), "3 observations < MIN_OBSERVATIONS=5");
     }
@@ -356,10 +365,19 @@ mod tests {
     #[test]
     fn high_failure_rate_above_threshold_emits_proposal() {
         // 8 failures, 2 successes → 80% failure rate → confidence well above 0.60
-        let mut obs = make_obs("grep", &ToolOutcome::Failure { error: "x".to_owned() }, 8);
+        let mut obs = make_obs(
+            "grep",
+            &ToolOutcome::Failure {
+                error: "x".to_owned(),
+            },
+            8,
+        );
         obs.extend(make_obs("grep", &ToolOutcome::Success, 2));
         let proposals = propose_rules(&obs, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_CONFIDENCE);
-        assert!(!proposals.is_empty(), "80% failure rate should generate a proposal");
+        assert!(
+            !proposals.is_empty(),
+            "80% failure rate should generate a proposal"
+        );
         assert!(proposals[0].confidence >= DEFAULT_MIN_CONFIDENCE);
     }
 
@@ -367,15 +385,30 @@ mod tests {
     fn all_successes_no_proposal() {
         let obs = make_obs("grep", &ToolOutcome::Success, 20);
         let proposals = propose_rules(&obs, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_CONFIDENCE);
-        assert!(proposals.is_empty(), "0% failure rate should not generate proposals");
+        assert!(
+            proposals.is_empty(),
+            "0% failure rate should not generate proposals"
+        );
     }
 
     #[test]
     fn proposals_sorted_by_confidence_descending() {
         // Two tools with different failure rates
-        let mut obs = make_obs("exec", &ToolOutcome::Failure { error: "x".to_owned() }, 9);
+        let mut obs = make_obs(
+            "exec",
+            &ToolOutcome::Failure {
+                error: "x".to_owned(),
+            },
+            9,
+        );
         obs.extend(make_obs("exec", &ToolOutcome::Success, 1)); // 90% failure
-        obs.extend(make_obs("grep", &ToolOutcome::Failure { error: "x".to_owned() }, 7));
+        obs.extend(make_obs(
+            "grep",
+            &ToolOutcome::Failure {
+                error: "x".to_owned(),
+            },
+            7,
+        ));
         obs.extend(make_obs("grep", &ToolOutcome::Success, 3)); // 70% failure
 
         let proposals = propose_rules(&obs, DEFAULT_MIN_OBSERVATIONS, DEFAULT_MIN_CONFIDENCE);
@@ -401,7 +434,13 @@ mod tests {
         let data_dir = dir.path().join("data");
 
         let obs = {
-            let mut v = make_obs("exec", &ToolOutcome::Failure { error: "x".to_owned() }, 8);
+            let mut v = make_obs(
+                "exec",
+                &ToolOutcome::Failure {
+                    error: "x".to_owned(),
+                },
+                8,
+            );
             v.extend(make_obs("exec", &ToolOutcome::Success, 2));
             v
         };
@@ -412,6 +451,9 @@ mod tests {
         assert!(out.exists(), "output file should be created");
 
         let content = std::fs::read_to_string(&out).unwrap();
-        assert!(content.contains("rule_name"), "TOML should contain rule_name field");
+        assert!(
+            content.contains("rule_name"),
+            "TOML should contain rule_name field"
+        );
     }
 }

--- a/crates/episteme/src/side_query.rs
+++ b/crates/episteme/src/side_query.rs
@@ -209,7 +209,10 @@ pub(crate) struct SideQuerySelector {
 
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "impl used from tests; production wiring lands with recall pipeline integration")
+    expect(
+        dead_code,
+        reason = "impl used from tests; production wiring lands with recall pipeline integration"
+    )
 )]
 impl SideQuerySelector {
     /// Create a new selector with the given configuration.
@@ -303,15 +306,13 @@ impl SideQuerySelector {
     /// Check whether a source ID has already been surfaced.
     #[must_use]
     pub(crate) fn is_surfaced(&self, id: &str) -> bool {
-        self.already_surfaced.lock()
-            .contains(id)
+        self.already_surfaced.lock().contains(id)
     }
 
     /// Number of entries in the relevance cache.
     #[must_use]
     pub(crate) fn cache_len(&self) -> usize {
-        self.cache.lock()
-            .len()
+        self.cache.lock().len()
     }
 
     /// Build a filtered manifest excluding already-surfaced entries.
@@ -331,10 +332,7 @@ impl fmt::Debug for SideQuerySelector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SideQuerySelector")
             .field("config", &self.config)
-            .field(
-                "surfaced_count",
-                &self.already_surfaced.lock().len(),
-            )
+            .field("surfaced_count", &self.already_surfaced.lock().len())
             .field("cache_len", &self.cache_len())
             .finish_non_exhaustive()
     }

--- a/crates/episteme/src/skills/candidate.rs
+++ b/crates/episteme/src/skills/candidate.rs
@@ -66,7 +66,10 @@ impl SkillCandidate {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if serialisation fails.
-    #[cfg_attr(not(test), expect(dead_code, reason = "skill candidate tracking for auto-extraction"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "skill candidate tracking for auto-extraction")
+    )]
     pub(crate) fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }
@@ -76,7 +79,10 @@ impl SkillCandidate {
     /// # Errors
     ///
     /// Returns a [`serde_json::Error`] if the JSON is malformed or the schema changed.
-    #[cfg_attr(not(test), expect(dead_code, reason = "skill candidate tracking for auto-extraction"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "skill candidate tracking for auto-extraction")
+    )]
     pub(crate) fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }
@@ -205,7 +211,10 @@ impl CandidateTracker {
     }
 
     /// Return all promoted candidates (`recurrence_count` ≥ threshold) for a nous.
-    #[cfg_attr(not(test), expect(dead_code, reason = "skill candidate tracking for auto-extraction"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "skill candidate tracking for auto-extraction")
+    )]
     pub(crate) fn promoted_for(&self, nous_id: &str) -> Vec<SkillCandidate> {
         let guard = self.candidates.lock().unwrap_or_else(|e| {
             tracing::warn!("CandidateTracker lock poisoned, recovering");
@@ -220,14 +229,20 @@ impl CandidateTracker {
 
     /// Total number of tracked candidates (all nous IDs).
     pub(crate) fn len(&self) -> usize {
-        self.candidates.lock().unwrap_or_else(|e| {
-            tracing::warn!("CandidateTracker lock poisoned, recovering");
-            e.into_inner()
-        }).len()
+        self.candidates
+            .lock()
+            .unwrap_or_else(|e| {
+                tracing::warn!("CandidateTracker lock poisoned, recovering");
+                e.into_inner()
+            })
+            .len()
     }
 
     /// Returns `true` if no candidates are tracked.
-    #[cfg_attr(not(test), expect(dead_code, reason = "skill candidate tracking for auto-extraction"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "skill candidate tracking for auto-extraction")
+    )]
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/crates/episteme/src/skills/extract.rs
+++ b/crates/episteme/src/skills/extract.rs
@@ -472,14 +472,20 @@ impl PendingSkill {
 
     /// Returns `true` if the skill is pending review.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "skill extraction lifecycle methods"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "skill extraction lifecycle methods")
+    )]
     pub(crate) fn is_pending(&self) -> bool {
         self.status == "pending_review"
     }
 
     /// Returns `true` if the skill has been approved.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "skill extraction lifecycle methods"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "skill extraction lifecycle methods")
+    )]
     pub(crate) fn is_approved(&self) -> bool {
         self.status == "approved"
     }

--- a/crates/episteme/src/staleness.rs
+++ b/crates/episteme/src/staleness.rs
@@ -95,11 +95,7 @@ impl StalenessChecker {
     /// The caller is responsible for fetching `source_content` from the fact's
     /// `source_uri`. Pass `None` if the source is unreachable.
     #[must_use]
-    pub fn check(
-        &self,
-        fact: &SourceLinkedFact,
-        source_content: Option<&str>,
-    ) -> StalenessResult {
+    pub fn check(&self, fact: &SourceLinkedFact, source_content: Option<&str>) -> StalenessResult {
         let Some(source) = source_content else {
             return StalenessResult {
                 fact_id: fact.fact_id.clone(),
@@ -255,8 +251,8 @@ const STOP_WORDS: &[&str] = &[
     "the", "and", "for", "are", "but", "not", "you", "all", "can", "had", "was", "one", "our",
     "out", "has", "his", "how", "its", "may", "new", "now", "old", "see", "way", "who", "did",
     "get", "let", "say", "she", "too", "use", "will", "with", "this", "that", "from", "have",
-    "been", "some", "they", "were", "what", "when", "your", "each", "make", "like", "into",
-    "just", "over", "such", "than", "them", "then", "also", "more", "should",
+    "been", "some", "they", "were", "what", "when", "your", "each", "make", "like", "into", "just",
+    "over", "such", "than", "them", "then", "also", "more", "should",
 ];
 
 /// Tokenize text into lowercase words, excluding stop words and short tokens.
@@ -346,7 +342,10 @@ mod tests {
         let checks = vec![
             (
                 make_fact("f1", "Rust uses ownership for memory safety", "url1"),
-                Some("Rust's ownership system ensures memory safety without garbage collection".to_owned()),
+                Some(
+                    "Rust's ownership system ensures memory safety without garbage collection"
+                        .to_owned(),
+                ),
             ),
             (
                 make_fact("f2", "Python is statically typed", "url2"),

--- a/crates/episteme/src/surprise.rs
+++ b/crates/episteme/src/surprise.rs
@@ -255,10 +255,7 @@ fn bigram_frequencies(text: &str) -> HashMap<[u8; NGRAM_SIZE], f64> {
 ///
 /// Computes `sum_x P(x) * ln(P(x) / Q(x))` over all n-grams present in
 /// either distribution, using [`SMOOTHING`] to avoid log(0).
-fn kl_divergence(
-    p: &HashMap<[u8; NGRAM_SIZE], f64>,
-    q: &HashMap<[u8; NGRAM_SIZE], f64>,
-) -> f64 {
+fn kl_divergence(p: &HashMap<[u8; NGRAM_SIZE], f64>, q: &HashMap<[u8; NGRAM_SIZE], f64>) -> f64 {
     // Collect the union of keys.
     let mut all_keys: Vec<&[u8; NGRAM_SIZE]> = p.keys().collect();
     for k in q.keys() {
@@ -392,9 +389,8 @@ mod tests {
         }
 
         // First exposure to new topic: high surprise.
-        let first = calc.compute_surprise(
-            "the mitochondria is the powerhouse of the cell in biology",
-        );
+        let first =
+            calc.compute_surprise("the mitochondria is the powerhouse of the cell in biology");
 
         // Repeated new topic: surprise should decrease as prior adapts.
         let mut previous = first;
@@ -432,10 +428,7 @@ mod tests {
     fn kl_self_divergence_near_zero() {
         let freq = bigram_frequencies("hello world this is a test");
         let div = kl_divergence(&freq, &freq);
-        assert!(
-            div < 1e-6,
-            "self-divergence {div} should be near zero"
-        );
+        assert!(div < 1e-6, "self-divergence {div} should be near zero");
     }
 
     /// Bigram frequencies should sum to approximately 1.

--- a/crates/episteme/src/test_fixtures.rs
+++ b/crates/episteme/src/test_fixtures.rs
@@ -16,6 +16,9 @@ pub(crate) const DIM: usize = 4;
 
 /// Open an in-memory `KnowledgeStore` with test defaults.
 pub(crate) fn make_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() })
-        .expect("open in-memory knowledge store for test")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: DIM,
+        ..Default::default()
+    })
+    .expect("open in-memory knowledge store for test")
 }

--- a/crates/episteme/src/trace_ingest.rs
+++ b/crates/episteme/src/trace_ingest.rs
@@ -91,7 +91,10 @@ pub enum TraceEvent {
 /// schema. Only the `mneme-engine`-gated `engine_tests` mod reads it.
 #[cfg_attr(
     not(all(test, feature = "mneme-engine")),
-    expect(dead_code, reason = "schema referenced from mneme-engine tests only; production init path lives in knowledge_store::init")
+    expect(
+        dead_code,
+        reason = "schema referenced from mneme-engine tests only; production init path lives in knowledge_store::init"
+    )
 )]
 pub(crate) const OPS_DDL: &[&str] = &[
     r":create ops_turns {
@@ -224,7 +227,10 @@ impl Clone for TraceIngestLayer {
 
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "impl used from tests; production wiring lands with knowledge_store::init migration")
+    expect(
+        dead_code,
+        reason = "impl used from tests; production wiring lands with knowledge_store::init migration"
+    )
 )]
 impl TraceIngestLayer {
     /// Create a new ingest layer with an empty buffer.
@@ -241,17 +247,13 @@ impl TraceIngestLayer {
     /// a knowledge store is available.  Use [`TraceIngestLayer::flush`] to write
     /// them to Datalog.
     pub(crate) fn drain(&self) -> Vec<TraceEvent> {
-        let mut buf = self
-            .buffer
-            .lock();
+        let mut buf = self.buffer.lock();
         std::mem::take(&mut *buf)
     }
 
     /// How many events are waiting in the buffer.
     pub(crate) fn pending(&self) -> usize {
-        self.buffer
-            .lock()
-            .len()
+        self.buffer.lock().len()
     }
 
     /// Flush buffered events into the Datalog knowledge store.
@@ -273,7 +275,10 @@ impl TraceIngestLayer {
             return;
         }
 
-        tracing::debug!(count = events.len(), "trace_ingest: flushing buffered events");
+        tracing::debug!(
+            count = events.len(),
+            "trace_ingest: flushing buffered events"
+        );
 
         for event in events {
             let (script, params) = match event {
@@ -327,10 +332,7 @@ impl TraceIngestLayer {
                 } => {
                     let mut p = BTreeMap::new();
                     p.insert("session_id".to_owned(), DataValue::Str(session_id.into()));
-                    p.insert(
-                        "error_class".to_owned(),
-                        DataValue::Str(error_class.into()),
-                    );
+                    p.insert("error_class".to_owned(), DataValue::Str(error_class.into()));
                     p.insert("message".to_owned(), DataValue::Str(message.into()));
                     p.insert("timestamp".to_owned(), DataValue::Str(timestamp.into()));
                     let script = concat!(
@@ -438,15 +440,16 @@ where
             _ => return,
         };
 
-        let mut buf = self
-            .buffer
-            .lock();
+        let mut buf = self.buffer.lock();
         buf.push(captured);
     }
 }
 
 #[cfg(test)]
-#[expect(clippy::indexing_slicing, reason = "test assertions on collections with known length")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on collections with known length"
+)]
 mod tests {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
@@ -454,9 +457,7 @@ mod tests {
     use super::*;
 
     fn push_event(layer: &TraceIngestLayer, event: TraceEvent) {
-        let mut buf = layer
-            .buffer
-            .lock();
+        let mut buf = layer.buffer.lock();
         buf.push(event);
     }
 
@@ -602,9 +603,7 @@ mod tests {
         let captured = layer.clone();
 
         // Set a per-test default subscriber scoped to this thread.
-        let _guard = tracing_subscriber::registry()
-            .with(layer)
-            .set_default();
+        let _guard = tracing_subscriber::registry().with(layer).set_default();
 
         tracing::info!(
             message = "tool_executed",

--- a/crates/episteme/tests/public_api.rs
+++ b/crates/episteme/tests/public_api.rs
@@ -13,7 +13,10 @@
 //! suites.
 
 #![expect(clippy::expect_used, reason = "test assertions")]
-#![expect(clippy::indexing_slicing, reason = "test assertions on fixed-size vectors")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on fixed-size vectors"
+)]
 
 // ---------------------------------------------------------------------------
 // OpsFactExtractor
@@ -42,14 +45,22 @@ mod ops_facts {
         // task_sample_count > 0 must emit every category — sessions,
         // tool success rate, error count, task latency — so the knowledge
         // graph gets the full picture of system health at this tick.
-        let facts = OpsFactExtractor::extract(&full_snapshot(), episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS).expect("extraction");
+        let facts = OpsFactExtractor::extract(
+            &full_snapshot(),
+            episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS,
+        )
+        .expect("extraction");
         assert_eq!(facts.len(), 4, "full snapshot should yield 4 facts");
 
         let contents: Vec<&str> = facts.iter().map(|f| f.fact.content.as_str()).collect();
         assert!(contents.iter().any(|c| c.contains("active sessions: 4")));
         assert!(contents.iter().any(|c| c.contains("tool success rate")));
         assert!(contents.iter().any(|c| c.contains("error count: 1")));
-        assert!(contents.iter().any(|c| c.contains("avg task latency: 120ms")));
+        assert!(
+            contents
+                .iter()
+                .any(|c| c.contains("avg task latency: 120ms"))
+        );
     }
 
     #[test]
@@ -57,7 +68,11 @@ mod ops_facts {
         // WHY: downstream consumers rely on ops facts having a stable
         // shape — operational fact type, project scope, inferred tier,
         // non-empty nous_id. Drift here would silently break dashboards.
-        let facts = OpsFactExtractor::extract(&full_snapshot(), episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS).expect("extraction");
+        let facts = OpsFactExtractor::extract(
+            &full_snapshot(),
+            episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS,
+        )
+        .expect("extraction");
         for ops_fact in &facts {
             let f = &ops_fact.fact;
             assert_eq!(f.fact_type, "operational");
@@ -70,8 +85,7 @@ mod ops_facts {
                 f.provenance.confidence
             );
             assert!(
-                (f.provenance.stability_hours - FactType::Operational.base_stability_hours())
-                    .abs()
+                (f.provenance.stability_hours - FactType::Operational.base_stability_hours()).abs()
                     < f64::EPSILON,
                 "operational facts must inherit the operational stability window"
             );
@@ -91,7 +105,9 @@ mod ops_facts {
             avg_task_latency_ms: 0,
             task_sample_count: 0,
         };
-        let facts = OpsFactExtractor::extract(&snapshot, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS).expect("extraction");
+        let facts =
+            OpsFactExtractor::extract(&snapshot, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS)
+                .expect("extraction");
         let contents: Vec<&str> = facts.iter().map(|f| f.fact.content.as_str()).collect();
         assert_eq!(facts.len(), 2, "should have only sessions + errors");
         assert!(
@@ -114,7 +130,9 @@ mod ops_facts {
             avg_task_latency_ms: 0,
             task_sample_count: 0,
         };
-        let facts = OpsFactExtractor::extract(&snapshot, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS).expect("extraction");
+        let facts =
+            OpsFactExtractor::extract(&snapshot, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS)
+                .expect("extraction");
         let contents: Vec<&str> = facts.iter().map(|f| f.fact.content.as_str()).collect();
         assert!(
             !contents.iter().any(|c| c.contains("avg task latency")),
@@ -131,7 +149,9 @@ mod ops_facts {
             nous_id: String::from("int-test-nous"),
             ..Default::default()
         };
-        let facts = OpsFactExtractor::extract(&snapshot, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS).expect("extraction");
+        let facts =
+            OpsFactExtractor::extract(&snapshot, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS)
+                .expect("extraction");
         assert_eq!(facts.len(), 2, "baseline = sessions + errors");
     }
 
@@ -140,10 +160,20 @@ mod ops_facts {
         // WHY: fact IDs collide across categories would cause upserts to
         // overwrite each other in the knowledge store. Each category must
         // mint its own ULID-suffixed id.
-        let facts = OpsFactExtractor::extract(&full_snapshot(), episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS).expect("extraction");
-        let ids: std::collections::HashSet<_> =
-            facts.iter().map(|f| f.fact.id.as_str().to_owned()).collect();
-        assert_eq!(ids.len(), facts.len(), "fact ids must be unique per snapshot");
+        let facts = OpsFactExtractor::extract(
+            &full_snapshot(),
+            episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS,
+        )
+        .expect("extraction");
+        let ids: std::collections::HashSet<_> = facts
+            .iter()
+            .map(|f| f.fact.id.as_str().to_owned())
+            .collect();
+        assert_eq!(
+            ids.len(),
+            facts.len(),
+            "fact ids must be unique per snapshot"
+        );
     }
 
     #[test]
@@ -162,8 +192,12 @@ mod ops_facts {
             error_count: 100,
             ..Default::default()
         };
-        let low_facts = OpsFactExtractor::extract(&low_err, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS).expect("low");
-        let high_facts = OpsFactExtractor::extract(&high_err, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS).expect("high");
+        let low_facts =
+            OpsFactExtractor::extract(&low_err, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS)
+                .expect("low");
+        let high_facts =
+            OpsFactExtractor::extract(&high_err, episteme::ops_facts::DEFAULT_MIN_TOOL_CALLS)
+                .expect("high");
         let low_conf = low_facts
             .iter()
             .find(|f| f.fact.content.starts_with("error count"))
@@ -363,8 +397,10 @@ mod causal_store {
             .add_edge(make_edge("e3", "fact-c", "fact-d", 0.8))
             .expect("e3");
 
-        let ids: std::collections::HashSet<_> =
-            store.all_edges().map(|e| e.id.as_str().to_owned()).collect();
+        let ids: std::collections::HashSet<_> = store
+            .all_edges()
+            .map(|e| e.id.as_str().to_owned())
+            .collect();
         assert_eq!(ids.len(), 3);
         assert!(ids.contains("e1"));
         assert!(ids.contains("e2"));

--- a/crates/eval/src/benchmarks/locomo.rs
+++ b/crates/eval/src/benchmarks/locomo.rs
@@ -188,8 +188,7 @@ mod tests {
 
     #[test]
     fn parses_sample_dataset() {
-        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         assert_eq!(dataset.conversations.len(), 1);
         assert_eq!(dataset.question_count(), 2);
         assert_eq!(dataset.len(), 2);
@@ -199,8 +198,7 @@ mod tests {
 
     #[test]
     fn questions_include_all_sessions() {
-        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         let questions: Vec<_> = dataset.questions().collect();
         assert_eq!(questions.len(), 2);
 
@@ -212,8 +210,7 @@ mod tests {
 
     #[test]
     fn question_ids_include_sample_and_index() {
-        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         let questions: Vec<_> = dataset.questions().collect();
         assert_eq!(questions[0].id, "conv_1:qa_0");
         assert_eq!(questions[1].id, "conv_1:qa_1");
@@ -221,19 +218,20 @@ mod tests {
 
     #[test]
     fn answer_alternatives_preserved() {
-        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         let questions: Vec<_> = dataset.questions().collect();
         assert_eq!(
             questions[1].expected_answers,
-            vec!["visited the museums".to_owned(), "went to museums".to_owned()]
+            vec![
+                "visited the museums".to_owned(),
+                "went to museums".to_owned()
+            ]
         );
     }
 
     #[test]
     fn category_preserved() {
-        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         let questions: Vec<_> = dataset.questions().collect();
         assert_eq!(questions[0].category, "single_hop");
         assert_eq!(questions[1].category, "multi_hop");
@@ -241,12 +239,13 @@ mod tests {
 
     #[test]
     fn speaker_preserved_as_role() {
-        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset = LocomoDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         let questions: Vec<_> = dataset.questions().collect();
         let session_0 = &questions[0].sessions[0];
         assert!(
-            session_0.iter().any(|(role, _)| role == "Alice" || role == "Bob"),
+            session_0
+                .iter()
+                .any(|(role, _)| role == "Alice" || role == "Bob"),
             "speakers should be preserved as roles"
         );
     }

--- a/crates/eval/src/benchmarks/longmemeval.rs
+++ b/crates/eval/src/benchmarks/longmemeval.rs
@@ -164,8 +164,8 @@ mod tests {
 
     #[test]
     fn parses_sample_dataset() {
-        let dataset = LongMemEvalDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset =
+            LongMemEvalDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         assert_eq!(dataset.len(), 2);
         assert!(!dataset.is_empty());
         assert_eq!(dataset.name(), "LongMemEval");
@@ -173,8 +173,8 @@ mod tests {
 
     #[test]
     fn questions_preserve_metadata() {
-        let dataset = LongMemEvalDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset =
+            LongMemEvalDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         let questions: Vec<_> = dataset.questions().collect();
         assert_eq!(questions.len(), 2);
 
@@ -190,20 +190,24 @@ mod tests {
 
     #[test]
     fn answer_alternatives_included() {
-        let dataset = LongMemEvalDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset =
+            LongMemEvalDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         let questions: Vec<_> = dataset.questions().collect();
         let q2 = &questions[1];
         assert_eq!(
             q2.expected_answers,
-            vec!["2024".to_owned(), "year 2024".to_owned(), "2024-01".to_owned()]
+            vec![
+                "2024".to_owned(),
+                "year 2024".to_owned(),
+                "2024-01".to_owned()
+            ]
         );
     }
 
     #[test]
     fn multi_session_preserved() {
-        let dataset = LongMemEvalDataset::from_bytes(SAMPLE_JSON.as_bytes())
-            .expect("valid sample JSON");
+        let dataset =
+            LongMemEvalDataset::from_bytes(SAMPLE_JSON.as_bytes()).expect("valid sample JSON");
         let questions: Vec<_> = dataset.questions().collect();
         let q2 = &questions[1];
         assert_eq!(q2.sessions.len(), 2, "should have 2 sessions");
@@ -231,8 +235,7 @@ mod tests {
             "answer": "yes",
             "haystack_sessions": []
         }]"#;
-        let dataset = LongMemEvalDataset::from_bytes(json.as_bytes())
-            .expect("valid JSON");
+        let dataset = LongMemEvalDataset::from_bytes(json.as_bytes()).expect("valid JSON");
         let questions: Vec<_> = dataset.questions().collect();
         assert_eq!(questions[0].category, "unknown");
     }

--- a/crates/eval/src/benchmarks/metrics.rs
+++ b/crates/eval/src/benchmarks/metrics.rs
@@ -170,7 +170,11 @@ mod tests {
             &["alice is a software engineer".to_owned()],
         );
         assert!(!score.exact_match);
-        assert!((score.f1 - 0.6).abs() < 0.01, "expected ~0.6, got {}", score.f1);
+        assert!(
+            (score.f1 - 0.6).abs() < 0.01,
+            "expected ~0.6, got {}",
+            score.f1
+        );
     }
 
     #[test]

--- a/crates/eval/src/benchmarks/mod.rs
+++ b/crates/eval/src/benchmarks/mod.rs
@@ -31,10 +31,10 @@
 //! Datasets must be downloaded separately — see [`download_instructions`].
 //! The harness does not commit dataset files to the repo.
 
-/// Dataset loader + question iterator for the `LongMemEval` benchmark.
-pub mod longmemeval;
 /// Dataset loader + question iterator for the `LoCoMo` benchmark.
 pub mod locomo;
+/// Dataset loader + question iterator for the `LongMemEval` benchmark.
+pub mod longmemeval;
 /// Benchmark scoring (exact match, F1, contains).
 pub mod metrics;
 /// Live benchmark runner: executes a benchmark against an aletheia instance.
@@ -229,9 +229,7 @@ pub async fn load_longmemeval(
 ///
 /// Returns an error if the file cannot be read or the JSON is not in the
 /// expected `LoCoMo` format.
-pub async fn load_locomo(
-    path: impl AsRef<Path> + Send,
-) -> std::io::Result<locomo::LocomoDataset> {
+pub async fn load_locomo(path: impl AsRef<Path> + Send) -> std::io::Result<locomo::LocomoDataset> {
     locomo::LocomoDataset::from_path(path).await
 }
 

--- a/crates/eval/src/benchmarks/runner.rs
+++ b/crates/eval/src/benchmarks/runner.rs
@@ -20,9 +20,7 @@ use tracing::{info, instrument, warn};
 use crate::client::EvalClient;
 use crate::error::{BenchmarkSnafu, Result};
 
-use super::{
-    BenchmarkQuestion, BenchmarkReport, MemoryBenchmark, QuestionResult, score_answer,
-};
+use super::{BenchmarkQuestion, BenchmarkReport, MemoryBenchmark, QuestionResult, score_answer};
 
 /// Configuration for a benchmark run.
 #[derive(Debug, Clone)]
@@ -80,9 +78,7 @@ impl BenchmarkRunner {
         let limit = self.config.max_questions.unwrap_or(total);
         info!(
             benchmark = benchmark.name(),
-            total,
-            limit,
-            "starting benchmark run"
+            total, limit, "starting benchmark run"
         );
 
         let mut results = Vec::new();
@@ -166,7 +162,10 @@ impl BenchmarkRunner {
         }
 
         // Ask the question.
-        let events = self.client.send_message(&session_id, &question.question).await?;
+        let events = self
+            .client
+            .send_message(&session_id, &question.question)
+            .await?;
 
         // Extract the concatenated text response.
         let answer = crate::sse::extract_text(&events);
@@ -243,7 +242,10 @@ mod tests {
         };
         // Simulate the `.take(limit)` pattern the runner uses
         let items: Vec<i32> = (0..10).collect();
-        let taken: Vec<_> = items.iter().take(config.max_questions.unwrap_or(items.len())).collect();
+        let taken: Vec<_> = items
+            .iter()
+            .take(config.max_questions.unwrap_or(items.len()))
+            .collect();
         assert_eq!(taken.len(), 3);
     }
 }

--- a/crates/eval/src/provider.rs
+++ b/crates/eval/src/provider.rs
@@ -46,16 +46,17 @@ mod tests {
     fn builtin_provider_returns_scenarios() {
         let provider = BuiltinProvider;
         let scenarios = provider.provide();
-        assert!(!scenarios.is_empty(), "builtin provider should return scenarios");
+        assert!(
+            !scenarios.is_empty(),
+            "builtin provider should return scenarios"
+        );
         assert_eq!(provider.name(), "builtin");
     }
 
     #[test]
     fn composite_provider_combines() {
-        let composite = CompositeProvider::new(vec![
-            Box::new(BuiltinProvider),
-            Box::new(BuiltinProvider),
-        ]);
+        let composite =
+            CompositeProvider::new(vec![Box::new(BuiltinProvider), Box::new(BuiltinProvider)]);
         let scenarios = composite.provide();
         let single = BuiltinProvider.provide().len();
         assert_eq!(scenarios.len(), single * 2);

--- a/crates/eval/src/scenarios/canary/conflict.rs
+++ b/crates/eval/src/scenarios/canary/conflict.rs
@@ -19,7 +19,9 @@ impl Scenario for ConflictBalancedAnalysis {
             requires_auth: true,
             requires_nous: true,
             expected_contains: None,
-            expected_pattern: Some(r"(?i)(pros|cons|trade|advantage|disadvantage|option A|option B|approach 1|approach 2)"),
+            expected_pattern: Some(
+                r"(?i)(pros|cons|trade|advantage|disadvantage|option A|option B|approach 1|approach 2)",
+            ),
         }
     }
 
@@ -83,10 +85,7 @@ impl Scenario for ConflictDirectCorrection {
                 let session = client.create_session(nous_id, &key).await?;
 
                 let events = client
-                    .send_message(
-                        &session.id,
-                        "The Earth is flat. What shape is the Earth?",
-                    )
+                    .send_message(&session.id, "The Earth is flat. What shape is the Earth?")
                     .await?;
                 let text = sse::extract_text(&events);
                 validate_response(&self.meta(), &text)?;
@@ -162,7 +161,9 @@ impl Scenario for ConflictNuancedPosition {
             requires_auth: true,
             requires_nous: true,
             expected_contains: None,
-            expected_pattern: Some(r"(?i)(complex|nuanced|perspective|viewpoint|context matters|depends on)"),
+            expected_pattern: Some(
+                r"(?i)(complex|nuanced|perspective|viewpoint|context matters|depends on)",
+            ),
         }
     }
 
@@ -210,7 +211,9 @@ impl Scenario for ConflictScopeRedirect {
             requires_auth: true,
             requires_nous: true,
             expected_contains: None,
-            expected_pattern: Some(r"(?i)(instead|alternative|helpful|constructive|positive|help you with|can help)"),
+            expected_pattern: Some(
+                r"(?i)(instead|alternative|helpful|constructive|positive|help you with|can help)",
+            ),
         }
     }
 

--- a/crates/eval/src/scenarios/canary/knowledge.rs
+++ b/crates/eval/src/scenarios/canary/knowledge.rs
@@ -243,7 +243,10 @@ impl Scenario for KnowledgeMetaCategorization {
                     )
                     .await?;
                 let text = sse::extract_text(&events);
-                assert_eval(!text.is_empty(), "Meta-knowledge response should not be empty")?;
+                assert_eval(
+                    !text.is_empty(),
+                    "Meta-knowledge response should not be empty",
+                )?;
 
                 let _ = client.close_session(&session.id).await;
                 Ok(())

--- a/crates/eval/src/scenarios/canary/recall.rs
+++ b/crates/eval/src/scenarios/canary/recall.rs
@@ -150,7 +150,10 @@ impl Scenario for RecallConflictDetection {
                     )
                     .await?;
                 let events = client
-                    .send_message(&session.id, "What is the capital of France? Is there any conflict in what I told you?")
+                    .send_message(
+                        &session.id,
+                        "What is the capital of France? Is there any conflict in what I told you?",
+                    )
                     .await?;
                 let text = sse::extract_text(&events);
                 validate_response(&self.meta(), &text)?;
@@ -233,7 +236,9 @@ impl Scenario for RecallEmptyKnowledgeGraceful {
             requires_auth: true,
             requires_nous: true,
             expected_contains: None,
-            expected_pattern: Some(r"(?i)(don't know|not sure|no information|haven't been told|unclear)"),
+            expected_pattern: Some(
+                r"(?i)(don't know|not sure|no information|haven't been told|unclear)",
+            ),
         }
     }
 

--- a/crates/eval/src/scenarios/canary/sessions.rs
+++ b/crates/eval/src/scenarios/canary/sessions.rs
@@ -38,7 +38,10 @@ impl Scenario for SessionCreateSendHistory {
                 let _ = client.send_message(&session.id, test_msg).await?;
                 let history = client.get_history(&session.id).await?;
 
-                assert_eval(history.messages.len() >= 2, "History should have user + assistant")?;
+                assert_eval(
+                    history.messages.len() >= 2,
+                    "History should have user + assistant",
+                )?;
                 let user_msg = history
                     .messages
                     .iter()
@@ -194,13 +197,22 @@ impl Scenario for SessionConcurrentOrdering {
                 let session = client.create_session(nous_id, &key).await?;
 
                 // Send messages in known order
-                let _ = client.send_message(&session.id, "First message: ALPHA").await?;
-                let _ = client.send_message(&session.id, "Second message: BETA").await?;
-                let _ = client.send_message(&session.id, "Third message: GAMMA").await?;
+                let _ = client
+                    .send_message(&session.id, "First message: ALPHA")
+                    .await?;
+                let _ = client
+                    .send_message(&session.id, "Second message: BETA")
+                    .await?;
+                let _ = client
+                    .send_message(&session.id, "Third message: GAMMA")
+                    .await?;
 
                 let history = client.get_history(&session.id).await?;
                 // Verify we have the expected number of messages
-                assert_eval(history.messages.len() >= 6, "Should have 6+ messages (3 user + 3 assistant)")?;
+                assert_eval(
+                    history.messages.len() >= 6,
+                    "Should have 6+ messages (3 user + 3 assistant)",
+                )?;
 
                 let _ = client.close_session(&session.id).await;
                 Ok(())
@@ -259,7 +271,10 @@ impl Scenario for SessionLargeContextDistillation {
                     .send_message(&session.id, "Summarize what we've discussed.")
                     .await?;
                 let text = sse::extract_text(&events);
-                assert_eval(!text.is_empty(), "Large context response should not be empty")?;
+                assert_eval(
+                    !text.is_empty(),
+                    "Large context response should not be empty",
+                )?;
 
                 let _ = client.close_session(&session.id).await;
                 Ok(())

--- a/crates/eval/src/scenarios/canary/tools.rs
+++ b/crates/eval/src/scenarios/canary/tools.rs
@@ -43,10 +43,7 @@ impl Scenario for ToolFileReadContent {
                     )
                     .await?;
                 assert_eval(!events.is_empty(), "Tool use should produce events")?;
-                assert_eval(
-                    sse::is_complete(&events),
-                    "SSE stream should complete",
-                )?;
+                assert_eval(sse::is_complete(&events), "SSE stream should complete")?;
                 let text = sse::extract_text(&events);
                 assert_eval(!text.is_empty(), "Tool use response should not be empty")?;
 
@@ -97,7 +94,10 @@ impl Scenario for ToolFileWriteReadRoundtrip {
                     )
                     .await?;
                 let text = sse::extract_text(&events);
-                assert_eval(!text.is_empty(), "Tool capability response should not be empty")?;
+                assert_eval(
+                    !text.is_empty(),
+                    "Tool capability response should not be empty",
+                )?;
 
                 let _ = client.close_session(&session.id).await;
                 Ok(())
@@ -243,7 +243,10 @@ impl Scenario for ToolInvalidInputError {
                     )
                     .await?;
                 let text = sse::extract_text(&events);
-                assert_eval(!text.is_empty(), "Error handling response should not be empty")?;
+                assert_eval(
+                    !text.is_empty(),
+                    "Error handling response should not be empty",
+                )?;
 
                 let _ = client.close_session(&session.id).await;
                 Ok(())

--- a/crates/eval/src/scenarios/canary_tests.rs
+++ b/crates/eval/src/scenarios/canary_tests.rs
@@ -4,7 +4,10 @@ use super::*;
 fn canary_provider_returns_scenarios() {
     let provider = CanaryProvider;
     let scenarios = provider.provide();
-    assert!(!scenarios.is_empty(), "canary provider should return scenarios");
+    assert!(
+        !scenarios.is_empty(),
+        "canary provider should return scenarios"
+    );
     assert_eq!(provider.name(), "canary");
 }
 

--- a/crates/eval/src/sse.rs
+++ b/crates/eval/src/sse.rs
@@ -109,7 +109,10 @@ pub(crate) fn is_complete(events: &[ParsedSseEvent]) -> bool {
 
 /// Check whether the stream contains an error event.
 #[tracing::instrument(skip_all, fields(event_count = events.len()))]
-#[cfg_attr(not(test), expect(dead_code, reason = "SSE stream error detection for eval scenarios"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "SSE stream error detection for eval scenarios")
+)]
 pub(crate) fn has_error(events: &[ParsedSseEvent]) -> bool {
     events.iter().any(|e| e.event_type == "error")
 }
@@ -138,7 +141,10 @@ pub struct UsageData {
 
 /// Extract usage data from the `message_complete` event, if present.
 #[tracing::instrument(skip_all, fields(event_count = events.len()))]
-#[cfg_attr(not(test), expect(dead_code, reason = "SSE usage extraction for eval cost tracking"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "SSE usage extraction for eval cost tracking")
+)]
 pub(crate) fn extract_usage(events: &[ParsedSseEvent]) -> Option<UsageData> {
     events
         .iter()

--- a/crates/eval/tests/benchmark_runner.rs
+++ b/crates/eval/tests/benchmark_runner.rs
@@ -38,20 +38,17 @@ async fn setup_mock_server(answer_text: &str) -> MockServer {
     // POST /api/v1/sessions → 201 with a session ID + all fields SessionResponse requires
     Mock::given(method("POST"))
         .and(path("/api/v1/sessions"))
-        .respond_with(
-            ResponseTemplate::new(201)
-                .set_body_json(serde_json::json!({
-                    "id": "sess_benchmark_123",
-                    "nous_id": "benchmark",
-                    "session_key": "bench-key",
-                    "status": "active",
-                    "model": null,
-                    "message_count": 0,
-                    "token_count_estimate": 0,
-                    "created_at": "2026-04-10T00:00:00Z",
-                    "updated_at": "2026-04-10T00:00:00Z"
-                })),
-        )
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "sess_benchmark_123",
+            "nous_id": "benchmark",
+            "session_key": "bench-key",
+            "status": "active",
+            "model": null,
+            "message_count": 0,
+            "token_count_estimate": 0,
+            "created_at": "2026-04-10T00:00:00Z",
+            "updated_at": "2026-04-10T00:00:00Z"
+        })))
         .mount(&server)
         .await;
 
@@ -99,8 +96,7 @@ async fn runner_scores_perfect_answer() {
     let config = BenchmarkRunnerConfig::default();
     let runner = BenchmarkRunner::new(client, config);
 
-    let dataset =
-        LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
+    let dataset = LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
     let report = runner.run(&dataset).await.expect("run should succeed");
 
     assert_eq!(report.total, 1);
@@ -116,12 +112,14 @@ async fn runner_scores_wrong_answer_as_zero() {
     let config = BenchmarkRunnerConfig::default();
     let runner = BenchmarkRunner::new(client, config);
 
-    let dataset =
-        LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
+    let dataset = LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
     let report = runner.run(&dataset).await.expect("run should succeed");
 
     assert_eq!(report.total, 1);
-    assert!(report.exact_match_rate() < 0.01, "wrong answer should not EM");
+    assert!(
+        report.exact_match_rate() < 0.01,
+        "wrong answer should not EM"
+    );
     assert!(report.mean_f1() < 0.01, "wrong answer should have zero F1");
 }
 
@@ -136,8 +134,7 @@ async fn runner_respects_max_questions_limit() {
     };
     let runner = BenchmarkRunner::new(client, config);
 
-    let dataset =
-        LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
+    let dataset = LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
     let report = runner.run(&dataset).await.expect("run should succeed");
 
     assert_eq!(report.total, 0, "max_questions=0 should score nothing");
@@ -150,8 +147,7 @@ async fn runner_preserves_question_metadata_in_results() {
     let client = EvalClient::new(server.uri(), None);
     let runner = BenchmarkRunner::new(client, BenchmarkRunnerConfig::default());
 
-    let dataset =
-        LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
+    let dataset = LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
     let report = runner.run(&dataset).await.expect("run should succeed");
 
     let question = &report.questions[0];
@@ -167,8 +163,7 @@ async fn runner_produces_per_category_breakdown() {
     let client = EvalClient::new(server.uri(), None);
     let runner = BenchmarkRunner::new(client, BenchmarkRunnerConfig::default());
 
-    let dataset =
-        LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
+    let dataset = LongMemEvalDataset::from_bytes(SAMPLE_DATASET.as_bytes()).expect("valid dataset");
     let report = runner.run(&dataset).await.expect("run should succeed");
 
     let per_cat = report.per_category();

--- a/crates/graphe/src/migration.rs
+++ b/crates/graphe/src/migration.rs
@@ -655,7 +655,10 @@ CREATE INDEX IF NOT EXISTS idx_blackboard_key ON blackboard(key);",
 #[derive(Debug)]
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "fields are read by #[cfg(test)] migration test suite")
+    expect(
+        dead_code,
+        reason = "fields are read by #[cfg(test)] migration test suite"
+    )
 )]
 pub(crate) struct MigrationResult {
     /// Versions applied during this run.
@@ -672,7 +675,10 @@ pub(crate) struct MigrationResult {
 #[derive(Debug)]
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "fields are read by #[cfg(test)] migration test suite")
+    expect(
+        dead_code,
+        reason = "fields are read by #[cfg(test)] migration test suite"
+    )
 )]
 pub(crate) struct PendingMigration {
     /// Version number that would be applied.

--- a/crates/graphe/src/store/fjall_store.rs
+++ b/crates/graphe/src/store/fjall_store.rs
@@ -58,7 +58,10 @@ fn pad_u64(v: u64) -> String {
 
 /// Decode a big-endian u64 from 8 bytes.
 fn decode_u64(bytes: &[u8]) -> u64 {
-    let arr: [u8; 8] = bytes.get(..8).and_then(|s| s.try_into().ok()).unwrap_or([0u8; 8]);
+    let arr: [u8; 8] = bytes
+        .get(..8)
+        .and_then(|s| s.try_into().ok())
+        .unwrap_or([0u8; 8]);
     u64::from_be_bytes(arr)
 }
 
@@ -119,8 +122,12 @@ impl SessionStore {
     #[instrument(skip(path))]
     pub fn open(path: &Path) -> Result<Self> {
         info!(path = %path.display(), "Opening fjall session store");
-        let fdb = koina::fjall::FjallDb::open(path, PARTITIONS)
-            .map_err(|e| error::StorageSnafu { message: e.to_string() }.build())?;
+        let fdb = koina::fjall::FjallDb::open(path, PARTITIONS).map_err(|e| {
+            error::StorageSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
         Ok(Self::from_fjall_db(fdb))
     }
 
@@ -134,8 +141,12 @@ impl SessionStore {
     /// created.
     #[instrument]
     pub fn open_in_memory() -> Result<Self> {
-        let fdb = koina::fjall::FjallDb::open_temp(PARTITIONS)
-            .map_err(|e| error::StorageSnafu { message: e.to_string() }.build())?;
+        let fdb = koina::fjall::FjallDb::open_temp(PARTITIONS).map_err(|e| {
+            error::StorageSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
         Ok(Self::from_fjall_db(fdb))
     }
 
@@ -160,12 +171,21 @@ impl SessionStore {
             })
     }
 
-    fn get_bytes(&self, partition: &fjall::SingleWriterTxKeyspace, key: &str) -> Result<Option<Vec<u8>>> {
+    fn get_bytes(
+        &self,
+        partition: &fjall::SingleWriterTxKeyspace,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>> {
         use fjall::Readable;
         let snap = self.db.read_tx();
         snap.get(partition, key.as_bytes())
             .map(|opt| opt.map(|s| s.to_vec()))
-            .map_err(|e| error::StorageSnafu { message: format!("fjall get: {e}") }.build())
+            .map_err(|e| {
+                error::StorageSnafu {
+                    message: format!("fjall get: {e}"),
+                }
+                .build()
+            })
     }
 
     fn get_json<T: for<'de> Deserialize<'de>>(
@@ -205,11 +225,16 @@ impl SessionStore {
         );
         tx.insert(
             &sessions,
-            Self::session_nous_index_key(&session.nous_id, &session.updated_at, &session.id).as_str(),
+            Self::session_nous_index_key(&session.nous_id, &session.updated_at, &session.id)
+                .as_str(),
             b"",
         );
-        tx.commit()
-            .map_err(|e| error::StorageSnafu { message: format!("fjall session write: {e}") }.build())?;
+        tx.commit().map_err(|e| {
+            error::StorageSnafu {
+                message: format!("fjall session write: {e}"),
+            }
+            .build()
+        })?;
         Ok(())
     }
 
@@ -279,7 +304,10 @@ impl SessionStore {
         parent_session_id: Option<&str>,
         model: Option<&str>,
     ) -> Result<Session> {
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let session_type = SessionType::from_key(session_key);
         let now = now_iso();
 
@@ -337,7 +365,10 @@ impl SessionStore {
         model: Option<&str>,
         parent_session_id: Option<&str>,
     ) -> Result<Session> {
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let sessions_part = self.partition("sessions")?;
         let idx_key = Self::session_key_index_key(nous_id, session_key);
 
@@ -349,14 +380,12 @@ impl SessionStore {
                 .build()
             })?;
 
-            let mut session = self
-                .read_session_by_raw_id(&existing_id)?
-                .ok_or_else(|| {
-                    error::SessionCreateSnafu {
-                        nous_id: nous_id.to_owned(),
-                    }
-                    .build()
-                })?;
+            let mut session = self.read_session_by_raw_id(&existing_id)?.ok_or_else(|| {
+                error::SessionCreateSnafu {
+                    nous_id: nous_id.to_owned(),
+                }
+                .build()
+            })?;
 
             if session.status != SessionStatus::Active {
                 let old_updated_at = session.updated_at.clone();
@@ -491,7 +520,10 @@ impl SessionStore {
     /// Update session status.
     #[instrument(skip(self))]
     pub fn update_session_status(&self, id: &str, status: SessionStatus) -> Result<()> {
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let sessions_part = self.partition("sessions")?;
         let mut session = self
             .read_session_by_raw_id(id)?
@@ -505,8 +537,7 @@ impl SessionStore {
         let mut tx = self.db.write_tx();
         tx.insert(&sessions_part, id, data.as_slice());
         Self::update_session_nous_index(&mut tx, &sessions_part, &session, &old_updated_at);
-        let new_nous_key =
-            Self::session_nous_index_key(&session.nous_id, &session.updated_at, id);
+        let new_nous_key = Self::session_nous_index_key(&session.nous_id, &session.updated_at, id);
         tx.insert(&sessions_part, new_nous_key.as_str(), b"");
         tx.commit().map_err(|e| {
             error::StorageSnafu {
@@ -520,7 +551,10 @@ impl SessionStore {
     /// Update session display name.
     #[instrument(skip(self))]
     pub fn update_display_name(&self, id: &str, display_name: &str) -> Result<()> {
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let sessions_part = self.partition("sessions")?;
         let mut session = self
             .read_session_by_raw_id(id)?
@@ -534,8 +568,7 @@ impl SessionStore {
         let mut tx = self.db.write_tx();
         tx.insert(&sessions_part, id, data.as_slice());
         Self::update_session_nous_index(&mut tx, &sessions_part, &session, &old_updated_at);
-        let new_nous_key =
-            Self::session_nous_index_key(&session.nous_id, &session.updated_at, id);
+        let new_nous_key = Self::session_nous_index_key(&session.nous_id, &session.updated_at, id);
         tx.insert(&sessions_part, new_nous_key.as_str(), b"");
         tx.commit().map_err(|e| {
             error::StorageSnafu {
@@ -554,7 +587,10 @@ impl SessionStore {
     pub fn delete_session(&self, id: &str) -> Result<bool> {
         use fjall::Readable;
 
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let sessions_part = self.partition("sessions")?;
 
         let Some(session) = self.read_session_by_raw_id(id)? else {
@@ -563,8 +599,7 @@ impl SessionStore {
 
         // Gather index keys to delete.
         let key_idx = Self::session_key_index_key(&session.nous_id, &session.session_key);
-        let nous_idx =
-            Self::session_nous_index_key(&session.nous_id, &session.updated_at, id);
+        let nous_idx = Self::session_nous_index_key(&session.nous_id, &session.updated_at, id);
 
         let messages_part = self.partition("messages")?;
         let usage_part = self.partition("usage")?;
@@ -667,7 +702,10 @@ impl SessionStore {
     ) -> Result<i64> {
         use fjall::Readable;
 
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let messages_part = self.partition("messages")?;
         let sessions_part = self.partition("sessions")?;
 
@@ -722,14 +760,12 @@ impl SessionStore {
         let msg_data = serde_json::to_vec(&msg).context(error::StoredJsonSnafu)?;
 
         // Update session counters.
-        let mut session = self
-            .read_session_by_raw_id(session_id)?
-            .ok_or_else(|| {
-                error::SessionNotFoundSnafu {
-                    id: session_id.to_owned(),
-                }
-                .build()
-            })?;
+        let mut session = self.read_session_by_raw_id(session_id)?.ok_or_else(|| {
+            error::SessionNotFoundSnafu {
+                id: session_id.to_owned(),
+            }
+            .build()
+        })?;
         let old_updated_at = session.updated_at.clone();
         session.metrics.message_count += 1;
         session.metrics.token_count_estimate += token_estimate;
@@ -759,11 +795,7 @@ impl SessionStore {
     }
 
     /// Get non-distilled messages, newest `limit` in chronological order.
-    fn load_messages_in_range(
-        &self,
-        session_id: &str,
-        limit: Option<i64>,
-    ) -> Result<Vec<Message>> {
+    fn load_messages_in_range(&self, session_id: &str, limit: Option<i64>) -> Result<Vec<Message>> {
         use fjall::Readable;
 
         let messages_part = self.partition("messages")?;
@@ -906,7 +938,10 @@ impl SessionStore {
             return Ok(());
         }
 
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let messages_part = self.partition("messages")?;
         let sessions_part = self.partition("sessions")?;
 
@@ -968,7 +1003,10 @@ impl SessionStore {
     pub fn insert_distillation_summary(&self, session_id: &str, content: &str) -> Result<()> {
         use fjall::Readable;
 
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let messages_part = self.partition("messages")?;
         let sessions_part = self.partition("sessions")?;
 
@@ -1057,7 +1095,10 @@ impl SessionStore {
             .build()
         })?;
 
-        info!(session_id, msg_count, total_tokens, "inserted distillation summary");
+        info!(
+            session_id,
+            msg_count, total_tokens, "inserted distillation summary"
+        );
         Ok(())
     }
 
@@ -1074,7 +1115,10 @@ impl SessionStore {
     ) -> Result<()> {
         use fjall::Readable;
 
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let distillations_part = self.partition("distillations")?;
         let sessions_part = self.partition("sessions")?;
         let counters_part = self.partition("counters")?;
@@ -1141,9 +1185,16 @@ impl SessionStore {
     /// Record token usage for a turn.
     #[instrument(skip(self, record), level = "debug")]
     pub fn record_usage(&self, record: &UsageRecord) -> Result<()> {
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let usage_part = self.partition("usage")?;
-        let key = format!("{}:{}", record.session_id, pad_u64(record.turn_seq.cast_unsigned()));
+        let key = format!(
+            "{}:{}",
+            record.session_id,
+            pad_u64(record.turn_seq.cast_unsigned())
+        );
         let data = serde_json::to_vec(record).context(error::StoredJsonSnafu)?;
         let mut tx = self.db.write_tx();
         tx.insert(&usage_part, key.as_str(), data.as_slice());
@@ -1184,7 +1235,10 @@ impl SessionStore {
             .build());
         }
 
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let notes_part = self.partition("notes")?;
         let counters_part = self.partition("counters")?;
 
@@ -1253,7 +1307,10 @@ impl SessionStore {
     pub fn delete_note(&self, note_id: i64) -> Result<bool> {
         use fjall::Readable;
 
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let notes_part = self.partition("notes")?;
 
         let gid_key = format!("gid:{}", pad_u64(note_id.cast_unsigned()));
@@ -1300,7 +1357,10 @@ impl SessionStore {
         author: &str,
         ttl_secs: i64,
     ) -> Result<()> {
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let bb_part = self.partition("blackboard")?;
 
         let now = now_iso();
@@ -1367,7 +1427,10 @@ impl SessionStore {
     pub(crate) fn cleanup_expired_entries(&self) -> Result<u64> {
         use fjall::Readable;
 
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let bb_part = self.partition("blackboard")?;
         let snap = self.db.read_tx();
 
@@ -1403,7 +1466,10 @@ impl SessionStore {
     /// Delete a blackboard entry. Only the original author can delete.
     #[instrument(skip(self))]
     pub fn blackboard_delete(&self, key: &str, author: &str) -> Result<bool> {
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let bb_part = self.partition("blackboard")?;
 
         let row: Option<BlackboardRow> = self.get_json(&bb_part, key)?;

--- a/crates/graphe/src/store/fjall_store_tests.rs
+++ b/crates/graphe/src/store/fjall_store_tests.rs
@@ -23,25 +23,38 @@ fn create_and_find_session() {
 #[test]
 fn find_session_returns_none_for_missing() {
     let store = test_store();
-    let found = store.find_session("syn", "nonexistent").expect("find session");
+    let found = store
+        .find_session("syn", "nonexistent")
+        .expect("find session");
     assert!(found.is_none());
 }
 
 #[test]
 fn create_session_unique_constraint() {
     let store = test_store();
-    store.create_session("ses-1", "syn", "main", None, None).expect("first create");
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("first create");
     let result = store.create_session("ses-2", "syn", "main", None, None);
-    assert!(result.is_err(), "duplicate (nous_id, session_key) must fail");
+    assert!(
+        result.is_err(),
+        "duplicate (nous_id, session_key) must fail"
+    );
 }
 
 #[test]
 fn append_and_retrieve_messages() {
     let store = test_store();
-    store.create_session("ses-1", "syn", "main", None, None).expect("create");
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("create");
 
-    let seq1 = store.append_message("ses-1", Role::User, "hello", None, None, 10).expect("append");
-    let seq2 = store.append_message("ses-1", Role::Assistant, "hi there", None, None, 15).expect("append");
+    let seq1 = store
+        .append_message("ses-1", Role::User, "hello", None, None, 10)
+        .expect("append");
+    let seq2 = store
+        .append_message("ses-1", Role::Assistant, "hi there", None, None, 15)
+        .expect("append");
 
     assert_eq!(seq1, 1);
     assert_eq!(seq2, 2);
@@ -55,9 +68,15 @@ fn append_and_retrieve_messages() {
 #[test]
 fn message_updates_session_counts() {
     let store = test_store();
-    store.create_session("ses-1", "syn", "main", None, None).expect("create");
-    store.append_message("ses-1", Role::User, "hello", None, None, 100).expect("append");
-    store.append_message("ses-1", Role::Assistant, "world", None, None, 200).expect("append");
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("create");
+    store
+        .append_message("ses-1", Role::User, "hello", None, None, 100)
+        .expect("append");
+    store
+        .append_message("ses-1", Role::Assistant, "world", None, None, 200)
+        .expect("append");
 
     let session = store.find_session_by_id("ses-1").expect("query").unwrap();
     assert_eq!(session.metrics.message_count, 2);
@@ -67,9 +86,15 @@ fn message_updates_session_counts() {
 #[test]
 fn list_sessions_by_nous_id() {
     let store = test_store();
-    store.create_session("ses-a", "agent-x", "main", None, None).expect("create a");
-    store.create_session("ses-b", "agent-x", "secondary", None, None).expect("create b");
-    store.create_session("ses-c", "agent-y", "main", None, None).expect("create c");
+    store
+        .create_session("ses-a", "agent-x", "main", None, None)
+        .expect("create a");
+    store
+        .create_session("ses-b", "agent-x", "secondary", None, None)
+        .expect("create b");
+    store
+        .create_session("ses-c", "agent-y", "main", None, None)
+        .expect("create c");
 
     let agent_x = store.list_sessions(Some("agent-x")).expect("list");
     assert_eq!(agent_x.len(), 2);
@@ -80,8 +105,12 @@ fn list_sessions_by_nous_id() {
 #[test]
 fn update_session_status() {
     let store = test_store();
-    store.create_session("ses-1", "syn", "main", None, None).expect("create");
-    store.update_session_status("ses-1", SessionStatus::Archived).expect("update status");
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("create");
+    store
+        .update_session_status("ses-1", SessionStatus::Archived)
+        .expect("update status");
     let session = store.find_session_by_id("ses-1").expect("query").unwrap();
     assert_eq!(session.status, SessionStatus::Archived);
 }
@@ -89,25 +118,42 @@ fn update_session_status() {
 #[test]
 fn find_or_create_reactivates_archived() {
     let store = test_store();
-    store.create_session("ses-1", "syn", "main", None, None).expect("create");
-    store.update_session_status("ses-1", SessionStatus::Archived).expect("archive");
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("create");
+    store
+        .update_session_status("ses-1", SessionStatus::Archived)
+        .expect("archive");
 
     let session = store
         .find_or_create_session("ses-new", "syn", "main", None, None)
         .expect("find_or_create");
-    assert_eq!(session.id, "ses-1", "should return existing, not create new");
+    assert_eq!(
+        session.id, "ses-1",
+        "should return existing, not create new"
+    );
     assert_eq!(session.status, SessionStatus::Active);
 }
 
 #[test]
 fn distillation_marks_and_recalculates() {
     let store = test_store();
-    store.create_session("ses-1", "syn", "main", None, None).expect("create");
-    store.append_message("ses-1", Role::User, "old 1", None, None, 100).expect("append");
-    store.append_message("ses-1", Role::User, "old 2", None, None, 150).expect("append");
-    store.append_message("ses-1", Role::User, "keep this", None, None, 50).expect("append");
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("create");
+    store
+        .append_message("ses-1", Role::User, "old 1", None, None, 100)
+        .expect("append");
+    store
+        .append_message("ses-1", Role::User, "old 2", None, None, 150)
+        .expect("append");
+    store
+        .append_message("ses-1", Role::User, "keep this", None, None, 50)
+        .expect("append");
 
-    store.mark_messages_distilled("ses-1", &[1, 2]).expect("distill");
+    store
+        .mark_messages_distilled("ses-1", &[1, 2])
+        .expect("distill");
 
     let history = store.get_history("ses-1", None).expect("history");
     assert_eq!(history.len(), 1);
@@ -121,13 +167,25 @@ fn distillation_marks_and_recalculates() {
 #[test]
 fn insert_distillation_summary() {
     let store = test_store();
-    store.create_session("ses-1", "syn", "main", None, None).expect("create");
-    store.append_message("ses-1", Role::User, "msg1", None, None, 100).expect("append");
-    store.append_message("ses-1", Role::Assistant, "msg2", None, None, 200).expect("append");
-    store.append_message("ses-1", Role::User, "msg3", None, None, 50).expect("append");
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("create");
+    store
+        .append_message("ses-1", Role::User, "msg1", None, None, 100)
+        .expect("append");
+    store
+        .append_message("ses-1", Role::Assistant, "msg2", None, None, 200)
+        .expect("append");
+    store
+        .append_message("ses-1", Role::User, "msg3", None, None, 50)
+        .expect("append");
 
-    store.mark_messages_distilled("ses-1", &[1, 2]).expect("distill");
-    store.insert_distillation_summary("ses-1", "[Distillation #1]\n\nSummary").expect("summary");
+    store
+        .mark_messages_distilled("ses-1", &[1, 2])
+        .expect("distill");
+    store
+        .insert_distillation_summary("ses-1", "[Distillation #1]\n\nSummary")
+        .expect("summary");
 
     let history = store.get_history("ses-1", None).expect("history");
     assert_eq!(history.len(), 2, "summary + undistilled msg3");
@@ -139,12 +197,16 @@ fn insert_distillation_summary() {
 #[test]
 fn blackboard_crud() {
     let store = test_store();
-    store.blackboard_write("goal", "finish M0b", "syn", 3600).expect("write");
+    store
+        .blackboard_write("goal", "finish M0b", "syn", 3600)
+        .expect("write");
     let entry = store.blackboard_read("goal").expect("read").unwrap();
     assert_eq!(entry.value, "finish M0b");
     assert_eq!(entry.author_nous_id, "syn");
 
-    store.blackboard_write("goal", "updated goal", "syn", 3600).expect("overwrite");
+    store
+        .blackboard_write("goal", "updated goal", "syn", 3600)
+        .expect("overwrite");
     let updated = store.blackboard_read("goal").expect("read").unwrap();
     assert_eq!(updated.value, "updated goal");
 
@@ -156,9 +218,15 @@ fn blackboard_crud() {
 #[test]
 fn notes_crud() {
     let store = test_store();
-    store.create_session("ses-1", "syn", "main", None, None).expect("create");
-    store.add_note("ses-1", "syn", "task", "do something").expect("add note");
-    store.add_note("ses-1", "syn", "context", "background").expect("add note");
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("create");
+    store
+        .add_note("ses-1", "syn", "task", "do something")
+        .expect("add note");
+    store
+        .add_note("ses-1", "syn", "context", "background")
+        .expect("add note");
 
     let notes = store.get_notes("ses-1").expect("get notes");
     assert_eq!(notes.len(), 2);
@@ -173,13 +241,22 @@ fn notes_crud() {
 #[test]
 fn delete_session_removes_all_data() {
     let store = test_store();
-    store.create_session("ses-1", "syn", "main", None, None).expect("create");
-    store.append_message("ses-1", Role::User, "hi", None, None, 10).expect("append");
+    store
+        .create_session("ses-1", "syn", "main", None, None)
+        .expect("create");
+    store
+        .append_message("ses-1", Role::User, "hi", None, None, 10)
+        .expect("append");
 
     let deleted = store.delete_session("ses-1").expect("delete");
     assert!(deleted);
     assert!(store.find_session_by_id("ses-1").expect("query").is_none());
-    assert!(store.get_history("ses-1", None).expect("history").is_empty());
+    assert!(
+        store
+            .get_history("ses-1", None)
+            .expect("history")
+            .is_empty()
+    );
 }
 
 #[test]

--- a/crates/graphe/src/store/message.rs
+++ b/crates/graphe/src/store/message.rs
@@ -101,7 +101,10 @@ impl SessionStore {
         };
 
         let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| &**p).collect();
-        let mut stmt = self.conn.prepare_cached(&sql).context(error::DatabaseSnafu)?;
+        let mut stmt = self
+            .conn
+            .prepare_cached(&sql)
+            .context(error::DatabaseSnafu)?;
         let rows = stmt
             .query_map(&*param_refs, map_message)
             .context(error::DatabaseSnafu)?;

--- a/crates/graphe/src/store/mod.rs
+++ b/crates/graphe/src/store/mod.rs
@@ -109,7 +109,10 @@ impl SessionStore {
     /// # Errors
     /// Returns an error if the database cannot be opened or initialized.
     #[instrument(skip(path, recovery_config))]
-    pub(crate) fn open_with_recovery(path: &Path, recovery_config: &RecoveryConfig) -> Result<Self> {
+    pub(crate) fn open_with_recovery(
+        path: &Path,
+        recovery_config: &RecoveryConfig,
+    ) -> Result<Self> {
         info!(path = %path.display(), "Opening session store");
         let conn = Connection::open(path).context(error::DatabaseSnafu)?;
 

--- a/crates/graphe/src/store/tests/session_crud.rs
+++ b/crates/graphe/src/store/tests/session_crud.rs
@@ -504,7 +504,10 @@ fn delete_session_removes_session_and_messages() {
         .execute("DELETE FROM messages WHERE session_id = 'ses-1'", [])
         .expect("delete messages");
     let deleted = store.delete_session("ses-1").expect("delete session");
-    assert!(deleted, "delete_session should return true for existing session");
+    assert!(
+        deleted,
+        "delete_session should return true for existing session"
+    );
 
     // Verify session is gone
     let session = store.find_session_by_id("ses-1").expect("query succeeds");
@@ -514,7 +517,9 @@ fn delete_session_removes_session_and_messages() {
 #[test]
 fn delete_session_returns_false_for_nonexistent() {
     let store = test_store();
-    let deleted = store.delete_session("nonexistent-session").expect("delete session");
+    let deleted = store
+        .delete_session("nonexistent-session")
+        .expect("delete session");
     assert!(
         !deleted,
         "delete_session should return false for non-existent session"
@@ -540,7 +545,10 @@ fn get_history_filtered_with_before_seq() {
         .expect("get history filtered");
     assert_eq!(history.len(), 3, "should return 3 messages before seq 4");
     assert_eq!(history[0].content, "msg 1", "first message should be msg 1");
-    assert_eq!(history[1].content, "msg 2", "second message should be msg 2");
+    assert_eq!(
+        history[1].content, "msg 2",
+        "second message should be msg 2"
+    );
     assert_eq!(history[2].content, "msg 3", "third message should be msg 3");
 
     // Get history before seq 4 with limit 2
@@ -548,7 +556,10 @@ fn get_history_filtered_with_before_seq() {
         .get_history_filtered("ses-1", Some(2), Some(4))
         .expect("get history filtered with limit");
     assert_eq!(history.len(), 2, "should return 2 messages with limit");
-    assert_eq!(history[0].content, "msg 2", "first should be msg 2 (most recent 2 before 4)");
+    assert_eq!(
+        history[0].content, "msg 2",
+        "first should be msg 2 (most recent 2 before 4)"
+    );
     assert_eq!(history[1].content, "msg 3", "second should be msg 3");
 }
 
@@ -580,7 +591,10 @@ fn distillation_summary_operations() {
     let summary = store
         .get_distillation_summary("ses-1")
         .expect("get distillation summary");
-    assert_eq!(summary, None, "new session should have no distillation summary");
+    assert_eq!(
+        summary, None,
+        "new session should have no distillation summary"
+    );
 
     // Add some messages and mark some as distilled
     store
@@ -615,10 +629,21 @@ fn distillation_summary_operations() {
     // Verify distilled messages are deleted and summary is added
     // History contains: seq=0 (summary) and seq=3 (undistilled message)
     let history = store.get_history("ses-1", None).expect("get history");
-    assert_eq!(history.len(), 2, "summary + undistilled message should remain");
-    assert_eq!(history[0].role, Role::System, "first message should be system summary");
+    assert_eq!(
+        history.len(),
+        2,
+        "summary + undistilled message should remain"
+    );
+    assert_eq!(
+        history[0].role,
+        Role::System,
+        "first message should be system summary"
+    );
     assert_eq!(history[0].content, "Summary of distilled messages");
-    assert_eq!(history[1].content, "keep this", "second message should be undistilled");
+    assert_eq!(
+        history[1].content, "keep this",
+        "second message should be undistilled"
+    );
 
     // Verify session metrics are updated (summary + 1 message)
     let session = store
@@ -761,26 +786,43 @@ fn usage_exists_for_turn_detects_duplicates() {
 fn create_session_with_parent_and_model() {
     let store = test_store();
     let session = store
-        .create_session("ses-1", "alice", "main", Some("parent-123"), Some("claude-opus-4"))
+        .create_session(
+            "ses-1",
+            "alice",
+            "main",
+            Some("parent-123"),
+            Some("claude-opus-4"),
+        )
         .expect("create session with parent and model");
 
     assert_eq!(session.id, "ses-1");
-    assert_eq!(session.origin.parent_session_id, Some("parent-123".to_owned()));
+    assert_eq!(
+        session.origin.parent_session_id,
+        Some("parent-123".to_owned())
+    );
     assert_eq!(session.model, Some("claude-opus-4".to_owned()));
 
     let found = store
         .find_session_by_id("ses-1")
         .expect("find session")
         .expect("session should exist");
-    assert_eq!(found.origin.parent_session_id, Some("parent-123".to_owned()));
+    assert_eq!(
+        found.origin.parent_session_id,
+        Some("parent-123".to_owned())
+    );
     assert_eq!(found.model, Some("claude-opus-4".to_owned()));
 }
 
 #[test]
 fn find_session_by_id_not_found() {
     let store = test_store();
-    let result = store.find_session_by_id("nonexistent-id").expect("query succeeds");
-    assert!(result.is_none(), "find_session_by_id should return None for non-existent ID");
+    let result = store
+        .find_session_by_id("nonexistent-id")
+        .expect("query succeeds");
+    assert!(
+        result.is_none(),
+        "find_session_by_id should return None for non-existent ID"
+    );
 }
 
 #[test]
@@ -793,7 +835,10 @@ fn list_sessions_returns_empty_for_nonexistent_nous() {
 
     // List sessions for bob (who has no sessions)
     let sessions = store.list_sessions(Some("bob")).expect("list sessions");
-    assert!(sessions.is_empty(), "should return empty vec for nous with no sessions");
+    assert!(
+        sessions.is_empty(),
+        "should return empty vec for nous with no sessions"
+    );
 }
 
 #[test]
@@ -895,11 +940,19 @@ fn find_session_only_returns_active() {
 
     // Should not find archived session
     let found = store.find_session("alice", "main").expect("find session");
-    assert!(found.is_none(), "should not find archived session with find_session");
+    assert!(
+        found.is_none(),
+        "should not find archived session with find_session"
+    );
 
     // But find_session_by_id should still find it
-    let found = store.find_session_by_id("ses-1").expect("find session by id");
-    assert!(found.is_some(), "find_session_by_id should find archived session");
+    let found = store
+        .find_session_by_id("ses-1")
+        .expect("find session by id");
+    assert!(
+        found.is_some(),
+        "find_session_by_id should find archived session"
+    );
 }
 
 #[test]
@@ -921,7 +974,11 @@ fn find_or_create_with_archived_session_reactivates() {
         .find_or_create_session("ses-new", "bob", "main", None, None)
         .expect("find or create session");
     assert_eq!(session.id, "ses-1", "should return same session");
-    assert_eq!(session.status, SessionStatus::Active, "should reactivate archived session");
+    assert_eq!(
+        session.status,
+        SessionStatus::Active,
+        "should reactivate archived session"
+    );
 }
 
 #[test]
@@ -944,17 +1001,25 @@ fn multiple_sessions_same_nous_different_keys() {
     assert_eq!(s3.session_type, SessionType::Ephemeral);
 
     // List all sessions for acme.corp
-    let sessions = store.list_sessions(Some("acme.corp")).expect("list sessions");
+    let sessions = store
+        .list_sessions(Some("acme.corp"))
+        .expect("list sessions");
     assert_eq!(sessions.len(), 3, "should have 3 sessions");
 
     // Find each session by its key
-    let found1 = store.find_session("acme.corp", "main").expect("find session");
+    let found1 = store
+        .find_session("acme.corp", "main")
+        .expect("find session");
     assert_eq!(found1.unwrap().id, "ses-1");
 
-    let found2 = store.find_session("acme.corp", "secondary").expect("find session");
+    let found2 = store
+        .find_session("acme.corp", "secondary")
+        .expect("find session");
     assert_eq!(found2.unwrap().id, "ses-2");
 
-    let found3 = store.find_session("acme.corp", "ephemeral:task1").expect("find session");
+    let found3 = store
+        .find_session("acme.corp", "ephemeral:task1")
+        .expect("find session");
     assert_eq!(found3.unwrap().id, "ses-3");
 }
 
@@ -1034,10 +1099,18 @@ fn session_notes_with_valid_categories() {
     let notes = store.get_notes("ses-1").expect("get notes");
     assert_eq!(notes.len(), 4);
 
-    store.delete_note(note_decision).expect("delete decision note");
-    store.delete_note(note_preference).expect("delete preference note");
-    store.delete_note(note_correction).expect("delete correction note");
-    store.delete_note(note_context).expect("delete context note");
+    store
+        .delete_note(note_decision)
+        .expect("delete decision note");
+    store
+        .delete_note(note_preference)
+        .expect("delete preference note");
+    store
+        .delete_note(note_correction)
+        .expect("delete correction note");
+    store
+        .delete_note(note_context)
+        .expect("delete context note");
 
     let notes = store.get_notes("ses-1").expect("get notes");
     assert!(notes.is_empty(), "all notes should be deleted");
@@ -1069,7 +1142,10 @@ fn list_sessions_ordering_by_updated_at() {
     // List should be ordered by updated_at DESC (most recent first)
     let sessions = store.list_sessions(Some("alice")).expect("list sessions");
     assert_eq!(sessions.len(), 3);
-    assert_eq!(sessions[0].id, "ses-1", "most recently updated should be first");
+    assert_eq!(
+        sessions[0].id, "ses-1",
+        "most recently updated should be first"
+    );
     assert_eq!(sessions[1].id, "ses-3");
     assert_eq!(sessions[2].id, "ses-2");
 }

--- a/crates/graphe/tests/session_lifecycle.rs
+++ b/crates/graphe/tests/session_lifecycle.rs
@@ -45,7 +45,13 @@ fn create_session_returns_populated_record() {
     let (store, _dir) = fresh_store();
     let id = Ulid::new().to_string();
     let session = store
-        .create_session(&id, "nous-int-test", "primary", None, Some("claude-sonnet-4-6"))
+        .create_session(
+            &id,
+            "nous-int-test",
+            "primary",
+            None,
+            Some("claude-sonnet-4-6"),
+        )
         .expect("create_session succeeds");
 
     assert_eq!(session.id, id, "id should round-trip");
@@ -220,9 +226,7 @@ fn list_sessions_filters_by_nous_id() {
         .create_session(&id_b, "nous-b", "primary", None, None)
         .expect("create b");
 
-    let nous_a_sessions = store
-        .list_sessions(Some("nous-a"))
-        .expect("list nous-a");
+    let nous_a_sessions = store.list_sessions(Some("nous-a")).expect("list nous-a");
     assert_eq!(nous_a_sessions.len(), 1);
     assert_eq!(nous_a_sessions[0].id, id_a);
 
@@ -244,9 +248,7 @@ fn delete_session_removes_empty_session() {
 
     let deleted = store.delete_session(&session_id).expect("delete");
     assert!(deleted, "delete should report success");
-    let after = store
-        .find_session_by_id(&session_id)
-        .expect("query");
+    let after = store.find_session_by_id(&session_id).expect("query");
     assert!(
         after.is_none(),
         "session should not be findable after delete"
@@ -270,17 +272,13 @@ fn delete_session_removes_session_and_messages() {
 
     let deleted = store.delete_session(&session_id).expect("delete");
     assert!(deleted, "delete should report success");
-    let after = store
-        .find_session_by_id(&session_id)
-        .expect("query");
+    let after = store.find_session_by_id(&session_id).expect("query");
     assert!(
         after.is_none(),
         "session should not be findable after delete"
     );
     // WHY: also verify no orphan rows remain in messages.
-    let history = store
-        .get_history(&session_id, None)
-        .expect("history query");
+    let history = store.get_history(&session_id, None).expect("history query");
     assert!(
         history.is_empty(),
         "messages should be deleted along with the session"
@@ -305,9 +303,7 @@ fn open_in_memory_creates_isolated_stores() {
         .create_session(&id, "nous-mem", "primary", None, None)
         .expect("create in store_a");
 
-    let in_b = store_b
-        .find_session_by_id(&id)
-        .expect("query store_b");
+    let in_b = store_b.find_session_by_id(&id).expect("query store_b");
     assert!(
         in_b.is_none(),
         "store_b should not see sessions created in store_a"

--- a/crates/hermeneus/benches/parser.rs
+++ b/crates/hermeneus/benches/parser.rs
@@ -29,9 +29,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use hermeneus::complexity::{ComplexityInput, score_complexity};
-use hermeneus::concurrency::{
-    AdaptiveConcurrencyLimiter, ConcurrencyConfig, RequestOutcome,
-};
+use hermeneus::concurrency::{AdaptiveConcurrencyLimiter, ConcurrencyConfig, RequestOutcome};
 use hermeneus::types::{StopReason, ToolResultType, Usage};
 
 /// Baseline: sum two `u64` fields inside a `Copy` struct. Establishes the
@@ -129,8 +127,7 @@ fn score_complexity_short(c: &mut Criterion) {
 /// closer to the realistic cost of routing a typical assistant turn.
 fn score_complexity_long(c: &mut Criterion) {
     let input = ComplexityInput {
-        message_text:
-            "Please analyze the architecture of this service, then implement a refactor \
+        message_text: "Please analyze the architecture of this service, then implement a refactor \
              that migrates the session store to the new backend. Review the diff \
              and investigate any failing tests. After that, commit and push.",
         tool_count: 12,
@@ -179,10 +176,7 @@ fn concurrency_acquire_release(c: &mut Criterion) {
         b.iter(|| {
             rt.block_on(async {
                 let permit = limiter.acquire().await;
-                permit.finish_with_latency(
-                    RequestOutcome::Neutral,
-                    Duration::from_millis(1),
-                );
+                permit.finish_with_latency(RequestOutcome::Neutral, Duration::from_millis(1));
             });
             black_box(&limiter);
         });

--- a/crates/hermeneus/src/anthropic/cc_profile.rs
+++ b/crates/hermeneus/src/anthropic/cc_profile.rs
@@ -6,8 +6,8 @@
 
 use std::process::Command;
 
-use tracing::warn;
 use koina::uuid::Uuid;
+use tracing::warn;
 
 /// Fingerprint salt from CC source (constants/system.ts).
 /// Must match exactly for server-side validation.
@@ -58,7 +58,10 @@ impl CcProfile {
     }
 
     /// Add the 1M context beta header if the model supports it.
-    #[expect(dead_code, reason = "public API reserved for extended context window callers")]
+    #[expect(
+        dead_code,
+        reason = "public API reserved for extended context window callers"
+    )]
     pub fn with_context_1m(&mut self) {
         let header = "context-1m-2025-08-07";
         if !self.beta_headers.iter().any(|h| h == header) {
@@ -115,12 +118,19 @@ pub(crate) fn compute_fingerprint(first_message_text: &str, version: &str) -> St
     let hash = Sha256::digest(input.as_bytes());
     // First 3 hex chars: take 2 bytes (= 4 hex chars), then slice to 3.
     // All chars are ASCII hex digits so the byte slice is always valid UTF-8.
-    let hex: String = hash.iter().take(2).flat_map(|b| {
-        let hi = char::from_digit(u32::from(b >> 4), 16).unwrap_or('0');
-        let lo = char::from_digit(u32::from(b & 0xf), 16).unwrap_or('0');
-        [hi, lo]
-    }).collect();
-    #[expect(clippy::string_slice, reason = "ASCII hex digits: byte slice is always on char boundary")]
+    let hex: String = hash
+        .iter()
+        .take(2)
+        .flat_map(|b| {
+            let hi = char::from_digit(u32::from(b >> 4), 16).unwrap_or('0');
+            let lo = char::from_digit(u32::from(b & 0xf), 16).unwrap_or('0');
+            [hi, lo]
+        })
+        .collect();
+    #[expect(
+        clippy::string_slice,
+        reason = "ASCII hex digits: byte slice is always on char boundary"
+    )]
     hex[..3].to_owned()
 }
 

--- a/crates/hermeneus/src/anthropic/stream/accumulator.rs
+++ b/crates/hermeneus/src/anthropic/stream/accumulator.rs
@@ -654,7 +654,10 @@ mod tests {
 
         let response = acc.finish();
         match &response.content[0] {
-            ContentBlock::Thinking { thinking, signature } => {
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => {
                 assert_eq!(thinking, "Let me think... ");
                 assert_eq!(signature.as_deref(), Some("sig123"));
             }
@@ -686,7 +689,11 @@ mod tests {
             .expect("stop");
 
         let response = acc.finish();
-        assert_eq!(response.content.len(), 3, "should have 3 blocks (gaps filled)");
+        assert_eq!(
+            response.content.len(),
+            3,
+            "should have 3 blocks (gaps filled)"
+        );
     }
 
     #[test]

--- a/crates/hermeneus/src/cc/parse.rs
+++ b/crates/hermeneus/src/cc/parse.rs
@@ -17,16 +17,17 @@ use crate::types::{CompletionResponse, ContentBlock, StopReason, Usage};
 pub(crate) enum CcEvent {
     /// Incremental assistant message (streaming text).
     #[serde(rename = "assistant")]
-    Assistant {
-        message: AssistantMessage,
-    },
+    Assistant { message: AssistantMessage },
 
     /// Final result event with usage and cost.
     #[serde(rename = "result")]
     Result {
         #[cfg_attr(
             not(test),
-            expect(dead_code, reason = "deserialized for completeness; not consumed by provider")
+            expect(
+                dead_code,
+                reason = "deserialized for completeness; not consumed by provider"
+            )
         )]
         subtype: String,
         result: String,
@@ -72,7 +73,10 @@ pub(crate) struct AssistantMessage {
     #[serde(rename = "type")]
     #[cfg_attr(
         not(test),
-        expect(dead_code, reason = "deserialized for completeness; only `text` is consumed")
+        expect(
+            dead_code,
+            reason = "deserialized for completeness; only `text` is consumed"
+        )
     )]
     pub message_type: String,
     /// The text content.
@@ -237,9 +241,14 @@ mod tests {
             cache_read_input_tokens: 10,
             cache_creation_input_tokens: 5,
         };
-        let resp =
-            result_to_response("Hello", false, Some(&usage), "claude-sonnet-4-20250514", Some("sess_1"))
-                .unwrap();
+        let resp = result_to_response(
+            "Hello",
+            false,
+            Some(&usage),
+            "claude-sonnet-4-20250514",
+            Some("sess_1"),
+        )
+        .unwrap();
         assert_eq!(resp.id, "sess_1");
         assert_eq!(resp.model, "claude-sonnet-4-20250514");
         assert_eq!(resp.stop_reason, StopReason::EndTurn);

--- a/crates/hermeneus/src/cc/process.rs
+++ b/crates/hermeneus/src/cc/process.rs
@@ -41,8 +41,8 @@ const MAX_SYSTEM_PROMPT_BYTES: usize = 100 * 1024; // 100 KB
 /// Separated from I/O so it can be unit-tested without touching the real filesystem
 /// or the process environment.
 fn parse_oauth_token_from_json(content: &str) -> std::io::Result<String> {
-    let parsed: serde_json::Value = serde_json::from_str(content)
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(content).map_err(|e| std::io::Error::other(e.to_string()))?;
     // WHY: serde_json::Value::get returns None on missing keys (vs the
     // panic from indexing), so this is the safe form of
     // `parsed["claudeAiOauth"]["accessToken"]`.
@@ -241,10 +241,7 @@ pub(crate) async fn run_completion(
             );
             let _ = child.kill().await;
             Err(error::ApiRequestSnafu {
-                message: format!(
-                    "CC subprocess timed out after {}s",
-                    timeout.as_secs()
-                ),
+                message: format!("CC subprocess timed out after {}s", timeout.as_secs()),
             }
             .build())
         }
@@ -439,8 +436,7 @@ pub(crate) async fn run_streaming(
         .build()
     })?;
 
-    let result =
-        tokio::time::timeout(timeout, read_stream_with_callback(stdout, on_delta)).await;
+    let result = tokio::time::timeout(timeout, read_stream_with_callback(stdout, on_delta)).await;
 
     match result {
         Ok(Ok(output)) => {
@@ -458,10 +454,7 @@ pub(crate) async fn run_streaming(
             );
             let _ = child.kill().await;
             Err(error::ApiRequestSnafu {
-                message: format!(
-                    "CC subprocess timed out after {}s",
-                    timeout.as_secs()
-                ),
+                message: format!("CC subprocess timed out after {}s", timeout.as_secs()),
             }
             .build())
         }

--- a/crates/hermeneus/src/cc/process_tests.rs
+++ b/crates/hermeneus/src/cc/process_tests.rs
@@ -10,12 +10,16 @@ use super::*;
 /// Returns the script path. The caller is responsible for cleanup (or letting
 /// the OS reclaim the temp dir on process exit).
 fn write_script(name: &str, body: &str) -> PathBuf {
-    let path = std::env::temp_dir().join(format!("hermeneus_test_{name}_{}.sh", std::process::id()));
+    let path =
+        std::env::temp_dir().join(format!("hermeneus_test_{name}_{}.sh", std::process::id()));
     let script = format!("#!/bin/sh\n{body}\n");
     // WHY: Open, write, fsync, close, then set permissions. Without fsync
     // the kernel may not have finished writing page cache to disk when we
     // exec the script, producing ETXTBSY (errno 26) on Linux.
-    #[expect(clippy::disallowed_methods, reason = "test helper writes temp scripts, async not needed")]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test helper writes temp scripts, async not needed"
+    )]
     {
         use std::io::Write;
         let mut f = fs::File::create(&path).unwrap();
@@ -60,9 +64,8 @@ async fn read_stream_assistant_then_result() {
 async fn read_stream_result_only() {
     // WHY: CC can emit a result event with no preceding assistant deltas
     // (e.g. when the response is short and CC batches it into the result).
-    let buf = stream_buf(&[
-        r#"{"type":"result","subtype":"success","result":"ok","is_error":false}"#,
-    ]);
+    let buf =
+        stream_buf(&[r#"{"type":"result","subtype":"success","result":"ok","is_error":false}"#]);
     let output = read_stream(buf.as_slice()).await.unwrap();
     assert_eq!(output.result_text, "ok");
     assert!(output.stream_deltas.is_empty());
@@ -148,7 +151,10 @@ async fn read_stream_with_callback_skips_empty_text() {
     let _ = read_stream_with_callback(buf.as_slice(), &mut on_delta)
         .await
         .unwrap();
-    assert_eq!(count, 1, "callback should fire once for the non-empty delta");
+    assert_eq!(
+        count, 1,
+        "callback should fire once for the non-empty delta"
+    );
 }
 
 #[tokio::test]
@@ -208,7 +214,10 @@ fn parse_oauth_token_fails_on_malformed_json() {
     // WHY: Malformed credentials (e.g. truncated write) must return an
     // error, not panic. The caller silently skips OAuth injection on error.
     let err = parse_oauth_token_from_json("not-json{{{").unwrap_err();
-    assert!(!err.to_string().is_empty(), "error message must not be empty");
+    assert!(
+        !err.to_string().is_empty(),
+        "error message must not be empty"
+    );
 }
 
 #[test]

--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -221,12 +221,14 @@ fn extract_text_content(content: &Content) -> String {
             let parts: Vec<String> = blocks
                 .iter()
                 .filter_map(|block| match block {
-                    ContentBlock::Text { text, .. } if !text.is_empty() => {
-                        Some(text.to_owned())
-                    }
+                    ContentBlock::Text { text, .. } if !text.is_empty() => Some(text.to_owned()),
                     ContentBlock::ToolResult { content, .. } => {
                         let summary = content.text_summary();
-                        if summary.is_empty() { None } else { Some(summary) }
+                        if summary.is_empty() {
+                            None
+                        } else {
+                            Some(summary)
+                        }
                     }
                     // Thinking, server tool use, web search, code execution have
                     // no text representation for CC's flat prompt format.

--- a/crates/hermeneus/src/circuit_breaker.rs
+++ b/crates/hermeneus/src/circuit_breaker.rs
@@ -124,7 +124,10 @@ impl CircuitBreaker {
     #[must_use]
     pub fn is_allowed(&self) -> bool {
         // kanon:ignore RUST/pub-visibility
-        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         match &inner.state {
             CircuitState::Closed => true,
             CircuitState::HalfOpen => false,
@@ -155,7 +158,10 @@ impl CircuitBreaker {
     /// - `HalfOpen`: transitions to `Closed` and resets probe attempt count.
     pub fn on_success(&self) {
         // kanon:ignore RUST/pub-visibility
-        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         match inner.state {
             CircuitState::Closed => {
                 inner.consecutive_failures = 0;
@@ -183,7 +189,10 @@ impl CircuitBreaker {
     /// - `Open`: no-op (already open).
     pub fn on_failure(&self) {
         // kanon:ignore RUST/pub-visibility
-        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         match inner.state {
             CircuitState::Closed => {
                 inner.consecutive_failures += 1;

--- a/crates/hermeneus/src/error.rs
+++ b/crates/hermeneus/src/error.rs
@@ -328,10 +328,7 @@ mod tests {
             message: "CC process exited with exit status: 1: OAuth token rejected",
         }
         .build();
-        assert!(
-            err.is_retryable(),
-            "CC process exit should be retryable"
-        );
+        assert!(err.is_retryable(), "CC process exit should be retryable");
     }
 
     #[test]

--- a/crates/hermeneus/src/health.rs
+++ b/crates/hermeneus/src/health.rs
@@ -101,7 +101,9 @@ impl ProviderHealthTracker {
     }
 
     fn lock_inner(&self) -> std::sync::MutexGuard<'_, TrackerInner> {
-        self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     /// Current health state.

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -9,6 +9,12 @@
 
 /// Anthropic Messages API client with streaming, retries, and cost estimation.
 pub mod anthropic;
+/// Claude Code subprocess provider: delegates LLM calls to the `claude` CLI.
+///
+/// Bypasses attestation-based API blocking by routing through CC's own
+/// authentication. Gated behind the `cc-provider` feature flag.
+#[cfg(feature = "cc-provider")]
+pub mod cc;
 /// Circuit breaker (Closed / Open / HalfOpen) with exponential backoff for LLM provider health.
 pub mod circuit_breaker;
 /// Complexity-based model routing: scores queries and routes to Haiku/Sonnet/Opus.
@@ -21,12 +27,6 @@ pub mod error;
 pub mod fallback;
 /// Provider health state machine (Up / Degraded / Down) with automatic recovery.
 pub mod health;
-/// Claude Code subprocess provider: delegates LLM calls to the `claude` CLI.
-///
-/// Bypasses attestation-based API blocking by routing through CC's own
-/// authentication. Gated behind the `cc-provider` feature flag.
-#[cfg(feature = "cc-provider")]
-pub mod cc;
 /// Prometheus metrics for LLM request counts, latency, and token usage.
 pub mod metrics;
 /// Model constants and API configuration defaults.

--- a/crates/hermeneus/src/metrics.rs
+++ b/crates/hermeneus/src/metrics.rs
@@ -270,10 +270,8 @@ mod tests {
                 for metric in family.get_metric() {
                     let labels = metric.get_label();
                     // Match labels by name->value
-                    let label_map: std::collections::HashMap<_, _> = labels
-                        .iter()
-                        .map(|l| (l.name(), l.value()))
-                        .collect();
+                    let label_map: std::collections::HashMap<_, _> =
+                        labels.iter().map(|l| (l.name(), l.value())).collect();
                     let matches =
                         label_names
                             .iter()
@@ -297,10 +295,8 @@ mod tests {
             if family.name() == name {
                 for metric in family.get_metric() {
                     let labels = metric.get_label();
-                    let label_map: std::collections::HashMap<_, _> = labels
-                        .iter()
-                        .map(|l| (l.name(), l.value()))
-                        .collect();
+                    let label_map: std::collections::HashMap<_, _> =
+                        labels.iter().map(|l| (l.name(), l.value())).collect();
                     let matches =
                         label_names
                             .iter()
@@ -324,10 +320,8 @@ mod tests {
             if family.name() == name {
                 for metric in family.get_metric() {
                     let labels = metric.get_label();
-                    let label_map: std::collections::HashMap<_, _> = labels
-                        .iter()
-                        .map(|l| (l.name(), l.value()))
-                        .collect();
+                    let label_map: std::collections::HashMap<_, _> =
+                        labels.iter().map(|l| (l.name(), l.value())).collect();
                     let matches =
                         label_names
                             .iter()
@@ -366,43 +360,92 @@ mod tests {
             .collect();
 
         // Core metrics that are always registered after recording
-        assert!(metric_names.contains("aletheia_llm_tokens_total"), "tokens metric should be registered");
-        assert!(metric_names.contains("aletheia_llm_cost_total"), "cost metric should be registered");
-        assert!(metric_names.contains("aletheia_llm_requests_total"), "requests metric should be registered");
-        assert!(metric_names.contains("aletheia_llm_cache_tokens_total"), "cache tokens metric should be registered");
-        assert!(metric_names.contains("aletheia_llm_request_duration_seconds"), "request duration metric should be registered");
-        assert!(metric_names.contains("aletheia_llm_ttft_seconds"), "ttft metric should be registered");
+        assert!(
+            metric_names.contains("aletheia_llm_tokens_total"),
+            "tokens metric should be registered"
+        );
+        assert!(
+            metric_names.contains("aletheia_llm_cost_total"),
+            "cost metric should be registered"
+        );
+        assert!(
+            metric_names.contains("aletheia_llm_requests_total"),
+            "requests metric should be registered"
+        );
+        assert!(
+            metric_names.contains("aletheia_llm_cache_tokens_total"),
+            "cache tokens metric should be registered"
+        );
+        assert!(
+            metric_names.contains("aletheia_llm_request_duration_seconds"),
+            "request duration metric should be registered"
+        );
+        assert!(
+            metric_names.contains("aletheia_llm_ttft_seconds"),
+            "ttft metric should be registered"
+        );
         // Concurrency metrics registered after setting values
-        assert!(metric_names.contains("aletheia_llm_concurrency_limit"), "concurrency limit metric should be registered");
-        assert!(metric_names.contains("aletheia_llm_concurrency_latency_ewma_seconds"), "concurrency latency metric should be registered");
-        assert!(metric_names.contains("aletheia_llm_concurrency_in_flight"), "concurrency in-flight metric should be registered");
+        assert!(
+            metric_names.contains("aletheia_llm_concurrency_limit"),
+            "concurrency limit metric should be registered"
+        );
+        assert!(
+            metric_names.contains("aletheia_llm_concurrency_latency_ewma_seconds"),
+            "concurrency latency metric should be registered"
+        );
+        assert!(
+            metric_names.contains("aletheia_llm_concurrency_in_flight"),
+            "concurrency in-flight metric should be registered"
+        );
     }
 
     #[test]
     fn record_completion_success_updates_all_metrics() {
         // Use a unique provider name to avoid test interference
         let provider = "test-completion-success";
-        let before_requests = read_counter("aletheia_llm_requests_total", &["provider", "status"], &[provider, "ok"]);
-        let before_tokens_in =
-            read_counter("aletheia_llm_tokens_total", &["provider", "direction"], &[provider, "input"]);
-        let before_tokens_out =
-            read_counter("aletheia_llm_tokens_total", &["provider", "direction"], &[provider, "output"]);
+        let before_requests = read_counter(
+            "aletheia_llm_requests_total",
+            &["provider", "status"],
+            &[provider, "ok"],
+        );
+        let before_tokens_in = read_counter(
+            "aletheia_llm_tokens_total",
+            &["provider", "direction"],
+            &[provider, "input"],
+        );
+        let before_tokens_out = read_counter(
+            "aletheia_llm_tokens_total",
+            &["provider", "direction"],
+            &[provider, "output"],
+        );
         let before_cost = read_float_counter("aletheia_llm_cost_total", &["provider"], &[provider]);
 
         record_completion(provider, 100, 50, 0.001, true);
 
         assert_eq!(
-            read_counter("aletheia_llm_requests_total", &["provider", "status"], &[provider, "ok"]),
+            read_counter(
+                "aletheia_llm_requests_total",
+                &["provider", "status"],
+                &[provider, "ok"]
+            ),
             before_requests + 1,
             "request counter should increment"
         );
         assert_eq!(
-            read_counter("aletheia_llm_tokens_total", &["provider", "direction"], &[provider, "input"]),
+            read_counter(
+                "aletheia_llm_tokens_total",
+                &["provider", "direction"],
+                &[provider, "input"]
+            ),
             before_tokens_in + 100,
             "input token counter should increment by 100"
         );
         assert_eq!(
-            read_counter("aletheia_llm_tokens_total", &["provider", "direction"], &[provider, "output"]),
+            read_counter(
+                "aletheia_llm_tokens_total",
+                &["provider", "direction"],
+                &[provider, "output"]
+            ),
             before_tokens_out + 50,
             "output token counter should increment by 50"
         );
@@ -416,12 +459,20 @@ mod tests {
     #[test]
     fn record_completion_failure_updates_error_metrics() {
         let provider = "test-completion-failure";
-        let before = read_counter("aletheia_llm_requests_total", &["provider", "status"], &[provider, "error"]);
+        let before = read_counter(
+            "aletheia_llm_requests_total",
+            &["provider", "status"],
+            &[provider, "error"],
+        );
 
         record_completion(provider, 0, 0, 0.0, false);
 
         assert_eq!(
-            read_counter("aletheia_llm_requests_total", &["provider", "status"], &[provider, "error"]),
+            read_counter(
+                "aletheia_llm_requests_total",
+                &["provider", "status"],
+                &[provider, "error"]
+            ),
             before + 1,
             "error request counter should increment"
         );
@@ -463,7 +514,11 @@ mod tests {
         record_ttft(model, status, 0.25);
 
         assert_eq!(
-            read_histogram_count("aletheia_llm_ttft_seconds", &["model", "status"], &[model, status]),
+            read_histogram_count(
+                "aletheia_llm_ttft_seconds",
+                &["model", "status"],
+                &[model, status]
+            ),
             before + 1,
             "ttft histogram should have one more observation"
         );
@@ -472,20 +527,34 @@ mod tests {
     #[test]
     fn record_cache_tokens_increments_counters() {
         let provider = "test-cache-tokens";
-        let before_read =
-            read_counter("aletheia_llm_cache_tokens_total", &["provider", "direction"], &[provider, "read"]);
-        let before_write =
-            read_counter("aletheia_llm_cache_tokens_total", &["provider", "direction"], &[provider, "write"]);
+        let before_read = read_counter(
+            "aletheia_llm_cache_tokens_total",
+            &["provider", "direction"],
+            &[provider, "read"],
+        );
+        let before_write = read_counter(
+            "aletheia_llm_cache_tokens_total",
+            &["provider", "direction"],
+            &[provider, "write"],
+        );
 
         record_cache_tokens(provider, 1000, 500);
 
         assert_eq!(
-            read_counter("aletheia_llm_cache_tokens_total", &["provider", "direction"], &[provider, "read"]),
+            read_counter(
+                "aletheia_llm_cache_tokens_total",
+                &["provider", "direction"],
+                &[provider, "read"]
+            ),
             before_read + 1000,
             "read cache token counter should increment by 1000"
         );
         assert_eq!(
-            read_counter("aletheia_llm_cache_tokens_total", &["provider", "direction"], &[provider, "write"]),
+            read_counter(
+                "aletheia_llm_cache_tokens_total",
+                &["provider", "direction"],
+                &[provider, "write"]
+            ),
             before_write + 500,
             "write cache token counter should increment by 500"
         );

--- a/crates/integration-tests/tests/access_tracking.rs
+++ b/crates/integration-tests/tests/access_tracking.rs
@@ -27,7 +27,11 @@ fn ts(s: &str) -> jiff::Timestamp {
 }
 
 fn open_store(dim: usize) -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim,
+        ..Default::default()
+    })
+    .expect("open_mem")
 }
 
 fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {

--- a/crates/integration-tests/tests/domain_packs.rs
+++ b/crates/integration-tests/tests/domain_packs.rs
@@ -10,9 +10,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use hermeneus::provider::{LlmProvider, ProviderRegistry};
-use hermeneus::types::{
-    CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage,
-};
+use hermeneus::types::{CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage};
 use koina::id::ToolName;
 use nous::config::{NousConfig, PipelineConfig};
 use nous::manager::NousManager;
@@ -180,7 +178,10 @@ priority = "important"
         },
         ..NousConfig::default()
     };
-    let handle = manager.spawn(config, PipelineConfig::default()).await.expect("spawn");
+    let handle = manager
+        .spawn(config, PipelineConfig::default())
+        .await
+        .expect("spawn");
 
     handle.send_turn("main", "Hello").await.expect("turn");
 

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -26,7 +26,10 @@ use symbolon::jwt::{JwtConfig, JwtManager};
 use symbolon::types::Role;
 use taxis::oikos::Oikos;
 
-#[expect(clippy::too_many_lines, reason = "test server setup is inherently verbose")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "test server setup is inherently verbose"
+)]
 async fn start_test_server() -> (String, String, tempfile::TempDir) {
     install_crypto_provider();
     let dir = tempfile::TempDir::new().expect("tmpdir");

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -100,7 +100,11 @@ fn make_chunk(
 // TEST-02: Fact inserted via insert_fact is queryable and returns identical data.
 #[test]
 fn fact_round_trip() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let fact = Fact {
         id: FactId::new("f-1").expect("valid test id"),
@@ -147,7 +151,11 @@ fn fact_round_trip() {
 #[test]
 fn hnsw_vector_search() {
     let dim = 16;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim,
+        ..Default::default()
+    })
+    .expect("open_mem");
     let provider = MockEmbeddingProvider::new(dim);
 
     let texts = [
@@ -184,7 +192,11 @@ fn hnsw_vector_search() {
 // INTG-05: Schema version is queryable and matches SCHEMA_VERSION constant.
 #[test]
 fn schema_version_queryable() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        ..Default::default()
+    })
+    .expect("open_mem");
     let version = store.schema_version().expect("version");
     assert_eq!(version, 6);
 }
@@ -215,7 +227,11 @@ fn multiple_facts_ordered_by_confidence() {
 // INTG-04: spawn_blocking async wrappers work from #[tokio::test] context.
 #[tokio::test]
 async fn async_spawn_blocking_wrapper() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let fact = make_fact(
         "f-async",
@@ -238,7 +254,11 @@ async fn async_spawn_blocking_wrapper() {
 // Raw query escape hatch returns the expected relations.
 #[test]
 fn raw_query_escape_hatch() {
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let rows = store
         .run_query("::relations", BTreeMap::new())
@@ -254,7 +274,11 @@ fn raw_query_escape_hatch() {
 #[test]
 fn hybrid_retrieval_end_to_end() {
     let dim = 8;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let facts = [
         ("fact-1", "Rust is a systems programming language", 0.9f64),
@@ -348,7 +372,11 @@ fn hybrid_retrieval_end_to_end() {
 #[test]
 fn hnsw_connectivity_after_delete_reinsert_cycles() {
     let dim = 8;
-    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim, ..Default::default() }).expect("open_mem");
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim,
+        ..Default::default()
+    })
+    .expect("open_mem");
 
     let primes: [u64; 8] = [7, 11, 13, 17, 19, 23, 29, 31];
     let make_vec = |i: u64| -> Vec<f32> {

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -254,7 +254,11 @@ struct AuditRow {
 }
 
 fn open_store() -> Arc<KnowledgeStore> {
-    KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: 4, ..Default::default() }).expect("open_mem")
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        ..Default::default()
+    })
+    .expect("open_mem")
 }
 
 #[path = "knowledge_lifecycle/forget.rs"]

--- a/crates/integration-tests/tests/organon_mneme_tools.rs
+++ b/crates/integration-tests/tests/organon_mneme_tools.rs
@@ -380,19 +380,16 @@ impl KnowledgeSearchService for StubKnowledgeService {
         _row_limit: Option<usize>,
     ) -> Pin<
         Box<
-            dyn Future<
-                    Output = Result<organon::types::DatalogResult, KnowledgeAdapterError>,
-                > + Send
+            dyn Future<Output = Result<organon::types::DatalogResult, KnowledgeAdapterError>>
+                + Send
                 + '_,
         >,
     > {
-        Box::pin(std::future::ready(Ok(
-            organon::types::DatalogResult {
-                columns: vec!["stub".to_owned()],
-                rows: vec![],
-                truncated: false,
-            },
-        )))
+        Box::pin(std::future::ready(Ok(organon::types::DatalogResult {
+            columns: vec!["stub".to_owned()],
+            rows: vec![],
+            truncated: false,
+        })))
     }
 }
 

--- a/crates/koina/src/fjall.rs
+++ b/crates/koina/src/fjall.rs
@@ -71,9 +71,7 @@ impl FjallDb {
 
         for name in partitions {
             db.keyspace(name, KeyspaceCreateOptions::default)
-                .map_err(|e| {
-                    FjallOpenError::Open(format!("fjall open partition {name}: {e}"))
-                })?;
+                .map_err(|e| FjallOpenError::Open(format!("fjall open partition {name}: {e}")))?;
         }
 
         Ok(Self {
@@ -94,8 +92,7 @@ impl FjallDb {
     /// Returns a `String` error message if temp-dir creation, database open, or
     /// partition initialization fails.
     pub fn open_temp(partitions: &[&str]) -> Result<Self, FjallOpenError> {
-        let dir =
-            tempfile::TempDir::new().map_err(|source| FjallOpenError::TempDir { source })?;
+        let dir = tempfile::TempDir::new().map_err(|source| FjallOpenError::TempDir { source })?;
 
         let db = SingleWriterTxDatabase::builder(dir.path())
             .open()
@@ -103,9 +100,7 @@ impl FjallDb {
 
         for name in partitions {
             db.keyspace(name, KeyspaceCreateOptions::default)
-                .map_err(|e| {
-                    FjallOpenError::Open(format!("fjall open partition {name}: {e}"))
-                })?;
+                .map_err(|e| FjallOpenError::Open(format!("fjall open partition {name}: {e}")))?;
         }
 
         Ok(Self {

--- a/crates/koina/src/fs.rs
+++ b/crates/koina/src/fs.rs
@@ -24,10 +24,7 @@ pub fn validate_within_root(path: &Path, root: &Path) -> std::io::Result<PathBuf
         if let std::path::Component::ParentDir = component {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
-                format!(
-                    "path contains '..' component: {}",
-                    path.display()
-                ),
+                format!("path contains '..' component: {}", path.display()),
             ));
         }
     }
@@ -137,7 +134,13 @@ mod tests {
     #[test]
     fn validate_within_root_rejects_dotdot_traversal() {
         let dir = tempfile::tempdir().unwrap();
-        let escape = dir.path().join("data").join("..").join("..").join("etc").join("passwd");
+        let escape = dir
+            .path()
+            .join("data")
+            .join("..")
+            .join("..")
+            .join("etc")
+            .join("passwd");
 
         let result = validate_within_root(&escape, dir.path());
         assert!(result.is_err(), "path with '..' should be rejected");
@@ -171,10 +174,7 @@ mod tests {
         std::os::unix::fs::symlink(&outside_file, &link).unwrap();
 
         let result = validate_within_root(&link, root.path());
-        assert!(
-            result.is_err(),
-            "symlink escaping root should be rejected"
-        );
+        assert!(result.is_err(), "symlink escaping root should be rejected");
     }
 
     #[test]

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -7,9 +7,6 @@
 
 /// Setup-time cleanup registration via RAII guards ([`cleanup::CleanupGuard`], [`cleanup::CleanupRegistry`]).
 pub mod cleanup;
-/// Shared fjall storage helpers: database open, temp stores, timestamp formatting.
-#[cfg(feature = "fjall")]
-pub mod fjall;
 /// Credential provider trait for dynamic API key resolution.
 pub mod credential;
 /// Shared configuration defaults (token budgets, timeouts, iteration limits).
@@ -22,6 +19,9 @@ pub mod error;
 pub mod error_class;
 /// Internal event system coupling metrics and structured logs.
 pub mod event;
+/// Shared fjall storage helpers: database open, temp stores, timestamp formatting.
+#[cfg(feature = "fjall")]
+pub mod fjall;
 /// Restricted filesystem helpers for writing sensitive files.
 pub mod fs;
 /// Shared HTTP constants (content types, auth prefix, API paths).

--- a/crates/koina/src/redact.rs
+++ b/crates/koina/src/redact.rs
@@ -14,20 +14,19 @@ use regex::Regex;
 // fire `unfulfilled_lint_expectations` on every invocation of this macro.
 macro_rules! static_regex {
     ($name:ident, $pattern:expr) => {
-        #[allow(clippy::expect_used, reason = "macro-generated static regex requires expect() for compilation failure")]
-        static $name: LazyLock<Regex> = LazyLock::new(||
-            Regex::new($pattern).expect("static regex must compile")
-        );
+        #[allow(
+            clippy::expect_used,
+            reason = "macro-generated static regex requires expect() for compilation failure"
+        )]
+        static $name: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new($pattern).expect("static regex must compile"));
     };
 }
 
 static_regex!(RE_ANTHROPIC_KEY, r"sk-ant-api03-[A-Za-z0-9_-]+");
 static_regex!(RE_SK_KEY, r"sk-[A-Za-z0-9_-]{20,}");
 static_regex!(RE_BEARER, r"Bearer [A-Za-z0-9._-]+");
-static_regex!(
-    RE_JWT,
-    r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
-);
+static_regex!(RE_JWT, r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+");
 static_regex!(
     RE_SECRETS,
     r"(?i)(password|secret|api_key|apikey)\s*[:=]\s*\S+"

--- a/crates/koina/src/system/system_impl.rs
+++ b/crates/koina/src/system/system_impl.rs
@@ -8,9 +8,9 @@ use std::collections::HashSet;
 
 use jiff::{SignedDuration, Timestamp};
 
-use super::{Clock, Environment, FileSystem, RealSystem};
 #[cfg(any(test, feature = "test-support"))]
 use super::TestSystem;
+use super::{Clock, Environment, FileSystem, RealSystem};
 
 // ── RealSystem implementations ───────────────────────────────────────────────
 

--- a/crates/koina/src/ulid.rs
+++ b/crates/koina/src/ulid.rs
@@ -247,9 +247,7 @@ impl FromStr for Ulid {
             }
             value = value
                 .checked_shl(5)
-                .ok_or(DecodeError {
-                    reason: "overflow",
-                })?
+                .ok_or(DecodeError { reason: "overflow" })?
                 | u128::from(digit);
         }
 

--- a/crates/koina/src/uuid.rs
+++ b/crates/koina/src/uuid.rs
@@ -66,7 +66,10 @@ impl Uuid {
                     // SAFETY: `to_digit(16)` returns 0-15, which always fits in u8.
                     // This is an infallible conversion, but `try_into()` is used
                     // for type safety and to satisfy clippy::as_conversions.
-                    #[expect(clippy::expect_used, reason = "infallible: hex digit 0-15 always fits in u8")]
+                    #[expect(
+                        clippy::expect_used,
+                        reason = "infallible: hex digit 0-15 always fits in u8"
+                    )]
                     let nibble: u8 = c
                         .to_digit(16)
                         .ok_or(UuidParseError)?

--- a/crates/krites/src/data/aggr/boolean.rs
+++ b/crates/krites/src/data/aggr/boolean.rs
@@ -1,5 +1,8 @@
 //! Boolean and collection aggregation operators.
-#![expect(clippy::mutable_key_type, reason = "DataValue contains interior-mutable Regex; BTreeSet/Map usage is engine-internal")]
+#![expect(
+    clippy::mutable_key_type,
+    reason = "DataValue contains interior-mutable Regex; BTreeSet/Map usage is engine-internal"
+)]
 use std::collections::{BTreeMap, BTreeSet};
 
 use rand::prelude::*;

--- a/crates/krites/src/data/aggr/misc.rs
+++ b/crates/krites/src/data/aggr/misc.rs
@@ -1,5 +1,8 @@
 //! Miscellaneous aggregation operators: path, choice, bitwise.
-#![expect(clippy::assigning_clones, reason = "aggregation accumulators clone into existing storage — clone_from not always applicable")]
+#![expect(
+    clippy::assigning_clones,
+    reason = "aggregation accumulators clone into existing storage — clone_from not always applicable"
+)]
 use super::super::error::*;
 
 type Result<T> = DataResult<T>;

--- a/crates/krites/src/data/aggr/numeric.rs
+++ b/crates/krites/src/data/aggr/numeric.rs
@@ -382,7 +382,10 @@ impl Default for AggrLatestBy {
 }
 
 impl NormalAggrObj for AggrLatestBy {
-    #[expect(clippy::indexing_slicing, reason = "l.len() == 2 validated by ensure! above")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "l.len() == 2 validated by ensure! above"
+    )]
     fn set(&mut self, value: &DataValue) -> Result<()> {
         match value {
             DataValue::List(l) => {
@@ -427,7 +430,10 @@ impl Default for AggrSmallestBy {
 }
 
 impl NormalAggrObj for AggrSmallestBy {
-    #[expect(clippy::indexing_slicing, reason = "l.len() == 2 validated by ensure! above")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "l.len() == 2 validated by ensure! above"
+    )]
     fn set(&mut self, value: &DataValue) -> Result<()> {
         match value {
             DataValue::List(l) => {
@@ -472,7 +478,10 @@ impl Default for AggrMinCost {
 }
 
 impl NormalAggrObj for AggrMinCost {
-    #[expect(clippy::indexing_slicing, reason = "l.len() == 2 validated by ensure! above")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "l.len() == 2 validated by ensure! above"
+    )]
     fn set(&mut self, value: &DataValue) -> Result<()> {
         match value {
             DataValue::List(l) => {

--- a/crates/krites/src/data/expr/expr_impl.rs
+++ b/crates/krites/src/data/expr/expr_impl.rs
@@ -1,11 +1,32 @@
 //! Expr type and all its implementations.
-#![expect(clippy::result_large_err, reason = "engine InternalError carries structured context — boxing deferred")]
-#![expect(clippy::indexing_slicing, reason = "expression evaluator indices are structurally validated by arity checks")]
-#![expect(clippy::explicit_iter_loop, reason = "explicit .iter() calls are idiomatic in expression evaluator match arms")]
-#![expect(clippy::uninlined_format_args, reason = "format args style is consistent within expression evaluation code")]
-#![expect(clippy::match_same_arms, reason = "expression type variants intentionally list each case for clarity")]
-#![expect(clippy::if_not_else, reason = "negative condition reads better for the dispatch control flow")]
-#![expect(clippy::doc_markdown, reason = "DataValue type names in doc comments are engine-internal terminology")]
+#![expect(
+    clippy::result_large_err,
+    reason = "engine InternalError carries structured context — boxing deferred"
+)]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "expression evaluator indices are structurally validated by arity checks"
+)]
+#![expect(
+    clippy::explicit_iter_loop,
+    reason = "explicit .iter() calls are idiomatic in expression evaluator match arms"
+)]
+#![expect(
+    clippy::uninlined_format_args,
+    reason = "format args style is consistent within expression evaluation code"
+)]
+#![expect(
+    clippy::match_same_arms,
+    reason = "expression type variants intentionally list each case for clarity"
+)]
+#![expect(
+    clippy::if_not_else,
+    reason = "negative condition reads better for the dispatch control flow"
+)]
+#![expect(
+    clippy::doc_markdown,
+    reason = "DataValue type names in doc comments are engine-internal terminology"
+)]
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Display, Formatter};
 use std::mem;
@@ -260,7 +281,10 @@ impl Expr {
     /// Returns an error if the expression contains unevaluated bindings
     /// or if partial evaluation fails.
     #[must_use = "returns the evaluated constant or an error"]
-    #[expect(private_interfaces, reason = "DataError is pub(crate) but eval_to_const is only used within the crate")]
+    #[expect(
+        private_interfaces,
+        reason = "DataError is pub(crate) but eval_to_const is only used within the crate"
+    )]
     pub fn eval_to_const(mut self) -> Result<DataValue> {
         self.partial_eval()?;
         match self {

--- a/crates/krites/src/data/expr/mod.rs
+++ b/crates/krites/src/data/expr/mod.rs
@@ -1,6 +1,12 @@
 //! Expression evaluation and representation.
-#![expect(clippy::result_large_err, reason = "engine InternalError carries structured context — boxing deferred")]
-#![expect(clippy::indexing_slicing, reason = "expression binding indices are validated by arity checks")]
+#![expect(
+    clippy::result_large_err,
+    reason = "engine InternalError carries structured context — boxing deferred"
+)]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "expression binding indices are validated by arity checks"
+)]
 
 use std::fmt::Debug;
 

--- a/crates/krites/src/data/expr/op.rs
+++ b/crates/krites/src/data/expr/op.rs
@@ -1,8 +1,20 @@
 //! Op and ValueRange types.
-#![expect(clippy::indexing_slicing, reason = "operator evaluation indices are validated by arity checks")]
-#![expect(clippy::result_large_err, reason = "engine InternalError carries structured context — boxing deferred")]
-#![expect(clippy::too_many_lines, reason = "op_to_static maps all builtin operator names — one match arm per op")]
-#![expect(clippy::doc_markdown, reason = "Op and ValueRange are type names in module-level documentation")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "operator evaluation indices are validated by arity checks"
+)]
+#![expect(
+    clippy::result_large_err,
+    reason = "engine InternalError carries structured context — boxing deferred"
+)]
+#![expect(
+    clippy::too_many_lines,
+    reason = "op_to_static maps all builtin operator names — one match arm per op"
+)]
+#![expect(
+    clippy::doc_markdown,
+    reason = "Op and ValueRange are type names in module-level documentation"
+)]
 use std::cmp::{max, min};
 use std::fmt::{Debug, Formatter};
 

--- a/crates/krites/src/data/functions/aggregate.rs
+++ b/crates/krites/src/data/functions/aggregate.rs
@@ -1,7 +1,16 @@
 //! List construction, concatenation, get/set, and JSON merge functions.
-#![expect(clippy::as_conversions, reason = "numeric aggregation requires i64/usize/f64 casts — values are engine-internal")]
-#![expect(clippy::unnecessary_wraps, reason = "op_list and op_maybe_get return Result for API consistency with other builtins")]
-#![expect(clippy::redundant_else, reason = "else after early return keeps the fallback visually grouped")]
+#![expect(
+    clippy::as_conversions,
+    reason = "numeric aggregation requires i64/usize/f64 casts — values are engine-internal"
+)]
+#![expect(
+    clippy::unnecessary_wraps,
+    reason = "op_list and op_maybe_get return Result for API consistency with other builtins"
+)]
+#![expect(
+    clippy::redundant_else,
+    reason = "else after early return keeps the fallback visually grouped"
+)]
 
 use itertools::Itertools;
 use serde_json::{Value, json};

--- a/crates/krites/src/data/functions/bits.rs
+++ b/crates/krites/src/data/functions/bits.rs
@@ -1,7 +1,16 @@
 //! Bitwise and boolean operations.
-#![expect(clippy::unreadable_literal, reason = "bit mask literals (0b10000000) are clearer without separators")]
-#![expect(clippy::indexing_slicing, reason = "bit pack/unpack indices are structurally bounded by chunk iteration")]
-#![expect(clippy::explicit_iter_loop, reason = "explicit .iter_mut() is clearer for byte buffer mutation")]
+#![expect(
+    clippy::unreadable_literal,
+    reason = "bit mask literals (0b10000000) are clearer without separators"
+)]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "bit pack/unpack indices are structurally bounded by chunk iteration"
+)]
+#![expect(
+    clippy::explicit_iter_loop,
+    reason = "explicit .iter_mut() is clearer for byte buffer mutation"
+)]
 
 use std::ops::Div;
 

--- a/crates/krites/src/data/functions/collections.rs
+++ b/crates/krites/src/data/functions/collections.rs
@@ -1,6 +1,12 @@
 //! Collection, set, range, and assertion functions.
-#![expect(clippy::as_conversions, reason = "collection functions require i64/usize casts — engine-internal")]
-#![expect(clippy::mutable_key_type, reason = "DataValue contains interior-mutable Regex; BTreeSet usage is engine-internal")]
+#![expect(
+    clippy::as_conversions,
+    reason = "collection functions require i64/usize casts — engine-internal"
+)]
+#![expect(
+    clippy::mutable_key_type,
+    reason = "DataValue contains interior-mutable Regex; BTreeSet usage is engine-internal"
+)]
 use std::collections::BTreeSet;
 
 use itertools::Itertools;

--- a/crates/krites/src/data/functions/math/arithmetic.rs
+++ b/crates/krites/src/data/functions/math/arithmetic.rs
@@ -1,7 +1,16 @@
 //! Basic arithmetic operators.
-#![expect(clippy::as_conversions, reason = "mixed-type arithmetic requires i64-to-f64 casts — precision loss is acceptable")]
-#![expect(clippy::redundant_closure_for_method_calls, reason = "closure form is consistent with surrounding numeric dispatch")]
-#![expect(clippy::float_cmp, reason = "exact zero check in division-by-zero guard — not accumulated floating-point")]
+#![expect(
+    clippy::as_conversions,
+    reason = "mixed-type arithmetic requires i64-to-f64 casts — precision loss is acceptable"
+)]
+#![expect(
+    clippy::redundant_closure_for_method_calls,
+    reason = "closure form is consistent with surrounding numeric dispatch"
+)]
+#![expect(
+    clippy::float_cmp,
+    reason = "exact zero check in division-by-zero guard — not accumulated floating-point"
+)]
 
 use super::{arg, mul_vecs};
 use crate::data::error::*;

--- a/crates/krites/src/data/functions/math/mod.rs
+++ b/crates/krites/src/data/functions/math/mod.rs
@@ -1,8 +1,20 @@
 //! Comparison, arithmetic, and basic math functions.
-#![expect(clippy::as_conversions, reason = "numeric comparison and clamping require i64/f64 casts — engine-internal")]
-#![expect(clippy::cast_precision_loss, reason = "i64-to-f64 casts for numeric operations — precision loss is acceptable")]
-#![expect(clippy::float_cmp, reason = "exact equality for integer-representable float check — not accumulated arithmetic")]
-#![expect(clippy::enum_glob_use, reason = "DataValue::* glob import is scoped to function body for pattern matching")]
+#![expect(
+    clippy::as_conversions,
+    reason = "numeric comparison and clamping require i64/f64 casts — engine-internal"
+)]
+#![expect(
+    clippy::cast_precision_loss,
+    reason = "i64-to-f64 casts for numeric operations — precision loss is acceptable"
+)]
+#![expect(
+    clippy::float_cmp,
+    reason = "exact equality for integer-representable float check — not accumulated arithmetic"
+)]
+#![expect(
+    clippy::enum_glob_use,
+    reason = "DataValue::* glob import is scoped to function body for pattern matching"
+)]
 
 use super::arg;
 use crate::data::error::*;

--- a/crates/krites/src/data/functions/math/transcendental.rs
+++ b/crates/krites/src/data/functions/math/transcendental.rs
@@ -1,7 +1,16 @@
 //! Transcendental and utility math operators.
-#![expect(clippy::as_conversions, reason = "transcendental functions require i64-to-f64 casts — precision loss is acceptable")]
-#![expect(clippy::redundant_closure_for_method_calls, reason = "vector mapv closures (|x| x.sqrt()) are clearer than method references for ndarray")]
-#![expect(clippy::unnecessary_wraps, reason = "op_coalesce returns Result for API consistency with other builtins")]
+#![expect(
+    clippy::as_conversions,
+    reason = "transcendental functions require i64-to-f64 casts — precision loss is acceptable"
+)]
+#![expect(
+    clippy::redundant_closure_for_method_calls,
+    reason = "vector mapv closures (|x| x.sqrt()) are clearer than method references for ndarray"
+)]
+#![expect(
+    clippy::unnecessary_wraps,
+    reason = "op_coalesce returns Result for API consistency with other builtins"
+)]
 use std::ops::Rem;
 
 use super::arg;

--- a/crates/krites/src/data/functions/string.rs
+++ b/crates/krites/src/data/functions/string.rs
@@ -1,5 +1,8 @@
 //! String manipulation, regex, unicode, and encoding functions.
-#![expect(clippy::as_conversions, reason = "string function casts (CompactString as &str) are safe coercions")]
+#![expect(
+    clippy::as_conversions,
+    reason = "string function casts (CompactString as &str) are safe coercions"
+)]
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use compact_str::CompactString;
@@ -302,9 +305,7 @@ pub(crate) fn op_slice_string(args: &[DataValue]) -> Result<DataValue> {
     // unless they exceed usize::MAX, which on 64-bit is the same as i64::MAX.
     let m_us = usize::try_from(m).unwrap_or(usize::MAX);
     let span = usize::try_from(n - m).unwrap_or(usize::MAX);
-    Ok(DataValue::Str(
-        s.chars().skip(m_us).take(span).collect(),
-    ))
+    Ok(DataValue::Str(s.chars().skip(m_us).take(span).collect()))
 }
 
 pub(crate) fn op_from_substrings(args: &[DataValue]) -> Result<DataValue> {

--- a/crates/krites/src/data/functions/temporal.rs
+++ b/crates/krites/src/data/functions/temporal.rs
@@ -1,9 +1,24 @@
 //! UUID, timestamp, validity, and random number functions.
-#![expect(clippy::as_conversions, reason = "temporal functions require i64/f64 casts for Unix timestamps")]
-#![expect(clippy::unnecessary_wraps, reason = "temporal functions return Result for API consistency with other builtins")]
-#![expect(clippy::cast_lossless, reason = "uuid timestamp subsec is u32 — cast_lossless wants From but as is clearer in context")]
-#![expect(clippy::single_match_else, reason = "timezone branch reads better as if-let for the happy path")]
-#![expect(clippy::cloned_instead_of_copied, reason = "DataValue is not Copy — .cloned() is correct")]
+#![expect(
+    clippy::as_conversions,
+    reason = "temporal functions require i64/f64 casts for Unix timestamps"
+)]
+#![expect(
+    clippy::unnecessary_wraps,
+    reason = "temporal functions return Result for API consistency with other builtins"
+)]
+#![expect(
+    clippy::cast_lossless,
+    reason = "uuid timestamp subsec is u32 — cast_lossless wants From but as is clearer in context"
+)]
+#![expect(
+    clippy::single_match_else,
+    reason = "timezone branch reads better as if-let for the happy path"
+)]
+#![expect(
+    clippy::cloned_instead_of_copied,
+    reason = "DataValue is not Copy — .cloned() is correct"
+)]
 
 use std::cmp::Reverse;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -158,7 +173,10 @@ pub(crate) fn op_parse_timestamp(args: &[DataValue]) -> Result<DataValue> {
 
 pub(crate) fn op_rand_uuid_v1(_args: &[DataValue]) -> Result<DataValue> {
     let mut rng = rand::rng();
-    #[expect(deprecated, reason = "vendored CozoDB: uuid Context → ContextV1 rename pending uuid 2.x")]
+    #[expect(
+        deprecated,
+        reason = "vendored CozoDB: uuid Context → ContextV1 rename pending uuid 2.x"
+    )]
     let uuid_ctx = uuid::v1::Context::new(rng.random());
     #[cfg(target_arch = "wasm32")]
     let ts = {

--- a/crates/krites/src/data/functions/trig.rs
+++ b/crates/krites/src/data/functions/trig.rs
@@ -1,6 +1,12 @@
 //! Trigonometric, hyperbolic, and geographic functions.
-#![expect(clippy::as_conversions, reason = "trig functions require i64-to-f64 casts — precision loss is acceptable")]
-#![expect(clippy::redundant_closure_for_method_calls, reason = "vector mapv closures (|x| x.sin()) are clearer than method references for ndarray")]
+#![expect(
+    clippy::as_conversions,
+    reason = "trig functions require i64-to-f64 casts — precision loss is acceptable"
+)]
+#![expect(
+    clippy::redundant_closure_for_method_calls,
+    reason = "vector mapv closures (|x| x.sin()) are clearer than method references for ndarray"
+)]
 use crate::data::error::*;
 type Result<T> = DataResult<T>;
 use super::arg;

--- a/crates/krites/src/data/functions/utility.rs
+++ b/crates/krites/src/data/functions/utility.rs
@@ -1,10 +1,28 @@
 //! Type checking, conversion, and JSON operation functions.
-#![expect(clippy::as_conversions, reason = "type conversion functions require numeric casts")]
-#![expect(clippy::match_same_arms, reason = "type-check functions intentionally list variants for completeness")]
-#![expect(clippy::indexing_slicing, reason = "json_object pair[0]/pair[1] bounded by chunks_exact(2) iteration")]
-#![expect(clippy::implicit_clone, reason = "val2str().into() is clearer than restructuring the conversion")]
-#![expect(clippy::unnested_or_patterns, reason = "separate DataValue::Num variants are clearer for type dispatch")]
-#![expect(clippy::bool_to_int_with_if, reason = "conditional zero/one is clearer than i64::from(bool) in to_int context")]
+#![expect(
+    clippy::as_conversions,
+    reason = "type conversion functions require numeric casts"
+)]
+#![expect(
+    clippy::match_same_arms,
+    reason = "type-check functions intentionally list variants for completeness"
+)]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "json_object pair[0]/pair[1] bounded by chunks_exact(2) iteration"
+)]
+#![expect(
+    clippy::implicit_clone,
+    reason = "val2str().into() is clearer than restructuring the conversion"
+)]
+#![expect(
+    clippy::unnested_or_patterns,
+    reason = "separate DataValue::Num variants are clearer for type dispatch"
+)]
+#![expect(
+    clippy::bool_to_int_with_if,
+    reason = "conditional zero/one is clearer than i64::from(bool) in to_int context"
+)]
 
 use std::str::FromStr;
 

--- a/crates/krites/src/data/functions/vector.rs
+++ b/crates/krites/src/data/functions/vector.rs
@@ -1,7 +1,16 @@
 //! Vector creation and distance operations.
-#![expect(clippy::as_conversions, reason = "vector operations require numeric casts (f64 → f32) for element conversion")]
-#![expect(clippy::map_err_ignore, reason = "bytemuck PodCastError detail is not useful to the caller; the message describes the failure")]
-#![expect(clippy::too_many_lines, reason = "op_vec handles multiple input types and vector element types")]
+#![expect(
+    clippy::as_conversions,
+    reason = "vector operations require numeric casts (f64 → f32) for element conversion"
+)]
+#![expect(
+    clippy::map_err_ignore,
+    reason = "bytemuck PodCastError detail is not useful to the caller; the message describes the failure"
+)]
+#![expect(
+    clippy::too_many_lines,
+    reason = "op_vec handles multiple input types and vector element types"
+)]
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;

--- a/crates/krites/src/data/memcmp.rs
+++ b/crates/krites/src/data/memcmp.rs
@@ -1,11 +1,32 @@
 //! Memory-comparable encoding for composite keys.
-#![expect(unsafe_code, reason = "memcmp decoding uses from_utf8_unchecked for strings known to be valid UTF-8 from encoding")]
-#![expect(clippy::indexing_slicing, reason = "memcmp encoding indices are structurally bounded by length prefix parsing")]
-#![expect(clippy::as_conversions, reason = "binary encoding requires byte-level numeric casts")]
-#![expect(clippy::unreadable_literal, reason = "bit flag constants (0b00010000) are clearer without separators")]
-#![expect(clippy::too_many_lines, reason = "memcmp decode_tuple is inherently large — one arm per DataValue variant")]
-#![expect(clippy::mutable_key_type, reason = "DataValue contains interior-mutable Regex; BTreeSet usage is engine-internal")]
-#![expect(clippy::semicolon_if_nothing_returned, reason = "encode_bytes write calls — semicolon style consistent")]
+#![expect(
+    unsafe_code,
+    reason = "memcmp decoding uses from_utf8_unchecked for strings known to be valid UTF-8 from encoding"
+)]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "memcmp encoding indices are structurally bounded by length prefix parsing"
+)]
+#![expect(
+    clippy::as_conversions,
+    reason = "binary encoding requires byte-level numeric casts"
+)]
+#![expect(
+    clippy::unreadable_literal,
+    reason = "bit flag constants (0b00010000) are clearer without separators"
+)]
+#![expect(
+    clippy::too_many_lines,
+    reason = "memcmp decode_tuple is inherently large — one arm per DataValue variant"
+)]
+#![expect(
+    clippy::mutable_key_type,
+    reason = "DataValue contains interior-mutable Regex; BTreeSet usage is engine-internal"
+)]
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    reason = "encode_bytes write calls — semicolon style consistent"
+)]
 
 use std::cmp::Reverse;
 use std::collections::BTreeSet;
@@ -271,7 +292,9 @@ impl Num {
                 let i = order_decode_i64(iu);
                 (Num::Int(i), remaining)
             }
-            _ => unreachable!("INVARIANT: Num key tag is always IS_FLOAT, IS_NEG_INT, IS_POS_INT, or IS_APPROX_INT"),
+            _ => unreachable!(
+                "INVARIANT: Num key tag is always IS_FLOAT, IS_NEG_INT, IS_POS_INT, or IS_APPROX_INT"
+            ),
         }
     }
 }
@@ -325,7 +348,9 @@ impl DataValue {
                 // UTF-8 validity is guaranteed by the encoding invariant.
                 let s = unsafe { String::from_utf8_unchecked(bytes) };
                 // INVARIANT: regex source was serialized from a valid Regex
-                let rx = Regex::from_str(&s).unwrap_or_else(|_| unreachable!("INVARIANT: regex source was serialized from a valid Regex"));
+                let rx = Regex::from_str(&s).unwrap_or_else(|_| {
+                    unreachable!("INVARIANT: regex source was serialized from a valid Regex")
+                });
                 (DataValue::Regex(RegexWrapper(rx)), remaining)
             }
             LIST_TAG => {
@@ -403,7 +428,10 @@ impl DataValue {
                     _ => unreachable!("INVARIANT: vector type tag is always VEC_F32 or VEC_F64"),
                 }
             }
-            _ => unreachable!("INVARIANT: encoded key tag is always a known DataValue variant: {:?}", bs),
+            _ => unreachable!(
+                "INVARIANT: encoded key tag is always a known DataValue variant: {:?}",
+                bs
+            ),
         }
     }
 }

--- a/crates/krites/src/data/mod.rs
+++ b/crates/krites/src/data/mod.rs
@@ -4,7 +4,10 @@
 //! expression evaluation ([`expr`]), scalar functions ([`functions`]),
 //! aggregation operators ([`aggr`]), relation metadata ([`relation`]),
 //! binary key encoding ([`memcmp`]), and the Datalog program AST ([`program`]).
-#![expect(clippy::wildcard_imports, reason = "error selectors and re-exports used pervasively across data module")]
+#![expect(
+    clippy::wildcard_imports,
+    reason = "error selectors and re-exports used pervasively across data module"
+)]
 pub(crate) mod aggr;
 pub(crate) mod error;
 pub(crate) mod expr;

--- a/crates/krites/src/data/program/fixed_rule.rs
+++ b/crates/krites/src/data/program/fixed_rule.rs
@@ -1,5 +1,11 @@
-#![expect(clippy::result_large_err, reason = "engine InternalError carries structured context — boxing deferred")]
-#![expect(clippy::missing_fields_in_debug, reason = "MagicFixedRuleApply Debug omits large fields for readability")]
+#![expect(
+    clippy::result_large_err,
+    reason = "engine InternalError carries structured context — boxing deferred"
+)]
+#![expect(
+    clippy::missing_fields_in_debug,
+    reason = "MagicFixedRuleApply Debug omits large fields for readability"
+)]
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;

--- a/crates/krites/src/data/program/input.rs
+++ b/crates/krites/src/data/program/input.rs
@@ -1,11 +1,35 @@
-#![expect(clippy::result_large_err, reason = "engine InternalError carries structured context — boxing deferred")]
-#![expect(clippy::indexing_slicing, reason = "input head[0] access is validated by non-empty check")]
-#![expect(clippy::semicolon_if_nothing_returned, reason = "push calls in builder pattern — semicolon not needed before Ok")]
-#![expect(clippy::explicit_iter_loop, reason = "explicit .iter() calls are idiomatic in program input processing")]
-#![expect(clippy::if_not_else, reason = "negative condition check reads better for the control flow")]
-#![expect(clippy::single_match_else, reason = "if-let reads better than match for single-pattern dispatch")]
-#![expect(clippy::implicit_clone, reason = "clone via method call is clearer in context")]
-#![expect(clippy::default_trait_access, reason = "BTreeMap::new() is idiomatic for explicit construction")]
+#![expect(
+    clippy::result_large_err,
+    reason = "engine InternalError carries structured context — boxing deferred"
+)]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "input head[0] access is validated by non-empty check"
+)]
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    reason = "push calls in builder pattern — semicolon not needed before Ok"
+)]
+#![expect(
+    clippy::explicit_iter_loop,
+    reason = "explicit .iter() calls are idiomatic in program input processing"
+)]
+#![expect(
+    clippy::if_not_else,
+    reason = "negative condition check reads better for the control flow"
+)]
+#![expect(
+    clippy::single_match_else,
+    reason = "if-let reads better than match for single-pattern dispatch"
+)]
+#![expect(
+    clippy::implicit_clone,
+    reason = "clone via method call is clearer in context"
+)]
+#![expect(
+    clippy::default_trait_access,
+    reason = "BTreeMap::new() is idiomatic for explicit construction"
+)]
 #![expect(clippy::as_conversions, reason = "input arity cast is engine-internal")]
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;

--- a/crates/krites/src/data/program/magic.rs
+++ b/crates/krites/src/data/program/magic.rs
@@ -1,5 +1,11 @@
-#![expect(clippy::result_large_err, reason = "engine InternalError carries structured context — boxing deferred")]
-#![expect(clippy::explicit_iter_loop, reason = "explicit .iter() in magic set rewriting")]
+#![expect(
+    clippy::result_large_err,
+    reason = "engine InternalError carries structured context — boxing deferred"
+)]
+#![expect(
+    clippy::explicit_iter_loop,
+    reason = "explicit .iter() in magic set rewriting"
+)]
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::fmt::{Debug, Display, Formatter};

--- a/crates/krites/src/data/program/search/atom_impl.rs
+++ b/crates/krites/src/data/program/search/atom_impl.rs
@@ -1,7 +1,16 @@
 //! InputAtom Debug, Display, span, and Unification.
-#![expect(clippy::result_large_err, reason = "engine InternalError carries structured context — boxing deferred")]
-#![expect(clippy::explicit_iter_loop, reason = "explicit .iter() is idiomatic in search atom processing")]
-#![expect(clippy::doc_markdown, reason = "InputAtom is a type name in module-level documentation")]
+#![expect(
+    clippy::result_large_err,
+    reason = "engine InternalError carries structured context — boxing deferred"
+)]
+#![expect(
+    clippy::explicit_iter_loop,
+    reason = "explicit .iter() is idiomatic in search atom processing"
+)]
+#![expect(
+    clippy::doc_markdown,
+    reason = "InputAtom is a type name in module-level documentation"
+)]
 use std::collections::BTreeSet;
 use std::fmt::{Debug, Display, Formatter};
 

--- a/crates/krites/src/data/program/search/hnsw_normalize.rs
+++ b/crates/krites/src/data/program/search/hnsw_normalize.rs
@@ -1,8 +1,20 @@
 //! SearchInput normalize_hnsw and normalize implementations.
-#![expect(clippy::result_large_err, reason = "engine InternalError carries structured context — boxing deferred")]
-#![expect(clippy::too_many_lines, reason = "HNSW normalization handles multiple index configurations")]
-#![expect(clippy::semicolon_if_nothing_returned, reason = "push calls in normalization — semicolon not needed before continue")]
-#![expect(clippy::doc_markdown, reason = "SearchInput and HNSW are type/algorithm names in module documentation")]
+#![expect(
+    clippy::result_large_err,
+    reason = "engine InternalError carries structured context — boxing deferred"
+)]
+#![expect(
+    clippy::too_many_lines,
+    reason = "HNSW normalization handles multiple index configurations"
+)]
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    reason = "push calls in normalization — semicolon not needed before continue"
+)]
+#![expect(
+    clippy::doc_markdown,
+    reason = "SearchInput and HNSW are type/algorithm names in module documentation"
+)]
 use std::collections::BTreeSet;
 
 use crate::data::error::*;

--- a/crates/krites/src/data/program/search/lsh_fts.rs
+++ b/crates/krites/src/data/program/search/lsh_fts.rs
@@ -1,9 +1,24 @@
 //! SearchInput normalize_lsh and normalize_fts implementations.
-#![expect(clippy::result_large_err, reason = "engine InternalError carries structured context — boxing deferred")]
-#![expect(clippy::too_many_lines, reason = "FTS LSH normalization handles multiple index configurations")]
-#![expect(clippy::semicolon_if_nothing_returned, reason = "push calls in normalization — semicolon not needed before continue")]
-#![expect(clippy::uninlined_format_args, reason = "format args style is consistent within FTS normalization code")]
-#![expect(clippy::doc_markdown, reason = "SearchInput, LSH, and FTS are type/algorithm names in module documentation")]
+#![expect(
+    clippy::result_large_err,
+    reason = "engine InternalError carries structured context — boxing deferred"
+)]
+#![expect(
+    clippy::too_many_lines,
+    reason = "FTS LSH normalization handles multiple index configurations"
+)]
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    reason = "push calls in normalization — semicolon not needed before continue"
+)]
+#![expect(
+    clippy::uninlined_format_args,
+    reason = "format args style is consistent within FTS normalization code"
+)]
+#![expect(
+    clippy::doc_markdown,
+    reason = "SearchInput, LSH, and FTS are type/algorithm names in module documentation"
+)]
 use std::collections::BTreeSet;
 
 use crate::data::error::*;

--- a/crates/krites/src/data/program/types.rs
+++ b/crates/krites/src/data/program/types.rs
@@ -1,6 +1,15 @@
-#![expect(clippy::as_conversions, reason = "column type metadata requires numeric casts")]
-#![expect(clippy::too_many_lines, reason = "column type display handles all type combinations")]
-#![expect(clippy::semicolon_if_nothing_returned, reason = "write! calls in Display impl — semicolon not needed")]
+#![expect(
+    clippy::as_conversions,
+    reason = "column type metadata requires numeric casts"
+)]
+#![expect(
+    clippy::too_many_lines,
+    reason = "column type display handles all type combinations"
+)]
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    reason = "write! calls in Display impl — semicolon not needed"
+)]
 use std::fmt::{Debug, Display, Formatter};
 
 use crate::data::relation::StoredRelationMetadata;

--- a/crates/krites/src/data/relation.rs
+++ b/crates/krites/src/data/relation.rs
@@ -1,10 +1,28 @@
 //! Relation metadata and schema definitions.
-#![expect(clippy::as_conversions, reason = "relation metadata requires numeric casts for column indices")]
-#![expect(clippy::too_many_lines, reason = "ensure_compatible handles all DataValue variant combinations")]
-#![expect(clippy::uninlined_format_args, reason = "format args style is consistent within relation coercion code")]
-#![expect(clippy::semicolon_if_nothing_returned, reason = "Display write calls — semicolon not needed")]
-#![expect(clippy::match_same_arms, reason = "coerce variant arms are intentionally explicit for type safety")]
-#![expect(clippy::redundant_else, reason = "else after return keeps error path visually grouped with the check")]
+#![expect(
+    clippy::as_conversions,
+    reason = "relation metadata requires numeric casts for column indices"
+)]
+#![expect(
+    clippy::too_many_lines,
+    reason = "ensure_compatible handles all DataValue variant combinations"
+)]
+#![expect(
+    clippy::uninlined_format_args,
+    reason = "format args style is consistent within relation coercion code"
+)]
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    reason = "Display write calls — semicolon not needed"
+)]
+#![expect(
+    clippy::match_same_arms,
+    reason = "coerce variant arms are intentionally explicit for type safety"
+)]
+#![expect(
+    clippy::redundant_else,
+    reason = "else after return keeps error path visually grouped with the check"
+)]
 use std::cmp::Reverse;
 use std::fmt::{Display, Formatter};
 

--- a/crates/krites/src/data/symb.rs
+++ b/crates/krites/src/data/symb.rs
@@ -1,5 +1,8 @@
 //! Symbol (identifier) types.
-#![expect(clippy::semicolon_if_nothing_returned, reason = "push calls in symbol builder — semicolon style consistent")]
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    reason = "push calls in symbol builder — semicolon style consistent"
+)]
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};

--- a/crates/krites/src/data/tests/proptest_memcmp.rs
+++ b/crates/krites/src/data/tests/proptest_memcmp.rs
@@ -4,10 +4,7 @@
 //! deserializes, and verifies equality. Also tests rmp-serde round-trips
 //! and sort-order preservation.
 #![expect(clippy::expect_used, reason = "test assertions")]
-#![expect(
-    clippy::indexing_slicing,
-    reason = "test data with known structure"
-)]
+#![expect(clippy::indexing_slicing, reason = "test data with known structure")]
 
 use std::collections::BTreeSet;
 
@@ -37,13 +34,11 @@ fn arb_validity() -> impl Strategy<Value = Validity> {
 }
 
 fn arb_vector_f32(max_len: usize) -> impl Strategy<Value = Vector> {
-    proptest::collection::vec(any::<f32>(), 0..=max_len)
-        .prop_map(|v| Vector::F32(Array1::from(v)))
+    proptest::collection::vec(any::<f32>(), 0..=max_len).prop_map(|v| Vector::F32(Array1::from(v)))
 }
 
 fn arb_vector_f64(max_len: usize) -> impl Strategy<Value = Vector> {
-    proptest::collection::vec(any::<f64>(), 0..=max_len)
-        .prop_map(|v| Vector::F64(Array1::from(v)))
+    proptest::collection::vec(any::<f64>(), 0..=max_len).prop_map(|v| Vector::F64(Array1::from(v)))
 }
 
 fn arb_vector() -> impl Strategy<Value = Vector> {

--- a/crates/krites/src/data/tuple.rs
+++ b/crates/krites/src/data/tuple.rs
@@ -1,7 +1,16 @@
 //! Tuple encoding and decoding.
-#![expect(clippy::explicit_iter_loop, reason = "explicit .iter() is idiomatic in tuple processing")]
-#![expect(clippy::indexing_slicing, reason = "tuple indices validated by caller contract")]
-#![expect(clippy::manual_let_else, reason = "if-let pattern is clearer for the fallback logic")]
+#![expect(
+    clippy::explicit_iter_loop,
+    reason = "explicit .iter() is idiomatic in tuple processing"
+)]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "tuple indices validated by caller contract"
+)]
+#![expect(
+    clippy::manual_let_else,
+    reason = "if-let pattern is clearer for the fallback logic"
+)]
 
 use std::cmp::Reverse;
 
@@ -60,26 +69,40 @@ pub fn check_key_for_validity(
     size_hint: Option<usize>,
 ) -> (Option<Tuple>, Vec<u8>) {
     let mut decoded = decode_tuple_from_key(key, size_hint.unwrap_or(DEFAULT_SIZE_HINT));
-    let rel_id = RelationId::raw_decode(key).unwrap_or_else(|_| unreachable!("INVARIANT: key always contains a valid RelationId prefix"));
-    let vld = match decoded.last().unwrap_or_else(|| unreachable!("INVARIANT: decoded tuple is never empty")) {
+    let rel_id = RelationId::raw_decode(key).unwrap_or_else(|_| {
+        unreachable!("INVARIANT: key always contains a valid RelationId prefix")
+    });
+    let vld = match decoded
+        .last()
+        .unwrap_or_else(|| unreachable!("INVARIANT: decoded tuple is never empty"))
+    {
         DataValue::Validity(vld) => vld,
-        _ => unreachable!("INVARIANT: last element of a validity-keyed tuple is always DataValue::Validity"),
+        _ => unreachable!(
+            "INVARIANT: last element of a validity-keyed tuple is always DataValue::Validity"
+        ),
     };
     if vld.timestamp < valid_at {
-        *decoded.last_mut().unwrap_or_else(|| unreachable!("INVARIANT: decoded tuple is never empty")) = DataValue::Validity(Validity {
-            timestamp: valid_at,
-            is_assert: Reverse(true),
-        });
+        *decoded
+            .last_mut()
+            .unwrap_or_else(|| unreachable!("INVARIANT: decoded tuple is never empty")) =
+            DataValue::Validity(Validity {
+                timestamp: valid_at,
+                is_assert: Reverse(true),
+            });
         let nxt_seek = decoded.encode_as_key(rel_id);
         (None, nxt_seek)
     } else if !vld.is_assert.0 {
-        *decoded.last_mut().unwrap_or_else(|| unreachable!("INVARIANT: decoded tuple is never empty")) =
+        *decoded
+            .last_mut()
+            .unwrap_or_else(|| unreachable!("INVARIANT: decoded tuple is never empty")) =
             DataValue::Validity(TERMINAL_VALIDITY);
         let nxt_seek = decoded.encode_as_key(rel_id);
         (None, nxt_seek)
     } else {
         let ret = decoded.clone();
-        *decoded.last_mut().unwrap_or_else(|| unreachable!("INVARIANT: decoded tuple is never empty")) =
+        *decoded
+            .last_mut()
+            .unwrap_or_else(|| unreachable!("INVARIANT: decoded tuple is never empty")) =
             DataValue::Validity(TERMINAL_VALIDITY);
         let nxt_seek = decoded.encode_as_key(rel_id);
         (Some(ret), nxt_seek)

--- a/crates/krites/src/data/value.rs
+++ b/crates/krites/src/data/value.rs
@@ -1,11 +1,32 @@
 //! Core value type for the Datalog engine.
-#![expect(clippy::as_conversions, reason = "DataValue numeric conversions require i64/f64/pointer casts")]
-#![expect(clippy::semicolon_if_nothing_returned, reason = "hash/display impls — semicolon not needed before closing brace")]
-#![expect(clippy::explicit_iter_loop, reason = "explicit .iter() in DataValue collection processing")]
-#![expect(clippy::needless_continue, reason = "explicit continue in sort comparison arms aids readability")]
-#![expect(clippy::match_same_arms, reason = "Ord comparison arms are explicit for correctness auditing")]
-#![expect(clippy::float_cmp, reason = "exact f64 equality check for hash consistency — not accumulated arithmetic")]
-#![expect(clippy::doc_markdown, reason = "JsonValue and DataValues are type names in doc comments")]
+#![expect(
+    clippy::as_conversions,
+    reason = "DataValue numeric conversions require i64/f64/pointer casts"
+)]
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    reason = "hash/display impls — semicolon not needed before closing brace"
+)]
+#![expect(
+    clippy::explicit_iter_loop,
+    reason = "explicit .iter() in DataValue collection processing"
+)]
+#![expect(
+    clippy::needless_continue,
+    reason = "explicit continue in sort comparison arms aids readability"
+)]
+#![expect(
+    clippy::match_same_arms,
+    reason = "Ord comparison arms are explicit for correctness auditing"
+)]
+#![expect(
+    clippy::float_cmp,
+    reason = "exact f64 equality check for hash consistency — not accumulated arithmetic"
+)]
+#![expect(
+    clippy::doc_markdown,
+    reason = "JsonValue and DataValues are type names in doc comments"
+)]
 
 use std::cmp::{Ordering, Reverse};
 use std::collections::BTreeSet;

--- a/crates/krites/src/fixed_rule/algos/all_pairs_shortest_path.rs
+++ b/crates/krites/src/fixed_rule/algos/all_pairs_shortest_path.rs
@@ -87,7 +87,9 @@ impl FixedRule for BetweennessCentrality {
                 let paths_for_start =
                     dijkstra_keep_ties(&graph, start, &(), &(), &(), poison.clone())?;
                 let mut accumulator: BTreeMap<u32, f32> = Default::default();
-                let grouped = paths_for_start.into_iter().chunk_by(|(target, _, _)| *target);
+                let grouped = paths_for_start
+                    .into_iter()
+                    .chunk_by(|(target, _, _)| *target);
                 for (_, group) in grouped.into_iter() {
                     let group = group.collect_vec();
                     #[expect(
@@ -185,7 +187,8 @@ impl FixedRule for ClosenessCentrality {
                     clippy::cast_precision_loss,
                     reason = "reachable node count acceptable as approximate float"
                 )]
-                let reachable_count: f32 = distances.iter().filter(|d| d.is_finite()).count() as f32;
+                let reachable_count: f32 =
+                    distances.iter().filter(|d| d.is_finite()).count() as f32;
                 #[expect(
                     clippy::cast_precision_loss,
                     reason = "node count minus one acceptable as approximate float"

--- a/crates/krites/src/fixed_rule/algos/astar.rs
+++ b/crates/krites/src/fixed_rule/algos/astar.rs
@@ -197,7 +197,10 @@ fn astar(
 
             let cost_to_source = g_score.get(&node).cloned().unwrap_or(f64::INFINITY);
             let tentative_cost = cost_to_source + edge_cost;
-            let previous_cost = g_score.get(edge_destination).cloned().unwrap_or(f64::INFINITY);
+            let previous_cost = g_score
+                .get(edge_destination)
+                .cloned()
+                .unwrap_or(f64::INFINITY);
             if tentative_cost < previous_cost {
                 back_trace.insert(edge_destination.clone(), node.clone());
                 g_score.insert(edge_destination.clone(), tentative_cost);

--- a/crates/krites/src/fixed_rule/algos/label_propagation.rs
+++ b/crates/krites/src/fixed_rule/algos/label_propagation.rs
@@ -119,15 +119,13 @@ fn label_propagation(
                 .take_while(|(_, score)| *score == max_score)
                 .map(|(label, _)| label)
                 .collect_vec();
-            let new_label = candidate_labels
-                .choose(&mut rng)
-                .ok_or_else(|| {
-                    GraphAlgorithmSnafu {
-                        algorithm: "label_propagation",
-                        message: "candidate label set is unexpectedly empty",
-                    }
-                    .build()
-                })?;
+            let new_label = candidate_labels.choose(&mut rng).ok_or_else(|| {
+                GraphAlgorithmSnafu {
+                    algorithm: "label_propagation",
+                    message: "candidate label set is unexpectedly empty",
+                }
+                .build()
+            })?;
             if *new_label != labels[*node as usize] {
                 changed = true;
                 labels[*node as usize] = *new_label;

--- a/crates/krites/src/fixed_rule/algos/louvain.rs
+++ b/crates/krites/src/fixed_rule/algos/louvain.rs
@@ -344,18 +344,15 @@ fn louvain_step(
 
     let coarsened_graph: DirectedCsrGraph<f32> = CsrBuilder::new()
         .sorted()
-        .edges_with_values(
-            coarsened_adjacency
-                .into_iter()
-                .enumerate()
-                .flat_map(move |(from_community, neighbors)| {
-                    neighbors.into_iter().map(move |(to_community, weight)| {
-                        #[expect(clippy::cast_possible_truncation, reason = "value fits u32")]
-                        let from_u32 = from_community as u32;
-                        (from_u32, to_community, weight)
-                    })
-                }),
-        )
+        .edges_with_values(coarsened_adjacency.into_iter().enumerate().flat_map(
+            move |(from_community, neighbors)| {
+                neighbors.into_iter().map(move |(to_community, weight)| {
+                    #[expect(clippy::cast_possible_truncation, reason = "value fits u32")]
+                    let from_u32 = from_community as u32;
+                    (from_u32, to_community, weight)
+                })
+            },
+        ))
         .build();
 
     Ok((node_to_community, coarsened_graph))

--- a/crates/krites/src/fixed_rule/algos/prim.rs
+++ b/crates/krites/src/fixed_rule/algos/prim.rs
@@ -64,9 +64,7 @@ impl FixedRule for MinimumSpanningTreePrim {
                 *inv_indices.get(node_value).ok_or_else(|| {
                     crate::fixed_rule::error::InvalidInputSnafu {
                         rule: "MinimumSpanningTreePrim",
-                        message: format!(
-                            "The requested starting node {node_value:?} is not found"
-                        ),
+                        message: format!("The requested starting node {node_value:?} is not found"),
                     }
                     .build()
                 })?

--- a/crates/krites/src/fixed_rule/algos/random_walk.rs
+++ b/crates/krites/src/fixed_rule/algos/random_walk.rs
@@ -96,9 +96,8 @@ impl FixedRule for RandomWalk {
                     if candidate_steps.is_empty() {
                         break;
                     }
-                    let next_step =
-                        if let Some((weight_bytecode, _span)) = &maybe_weight_bytecode {
-                            let weights: Vec<_> = candidate_steps
+                    let next_step = if let Some((weight_bytecode, _span)) = &maybe_weight_bytecode {
+                        let weights: Vec<_> = candidate_steps
                                 .iter()
                                 .map(|tuple| -> Result<f64> {
                                     let mut combined = current_tuple.clone();
@@ -130,17 +129,16 @@ impl FixedRule for RandomWalk {
                                     )
                                 })
                                 .try_collect()?;
-                            let distribution =
-                                WeightedIndex::new(&weights).map_err(|err| {
-                                    GraphAlgorithmSnafu {
-                                        algorithm: "random_walk",
-                                        message: format!("invalid edge weights: {err}"),
-                                    }
-                                    .build()
-                                })?;
-                            &candidate_steps[distribution.sample(&mut rng)]
-                        } else {
-                            candidate_steps.choose(&mut rng).ok_or_else(|| {
+                        let distribution = WeightedIndex::new(&weights).map_err(|err| {
+                            GraphAlgorithmSnafu {
+                                algorithm: "random_walk",
+                                message: format!("invalid edge weights: {err}"),
+                            }
+                            .build()
+                        })?;
+                        &candidate_steps[distribution.sample(&mut rng)]
+                    } else {
+                        candidate_steps.choose(&mut rng).ok_or_else(|| {
                                 GraphAlgorithmSnafu {
                                     algorithm: "random_walk",
                                     message:
@@ -148,7 +146,7 @@ impl FixedRule for RandomWalk {
                                 }
                                 .build()
                             })?
-                        };
+                    };
                     let next_node = &next_step[1];
                     path.push(next_node.clone());
                     current_tuple = nodes.prefix_iter(next_node)?.next().ok_or_else(

--- a/crates/krites/src/fixed_rule/algos/shortest_path_dijkstra.rs
+++ b/crates/krites/src/fixed_rule/algos/shortest_path_dijkstra.rs
@@ -413,8 +413,7 @@ pub(crate) fn dijkstra_keep_ties<FE: ForbiddenEdge, FN: ForbiddenNode, G: Goal +
 ) -> Result<Vec<(u32, f32, Vec<u32>)>> {
     let mut distance = vec![f32::INFINITY; edges.node_count() as usize];
     let mut priority_queue = PriorityQueue::new();
-    let mut back_pointers: Vec<SmallVec<[u32; 1]>> =
-        vec![smallvec![]; edges.node_count() as usize];
+    let mut back_pointers: Vec<SmallVec<[u32; 1]>> = vec![smallvec![]; edges.node_count() as usize];
     distance[start as usize] = 0.;
     priority_queue.push(start, Reverse(OrderedFloat(0.)));
     let mut goals_remaining = goals.clone();
@@ -484,13 +483,7 @@ pub(crate) fn dijkstra_keep_ties<FE: ForbiddenEdge, FN: ForbiddenNode, G: Goal +
                                 extended.reverse();
                                 self.collected.push((target, cost, extended));
                             } else {
-                                self.collect(
-                                    &extended,
-                                    start,
-                                    target,
-                                    cost,
-                                    back_pointers,
-                                )
+                                self.collect(&extended, start, target, cost, back_pointers)
                             }
                         }
                     }

--- a/crates/krites/src/fixed_rule/algos/strongly_connected_components.rs
+++ b/crates/krites/src/fixed_rule/algos/strongly_connected_components.rs
@@ -187,8 +187,10 @@ impl TarjanScc {
                 self.dfs(neighbor);
             }
             if self.on_stack[neighbor as usize] {
-                self.low_links[at as usize] =
-                    min(self.low_links[at as usize], self.low_links[neighbor as usize]);
+                self.low_links[at as usize] = min(
+                    self.low_links[at as usize],
+                    self.low_links[neighbor as usize],
+                );
             }
         }
         if self.discovery_ids[at as usize].unwrap_or(0) == self.low_links[at as usize] {

--- a/crates/krites/src/fixed_rule/algos/top_sort.rs
+++ b/crates/krites/src/fixed_rule/algos/top_sort.rs
@@ -92,10 +92,7 @@ impl FixedRule for TopSort {
     clippy::needless_pass_by_value,
     reason = "Poison is lightweight and passed by value for ergonomic .check() calls"
 )]
-pub(crate) fn kahn_topological_sort(
-    graph: &DirectedCsrGraph,
-    poison: Poison,
-) -> Result<Vec<u32>> {
+pub(crate) fn kahn_topological_sort(graph: &DirectedCsrGraph, poison: Poison) -> Result<Vec<u32>> {
     let graph_size = graph.node_count();
     let mut in_degree = vec![0; graph_size as usize];
     for source in 0..graph_size {

--- a/crates/krites/src/fixed_rule/algos/yen.rs
+++ b/crates/krites/src/fixed_rule/algos/yen.rs
@@ -117,13 +117,7 @@ impl FixedRule for KShortestPathYen {
                         Ok((
                             start,
                             goal,
-                            k_shortest_path_yen(
-                                path_count,
-                                &graph,
-                                start,
-                                goal,
-                                poison.clone(),
-                            )?,
+                            k_shortest_path_yen(path_count, &graph, start, goal, poison.clone())?,
                         ))
                     },
                 )
@@ -252,7 +246,10 @@ fn k_shortest_path_yen(
                 let mut total_path = root_path.to_vec();
                 total_path.pop();
                 total_path.extend(spur_path);
-                if candidates.iter().all(|(_, existing)| *existing != total_path) {
+                if candidates
+                    .iter()
+                    .all(|(_, existing)| *existing != total_path)
+                {
                     candidates.push((total_cost, total_path));
                 }
                 poison.check()?;

--- a/crates/krites/src/fixed_rule/error.rs
+++ b/crates/krites/src/fixed_rule/error.rs
@@ -35,4 +35,3 @@ pub(crate) enum FixedRuleError {
         location: snafu::Location,
     },
 }
-

--- a/crates/krites/src/fixed_rule/tests/proptest_algos.rs
+++ b/crates/krites/src/fixed_rule/tests/proptest_algos.rs
@@ -7,10 +7,7 @@
 //! - TopSort: ordering respects all edges
 #![cfg(test)]
 #![expect(clippy::expect_used, reason = "test assertions")]
-#![expect(
-    clippy::indexing_slicing,
-    reason = "test data with known structure"
-)]
+#![expect(clippy::indexing_slicing, reason = "test data with known structure")]
 #![expect(
     clippy::cast_precision_loss,
     reason = "small graph sizes -- precision loss irrelevant"

--- a/crates/krites/src/fts/ast.rs
+++ b/crates/krites/src/fts/ast.rs
@@ -53,7 +53,10 @@ impl FtsExpr {
         match self {
             FtsExpr::Literal(l) => l.booster == 0. || l.value.is_empty(),
             FtsExpr::Near(FtsNear { literals, .. }) => literals.is_empty(),
-            #[expect(clippy::match_same_arms, reason = "FTS AST variants listed separately for clarity")]
+            #[expect(
+                clippy::match_same_arms,
+                reason = "FTS AST variants listed separately for clarity"
+            )]
             FtsExpr::And(v) => v.is_empty(),
             FtsExpr::Or(v) => v.is_empty(),
             FtsExpr::Not(lhs, _) => lhs.is_empty(),
@@ -75,10 +78,11 @@ impl FtsExpr {
                     }
                 }
                 if flattened.len() == 1 {
-                    flattened
-                        .into_iter()
-                        .next()
-                        .unwrap_or_else(|| unreachable!("INVARIANT: flattened.len() == 1 guarantees next() yields Some"))
+                    flattened.into_iter().next().unwrap_or_else(|| {
+                        unreachable!(
+                            "INVARIANT: flattened.len() == 1 guarantees next() yields Some"
+                        )
+                    })
                 } else {
                     FtsExpr::And(flattened)
                 }
@@ -96,10 +100,11 @@ impl FtsExpr {
                     }
                 }
                 if flattened.len() == 1 {
-                    flattened
-                        .into_iter()
-                        .next()
-                        .unwrap_or_else(|| unreachable!("INVARIANT: flattened.len() == 1 guarantees next() yields Some"))
+                    flattened.into_iter().next().unwrap_or_else(|| {
+                        unreachable!(
+                            "INVARIANT: flattened.len() == 1 guarantees next() yields Some"
+                        )
+                    })
                 } else {
                     FtsExpr::Or(flattened)
                 }
@@ -124,7 +129,9 @@ impl FtsExpr {
                 let mut tokens = vec![];
                 l.tokenize(tokenizer, &mut tokens);
                 if tokens.len() == 1 {
-                    FtsExpr::Literal(tokens.into_iter().next().unwrap_or_else(|| unreachable!("INVARIANT: tokens.len() == 1 guarantees next() yields Some")))
+                    FtsExpr::Literal(tokens.into_iter().next().unwrap_or_else(|| {
+                        unreachable!("INVARIANT: tokens.len() == 1 guarantees next() yields Some")
+                    }))
                 } else {
                     FtsExpr::And(tokens.into_iter().map(FtsExpr::Literal).collect())
                 }

--- a/crates/krites/src/fts/config.rs
+++ b/crates/krites/src/fts/config.rs
@@ -6,13 +6,13 @@ use sha2::{Digest, Sha256};
 use crate::data::memcmp::MemCmpEncoder;
 use crate::data::value::DataValue;
 use crate::error::InternalResult as Result;
+use crate::fts::TokenizerConfig;
 use crate::fts::error::TokenizationFailedSnafu;
 use crate::fts::tokenizer::{
     AlphaNumOnlyFilter, AsciiFoldingFilter, BoxTokenFilter, Language, LowerCaser, NgramTokenizer,
     RawTokenizer, RemoveLongFilter, SimpleTokenizer, SplitCompoundWords, Stemmer, StopWordFilter,
     TextAnalyzer, Tokenizer, WhitespaceTokenizer,
 };
-use crate::fts::TokenizerConfig;
 
 impl TokenizerConfig {
     /// Compute a content-addressed hash of this tokenizer + filter chain.

--- a/crates/krites/src/fts/indexing.rs
+++ b/crates/krites/src/fts/indexing.rs
@@ -35,7 +35,10 @@ impl FtsCache {
     /// # Complexity
     ///
     /// O(1) cached, or O(1) for the underlying range count operation.
-    #[expect(clippy::result_large_err, reason = "FTS error carries structured tokenization context")]
+    #[expect(
+        clippy::result_large_err,
+        reason = "FTS error carries structured tokenization context"
+    )]
     fn get_n_for_relation(&mut self, rel: &RelationHandle, tx: &SessionTx<'_>) -> Result<usize> {
         Ok(match self.total_n_cache.entry(rel.name.clone()) {
             Entry::Vacant(v) => {
@@ -150,7 +153,10 @@ struct LiteralStats {
 /// # Complexity
 ///
 /// O(1) arithmetic operations.
-#[expect(clippy::too_many_arguments, reason = "BM25 formula requires all statistical parameters")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "BM25 formula requires all statistical parameters"
+)]
 pub(crate) fn bm25_compute_score(
     tf: usize,
     df: usize,
@@ -286,14 +292,14 @@ impl SessionTx<'_> {
                         )
                     })?;
                     let position = u32::try_from(raw_pos).map_err(|_e| {
-                            crate::error::InternalError::from(
-                                InvalidOperationSnafu {
-                                    op: "fts_search",
-                                    reason: "token position does not fit in u32",
-                                }
-                                .build(),
-                            )
-                        })?;
+                        crate::error::InternalError::from(
+                            InvalidOperationSnafu {
+                                op: "fts_search",
+                                reason: "token position does not fit in u32",
+                            }
+                            .build(),
+                        )
+                    })?;
                     Ok(PositionInfo { position })
                 })
                 .collect::<Result<Vec<_>>>()?;

--- a/crates/krites/src/fts/mod.rs
+++ b/crates/krites/src/fts/mod.rs
@@ -49,7 +49,10 @@ pub(crate) struct TokenizerCache {
 }
 
 impl TokenizerCache {
-    #[expect(clippy::result_large_err, reason = "FTS error carries structured tokenization context")]
+    #[expect(
+        clippy::result_large_err,
+        reason = "FTS error carries structured tokenization context"
+    )]
     pub(crate) fn get(
         &self,
         tokenizer_name: &str,
@@ -57,25 +60,40 @@ impl TokenizerCache {
         filters: &[TokenizerConfig],
     ) -> Result<Arc<TextAnalyzer>> {
         {
-            let idx_cache = self.named_cache.read().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let idx_cache = self
+                .named_cache
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             if let Some(analyzer) = idx_cache.get(tokenizer_name) {
                 return Ok(analyzer.clone());
             }
         }
         let hash = tokenizer.config_hash(filters);
         {
-            let hashed_cache = self.hashed_cache.read().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let hashed_cache = self
+                .hashed_cache
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             if let Some(analyzer) = hashed_cache.get(hash.as_ref()) {
-                let mut idx_cache = self.named_cache.write().unwrap_or_else(std::sync::PoisonError::into_inner);
+                let mut idx_cache = self
+                    .named_cache
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 idx_cache.insert(tokenizer_name.into(), analyzer.clone());
                 return Ok(analyzer.clone());
             }
         }
         {
             let analyzer = Arc::new(tokenizer.build(filters)?);
-            let mut hashed_cache = self.hashed_cache.write().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut hashed_cache = self
+                .hashed_cache
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             hashed_cache.insert(hash.as_ref().to_vec(), analyzer.clone());
-            let mut idx_cache = self.named_cache.write().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut idx_cache = self
+                .named_cache
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             idx_cache.insert(tokenizer_name.into(), analyzer.clone());
             Ok(analyzer)
         }

--- a/crates/krites/src/fts/tokenizer/alphanum_only.rs
+++ b/crates/krites/src/fts/tokenizer/alphanum_only.rs
@@ -10,7 +10,10 @@ pub(crate) struct AlphaNumOnlyFilterStream<'a> {
 }
 
 impl AlphaNumOnlyFilterStream<'_> {
-    #[expect(clippy::unused_self, reason = "method predicate follows TokenFilter pattern for consistency")]
+    #[expect(
+        clippy::unused_self,
+        reason = "method predicate follows TokenFilter pattern for consistency"
+    )]
     fn predicate(&self, token: &Token) -> bool {
         token.text.chars().all(|c| c.is_ascii_alphanumeric())
     }

--- a/crates/krites/src/fts/tokenizer/ascii_folding_filter/fold_table.rs
+++ b/crates/krites/src/fts/tokenizer/ascii_folding_filter/fold_table.rs
@@ -3,11 +3,20 @@
 //! Maps Unicode characters to their ASCII equivalents where one exists.
 //! Dispatches to sub-tables by character category.
 
-#[expect(clippy::too_many_lines, reason = "generated Unicode folding table — one match arm per codepoint")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "generated Unicode folding table — one match arm per codepoint"
+)]
 mod fold_digits_symbols;
-#[expect(clippy::too_many_lines, reason = "generated Unicode folding table — one match arm per codepoint")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "generated Unicode folding table — one match arm per codepoint"
+)]
 mod fold_letters_a_m;
-#[expect(clippy::too_many_lines, reason = "generated Unicode folding table — one match arm per codepoint")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "generated Unicode folding table — one match arm per codepoint"
+)]
 mod fold_letters_n_z;
 
 use fold_digits_symbols::fold_digit_or_symbol;

--- a/crates/krites/src/fts/tokenizer/ngram_tokenizer.rs
+++ b/crates/krites/src/fts/tokenizer/ngram_tokenizer.rs
@@ -179,7 +179,10 @@ where
 {
     type Item = (usize, usize);
 
-    #[expect(clippy::indexing_slicing, reason = "cursor is bounded by memory.len() via modular arithmetic")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "cursor is bounded by memory.len() via modular arithmetic"
+    )]
     fn next(&mut self) -> Option<(usize, usize)> {
         if self.gram_len > self.max_gram {
             self.gram_len = self.min_gram;
@@ -224,7 +227,10 @@ impl<'a> CodepointFrontiers<'a> {
 impl Iterator for CodepointFrontiers<'_> {
     type Item = usize;
 
-    #[expect(clippy::indexing_slicing, reason = "is_empty() guard ensures index 0 is valid")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "is_empty() guard ensures index 0 is valid"
+    )]
     fn next(&mut self) -> Option<usize> {
         self.next_el.inspect(|&offset| {
             if self.s.is_empty() {

--- a/crates/krites/src/fts/tokenizer/split_compound_words.rs
+++ b/crates/krites/src/fts/tokenizer/split_compound_words.rs
@@ -22,7 +22,10 @@ impl SplitCompoundWords {
     /// The dictionary will be used to construct an [`AhoCorasick`] automaton
     /// with reasonable defaults. See [`from_automaton`][Self::from_automaton] if
     /// more control over its construction is required.
-    #[expect(clippy::result_large_err, reason = "FTS error carries structured tokenization context")]
+    #[expect(
+        clippy::result_large_err,
+        reason = "FTS error carries structured tokenization context"
+    )]
     pub(crate) fn from_dictionary<I, P>(dict: I) -> Result<Self>
     where
         I: IntoIterator<Item = P>,

--- a/crates/krites/src/fts/tokenizer/stemmer.rs
+++ b/crates/krites/src/fts/tokenizer/stemmer.rs
@@ -32,7 +32,10 @@ pub(crate) enum Language {
 
 impl Language {
     fn algorithm(self) -> Algorithm {
-        #[expect(clippy::enum_glob_use, reason = "local import for concise match arms in Language-to-Algorithm mapping")]
+        #[expect(
+            clippy::enum_glob_use,
+            reason = "local import for concise match arms in Language-to-Algorithm mapping"
+        )]
         use self::Language::*;
         match self {
             Arabic => Algorithm::Arabic,

--- a/crates/krites/src/fts/tokenizer/stop_word_filter/mod.rs
+++ b/crates/krites/src/fts/tokenizer/stop_word_filter/mod.rs
@@ -22,7 +22,10 @@ impl StopWordFilter {
     /// Creates a new [`StopWordFilter`] for the given ISO 639-1 language code.
     ///
     /// Supports 58 languages from the [stopwords-iso](https://github.com/stopwords-iso/stopwords-iso/) project.
-    #[expect(clippy::result_large_err, reason = "FTS error carries structured tokenization context")]
+    #[expect(
+        clippy::result_large_err,
+        reason = "FTS error carries structured tokenization context"
+    )]
     pub(crate) fn for_lang(language: &str) -> Result<Self> {
         let words = match language {
             "af" => stopwords::AF,

--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -401,7 +401,8 @@ mod db_cache_tests {
 
     #[test]
     fn cache_stats_none_without_cache() {
-        let db = Db::open_mem().unwrap_or_else(|_| unreachable!("INVARIANT: in-memory db creation should not fail"));
+        let db = Db::open_mem()
+            .unwrap_or_else(|_| unreachable!("INVARIANT: in-memory db creation should not fail"));
         assert!(
             db.cache_stats().is_none(),
             "cache_stats should be None when no cache is attached"
@@ -412,13 +413,17 @@ mod db_cache_tests {
     fn cache_tracks_misses_and_hits() {
         let db = Db::open_mem()
             .unwrap_or_else(|_| unreachable!("INVARIANT: in-memory db creation should not fail"))
-            .with_cache(NonZeroUsize::new(16).unwrap_or_else(|| unreachable!("INVARIANT: 16 is non-zero")));
+            .with_cache(
+                NonZeroUsize::new(16).unwrap_or_else(|| unreachable!("INVARIANT: 16 is non-zero")),
+            );
 
         let script = "?[x] := x = 1";
         let _ = db.run(script, BTreeMap::new(), ScriptMutability::Immutable);
         let _ = db.run(script, BTreeMap::new(), ScriptMutability::Immutable);
 
-        let stats = db.cache_stats().unwrap_or_else(|| unreachable!("INVARIANT: cache was attached, stats are always Some"));
+        let stats = db.cache_stats().unwrap_or_else(|| {
+            unreachable!("INVARIANT: cache was attached, stats are always Some")
+        });
         assert_eq!(stats.misses, 1, "first run should be a cache miss");
         assert_eq!(stats.hits, 1, "second identical run should be a cache hit");
     }
@@ -427,7 +432,9 @@ mod db_cache_tests {
     fn cache_normalizes_whitespace() {
         let db = Db::open_mem()
             .unwrap_or_else(|_| unreachable!("INVARIANT: in-memory db creation should not fail"))
-            .with_cache(NonZeroUsize::new(16).unwrap_or_else(|| unreachable!("INVARIANT: 16 is non-zero")));
+            .with_cache(
+                NonZeroUsize::new(16).unwrap_or_else(|| unreachable!("INVARIANT: 16 is non-zero")),
+            );
 
         let _ = db.run(
             "?[x] := x = 1",
@@ -441,7 +448,9 @@ mod db_cache_tests {
             ScriptMutability::Immutable,
         );
 
-        let stats = db.cache_stats().unwrap_or_else(|| unreachable!("INVARIANT: cache was attached, stats are always Some"));
+        let stats = db.cache_stats().unwrap_or_else(|| {
+            unreachable!("INVARIANT: cache was attached, stats are always Some")
+        });
         assert_eq!(
             stats.hits, 1,
             "whitespace-normalized query should be a cache hit"

--- a/crates/krites/src/parse/expr/bytecode.rs
+++ b/crates/krites/src/parse/expr/bytecode.rs
@@ -66,16 +66,10 @@ fn compile_cond_bytecode(
     let mut return_jump_pos = vec![];
     for (cond, val) in clauses {
         expr2bytecode(cond, collector)?;
-        collector.push(Bytecode::JumpIfFalse {
-            jump_to: 0,
-            span,
-        });
+        collector.push(Bytecode::JumpIfFalse { jump_to: 0, span });
         let false_jump_amend_pos = collector.len() - 1;
         expr2bytecode(val, collector)?;
-        collector.push(Bytecode::Goto {
-            jump_to: 0,
-            span,
-        });
+        collector.push(Bytecode::Goto { jump_to: 0, span });
         return_jump_pos.push(collector.len() - 1);
         // SAFETY: `false_jump_amend_pos` is `collector.len() - 1` from above,
         // so it is always a valid index.

--- a/crates/krites/src/parse/expr/mod.rs
+++ b/crates/krites/src/parse/expr/mod.rs
@@ -148,9 +148,15 @@ fn build_expr_infix(lhs: Result<Expr>, op: Pair<'_>, rhs: Result<Expr>) -> Resul
             .into());
         }
     };
-    #[expect(clippy::indexing_slicing, reason = "index bounds validated — vec has exactly 2 elements")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "index bounds validated — vec has exactly 2 elements"
+    )]
     let start = args[0].span().0;
-    #[expect(clippy::indexing_slicing, reason = "index bounds validated — vec has exactly 2 elements")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "index bounds validated — vec has exactly 2 elements"
+    )]
     let end = args[1].span().0 + args[1].span().1;
     let length = end - start;
     Ok(Expr::Apply {

--- a/crates/krites/src/parse/fts.rs
+++ b/crates/krites/src/parse/fts.rs
@@ -40,11 +40,13 @@ pub(crate) fn parse_fts_query(q: &str) -> Result<FtsExpr> {
         }
         .build()
     })?;
-    let pairs = pairs.next()
+    let pairs = pairs
+        .next()
         .ok_or_else(|| {
             InvalidQuerySnafu {
                 message: "FTS parser produced no tokens".to_string(),
-            }.build()
+            }
+            .build()
         })?
         .into_inner();
     let pairs: Vec<_> = pairs
@@ -52,12 +54,12 @@ pub(crate) fn parse_fts_query(q: &str) -> Result<FtsExpr> {
         .map(parse_fts_expr)
         .try_collect()?;
     Ok(if pairs.len() == 1 {
-        pairs.into_iter().next()
-            .ok_or_else(|| {
-                InvalidQuerySnafu {
-                    message: "FTS parser produced empty expression".to_string(),
-                }.build()
-            })?
+        pairs.into_iter().next().ok_or_else(|| {
+            InvalidQuerySnafu {
+                message: "FTS parser produced empty expression".to_string(),
+            }
+            .build()
+        })?
     } else {
         FtsExpr::And(pairs)
     })
@@ -84,7 +86,9 @@ fn build_infix(lhs: Result<FtsExpr>, op: Pair<'_>, rhs: Result<FtsExpr>) -> Resu
         r => {
             return Err(InvalidQuerySnafu {
                 message: format!("unexpected rule {:?} in FTS parser - grammar mismatch", r),
-            }.build().into());
+            }
+            .build()
+            .into());
         }
     })
 }
@@ -95,14 +99,12 @@ fn build_term(pair: Pair<'_>) -> Result<FtsExpr> {
         Rule::fts_grouped => {
             let collected: Vec<_> = pair.into_inner().map(parse_fts_expr).try_collect()?;
             if collected.len() == 1 {
-                collected
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| {
-                        InvalidQuerySnafu {
-                            message: "FTS grouped expression is empty".to_string(),
-                        }.build()
-                    })?
+                collected.into_iter().next().ok_or_else(|| {
+                    InvalidQuerySnafu {
+                        message: "FTS grouped expression is empty".to_string(),
+                    }
+                    .build()
+                })?
             } else {
                 FtsExpr::And(collected)
             }
@@ -146,19 +148,21 @@ fn build_term(pair: Pair<'_>) -> Result<FtsExpr> {
 /// Build an FTS phrase literal with optional prefix marker and boost weight.
 fn build_phrase(pair: Pair<'_>) -> Result<FtsLiteral> {
     let mut inner = pair.into_inner();
-    let kernel = inner.next()
-        .ok_or_else(|| {
-            InvalidQuerySnafu {
-                message: "FTS phrase has no content".to_string(),
-            }.build()
-        })?;
+    let kernel = inner.next().ok_or_else(|| {
+        InvalidQuerySnafu {
+            message: "FTS phrase has no content".to_string(),
+        }
+        .build()
+    })?;
     let core_text = match kernel.as_rule() {
         Rule::fts_phrase_group => CompactString::from(kernel.as_str().trim()),
         Rule::quoted_string | Rule::s_quoted_string | Rule::raw_string => parse_string(kernel)?,
         r => {
             return Err(InvalidQuerySnafu {
                 message: format!("unexpected rule {:?} in FTS phrase - grammar mismatch", r),
-            }.build().into());
+            }
+            .build()
+            .into());
         }
     };
     let mut is_quoted = false;
@@ -167,12 +171,12 @@ fn build_phrase(pair: Pair<'_>) -> Result<FtsLiteral> {
         match pair.as_rule() {
             Rule::fts_prefix_marker => is_quoted = true,
             Rule::fts_booster => {
-                let boosted = pair.into_inner().next()
-                    .ok_or_else(|| {
-                        InvalidQuerySnafu {
-                            message: "FTS booster has no value".to_string(),
-                        }.build()
-                    })?;
+                let boosted = pair.into_inner().next().ok_or_else(|| {
+                    InvalidQuerySnafu {
+                        message: "FTS booster has no value".to_string(),
+                    }
+                    .build()
+                })?;
                 match boosted.as_rule() {
                     Rule::dot_float => {
                         let f = boosted
@@ -209,15 +213,25 @@ fn build_phrase(pair: Pair<'_>) -> Result<FtsLiteral> {
                     }
                     r => {
                         return Err(InvalidQuerySnafu {
-                            message: format!("unexpected rule {:?} in FTS booster - grammar mismatch", r),
-                        }.build().into());
+                            message: format!(
+                                "unexpected rule {:?} in FTS booster - grammar mismatch",
+                                r
+                            ),
+                        }
+                        .build()
+                        .into());
                     }
                 }
             }
             r => {
                 return Err(InvalidQuerySnafu {
-                    message: format!("unexpected rule {:?} in FTS phrase modifier - grammar mismatch", r),
-                }.build().into());
+                    message: format!(
+                        "unexpected rule {:?} in FTS phrase modifier - grammar mismatch",
+                        r
+                    ),
+                }
+                .build()
+                .into());
             }
         }
     }

--- a/crates/krites/src/parse/imperative.rs
+++ b/crates/krites/src/parse/imperative.rs
@@ -20,8 +20,8 @@ use crate::error::InternalResult as Result;
 use crate::parse::query::parse_query;
 use crate::parse::sys::parse_sys;
 use crate::parse::{
-    error::InvalidQuerySnafu, ExtractSpan, ImperativeProgram, ImperativeStmt, ImperativeStmtClause,
-    ImperativeSysop, Pair, Rule,
+    ExtractSpan, ImperativeProgram, ImperativeStmt, ImperativeStmtClause, ImperativeSysop, Pair,
+    Rule, error::InvalidQuerySnafu,
 };
 use crate::{DataValue, FixedRule, ValidityTs};
 
@@ -144,8 +144,7 @@ fn parse_imperative_stmt(
             }
         }
         Rule::imperative_clause => {
-            let prog =
-                parse_query_with_store_as(pair, param_pool, fixed_rules, cur_vld)?;
+            let prog = parse_query_with_store_as(pair, param_pool, fixed_rules, cur_vld)?;
             ImperativeStmt::Program { prog }
         }
         Rule::ignore_error_script => {
@@ -155,8 +154,7 @@ fn parse_imperative_stmt(
                 }
                 .build()
             })?;
-            let prog =
-                parse_query_with_store_as(inner_pair, param_pool, fixed_rules, cur_vld)?;
+            let prog = parse_query_with_store_as(inner_pair, param_pool, fixed_rules, cur_vld)?;
             ImperativeStmt::IgnoreErrorProgram { prog }
         }
         r => {
@@ -183,8 +181,7 @@ fn parse_return_stmt(
                 rets.push(Right(CompactString::from(p.as_str())));
             }
             Rule::query_script_inner => {
-                let prog =
-                    parse_query_with_store_as(p, param_pool, fixed_rules, cur_vld)?;
+                let prog = parse_query_with_store_as(p, param_pool, fixed_rules, cur_vld)?;
                 rets.push(Left(prog));
             }
             r => {
@@ -217,9 +214,7 @@ fn parse_if_stmt(
     let cond = match condition.as_rule() {
         Rule::underscore_ident => Left(CompactString::from(condition.as_str())),
         Rule::imperative_clause => {
-            let prog = parse_query_with_store_as(
-                condition, param_pool, fixed_rules, cur_vld,
-            )?;
+            let prog = parse_query_with_store_as(condition, param_pool, fixed_rules, cur_vld)?;
             Right(prog)
         }
         r => {

--- a/crates/krites/src/parse/mod.rs
+++ b/crates/krites/src/parse/mod.rs
@@ -104,17 +104,11 @@ pub enum ImperativeStmt {
         returns: Vec<Either<ImperativeStmtClause, CompactString>>,
     },
     /// Execute a query program.
-    Program {
-        prog: ImperativeStmtClause,
-    },
+    Program { prog: ImperativeStmtClause },
     /// Execute a system operation.
-    SysOp {
-        sysop: ImperativeSysop,
-    },
+    SysOp { sysop: ImperativeSysop },
     /// Execute a query, suppressing any errors.
-    IgnoreErrorProgram {
-        prog: ImperativeStmtClause,
-    },
+    IgnoreErrorProgram { prog: ImperativeStmtClause },
     /// Conditional branch.
     If {
         condition: ImperativeCondition,
@@ -133,9 +127,7 @@ pub enum ImperativeStmt {
         right: CompactString,
     },
     /// Debug-print a temporary relation.
-    TempDebug {
-        temp: CompactString,
-    },
+    TempDebug { temp: CompactString },
 }
 
 pub(crate) type ImperativeCondition = Either<CompactString, ImperativeStmtClause>;

--- a/crates/krites/src/parse/schema.rs
+++ b/crates/krites/src/parse/schema.rs
@@ -43,12 +43,16 @@ pub(crate) fn parse_schema(
     let mut dep_bindings = vec![];
     let mut seen_names = BTreeSet::new();
 
-    for p in src.next().ok_or_else(|| {
-        InvalidQuerySnafu {
-            message: "expected element".to_string(),
-        }
-        .build()
-    })?.into_inner() {
+    for p in src
+        .next()
+        .ok_or_else(|| {
+            InvalidQuerySnafu {
+                message: "expected element".to_string(),
+            }
+            .build()
+        })?
+        .into_inner()
+    {
         let _span = p.extract_span();
         let (col, ident) = parse_col(p)?;
         if !seen_names.insert(col.name.clone()) {
@@ -195,12 +199,16 @@ fn parse_type_inner(pair: Pair<'_>) -> Result<ColType> {
         }
         Rule::vec_type => {
             let mut inner = pair.into_inner();
-            let eltype = match inner.next().ok_or_else(|| {
-                InvalidQuerySnafu {
-                    message: "expected element".to_string(),
-                }
-                .build()
-            })?.as_str() {
+            let eltype = match inner
+                .next()
+                .ok_or_else(|| {
+                    InvalidQuerySnafu {
+                        message: "expected element".to_string(),
+                    }
+                    .build()
+                })?
+                .as_str()
+            {
                 "F32" | "Float" => VecElementType::F32,
                 "F64" | "Double" => VecElementType::F64,
                 _ => {

--- a/crates/krites/src/parse/sys/index.rs
+++ b/crates/krites/src/parse/sys/index.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 
 use compact_str::CompactString;
 
+use crate::Expr;
 use crate::data::relation::VecElementType;
 use crate::data::symb::Symbol;
 use crate::data::value::DataValue;
@@ -20,7 +21,6 @@ use crate::fts::TokenizerConfig;
 use crate::parse::error::InvalidQuerySnafu;
 use crate::parse::expr::build_expr;
 use crate::parse::{ExtractSpan, Pair};
-use crate::Expr;
 
 use super::{FtsIndexConfig, HnswDistance, HnswIndexConfig, MinHashLshConfig, SysOp};
 
@@ -148,8 +148,7 @@ fn parse_tokenizer_value(
             args: vec![],
         }),
         _ => Err(InvalidQuerySnafu {
-            message:
-                "Tokenizer must be a symbol or a call for an existing tokenizer".to_string(),
+            message: "Tokenizer must be a symbol or a call for an existing tokenizer".to_string(),
         }
         .build()
         .into()),
@@ -193,7 +192,9 @@ fn parse_filter_list(
                     }
                     _ => {
                         return Err(InvalidQuerySnafu {
-                            message: "Tokenizer must be a symbol or a call for an existing tokenizer".to_string(),
+                            message:
+                                "Tokenizer must be a symbol or a call for an existing tokenizer"
+                                    .to_string(),
                         }
                         .build()
                         .into());

--- a/crates/krites/src/parse/sys/parse.rs
+++ b/crates/krites/src/parse/sys/parse.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 
+use crate::FixedRule;
 use crate::data::symb::Symbol;
 use crate::data::value::{DataValue, ValidityTs};
 use crate::error::InternalResult as Result;
@@ -21,7 +22,6 @@ use crate::parse::expr::{build_expr, parse_string};
 use crate::parse::query::parse_query;
 use crate::parse::{ExtractSpan, Pairs, Rule};
 use crate::runtime::relation::AccessLevel;
-use crate::FixedRule;
 
 use super::SysOp;
 use super::index::{
@@ -67,12 +67,8 @@ pub(crate) fn parse_sys(
         Rule::list_indices_op => parse_single_relation_op(inner, SysOp::ListIndices)?,
         Rule::rename_relations_op => parse_rename_op(inner)?,
         Rule::access_level_op => parse_access_level_op(inner)?,
-        Rule::trigger_relation_show_op => {
-            parse_single_relation_op(inner, SysOp::ShowTrigger)?
-        }
-        Rule::trigger_relation_op => {
-            parse_trigger_op(inner, param_pool, algorithms, cur_vld)?
-        }
+        Rule::trigger_relation_show_op => parse_single_relation_op(inner, SysOp::ShowTrigger)?,
+        Rule::trigger_relation_op => parse_trigger_op(inner, param_pool, algorithms, cur_vld)?,
         Rule::lsh_idx_op => parse_adv_index_op(inner, param_pool, parse_lsh_index_create)?,
         Rule::fts_idx_op => parse_adv_index_op(inner, param_pool, parse_fts_index_create)?,
         Rule::vec_idx_op => parse_adv_index_op(inner, param_pool, parse_hnsw_index_create)?,

--- a/crates/krites/src/query/compile.rs
+++ b/crates/krites/src/query/compile.rs
@@ -613,9 +613,12 @@ impl<'a> SessionTx<'a> {
                 .difference(&cur_ret_set)
                 .next()
                 .ok_or_else(|| {
-                    crate::error::InternalError::from(CompilationFailedSnafu {
-                        message: "no unbound symbols found despite set mismatch",
-                    }.build())
+                    crate::error::InternalError::from(
+                        CompilationFailedSnafu {
+                            message: "no unbound symbols found despite set mismatch",
+                        }
+                        .build(),
+                    )
                 })?;
             return Err(UnboundVariableSnafu {
                 message: format!("symbol '{unbound}' in rule head is unbound"),

--- a/crates/krites/src/query/eval.rs
+++ b/crates/krites/src/query/eval.rs
@@ -34,10 +34,10 @@ use crate::data::value::DataValue;
 use crate::error::InternalResult as Result;
 use crate::fixed_rule::FixedRulePayload;
 use crate::parse::SourceSpan;
-use crate::query::error::*;
 use crate::query::compile::{
     AggrKind, CompiledProgram, CompiledRule, CompiledRuleSet, ContainedRuleMultiplicity,
 };
+use crate::query::error::*;
 use crate::runtime::db::Poison;
 use crate::runtime::temp_store::{EpochStore, MeetAggrStore, RegularTempStore, TempStore};
 use crate::runtime::transact::SessionTx;
@@ -375,9 +375,12 @@ impl<'a> SessionTx<'a> {
             let mut changed = false;
             for (k, new_store) in to_merge {
                 let old_store = stores.get_mut(k).ok_or_else(|| {
-                    crate::error::InternalError::from(EvalFailedSnafu {
-                        message: format!("epoch store not found for rule '{k}'"),
-                    }.build())
+                    crate::error::InternalError::from(
+                        EvalFailedSnafu {
+                            message: format!("epoch store not found for rule '{k}'"),
+                        }
+                        .build(),
+                    )
                 })?;
                 old_store.merge_in(new_store)?;
                 trace!("delta for {}: {}", k, old_store.has_delta());
@@ -471,14 +474,20 @@ impl<'a> SessionTx<'a> {
                 .iter()
                 .map(|a| -> Result<DataValue> {
                     let (aggr, _) = a.as_ref().ok_or_else(|| {
-                        crate::error::InternalError::from(EvalFailedSnafu {
-                            message: "aggregation entry missing in meet evaluation",
-                        }.build())
+                        crate::error::InternalError::from(
+                            EvalFailedSnafu {
+                                message: "aggregation entry missing in meet evaluation",
+                            }
+                            .build(),
+                        )
                     })?;
                     let op = aggr.meet_op.as_ref().ok_or_else(|| {
-                        crate::error::InternalError::from(EvalFailedSnafu {
-                            message: "meet_op missing on aggregation",
-                        }.build())
+                        crate::error::InternalError::from(
+                            EvalFailedSnafu {
+                                message: "meet_op missing on aggregation",
+                            }
+                            .build(),
+                        )
                     })?;
                     Ok(op.init_val())
                 })
@@ -545,9 +554,12 @@ impl<'a> SessionTx<'a> {
                                 .normal_op
                                 .as_mut()
                                 .ok_or_else(|| {
-                                    crate::error::InternalError::from(EvalFailedSnafu {
-                                        message: "normal_op missing on aggregation",
-                                    }.build())
+                                    crate::error::InternalError::from(
+                                        EvalFailedSnafu {
+                                            message: "normal_op missing on aggregation",
+                                        }
+                                        .build(),
+                                    )
                                 })?
                                 .set(&item[*tuple_idx])?;
                         }
@@ -561,9 +573,12 @@ impl<'a> SessionTx<'a> {
                                 .normal_op
                                 .as_mut()
                                 .ok_or_else(|| {
-                                    crate::error::InternalError::from(EvalFailedSnafu {
-                                        message: "normal_op missing on aggregation after init",
-                                    }.build())
+                                    crate::error::InternalError::from(
+                                        EvalFailedSnafu {
+                                            message: "normal_op missing on aggregation after init",
+                                        }
+                                        .build(),
+                                    )
                                 })?
                                 .set(&item[*i])?;
                             aggr_ops.push(cur_aggr)
@@ -596,16 +611,22 @@ impl<'a> SessionTx<'a> {
                 .iter()
                 .map(|a| -> Result<DataValue> {
                     let (aggr, args) = a.as_ref().ok_or_else(|| {
-                        crate::error::InternalError::from(EvalFailedSnafu {
-                            message: "aggregation entry missing in empty-result path",
-                        }.build())
+                        crate::error::InternalError::from(
+                            EvalFailedSnafu {
+                                message: "aggregation entry missing in empty-result path",
+                            }
+                            .build(),
+                        )
                     })?;
                     let mut aggr = aggr.clone();
                     aggr.normal_init(args)?;
                     let op = aggr.normal_op.ok_or_else(|| {
-                        crate::error::InternalError::from(EvalFailedSnafu {
-                            message: "normal_op missing on aggregation after init",
-                        }.build())
+                        crate::error::InternalError::from(
+                            EvalFailedSnafu {
+                                message: "normal_op missing on aggregation after init",
+                            }
+                            .build(),
+                        )
                     })?;
                     Ok(op.get()?)
                 })
@@ -666,9 +687,12 @@ impl<'a> SessionTx<'a> {
         poison: Poison,
     ) -> Result<(bool, RegularTempStore)> {
         let prev_store = stores.get(rule_symb).ok_or_else(|| {
-            crate::error::InternalError::from(EvalFailedSnafu {
-                message: format!("epoch store not found for rule '{rule_symb}'"),
-            }.build())
+            crate::error::InternalError::from(
+                EvalFailedSnafu {
+                    message: format!("epoch store not found for rule '{rule_symb}'"),
+                }
+                .build(),
+            )
         })?;
         let mut out_store = RegularTempStore::default();
         let should_check_limit = limiter.total.is_some() && rule_symb.is_prog_entry();
@@ -680,9 +704,12 @@ impl<'a> SessionTx<'a> {
                 if stores
                     .get(symb)
                     .ok_or_else(|| {
-                        crate::error::InternalError::from(EvalFailedSnafu {
-                            message: format!("epoch store not found for dependency '{symb}'"),
-                        }.build())
+                        crate::error::InternalError::from(
+                            EvalFailedSnafu {
+                                message: format!("epoch store not found for dependency '{symb}'"),
+                            }
+                            .build(),
+                        )
                     })?
                     .has_delta()
                 {
@@ -784,9 +811,12 @@ impl<'a> SessionTx<'a> {
                 if stores
                     .get(symb)
                     .ok_or_else(|| {
-                        crate::error::InternalError::from(EvalFailedSnafu {
-                            message: format!("epoch store not found for dependency '{symb}'"),
-                        }.build())
+                        crate::error::InternalError::from(
+                            EvalFailedSnafu {
+                                message: format!("epoch store not found for dependency '{symb}'"),
+                            }
+                            .build(),
+                        )
                     })?
                     .has_delta()
                 {

--- a/crates/krites/src/query/graph.rs
+++ b/crates/krites/src/query/graph.rs
@@ -122,7 +122,9 @@ pub(crate) fn generalized_kahn(
             break;
         }
         // INVARIANT: the `safe_pending.is_empty()` check above guarantees at least one element
-        let removed = safe_pending.pop().unwrap_or_else(|| panic!("safe_pending verified non-empty above"));
+        let removed = safe_pending
+            .pop()
+            .unwrap_or_else(|| panic!("safe_pending verified non-empty above"));
         current_stratum.push(removed);
         if let Some(edges) = graph.get(&removed) {
             for (nxt, poisoned) in edges {
@@ -205,7 +207,8 @@ impl<'a> TarjanScc<'a> {
                 // SAFETY: `node` was pushed from valid indices within this function.
                 self.on_stack[node] = false;
                 // INVARIANT: `self.ids[at]` was set to `Some(self.id)` at the top of this function
-                self.low[node] = self.ids[at].unwrap_or_else(|| panic!("ids[at] set earlier in dfs"));
+                self.low[node] =
+                    self.ids[at].unwrap_or_else(|| panic!("ids[at] set earlier in dfs"));
                 if node == at {
                     break;
                 }

--- a/crates/krites/src/query/logical.rs
+++ b/crates/krites/src/query/logical.rs
@@ -244,7 +244,9 @@ impl InputAtom {
                             "negation not supported for atom type: {:?}",
                             std::mem::discriminant(&other)
                         ),
-                    }.build().into());
+                    }
+                    .build()
+                    .into());
                 }
             },
             InputAtom::Unification { inner: u } => {

--- a/crates/krites/src/query/magic.rs
+++ b/crates/krites/src/query/magic.rs
@@ -214,7 +214,9 @@ fn magic_rewrite_ruleset(
                             .entry(sup_kw.clone())
                             .or_default()
                             .mut_rules()
-                            .unwrap_or_else(|| panic!("freshly-defaulted MagicRulesOrFixed must be Rules"));
+                            .unwrap_or_else(|| {
+                                panic!("freshly-defaulted MagicRulesOrFixed must be Rules")
+                            });
                         let mut sup_rule_atoms = vec![];
                         mem::swap(&mut sup_rule_atoms, &mut collected_atoms);
 
@@ -240,7 +242,9 @@ fn magic_rewrite_ruleset(
                             .entry(inp_kw.clone())
                             .or_default()
                             .mut_rules()
-                            .unwrap_or_else(|| panic!("freshly-defaulted MagicRulesOrFixed must be Rules"));
+                            .unwrap_or_else(|| {
+                                panic!("freshly-defaulted MagicRulesOrFixed must be Rules")
+                            });
                         let inp_args = r_app
                             .args
                             .iter()
@@ -500,29 +504,29 @@ impl NormalFormProgram {
             if adorned_prog.prog.contains_key(&head) {
                 continue;
             }
-            let original_rules = self
-                .prog
-                .get(head.as_plain_symbol())
-                .ok_or_else(|| {
-                    crate::error::InternalError::from(CompilationFailedSnafu {
+            let original_rules =
+                self.prog
+                    .get(head.as_plain_symbol())
+                    .ok_or_else(|| {
+                        crate::error::InternalError::from(CompilationFailedSnafu {
                         message: format!(
                             "rule '{}' referenced during adornment but not found in program",
                             head.as_plain_symbol()
                         ),
                     }.build())
-                })?
-                .rules()
-                .ok_or_else(|| {
-                    crate::error::InternalError::from(
-                        CompilationFailedSnafu {
-                            message: format!(
-                                "expected rules for '{}' but found fixed rule",
-                                head.as_plain_symbol()
-                            ),
-                        }
-                        .build(),
-                    )
-                })?;
+                    })?
+                    .rules()
+                    .ok_or_else(|| {
+                        crate::error::InternalError::from(
+                            CompilationFailedSnafu {
+                                message: format!(
+                                    "expected rules for '{}' but found fixed rule",
+                                    head.as_plain_symbol()
+                                ),
+                            }
+                            .build(),
+                        )
+                    })?;
             let adornment = head.magic_adornment();
             let mut adorned_rules = Vec::with_capacity(original_rules.len());
             for rule in original_rules {

--- a/crates/krites/src/query/ra/join.rs
+++ b/crates/krites/src/query/ra/join.rs
@@ -86,14 +86,20 @@ impl Joiner {
         let mut ret_r = Vec::with_capacity(self.left_keys.len());
         for (l, r) in self.left_keys.iter().zip(self.right_keys.iter()) {
             let l_pos = left_binding_map.get(l).ok_or_else(|| {
-                crate::error::InternalError::from(CompilationFailedSnafu {
-                    message: format!("left join key '{l}' not found in bindings"),
-                }.build())
+                crate::error::InternalError::from(
+                    CompilationFailedSnafu {
+                        message: format!("left join key '{l}' not found in bindings"),
+                    }
+                    .build(),
+                )
             })?;
             let r_pos = right_binding_map.get(r).ok_or_else(|| {
-                crate::error::InternalError::from(CompilationFailedSnafu {
-                    message: format!("right join key '{r}' not found in bindings"),
-                }.build())
+                crate::error::InternalError::from(
+                    CompilationFailedSnafu {
+                        message: format!("right join key '{r}' not found in bindings"),
+                    }
+                    .build(),
+                )
             })?;
             ret_l.push(*l_pos);
             ret_r.push(*r_pos)
@@ -131,24 +137,20 @@ impl NegJoin {
     pub(crate) fn join_type(&self) -> &str {
         match &self.right {
             RelAlgebra::TempStore(_) => {
-                match self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    ) {
+                match self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                ) {
                     Ok(join_indices) if join_is_prefix(&join_indices.1) => "mem_neg_prefix_join",
                     Ok(_) => "mem_neg_mat_join",
                     Err(_) => "mem_neg_join_unknown",
                 }
             }
             RelAlgebra::Stored(_) => {
-                match self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    ) {
+                match self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                ) {
                     Ok(join_indices) if join_is_prefix(&join_indices.1) => "stored_neg_prefix_join",
                     Ok(_) => "stored_neg_mat_join",
                     Err(_) => "stored_neg_join_unknown",
@@ -251,24 +253,20 @@ impl InnerJoin {
         match &self.right {
             RelAlgebra::Fixed(f) => f.join_type(),
             RelAlgebra::TempStore(_) => {
-                match self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    ) {
+                match self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                ) {
                     Ok(join_indices) if join_is_prefix(&join_indices.1) => "mem_prefix_join",
                     Ok(_) => "mem_mat_join",
                     Err(_) => "mem_join_unknown",
                 }
             }
             RelAlgebra::Stored(_) => {
-                match self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    ) {
+                match self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                ) {
                     Ok(join_indices) if join_is_prefix(&join_indices.1) => "stored_prefix_join",
                     Ok(_) => "stored_mat_join",
                     Err(_) => "stored_join_unknown",
@@ -278,12 +276,10 @@ impl InnerJoin {
             RelAlgebra::FtsSearch(_) => "fts_search_join",
             RelAlgebra::LshSearch(_) => "lsh_search_join",
             RelAlgebra::StoredWithValidity(_) => {
-                match self
-                    .joiner
-                    .join_indices(
-                        &self.left.bindings_after_eliminate(),
-                        &self.right.bindings_after_eliminate(),
-                    ) {
+                match self.joiner.join_indices(
+                    &self.left.bindings_after_eliminate(),
+                    &self.right.bindings_after_eliminate(),
+                ) {
                     Ok(join_indices) if join_is_prefix(&join_indices.1) => "stored_prefix_join",
                     Ok(_) => "stored_mat_join",
                     Err(_) => "stored_validity_join_unknown",

--- a/crates/krites/src/query/ra/mod.rs
+++ b/crates/krites/src/query/ra/mod.rs
@@ -224,7 +224,11 @@ impl Debug for RelAlgebra {
                     f.debug_tuple("Singlet")
                         .field(&bindings)
                         // SAFETY: data.len()==1 checked above
-                        .field(r.data.first().unwrap_or_else(|| panic!("data.len()==1 checked above")))
+                        .field(
+                            r.data
+                                .first()
+                                .unwrap_or_else(|| panic!("data.len()==1 checked above")),
+                        )
                         .finish()
                 } else {
                     f.debug_tuple("Fixed")

--- a/crates/krites/src/query/ra/sort.rs
+++ b/crates/krites/src/query/ra/sort.rs
@@ -54,9 +54,12 @@ impl ReorderRA {
             .iter()
             .map(|k| {
                 old_order_indices.get(k).copied().ok_or_else(|| {
-                    crate::error::InternalError::from(crate::query::error::CompilationFailedSnafu {
-                        message: format!("reorder binding '{k}' not found in original order"),
-                    }.build())
+                    crate::error::InternalError::from(
+                        crate::query::error::CompilationFailedSnafu {
+                            message: format!("reorder binding '{k}' not found in original order"),
+                        }
+                        .build(),
+                    )
                 })
             })
             .collect::<crate::error::InternalResult<Vec<_>>>()?

--- a/crates/krites/src/query/ra/temp_store.rs
+++ b/crates/krites/src/query/ra/temp_store.rs
@@ -65,13 +65,17 @@ impl TempStoreRA {
         &self,
         stores: &'a BTreeMap<MagicSymbol, EpochStore>,
     ) -> Result<&'a EpochStore> {
-        stores
-            .get(&self.storage_key)
-            .ok_or_else(|| {
-                crate::error::InternalError::from(crate::query::error::EvalFailedSnafu {
-                    message: format!("temp store '{}' not found in epoch stores", self.storage_key),
-                }.build())
-            })
+        stores.get(&self.storage_key).ok_or_else(|| {
+            crate::error::InternalError::from(
+                crate::query::error::EvalFailedSnafu {
+                    message: format!(
+                        "temp store '{}' not found in epoch stores",
+                        self.storage_key
+                    ),
+                }
+                .build(),
+            )
+        })
     }
 
     /// Iterate over all (or delta) tuples in this derived relation.

--- a/crates/krites/src/query/reorder.rs
+++ b/crates/krites/src/query/reorder.rs
@@ -105,7 +105,9 @@ impl NormalFormInlineRule {
                 | NormalFormAtom::Predicate(_) => {
                     return Err(CompilationFailedSnafu {
                         message: "unexpected atom type in round_1_collected during reorder",
-                    }.build().into());
+                    }
+                    .build()
+                    .into());
                 }
                 NormalFormAtom::Unification(u) => {
                     seen_variables.insert(u.binding.clone());
@@ -130,7 +132,9 @@ impl NormalFormInlineRule {
                     NormalFormAtom::Rule(_) | NormalFormAtom::Relation(_) => {
                         return Err(CompilationFailedSnafu {
                             message: "unexpected Rule/Relation in pending during reorder",
-                        }.build().into());
+                        }
+                        .build()
+                        .into());
                     }
                     NormalFormAtom::NegatedRule(r) => {
                         if r.args.iter().all(|a| seen_variables.contains(a)) {

--- a/crates/krites/src/query/stored/mutation.rs
+++ b/crates/krites/src/query/stored/mutation.rs
@@ -379,9 +379,12 @@ impl<'a> crate::runtime::transact::SessionTx<'a> {
     ) -> Result<()> {
         for (k, (idx_handle, _)) in rel_handle.fts_indices.iter() {
             let (tokenizer, extractor) = processors.get(k).ok_or_else(|| {
-                crate::error::InternalError::from(CompilationFailedSnafu {
-                    message: format!("FTS processor not found for index '{k}'"),
-                }.build())
+                crate::error::InternalError::from(
+                    CompilationFailedSnafu {
+                        message: format!("FTS processor not found for index '{k}'"),
+                    }
+                    .build(),
+                )
             })?;
             self.put_fts_index_item(new_kv, extractor, stack, tokenizer, rel_handle, idx_handle)?;
         }
@@ -397,9 +400,12 @@ impl<'a> crate::runtime::transact::SessionTx<'a> {
     ) -> Result<()> {
         for (k, (idx_handle, _)) in rel_handle.fts_indices.iter() {
             let (tokenizer, extractor) = processors.get(k).ok_or_else(|| {
-                crate::error::InternalError::from(CompilationFailedSnafu {
-                    message: format!("FTS processor not found for index '{k}'"),
-                }.build())
+                crate::error::InternalError::from(
+                    CompilationFailedSnafu {
+                        message: format!("FTS processor not found for index '{k}'"),
+                    }
+                    .build(),
+                )
             })?;
             self.del_fts_index_item(old_kv, extractor, stack, tokenizer, rel_handle, idx_handle)?;
         }
@@ -416,9 +422,12 @@ impl<'a> crate::runtime::transact::SessionTx<'a> {
     ) -> Result<()> {
         for (k, (idx_handle, inv_idx_handle, manifest)) in rel_handle.lsh_indices.iter() {
             let (tokenizer, extractor) = processors.get(k).ok_or_else(|| {
-                crate::error::InternalError::from(CompilationFailedSnafu {
-                    message: format!("LSH processor not found for index '{k}'"),
-                }.build())
+                crate::error::InternalError::from(
+                    CompilationFailedSnafu {
+                        message: format!("LSH processor not found for index '{k}'"),
+                    }
+                    .build(),
+                )
             })?;
             self.put_lsh_index_item(
                 new_kv,
@@ -430,9 +439,12 @@ impl<'a> crate::runtime::transact::SessionTx<'a> {
                 inv_idx_handle,
                 manifest,
                 hash_perms_map.get(k).ok_or_else(|| {
-                    crate::error::InternalError::from(CompilationFailedSnafu {
-                        message: format!("LSH hash permutations not found for index '{k}'"),
-                    }.build())
+                    crate::error::InternalError::from(
+                        CompilationFailedSnafu {
+                            message: format!("LSH hash permutations not found for index '{k}'"),
+                        }
+                        .build(),
+                    )
                 })?,
             )?;
         }

--- a/crates/krites/src/query/stratify.rs
+++ b/crates/krites/src/query/stratify.rs
@@ -199,7 +199,9 @@ fn make_scc_reduced_graph(
     let mut ret: BTreeMap<usize, BTreeMap<usize, bool>> = Default::default();
     for (from, tos) in graph {
         // INVARIANT: `from` is a key of `graph` which was used to build `indices`
-        let from_idx = *indices.get(from).unwrap_or_else(|| panic!("graph key must exist in SCC indices"));
+        let from_idx = *indices
+            .get(from)
+            .unwrap_or_else(|| panic!("graph key must exist in SCC indices"));
         let cur_entry = ret.entry(from_idx).or_default();
         for (to, poisoned) in tos {
             let to_idx = match indices.get(to) {
@@ -294,13 +296,16 @@ impl NormalFormProgram {
                 && let Some(rev_stratum_idx) = invert_sort_result.get(scc_idx)
             {
                 // INVARIANT: `rev_stratum_idx` comes from `invert_sort_result` which maps to 0..n_strata
-                let target = ret
-                    .get_mut(*rev_stratum_idx)
-                    .ok_or_else(|| {
-                        crate::error::InternalError::from(StratificationFailedSnafu {
-                            message: format!("stratum index {rev_stratum_idx} out of range (n_strata={n_strata})"),
-                        }.build())
-                    })?;
+                let target = ret.get_mut(*rev_stratum_idx).ok_or_else(|| {
+                    crate::error::InternalError::from(
+                        StratificationFailedSnafu {
+                            message: format!(
+                                "stratum index {rev_stratum_idx} out of range (n_strata={n_strata})"
+                            ),
+                        }
+                        .build(),
+                    )
+                })?;
                 target.prog.insert(name, ruleset);
             }
         }

--- a/crates/krites/src/query_cache.rs
+++ b/crates/krites/src/query_cache.rs
@@ -111,7 +111,11 @@ mod tests {
     use super::*;
 
     fn cache(cap: usize) -> QueryCache {
-        QueryCache::new(NonZeroUsize::new(cap).unwrap_or_else(|| unreachable!("INVARIANT: test cache capacity is always non-zero")))
+        QueryCache::new(
+            NonZeroUsize::new(cap).unwrap_or_else(|| {
+                unreachable!("INVARIANT: test cache capacity is always non-zero")
+            }),
+        )
     }
 
     #[test]

--- a/crates/krites/src/runtime/db.rs
+++ b/crates/krites/src/runtime/db.rs
@@ -179,11 +179,7 @@ impl NamedRows {
         let rows = self
             .rows
             .into_iter()
-            .map(|row| {
-                row.into_iter()
-                    .map(JsonValue::from)
-                    .collect::<JsonValue>()
-            })
+            .map(|row| row.into_iter().map(JsonValue::from).collect::<JsonValue>())
             .collect::<JsonValue>();
         json!({
             "headers": self.headers,
@@ -487,13 +483,17 @@ impl<'s, S: Storage<'s>> Db<S> {
                 .1
                 // INVARIANT: register_callback inserts into both maps
                 .get_mut(&cb.dependent)
-                .unwrap_or_else(|| unreachable!("callback dependent entry missing from reverse index"))
+                .unwrap_or_else(|| {
+                    unreachable!("callback dependent entry missing from reverse index")
+                })
                 .remove(&id);
 
             if guard
                 .1
                 .get(&cb.dependent)
-                .unwrap_or_else(|| unreachable!("callback dependent entry missing from reverse index"))
+                .unwrap_or_else(|| {
+                    unreachable!("callback dependent entry missing from reverse index")
+                })
                 .is_empty()
             {
                 guard.1.remove(&cb.dependent);

--- a/crates/krites/src/runtime/hnsw/graph.rs
+++ b/crates/krites/src/runtime/hnsw/graph.rs
@@ -132,13 +132,13 @@ impl SessionTx<'_> {
                     }
                     .build(),
                 })?;
-                if old_existing_val[2]
-                    .get_bool()
-                    .ok_or_else(|| InvalidOperationSnafu {
+                if old_existing_val[2].get_bool().ok_or_else(|| {
+                    InvalidOperationSnafu {
                         op: "hnsw_index",
                         reason: "deleted flag is not a boolean".to_string(),
-                    }.build())?
-                {
+                    }
+                    .build()
+                })? {
                     self.store_tx.del(&old_key_bytes)?;
                 } else {
                     let old_val = vec![
@@ -202,10 +202,13 @@ impl SessionTx<'_> {
         }
         while !candidates.is_empty() && ret.len() < m {
             let (cand_key, Reverse(OrderedFloat(cand_dist_to_q))) =
-                candidates.pop().ok_or_else(|| InvalidOperationSnafu {
-                    op: "hnsw_select_neighbors",
-                    reason: "candidate queue unexpectedly empty".to_string(),
-                }.build())?;
+                candidates.pop().ok_or_else(|| {
+                    InvalidOperationSnafu {
+                        op: "hnsw_select_neighbors",
+                        reason: "candidate queue unexpectedly empty".to_string(),
+                    }
+                    .build()
+                })?;
             let mut should_add = true;
             for (existing, _) in ret.iter() {
                 vec_cache.ensure_key(&cand_key, orig_table, self)?;
@@ -225,10 +228,13 @@ impl SessionTx<'_> {
         if manifest.keep_pruned_connections {
             while !discarded.is_empty() && ret.len() < m {
                 let (nearest_triple, Reverse(OrderedFloat(nearest_dist))) =
-                    discarded.pop().ok_or_else(|| InvalidOperationSnafu {
-                        op: "hnsw_select_neighbors",
-                        reason: "discarded queue unexpectedly empty".to_string(),
-                    }.build())?;
+                    discarded.pop().ok_or_else(|| {
+                        InvalidOperationSnafu {
+                            op: "hnsw_select_neighbors",
+                            reason: "discarded queue unexpectedly empty".to_string(),
+                        }
+                        .build()
+                    })?;
                 ret.push(nearest_triple, Reverse(OrderedFloat(nearest_dist)));
             }
         }
@@ -297,11 +303,13 @@ impl SessionTx<'_> {
         }
 
         while let Some((candidate, Reverse(OrderedFloat(candidate_dist)))) = candidates.pop() {
-            let (_, OrderedFloat(furtherest_dist)) =
-                found_nn.peek().ok_or_else(|| InvalidOperationSnafu {
+            let (_, OrderedFloat(furtherest_dist)) = found_nn.peek().ok_or_else(|| {
+                InvalidOperationSnafu {
                     op: "hnsw_search_level",
                     reason: "found_nn empty during level search".to_string(),
-                }.build())?;
+                }
+                .build()
+            })?;
             let furtherest_dist = *furtherest_dist;
             if candidate_dist > furtherest_dist {
                 break;
@@ -314,11 +322,13 @@ impl SessionTx<'_> {
                 }
                 vec_cache.ensure_key(&neighbour_key, orig_table, self)?;
                 let neighbour_dist = vec_cache.v_dist(q, &neighbour_key)?;
-                let (_, OrderedFloat(cand_furtherest_dist)) =
-                    found_nn.peek().ok_or_else(|| InvalidOperationSnafu {
+                let (_, OrderedFloat(cand_furtherest_dist)) = found_nn.peek().ok_or_else(|| {
+                    InvalidOperationSnafu {
                         op: "hnsw_search_level",
                         reason: "found_nn empty during neighbor evaluation".to_string(),
-                    }.build())?;
+                    }
+                    .build()
+                })?;
                 if found_nn.len() < ef || neighbour_dist < *cand_furtherest_dist {
                     candidates.push(neighbour_key.clone(), Reverse(OrderedFloat(neighbour_dist)));
                     found_nn.push(neighbour_key.clone(), OrderedFloat(neighbour_dist));
@@ -366,18 +376,23 @@ impl SessionTx<'_> {
                 let tuple = res.ok()?;
 
                 #[expect(clippy::cast_sign_loss, reason = "HNSW indices are non-negative")]
-                #[expect(clippy::cast_possible_truncation, reason = "HNSW index fits in usize on all platforms")]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "HNSW index fits in usize on all platforms"
+                )]
                 // INVARIANT: HNSW index tuples store int values at these positions
                 let key_idx = tuple[2 * key_len + 3]
                     .get_int()
-                    .unwrap_or_else(|| unreachable!("HNSW neighbor index is not an integer")) as usize;
+                    .unwrap_or_else(|| unreachable!("HNSW neighbor index is not an integer"))
+                    as usize;
                 #[expect(
                     clippy::cast_possible_truncation,
                     reason = "HNSW subindex bounded by m_max (< i32::MAX)"
                 )]
                 let key_subidx = tuple[2 * key_len + 4]
                     .get_int()
-                    .unwrap_or_else(|| unreachable!("HNSW neighbor subindex is not an integer")) as i32;
+                    .unwrap_or_else(|| unreachable!("HNSW neighbor subindex is not an integer"))
+                    as i32;
                 let key_tup = tuple[key_len + 3..2 * key_len + 3].to_vec();
                 if key_tup == cand_key.0 {
                     None
@@ -385,9 +400,9 @@ impl SessionTx<'_> {
                     if include_deleted {
                         return Some((
                             (key_tup, key_idx, key_subidx),
-                            tuple[2 * key_len + 5]
-                                .get_float()
-                                .unwrap_or_else(|| unreachable!("HNSW neighbor distance is not a float")),
+                            tuple[2 * key_len + 5].get_float().unwrap_or_else(|| {
+                                unreachable!("HNSW neighbor distance is not a float")
+                            }),
                         ));
                     }
                     let is_deleted = tuple[2 * key_len + 7]
@@ -398,9 +413,9 @@ impl SessionTx<'_> {
                     } else {
                         Some((
                             (key_tup, key_idx, key_subidx),
-                            tuple[2 * key_len + 5]
-                                .get_float()
-                                .unwrap_or_else(|| unreachable!("HNSW neighbor distance is not a float")),
+                            tuple[2 * key_len + 5].get_float().unwrap_or_else(|| {
+                                unreachable!("HNSW neighbor distance is not a float")
+                            }),
                         ))
                     }
                 }

--- a/crates/krites/src/runtime/hnsw/mmap_storage.rs
+++ b/crates/krites/src/runtime/hnsw/mmap_storage.rs
@@ -476,24 +476,35 @@ mod tests {
 
     #[test]
     fn roundtrip_push_and_get() {
-        let dir = tempfile::tempdir().unwrap_or_else(|_| unreachable!("INVARIANT: temp dir creation should not fail in tests"));
+        let dir = tempfile::tempdir().unwrap_or_else(|_| {
+            unreachable!("INVARIANT: temp dir creation should not fail in tests")
+        });
         let path = dir.path().join("vectors.bin");
-        let mut storage = MmapVectorStorage::open(&path, 3).unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=3 should not fail"));
+        let mut storage = MmapVectorStorage::open(&path, 3)
+            .unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=3 should not fail"));
         assert!(storage.is_empty(), "new storage must be empty");
 
         let v1 = [1.0f32, 2.0, 3.0];
         let v2 = [4.0f32, 5.0, 6.0];
-        let idx1 = storage.push(&v1).unwrap_or_else(|_| unreachable!("INVARIANT: push with correct dimension should not fail"));
-        let idx2 = storage.push(&v2).unwrap_or_else(|_| unreachable!("INVARIANT: push with correct dimension should not fail"));
+        let idx1 = storage.push(&v1).unwrap_or_else(|_| {
+            unreachable!("INVARIANT: push with correct dimension should not fail")
+        });
+        let idx2 = storage.push(&v2).unwrap_or_else(|_| {
+            unreachable!("INVARIANT: push with correct dimension should not fail")
+        });
 
         assert_eq!(idx1, 0, "first vector index");
         assert_eq!(idx2, 1, "second vector index");
         assert_eq!(storage.len(), 2, "count after two pushes");
 
-        let got1 = storage.get(0).unwrap_or_else(|| unreachable!("INVARIANT: index 0 exists after push"));
+        let got1 = storage
+            .get(0)
+            .unwrap_or_else(|| unreachable!("INVARIANT: index 0 exists after push"));
         assert_eq!(got1, &v1, "vector 0 roundtrip");
 
-        let got2 = storage.get(1).unwrap_or_else(|| unreachable!("INVARIANT: index 1 exists after push"));
+        let got2 = storage
+            .get(1)
+            .unwrap_or_else(|| unreachable!("INVARIANT: index 1 exists after push"));
         assert_eq!(got2, &v2, "vector 1 roundtrip");
 
         assert!(storage.get(2).is_none(), "out-of-bounds returns None");
@@ -501,10 +512,15 @@ mod tests {
 
     #[test]
     fn access_hint_switching() {
-        let dir = tempfile::tempdir().unwrap_or_else(|_| unreachable!("INVARIANT: temp dir creation should not fail in tests"));
+        let dir = tempfile::tempdir().unwrap_or_else(|_| {
+            unreachable!("INVARIANT: temp dir creation should not fail in tests")
+        });
         let path = dir.path().join("vectors.bin");
-        let mut storage = MmapVectorStorage::open(&path, 2).unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=2 should not fail"));
-        storage.push(&[1.0, 2.0]).unwrap_or_else(|_| unreachable!("INVARIANT: push with correct dimension should not fail"));
+        let mut storage = MmapVectorStorage::open(&path, 2)
+            .unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=2 should not fail"));
+        storage.push(&[1.0, 2.0]).unwrap_or_else(|_| {
+            unreachable!("INVARIANT: push with correct dimension should not fail")
+        });
 
         assert_eq!(
             storage.access_hint(),
@@ -521,16 +537,21 @@ mod tests {
 
     #[test]
     fn dimension_mismatch_rejected() {
-        let dir = tempfile::tempdir().unwrap_or_else(|_| unreachable!("INVARIANT: temp dir creation should not fail in tests"));
+        let dir = tempfile::tempdir().unwrap_or_else(|_| {
+            unreachable!("INVARIANT: temp dir creation should not fail in tests")
+        });
         let path = dir.path().join("vectors.bin");
-        let mut storage = MmapVectorStorage::open(&path, 4).unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=4 should not fail"));
+        let mut storage = MmapVectorStorage::open(&path, 4)
+            .unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=4 should not fail"));
         let result = storage.push(&[1.0, 2.0]);
         assert!(result.is_err(), "wrong dimension should error");
     }
 
     #[test]
     fn zero_dimension_rejected() {
-        let dir = tempfile::tempdir().unwrap_or_else(|_| unreachable!("INVARIANT: temp dir creation should not fail in tests"));
+        let dir = tempfile::tempdir().unwrap_or_else(|_| {
+            unreachable!("INVARIANT: temp dir creation should not fail in tests")
+        });
         let path = dir.path().join("vectors.bin");
         let result = MmapVectorStorage::open(&path, 0);
         assert!(result.is_err(), "zero dimension should error");
@@ -538,27 +559,43 @@ mod tests {
 
     #[test]
     fn reopen_persists_data() {
-        let dir = tempfile::tempdir().unwrap_or_else(|_| unreachable!("INVARIANT: temp dir creation should not fail in tests"));
+        let dir = tempfile::tempdir().unwrap_or_else(|_| {
+            unreachable!("INVARIANT: temp dir creation should not fail in tests")
+        });
         let path = dir.path().join("vectors.bin");
 
         {
-            let mut storage = MmapVectorStorage::open(&path, 2).unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=2 should not fail"));
-            storage.push(&[1.0, 2.0]).unwrap_or_else(|_| unreachable!("INVARIANT: push with correct dimension should not fail"));
-            storage.push(&[3.0, 4.0]).unwrap_or_else(|_| unreachable!("INVARIANT: push with correct dimension should not fail"));
-            storage.flush().unwrap_or_else(|_| unreachable!("INVARIANT: flush should not fail on valid storage"));
+            let mut storage = MmapVectorStorage::open(&path, 2).unwrap_or_else(|_| {
+                unreachable!("INVARIANT: valid path and dim=2 should not fail")
+            });
+            storage.push(&[1.0, 2.0]).unwrap_or_else(|_| {
+                unreachable!("INVARIANT: push with correct dimension should not fail")
+            });
+            storage.push(&[3.0, 4.0]).unwrap_or_else(|_| {
+                unreachable!("INVARIANT: push with correct dimension should not fail")
+            });
+            storage.flush().unwrap_or_else(|_| {
+                unreachable!("INVARIANT: flush should not fail on valid storage")
+            });
         }
 
-        let storage = MmapVectorStorage::open(&path, 2).unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=2 should not fail"));
+        let storage = MmapVectorStorage::open(&path, 2)
+            .unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=2 should not fail"));
         assert_eq!(storage.len(), 2, "persisted count");
-        let got = storage.get(1).unwrap_or_else(|| unreachable!("INVARIANT: index 1 exists after push"));
+        let got = storage
+            .get(1)
+            .unwrap_or_else(|| unreachable!("INVARIANT: index 1 exists after push"));
         assert_eq!(got, &[3.0f32, 4.0], "persisted vector roundtrip");
     }
 
     #[test]
     fn mmap_fallback_for_empty_file() {
-        let dir = tempfile::tempdir().unwrap_or_else(|_| unreachable!("INVARIANT: temp dir creation should not fail in tests"));
+        let dir = tempfile::tempdir().unwrap_or_else(|_| {
+            unreachable!("INVARIANT: temp dir creation should not fail in tests")
+        });
         let path = dir.path().join("empty.bin");
-        let storage = MmapVectorStorage::open(&path, 4).unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=4 should not fail"));
+        let storage = MmapVectorStorage::open(&path, 4)
+            .unwrap_or_else(|_| unreachable!("INVARIANT: valid path and dim=4 should not fail"));
         assert!(storage.is_empty(), "empty file yields empty storage");
         assert!(storage.get(0).is_none(), "no vectors in empty storage");
     }
@@ -577,9 +614,13 @@ mod tests {
         const NUM_THREADS: usize = 16;
         const READS_PER_THREAD: usize = 1000;
 
-        let dir = tempfile::tempdir().unwrap_or_else(|_| unreachable!("INVARIANT: temp dir creation should not fail in tests"));
+        let dir = tempfile::tempdir().unwrap_or_else(|_| {
+            unreachable!("INVARIANT: temp dir creation should not fail in tests")
+        });
         let path = dir.path().join("stress.bin");
-        let mut storage = MmapVectorStorage::open(&path, DIM).unwrap_or_else(|_| unreachable!("INVARIANT: valid path and non-zero DIM should not fail"));
+        let mut storage = MmapVectorStorage::open(&path, DIM).unwrap_or_else(|_| {
+            unreachable!("INVARIANT: valid path and non-zero DIM should not fail")
+        });
 
         // Deterministic pattern: vector[i][j] = (i * DIM + j) as f32
         for i in 0..NUM_VECTORS {
@@ -588,7 +629,9 @@ mod tests {
                 reason = "test fixture uses small integers well within f32 mantissa range"
             )]
             let vec: Vec<f32> = (0..DIM).map(|j| (i * DIM + j) as f32).collect();
-            storage.push(&vec).unwrap_or_else(|_| unreachable!("INVARIANT: push with correct dimension should not fail"));
+            storage.push(&vec).unwrap_or_else(|_| {
+                unreachable!("INVARIANT: push with correct dimension should not fail")
+            });
         }
 
         let storage_ref = &storage;

--- a/crates/krites/src/runtime/hnsw/put.rs
+++ b/crates/krites/src/runtime/hnsw/put.rs
@@ -85,18 +85,24 @@ impl SessionTx<'_> {
             .next();
         if let Some(ep) = ep_res {
             let ep = ep?;
-            let bottom_level = ep[0].get_int().ok_or_else(|| InvalidOperationSnafu {
-                op: "hnsw_read",
-                reason: "entry point bottom_level is not an integer".to_string(),
-            }.build())?;
+            let bottom_level = ep[0].get_int().ok_or_else(|| {
+                InvalidOperationSnafu {
+                    op: "hnsw_read",
+                    reason: "entry point bottom_level is not an integer".to_string(),
+                }
+                .build()
+            })?;
             let ep_t_key = ep[1..orig_table.metadata.keys.len() + 1].to_vec();
             let ep_idx = usize::try_from(
                 ep[orig_table.metadata.keys.len() + 1]
                     .get_int()
-                    .ok_or_else(|| InvalidOperationSnafu {
-                        op: "hnsw_read",
-                        reason: "stored index is not an integer".to_string(),
-                    }.build())?,
+                    .ok_or_else(|| {
+                        InvalidOperationSnafu {
+                            op: "hnsw_read",
+                            reason: "stored index is not an integer".to_string(),
+                        }
+                        .build()
+                    })?,
             )
             .map_err(|_e| {
                 InvalidOperationSnafu {
@@ -108,10 +114,13 @@ impl SessionTx<'_> {
             let ep_subidx = i32::try_from(
                 ep[orig_table.metadata.keys.len() + 2]
                     .get_int()
-                    .ok_or_else(|| InvalidOperationSnafu {
-                        op: "hnsw_read",
-                        reason: "stored subindex is not an integer".to_string(),
-                    }.build())?,
+                    .ok_or_else(|| {
+                        InvalidOperationSnafu {
+                            op: "hnsw_read",
+                            reason: "stored subindex is not an integer".to_string(),
+                        }
+                        .build()
+                    })?,
             )
             .map_err(|_e| {
                 InvalidOperationSnafu {
@@ -276,13 +285,13 @@ impl SessionTx<'_> {
                         clippy::cast_sign_loss,
                         reason = "degree is a small non-negative integer stored as f64"
                     )]
-                    let mut target_degree = target_self_val[0]
-                        .get_float()
-                        .ok_or_else(|| InvalidOperationSnafu {
+                    let mut target_degree = target_self_val[0].get_float().ok_or_else(|| {
+                        InvalidOperationSnafu {
                             op: "hnsw_index",
                             reason: "degree is not a float".to_string(),
-                        }.build())?
-                        as usize
+                        }
+                        .build()
+                    })? as usize
                         + 1;
                     if target_degree > m_max {
                         target_degree = self.hnsw_shrink_neighbour(
@@ -348,10 +357,21 @@ impl SessionTx<'_> {
         let mut canary_key = vec![DataValue::from(1)];
         for _ in 0..2 {
             for i in 0..orig_table.metadata.keys.len() {
-                target_key.push(tuple.get(i).ok_or_else(|| InvalidOperationSnafu {
-                    op: "hnsw_put",
-                    reason: format!("tuple index {i} out of bounds (len {})", tuple.len()),
-                }.build())?.clone());
+                target_key.push(
+                    tuple
+                        .get(i)
+                        .ok_or_else(|| {
+                            InvalidOperationSnafu {
+                                op: "hnsw_put",
+                                reason: format!(
+                                    "tuple index {i} out of bounds (len {})",
+                                    tuple.len()
+                                ),
+                            }
+                            .build()
+                        })?
+                        .clone(),
+                );
                 canary_key.push(DataValue::Null);
             }
             target_key.push(DataValue::from(idx_to_i64(idx)));
@@ -454,10 +474,17 @@ impl SessionTx<'_> {
 
         let mut extracted_vectors = vec![];
         for idx in &manifest.vec_fields {
-            let val = tuple.get(*idx).ok_or_else(|| InvalidOperationSnafu {
-                op: "hnsw_put",
-                reason: format!("vector field index {} out of bounds (tuple len {})", idx, tuple.len()),
-            }.build())?;
+            let val = tuple.get(*idx).ok_or_else(|| {
+                InvalidOperationSnafu {
+                    op: "hnsw_put",
+                    reason: format!(
+                        "vector field index {} out of bounds (tuple len {})",
+                        idx,
+                        tuple.len()
+                    ),
+                }
+                .build()
+            })?;
             if let DataValue::Vec(v) = val {
                 extracted_vectors.push((v, *idx, -1));
             } else if let DataValue::List(l) = val {
@@ -595,7 +622,10 @@ mod tests {
     // Insert `n` vectors into the index. Vector for id `i` is [i,i,i,i].
     fn insert_vectors(db: &DbInstance, n: usize) {
         for i in 0..n {
-            #[expect(clippy::cast_precision_loss, reason = "test fixture with small integers")]
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "test fixture with small integers"
+            )]
             let val = i as f32;
             db.run_default(&format!(
                 "?[id, vec] <- [[{i}, vec([{val}, {val}, {val}, {val}])]] :put vectors {{}}"
@@ -622,7 +652,11 @@ mod tests {
         let db = setup_db();
         insert_vectors(&db, 10);
         let res = db.run_default("?[id] := *vectors{id}").unwrap();
-        assert_eq!(res.rows.len(), 10, "all 10 inserted vectors should be stored");
+        assert_eq!(
+            res.rows.len(),
+            10,
+            "all 10 inserted vectors should be stored"
+        );
     }
 
     #[test]
@@ -633,7 +667,11 @@ mod tests {
         db.run_default("?[id, vec] <- [[1, vec([1.0, 1.0, 1.0, 1.0])]] :put vectors {}")
             .unwrap();
         let res = db.run_default("?[id] := *vectors{id}").unwrap();
-        assert_eq!(res.rows.len(), 1, "duplicate insert must not create extra rows");
+        assert_eq!(
+            res.rows.len(),
+            1,
+            "duplicate insert must not create extra rows"
+        );
     }
 
     #[test]
@@ -651,7 +689,10 @@ mod tests {
         assert_eq!(res.rows.len(), 1);
         assert_eq!(res.rows[0][0].get_int().unwrap(), 7);
         let dist = res.rows[0][1].get_float().unwrap();
-        assert!(dist < 1e-6, "updated vector should be at distance ~0 from query");
+        assert!(
+            dist < 1e-6,
+            "updated vector should be at distance ~0 from query"
+        );
     }
 
     #[test]
@@ -669,7 +710,10 @@ mod tests {
     fn search_level_returns_nearest_first() {
         let db = setup_db();
         for i in 0..50 {
-            #[expect(clippy::cast_precision_loss, reason = "test fixture with small integers")]
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "test fixture with small integers"
+            )]
             let val = i as f32;
             db.run_default(&format!(
                 "?[id, vec] <- [[{i}, vec([{val}, 0.0, 0.0, 0.0])]] :put vectors {{}}"
@@ -683,7 +727,10 @@ mod tests {
             .unwrap();
         assert!(!res.rows.is_empty(), "search should return results");
         let first_id = res.rows[0][0].get_int().unwrap();
-        assert_eq!(first_id, 25, "nearest neighbor (id=25) must be returned first");
+        assert_eq!(
+            first_id, 25,
+            "nearest neighbor (id=25) must be returned first"
+        );
     }
 
     #[test]
@@ -695,7 +742,10 @@ mod tests {
                 r#"?[id, dist] := ~vectors:idx{id | query: vec([15.0, 15.0, 15.0, 15.0]), k: 10, ef: 50, bind_distance: dist} :order dist"#,
             )
             .unwrap();
-        assert!(!res.rows.is_empty(), "search must return results after 30 inserts");
+        assert!(
+            !res.rows.is_empty(),
+            "search must return results after 30 inserts"
+        );
         let distances: Vec<f64> = res.rows.iter().filter_map(|r| r[1].get_float()).collect();
         for window in distances.windows(2) {
             assert!(
@@ -760,10 +810,11 @@ mod tests {
         insert_vectors(&db, 10);
         db.run_default("?[id] <- [[5]] :rm vectors {}").unwrap();
 
-        let base = db
-            .run_default("?[id] := *vectors{id}, id = 5")
-            .unwrap();
-        assert!(base.rows.is_empty(), "deleted vector must be absent from base relation");
+        let base = db.run_default("?[id] := *vectors{id}, id = 5").unwrap();
+        assert!(
+            base.rows.is_empty(),
+            "deleted vector must be absent from base relation"
+        );
 
         let search = db
             .run_default(

--- a/crates/krites/src/runtime/hnsw/remove.rs
+++ b/crates/krites/src/runtime/hnsw/remove.rs
@@ -31,18 +31,23 @@ impl SessionTx<'_> {
             .filter_map(|t| match t {
                 Ok(t) => {
                     #[expect(clippy::cast_sign_loss, reason = "HNSW indices are non-negative")]
-                    #[expect(clippy::cast_possible_truncation, reason = "HNSW index fits in usize on all platforms")]
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "HNSW index fits in usize on all platforms"
+                    )]
                     // INVARIANT: HNSW index tuples store int values at index positions
                     let idx = t[orig_table.metadata.keys.len() + 1]
                         .get_int()
-                        .unwrap_or_else(|| unreachable!("HNSW index value is not an integer")) as usize;
+                        .unwrap_or_else(|| unreachable!("HNSW index value is not an integer"))
+                        as usize;
                     #[expect(
                         clippy::cast_possible_truncation,
                         reason = "HNSW subindex bounded by m_max (< i32::MAX)"
                     )]
                     let subidx = t[orig_table.metadata.keys.len() + 2]
                         .get_int()
-                        .unwrap_or_else(|| unreachable!("HNSW subindex value is not an integer")) as i32;
+                        .unwrap_or_else(|| unreachable!("HNSW subindex value is not an integer"))
+                        as i32;
                     Some((
                         t[1..orig_table.metadata.keys.len() + 1].to_vec(),
                         idx,
@@ -140,13 +145,13 @@ impl SessionTx<'_> {
                     .build(),
                 })?;
                 neighbour_val[0] = DataValue::from(
-                    neighbour_val[0]
-                        .get_float()
-                        .ok_or_else(|| InvalidOperationSnafu {
+                    neighbour_val[0].get_float().ok_or_else(|| {
+                        InvalidOperationSnafu {
                             op: "hnsw_remove",
                             reason: "neighbor degree is not a float".to_string(),
-                        }.build())?
-                        - 1.,
+                        }
+                        .build()
+                    })? - 1.,
                 );
                 self.store_tx.put(
                     &idx_table.encode_key_for_store(&neighbour_self_key, Default::default())?,
@@ -178,10 +183,13 @@ impl SessionTx<'_> {
                 let ep = ep?;
                 let target_key_bytes = idx_table.encode_key_for_store(&ep, Default::default())?;
                 // SAFETY: `ep` comes from HNSW index scan which yields tuples with at least 1 element.
-                let bottom_level = ep[0].get_int().ok_or_else(|| InvalidOperationSnafu {
-                    op: "hnsw_remove",
-                    reason: "entry point bottom_level is not an integer".to_string(),
-                }.build())?;
+                let bottom_level = ep[0].get_int().ok_or_else(|| {
+                    InvalidOperationSnafu {
+                        op: "hnsw_remove",
+                        reason: "entry point bottom_level is not an integer".to_string(),
+                    }
+                    .build()
+                })?;
                 // WHY: canary value is for conflict detection: prevent the scenario of disconnected graphs at all levels
                 let canary_value = [
                     DataValue::from(bottom_level),

--- a/crates/krites/src/runtime/hnsw/search.rs
+++ b/crates/krites/src/runtime/hnsw/search.rs
@@ -68,10 +68,13 @@ impl SessionTx<'_> {
         if let Some(ep) = ep_res {
             let ep = ep?;
             // SAFETY: `ep` comes from HNSW index scan which yields tuples with at least 1 element.
-            let bottom_level = ep[0].get_int().ok_or_else(|| InvalidOperationSnafu {
-                op: "hnsw_search",
-                reason: "entry point bottom_level is not an integer".to_string(),
-            }.build())?;
+            let bottom_level = ep[0].get_int().ok_or_else(|| {
+                InvalidOperationSnafu {
+                    op: "hnsw_search",
+                    reason: "entry point bottom_level is not an integer".to_string(),
+                }
+                .build()
+            })?;
             let ep_idx = match ep[config.base_handle.metadata.keys.len() + 1].get_int() {
                 Some(x) => usize::try_from(x).map_err(|_e| {
                     InvalidOperationSnafu {
@@ -88,10 +91,13 @@ impl SessionTx<'_> {
             let ep_subidx = i32::try_from(
                 ep[config.base_handle.metadata.keys.len() + 2]
                     .get_int()
-                    .ok_or_else(|| InvalidOperationSnafu {
-                        op: "hnsw_search",
-                        reason: "stored subindex is not an integer".to_string(),
-                    }.build())?,
+                    .ok_or_else(|| {
+                        InvalidOperationSnafu {
+                            op: "hnsw_search",
+                            reason: "stored subindex is not an integer".to_string(),
+                        }
+                        .build()
+                    })?,
             )
             .map_err(|_e| {
                 InvalidOperationSnafu {

--- a/crates/krites/src/runtime/hnsw/types.rs
+++ b/crates/krites/src/runtime/hnsw/types.rs
@@ -68,7 +68,10 @@ impl VectorCache {
     pub(crate) fn new(distance: HnswDistance, capacity: usize) -> Self {
         Self {
             // INVARIANT: capacity is validated as positive at config time
-            cache: LruCache::new(NonZeroUsize::new(capacity).unwrap_or_else(|| unreachable!("vector cache capacity must be non-zero"))),
+            cache: LruCache::new(
+                NonZeroUsize::new(capacity)
+                    .unwrap_or_else(|| unreachable!("vector cache capacity must be non-zero")),
+            ),
             distance,
         }
     }
@@ -93,7 +96,10 @@ impl VectorCache {
                     }))
                 }
                 _ => {
-                    #[expect(clippy::needless_return, reason = "explicit return for early exit in match arm")]
+                    #[expect(
+                        clippy::needless_return,
+                        reason = "explicit return for early exit in match arm"
+                    )]
                     return Err(InvalidOperationSnafu {
                         op: "hnsw_l2",
                         reason: format!("Cannot compute L2 distance between {:?} and {:?}", v1, v2),
@@ -120,7 +126,10 @@ impl VectorCache {
                     Ok(1.0 - dot / (a_norm * b_norm).sqrt())
                 }
                 _ => {
-                    #[expect(clippy::needless_return, reason = "explicit return for early exit in match arm")]
+                    #[expect(
+                        clippy::needless_return,
+                        reason = "explicit return for early exit in match arm"
+                    )]
                     return Err(InvalidOperationSnafu {
                         op: "hnsw_cosine",
                         reason: format!(
@@ -142,7 +151,10 @@ impl VectorCache {
                     Ok(1. - dot)
                 }
                 _ => {
-                    #[expect(clippy::needless_return, reason = "explicit return for early exit in match arm")]
+                    #[expect(
+                        clippy::needless_return,
+                        reason = "explicit return for early exit in match arm"
+                    )]
                     return Err(InvalidOperationSnafu {
                         op: "hnsw_ip",
                         reason: format!(
@@ -162,10 +174,13 @@ impl VectorCache {
     // many keys were ensured between the ensure and the access: callers that
     // need multiple keys should ensure them close to their use site).
     pub(crate) fn v_dist(&self, v: &Vector, key: &CompoundKey) -> Result<f64> {
-        let v2 = self.cache.peek(key).ok_or_else(|| InvalidOperationSnafu {
-            op: "hnsw_cache",
-            reason: "vector not found in cache after ensure_key".to_string(),
-        }.build())?;
+        let v2 = self.cache.peek(key).ok_or_else(|| {
+            InvalidOperationSnafu {
+                op: "hnsw_cache",
+                reason: "vector not found in cache after ensure_key".to_string(),
+            }
+            .build()
+        })?;
         self.dist(v, v2)
     }
     pub(crate) fn k_dist(&self, k1: &CompoundKey, k2: &CompoundKey) -> Result<f64> {
@@ -173,20 +188,28 @@ impl VectorCache {
         let v1 = self
             .cache
             .peek(k1)
-            .ok_or_else(|| InvalidOperationSnafu {
-                op: "hnsw_cache",
-                reason: "vector k1 not found in cache after ensure_key".to_string(),
-            }.build())?
+            .ok_or_else(|| {
+                InvalidOperationSnafu {
+                    op: "hnsw_cache",
+                    reason: "vector k1 not found in cache after ensure_key".to_string(),
+                }
+                .build()
+            })?
             .clone();
-        let v2 = self.cache.peek(k2).ok_or_else(|| InvalidOperationSnafu {
-            op: "hnsw_cache",
-            reason: "vector k2 not found in cache after ensure_key".to_string(),
-        }.build())?;
+        let v2 = self.cache.peek(k2).ok_or_else(|| {
+            InvalidOperationSnafu {
+                op: "hnsw_cache",
+                reason: "vector k2 not found in cache after ensure_key".to_string(),
+            }
+            .build()
+        })?;
         self.dist(&v1, v2)
     }
     pub(crate) fn get_key(&self, key: &CompoundKey) -> &Vector {
         // INVARIANT: callers must call ensure_key() before get_key
-        self.cache.peek(key).unwrap_or_else(|| unreachable!("vector not found in cache; ensure_key was not called"))
+        self.cache
+            .peek(key)
+            .unwrap_or_else(|| unreachable!("vector not found in cache; ensure_key was not called"))
     }
     pub(crate) fn ensure_key(
         &mut self,

--- a/crates/krites/src/runtime/imperative.rs
+++ b/crates/krites/src/runtime/imperative.rs
@@ -147,15 +147,15 @@ impl<'s, S: Storage<'s>> Db<S> {
             nr.next = current;
             current = Some(Box::new(nr))
         }
-        Ok(ControlCode::Termination(
-            *current.ok_or_else(|| crate::error::InternalError::Runtime {
+        Ok(ControlCode::Termination(*current.ok_or_else(|| {
+            crate::error::InternalError::Runtime {
                 source: crate::runtime::error::InvalidOperationSnafu {
                     op: "collect_return_rows",
                     reason: "non-empty returns produced no result".to_string(),
                 }
                 .build(),
-            })?,
-        ))
+            }
+        })?))
     }
 
     fn execute_ignore_error_program(

--- a/crates/krites/src/runtime/relation/handles.rs
+++ b/crates/krites/src/runtime/relation/handles.rs
@@ -181,7 +181,11 @@ impl RelationHandle {
             return None;
         }
         // INVARIANT: choose_index is only called when arg_uses is non-empty
-        if *arg_uses.first().unwrap_or_else(|| unreachable!("arg_uses must be non-empty")) == IndexPositionUse::Join {
+        if *arg_uses
+            .first()
+            .unwrap_or_else(|| unreachable!("arg_uses must be non-empty"))
+            == IndexPositionUse::Join
+        {
             return None;
         }
         let mut max_prefix_len = 0;
@@ -544,8 +548,8 @@ pub fn decode_tuple_from_kv(key: &[u8], val: &[u8], size_hint: Option<usize>) ->
 pub fn extend_tuple_from_v(key: &mut Tuple, val: &[u8]) {
     if !val.is_empty() {
         // INVARIANT: storage layer writes well-formed msgpack tuples; deserialization only fails on data corruption
-        let vals: Vec<DataValue> =
-            rmp_serde::from_slice(&val[ENCODED_KEY_MIN_LEN..]).unwrap_or_else(|_| unreachable!("corrupt msgpack in stored tuple value"));
+        let vals: Vec<DataValue> = rmp_serde::from_slice(&val[ENCODED_KEY_MIN_LEN..])
+            .unwrap_or_else(|_| unreachable!("corrupt msgpack in stored tuple value"));
         key.extend(vals);
     }
 }

--- a/crates/krites/src/runtime/sys.rs
+++ b/crates/krites/src/runtime/sys.rs
@@ -45,10 +45,13 @@ impl<'s, S: Storage<'s>> Db<S> {
             let lock = self
                 .obtain_relation_locks(iter::once(relation_name))
                 .pop()
-                .ok_or_else(|| crate::runtime::error::InvalidOperationSnafu {
-                    op: "sys_op",
-                    reason: "failed to obtain relation lock".to_string(),
-                }.build())?;
+                .ok_or_else(|| {
+                    crate::runtime::error::InvalidOperationSnafu {
+                        op: "sys_op",
+                        reason: "failed to obtain relation lock".to_string(),
+                    }
+                    .build()
+                })?;
             let _guard = lock.write().unwrap_or_else(|e| e.into_inner());
             body()
         }
@@ -184,10 +187,13 @@ impl<'s, S: Storage<'s>> Db<S> {
                     let lock = self
                         .obtain_relation_locks(iter::once(&rel_name.name))
                         .pop()
-                        .ok_or_else(|| crate::runtime::error::InvalidOperationSnafu {
-                            op: "sys_op",
-                            reason: "failed to obtain relation lock".to_string(),
-                        }.build())?;
+                        .ok_or_else(|| {
+                            crate::runtime::error::InvalidOperationSnafu {
+                                op: "sys_op",
+                                reason: "failed to obtain relation lock".to_string(),
+                            }
+                            .build()
+                        })?;
                     let _guard = lock.read().unwrap_or_else(|e| e.into_inner());
                     tx.remove_index(rel_name, idx_name)?
                 };

--- a/crates/krites/src/runtime/temp_store.rs
+++ b/crates/krites/src/runtime/temp_store.rs
@@ -133,7 +133,8 @@ impl MeetAggrStore {
                             source: crate::runtime::error::InvalidOperationSnafu {
                                 op: "meet_put",
                                 reason: "aggregation missing meet_op".to_string(),
-                            }.build(),
+                            }
+                            .build(),
                         }
                     })?;
                     changed |= op.update(&mut prev_aggr[i], &val_part[i])?;
@@ -174,8 +175,9 @@ impl MeetAggrStore {
                     match ret
                         .partial_cmp(&upper as &[DataValue])
                         // INVARIANT: well-formed tuples always have comparable DataValue types
-                        .unwrap_or_else(|| unreachable!("incomparable DataValue types in tuple range scan"))
-                    {
+                        .unwrap_or_else(|| {
+                            unreachable!("incomparable DataValue types in tuple range scan")
+                        }) {
                         Ordering::Less => Some(ret),
                         Ordering::Equal => {
                             if upper_inclusive {
@@ -216,7 +218,8 @@ impl MeetAggrStore {
                                     source: crate::runtime::error::InvalidOperationSnafu {
                                         op: "merge_in",
                                         reason: "aggregation missing meet_op".to_string(),
-                                    }.build(),
+                                    }
+                                    .build(),
                                 }
                             })?;
                             changed |= op.update(&mut target[i], &v[i])?;
@@ -305,7 +308,8 @@ impl EpochStore {
                     source: crate::runtime::error::InvalidOperationSnafu {
                         op: "epoch_merge",
                         reason: "mismatched TempStore variants".to_string(),
-                    }.build(),
+                    }
+                    .build(),
                 });
             }
         }

--- a/crates/krites/src/storage/fjall_backend.rs
+++ b/crates/krites/src/storage/fjall_backend.rs
@@ -190,7 +190,9 @@ unsafe impl Sync for FjallWriteTx<'_> {}
 
 impl FjallWriteTx<'_> {
     fn tx_ref(&self) -> &fjall::SingleWriterWriteTx<'_> {
-        self.tx.as_ref().unwrap_or_else(|| unreachable!("INVARIANT: tx is always Some while FjallWriteTx is live"))
+        self.tx.as_ref().unwrap_or_else(|| {
+            unreachable!("INVARIANT: tx is always Some while FjallWriteTx is live")
+        })
     }
 }
 
@@ -534,7 +536,9 @@ mod tests {
     use crate::runtime::db::ScriptMutability;
 
     fn setup_test_db() -> InternalResult<(TempDir, DbCore<FjallStorage>)> {
-        let temp_dir = TempDir::new().unwrap_or_else(|_| unreachable!("INVARIANT: temp dir creation should not fail in tests"));
+        let temp_dir = TempDir::new().unwrap_or_else(|_| {
+            unreachable!("INVARIANT: temp dir creation should not fail in tests")
+        });
         let db = new_krites_fjall(temp_dir.path())?;
         db.run_script(
             r#"
@@ -649,7 +653,9 @@ mod tests {
 
     #[test]
     fn persistence_across_restarts() -> InternalResult<()> {
-        let dir = TempDir::new().unwrap_or_else(|_| unreachable!("INVARIANT: temp dir creation should not fail in tests"));
+        let dir = TempDir::new().unwrap_or_else(|_| {
+            unreachable!("INVARIANT: temp dir creation should not fail in tests")
+        });
 
         {
             let db = new_krites_fjall(dir.path())?;
@@ -766,7 +772,8 @@ mod tests {
         );
         db.import_relations(to_import)?;
 
-        let expected_rows = usize::try_from(NUM_ROWS).unwrap_or_else(|_| unreachable!("INVARIANT: NUM_ROWS fits in usize"));
+        let expected_rows = usize::try_from(NUM_ROWS)
+            .unwrap_or_else(|_| unreachable!("INVARIANT: NUM_ROWS fits in usize"));
         std::thread::scope(|s| {
             for _ in 0..NUM_THREADS {
                 let db = db.clone();
@@ -778,7 +785,9 @@ mod tests {
                                 Default::default(),
                                 ScriptMutability::Immutable,
                             )
-                            .unwrap_or_else(|_| unreachable!("INVARIANT: concurrent read query should not fail"));
+                            .unwrap_or_else(|_| {
+                                unreachable!("INVARIANT: concurrent read query should not fail")
+                            });
                         assert_eq!(
                             result.rows.len(),
                             expected_rows,
@@ -835,7 +844,9 @@ mod tests {
                                 Default::default(),
                                 ScriptMutability::Immutable,
                             )
-                            .unwrap_or_else(|_| unreachable!("INVARIANT: concurrent read query should not fail"));
+                            .unwrap_or_else(|_| {
+                                unreachable!("INVARIANT: concurrent read query should not fail")
+                            });
                         // Every row must have exactly 2 columns matching the
                         // relation schema. A torn read would surface here.
                         for row in &result.rows {
@@ -856,7 +867,9 @@ mod tests {
                             Default::default(),
                             ScriptMutability::Mutable,
                         )
-                        .unwrap_or_else(|_| unreachable!("INVARIANT: sequential write should not fail"));
+                        .unwrap_or_else(|_| {
+                            unreachable!("INVARIANT: sequential write should not fail")
+                        });
                 }
                 done_writer.store(true, std::sync::atomic::Ordering::Relaxed);
             });
@@ -868,7 +881,8 @@ mod tests {
             Default::default(),
             ScriptMutability::Immutable,
         )?;
-        let expected_total = usize::try_from(NUM_WRITES).unwrap_or_else(|_| unreachable!("INVARIANT: NUM_WRITES fits in usize"));
+        let expected_total = usize::try_from(NUM_WRITES)
+            .unwrap_or_else(|_| unreachable!("INVARIANT: NUM_WRITES fits in usize"));
         assert_eq!(result.rows.len(), expected_total, "all writes persisted");
 
         Ok(())

--- a/crates/krites/tests/integration.rs
+++ b/crates/krites/tests/integration.rs
@@ -13,10 +13,7 @@
 //! - Parameterized queries
 #![expect(clippy::expect_used, reason = "test assertions")]
 #![expect(clippy::unwrap_used, reason = "test assertions")]
-#![expect(
-    clippy::indexing_slicing,
-    reason = "test data with known structure"
-)]
+#![expect(clippy::indexing_slicing, reason = "test data with known structure")]
 
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
@@ -128,10 +125,7 @@ fn relation_create_insert_query_pipeline() {
     .expect("updating Bob should succeed");
 
     let result = db
-        .run_read_only(
-            "?[dept] := *employees{id: 2, dept}",
-            BTreeMap::new(),
-        )
+        .run_read_only("?[dept] := *employees{id: 2, dept}", BTreeMap::new())
         .expect("querying updated Bob should succeed");
     assert_eq!(result.rows[0][0], DataValue::from("Engineering"));
 
@@ -538,10 +532,7 @@ fn export_import_preserves_data() {
         .expect("import should succeed");
 
     let result = db2
-        .run_read_only(
-            "?[key, val] := *data{key, val} :order key",
-            BTreeMap::new(),
-        )
+        .run_read_only("?[key, val] := *data{key, val} :order key", BTreeMap::new())
         .expect("querying imported data should succeed");
     assert_eq!(result.rows.len(), 3);
     assert_eq!(result.rows[0][0], DataValue::from("a"));
@@ -653,16 +644,16 @@ fn cache_with_mutations_tracks_separately() {
         .with_cache(NonZeroUsize::new(16).unwrap());
 
     // Run same query in different mutability modes
-    let _ = db.run("?[x] := x = 1", BTreeMap::new(), ScriptMutability::Immutable);
+    let _ = db.run(
+        "?[x] := x = 1",
+        BTreeMap::new(),
+        ScriptMutability::Immutable,
+    );
     let _ = db.run("?[x] := x = 1", BTreeMap::new(), ScriptMutability::Mutable);
 
     let stats = db.cache_stats().unwrap();
     // The cache tracks by normalized query string, not by mutability
-    assert_eq!(
-        stats.hits + stats.misses,
-        2,
-        "both runs should be tracked"
-    );
+    assert_eq!(stats.hits + stats.misses, 2, "both runs should be tracked");
 }
 
 // ── Callback notifications ──────────────────────────────────────────────────
@@ -743,7 +734,10 @@ fn named_rows_headers_match_query_columns() {
     let db = Db::open_mem().expect("in-memory db creation should succeed");
 
     let result = db
-        .run_read_only("?[alpha, beta, gamma] := alpha = 1, beta = 2, gamma = 3", BTreeMap::new())
+        .run_read_only(
+            "?[alpha, beta, gamma] := alpha = 1, beta = 2, gamma = 3",
+            BTreeMap::new(),
+        )
         .expect("named column query should succeed");
 
     assert_eq!(result.headers, vec!["alpha", "beta", "gamma"]);
@@ -781,7 +775,10 @@ fn vector_l2_distance_self_is_zero() {
         .expect("L2 self-distance query should succeed");
 
     let dist = result.rows[0][0].get_float().unwrap();
-    assert!(dist.abs() < 1e-9, "L2 distance to self should be 0, got {dist}");
+    assert!(
+        dist.abs() < 1e-9,
+        "L2 distance to self should be 0, got {dist}"
+    );
 }
 
 #[test]
@@ -835,11 +832,7 @@ fn list_relations_includes_created_relation() {
         .run_read_only("::relations", BTreeMap::new())
         .expect("listing relations should succeed");
 
-    let relation_names: Vec<&str> = result
-        .rows
-        .iter()
-        .filter_map(|r| r[0].get_str())
-        .collect();
+    let relation_names: Vec<&str> = result.rows.iter().filter_map(|r| r[0].get_str()).collect();
 
     assert!(
         relation_names.contains(&"my_relation"),

--- a/crates/krites/tests/public_api.rs
+++ b/crates/krites/tests/public_api.rs
@@ -189,10 +189,7 @@ fn datalog_query_execution() {
 
     // Test aggregation
     let result = db
-        .run_read_only(
-            "?[count(from)] := *edge{from, to}",
-            BTreeMap::new(),
-        )
+        .run_read_only("?[count(from)] := *edge{from, to}", BTreeMap::new())
         .expect("aggregation query should succeed");
     assert_eq!(result.rows[0][0], DataValue::from(4i64));
 
@@ -200,10 +197,7 @@ fn datalog_query_execution() {
     let mut params = BTreeMap::new();
     params.insert("start".to_string(), DataValue::from(1i64));
     let result = db
-        .run_read_only(
-            "?[to] := *edge{from: $start, to}",
-            params,
-        )
+        .run_read_only("?[to] := *edge{from: $start, to}", params)
         .expect("parameterized query should succeed");
     assert_eq!(result.rows.len(), 2); // 1->2 and 1->3
 }
@@ -311,15 +305,18 @@ fn hnsw_vector_search_lifecycle() {
     let vec3: Vec<f32> = (0..128).map(|i| (i + 100) as f32).collect();
 
     let mut params = BTreeMap::new();
-    params.insert("v1".to_string(), DataValue::Vec(krites::Vector::F32(
-        ndarray::Array1::from(vec1.clone()),
-    )));
-    params.insert("v2".to_string(), DataValue::Vec(krites::Vector::F32(
-        ndarray::Array1::from(vec2),
-    )));
-    params.insert("v3".to_string(), DataValue::Vec(krites::Vector::F32(
-        ndarray::Array1::from(vec3.clone()),
-    )));
+    params.insert(
+        "v1".to_string(),
+        DataValue::Vec(krites::Vector::F32(ndarray::Array1::from(vec1.clone()))),
+    );
+    params.insert(
+        "v2".to_string(),
+        DataValue::Vec(krites::Vector::F32(ndarray::Array1::from(vec2))),
+    );
+    params.insert(
+        "v3".to_string(),
+        DataValue::Vec(krites::Vector::F32(ndarray::Array1::from(vec3.clone()))),
+    );
 
     db.run(
         r#"?[id, vec] <- [["a", $v1], ["b", $v2], ["c", $v3]] :put embeddings {id => vec}"#,
@@ -345,9 +342,10 @@ fn hnsw_vector_search_lifecycle() {
     // Perform KNN search using the index
     let query_vec: Vec<f32> = (0..128).map(|i| i as f32 + 0.5).collect();
     let mut params = BTreeMap::new();
-    params.insert("q".to_string(), DataValue::Vec(krites::Vector::F32(
-        ndarray::Array1::from(query_vec),
-    )));
+    params.insert(
+        "q".to_string(),
+        DataValue::Vec(krites::Vector::F32(ndarray::Array1::from(query_vec))),
+    );
 
     let result = db
         .run(
@@ -395,7 +393,10 @@ fn vector_operations_in_memory() {
 
     // Query vectors back
     let result = db
-        .run_read_only("?[id, embedding] := *vectors{id, embedding}", BTreeMap::new())
+        .run_read_only(
+            "?[id, embedding] := *vectors{id, embedding}",
+            BTreeMap::new(),
+        )
         .expect("querying vectors should succeed");
     assert_eq!(result.rows.len(), 3);
 
@@ -457,7 +458,11 @@ fn fts_index_lifecycle() {
             BTreeMap::new(),
         )
         .expect("FTS search should succeed");
-    assert_eq!(result.rows.len(), 2, "should find documents containing 'quick'");
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "should find documents containing 'quick'"
+    );
 
     // Search for "fox" - FTS requires k parameter in the search options
     let result = db
@@ -466,7 +471,11 @@ fn fts_index_lifecycle() {
             BTreeMap::new(),
         )
         .expect("FTS search for 'fox' should succeed");
-    assert_eq!(result.rows.len(), 2, "should find documents containing 'fox'");
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "should find documents containing 'fox'"
+    );
 
     // Add more documents after index creation (should be auto-indexed)
     db.run(
@@ -483,7 +492,11 @@ fn fts_index_lifecycle() {
             BTreeMap::new(),
         )
         .expect("FTS search for 'red' should succeed");
-    assert_eq!(result.rows.len(), 1, "should find document containing 'red'");
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "should find document containing 'red'"
+    );
 
     // Drop the FTS index
     db.run(
@@ -684,10 +697,7 @@ fn malformed_query_errors() {
     )
     .expect("creating relation should succeed");
     let result = db.run_read_only(r#"?[n] := *typed{n: "string"}"#, BTreeMap::new());
-    assert!(
-        result.is_err(),
-        "type mismatch in query should error"
-    );
+    assert!(result.is_err(), "type mismatch in query should error");
 }
 
 /// Test error on invalid relation operations.
@@ -717,7 +727,10 @@ fn invalid_relation_operations() {
         BTreeMap::new(),
         ScriptMutability::Mutable,
     );
-    assert!(result.is_err(), "dropping non-existent relation should fail");
+    assert!(
+        result.is_err(),
+        "dropping non-existent relation should fail"
+    );
 }
 
 // ============================================================================
@@ -803,5 +816,3 @@ fn data_value_types() {
     assert_eq!(result.rows[0][1], DataValue::from(true));
     assert!(result.rows[0][2].get_float().unwrap() - 3.14 < 0.001);
 }
-
-

--- a/crates/melete/src/distill.rs
+++ b/crates/melete/src/distill.rs
@@ -446,7 +446,8 @@ impl DistillEngine {
                 r
             }
             Ok(Err(e)) => {
-                self.lock_retry_state().record_failure(self.config.max_backoff_turns);
+                self.lock_retry_state()
+                    .record_failure(self.config.max_backoff_turns);
                 record_outcome(nous_id, &distill_start, false, 0, 0);
                 return Err(e).context(LlmCallSnafu);
             }
@@ -459,7 +460,8 @@ impl DistillEngine {
                     "unknown panic".to_owned()
                 };
                 tracing::error!(nous_id, panic_message = %msg, "LLM provider panicked during distillation");
-                self.lock_retry_state().record_failure(self.config.max_backoff_turns);
+                self.lock_retry_state()
+                    .record_failure(self.config.max_backoff_turns);
                 record_outcome(nous_id, &distill_start, false, 0, 0);
                 return LlmPanicSnafu { message: msg }.fail();
             }
@@ -467,7 +469,8 @@ impl DistillEngine {
 
         let summary = extract_summary_text(&response.content);
         if summary.is_empty() {
-            self.lock_retry_state().record_failure(self.config.max_backoff_turns);
+            self.lock_retry_state()
+                .record_failure(self.config.max_backoff_turns);
             record_outcome(nous_id, &distill_start, false, 0, 0);
             return EmptySummarySnafu.fail();
         }

--- a/crates/melete/src/distill_tests/extraction_integration/context_parse.rs
+++ b/crates/melete/src/distill_tests/extraction_integration/context_parse.rs
@@ -394,11 +394,15 @@ Auth work.
         "should extract 2 Completed Work items as facts"
     );
     assert!(
-        completed_facts.iter().any(|f| f.content.contains("null check")),
+        completed_facts
+            .iter()
+            .any(|f| f.content.contains("null check")),
         "first completed work fact should mention null check"
     );
     assert!(
-        completed_facts.iter().any(|f| f.content.contains("regression test")),
+        completed_facts
+            .iter()
+            .any(|f| f.content.contains("regression test")),
         "second completed work fact should mention regression test"
     );
 }
@@ -451,7 +455,9 @@ Auth work.
         "should extract 2 Open Threads items as facts"
     );
     assert!(
-        open_facts.iter().any(|f| f.content.contains("performance regression")),
+        open_facts
+            .iter()
+            .any(|f| f.content.contains("performance regression")),
         "first open thread fact should mention performance regression"
     );
 }
@@ -481,11 +487,17 @@ fn parse_summary_extracts_all_seven_sections() {
 
     // Facts from Summary, Completed Work, Current State, Open Threads
     assert!(
-        flush.facts.iter().any(|f| f.content.starts_with("[Summary]")),
+        flush
+            .facts
+            .iter()
+            .any(|f| f.content.starts_with("[Summary]")),
         "Summary section should produce a [Summary] fact"
     );
     assert!(
-        flush.facts.iter().any(|f| f.content.starts_with("[Completed]")),
+        flush
+            .facts
+            .iter()
+            .any(|f| f.content.starts_with("[Completed]")),
         "Completed Work section should produce [Completed] facts"
     );
     assert!(

--- a/crates/melete/src/dream/dream_tests.rs
+++ b/crates/melete/src/dream/dream_tests.rs
@@ -41,11 +41,7 @@ impl TranscriptSource for MockTranscriptSource {
         &self,
         _since: jiff::Timestamp,
     ) -> std::result::Result<Vec<SessionTranscript>, std::io::Error> {
-        Ok(self
-            .transcripts
-            .lock()
-            .unwrap()
-            .clone())
+        Ok(self.transcripts.lock().unwrap().clone())
     }
 }
 

--- a/crates/melete/src/dream/lock.rs
+++ b/crates/melete/src/dream/lock.rs
@@ -295,7 +295,8 @@ fn is_stale(mtime: Option<&std::time::SystemTime>, stale_threshold_secs: i64) ->
         // NOTE: mtime in the future → not stale.
         return false;
     };
-    let threshold = std::time::Duration::from_secs(u64::try_from(stale_threshold_secs).unwrap_or_default());
+    let threshold =
+        std::time::Duration::from_secs(u64::try_from(stale_threshold_secs).unwrap_or_default());
     elapsed > threshold
 }
 
@@ -342,8 +343,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let result =
-            try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS).unwrap();
+        let result = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS).unwrap();
         assert!(result.is_none(), "should reject concurrent acquisition");
     }
 
@@ -382,9 +382,7 @@ mod tests {
         drop(file);
 
         // NOTE: stale threshold of 0 so the lock is reclaimable.
-        let acquired = try_acquire(&lock_path, 0)
-            .unwrap()
-            .unwrap();
+        let acquired = try_acquire(&lock_path, 0).unwrap().unwrap();
 
         assert!(
             acquired.prior_mtime().is_some(),
@@ -444,8 +442,7 @@ mod tests {
         // and the lock should be reclaimable without waiting for mtime stale.
         #[cfg(unix)]
         {
-            let acquired =
-                try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS).unwrap();
+            let acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS).unwrap();
             assert!(
                 acquired.is_some(),
                 "lock with dead PID should be reclaimable on Unix"
@@ -459,8 +456,7 @@ mod tests {
         // the lock is also reclaimable.
         #[cfg(not(unix))]
         {
-            let acquired =
-                try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS).unwrap();
+            let acquired = try_acquire(&lock_path, DEFAULT_STALE_THRESHOLD_SECS).unwrap();
             assert!(
                 acquired.is_some(),
                 "lock with dead PID should be reclaimable on non-Unix"

--- a/crates/melete/src/metrics.rs
+++ b/crates/melete/src/metrics.rs
@@ -97,7 +97,9 @@ mod tests {
     fn record_distillation_records_success_and_failure() {
         let nous_id = "test-nous-distillation";
         let ok_before = DISTILLATION_TOTAL.with_label_values(&[nous_id, "ok"]).get();
-        let error_before = DISTILLATION_TOTAL.with_label_values(&[nous_id, "error"]).get();
+        let error_before = DISTILLATION_TOTAL
+            .with_label_values(&[nous_id, "error"])
+            .get();
         let hist_before = DISTILLATION_DURATION_SECONDS
             .with_label_values(&[nous_id])
             .get_sample_count();
@@ -110,7 +112,9 @@ mod tests {
             "ok counter should increment for success=true"
         );
         assert_eq!(
-            DISTILLATION_TOTAL.with_label_values(&[nous_id, "error"]).get(),
+            DISTILLATION_TOTAL
+                .with_label_values(&[nous_id, "error"])
+                .get(),
             error_before,
             "error counter should not change for success=true"
         );
@@ -123,7 +127,9 @@ mod tests {
             "ok counter should be unchanged after error"
         );
         assert_eq!(
-            DISTILLATION_TOTAL.with_label_values(&[nous_id, "error"]).get(),
+            DISTILLATION_TOTAL
+                .with_label_values(&[nous_id, "error"])
+                .get(),
             error_before + 1,
             "error counter should increment for success=false"
         );

--- a/crates/melete/src/probe.rs
+++ b/crates/melete/src/probe.rs
@@ -356,8 +356,8 @@ const STOP_WORDS: &[&str] = &[
     "the", "and", "for", "are", "but", "not", "you", "all", "can", "had", "her", "was", "one",
     "our", "out", "has", "his", "how", "its", "may", "new", "now", "old", "see", "way", "who",
     "did", "get", "let", "say", "she", "too", "use", "will", "with", "this", "that", "from",
-    "have", "been", "some", "they", "were", "what", "when", "your", "each", "make", "like",
-    "into", "just", "over", "such", "than", "them", "then", "also", "more", "should",
+    "have", "been", "some", "they", "were", "what", "when", "your", "each", "make", "like", "into",
+    "just", "over", "such", "than", "them", "then", "also", "more", "should",
 ];
 
 /// Tokenize text into lowercase words for overlap comparison, excluding stop words.
@@ -468,7 +468,10 @@ mod tests {
         let report = verifier.verify(&flush, transcript);
         assert!(!report.all_passed());
         // Skydiving fact should fail, the others should pass
-        assert!(!report.failed_facts.is_empty(), "hallucinated fact should fail");
+        assert!(
+            !report.failed_facts.is_empty(),
+            "hallucinated fact should fail"
+        );
     }
 
     #[test]

--- a/crates/melete/tests/public_api.rs
+++ b/crates/melete/tests/public_api.rs
@@ -96,7 +96,10 @@ mod distill_config {
         assert!(
             (restored.similarity_threshold - original.similarity_threshold).abs() < f64::EPSILON,
         );
-        assert_eq!(restored.detect_contradictions, original.detect_contradictions);
+        assert_eq!(
+            restored.detect_contradictions,
+            original.detect_contradictions
+        );
     }
 
     #[test]
@@ -179,7 +182,11 @@ mod distill_engine {
         // and min_messages=6 so the engine has real work to split.
         (0..10)
             .map(|i| {
-                let role = if i % 2 == 0 { Role::User } else { Role::Assistant };
+                let role = if i % 2 == 0 {
+                    Role::User
+                } else {
+                    Role::Assistant
+                };
                 text_msg(role, &format!("turn {i}: building the auth module"))
             })
             .collect()
@@ -375,12 +382,7 @@ mod distill_engine {
         let provider = MockProvider::new("## Summary\ns").models(&["claude-sonnet-4-20250514"]);
         let engine = DistillEngine::new(DistillConfig::default());
         engine
-            .distill(
-                &long_conversation(),
-                "bad`id\nevil",
-                &provider,
-                1,
-            )
+            .distill(&long_conversation(), "bad`id\nevil", &provider, 1)
             .await
             .expect("distillation");
 

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -162,7 +162,7 @@ pub mod types {
 /// [`TrainingRecord`](training::TrainingRecord),
 /// [`TRAINING_RECORD_SCHEMA_VERSION`](training::TRAINING_RECORD_SCHEMA_VERSION)
 pub mod training {
-    pub use eidos::training::{TrainingConfig, TrainingRecord, TRAINING_RECORD_SCHEMA_VERSION};
+    pub use eidos::training::{TRAINING_RECORD_SCHEMA_VERSION, TrainingConfig, TrainingRecord};
 }
 
 // ── Knowledge pipeline (episteme) ──────────────────────────────────────────
@@ -234,8 +234,8 @@ pub mod extract {
 /// [`truncate_context_summary`](instinct::truncate_context_summary)
 pub mod instinct {
     pub use episteme::instinct::{
-        DEFAULT_MAX_CONTEXT_SUMMARY_LEN, DEFAULT_MAX_PARAM_VALUE_LEN, ToolObservation,
-        ToolOutcome, sanitize_parameters, truncate_context_summary,
+        DEFAULT_MAX_CONTEXT_SUMMARY_LEN, DEFAULT_MAX_PARAM_VALUE_LEN, ToolObservation, ToolOutcome,
+        sanitize_parameters, truncate_context_summary,
     };
 }
 

--- a/crates/nous/benches/budget.rs
+++ b/crates/nous/benches/budget.rs
@@ -62,8 +62,12 @@ fn estimate_long(c: &mut Criterion) {
 fn budget_new(c: &mut Criterion) {
     c.bench_function("token_budget_new", |b| {
         b.iter(|| {
-            let budget =
-                TokenBudget::new(black_box(200_000), black_box(0.6), black_box(8_192), black_box(40_000));
+            let budget = TokenBudget::new(
+                black_box(200_000),
+                black_box(0.6),
+                black_box(8_192),
+                black_box(40_000),
+            );
             black_box(budget)
         });
     });

--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -59,7 +59,9 @@ impl NousActor {
         let cutoff = std::time::Instant::now()
             .checked_sub(degraded_window)
             .unwrap_or(self.runtime.started_at);
-        self.runtime.background_panic_timestamps.retain(|t| *t > cutoff);
+        self.runtime
+            .background_panic_timestamps
+            .retain(|t| *t > cutoff);
 
         warn!(
             nous_id = %self.id,
@@ -570,12 +572,11 @@ async fn run_background_distillation(
     };
 
     let messages = crate::distillation::convert_to_hermeneus_messages(&history);
-    let engine =
-        melete::distill::DistillEngine::new(melete::distill::DistillConfig {
-            model: config.model.clone(),
-            verbatim_tail: config.verbatim_tail,
-            ..Default::default()
-        });
+    let engine = melete::distill::DistillEngine::new(melete::distill::DistillConfig {
+        model: config.model.clone(),
+        verbatim_tail: config.verbatim_tail,
+        ..Default::default()
+    });
 
     #[expect(
         clippy::cast_possible_truncation,

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -553,7 +553,10 @@ impl NousActor {
             if let Some(ref loader) = self.stores.skill_loader {
                 let task_context = crate::skills::extract_task_context(content);
                 let max_skills = self.config.behavior.skills_max_skills;
-                tracing::debug!(max_skills, "resolve_skill_sections: max_skills from behavior");
+                tracing::debug!(
+                    max_skills,
+                    "resolve_skill_sections: max_skills from behavior"
+                );
                 return loader
                     .resolve_skills(&self.id, &task_context, max_skills)
                     .await;

--- a/crates/nous/src/actor/spawn.rs
+++ b/crates/nous/src/actor/spawn.rs
@@ -52,7 +52,12 @@ pub(crate) fn spawn(
     cross_rx: Option<mpsc::Receiver<CrossNousEnvelope>>,
     cancel: CancellationToken,
     nous_behavior: taxis::config::NousBehaviorConfig,
-) -> (NousHandle, tokio::task::JoinHandle<()>, Arc<AtomicBool>, Arc<AtomicU64>) {
+) -> (
+    NousHandle,
+    tokio::task::JoinHandle<()>,
+    Arc<AtomicBool>,
+    Arc<AtomicU64>,
+) {
     let (tx, rx) = mpsc::channel(DEFAULT_INBOX_CAPACITY);
     let id = config.id.to_string();
     let handle = NousHandle::new(id.clone(), tx);
@@ -134,7 +139,12 @@ pub struct DaemonSpawnParams {
 pub fn spawn_for_daemon(
     params: DaemonSpawnParams,
     cancel: CancellationToken,
-) -> (NousHandle, tokio::task::JoinHandle<()>, Arc<AtomicBool>, Arc<AtomicU64>) {
+) -> (
+    NousHandle,
+    tokio::task::JoinHandle<()>,
+    Arc<AtomicBool>,
+    Arc<AtomicU64>,
+) {
     spawn(
         params.config,
         params.pipeline_config,

--- a/crates/nous/src/actor/tests.rs
+++ b/crates/nous/src/actor/tests.rs
@@ -599,13 +599,23 @@ fn mark_turn_active_sets_active_lifecycle_and_session() {
     let (mut actor, _tx, _dir) = make_test_actor(PipelineConfig::default());
     assert_eq!(actor.channel.status, NousLifecycle::Idle);
     assert!(actor.active_session.is_none());
-    assert!(!actor.runtime.active_turn.load(std::sync::atomic::Ordering::Acquire));
+    assert!(
+        !actor
+            .runtime
+            .active_turn
+            .load(std::sync::atomic::Ordering::Acquire)
+    );
 
     actor.mark_turn_active("my-session");
 
     assert_eq!(actor.channel.status, NousLifecycle::Active);
     assert_eq!(actor.active_session.as_deref(), Some("my-session"));
-    assert!(actor.runtime.active_turn.load(std::sync::atomic::Ordering::Acquire));
+    assert!(
+        actor
+            .runtime
+            .active_turn
+            .load(std::sync::atomic::Ordering::Acquire)
+    );
 }
 
 #[test]
@@ -733,10 +743,7 @@ fn record_drift_metrics_zero_tool_calls_produces_zero_error_rate() {
 #[test]
 fn record_drift_metrics_all_errored_calls_produces_rate_one() {
     let (mut actor, _tx, _dir) = make_test_actor(PipelineConfig::default());
-    let calls = vec![
-        make_tool_call("bash", true),
-        make_tool_call("read", true),
-    ];
+    let calls = vec![make_tool_call("bash", true), make_tool_call("read", true)];
     let result = make_turn_result(80, calls);
     // Should not panic; rate = 1.0.
     actor.record_drift_metrics("s", &result);
@@ -749,7 +756,7 @@ fn record_drift_metrics_mixed_calls_partial_error_rate() {
     let (mut actor, _tx, _dir) = make_test_actor(PipelineConfig::default());
     let calls = vec![
         make_tool_call("bash", false),
-        make_tool_call("read", true),  // 1 of 2 errors → rate = 0.5
+        make_tool_call("read", true), // 1 of 2 errors → rate = 0.5
     ];
     let result = make_turn_result(60, calls);
     actor.record_drift_metrics("s", &result);
@@ -835,8 +842,7 @@ async fn reap_background_tasks_records_background_panic() {
     actor.reap_background_tasks();
 
     assert_eq!(
-        actor.runtime.background_panic_count,
-        1,
+        actor.runtime.background_panic_count, 1,
         "panic in background task should increment background_panic_count"
     );
 }

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -49,7 +49,9 @@ impl NousActor {
             reason = "u128→u64: actor uptime in ms won't exceed u64::MAX"
         )]
         let elapsed_ms = self.runtime.started_at.elapsed().as_millis() as u64; // kanon:ignore RUST/as-cast
-        self.runtime.turn_started_at_ms.store(elapsed_ms, Ordering::Release);
+        self.runtime
+            .turn_started_at_ms
+            .store(elapsed_ms, Ordering::Release);
     }
 
     /// Finalize turn: update session tokens, check drift, spawn side-effects, reset state.
@@ -90,7 +92,11 @@ impl NousActor {
     /// per-session drift detector.
     pub(super) fn record_drift_metrics(&mut self, session_key: &str, turn_result: &TurnResult) {
         let total_calls = turn_result.tool_calls.len();
-        let error_calls = turn_result.tool_calls.iter().filter(|tc| tc.is_error).count();
+        let error_calls = turn_result
+            .tool_calls
+            .iter()
+            .filter(|tc| tc.is_error)
+            .count();
 
         // WHY: tool call counts are in the low tens per turn; u32 is ample and
         // the u32→f64 conversion is lossless (u32::MAX < f64 mantissa precision).
@@ -486,7 +492,9 @@ impl NousActor {
         let cutoff = std::time::Instant::now()
             .checked_sub(degraded_window)
             .unwrap_or(self.runtime.started_at);
-        self.runtime.pipeline_panic_timestamps.retain(|t| *t > cutoff);
+        self.runtime
+            .pipeline_panic_timestamps
+            .retain(|t| *t > cutoff);
 
         let threshold = self.nous_behavior.degraded_panic_threshold;
         tracing::debug!(

--- a/crates/nous/src/bootstrap/bootstrap_tests/mod.rs
+++ b/crates/nous/src/bootstrap/bootstrap_tests/mod.rs
@@ -724,10 +724,7 @@ fn extract_output_style_case_insensitive() {
 - Be terse
 ";
     let style = extract_output_style(user_md);
-    assert!(
-        style.is_some(),
-        "heading match should be case-insensitive"
-    );
+    assert!(style.is_some(), "heading match should be case-insensitive");
     let style = style.expect("just asserted Some");
     assert!(
         style.contains("Be terse"),

--- a/crates/nous/src/competence/tests.rs
+++ b/crates/nous/src/competence/tests.rs
@@ -150,8 +150,7 @@ fn overall_score_averages_domains() {
         .unwrap();
 
     let comp = t.agent_competence("syn").unwrap();
-    let expected =
-        (c.default_score + c.success_bonus + c.default_score + c.success_bonus) / 2.0;
+    let expected = (c.default_score + c.success_bonus + c.default_score + c.success_bonus) / 2.0;
     assert!(
         (comp.overall_score - expected).abs() < f64::EPSILON,
         "overall score should average domains: expected {expected}, got {}",

--- a/crates/nous/src/cross/router.rs
+++ b/crates/nous/src/cross/router.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use koina::ulid::Ulid;
 use tokio::sync::{RwLock, mpsc, oneshot};
 use tracing::{instrument, warn};
-use koina::ulid::Ulid;
 
 use crate::error::{
     self, AskCycleDetectedSnafu, AskTimeoutSnafu, DeliveryFailedSnafu, NousNotFoundSnafu,

--- a/crates/nous/src/degraded_mode.rs
+++ b/crates/nous/src/degraded_mode.rs
@@ -40,8 +40,9 @@ impl DegradedMode {
     #[must_use]
     pub fn status_banner(&self) -> &str {
         match self {
-            Self::DistillationCache { status_banner }
-            | Self::Unavailable { status_banner } => status_banner,
+            Self::DistillationCache { status_banner } | Self::Unavailable { status_banner } => {
+                status_banner
+            }
         }
     }
 }
@@ -95,15 +96,13 @@ pub fn build_degraded_response(
     );
 
     if let Some(summary) = recent_distillation {
-        let banner =
-            "Operating in degraded mode — LLM unavailable. \
+        let banner = "Operating in degraded mode — LLM unavailable. \
              Showing response based on previous conversation context."
-                .to_owned();
+            .to_owned();
 
         info!(
             nous_id,
-            session_id,
-            "degraded mode: returning cached distillation summary"
+            session_id, "degraded mode: returning cached distillation summary"
         );
 
         let content = format!(
@@ -124,15 +123,13 @@ pub fn build_degraded_response(
             }),
         }
     } else {
-        let banner =
-            "Operating in degraded mode — LLM unavailable. \
+        let banner = "Operating in degraded mode — LLM unavailable. \
              No cached context available for this session."
-                .to_owned();
+            .to_owned();
 
         info!(
             nous_id,
-            session_id,
-            "degraded mode: no distillation cache, returning unavailable message"
+            session_id, "degraded mode: no distillation cache, returning unavailable message"
         );
 
         let content = "I can't reach the LLM right now and have no cached context \
@@ -208,7 +205,10 @@ mod tests {
         let err = llm_rate_limit_error();
         let result = build_degraded_response("alice", "ses-1", &err, Some("User prefers brevity."));
         assert!(
-            matches!(result.degraded, Some(DegradedMode::DistillationCache { .. })),
+            matches!(
+                result.degraded,
+                Some(DegradedMode::DistillationCache { .. })
+            ),
             "expected DistillationCache, got {:?}",
             result.degraded
         );
@@ -237,18 +237,22 @@ mod tests {
         let with_cache = build_degraded_response("alice", "ses-1", &err, Some("ctx"));
         let without_cache = build_degraded_response("alice", "ses-1", &err, None);
 
-        assert!(!with_cache
-            .degraded
-            .as_ref()
-            .unwrap()
-            .status_banner()
-            .is_empty());
-        assert!(!without_cache
-            .degraded
-            .as_ref()
-            .unwrap()
-            .status_banner()
-            .is_empty());
+        assert!(
+            !with_cache
+                .degraded
+                .as_ref()
+                .unwrap()
+                .status_banner()
+                .is_empty()
+        );
+        assert!(
+            !without_cache
+                .degraded
+                .as_ref()
+                .unwrap()
+                .status_banner()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -143,8 +143,7 @@ pub fn should_trigger_distillation(
     if session.metrics.message_count >= config.message_count_trigger {
         return Some(format!(
             "message_count={} >= {}",
-            session.metrics.message_count,
-            config.message_count_trigger
+            session.metrics.message_count, config.message_count_trigger
         ));
     }
 
@@ -337,9 +336,7 @@ pub fn apply_distillation(
 
 /// Convert mneme messages to hermeneus messages for the distillation engine.
 #[must_use]
-pub fn convert_to_hermeneus_messages(
-    history: &[mneme::types::Message],
-) -> Vec<HermeneusMessage> {
+pub fn convert_to_hermeneus_messages(history: &[mneme::types::Message]) -> Vec<HermeneusMessage> {
     history
         .iter()
         .map(|msg| {

--- a/crates/nous/src/drift.rs
+++ b/crates/nous/src/drift.rs
@@ -221,7 +221,12 @@ impl DriftDetector {
         let baseline_end = n.saturating_sub(recent_size);
 
         // WHY: need enough baseline samples for meaningful statistics
-        if baseline_end < self.config.min_samples.saturating_sub(self.config.recent_size) {
+        if baseline_end
+            < self
+                .config
+                .min_samples
+                .saturating_sub(self.config.recent_size)
+        {
             return None;
         }
         if baseline_end == 0 {
@@ -229,7 +234,10 @@ impl DriftDetector {
         }
 
         // SAFETY: baseline_end > 0 checked above, and baseline_end <= n
-        #[expect(clippy::indexing_slicing, reason = "baseline_end > 0 and <= values.len()")]
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "baseline_end > 0 and <= values.len()"
+        )]
         let baseline_slice = &values[..baseline_end];
         #[expect(clippy::indexing_slicing, reason = "baseline_end <= values.len()")]
         let recent_slice = &values[baseline_end..];
@@ -357,7 +365,11 @@ fn slice_mean(values: &[f64]) -> f64 {
 mod tests {
     use super::*;
 
-    fn make_metrics(response_tokens: u64, tool_error_rate: f64, user_correction: bool) -> TurnMetrics {
+    fn make_metrics(
+        response_tokens: u64,
+        tool_error_rate: f64,
+        user_correction: bool,
+    ) -> TurnMetrics {
         TurnMetrics {
             response_tokens,
             tool_error_rate,
@@ -372,7 +384,10 @@ mod tests {
         let mut detector = DriftDetector::default();
         for _ in 0..5 {
             let events = detector.record(make_metrics(500, 0.1, false));
-            assert!(events.is_empty(), "should not detect drift with few samples");
+            assert!(
+                events.is_empty(),
+                "should not detect drift with few samples"
+            );
         }
     }
 
@@ -410,7 +425,10 @@ mod tests {
         let mut drift_detected = false;
         for _ in 0..5 {
             let events = detector.record(make_metrics(50, 0.1, false));
-            if events.iter().any(|e| e.metric == DriftMetric::ResponseLength) {
+            if events
+                .iter()
+                .any(|e| e.metric == DriftMetric::ResponseLength)
+            {
                 drift_detected = true;
             }
         }
@@ -435,7 +453,10 @@ mod tests {
         let mut drift_detected = false;
         for _ in 0..5 {
             let events = detector.record(make_metrics(500, 0.8, false));
-            if events.iter().any(|e| e.metric == DriftMetric::ToolErrorRate) {
+            if events
+                .iter()
+                .any(|e| e.metric == DriftMetric::ToolErrorRate)
+            {
                 drift_detected = true;
             }
         }
@@ -460,7 +481,10 @@ mod tests {
         let mut drift_detected = false;
         for _ in 0..5 {
             let events = detector.record(make_metrics(500, 0.1, true));
-            if events.iter().any(|e| e.metric == DriftMetric::UserCorrections) {
+            if events
+                .iter()
+                .any(|e| e.metric == DriftMetric::UserCorrections)
+            {
                 drift_detected = true;
             }
         }
@@ -480,7 +504,11 @@ mod tests {
             detector.record(make_metrics(500, 0.1, false));
         }
 
-        assert_eq!(detector.turn_count(), 10, "window should cap at window_size");
+        assert_eq!(
+            detector.turn_count(),
+            10,
+            "window should cap at window_size"
+        );
     }
 
     #[test]
@@ -517,10 +545,19 @@ mod tests {
         let tool_drift = events_seen
             .iter()
             .find(|e| e.metric == DriftMetric::ToolErrorRate);
-        assert!(tool_drift.is_some(), "should have a tool error rate drift event");
+        assert!(
+            tool_drift.is_some(),
+            "should have a tool error rate drift event"
+        );
         let event = tool_drift.unwrap(); // kanon:ignore RUST/unwrap
-        assert!(event.current > event.baseline, "current should exceed baseline for error rate");
-        assert!(event.z_score > 0.0, "z-score should be positive for increases");
+        assert!(
+            event.current > event.baseline,
+            "current should exceed baseline for error rate"
+        );
+        assert!(
+            event.z_score > 0.0,
+            "z-score should be positive for increases"
+        );
     }
 
     #[test]
@@ -584,8 +621,14 @@ mod tests {
         // [2, 4, 4, 4, 5, 5, 7, 9] -> mean=5, stddev=2
         let values = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
         let (mean, stddev) = mean_and_stddev(&values);
-        assert!((mean - 5.0).abs() < f64::EPSILON, "mean should be 5.0, got {mean}");
-        assert!((stddev - 2.0).abs() < f64::EPSILON, "stddev should be 2.0, got {stddev}");
+        assert!(
+            (mean - 5.0).abs() < f64::EPSILON,
+            "mean should be 5.0, got {mean}"
+        );
+        assert!(
+            (stddev - 2.0).abs() < f64::EPSILON,
+            "stddev should be 2.0, got {stddev}"
+        );
     }
 
     // --- slice_mean ---

--- a/crates/nous/src/execute/dispatch.rs
+++ b/crates/nous/src/execute/dispatch.rs
@@ -274,10 +274,7 @@ pub(super) async fn dispatch_tools(
             );
             crate::metrics::record_tool_failure(tool_ctx.nous_id.as_ref(), tool_name);
         } else {
-            debug!(
-                tool = tool_name.as_str(),
-                duration_ms, "tool executed"
-            );
+            debug!(tool = tool_name.as_str(), duration_ms, "tool executed");
         }
 
         all_tool_calls.push(ToolCall {
@@ -418,10 +415,7 @@ pub(super) async fn dispatch_tools_streaming(
             );
             crate::metrics::record_tool_failure(tool_ctx.nous_id.as_ref(), tool_name);
         } else {
-            debug!(
-                tool = tool_name.as_str(),
-                duration_ms, "tool executed"
-            );
+            debug!(tool = tool_name.as_str(), duration_ms, "tool executed");
         }
 
         if let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolResult {

--- a/crates/nous/src/execute/tests/mod.rs
+++ b/crates/nous/src/execute/tests/mod.rs
@@ -10,9 +10,7 @@ use hermeneus::test_utils::MockProvider;
 use hermeneus::types::{CompletionResponse, ContentBlock, StopReason, Usage};
 use koina::id::{NousId, SessionId, ToolName};
 use organon::registry::{ToolExecutor, ToolRegistry};
-use organon::types::{
-    InputSchema, ToolCategory, ToolContext, ToolDef, ToolInput, ToolResult,
-};
+use organon::types::{InputSchema, ToolCategory, ToolContext, ToolDef, ToolInput, ToolResult};
 
 use super::*;
 use crate::config::NousConfig;
@@ -27,8 +25,7 @@ impl ToolExecutor for EchoExecutor {
         &'a self,
         input: &'a ToolInput,
         _ctx: &'a ToolContext,
-    ) -> Pin<Box<dyn Future<Output = organon::error::Result<ToolResult>> + Send + 'a>>
-    {
+    ) -> Pin<Box<dyn Future<Output = organon::error::Result<ToolResult>> + Send + 'a>> {
         Box::pin(async {
             Ok(ToolResult::text(format!(
                 "executed: {}",
@@ -45,8 +42,7 @@ impl ToolExecutor for ErrorExecutor {
         &'a self,
         _input: &'a ToolInput,
         _ctx: &'a ToolContext,
-    ) -> Pin<Box<dyn Future<Output = organon::error::Result<ToolResult>> + Send + 'a>>
-    {
+    ) -> Pin<Box<dyn Future<Output = organon::error::Result<ToolResult>> + Send + 'a>> {
         Box::pin(async { Ok(ToolResult::error("tool failed")) })
     }
 }

--- a/crates/nous/src/finalize.rs
+++ b/crates/nous/src/finalize.rs
@@ -6,9 +6,9 @@
 //! 3. Persists the assistant's response
 //! 4. Records token usage
 
+use koina::ulid::Ulid;
 use snafu::ResultExt;
 use tracing::{debug, instrument, warn};
-use koina::ulid::Ulid;
 
 use mneme::store::SessionStore;
 use mneme::types::{Role, UsageRecord};

--- a/crates/nous/src/hooks/builtins/correction.rs
+++ b/crates/nous/src/hooks/builtins/correction.rs
@@ -73,7 +73,10 @@ pub(crate) struct CorrectionDetector {
     ///
     /// WHY: Reserved for future use when the detector gains the ability to
     /// extract corrections from multi-turn patterns in `on_turn_complete`.
-    #[expect(dead_code, reason = "reserved for future on_turn_complete correction extraction")]
+    #[expect(
+        dead_code,
+        reason = "reserved for future on_turn_complete correction extraction"
+    )]
     workspace: PathBuf,
 }
 
@@ -369,13 +372,12 @@ async fn load_corrections(workspace: &Path) -> Result<Vec<Correction>, std::io::
 
     match tokio::fs::read_to_string(&path).await {
         Ok(content) => {
-            let corrections: Vec<Correction> =
-                serde_json::from_str(&content).map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("invalid corrections JSON: {e}"),
-                    )
-                })?;
+            let corrections: Vec<Correction> = serde_json::from_str(&content).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid corrections JSON: {e}"),
+                )
+            })?;
             Ok(corrections)
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
@@ -384,10 +386,7 @@ async fn load_corrections(workspace: &Path) -> Result<Vec<Correction>, std::io::
 }
 
 /// Append a correction to the workspace file, enforcing the max cap.
-async fn append_correction(
-    workspace: &Path,
-    correction: Correction,
-) -> Result<(), std::io::Error> {
+async fn append_correction(workspace: &Path, correction: Correction) -> Result<(), std::io::Error> {
     let path = corrections_path(workspace);
 
     // Ensure the workspace directory exists.
@@ -412,9 +411,8 @@ async fn append_correction(
         corrections.drain(..excess);
     }
 
-    let json = serde_json::to_string_pretty(&corrections).map_err(|e| {
-        std::io::Error::other(format!("failed to serialize corrections: {e}"))
-    })?;
+    let json = serde_json::to_string_pretty(&corrections)
+        .map_err(|e| std::io::Error::other(format!("failed to serialize corrections: {e}")))?;
 
     tokio::fs::write(&path, json).await
 }

--- a/crates/nous/src/hooks/builtins/correction_tests.rs
+++ b/crates/nous/src/hooks/builtins/correction_tests.rs
@@ -1,5 +1,8 @@
 #![expect(clippy::expect_used, reason = "test assertions")]
-#![expect(clippy::indexing_slicing, reason = "test assertions on known-length collections")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on known-length collections"
+)]
 
 use super::*;
 
@@ -66,13 +69,15 @@ fn ignores_non_correction() {
 #[test]
 fn ignores_empty_message() {
     let result = extract_correction("");
-    assert!(result.is_none(), "should not detect correction in empty string");
+    assert!(
+        result.is_none(),
+        "should not detect correction in empty string"
+    );
 }
 
 #[test]
 fn detects_correction_in_multi_sentence() {
-    let result =
-        extract_correction("That looks good. Always use snake_case for variable names.");
+    let result = extract_correction("That looks good. Always use snake_case for variable names.");
     assert!(
         result.is_some(),
         "should detect correction in second sentence"
@@ -171,7 +176,10 @@ fn formats_multiple_corrections() {
 async fn load_returns_empty_when_no_file() {
     let dir = tempfile::tempdir().expect("create temp dir");
     let corrections = load_corrections(dir.path()).await.expect("load");
-    assert!(corrections.is_empty(), "should return empty vec for missing file");
+    assert!(
+        corrections.is_empty(),
+        "should return empty vec for missing file"
+    );
 }
 
 #[tokio::test]

--- a/crates/nous/src/instinct.rs
+++ b/crates/nous/src/instinct.rs
@@ -35,7 +35,8 @@ pub(crate) fn observation_from_tool_call(
     };
 
     let sanitized_params = sanitize_parameters(&tool_call.input, DEFAULT_MAX_PARAM_VALUE_LEN);
-    let truncated_summary = truncate_context_summary(context_summary, DEFAULT_MAX_CONTEXT_SUMMARY_LEN);
+    let truncated_summary =
+        truncate_context_summary(context_summary, DEFAULT_MAX_CONTEXT_SUMMARY_LEN);
 
     ToolObservation {
         tool_name: tool_call.name.clone(),

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -9,8 +9,6 @@ pub mod adapters;
 pub mod bootstrap;
 /// Token and wall-clock time budget tracking for pipeline stages.
 pub mod budget;
-/// Self-auditing loop: prosoche checks, audit triggers, and knowledge graph storage.
-pub mod self_audit;
 /// Context compaction: microcompaction (per-turn clearing) and full compaction (summarization).
 pub(crate) mod compact;
 /// Per-agent per-domain competence tracking with rolling statistics and model escalation.
@@ -54,6 +52,8 @@ pub mod recall;
 pub mod research;
 /// Specialized role templates for ephemeral sub-agents.
 pub mod roles;
+/// Self-auditing loop: prosoche checks, audit triggers, and knowledge graph storage.
+pub mod self_audit;
 /// Session state tracking within a nous actor.
 pub mod session;
 /// Skill loading: queries mneme for task-relevant skills and injects them as bootstrap sections.
@@ -62,6 +62,8 @@ pub(crate) mod skills;
 pub mod spawn_svc;
 /// Real-time streaming events for the turn pipeline.
 pub mod stream;
+/// Task registry with progress streaming, cooperative cancellation, and GC.
+pub mod tasks;
 /// Training data capture: append-only JSONL writer for conversation turns.
 ///
 /// Pipeline tap that observes the turn loop and writes qualifying turns
@@ -69,8 +71,6 @@ pub mod stream;
 /// `TrainingRecord`) live in eidos; capture logic lives here because it
 /// is a pipeline concern, not a memory operation.
 pub mod training;
-/// Task registry with progress streaming, cooperative cancellation, and GC.
-pub mod tasks;
 /// Self-tuning feedback loop: evidence-based parameter change proposals.
 pub mod tuning;
 /// Uncertainty quantification: calibration tracking for agent confidence predictions.

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -56,7 +56,6 @@ struct ActorEntry {
     turn_started_at_ms: Arc<AtomicU64>,
 }
 
-
 /// Manages the lifecycle of all nous actors.
 // NOTE: 14 fields: runtime dependency injection (providers, tools, stores) plus
 // actor state. Kept flat because splitting would scatter logically-paired fields.
@@ -162,10 +161,14 @@ impl NousManager {
             warn!(nous_id = %id, "replacing existing actor");
             let _ = old.handle.shutdown().await;
             // WHY: take join handle before awaiting: must not hold MutexGuard across .await
-            let join_opt = old.join.lock().unwrap_or_else(|e| {
-                warn!(nous_id = %id, "join mutex poisoned, recovering");
-                e.into_inner()
-            }).take();
+            let join_opt = old
+                .join
+                .lock()
+                .unwrap_or_else(|e| {
+                    warn!(nous_id = %id, "join mutex poisoned, recovering");
+                    e.into_inner()
+                })
+                .take();
             if let Some(join) = join_opt {
                 let _ = join.await;
             }
@@ -453,10 +456,14 @@ impl NousManager {
 
         if let Some(old) = self.actors.remove(id) {
             // WHY: take join handle before awaiting: must not hold MutexGuard across .await
-            let join_opt = old.join.lock().unwrap_or_else(|e| {
-                warn!(nous_id = %id, "join mutex poisoned, recovering");
-                e.into_inner()
-            }).take();
+            let join_opt = old
+                .join
+                .lock()
+                .unwrap_or_else(|e| {
+                    warn!(nous_id = %id, "join mutex poisoned, recovering");
+                    e.into_inner()
+                })
+                .take();
             if let Some(join) = join_opt {
                 let restart_drain_timeout =
                     Duration::from_secs(self.nous_behavior.manager_restart_drain_timeout_secs);

--- a/crates/nous/src/manager_tests.rs
+++ b/crates/nous/src/manager_tests.rs
@@ -77,7 +77,10 @@ async fn spawn_returns_handle() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    let handle = mgr
+        .spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
     assert_eq!(handle.id(), "syn", "spawned handle should have syn id");
     assert_eq!(mgr.count(), 1, "manager should have one actor after spawn");
 
@@ -89,7 +92,9 @@ async fn get_finds_spawned_actor() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
 
     let handle = mgr.get("syn").expect("found");
     assert_eq!(handle.id(), "syn", "retrieved handle should have syn id");
@@ -112,7 +117,9 @@ async fn get_config_returns_stored_config() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
 
     let config = mgr.get_config("syn").expect("config");
     assert_eq!(config.id.as_ref(), "syn", "config id should match");
@@ -139,9 +146,12 @@ async fn configs_returns_all() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
     mgr.spawn(demiurge_config(), PipelineConfig::default())
-        .await.expect("spawn");
+        .await
+        .expect("spawn");
 
     let configs = mgr.configs();
     assert_eq!(configs.len(), 2, "should have two configs");
@@ -158,9 +168,12 @@ async fn list_returns_all_statuses() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
     mgr.spawn(demiurge_config(), PipelineConfig::default())
-        .await.expect("spawn");
+        .await
+        .expect("spawn");
 
     let statuses = mgr.list().await;
     assert_eq!(statuses.len(), 2, "should list two actors");
@@ -180,10 +193,14 @@ async fn shutdown_all_stops_all_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle1 = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    let handle1 = mgr
+        .spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
     let handle2 = mgr
         .spawn(demiurge_config(), PipelineConfig::default())
-        .await.expect("spawn");
+        .await
+        .expect("spawn");
 
     mgr.shutdown_all().await;
 
@@ -207,9 +224,12 @@ async fn spawn_multiple_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
     mgr.spawn(demiurge_config(), PipelineConfig::default())
-        .await.expect("spawn");
+        .await
+        .expect("spawn");
 
     assert_eq!(mgr.count(), 2, "manager should have two actors");
 
@@ -229,8 +249,14 @@ async fn spawn_replaces_existing_actor() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let old_handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
-    let new_handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    let old_handle = mgr
+        .spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
+    let new_handle = mgr
+        .spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
 
     assert_eq!(mgr.count(), 1, "re-spawn should replace, not add");
 
@@ -250,7 +276,10 @@ async fn manager_turn_through_handle() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    let handle = mgr
+        .spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
     let result = handle.send_turn("main", "Hello").await.expect("turn");
     assert_eq!(result.content, "Hello!", "turn should return mock response");
 
@@ -263,10 +292,14 @@ async fn drain_stops_all_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle1 = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    let handle1 = mgr
+        .spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
     let handle2 = mgr
         .spawn(demiurge_config(), PipelineConfig::default())
-        .await.expect("spawn");
+        .await
+        .expect("spawn");
 
     // WHY: drain() takes &self: no mutable access needed.
     mgr.drain(Duration::from_secs(5)).await;
@@ -287,7 +320,10 @@ async fn cancel_token_propagates_to_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    let handle = mgr
+        .spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
 
     // WHY: Cancel via manager's root token directly (as drain() would do internally).
     mgr.cancel.cancel();
@@ -311,9 +347,12 @@ async fn drain_timeout_does_not_panic() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
     mgr.spawn(demiurge_config(), PipelineConfig::default())
-        .await.expect("spawn");
+        .await
+        .expect("spawn");
 
     // NOTE: 1-nanosecond timeout: drain will warn but must not panic.
     mgr.drain(Duration::from_nanos(1)).await;
@@ -324,7 +363,9 @@ async fn check_health_reports_alive_actors() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
 
     let health = mgr.check_health().await;
     assert_eq!(health.len(), 1, "health map should have one entry");
@@ -343,7 +384,10 @@ async fn check_health_detects_dead_actor() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    let handle = mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    let handle = mgr
+        .spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
 
     handle.shutdown().await.expect("shutdown");
     // kanon:ignore TESTING/sleep-in-test reason = "waiting for actor task to fully stop before health check; real async shutdown cannot use pause+advance"
@@ -362,11 +406,15 @@ async fn check_health_busy_actor_reports_alive() {
     let (_dir, oikos) = make_oikos();
     let mut mgr = make_manager(oikos);
 
-    mgr.spawn(syn_config(), PipelineConfig::default()).await.expect("spawn");
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
 
     // NOTE: Simulate: actor is mid-turn (flag set) but its inbox is closed (ping fails).
     let entry = mgr.actors.get("syn").expect("actor registered");
-    entry.active_turn.store(true, std::sync::atomic::Ordering::Release);
+    entry
+        .active_turn
+        .store(true, std::sync::atomic::Ordering::Release);
     // WHY: set a recent turn_started_at_ms so stuck-turn detection doesn't trigger
     #[expect(
         clippy::cast_possible_truncation,
@@ -374,7 +422,9 @@ async fn check_health_busy_actor_reports_alive() {
         reason = "u128→u64: test uptime in ms won't exceed u64::MAX"
     )]
     let now_ms = entry.last_start.elapsed().as_millis() as u64; // kanon:ignore RUST/as-cast
-    entry.turn_started_at_ms.store(now_ms, std::sync::atomic::Ordering::Release);
+    entry
+        .turn_started_at_ms
+        .store(now_ms, std::sync::atomic::Ordering::Release);
 
     let handle = mgr.actors.get("syn").expect("entry").handle.clone();
     handle.shutdown().await.expect("shutdown sent");

--- a/crates/nous/src/metrics.rs
+++ b/crates/nous/src/metrics.rs
@@ -248,15 +248,11 @@ mod tests {
     #[test]
     fn record_turn_increments_counter() {
         let agent = "test-record-turn";
-        let before = PIPELINE_TURNS_TOTAL
-            .with_label_values(&[agent])
-            .get();
+        let before = PIPELINE_TURNS_TOTAL.with_label_values(&[agent]).get();
         record_turn(agent);
         record_turn(agent);
         record_turn(agent);
-        let after = PIPELINE_TURNS_TOTAL
-            .with_label_values(&[agent])
-            .get();
+        let after = PIPELINE_TURNS_TOTAL.with_label_values(&[agent]).get();
         assert_eq!(after - before, 3, "expected counter to increment by 3");
     }
 
@@ -271,7 +267,11 @@ mod tests {
         let after = PIPELINE_ERRORS_TOTAL
             .with_label_values(&[agent, "execute", error_type])
             .get();
-        assert_eq!(after - before, 1, "expected error counter to increment by 1");
+        assert_eq!(
+            after - before,
+            1,
+            "expected error counter to increment by 1"
+        );
     }
 
     #[test]
@@ -301,16 +301,12 @@ mod tests {
     #[test]
     fn record_cache_usage_increments_counters() {
         let agent = "test-cache-usage";
-        let read_before = CACHE_READ_TOKENS_TOTAL
-            .with_label_values(&[agent])
-            .get();
+        let read_before = CACHE_READ_TOKENS_TOTAL.with_label_values(&[agent]).get();
         let creation_before = CACHE_CREATION_TOKENS_TOTAL
             .with_label_values(&[agent])
             .get();
         record_cache_usage(agent, 1500, 500);
-        let read_after = CACHE_READ_TOKENS_TOTAL
-            .with_label_values(&[agent])
-            .get();
+        let read_after = CACHE_READ_TOKENS_TOTAL.with_label_values(&[agent]).get();
         let creation_after = CACHE_CREATION_TOKENS_TOTAL
             .with_label_values(&[agent])
             .get();
@@ -364,19 +360,13 @@ mod tests {
         let agents = ["parent-agent", "child-fork-1", "child-fork-2"];
         let before_counts: Vec<_> = agents
             .iter()
-            .map(|agent| {
-                CACHE_READ_TOKENS_TOTAL
-                    .with_label_values(&[agent])
-                    .get()
-            })
+            .map(|agent| CACHE_READ_TOKENS_TOTAL.with_label_values(&[agent]).get())
             .collect();
         for agent in agents {
             record_cache_usage(agent, 1000, 200);
         }
         for (i, agent) in agents.iter().enumerate() {
-            let after = CACHE_READ_TOKENS_TOTAL
-                .with_label_values(&[agent])
-                .get();
+            let after = CACHE_READ_TOKENS_TOTAL.with_label_values(&[agent]).get();
             assert_eq!(
                 after - before_counts[i],
                 1000,

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -758,179 +758,175 @@ pub(crate) async fn run_pipeline(
     // Wrapping the async body with .instrument() sets the span correctly
     // for each poll without holding a guard across suspension points.
     async move {
-    let mut stages_completed: u32 = 0;
+        let mut stages_completed: u32 = 0;
 
-    let mut ctx = PipelineContext::default();
-    let task_hint = classify_task_hint(&input.content);
+        let mut ctx = PipelineContext::default();
+        let task_hint = classify_task_hint(&input.content);
 
-    run_context_stage(
-        oikos,
-        config,
-        pipeline_config,
-        &mut ctx,
-        extra_bootstrap,
-        task_hint,
-        emitter,
-    )
-    .await?;
-    stages_completed += 1;
+        run_context_stage(
+            oikos,
+            config,
+            pipeline_config,
+            &mut ctx,
+            extra_bootstrap,
+            task_hint,
+            emitter,
+        )
+        .await?;
+        stages_completed += 1;
 
-    run_recall_stage(
-        config,
-        pipeline_config,
-        &mut ctx,
-        &input.content,
-        embedding_provider,
-        vector_search,
-        text_search,
-        emitter,
-    )
-    .await;
-    stages_completed += 1;
+        run_recall_stage(
+            config,
+            pipeline_config,
+            &mut ctx,
+            &input.content,
+            embedding_provider,
+            vector_search,
+            text_search,
+            emitter,
+        )
+        .await;
+        stages_completed += 1;
 
-    run_history_stage(config, &mut ctx, &input, session_store, emitter).await?;
-    stages_completed += 1;
+        run_history_stage(config, &mut ctx, &input, session_store, emitter).await?;
+        stages_completed += 1;
 
-    run_microcompact_stage(config, &mut ctx, emitter);
-    stages_completed += 1;
+        run_microcompact_stage(config, &mut ctx, emitter);
+        stages_completed += 1;
 
-    run_full_compact_stage(config, &mut ctx, emitter);
-    stages_completed += 1;
+        run_full_compact_stage(config, &mut ctx, emitter);
+        stages_completed += 1;
 
-    run_guard_stage(&input.session, config, emitter)?;
-    stages_completed += 1;
+        run_guard_stage(&input.session, config, emitter)?;
+        stages_completed += 1;
 
-    // Before-query hooks run after guard (so rejected requests never reach hooks)
-    // but before execute (so hooks can modify context before the model call).
-    if let Some(hook_registry) = hooks {
-        let mut query_ctx = QueryContext {
-            pipeline: &mut ctx,
-            nous_id: &config.id,
-            user_message: &input.content,
-        };
-        if let crate::hooks::HookResult::Abort { reason } =
-            hook_registry.run_before_query(&mut query_ctx).await
+        // Before-query hooks run after guard (so rejected requests never reach hooks)
+        // but before execute (so hooks can modify context before the model call).
+        if let Some(hook_registry) = hooks {
+            let mut query_ctx = QueryContext {
+                pipeline: &mut ctx,
+                nous_id: &config.id,
+                user_message: &input.content,
+            };
+            if let crate::hooks::HookResult::Abort { reason } =
+                hook_registry.run_before_query(&mut query_ctx).await
+            {
+                return Err(error::GuardRejectedSnafu { reason }.build());
+            }
+        }
+
+        let result = run_execute_stage(
+            config,
+            pipeline_config,
+            &ctx,
+            &input,
+            providers,
+            tools,
+            tool_ctx,
+            stream_tx,
+            pipeline_start,
+            total_timeout,
+            emitter,
+            hooks,
+            session_store,
+        )
+        .await?;
+        stages_completed += 1;
+
+        run_finalize_stage(config, &input, &result, session_store, emitter).await;
+        stages_completed += 1;
+
+        // WHY: training capture runs after finalize so only persisted, successful
+        // turns enter the training corpus. Errors are logged, never propagated:
+        // training capture must never block the pipeline.
+        if pipeline_config.training.enabled {
+            match crate::training::TrainingCapture::new(oikos.root(), &pipeline_config.training) {
+                Ok(mut capture) => {
+                    // Compute episteme labels from the user message for training enrichment.
+                    // These are cheap heuristic classifiers — no LLM calls.
+                    let turn_classification =
+                        episteme::extract::refinement::classify_turn(&input.content);
+                    let correction_signal =
+                        episteme::extract::refinement::detect_correction(&input.content);
+                    let fact_type = episteme::extract::refinement::classify_fact(&input.content);
+
+                    capture.maybe_capture(crate::training::CaptureInput {
+                        session_id: &input.session.id,
+                        nous_id: &config.id,
+                        user_message: &input.content,
+                        assistant_response: &result.content,
+                        model: &config.generation.model,
+                        tokens: result.usage.total_tokens(),
+                        stop_reason: crate::training::CaptureStopReason::parse(&result.stop_reason),
+                        has_tool_calls: !result.tool_calls.is_empty(),
+                        turn_type: Some(turn_classification.to_string()),
+                        is_correction: Some(correction_signal.is_correction),
+                        fact_types: Some(vec![fact_type.to_string()]),
+                        quality_score: None,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "training capture initialization failed");
+                }
+            }
+        }
+
+        // WHY: on_turn_complete hooks run after finalize so audit hooks see the
+        // fully persisted state. Does not short-circuit: all hooks fire.
+        if let Some(hook_registry) = hooks {
+            let turn_ctx = TurnContext {
+                result: &result,
+                nous_id: &config.id,
+                session_tokens: input.session.cumulative_tokens,
+            };
+            hook_registry.run_on_turn_complete(&turn_ctx).await;
+        }
+
+        if !result.tool_calls.is_empty() {
+            crate::instinct::record_observations(&result.tool_calls, &input.content, &config.id);
+        }
+
+        let current_span = tracing::Span::current();
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::as_conversions,
+            reason = "u128→u64: pipeline duration fits in u64; usize→u64 for tool call count"
+        )]
         {
-            return Err(error::GuardRejectedSnafu { reason }.build());
+            current_span.record(
+                "pipeline.total_duration_ms",
+                pipeline_start.elapsed().as_millis() as u64, // kanon:ignore RUST/as-cast
+            );
         }
+        current_span.record("pipeline.stages_completed", stages_completed);
+        #[expect(
+            clippy::as_conversions,
+            reason = "usize→u64: tool call count fits in u64"
+        )]
+        current_span.record("pipeline.tool_calls", result.tool_calls.len() as u64); // kanon:ignore RUST/as-cast
+
+        // Single event emission replaces separate metrics::record_turn + tracing::info.
+        crate::metrics::record_turn(&config.id);
+        let duration_ms = u64::try_from(pipeline_start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        #[expect(
+            clippy::as_conversions,
+            reason = "usize→u64: tool call count fits in u64"
+        )]
+        let tool_calls_count = result.tool_calls.len() as u64; // kanon:ignore RUST/as-cast
+        emitter.emit(&events::TurnCompleted {
+            nous_id: config.id.to_string(),
+            model: config.generation.model.clone(),
+            duration_ms,
+            input_tokens: result.usage.input_tokens,
+            output_tokens: result.usage.output_tokens,
+            tool_calls: tool_calls_count,
+            stages_completed,
+        });
+
+        Ok(result)
     }
-
-    let result = run_execute_stage(
-        config,
-        pipeline_config,
-        &ctx,
-        &input,
-        providers,
-        tools,
-        tool_ctx,
-        stream_tx,
-        pipeline_start,
-        total_timeout,
-        emitter,
-        hooks,
-        session_store,
-    )
-    .await?;
-    stages_completed += 1;
-
-    run_finalize_stage(config, &input, &result, session_store, emitter).await;
-    stages_completed += 1;
-
-    // WHY: training capture runs after finalize so only persisted, successful
-    // turns enter the training corpus. Errors are logged, never propagated:
-    // training capture must never block the pipeline.
-    if pipeline_config.training.enabled {
-        match crate::training::TrainingCapture::new(
-            oikos.root(),
-            &pipeline_config.training,
-        ) {
-            Ok(mut capture) => {
-                // Compute episteme labels from the user message for training enrichment.
-                // These are cheap heuristic classifiers — no LLM calls.
-                let turn_classification =
-                    episteme::extract::refinement::classify_turn(&input.content);
-                let correction_signal =
-                    episteme::extract::refinement::detect_correction(&input.content);
-                let fact_type =
-                    episteme::extract::refinement::classify_fact(&input.content);
-
-                capture.maybe_capture(crate::training::CaptureInput {
-                    session_id: &input.session.id,
-                    nous_id: &config.id,
-                    user_message: &input.content,
-                    assistant_response: &result.content,
-                    model: &config.generation.model,
-                    tokens: result.usage.total_tokens(),
-                    stop_reason: crate::training::CaptureStopReason::parse(
-                        &result.stop_reason,
-                    ),
-                    has_tool_calls: !result.tool_calls.is_empty(),
-                    turn_type: Some(turn_classification.to_string()),
-                    is_correction: Some(correction_signal.is_correction),
-                    fact_types: Some(vec![fact_type.to_string()]),
-                    quality_score: None,
-                });
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "training capture initialization failed");
-            }
-        }
-    }
-
-    // WHY: on_turn_complete hooks run after finalize so audit hooks see the
-    // fully persisted state. Does not short-circuit: all hooks fire.
-    if let Some(hook_registry) = hooks {
-        let turn_ctx = TurnContext {
-            result: &result,
-            nous_id: &config.id,
-            session_tokens: input.session.cumulative_tokens,
-        };
-        hook_registry.run_on_turn_complete(&turn_ctx).await;
-    }
-
-    if !result.tool_calls.is_empty() {
-        crate::instinct::record_observations(&result.tool_calls, &input.content, &config.id);
-    }
-
-    let current_span = tracing::Span::current();
-    #[expect(
-        clippy::cast_possible_truncation,
-        clippy::as_conversions,
-        reason = "u128→u64: pipeline duration fits in u64; usize→u64 for tool call count"
-    )]
-    {
-        current_span.record(
-            "pipeline.total_duration_ms",
-            pipeline_start.elapsed().as_millis() as u64, // kanon:ignore RUST/as-cast
-        );
-    }
-    current_span.record("pipeline.stages_completed", stages_completed);
-    #[expect(
-        clippy::as_conversions,
-        reason = "usize→u64: tool call count fits in u64"
-    )]
-    current_span.record("pipeline.tool_calls", result.tool_calls.len() as u64); // kanon:ignore RUST/as-cast
-
-    // Single event emission replaces separate metrics::record_turn + tracing::info.
-    crate::metrics::record_turn(&config.id);
-    let duration_ms = u64::try_from(pipeline_start.elapsed().as_millis()).unwrap_or(u64::MAX);
-    #[expect(
-        clippy::as_conversions,
-        reason = "usize→u64: tool call count fits in u64"
-    )]
-    let tool_calls_count = result.tool_calls.len() as u64; // kanon:ignore RUST/as-cast
-    emitter.emit(&events::TurnCompleted {
-        nous_id: config.id.to_string(),
-        model: config.generation.model.clone(),
-        duration_ms,
-        input_tokens: result.usage.input_tokens,
-        output_tokens: result.usage.output_tokens,
-        tool_calls: tool_calls_count,
-        stages_completed,
-    });
-
-    Ok(result)
-    }.instrument(pipeline_span).await
+    .instrument(pipeline_span)
+    .await
 }
 
 /// Typed pipeline events for the internal event system.

--- a/crates/nous/src/pipeline/pipeline_tests/loop_detector.rs
+++ b/crates/nous/src/pipeline/pipeline_tests/loop_detector.rs
@@ -348,8 +348,7 @@ fn loop_detector_call_count_tracks() {
 
 #[test]
 fn loop_detector_window_cap_evicts_old_calls() {
-    let default_window =
-        taxis::config::NousBehaviorConfig::default().loop_detection_window;
+    let default_window = taxis::config::NousBehaviorConfig::default().loop_detection_window;
     let mut det = LoopDetector::new(100);
     for i in 0..default_window + 5 {
         det.record("tool", &format!("hash{i}"), false);

--- a/crates/nous/src/pipeline/stages_tests.rs
+++ b/crates/nous/src/pipeline/stages_tests.rs
@@ -41,8 +41,14 @@ fn structural_summary_preserves_recent_turns() {
     assert!(summary.contains("msg1"), "msg1 should be summarized");
     assert!(summary.contains("msg2"), "msg2 should be summarized");
     assert!(summary.contains("msg3"), "msg3 should be summarized");
-    assert!(!summary.contains("msg4"), "msg4 should be preserved (not summarized)");
-    assert!(!summary.contains("msg5"), "msg5 should be preserved (not summarized)");
+    assert!(
+        !summary.contains("msg4"),
+        "msg4 should be preserved (not summarized)"
+    );
+    assert!(
+        !summary.contains("msg5"),
+        "msg5 should be preserved (not summarized)"
+    );
     assert!(summary.contains("3 messages summarized"));
 }
 
@@ -116,10 +122,7 @@ fn structural_summary_handles_multibyte_content() {
 #[test]
 fn structural_summary_preserve_exactly_equals_len() {
     // preserve_turns == len: everything is preserved, nothing summarized
-    let msgs = vec![
-        make_msg("user", "one"),
-        make_msg("assistant", "two"),
-    ];
+    let msgs = vec![make_msg("user", "one"), make_msg("assistant", "two")];
     let config = config_with_preserve(2);
     let summary = build_structural_summary(&msgs, &config);
     assert!(summary.contains("0 messages summarized"));

--- a/crates/nous/src/recall_tests.rs
+++ b/crates/nous/src/recall_tests.rs
@@ -314,8 +314,11 @@ mod knowledge_bridge_tests {
     const DIM: usize = 4;
 
     fn make_store() -> Arc<KnowledgeStore> {
-        KnowledgeStore::open_mem_with_config(KnowledgeConfig { dim: DIM, ..Default::default() })
-            .expect("open in-memory store")
+        KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+            dim: DIM,
+            ..Default::default()
+        })
+        .expect("open in-memory store")
     }
 
     fn make_chunk(id: &str, content: &str, embedding: Vec<f32>) -> EmbeddedChunk {

--- a/crates/nous/src/roles/contract.rs
+++ b/crates/nous/src/roles/contract.rs
@@ -43,10 +43,7 @@ impl RoleContract {
     pub fn to_prompt_section(&self) -> String {
         use std::fmt::Write;
 
-        let mut out = format!(
-            "## Role Contract: {} (v{})\n\n",
-            self.role, self.version
-        );
+        let mut out = format!("## Role Contract: {} (v{})\n\n", self.role, self.version);
 
         if !self.behaviors.is_empty() {
             out.push_str("### Expected Behaviors\n\n");
@@ -271,7 +268,8 @@ fn reviewer_contract() -> RoleContract {
         behaviors: vec![
             "Provide specific findings with file paths and line numbers".to_owned(),
             "Categorize issues by severity (error, warning, info)".to_owned(),
-            "Check correctness, edge cases, error handling, style, backward compatibility".to_owned(),
+            "Check correctness, edge cases, error handling, style, backward compatibility"
+                .to_owned(),
             "Check test coverage for new code paths".to_owned(),
             "Acknowledge clean code without inventing problems".to_owned(),
         ],
@@ -448,10 +446,7 @@ constraints = ["Execute plans"]
             section.contains("Role Contract: coder (v2)"),
             "should contain role and version"
         );
-        assert!(
-            section.contains("- Write code"),
-            "should list behaviors"
-        );
+        assert!(section.contains("- Write code"), "should list behaviors");
         assert!(
             section.contains("- MUST NOT: Break the build"),
             "should list constraints with MUST NOT prefix"

--- a/crates/nous/src/self_audit/checks.rs
+++ b/crates/nous/src/self_audit/checks.rs
@@ -550,15 +550,13 @@ impl ProsocheCheck for SessionContinuityCheck {
             clippy::cast_precision_loss,
             reason = "usize→f64: turn counts are far below f64 precision limits"
         )]
-        let carry_rate =
-            ctx.session_continuity.context_carry_turns as f64 / total as f64; // kanon:ignore RUST/as-cast
+        let carry_rate = ctx.session_continuity.context_carry_turns as f64 / total as f64; // kanon:ignore RUST/as-cast
         #[expect(
             clippy::as_conversions,
             clippy::cast_precision_loss,
             reason = "usize→f64: turn counts are far below f64 precision limits"
         )]
-        let restatement_rate =
-            ctx.session_continuity.restatement_count as f64 / total as f64; // kanon:ignore RUST/as-cast
+        let restatement_rate = ctx.session_continuity.restatement_count as f64 / total as f64; // kanon:ignore RUST/as-cast
 
         let carry_status = if carry_rate < CONTINUITY_CARRY_FAIL_THRESHOLD {
             CheckStatus::Fail

--- a/crates/nous/src/self_audit/checks_tests.rs
+++ b/crates/nous/src/self_audit/checks_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::self_audit::{CorrectionRecord, MemoryRecallStats, SessionContinuityStats, ToolCallRecord};
+use crate::self_audit::{
+    CorrectionRecord, MemoryRecallStats, SessionContinuityStats, ToolCallRecord,
+};
 
 // --- KnowledgeConsistencyCheck ---
 
@@ -239,7 +241,10 @@ fn coherence_passes_when_responses_get_longer() {
     };
     let result = check.run(&ctx);
     assert_eq!(result.status, CheckStatus::Pass);
-    assert!(result.score >= 1.0 - f64::EPSILON, "lengthening should score 1.0");
+    assert!(
+        result.score >= 1.0 - f64::EPSILON,
+        "lengthening should score 1.0"
+    );
 }
 
 // --- CorrectionFrequencyCheck ---
@@ -459,20 +464,38 @@ fn continuity_fails_on_both_bad_signals() {
 
 #[test]
 fn worse_status_returns_fail_when_either_fails() {
-    assert_eq!(worse_status(CheckStatus::Fail, CheckStatus::Pass), CheckStatus::Fail);
-    assert_eq!(worse_status(CheckStatus::Pass, CheckStatus::Fail), CheckStatus::Fail);
-    assert_eq!(worse_status(CheckStatus::Fail, CheckStatus::Warn), CheckStatus::Fail);
+    assert_eq!(
+        worse_status(CheckStatus::Fail, CheckStatus::Pass),
+        CheckStatus::Fail
+    );
+    assert_eq!(
+        worse_status(CheckStatus::Pass, CheckStatus::Fail),
+        CheckStatus::Fail
+    );
+    assert_eq!(
+        worse_status(CheckStatus::Fail, CheckStatus::Warn),
+        CheckStatus::Fail
+    );
 }
 
 #[test]
 fn worse_status_returns_warn_when_either_warns() {
-    assert_eq!(worse_status(CheckStatus::Warn, CheckStatus::Pass), CheckStatus::Warn);
-    assert_eq!(worse_status(CheckStatus::Pass, CheckStatus::Warn), CheckStatus::Warn);
+    assert_eq!(
+        worse_status(CheckStatus::Warn, CheckStatus::Pass),
+        CheckStatus::Warn
+    );
+    assert_eq!(
+        worse_status(CheckStatus::Pass, CheckStatus::Warn),
+        CheckStatus::Warn
+    );
 }
 
 #[test]
 fn worse_status_returns_pass_when_both_pass() {
-    assert_eq!(worse_status(CheckStatus::Pass, CheckStatus::Pass), CheckStatus::Pass);
+    assert_eq!(
+        worse_status(CheckStatus::Pass, CheckStatus::Pass),
+        CheckStatus::Pass
+    );
 }
 
 // --- Trait conformance ---

--- a/crates/nous/src/self_audit/mod.rs
+++ b/crates/nous/src/self_audit/mod.rs
@@ -339,8 +339,7 @@ pub fn store_audit_report(
             CheckStatus::Fail => EpistemicTier::Assumed,
         };
 
-        let fact_id = match mneme::id::FactId::new(format!("audit-{}", koina::ulid::Ulid::new()))
-        {
+        let fact_id = match mneme::id::FactId::new(format!("audit-{}", koina::ulid::Ulid::new())) {
             Ok(id) => id,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to create audit fact ID");

--- a/crates/nous/src/session.rs
+++ b/crates/nous/src/session.rs
@@ -2,8 +2,8 @@
 
 use std::time::Instant;
 
-use tracing::{info, instrument};
 use koina::ulid::Ulid;
+use tracing::{info, instrument};
 
 use crate::config::NousConfig;
 

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -109,7 +109,6 @@ use crate::bootstrap::{BootstrapSection, SectionPriority};
 #[cfg(any(feature = "knowledge-store", test))]
 use crate::budget::CharEstimator;
 
-
 /// Resolves relevant skills from mneme and converts them to bootstrap sections.
 ///
 /// Skill loading is additive and gracefully degrades: if the knowledge store
@@ -242,13 +241,12 @@ impl SkillLoader {
 /// Falls back to the raw content string if parsing fails (e.g. plain-text skills).
 #[cfg(any(feature = "knowledge-store", test))]
 pub(crate) fn fact_to_section(fact: &Fact) -> BootstrapSection {
-    let content = if let Ok(skill) =
-        serde_json::from_str::<mneme::skill::SkillContent>(&fact.content)
-    {
-        format_skill_as_markdown(&skill)
-    } else {
-        fact.content.clone()
-    };
+    let content =
+        if let Ok(skill) = serde_json::from_str::<mneme::skill::SkillContent>(&fact.content) {
+            format_skill_as_markdown(&skill)
+        } else {
+            fact.content.clone()
+        };
 
     let tokens = CharEstimator::default().estimate(&content);
 

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -82,7 +82,10 @@ impl SpawnService for SpawnServiceImpl {
 
         let timeout = Duration::from_secs(request.timeout_secs);
         let task = request.task.clone();
-        let session_key = format!("spawn:{}", koina::ulid::Ulid::new().to_string().to_lowercase());
+        let session_key = format!(
+            "spawn:{}",
+            koina::ulid::Ulid::new().to_string().to_lowercase()
+        );
 
         let config = NousConfig {
             id: Arc::from(spawn_id.as_str()),
@@ -333,9 +336,8 @@ mod tests {
             _request: &'a CompletionRequest,
         ) -> std::pin::Pin<
             Box<
-                dyn std::future::Future<
-                        Output = hermeneus::error::Result<CompletionResponse>,
-                    > + Send
+                dyn std::future::Future<Output = hermeneus::error::Result<CompletionResponse>>
+                    + Send
                     + 'a,
             >,
         > {

--- a/crates/nous/src/tasks/gc.rs
+++ b/crates/nous/src/tasks/gc.rs
@@ -23,17 +23,12 @@ pub fn spawn_gc_task(
     registry: TaskRegistry,
     shutdown: CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
-    let gc_interval_secs =
-        taxis::config::NousBehaviorConfig::default().gc_interval_secs;
+    let gc_interval_secs = taxis::config::NousBehaviorConfig::default().gc_interval_secs;
     tracing::debug!(
         gc_interval_secs,
         "spawn_gc_task: interval from NousBehaviorConfig"
     );
-    spawn_gc_task_with_interval(
-        registry,
-        shutdown,
-        Duration::from_secs(gc_interval_secs),
-    )
+    spawn_gc_task_with_interval(registry, shutdown, Duration::from_secs(gc_interval_secs))
 }
 
 /// Spawn a GC task with a custom sweep interval.

--- a/crates/nous/src/training.rs
+++ b/crates/nous/src/training.rs
@@ -38,7 +38,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 // Re-export types from eidos for convenience
-pub use eidos::training::{TrainingConfig, TrainingRecord, TRAINING_RECORD_SCHEMA_VERSION};
+pub use eidos::training::{TRAINING_RECORD_SCHEMA_VERSION, TrainingConfig, TrainingRecord};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
@@ -154,10 +154,7 @@ impl CaptureStopReason {
     /// Whether this stop reason indicates the response should be excluded
     /// from training data.
     fn is_rejected(self) -> bool {
-        matches!(
-            self,
-            Self::MaxTokens | Self::Degraded | Self::Unknown
-        )
+        matches!(self, Self::MaxTokens | Self::Degraded | Self::Unknown)
     }
 }
 
@@ -190,7 +187,6 @@ pub struct CaptureInput<'a> {
     pub has_tool_calls: bool,
 
     // ── Episteme labels ──────────────────────────────────────────────
-
     /// Classification of the conversation turn (e.g. "discussion", "correction").
     pub turn_type: Option<String>,
     /// Whether this turn corrects a previous response.
@@ -240,8 +236,7 @@ impl TrainingManifest {
 
     /// Persist the manifest atomically: write to temp, then rename.
     fn persist(&self, manifest_path: &Path) -> Result<()> {
-        let json =
-            serde_json::to_string_pretty(self).context(SerializeManifestSnafu)?;
+        let json = serde_json::to_string_pretty(self).context(SerializeManifestSnafu)?;
 
         let tmp_path = manifest_path.with_extension("json.tmp");
 
@@ -322,18 +317,14 @@ impl TrainingCapture {
                 .iter()
                 .any(|s| s.file_name == "conversations.jsonl")
         {
-            let meta = fs::metadata(&legacy_path).context(ReadMetadataSnafu {
-                path: &legacy_path,
-            })?;
+            let meta =
+                fs::metadata(&legacy_path).context(ReadMetadataSnafu { path: &legacy_path })?;
             let line_count = fs::read_to_string(&legacy_path)
                 .unwrap_or_default()
                 .lines()
                 .filter(|l| !l.trim().is_empty())
                 .count();
-            #[expect(
-                clippy::as_conversions,
-                reason = "usize→u64: line count fits in u64"
-            )]
+            #[expect(clippy::as_conversions, reason = "usize→u64: line count fits in u64")]
             let record_count = line_count as u64; // kanon:ignore RUST/as-cast
 
             manifest.shards.push(ShardEntry {
@@ -390,9 +381,8 @@ impl TrainingCapture {
         if let Some(last) = manifest.shards.last() {
             let last_path = dir.join(&last.file_name);
             if last_path.exists() {
-                let meta = fs::metadata(&last_path).context(ReadMetadataSnafu {
-                    path: &last_path,
-                })?;
+                let meta =
+                    fs::metadata(&last_path).context(ReadMetadataSnafu { path: &last_path })?;
                 if meta.len() < max_shard_bytes {
                     return Ok(last_path);
                 }
@@ -410,17 +400,10 @@ impl TrainingCapture {
     fn new_shard_name(dir: &Path) -> String {
         let today = jiff::civil::date(
             Timestamp::now().to_zoned(jiff::tz::TimeZone::UTC).year(),
-            Timestamp::now()
-                .to_zoned(jiff::tz::TimeZone::UTC)
-                .month(),
+            Timestamp::now().to_zoned(jiff::tz::TimeZone::UTC).month(),
             Timestamp::now().to_zoned(jiff::tz::TimeZone::UTC).day(),
         );
-        let date_str = format!(
-            "{:04}{:02}{:02}",
-            today.year(),
-            today.month(),
-            today.day()
-        );
+        let date_str = format!("{:04}{:02}{:02}", today.year(), today.month(), today.day());
 
         // Find the highest sequence number for today's date
         let prefix = format!("training-{date_str}-");
@@ -490,19 +473,15 @@ impl TrainingCapture {
                 path: &self.current_shard,
             })?;
 
-        file.write_all(line.as_bytes())
-            .context(WriteRecordSnafu {
-                path: &self.current_shard,
-            })?;
+        file.write_all(line.as_bytes()).context(WriteRecordSnafu {
+            path: &self.current_shard,
+        })?;
 
         // Update manifest
         if let Some(last) = self.manifest.shards.last_mut() {
             last.record_count += 1;
             // Update size estimate from the line we just wrote
-            #[expect(
-                clippy::as_conversions,
-                reason = "usize→u64: line length fits in u64"
-            )]
+            #[expect(clippy::as_conversions, reason = "usize→u64: line length fits in u64")]
             {
                 last.size_bytes += line.len() as u64; // kanon:ignore RUST/as-cast
             }
@@ -541,7 +520,10 @@ impl TrainingCapture {
         // WHY: empty and whitespace-only responses teach the model to produce
         // vacuous output. `.trim().is_empty()` catches both `""` and `"  \n"`.
         if input.assistant_response.trim().is_empty() {
-            debug!(session_id = input.session_id, "training capture skipped: empty/whitespace response");
+            debug!(
+                session_id = input.session_id,
+                "training capture skipped: empty/whitespace response"
+            );
             return false;
         }
 

--- a/crates/nous/src/training_tests.rs
+++ b/crates/nous/src/training_tests.rs
@@ -1,5 +1,8 @@
 #![expect(clippy::expect_used, reason = "test assertions")]
-#![expect(clippy::indexing_slicing, reason = "test assertions on a known-length collection")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions on a known-length collection"
+)]
 
 use super::*;
 
@@ -152,7 +155,11 @@ fn shard_rotation_on_size_limit() {
     // All shard files should exist
     for shard in &capture.manifest().shards {
         let shard_path = dir.path().join("training").join(&shard.file_name);
-        assert!(shard_path.exists(), "shard {} should exist", shard.file_name);
+        assert!(
+            shard_path.exists(),
+            "shard {} should exist",
+            shard.file_name
+        );
     }
 }
 
@@ -210,8 +217,7 @@ fn manifest_persisted_atomically() {
 
     // Should be valid JSON
     let content = fs::read_to_string(&manifest_path).expect("read manifest");
-    let manifest: TrainingManifest =
-        serde_json::from_str(&content).expect("parse manifest");
+    let manifest: TrainingManifest = serde_json::from_str(&content).expect("parse manifest");
     assert_eq!(manifest.total_records, 1);
 }
 
@@ -249,7 +255,10 @@ fn quality_gate_rejects_whitespace_only_response() {
             assistant_response: ws,
             ..good_input()
         });
-        assert!(!captured, "whitespace-only response {ws:?} should be rejected");
+        assert!(
+            !captured,
+            "whitespace-only response {ws:?} should be rejected"
+        );
     }
 }
 
@@ -324,7 +333,10 @@ fn quality_gate_rejects_tool_use_only_turn() {
         has_tool_calls: true,
         ..good_input()
     });
-    assert!(!captured, "tool-use-only turn (tool_use stop + has_tool_calls) should be rejected");
+    assert!(
+        !captured,
+        "tool-use-only turn (tool_use stop + has_tool_calls) should be rejected"
+    );
 }
 
 #[test]
@@ -344,7 +356,10 @@ fn quality_gate_accepts_tool_use_with_end_turn() {
         has_tool_calls: true,
         ..good_input()
     });
-    assert!(captured, "tool-using turn that ended with text should be accepted");
+    assert!(
+        captured,
+        "tool-using turn that ended with text should be accepted"
+    );
 }
 
 // -- Quality gate: happy path -------------------------------------------------
@@ -420,13 +435,34 @@ fn capture_preserves_episteme_labels() {
 
 #[test]
 fn capture_stop_reason_from_str() {
-    assert_eq!(CaptureStopReason::parse("end_turn"), CaptureStopReason::EndTurn);
-    assert_eq!(CaptureStopReason::parse("tool_use"), CaptureStopReason::ToolUse);
-    assert_eq!(CaptureStopReason::parse("max_tokens"), CaptureStopReason::MaxTokens);
-    assert_eq!(CaptureStopReason::parse("stop_sequence"), CaptureStopReason::StopSequence);
-    assert_eq!(CaptureStopReason::parse("degraded"), CaptureStopReason::Degraded);
-    assert_eq!(CaptureStopReason::parse("error"), CaptureStopReason::Unknown);
-    assert_eq!(CaptureStopReason::parse("anything_else"), CaptureStopReason::Unknown);
+    assert_eq!(
+        CaptureStopReason::parse("end_turn"),
+        CaptureStopReason::EndTurn
+    );
+    assert_eq!(
+        CaptureStopReason::parse("tool_use"),
+        CaptureStopReason::ToolUse
+    );
+    assert_eq!(
+        CaptureStopReason::parse("max_tokens"),
+        CaptureStopReason::MaxTokens
+    );
+    assert_eq!(
+        CaptureStopReason::parse("stop_sequence"),
+        CaptureStopReason::StopSequence
+    );
+    assert_eq!(
+        CaptureStopReason::parse("degraded"),
+        CaptureStopReason::Degraded
+    );
+    assert_eq!(
+        CaptureStopReason::parse("error"),
+        CaptureStopReason::Unknown
+    );
+    assert_eq!(
+        CaptureStopReason::parse("anything_else"),
+        CaptureStopReason::Unknown
+    );
 }
 
 // -- Serde roundtrip ----------------------------------------------------------

--- a/crates/nous/src/tuning/evidence.rs
+++ b/crates/nous/src/tuning/evidence.rs
@@ -33,10 +33,7 @@ pub struct EvidenceResult {
 /// * `values` — Ordered metric observations (oldest first).
 /// * `significance_threshold` — Delta must exceed this many standard deviations.
 #[must_use]
-pub fn validate_evidence(
-    values: &[f64],
-    significance_threshold: f64,
-) -> Option<EvidenceResult> {
+pub fn validate_evidence(values: &[f64], significance_threshold: f64) -> Option<EvidenceResult> {
     if values.len() < 2 {
         return None;
     }
@@ -157,7 +154,10 @@ mod tests {
         // Very high noise with small difference
         let values = [0.49, 0.51, 0.48, 0.52, 0.50, 0.51, 0.49, 0.50, 0.51, 0.50];
         let result = validate_evidence(&values, 1.5).unwrap();
-        assert!(!result.is_significant, "tiny delta should not be significant");
+        assert!(
+            !result.is_significant,
+            "tiny delta should not be significant"
+        );
     }
 
     #[test]
@@ -172,7 +172,10 @@ mod tests {
         // Declining signal
         let values = [0.9, 0.9, 0.9, 0.9, 0.9, 0.1, 0.1, 0.1, 0.1, 0.1];
         let result = validate_evidence(&values, 0.5).unwrap();
-        assert!(result.delta < 0.0, "declining signal should have negative delta");
+        assert!(
+            result.delta < 0.0,
+            "declining signal should have negative delta"
+        );
         assert!(result.is_significant);
     }
 

--- a/crates/nous/src/tuning/mod.rs
+++ b/crates/nous/src/tuning/mod.rs
@@ -110,11 +110,7 @@ impl TuningProposer {
         clippy::as_conversions,
         reason = "u32->usize: max_changes_per_cycle is a small config value, always fits in usize"
     )]
-    pub fn evaluate(
-        &self,
-        observations: &[MetricSample],
-        nous_id: &str,
-    ) -> Vec<ProposalOutcome> {
+    pub fn evaluate(&self, observations: &[MetricSample], nous_id: &str) -> Vec<ProposalOutcome> {
         if !self.config.enabled {
             return Vec::new();
         }
@@ -125,7 +121,10 @@ impl TuningProposer {
         let mut by_metric: std::collections::HashMap<&str, Vec<&MetricSample>> =
             std::collections::HashMap::new();
         for obs in observations {
-            by_metric.entry(obs.metric_name.as_str()).or_default().push(obs);
+            by_metric
+                .entry(obs.metric_name.as_str())
+                .or_default()
+                .push(obs);
         }
 
         let mut outcomes = Vec::new();
@@ -192,10 +191,7 @@ impl TuningProposer {
 
         // Split samples into before/after halves for A/B comparison.
         let values: Vec<f64> = samples.iter().map(|s| s.value).collect();
-        let validation = evidence::validate_evidence(
-            &values,
-            self.config.significance_threshold,
-        );
+        let validation = evidence::validate_evidence(&values, self.config.significance_threshold);
 
         let Some(result) = validation else {
             return ProposalOutcome::Rejected {
@@ -291,10 +287,18 @@ fn derive_proposed_value(spec: &ParameterSpec, delta: f64) -> ParameterValue {
     // it degraded. The direction_hint tells us which direction to nudge.
     let nudge_factor = match spec.direction_hint {
         TuningDirection::Higher => {
-            if delta > 0.0 { 0.10 } else { -0.10 }
+            if delta > 0.0 {
+                0.10
+            } else {
+                -0.10
+            }
         }
         TuningDirection::Lower => {
-            if delta > 0.0 { -0.10 } else { 0.10 }
+            if delta > 0.0 {
+                -0.10
+            } else {
+                0.10
+            }
         }
         TuningDirection::Contextual => {
             // For contextual parameters, use the sign of delta directly.
@@ -344,7 +348,13 @@ fn parameter_value_to_f64(value: &ParameterValue) -> f64 {
     match value {
         ParameterValue::Int(v) => *v as f64, // kanon:ignore RUST/as-cast
         ParameterValue::Float(v) => *v,
-        ParameterValue::Bool(v) => if *v { 1.0 } else { 0.0 },
+        ParameterValue::Bool(v) => {
+            if *v {
+                1.0
+            } else {
+                0.0
+            }
+        }
         ParameterValue::Duration(v) => *v as f64, // kanon:ignore RUST/as-cast
     }
 }
@@ -407,7 +417,10 @@ mod tests {
         let proposer = TuningProposer::new(make_config(false));
         let samples = make_samples("turn_quality_post_distillation", &[0.5; 30]);
         let outcomes = proposer.evaluate(&samples, "test-nous");
-        assert!(outcomes.is_empty(), "disabled tuning should produce no outcomes");
+        assert!(
+            outcomes.is_empty(),
+            "disabled tuning should produce no outcomes"
+        );
     }
 
     #[test]
@@ -420,7 +433,10 @@ mod tests {
         for outcome in &outcomes {
             match outcome {
                 ProposalOutcome::Rejected { reason, .. } => {
-                    assert!(reason.contains("insufficient samples"), "expected insufficient samples rejection, got: {reason}");
+                    assert!(
+                        reason.contains("insufficient samples"),
+                        "expected insufficient samples rejection, got: {reason}"
+                    );
                 }
                 _ => panic!("expected Rejected outcome"),
             }
@@ -451,7 +467,8 @@ mod tests {
             match outcome {
                 ProposalOutcome::Rejected { reason, .. } => {
                     assert!(
-                        reason.contains("insufficient variance") || reason.contains("does not exceed"),
+                        reason.contains("insufficient variance")
+                            || reason.contains("does not exceed"),
                         "expected weak evidence rejection, got: {reason}"
                     );
                 }
@@ -473,9 +490,9 @@ mod tests {
         let outcomes = proposer.evaluate(&samples, "test-nous");
 
         // Should have at least one Applied or OutOfBounds (not all Rejected)
-        let has_non_rejected = outcomes.iter().any(|o| {
-            !matches!(o, ProposalOutcome::Rejected { .. })
-        });
+        let has_non_rejected = outcomes
+            .iter()
+            .any(|o| !matches!(o, ProposalOutcome::Rejected { .. }));
         // The test may produce OutOfBounds too, which is acceptable
         assert!(
             has_non_rejected || outcomes.is_empty(),
@@ -524,6 +541,8 @@ mod tests {
         assert!((parameter_value_to_f64(&ParameterValue::Float(2.78)) - 2.78).abs() < f64::EPSILON);
         assert!((parameter_value_to_f64(&ParameterValue::Bool(true)) - 1.0).abs() < f64::EPSILON);
         assert!((parameter_value_to_f64(&ParameterValue::Bool(false)) - 0.0).abs() < f64::EPSILON);
-        assert!((parameter_value_to_f64(&ParameterValue::Duration(100)) - 100.0).abs() < f64::EPSILON);
+        assert!(
+            (parameter_value_to_f64(&ParameterValue::Duration(100)) - 100.0).abs() < f64::EPSILON
+        );
     }
 }

--- a/crates/nous/src/tuning/signals.rs
+++ b/crates/nous/src/tuning/signals.rs
@@ -130,8 +130,7 @@ mod tests {
     use super::*;
 
     fn make_samples(values: &[f64]) -> Vec<MetricSample> {
-        let base = jiff::Timestamp::from_second(1_700_000_000)
-            .expect("valid timestamp");
+        let base = jiff::Timestamp::from_second(1_700_000_000).expect("valid timestamp");
         values
             .iter()
             .enumerate()
@@ -178,7 +177,10 @@ mod tests {
         // Linearly increasing: 0.1, 0.2, 0.3, 0.4, 0.5
         let samples = make_samples(&[0.1, 0.2, 0.3, 0.4, 0.5]);
         let slope = compute_competence_trajectory(&samples);
-        assert!(slope.unwrap() > 0.0, "increasing values should have positive slope");
+        assert!(
+            slope.unwrap() > 0.0,
+            "increasing values should have positive slope"
+        );
         assert!((slope.unwrap() - 0.1).abs() < 0.001, "slope should be ~0.1");
     }
 
@@ -186,7 +188,10 @@ mod tests {
     fn competence_trajectory_negative_slope() {
         let samples = make_samples(&[0.5, 0.4, 0.3, 0.2, 0.1]);
         let slope = compute_competence_trajectory(&samples);
-        assert!(slope.unwrap() < 0.0, "decreasing values should have negative slope");
+        assert!(
+            slope.unwrap() < 0.0,
+            "decreasing values should have negative slope"
+        );
     }
 
     #[test]
@@ -194,7 +199,10 @@ mod tests {
         let samples = make_samples(&[0.5, 0.5, 0.5, 0.5, 0.5]);
         let slope = compute_competence_trajectory(&samples);
         // With constant values, numerator is 0, denominator is non-zero
-        assert!((slope.unwrap()).abs() < f64::EPSILON, "flat values should have zero slope");
+        assert!(
+            (slope.unwrap()).abs() < f64::EPSILON,
+            "flat values should have zero slope"
+        );
     }
 
     #[test]
@@ -210,11 +218,7 @@ mod tests {
         let orig_len = names.len();
         names.sort_unstable();
         names.dedup();
-        assert_eq!(
-            names.len(),
-            orig_len,
-            "signal names must be unique"
-        );
+        assert_eq!(names.len(), orig_len, "signal names must be unique");
     }
 
     #[test]

--- a/crates/nous/src/uncertainty.rs
+++ b/crates/nous/src/uncertainty.rs
@@ -10,7 +10,6 @@ use snafu::ResultExt as _;
 
 use crate::error;
 
-
 /// Number of bins for the calibration curve (10 bins of width 0.1).
 const NUM_BINS: usize = 10;
 
@@ -90,7 +89,7 @@ impl UncertaintyTracker {
             message: "failed to open uncertainty database",
         })?;
         let max_calibration_points = u32::try_from(
-            taxis::config::AgentBehaviorDefaults::default().uncertainty_max_calibration_points
+            taxis::config::AgentBehaviorDefaults::default().uncertainty_max_calibration_points,
         )
         .unwrap_or(1_000);
         Self::init(conn, max_calibration_points)
@@ -117,7 +116,7 @@ impl UncertaintyTracker {
             message: "failed to open in-memory uncertainty database",
         })?;
         let max_calibration_points = u32::try_from(
-            taxis::config::AgentBehaviorDefaults::default().uncertainty_max_calibration_points
+            taxis::config::AgentBehaviorDefaults::default().uncertainty_max_calibration_points,
         )
         .unwrap_or(1_000);
         Self::init(conn, max_calibration_points)
@@ -151,7 +150,10 @@ impl UncertaintyTracker {
             message: "failed to initialize uncertainty schema",
         })?;
 
-        Ok(Self { conn, max_calibration_points })
+        Ok(Self {
+            conn,
+            max_calibration_points,
+        })
     }
 
     /// Record a confidence prediction and its actual outcome.
@@ -202,7 +204,10 @@ impl UncertaintyTracker {
     /// # Errors
     ///
     /// Returns `UncertaintyStore` on database read failure.
-    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: agent pipeline infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "WIP: agent pipeline infrastructure")
+    )]
     pub(crate) fn calibration_curve(
         &self,
         nous_id: Option<&str>,
@@ -218,7 +223,10 @@ impl UncertaintyTracker {
     /// # Errors
     ///
     /// Returns `UncertaintyStore` on database read failure.
-    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: agent pipeline infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "WIP: agent pipeline infrastructure")
+    )]
     pub(crate) fn brier_score(&self, nous_id: Option<&str>) -> error::Result<f64> {
         let points = self.load_points(nous_id)?;
         Ok(compute_brier_score(&points))
@@ -232,7 +240,10 @@ impl UncertaintyTracker {
     /// # Errors
     ///
     /// Returns `UncertaintyStore` on database read failure.
-    #[expect(dead_code, reason = "WIP: agent pipeline infrastructure — no callers yet, including tests")]
+    #[expect(
+        dead_code,
+        reason = "WIP: agent pipeline infrastructure — no callers yet, including tests"
+    )]
     pub(crate) fn ece(&self, nous_id: Option<&str>) -> error::Result<f64> {
         let points = self.load_points(nous_id)?;
         let curve = compute_calibration_curve(&points);
@@ -672,7 +683,8 @@ mod tests {
     #[test]
     fn pruning_keeps_most_recent_points() {
         let t = tracker();
-        let max = taxis::config::AgentBehaviorDefaults::default().uncertainty_max_calibration_points;
+        let max =
+            taxis::config::AgentBehaviorDefaults::default().uncertainty_max_calibration_points;
         #[expect(
             clippy::cast_possible_truncation,
             clippy::as_conversions,

--- a/crates/nous/src/working_state.rs
+++ b/crates/nous/src/working_state.rs
@@ -187,13 +187,19 @@ impl<'de> Deserialize<'de> for WorkingState {
 impl WorkingState {
     /// Create an empty working state.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "working state management for agent context"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "working state management for agent context")
+    )]
     pub(crate) fn new() -> Self {
         Self::default()
     }
 
     /// Push a task onto the stack.
-    #[cfg_attr(not(test), expect(dead_code, reason = "working state management for agent context"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "working state management for agent context")
+    )]
     pub(crate) fn push_task(&mut self, description: impl Into<String>) {
         let max_task_stack =
             taxis::config::AgentBehaviorDefaults::default().working_state_max_task_stack;
@@ -212,7 +218,10 @@ impl WorkingState {
     }
 
     /// Pop the most recent task from the stack.
-    #[cfg_attr(not(test), expect(dead_code, reason = "working state management for agent context"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "working state management for agent context")
+    )]
     pub(crate) fn pop_task(&mut self) -> Option<TaskEntry> {
         let task = self.task_stack.pop();
         if task.is_some() {
@@ -228,7 +237,10 @@ impl WorkingState {
     }
 
     /// Set the focus context.
-    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: agent pipeline infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "WIP: agent pipeline infrastructure")
+    )]
     pub(crate) fn set_focus(
         &mut self,
         file: Option<String>,
@@ -244,14 +256,20 @@ impl WorkingState {
     }
 
     /// Clear the focus context.
-    #[cfg_attr(not(test), expect(dead_code, reason = "WIP: agent pipeline infrastructure"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "WIP: agent pipeline infrastructure")
+    )]
     pub(crate) fn clear_focus(&mut self) {
         self.focus = None;
         self.touch();
     }
 
     /// Set the wait state.
-    #[cfg_attr(not(test), expect(dead_code, reason = "working state management for agent context"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "working state management for agent context")
+    )]
     pub(crate) fn set_wait(&mut self, kind: WaitKind, description: impl Into<String>) {
         self.wait = Some(WaitState {
             kind,
@@ -262,7 +280,10 @@ impl WorkingState {
     }
 
     /// Clear the wait state.
-    #[cfg_attr(not(test), expect(dead_code, reason = "working state management for agent context"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "working state management for agent context")
+    )]
     pub(crate) fn clear_wait(&mut self) {
         self.wait = None;
         self.touch();
@@ -312,7 +333,10 @@ impl WorkingState {
 
     /// Generate the blackboard key for persisting this state.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "working state management for agent context"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "working state management for agent context")
+    )]
     pub(crate) fn persist_key(nous_id: &str, session_id: &str) -> String {
         format!("ws:{nous_id}:{session_id}")
     }
@@ -322,7 +346,10 @@ impl WorkingState {
     /// # Errors
     ///
     /// Returns serialization error (should not happen for valid state).
-    #[cfg_attr(not(test), expect(dead_code, reason = "working state management for agent context"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "working state management for agent context")
+    )]
     pub(crate) fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }
@@ -332,7 +359,10 @@ impl WorkingState {
     /// # Errors
     ///
     /// Returns deserialization error if the JSON is malformed.
-    #[cfg_attr(not(test), expect(dead_code, reason = "working state management for agent context"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "working state management for agent context")
+    )]
     pub(crate) fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }
@@ -341,7 +371,10 @@ impl WorkingState {
     ///
     /// Returns `None` if the working state is empty.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "working state management for agent context"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "working state management for agent context")
+    )]
     pub(crate) fn to_bootstrap_section(&self) -> Option<BootstrapSection> {
         if self.is_empty() {
             return None;

--- a/crates/nous/src/working_state_tests.rs
+++ b/crates/nous/src/working_state_tests.rs
@@ -249,7 +249,10 @@ fn sample_cache_params() -> Arc<CacheSafeParams> {
         Arc::from(vec![sample_message("hello"), sample_message("world")]);
     Arc::new(CacheSafeParams::new(
         "You are a test agent.",
-        vec![sample_tool_definition("zeta_tool"), sample_tool_definition("alpha_tool")],
+        vec![
+            sample_tool_definition("zeta_tool"),
+            sample_tool_definition("alpha_tool"),
+        ],
         "claude-opus-4-20250514",
         messages,
         Some(ThinkingConfig {

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -17,10 +17,16 @@ use crate::types::{
 };
 
 /// Fallback default; runtime reads `ctx.tool_config.agent_dispatch_timeout_secs`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const DEFAULT_TIMEOUT_SECS: u64 = 300;
 /// Fallback default; runtime reads `ctx.tool_config.max_dispatch_tasks`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const MAX_DISPATCH_TASKS: usize = 10;
 
 struct SessionsSpawnExecutor;

--- a/crates/organon/src/builtins/communication.rs
+++ b/crates/organon/src/builtins/communication.rs
@@ -16,13 +16,22 @@ use crate::types::{
 };
 
 /// Fallback default; runtime reads `ctx.tool_config.message_max_len`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const MESSAGE_MAX_LEN: usize = 4000;
 /// Fallback default; runtime reads `ctx.tool_config.inter_session_max_message_len`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const INTER_SESSION_MAX_MESSAGE_LEN: usize = 100_000;
 /// Fallback default; runtime reads `ctx.tool_config.inter_session_max_timeout_secs`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const INTER_SESSION_MAX_TIMEOUT_SECS: u64 = 300;
 
 struct MessageExecutor;
@@ -584,18 +593,15 @@ mod tests {
         let calls = messenger_ref.send_calls.lock().unwrap();
         assert_eq!(calls.len(), 1, "expected calls.len() to equal 1");
         assert_eq!(
-            calls[0].0,
-            "+1234567890",
+            calls[0].0, "+1234567890",
             "expected calls[0].0 to equal \"+1234567890\""
         );
         assert_eq!(
-            calls[0].1,
-            "hello world",
+            calls[0].1, "hello world",
             "expected calls[0].1 to equal \"hello world\""
         );
         assert_eq!(
-            calls[0].2,
-            "test-agent",
+            calls[0].2, "test-agent",
             "expected calls[0].2 to equal \"test-agent\""
         );
     }
@@ -634,23 +640,13 @@ mod tests {
         let calls = cross_ref.send_calls.lock().unwrap();
         assert_eq!(calls.len(), 1, "expected calls.len() to equal 1");
         assert_eq!(
-            calls[0].0,
-            "test-agent",
+            calls[0].0, "test-agent",
             "expected calls[0].0 to equal \"test-agent\""
         );
+        assert_eq!(calls[0].1, "syn", "expected calls[0].1 to equal \"syn\"");
+        assert_eq!(calls[0].2, "main", "expected calls[0].2 to equal \"main\"");
         assert_eq!(
-            calls[0].1,
-            "syn",
-            "expected calls[0].1 to equal \"syn\""
-        );
-        assert_eq!(
-            calls[0].2,
-            "main",
-            "expected calls[0].2 to equal \"main\""
-        );
-        assert_eq!(
-            calls[0].3,
-            "do the thing",
+            calls[0].3, "do the thing",
             "expected calls[0].3 to equal \"do the thing\""
         );
     }
@@ -684,8 +680,7 @@ mod tests {
 
         let calls = cross_ref.send_calls.lock().unwrap();
         assert_eq!(
-            calls[0].2,
-            "custom",
+            calls[0].2, "custom",
             "expected calls[0].2 to equal \"custom\""
         );
     }

--- a/crates/organon/src/builtins/energeia/dispatch.rs
+++ b/crates/organon/src/builtins/energeia/dispatch.rs
@@ -117,15 +117,14 @@ impl ToolExecutor for DromeusExecutor {
 
             // WHY: spec is a JSON array of PromptSpec objects. Callers build the
             // spec programmatically (e.g. from prographe output) and pass it inline.
-            let prompts: Vec<energeia::prompt::PromptSpec> =
-                match serde_json::from_str(spec_str) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        return Ok(ToolResult::error(format!(
-                            "dromeus: invalid spec JSON: {e}"
-                        )));
-                    }
-                };
+            let prompts: Vec<energeia::prompt::PromptSpec> = match serde_json::from_str(spec_str) {
+                Ok(p) => p,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!(
+                        "dromeus: invalid spec JSON: {e}"
+                    )));
+                }
+            };
 
             if dry_run {
                 return match orchestrator.dry_run(&prompts) {

--- a/crates/organon/src/builtins/energeia/mod.rs
+++ b/crates/organon/src/builtins/energeia/mod.rs
@@ -58,7 +58,10 @@ pub fn register(
     )?;
     registry.register(qa::dokimasia_def(), Box::new(qa::DokimasiaExecutor))?;
     registry.register(qa::diorthosis_def(), Box::new(qa::DiorthosisExecutor))?;
-    registry.register(steward::epitropos_def(), Box::new(steward::EpitroposExecutor))?;
+    registry.register(
+        steward::epitropos_def(),
+        Box::new(steward::EpitroposExecutor),
+    )?;
     registry.register(
         observation::parateresis_def(),
         Box::new(observation::ParateresisExecutor {
@@ -71,9 +74,18 @@ pub fn register(
             store: store.clone(),
         }),
     )?;
-    registry.register(planning::prographe_def(), Box::new(planning::ProographeExecutor))?;
-    registry.register(planning::schedion_def(), Box::new(planning::SchedionExecutor))?;
-    registry.register(metrics::metron_def(), Box::new(metrics::MetronExecutor { store }))?;
+    registry.register(
+        planning::prographe_def(),
+        Box::new(planning::ProographeExecutor),
+    )?;
+    registry.register(
+        planning::schedion_def(),
+        Box::new(planning::SchedionExecutor),
+    )?;
+    registry.register(
+        metrics::metron_def(),
+        Box::new(metrics::MetronExecutor { store }),
+    )?;
     Ok(())
 }
 

--- a/crates/organon/src/builtins/energeia/qa.rs
+++ b/crates/organon/src/builtins/energeia/qa.rs
@@ -100,10 +100,8 @@ impl ToolExecutor for DokimasiaExecutor {
             // prompt spec loading (with real acceptance criteria) requires file
             // I/O outside the tool's scope. Callers can add criteria via a future
             // schema extension. Mechanical checks run against the empty diff.
-            let qa_prompt = energeia::qa::PromptSpec::new(
-                prompt_number,
-                format!("Prompt #{prompt_number}"),
-            );
+            let qa_prompt =
+                energeia::qa::PromptSpec::new(prompt_number, format!("Prompt #{prompt_number}"));
 
             // WHY: Diff is empty because fetching the PR diff requires GitHub API
             // access which is outside this tool's scope. Callers may pass a diff
@@ -191,16 +189,15 @@ impl ToolExecutor for DiorthosisExecutor {
             // dokimasia) so callers can chain dokimasia -> diorthosis without a
             // persistent QA result store. A future store extension will support opaque
             // IDs for server-side lookup.
-            let qa_result: energeia::types::QaResult =
-                match serde_json::from_str(qa_result_id) {
-                    Ok(r) => r,
-                    Err(_) => {
-                        return Ok(ToolResult::error(
-                            "diorthosis: qa_result_id must be a JSON-encoded QaResult \
+            let qa_result: energeia::types::QaResult = match serde_json::from_str(qa_result_id) {
+                Ok(r) => r,
+                Err(_) => {
+                    return Ok(ToolResult::error(
+                        "diorthosis: qa_result_id must be a JSON-encoded QaResult \
                             (copy the JSON output from a dokimasia call)",
-                        ));
-                    }
-                };
+                    ));
+                }
+            };
 
             let original = energeia::qa::PromptSpec::new(
                 original_prompt_number,

--- a/crates/organon/src/builtins/filesystem.rs
+++ b/crates/organon/src/builtins/filesystem.rs
@@ -48,7 +48,10 @@ fn canonicalize_and_revalidate(
 /// engine (`ReDoS`). Cap at 1000 chars which covers all legitimate search
 /// patterns. Closes #2167.
 /// Fallback default; runtime reads `ctx.tool_config.max_pattern_length`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const MAX_PATTERN_LENGTH: usize = 1000;
 
 fn truncate_output(mut output: String) -> String {

--- a/crates/organon/src/builtins/memory/datalog.rs
+++ b/crates/organon/src/builtins/memory/datalog.rs
@@ -20,10 +20,16 @@ use super::require_services;
 
 const MUTATION_KEYWORDS: &[&str] = &[":put", ":rm", ":replace", ":create", ":ensure"];
 /// Fallback default; runtime reads `ctx.tool_config.datalog_default_row_limit`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const DEFAULT_ROW_LIMIT: usize = 100;
 /// Fallback default; runtime reads `ctx.tool_config.datalog_default_timeout_secs`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const DEFAULT_TIMEOUT_SECS: f64 = 5.0;
 
 struct DatalogQueryExecutor;

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -18,10 +18,10 @@ pub mod enable_tool;
 pub mod energeia;
 /// Filesystem navigation tools (grep, find, ls).
 pub mod filesystem;
-/// Parameter registry query tool (discover tunable parameters).
-pub mod parameters;
 /// Knowledge graph and session memory tools (remember, recall).
 pub mod memory;
+/// Parameter registry query tool (discover tunable parameters).
+pub mod parameters;
 /// Planning project management tools (create, status, execute, verify).
 pub mod planning;
 /// Web research tools (web_fetch). Web search uses Anthropic server-side tools.

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -115,7 +115,8 @@ impl ToolExecutor for WebFetchExecutor {
             let max_length = extract_opt_u64(&input.arguments, "maxLength").unwrap_or(50_000);
 
             // SAFE: protocol validation for user-supplied URLs, not endpoint construction
-            if !url.starts_with("http://") && !url.starts_with("https://") { // kanon:ignore SECURITY/insecure-transport -- URL validation, not construction
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                // kanon:ignore SECURITY/insecure-transport -- URL validation, not construction
                 return Ok(ToolResult::error("URL must start with http:// or https://"));
             }
 

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -26,10 +26,16 @@ fn relativize_path(path: &Path, workspace: &Path) -> String {
 }
 
 /// Fallback default; runtime reads `ctx.tool_config.max_image_bytes`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const MAX_IMAGE_BYTES: u64 = 20 * 1024 * 1024;
 /// Fallback default; runtime reads `ctx.tool_config.max_pdf_bytes`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const MAX_PDF_BYTES: u64 = 32 * 1024 * 1024;
 
 enum MediaKind {

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -40,7 +40,10 @@ fn sanitize_path_in_msg(path: &std::path::Path) -> String {
 /// WHY: Prevents disk exhaustion or fork-bomb-like abuse via oversized writes.
 /// Closes #1714.
 /// Fallback default; runtime reads `ctx.tool_config.max_write_bytes`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const MAX_WRITE_BYTES: usize = 10 * 1024 * 1024;
 
 /// Expand a leading `~` in a path string to the HOME environment variable.
@@ -202,12 +205,18 @@ pub(crate) fn extract_opt_f64(args: &serde_json::Value, field: &str) -> Option<f
 
 /// Maximum file size the read tool will process.
 /// Fallback default; runtime reads `ctx.tool_config.max_read_bytes`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const MAX_READ_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Maximum command string length for exec.
 /// Fallback default; runtime reads `ctx.tool_config.max_command_length`.
-#[expect(dead_code, reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig")]
+#[expect(
+    dead_code,
+    reason = "retained as documentation of the default value; runtime reads from ToolLimitsConfig"
+)]
 pub(crate) const MAX_COMMAND_LENGTH: usize = 10_000;
 
 /// Files that the LLM must not overwrite.

--- a/crates/organon/src/builtins/workspace_tests/path_ops.rs
+++ b/crates/organon/src/builtins/workspace_tests/path_ops.rs
@@ -100,10 +100,7 @@ async fn write_creates_file() {
         "write",
         serde_json::json!({ "path": "out.txt", "content": "data" }),
     );
-    let result = WriteExecutor
-        .execute(&input, &ctx)
-        .await
-        .expect("execute");
+    let result = WriteExecutor.execute(&input, &ctx).await.expect("execute");
     assert!(
         !result.is_error,
         "writing a new file should not produce an error"
@@ -127,10 +124,7 @@ async fn write_creates_parent_dirs() {
         "write",
         serde_json::json!({ "path": "sub/deep/file.txt", "content": "nested" }),
     );
-    let result = WriteExecutor
-        .execute(&input, &ctx)
-        .await
-        .expect("execute");
+    let result = WriteExecutor.execute(&input, &ctx).await.expect("execute");
     assert!(
         !result.is_error,
         "writing to a nested path should create parent directories"
@@ -156,10 +150,7 @@ async fn write_append_mode() {
         "write",
         serde_json::json!({ "path": "log.txt", "content": "second\n", "append": true }),
     );
-    let result = WriteExecutor
-        .execute(&input, &ctx)
-        .await
-        .expect("execute");
+    let result = WriteExecutor.execute(&input, &ctx).await.expect("execute");
     assert!(!result.is_error, "append write should not produce an error");
     let on_disk = std::fs::read_to_string(dir.path().join("log.txt")).expect("read");
     assert_eq!(

--- a/crates/organon/src/metrics.rs
+++ b/crates/organon/src/metrics.rs
@@ -70,7 +70,9 @@ mod tests {
     fn init_registers_all_metrics() {
         init();
         // Verify metrics are registered by accessing them
-        let _ = TOOL_INVOCATIONS_TOTAL.with_label_values(&["test", "ok"]).get();
+        let _ = TOOL_INVOCATIONS_TOTAL
+            .with_label_values(&["test", "ok"])
+            .get();
         let _ = TOOL_DURATION_SECONDS
             .with_label_values(&["test"])
             .get_sample_count();
@@ -79,20 +81,28 @@ mod tests {
     #[test]
     fn record_invocation_records_success() {
         let tool_name = "test-tool-success";
-        let ok_before = TOOL_INVOCATIONS_TOTAL.with_label_values(&[tool_name, "ok"]).get();
-        let error_before = TOOL_INVOCATIONS_TOTAL.with_label_values(&[tool_name, "error"]).get();
+        let ok_before = TOOL_INVOCATIONS_TOTAL
+            .with_label_values(&[tool_name, "ok"])
+            .get();
+        let error_before = TOOL_INVOCATIONS_TOTAL
+            .with_label_values(&[tool_name, "error"])
+            .get();
         let hist_before = TOOL_DURATION_SECONDS
             .with_label_values(&[tool_name])
             .get_sample_count();
 
         record_invocation(tool_name, 0.05, true);
         assert_eq!(
-            TOOL_INVOCATIONS_TOTAL.with_label_values(&[tool_name, "ok"]).get(),
+            TOOL_INVOCATIONS_TOTAL
+                .with_label_values(&[tool_name, "ok"])
+                .get(),
             ok_before + 1,
             "ok counter should increment for success=true"
         );
         assert_eq!(
-            TOOL_INVOCATIONS_TOTAL.with_label_values(&[tool_name, "error"]).get(),
+            TOOL_INVOCATIONS_TOTAL
+                .with_label_values(&[tool_name, "error"])
+                .get(),
             error_before,
             "error counter should not change for success=true"
         );
@@ -108,20 +118,28 @@ mod tests {
     #[test]
     fn record_invocation_records_failure() {
         let tool_name = "test-tool-failure";
-        let ok_before = TOOL_INVOCATIONS_TOTAL.with_label_values(&[tool_name, "ok"]).get();
-        let error_before = TOOL_INVOCATIONS_TOTAL.with_label_values(&[tool_name, "error"]).get();
+        let ok_before = TOOL_INVOCATIONS_TOTAL
+            .with_label_values(&[tool_name, "ok"])
+            .get();
+        let error_before = TOOL_INVOCATIONS_TOTAL
+            .with_label_values(&[tool_name, "error"])
+            .get();
         let hist_before = TOOL_DURATION_SECONDS
             .with_label_values(&[tool_name])
             .get_sample_count();
 
         record_invocation(tool_name, 0.01, false);
         assert_eq!(
-            TOOL_INVOCATIONS_TOTAL.with_label_values(&[tool_name, "ok"]).get(),
+            TOOL_INVOCATIONS_TOTAL
+                .with_label_values(&[tool_name, "ok"])
+                .get(),
             ok_before,
             "ok counter should not change for success=false"
         );
         assert_eq!(
-            TOOL_INVOCATIONS_TOTAL.with_label_values(&[tool_name, "error"]).get(),
+            TOOL_INVOCATIONS_TOTAL
+                .with_label_values(&[tool_name, "error"])
+                .get(),
             error_before + 1,
             "error counter should increment for success=false"
         );

--- a/crates/organon/src/process_guard.rs
+++ b/crates/organon/src/process_guard.rs
@@ -103,7 +103,10 @@ mod tests {
     /// is no longer alive.
     #[test]
     fn kills_child_on_drop() {
-        let child = Command::new("sleep").arg("60").spawn().expect("spawn sleep");
+        let child = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
         let pid = child.id();
 
         let guard = ProcessGuard::new(child);
@@ -123,7 +126,10 @@ mod tests {
     /// After `detach()`, the guard no longer kills the child.
     #[test]
     fn detach_prevents_kill() {
-        let child = Command::new("sleep").arg("60").spawn().expect("spawn sleep");
+        let child = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
         let pid = child.id();
 
         let guard = ProcessGuard::new(child);
@@ -216,7 +222,10 @@ mod tests {
     fn guard_cleans_up_on_thread_panic() {
         use std::sync::mpsc;
 
-        let child = Command::new("sleep").arg("60").spawn().expect("spawn sleep");
+        let child = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
         let pid = child.id();
 
         let (tx, rx) = mpsc::channel::<std::process::Child>();

--- a/crates/organon/src/sandbox/policy_tests.rs
+++ b/crates/organon/src/sandbox/policy_tests.rs
@@ -201,8 +201,7 @@ fn landlock_blocks_symlink_escape() {
 
     // Symlink resolution should be blocked
     assert!(
-        !output.status.success()
-            || !String::from_utf8_lossy(&output.stdout).contains("escaped"),
+        !output.status.success() || !String::from_utf8_lossy(&output.stdout).contains("escaped"),
         "symlink escape should be blocked: {stderr}"
     );
 }

--- a/crates/organon/src/types/mod.rs
+++ b/crates/organon/src/types/mod.rs
@@ -9,9 +9,7 @@ pub use services::*;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-pub use hermeneus::types::{
-    DocumentSource, ImageSource, ToolResultBlock, ToolResultContent,
-};
+pub use hermeneus::types::{DocumentSource, ImageSource, ToolResultBlock, ToolResultContent};
 use koina::id::ToolName;
 
 /// Tool definition: the rich metadata that organon tracks internally.

--- a/crates/organon/tests/energeia_tools.rs
+++ b/crates/organon/tests/energeia_tools.rs
@@ -31,13 +31,8 @@ impl QaGate for AlwaysPassQaGate {
         prompt: &'a QaPromptSpec,
         pr_number: u64,
         _diff: &'a str,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<Output = energeia::error::Result<QaResult>>
-                + Send
-                + 'a,
-        >,
-    > {
+    ) -> Pin<Box<dyn std::future::Future<Output = energeia::error::Result<QaResult>> + Send + 'a>>
+    {
         Box::pin(async move {
             Ok(QaResult::new(
                 prompt.prompt_number,

--- a/crates/organon/tests/proptest_registry.rs
+++ b/crates/organon/tests/proptest_registry.rs
@@ -14,11 +14,11 @@
     reason = "proptest: ToolName::new() with controlled inputs; expect message documents constraint"
 )]
 
+use indexmap::IndexMap;
 use koina::id::ToolName;
 use organon::registry::ToolRegistry;
 use organon::testing::{MockToolExecutor, make_test_context, make_tool_input};
 use organon::types::{InputSchema, Reversibility, ToolCategory, ToolDef};
-use indexmap::IndexMap;
 use proptest::prelude::*;
 
 fn valid_tool_name() -> impl Strategy<Value = String> {

--- a/crates/organon/tests/sandbox_fallback.rs
+++ b/crates/organon/tests/sandbox_fallback.rs
@@ -6,9 +6,7 @@
 #[cfg(target_os = "linux")]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod linux {
-    use organon::sandbox::{
-        SandboxConfig, SandboxEnforcement, apply_sandbox, probe_landlock_abi,
-    };
+    use organon::sandbox::{SandboxConfig, SandboxEnforcement, apply_sandbox, probe_landlock_abi};
 
     #[test]
     fn probe_returns_consistent_result() {

--- a/crates/organon/tests/spec_validation.rs
+++ b/crates/organon/tests/spec_validation.rs
@@ -9,12 +9,12 @@
 
 #![expect(clippy::expect_used, reason = "test assertions may panic on failure")]
 
+use indexmap::IndexMap;
 use koina::id::ToolName;
 use organon::testing::{MockToolExecutor, ToolExecutorSpec, make_test_context};
 use organon::types::{
     InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolDef,
 };
-use indexmap::IndexMap;
 
 fn echo_def() -> ToolDef {
     ToolDef {

--- a/crates/poiesis/core/src/lib.rs
+++ b/crates/poiesis/core/src/lib.rs
@@ -5,16 +5,16 @@
 //! format-agnostic document tree that all poiesis backends consume.
 //! Backends implement the [`Renderer`] trait to produce format-specific bytes.
 
-/// Document metadata: title, author, creation timestamp.
-pub mod metadata;
 /// Block-level document elements: headings, paragraphs, tables, lists, images.
 pub mod block;
-/// Inline rich text spans: plain, bold, italic, code, links.
-pub mod rich_text;
 /// Top-level [`Document`] type assembling metadata and content blocks.
 pub mod document;
+/// Document metadata: title, author, creation timestamp.
+pub mod metadata;
 /// [`Renderer`] trait for format backends.
 pub mod renderer;
+/// Inline rich text spans: plain, bold, italic, code, links.
+pub mod rich_text;
 
 pub use block::{Block, Image, ListItem, Table};
 pub use document::Document;

--- a/crates/poiesis/sheet/src/ods.rs
+++ b/crates/poiesis/sheet/src/ods.rs
@@ -9,7 +9,7 @@
 
 use poiesis_core::{Block, Document, Renderer};
 use snafu::Snafu;
-use spreadsheet_ods::{WorkBook, Sheet, write_ods_buf};
+use spreadsheet_ods::{Sheet, WorkBook, write_ods_buf};
 
 /// Errors produced by the ODS renderer.
 #[derive(Debug, Snafu)]
@@ -140,8 +140,12 @@ mod tests {
             content: vec![Block::Table(Table {
                 headers: vec!["Item".to_owned(), "Qty".to_owned()],
                 rows: vec![vec![
-                    RichText { spans: vec![Span::Plain("Widget".to_owned())] },
-                    RichText { spans: vec![Span::Plain("42".to_owned())] },
+                    RichText {
+                        spans: vec![Span::Plain("Widget".to_owned())],
+                    },
+                    RichText {
+                        spans: vec![Span::Plain("42".to_owned())],
+                    },
                 ]],
             })],
         }
@@ -157,7 +161,10 @@ mod tests {
 
     #[test]
     #[expect(clippy::expect_used, reason = "test assertion")]
-    #[expect(clippy::indexing_slicing, reason = "test assertions on known-good data")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "test assertions on known-good data"
+    )]
     fn ods_starts_with_pk_magic() {
         // WHY: ODS is a ZIP archive; valid files start with PK (0x50 0x4B).
         let r = OdsRenderer::new();

--- a/crates/poiesis/sheet/src/xlsx.rs
+++ b/crates/poiesis/sheet/src/xlsx.rs
@@ -100,9 +100,10 @@ impl Renderer for XlsxRenderer {
                     // Data rows
                     for row in &table.rows {
                         for (col, cell) in row.iter().enumerate() {
-                            let col_u16 = u16::try_from(col).map_err(|e| XlsxRendererError::Xlsx {
-                                message: format!("column index {col} exceeds u16 max: {e}"),
-                            })?;
+                            let col_u16 =
+                                u16::try_from(col).map_err(|e| XlsxRendererError::Xlsx {
+                                    message: format!("column index {col} exceeds u16 max: {e}"),
+                                })?;
                             worksheet
                                 .write(current_row, col_u16, cell.plain_text().as_str())
                                 .map_err(XlsxRendererError::from)?;
@@ -138,9 +139,7 @@ impl Renderer for XlsxRenderer {
             }
         }
 
-        workbook
-            .save_to_buffer()
-            .map_err(XlsxRendererError::from)
+        workbook.save_to_buffer().map_err(XlsxRendererError::from)
     }
 }
 
@@ -182,12 +181,20 @@ mod tests {
                     headers: vec!["Name".to_owned(), "Score".to_owned()],
                     rows: vec![
                         vec![
-                            RichText { spans: vec![Span::Plain("Alice".to_owned())] },
-                            RichText { spans: vec![Span::Plain("95".to_owned())] },
+                            RichText {
+                                spans: vec![Span::Plain("Alice".to_owned())],
+                            },
+                            RichText {
+                                spans: vec![Span::Plain("95".to_owned())],
+                            },
                         ],
                         vec![
-                            RichText { spans: vec![Span::Plain("Bob".to_owned())] },
-                            RichText { spans: vec![Span::Plain("87".to_owned())] },
+                            RichText {
+                                spans: vec![Span::Plain("Bob".to_owned())],
+                            },
+                            RichText {
+                                spans: vec![Span::Plain("87".to_owned())],
+                            },
                         ],
                     ],
                 }),
@@ -205,7 +212,10 @@ mod tests {
 
     #[test]
     #[expect(clippy::expect_used, reason = "test assertion")]
-    #[expect(clippy::indexing_slicing, reason = "test assertions on known-good data")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "test assertions on known-good data"
+    )]
     fn xlsx_starts_with_pk_magic() {
         // WHY: XLSX is a ZIP archive; valid files start with PK (0x50 0x4B).
         let r = XlsxRenderer::new();

--- a/crates/poiesis/slides/src/pptx.rs
+++ b/crates/poiesis/slides/src/pptx.rs
@@ -13,7 +13,7 @@
 //! [`SlideContent`]: ppt_rs::SlideContent
 //! [`PageBreak`]: poiesis_core::Block::PageBreak
 
-use poiesis_core::{Block, Document, RichText, Renderer};
+use poiesis_core::{Block, Document, Renderer, RichText};
 use ppt_rs::{SlideContent, create_pptx_with_content};
 use snafu::Snafu;
 
@@ -68,8 +68,7 @@ impl Renderer for PptxRenderer {
                     current_slide = SlideContent::new(&text.plain_text());
                 }
                 Block::Paragraph(rt) => {
-                    current_slide =
-                        current_slide.add_bullet(&rt.plain_text());
+                    current_slide = current_slide.add_bullet(&rt.plain_text());
                 }
                 Block::List { ordered, items } => {
                     for (i, item) in items.iter().enumerate() {
@@ -91,8 +90,7 @@ impl Renderer for PptxRenderer {
                     }
                 }
                 Block::Image(img) => {
-                    current_slide =
-                        current_slide.add_bullet(&format!("[Image: {}]", img.alt));
+                    current_slide = current_slide.add_bullet(&format!("[Image: {}]", img.alt));
                 }
                 Block::PageBreak => {
                     slides.push(current_slide);
@@ -165,7 +163,11 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test assertions on known-good data")]
+    #[expect(
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        reason = "test assertions on known-good data"
+    )]
     fn pptx_starts_with_pk_magic() {
         // WHY: PPTX is a ZIP/OOXML archive; valid files start with PK (0x50 0x4B).
         let r = PptxRenderer::new();

--- a/crates/poiesis/text/src/odt.rs
+++ b/crates/poiesis/text/src/odt.rs
@@ -13,7 +13,7 @@
 use std::fmt::Write as FmtWrite;
 use std::io::Write as IoWrite;
 
-use poiesis_core::{Block, Document, RichText, Renderer, Span};
+use poiesis_core::{Block, Document, Renderer, RichText, Span};
 use snafu::Snafu;
 use zip::ZipWriter;
 use zip::write::SimpleFileOptions;
@@ -63,8 +63,7 @@ impl Renderer for OdtRenderer {
         // `mimetype` MUST be the first entry and MUST NOT be compressed.
         zip.start_file(
             "mimetype",
-            SimpleFileOptions::default()
-                .compression_method(zip::CompressionMethod::Stored),
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored),
         )
         .map_err(|e| OdtError::Zip {
             message: e.to_string(),
@@ -95,9 +94,10 @@ fn write_entry(
         .map_err(|e| OdtError::Zip {
             message: e.to_string(),
         })?;
-    zip.write_all(content.as_bytes()).map_err(|e| OdtError::Zip {
-        message: e.to_string(),
-    })
+    zip.write_all(content.as_bytes())
+        .map_err(|e| OdtError::Zip {
+            message: e.to_string(),
+        })
 }
 
 fn build_manifest() -> String {
@@ -237,16 +237,11 @@ fn render_block(block: &Block, out: &mut String) {
                     xml_escape(header)
                 );
             }
-            out.push_str(
-                "          </table:table-row>\n        </table:table-header-rows>\n",
-            );
+            out.push_str("          </table:table-row>\n        </table:table-header-rows>\n");
             for row in &table.rows {
                 out.push_str("        <table:table-row>\n");
                 for col_idx in 0..col_count {
-                    let cell_text = row
-                        .get(col_idx)
-                        .map(render_rich_text)
-                        .unwrap_or_default();
+                    let cell_text = row.get(col_idx).map(render_rich_text).unwrap_or_default();
                     let _ = writeln!(
                         out,
                         "          <table:table-cell><text:p>{cell_text}</text:p></table:table-cell>"
@@ -349,8 +344,12 @@ mod tests {
                 Block::Table(Table {
                     headers: vec!["A".to_owned(), "B".to_owned()],
                     rows: vec![vec![
-                        RichText { spans: vec![Span::Plain("x".to_owned())] },
-                        RichText { spans: vec![Span::Plain("y".to_owned())] },
+                        RichText {
+                            spans: vec![Span::Plain("x".to_owned())],
+                        },
+                        RichText {
+                            spans: vec![Span::Plain("y".to_owned())],
+                        },
                     ]],
                 }),
             ],
@@ -366,7 +365,11 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test assertions on known-good data")]
+    #[expect(
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        reason = "test assertions on known-good data"
+    )]
     fn odt_starts_with_pk_magic() {
         // WHY: ZIP files start with PK (0x50 0x4B).
         let r = OdtRenderer::new();
@@ -376,6 +379,9 @@ mod tests {
 
     #[test]
     fn xml_escape_handles_all_chars() {
-        assert_eq!(xml_escape("a&b<c>d\"e'f"), "a&amp;b&lt;c&gt;d&quot;e&apos;f");
+        assert_eq!(
+            xml_escape("a&b<c>d\"e'f"),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
     }
 }

--- a/crates/poiesis/text/src/pdf.rs
+++ b/crates/poiesis/text/src/pdf.rs
@@ -10,7 +10,7 @@ use krilla::geom::Point;
 use krilla::page::PageSettings;
 use krilla::text::{Font, TextDirection};
 
-use poiesis_core::{Block, Document, RichText, Renderer};
+use poiesis_core::{Block, Document, Renderer, RichText};
 use snafu::Snafu;
 
 /// A4 page width in PDF points (1 pt = 1/72 inch).
@@ -106,11 +106,9 @@ impl PdfRenderer {
             "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf",
         ];
 
-        candidates.iter().find_map(|path| {
-            std::fs::read(path)
-                .ok()
-                .filter(|data| !data.is_empty())
-        })
+        candidates
+            .iter()
+            .find_map(|path| std::fs::read(path).ok().filter(|data| !data.is_empty()))
     }
 }
 
@@ -129,13 +127,12 @@ impl Renderer for PdfRenderer {
         "pdf"
     }
 
-    #[expect(clippy::too_many_lines, reason = "PDF page layout is inherently sequential; splitting would scatter related rendering logic")]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "PDF page layout is inherently sequential; splitting would scatter related rendering logic"
+    )]
     fn render(&self, doc: &Document) -> Result<Vec<u8>, Self::Error> {
-        let font = Font::new(
-            self.font_data.clone().into(),
-            0,
-        )
-        .ok_or(PdfError::NoFont)?;
+        let font = Font::new(self.font_data.clone().into(), 0).ok_or(PdfError::NoFont)?;
 
         let mut krilla_doc = KrillaDocument::new();
 
@@ -249,15 +246,7 @@ impl Renderer for PdfRenderer {
                 Block::Image(img) => {
                     // Images are not rendered inline — emit the alt text instead.
                     let alt = format!("[Image: {}]", img.alt);
-                    y = draw_wrapped(
-                        &mut surface,
-                        &font,
-                        FONT_SIZE_BODY,
-                        &alt,
-                        x,
-                        y,
-                        USABLE_W,
-                    );
+                    y = draw_wrapped(&mut surface, &font, FONT_SIZE_BODY, &alt, x, y, USABLE_W);
                     y += PARA_SPACING;
                 }
                 Block::PageBreak => {
@@ -309,7 +298,12 @@ fn draw_wrapped(
     let char_w_approx = font_size * 0.55;
     // WHY: safe cast — max_width and char_w_approx are positive finite f32 values
     // produced from compile-time page constants; the ratio fits comfortably in usize.
-    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::as_conversions, reason = "max_width and char_w_approx are positive finite f32 from page constants; ratio fits in usize")]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::as_conversions,
+        reason = "max_width and char_w_approx are positive finite f32 from page constants; ratio fits in usize"
+    )]
     let chars_per_line = (max_width / char_w_approx).max(1.0) as usize;
 
     let line_h = font_size * LEADING;

--- a/crates/pylon/src/error.rs
+++ b/crates/pylon/src/error.rs
@@ -171,8 +171,8 @@ impl IntoResponse for ApiError {
             Self::ValidationFailed { errors, .. } => {
                 // WHY(#3275): serialize structured field errors so consumers
                 // can match on field + code without parsing English messages.
-                let errors_json = serde_json::to_value(errors)
-                    .unwrap_or_else(|_| serde_json::json!([]));
+                let errors_json =
+                    serde_json::to_value(errors).unwrap_or_else(|_| serde_json::json!([]));
                 (
                     StatusCode::UNPROCESSABLE_ENTITY,
                     "validation_failed",

--- a/crates/pylon/src/handlers/config.rs
+++ b/crates/pylon/src/handlers/config.rs
@@ -139,20 +139,18 @@ pub async fn reload_config(
     let outcome = taxis::reload::prepare_reload(&state.oikos, &current).map_err(|e| {
         tracing::error!(error = %e, "config reload failed");
         match e {
-            taxis::reload::ReloadError::Validation { source, .. } => {
-                ApiError::ValidationFailed {
-                    errors: source
-                        .errors
-                        .into_iter()
-                        .map(|msg| FieldError {
-                            field: "_config".to_owned(),
-                            code: "invalid".to_owned(),
-                            message: msg,
-                        })
-                        .collect(),
-                    location: snafu::location!(),
-                }
-            }
+            taxis::reload::ReloadError::Validation { source, .. } => ApiError::ValidationFailed {
+                errors: source
+                    .errors
+                    .into_iter()
+                    .map(|msg| FieldError {
+                        field: "_config".to_owned(),
+                        code: "invalid".to_owned(),
+                        message: msg,
+                    })
+                    .collect(),
+                location: snafu::location!(),
+            },
             other => ApiError::Internal {
                 message: other.to_string(),
                 location: snafu::location!(),
@@ -263,11 +261,9 @@ pub async fn update_section(
             }
         })?;
 
-    taxis::loader::write_config(&state.oikos, &new_config).map_err(|e| {
-        ApiError::Internal {
-            message: format!("failed to write config: {e}"),
-            location: snafu::location!(),
-        }
+    taxis::loader::write_config(&state.oikos, &new_config).map_err(|e| ApiError::Internal {
+        message: format!("failed to write config: {e}"),
+        location: snafu::location!(),
     })?;
 
     let restart_required: Vec<String> = taxis::reload::restart_prefixes()

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -2,11 +2,11 @@
 
 use std::time::Duration;
 
-use koina::system::{Environment, RealSystem};
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use koina::system::{Environment, RealSystem};
 use serde::Serialize;
 use utoipa::ToSchema;
 
@@ -118,7 +118,10 @@ async fn timed_check(
         Err(_elapsed) => HealthCheck {
             name,
             status: "timeout",
-            message: Some(format!("{name} check timed out after {}s", CHECK_TIMEOUT.as_secs())),
+            message: Some(format!(
+                "{name} check timed out after {}s",
+                CHECK_TIMEOUT.as_secs()
+            )),
         },
     }
 }
@@ -189,9 +192,10 @@ fn check_provider_reachability(state: &HealthState) -> HealthCheck {
     }
 
     // Check if any provider is healthy (Up status)
-    let any_healthy = providers
-        .iter()
-        .any(|p| state.provider_registry.provider_health(p.name()) == Some(hermeneus::health::ProviderHealth::Up));
+    let any_healthy = providers.iter().any(|p| {
+        state.provider_registry.provider_health(p.name())
+            == Some(hermeneus::health::ProviderHealth::Up)
+    });
 
     if any_healthy {
         HealthCheck {
@@ -398,13 +402,15 @@ fn check_credential_validity(
     }
 
     // Check if CC provider handles auth (Claude Code credentials)
-    let cc_credentials = symbolon::credential::claude_code_default_path()
-        .is_some_and(|p| p.exists());
+    let cc_credentials =
+        symbolon::credential::claude_code_default_path().is_some_and(|p| p.exists());
     if cc_credentials {
         HealthCheck {
             name: "credential_validity",
             status: "pass",
-            message: Some("Claude Code credentials available (CC provider handles auth)".to_owned()),
+            message: Some(
+                "Claude Code credentials available (CC provider handles auth)".to_owned(),
+            ),
         }
     } else {
         HealthCheck {
@@ -568,12 +574,12 @@ mod tests {
             reason = "compile-time shape assertion: proves field types via unused local fn"
         )]
         fn assert_health_state_fields(state: &HealthState) {
-            use std::sync::Arc;
-            use mneme::store::SessionStore;
             use hermeneus::provider::ProviderRegistry;
+            use mneme::store::SessionStore;
             use nous::manager::NousManager;
-            use taxis::oikos::Oikos;
+            use std::sync::Arc;
             use taxis::config::AletheiaConfig;
+            use taxis::oikos::Oikos;
 
             let _: &Arc<tokio::sync::Mutex<SessionStore>> = &state.session_store;
             let _: &Arc<ProviderRegistry> = &state.provider_registry;
@@ -717,7 +723,10 @@ mod tests {
         ];
         // WHY: "timeout" is treated as "fail" for aggregate status because
         // a timed-out check means we cannot confirm the subsystem is healthy.
-        let status = if checks.iter().any(|c| c.status == "fail" || c.status == "timeout") {
+        let status = if checks
+            .iter()
+            .any(|c| c.status == "fail" || c.status == "timeout")
+        {
             "unhealthy"
         } else if checks.iter().any(|c| c.status == "warn") {
             "degraded"

--- a/crates/pylon/src/handlers/knowledge/search.rs
+++ b/crates/pylon/src/handlers/knowledge/search.rs
@@ -223,9 +223,7 @@ pub(super) fn get_stored_facts(
     Vec::new()
 }
 
-pub(super) fn get_stored_entities(
-    state: &KnowledgeState,
-) -> Vec<mneme::knowledge::Entity> {
+pub(super) fn get_stored_entities(state: &KnowledgeState) -> Vec<mneme::knowledge::Entity> {
     #[cfg(feature = "knowledge-store")]
     if let Some(ref store) = state.knowledge_store {
         match store.list_entities() {

--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -126,9 +126,7 @@ pub async fn tools(
             config
                 .tool_allowlist
                 .as_ref()
-                .is_none_or(|allowlist| {
-                    allowlist.iter().any(|a| a == d.name.as_str())
-                })
+                .is_none_or(|allowlist| allowlist.iter().any(|a| a == d.name.as_str()))
         })
         .map(|d| ToolSummary {
             name: d.name.as_str().to_owned(),
@@ -269,9 +267,9 @@ mod tests {
             reason = "compile-time shape assertion: proves field types via unused local fn"
         )]
         fn assert_nous_state_fields(state: &NousState) {
-            use std::sync::Arc;
             use nous::manager::NousManager;
             use organon::registry::ToolRegistry;
+            use std::sync::Arc;
 
             let _: &Arc<NousManager> = &state.nous_manager;
             let _: &Arc<ToolRegistry> = &state.tool_registry;

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -88,7 +88,10 @@ pub async fn create(
         });
     }
     if !field_errors.is_empty() {
-        return Err(ValidationFailedSnafu { errors: field_errors }.build());
+        return Err(ValidationFailedSnafu {
+            errors: field_errors,
+        }
+        .build());
     }
 
     let config = state.nous_manager.get_config(&nous_id).ok_or_else(|| {

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -428,7 +428,10 @@ pub async fn stream_turn(
         });
     }
     if !field_errors.is_empty() {
-        return Err(ValidationFailedSnafu { errors: field_errors }.build());
+        return Err(ValidationFailedSnafu {
+            errors: field_errors,
+        }
+        .build());
     }
 
     let handle = state
@@ -672,9 +675,9 @@ fn sse_event_to_axum(event: SseEvent) -> Result<Event, Infallible> {
             warn!(error = %e, "failed to serialize SSE event");
             // WHY: Use the SseEvent::Error variant so the fallback event has the same
             // shape as all other error events in the stream (#3160).
-            Ok(Event::default()
-                .event("error")
-                .data(r#"{"type":"error","code":"serialization_error","message":"serialization failed"}"#))
+            Ok(Event::default().event("error").data(
+                r#"{"type":"error","code":"serialization_error","message":"serialization failed"}"#,
+            ))
         }
     }
 }
@@ -718,11 +721,19 @@ fn extract_idempotency_key(
 fn turn_error_info(err: &nous::error::Error) -> (String, String) {
     use nous::error::Error;
     match err {
-        Error::PipelineTimeout { stage, timeout_secs, .. } => (
+        Error::PipelineTimeout {
+            stage,
+            timeout_secs,
+            ..
+        } => (
             "turn_timeout".to_owned(),
             format!("pipeline stage '{stage}' timed out after {timeout_secs}s"),
         ),
-        Error::AskTimeout { nous_id, timeout_secs, .. } => (
+        Error::AskTimeout {
+            nous_id,
+            timeout_secs,
+            ..
+        } => (
             "turn_timeout".to_owned(),
             format!("cross-agent ask to '{nous_id}' timed out after {timeout_secs}s"),
         ),
@@ -742,7 +753,11 @@ fn turn_error_info(err: &nous::error::Error) -> (String, String) {
             "context_error".to_owned(),
             format!("context assembly failed: required file '{file}' unreadable"),
         ),
-        Error::LoopDetected { iterations, pattern, .. } => (
+        Error::LoopDetected {
+            iterations,
+            pattern,
+            ..
+        } => (
             "loop_detected".to_owned(),
             format!("loop detected after {iterations} iterations: {pattern}"),
         ),
@@ -774,23 +789,30 @@ fn classify_llm_error(err: &hermeneus::error::Error) -> (String, String) {
             "rate_limited".to_owned(),
             format!("rate limit exceeded, retry after {retry_after_ms}ms"),
         ),
-        Error::ApiError { status, .. } if *status == 429 => (
-            "rate_limited".to_owned(),
-            "rate limit exceeded".to_owned(),
-        ),
+        Error::ApiError { status, .. } if *status == 429 => {
+            ("rate_limited".to_owned(), "rate limit exceeded".to_owned())
+        }
         Error::AuthFailed { .. } => (
             "auth_failure".to_owned(),
-            "provider authentication failed — run 'aletheia credential status' to diagnose".to_owned(),
+            "provider authentication failed — run 'aletheia credential status' to diagnose"
+                .to_owned(),
         ),
         Error::ApiError { status, .. } if *status == 503 || *status == 529 => (
             "provider_unavailable".to_owned(),
             format!("provider returned {status} — temporarily unavailable"),
         ),
-        Error::ApiError { status, message, .. } if (400..500).contains(status) => (
+        Error::ApiError {
+            status, message, ..
+        } if (400..500).contains(status) => (
             "invalid_request".to_owned(),
-            format!("provider rejected request ({status}): {}", redact_secrets(message)),
+            format!(
+                "provider rejected request ({status}): {}",
+                redact_secrets(message)
+            ),
         ),
-        Error::ApiError { status, message, .. } if (500..600).contains(status) => (
+        Error::ApiError {
+            status, message, ..
+        } if (500..600).contains(status) => (
             "provider_error".to_owned(),
             format!("provider error ({status}): {}", redact_secrets(message)),
         ),

--- a/crates/pylon/src/handlers/sessions/streaming_tests.rs
+++ b/crates/pylon/src/handlers/sessions/streaming_tests.rs
@@ -58,7 +58,10 @@ fn idempotency_key_at_max_length_accepted() {
 fn idempotency_key_case_insensitive_header() {
     // HTTP headers are case-insensitive; axum normalizes them
     let mut headers = HeaderMap::new();
-    headers.insert("Idempotency-Key", "mixed-case".parse().expect("valid header"));
+    headers.insert(
+        "Idempotency-Key",
+        "mixed-case".parse().expect("valid header"),
+    );
     let result = extract_idempotency_key(&headers, TEST_MAX_KEY_LEN).expect("should succeed");
     assert_eq!(result.as_deref(), Some("mixed-case"));
 }
@@ -87,7 +90,10 @@ fn llm_error_rate_limited_classified() {
     .into_error(snafu::NoneError);
     let (code, msg) = classify_llm_error(&err);
     assert_eq!(code, "rate_limited");
-    assert!(msg.contains("60000"), "message should include retry_after_ms");
+    assert!(
+        msg.contains("60000"),
+        "message should include retry_after_ms"
+    );
 }
 
 #[test]
@@ -141,7 +147,10 @@ fn llm_error_api_500_classified_as_provider_error() {
     let (code, msg) = classify_llm_error(&err);
     assert_eq!(code, "provider_error");
     assert!(msg.contains("500"), "message should include status code");
-    assert!(msg.contains("Internal Server Error"), "message should include provider detail");
+    assert!(
+        msg.contains("Internal Server Error"),
+        "message should include provider detail"
+    );
 }
 
 #[test]
@@ -205,7 +214,10 @@ fn llm_error_api_500_redacts_secrets_in_message() {
     .into_error(snafu::NoneError);
     let (_, msg) = classify_llm_error(&err);
     // WHY #844: secrets must be redacted from client-visible messages
-    assert!(!msg.contains("sk-ant-abc123def456"), "API key must be redacted");
+    assert!(
+        !msg.contains("sk-ant-abc123def456"),
+        "API key must be redacted"
+    );
     assert!(msg.contains("[REDACTED]"));
 }
 
@@ -224,7 +236,10 @@ fn nous_pipeline_timeout_classified() {
     let (code, msg) = turn_error_info(&err);
     assert_eq!(code, "turn_timeout");
     assert!(msg.contains("execute"), "message should include stage name");
-    assert!(msg.contains("30"), "message should include timeout duration");
+    assert!(
+        msg.contains("30"),
+        "message should include timeout duration"
+    );
 }
 
 #[test]
@@ -237,7 +252,10 @@ fn nous_ask_timeout_classified() {
     .into_error(snafu::NoneError);
     let (code, msg) = turn_error_info(&err);
     assert_eq!(code, "turn_timeout");
-    assert!(msg.contains("target"), "message should include target nous_id");
+    assert!(
+        msg.contains("target"),
+        "message should include target nous_id"
+    );
 }
 
 #[test]
@@ -308,7 +326,10 @@ fn nous_guard_rejected_includes_reason() {
 fn redact_strips_anthropic_api_key() {
     let msg = "invalid key sk-ant-abc123def456ghi789";
     let redacted = redact_secrets(msg);
-    assert!(!redacted.contains("sk-ant-"), "API key prefix should be redacted");
+    assert!(
+        !redacted.contains("sk-ant-"),
+        "API key prefix should be redacted"
+    );
     assert!(redacted.contains("[REDACTED]"));
 }
 
@@ -316,7 +337,10 @@ fn redact_strips_anthropic_api_key() {
 fn redact_strips_generic_sk_key() {
     let msg = "auth error with sk-abcdefghijklmnopqrstuvwxyz";
     let redacted = redact_secrets(msg);
-    assert!(!redacted.contains("sk-abcdef"), "sk- key should be redacted");
+    assert!(
+        !redacted.contains("sk-abcdef"),
+        "sk- key should be redacted"
+    );
     assert!(redacted.contains("[REDACTED]"));
 }
 
@@ -331,7 +355,10 @@ fn redact_preserves_normal_messages() {
 fn redact_strips_bearer_token() {
     let msg = "rejected bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload";
     let redacted = redact_secrets(msg);
-    assert!(!redacted.contains("eyJh"), "bearer token should be redacted");
+    assert!(
+        !redacted.contains("eyJh"),
+        "bearer token should be redacted"
+    );
 }
 
 // ─────────────────────────────────────────────────────────

--- a/crates/pylon/src/lib.rs
+++ b/crates/pylon/src/lib.rs
@@ -17,6 +17,8 @@ pub(crate) mod metrics;
 pub mod middleware;
 /// OpenAPI specification generation via utoipa.
 pub(crate) mod openapi;
+/// Cursor-based pagination types for list endpoints.
+pub mod pagination;
 /// Axum router construction with CORS, auth, and body-limit layers.
 pub mod router;
 /// Security configuration derived from the gateway config section.
@@ -25,8 +27,6 @@ pub mod security;
 pub mod server;
 /// Shared application state accessible across all handlers.
 pub mod state;
-/// Cursor-based pagination types for list endpoints.
-pub mod pagination;
 /// SSE event types for streaming agent responses to clients.
 pub mod stream;
 

--- a/crates/pylon/src/middleware/mod.rs
+++ b/crates/pylon/src/middleware/mod.rs
@@ -117,9 +117,7 @@ pub async fn inject_request_id(mut request: Request, next: Next) -> Response {
 
     let mut response = next.run(request).await;
     if let Ok(header_value) = axum::http::HeaderValue::from_str(&id) {
-        response
-            .headers_mut()
-            .insert(X_REQUEST_ID, header_value);
+        response.headers_mut().insert(X_REQUEST_ID, header_value);
     }
     response
 }
@@ -482,7 +480,9 @@ mod tests {
                 "user {i} should be allowed (within per-user burst)"
             );
             assert!(
-                limiter.check_ip("192.168.1.100", EndpointCategory::General).is_none(),
+                limiter
+                    .check_ip("192.168.1.100", EndpointCategory::General)
+                    .is_none(),
                 "IP should be allowed for user {i} (within IP ceiling burst)"
             );
         }
@@ -493,7 +493,9 @@ mod tests {
             "user-5 per-user bucket should allow (first request)"
         );
         assert!(
-            limiter.check_ip("192.168.1.100", EndpointCategory::General).is_some(),
+            limiter
+                .check_ip("192.168.1.100", EndpointCategory::General)
+                .is_some(),
             "IP ceiling should reject the 6th request from the same IP"
         );
     }

--- a/crates/pylon/src/middleware/user_rate_limiter.rs
+++ b/crates/pylon/src/middleware/user_rate_limiter.rs
@@ -322,8 +322,7 @@ impl UserRateLimiter {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let before = ip_state.len();
-            ip_state
-                .retain(|_, buckets| now.duration_since(buckets.last_access) < stale_threshold);
+            ip_state.retain(|_, buckets| now.duration_since(buckets.last_access) < stale_threshold);
             before - ip_state.len()
         };
 
@@ -451,10 +450,7 @@ pub(crate) fn inject_rate_limit_headers(
 ) {
     // WHY: HeaderName::from_static requires lowercase; these are standard draft headers.
     if let Ok(v) = axum::http::HeaderValue::from_str(&quota.limit.to_string()) {
-        headers.insert(
-            axum::http::HeaderName::from_static("ratelimit-limit"),
-            v,
-        );
+        headers.insert(axum::http::HeaderName::from_static("ratelimit-limit"), v);
     }
     if let Ok(v) = axum::http::HeaderValue::from_str(&quota.remaining.to_string()) {
         headers.insert(
@@ -463,10 +459,7 @@ pub(crate) fn inject_rate_limit_headers(
         );
     }
     if let Ok(v) = axum::http::HeaderValue::from_str(&quota.reset_secs.to_string()) {
-        headers.insert(
-            axum::http::HeaderName::from_static("ratelimit-reset"),
-            v,
-        );
+        headers.insert(axum::http::HeaderName::from_static("ratelimit-reset"), v);
     }
 }
 
@@ -477,9 +470,7 @@ fn rate_limit_response(retry_after_secs: u64, category: EndpointCategory) -> Res
         axum::Json(ErrorResponse {
             error: ErrorBody {
                 code: "rate_limited".to_owned(),
-                message: format!(
-                    "per-user rate limit exceeded, retry after {retry_after_secs}s"
-                ),
+                message: format!("per-user rate limit exceeded, retry after {retry_after_secs}s"),
                 request_id: None,
                 details: Some(serde_json::json!({
                     "retry_after_secs": retry_after_secs,

--- a/crates/pylon/src/pagination.rs
+++ b/crates/pylon/src/pagination.rs
@@ -105,8 +105,7 @@ mod tests {
     #[test]
     fn from_vec_with_cursor_skips_past_it() {
         let items: Vec<String> = (0..10).map(|i| format!("item-{i}")).collect();
-        let resp =
-            PaginatedResponse::from_vec(items, 3, Some("item-2"), |s| s.clone(), Some(10));
+        let resp = PaginatedResponse::from_vec(items, 3, Some("item-2"), |s| s.clone(), Some(10));
         assert_eq!(resp.items.len(), 3);
         assert_eq!(resp.items[0], "item-3");
         assert!(resp.has_more);
@@ -116,8 +115,7 @@ mod tests {
     #[test]
     fn from_vec_last_page_no_more() {
         let items: Vec<String> = (0..5).map(|i| format!("item-{i}")).collect();
-        let resp =
-            PaginatedResponse::from_vec(items, 10, None, |s| s.clone(), Some(5));
+        let resp = PaginatedResponse::from_vec(items, 10, None, |s| s.clone(), Some(5));
         assert_eq!(resp.items.len(), 5);
         assert!(!resp.has_more);
         assert!(resp.next_cursor.is_none());
@@ -126,13 +124,7 @@ mod tests {
     #[test]
     fn from_vec_cursor_not_found_returns_all() {
         let items: Vec<String> = (0..3).map(|i| format!("item-{i}")).collect();
-        let resp = PaginatedResponse::from_vec(
-            items,
-            10,
-            Some("nonexistent"),
-            |s| s.clone(),
-            None,
-        );
+        let resp = PaginatedResponse::from_vec(items, 10, Some("nonexistent"), |s| s.clone(), None);
         assert_eq!(resp.items.len(), 3);
         assert!(!resp.has_more);
     }

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -45,9 +45,7 @@ pub struct ServerConfig {
 pub enum ServerError {
     /// Failed to open or initialize the session store.
     #[snafu(display("failed to open session store: {source}"))]
-    SessionStore {
-        source: mneme::error::Error,
-    },
+    SessionStore { source: mneme::error::Error },
 
     /// TCP listener failed to bind to the configured address.
     #[snafu(display("failed to bind to {addr}: {source}"))]
@@ -70,15 +68,11 @@ pub enum ServerError {
 
     /// Instance directory layout validation failed.
     #[snafu(display("instance layout invalid: {source}"))]
-    Validation {
-        source: taxis::error::Error,
-    },
+    Validation { source: taxis::error::Error },
 
     /// Default nous agent failed to spawn during startup.
     #[snafu(display("default nous spawn failed: {source}"))]
-    NousSpawn {
-        source: nous::error::Error,
-    },
+    NousSpawn { source: nous::error::Error },
 }
 
 /// Start the HTTP gateway and block until shutdown.

--- a/crates/pylon/src/tests/error_envelope.rs
+++ b/crates/pylon/src/tests/error_envelope.rs
@@ -54,7 +54,9 @@ async fn create_session_empty_nous_id_returns_422_with_envelope() {
         .as_array()
         .expect("details.errors should be an array");
     assert!(
-        errors.iter().any(|e| e["field"] == "nous_id" && e["code"] == "required"),
+        errors
+            .iter()
+            .any(|e| e["field"] == "nous_id" && e["code"] == "required"),
         "errors should contain a required error for nous_id"
     );
 }
@@ -85,7 +87,9 @@ async fn create_session_empty_session_key_returns_422_with_envelope() {
         .as_array()
         .expect("details.errors should be an array");
     assert!(
-        errors.iter().any(|e| e["field"] == "session_key" && e["code"] == "required"),
+        errors
+            .iter()
+            .any(|e| e["field"] == "session_key" && e["code"] == "required"),
         "errors should contain a required error for session_key"
     );
 }
@@ -164,7 +168,9 @@ async fn rename_session_empty_name_returns_422_with_envelope() {
         .as_array()
         .expect("details.errors should be an array");
     assert!(
-        errors.iter().any(|e| e["field"] == "name" && e["code"] == "required"),
+        errors
+            .iter()
+            .any(|e| e["field"] == "name" && e["code"] == "required"),
         "errors should contain a required error for name"
     );
 }

--- a/crates/pylon/src/tests/knowledge.rs
+++ b/crates/pylon/src/tests/knowledge.rs
@@ -31,10 +31,12 @@ async fn list_facts_invalid_sort_returns_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "bad_request");
-    assert!(body["error"]["message"]
-        .as_str()
-        .unwrap()
-        .contains("invalid sort field"));
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("invalid sort field")
+    );
 }
 
 /// Error path: `list_facts` with invalid order parameter returns 400 Bad Request.
@@ -49,10 +51,12 @@ async fn list_facts_invalid_order_returns_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "bad_request");
-    assert!(body["error"]["message"]
-        .as_str()
-        .unwrap()
-        .contains("invalid order"));
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("invalid order")
+    );
 }
 
 /// Error path: `forget_fact` returns 503 Service Unavailable when knowledge store not enabled.
@@ -113,10 +117,12 @@ async fn update_confidence_out_of_range_returns_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "bad_request");
-    assert!(body["error"]["message"]
-        .as_str()
-        .unwrap()
-        .contains("between 0.0 and 1.0"));
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("between 0.0 and 1.0")
+    );
 }
 
 /// Error path: `update_confidence` with negative confidence returns 400 Bad Request.
@@ -154,7 +160,9 @@ async fn check_graph_health_without_knowledge_store_returns_503() {
 async fn entity_relationships_without_knowledge_store_returns_empty() {
     let (app, _dir) = app().await;
     let resp = app
-        .oneshot(authed_get("/api/v1/knowledge/entities/some-id/relationships"))
+        .oneshot(authed_get(
+            "/api/v1/knowledge/entities/some-id/relationships",
+        ))
         .await
         .unwrap();
 

--- a/crates/pylon/src/tests/session.rs
+++ b/crates/pylon/src/tests/session.rs
@@ -494,14 +494,7 @@ async fn history_messages_have_expected_fields() {
     {
         let store = state.session_store.lock().await;
         store
-            .append_message(
-                id,
-                mneme::types::Role::User,
-                "test message",
-                None,
-                None,
-                10,
-            )
+            .append_message(id, mneme::types::Role::User, "test message", None, None, 10)
             .unwrap();
     }
 
@@ -537,7 +530,11 @@ async fn create_session_empty_nous_id_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "nous_id" && e["code"] == "required"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "nous_id" && e["code"] == "required")
+    );
 }
 
 #[tokio::test]
@@ -557,7 +554,11 @@ async fn create_session_empty_session_key_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "session_key" && e["code"] == "required"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "session_key" && e["code"] == "required")
+    );
 }
 
 #[tokio::test]
@@ -578,7 +579,11 @@ async fn create_session_oversized_nous_id_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "nous_id" && e["code"] == "too_long"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "nous_id" && e["code"] == "too_long")
+    );
 }
 
 #[tokio::test]
@@ -599,7 +604,11 @@ async fn create_session_oversized_session_key_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "session_key" && e["code"] == "too_long"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "session_key" && e["code"] == "too_long")
+    );
 }
 
 #[tokio::test]
@@ -619,7 +628,11 @@ async fn rename_session_empty_name_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "name" && e["code"] == "required"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "name" && e["code"] == "required")
+    );
 }
 
 #[tokio::test]
@@ -640,7 +653,11 @@ async fn rename_session_oversized_name_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "name" && e["code"] == "too_long"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "name" && e["code"] == "too_long")
+    );
 }
 
 #[tokio::test]

--- a/crates/pylon/src/tests/sse_events.rs
+++ b/crates/pylon/src/tests/sse_events.rs
@@ -109,7 +109,10 @@ fn sse_event_error_omits_request_id_when_none() {
         request_id: None,
     };
     let json = serde_json::to_value(&event).unwrap();
-    assert!(json.get("request_id").is_none(), "request_id should be omitted when None");
+    assert!(
+        json.get("request_id").is_none(),
+        "request_id should be omitted when None"
+    );
 }
 
 #[test]

--- a/crates/pylon/src/tests/streaming.rs
+++ b/crates/pylon/src/tests/streaming.rs
@@ -323,7 +323,11 @@ async fn send_message_empty_content_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "content" && e["code"] == "required"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "content" && e["code"] == "required")
+    );
 }
 
 /// Error path: sending an oversized message returns 422 Unprocessable Entity.
@@ -345,7 +349,11 @@ async fn send_message_oversized_content_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "content" && e["code"] == "too_long"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "content" && e["code"] == "too_long")
+    );
 }
 
 /// Error path: sending message to unknown session returns 404 Not Found.
@@ -435,7 +443,11 @@ async fn stream_turn_empty_message_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "message" && e["code"] == "required"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "message" && e["code"] == "required")
+    );
 }
 
 /// Error path: `stream_turn` with oversized message returns 422.
@@ -458,7 +470,11 @@ async fn stream_turn_oversized_message_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "message" && e["code"] == "too_long"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "message" && e["code"] == "too_long")
+    );
 }
 
 /// Error path: `stream_turn` with unknown `agent_id` returns 404 Not Found.
@@ -501,7 +517,11 @@ async fn stream_turn_oversized_agent_id_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "agent_id" && e["code"] == "too_long"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "agent_id" && e["code"] == "too_long")
+    );
 }
 
 /// Error path: `stream_turn` with oversized `session_key` returns 422.
@@ -524,5 +544,9 @@ async fn stream_turn_oversized_session_key_returns_422() {
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "validation_failed");
     let errors = body["error"]["details"]["errors"].as_array().unwrap();
-    assert!(errors.iter().any(|e| e["field"] == "session_key" && e["code"] == "too_long"));
+    assert!(
+        errors
+            .iter()
+            .any(|e| e["field"] == "session_key" && e["code"] == "too_long")
+    );
 }

--- a/crates/pylon/tests/public_api.rs
+++ b/crates/pylon/tests/public_api.rs
@@ -35,9 +35,7 @@ use nous::manager::NousManager;
 use organon::registry::ToolRegistry;
 use pylon::idempotency::IdempotencyCache;
 use pylon::router::build_router;
-use pylon::security::{
-    CorsConfig, CsrfConfig, RateLimitConfig, SecurityConfig, TlsConfig,
-};
+use pylon::security::{CorsConfig, CsrfConfig, RateLimitConfig, SecurityConfig, TlsConfig};
 use pylon::state::AppState;
 use symbolon::jwt::{JwtConfig, JwtManager};
 use symbolon::types::{Claims, Role, TokenKind};
@@ -252,7 +250,10 @@ async fn build_router_produces_router_with_health_endpoint() {
     let body = read_body_json(response).await;
     assert!(body["status"].is_string(), "health body lacks status");
     assert!(body["version"].is_string(), "health body lacks version");
-    assert!(body["uptime_seconds"].is_u64(), "uptime_seconds must be u64");
+    assert!(
+        body["uptime_seconds"].is_u64(),
+        "uptime_seconds must be u64"
+    );
     assert!(body["checks"].is_array(), "checks must be an array");
     assert!(
         !body["checks"].as_array().expect("checks array").is_empty(),
@@ -892,9 +893,7 @@ async fn raw_get(
     let mut stream = tokio::net::TcpStream::connect(addr)
         .await
         .expect("connect tcp");
-    let mut request = format!(
-        "GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n"
-    );
+    let mut request = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n");
     if let Some(value) = authorization {
         request.push_str("Authorization: ");
         request.push_str(value);

--- a/crates/symbolon/src/credential/pkce.rs
+++ b/crates/symbolon/src/credential/pkce.rs
@@ -394,7 +394,10 @@ fn parse_callback_request(reader: &mut BufReader<&TcpStream>) -> Result<Option<C
     // Extract query string
     let query_start = path.find('?');
     // INVARIANT: i is from find('?'), so i+1 is a valid byte boundary
-    #[expect(clippy::string_slice, reason = "i from find('?'), i+1 is valid boundary")]
+    #[expect(
+        clippy::string_slice,
+        reason = "i from find('?'), i+1 is valid boundary"
+    )]
     let query = query_start.map_or("", |i| &path[i + 1..]);
 
     // Parse query parameters
@@ -405,7 +408,10 @@ fn parse_callback_request(reader: &mut BufReader<&TcpStream>) -> Result<Option<C
             // SAFETY: eq_pos from find('='), always a valid byte boundary
             #[expect(clippy::string_slice, reason = "eq_pos from find('='), valid boundary")]
             let key = &pair[..eq_pos];
-            #[expect(clippy::string_slice, reason = "eq_pos from find('='), eq_pos+1 is valid")]
+            #[expect(
+                clippy::string_slice,
+                reason = "eq_pos from find('='), eq_pos+1 is valid"
+            )]
             let value = url_decode(&pair[eq_pos + 1..]).unwrap_or_default();
 
             match key {
@@ -519,9 +525,7 @@ fn handle_callback_connection(
     expected_state: &str,
 ) -> Result<CallbackData> {
     // Set blocking mode on the listener so accept() blocks until a connection arrives.
-    listener
-        .set_nonblocking(false)
-        .context(SetBlockingSnafu)?;
+    listener.set_nonblocking(false).context(SetBlockingSnafu)?;
 
     let (stream, addr) = listener.accept().context(AcceptConnectionSnafu)?;
     info!(addr = %addr, "received OAuth callback");

--- a/crates/symbolon/src/credential/refresh.rs
+++ b/crates/symbolon/src/credential/refresh.rs
@@ -409,7 +409,8 @@ async fn refresh_loop(
             continue;
         }
 
-        let Some((mut refresh_token_value, subscription_type, expires_at_ms)) = plan_refresh(&state)
+        let Some((mut refresh_token_value, subscription_type, expires_at_ms)) =
+            plan_refresh(&state)
         else {
             continue;
         };

--- a/crates/symbolon/src/credential_tests.rs
+++ b/crates/symbolon/src/credential_tests.rs
@@ -25,7 +25,10 @@ fn credential_file_roundtrip() {
     let loaded = CredentialFile::load(&path).expect("load saved credential file");
     assert_eq!(loaded.token.expose_secret(), "sk-test-123");
     assert_eq!(
-        loaded.refresh_token.as_ref().map(SecretString::expose_secret),
+        loaded
+            .refresh_token
+            .as_ref()
+            .map(SecretString::expose_secret),
         Some("rt-test-456")
     );
     assert_eq!(loaded.expires_at, Some(1_700_000_000_000));
@@ -65,7 +68,10 @@ fn credential_file_load_claude_code_oauth_wrapper() {
     let loaded = CredentialFile::load(&path).expect("load oauth wrapper credential file");
     assert_eq!(loaded.token.expose_secret(), "sk-ant-oat-wrapped");
     assert_eq!(
-        loaded.refresh_token.as_ref().map(SecretString::expose_secret),
+        loaded
+            .refresh_token
+            .as_ref()
+            .map(SecretString::expose_secret),
         Some("rt-wrapped")
     );
     assert_eq!(loaded.expires_at, Some(9_999_999_999_000));
@@ -718,7 +724,10 @@ async fn refresh_write_back_preserves_subscription_type() {
     let reloaded = CredentialFile::load(&path).expect("load refreshed credential");
     assert_eq!(reloaded.token.expose_secret(), "sk-ant-oat-refreshed");
     assert_eq!(
-        reloaded.refresh_token.as_ref().map(SecretString::expose_secret),
+        reloaded
+            .refresh_token
+            .as_ref()
+            .map(SecretString::expose_secret),
         Some("rt-new")
     );
     assert_eq!(
@@ -802,8 +811,14 @@ async fn credential_file_roundtrip_preserves_all_fields() {
     let loaded = CredentialFile::load(&path).expect("load full credential file");
     assert_eq!(loaded.token.expose_secret(), original.token.expose_secret());
     assert_eq!(
-        loaded.refresh_token.as_ref().map(SecretString::expose_secret),
-        original.refresh_token.as_ref().map(SecretString::expose_secret)
+        loaded
+            .refresh_token
+            .as_ref()
+            .map(SecretString::expose_secret),
+        original
+            .refresh_token
+            .as_ref()
+            .map(SecretString::expose_secret)
     );
     assert_eq!(loaded.expires_at, original.expires_at);
     assert_eq!(loaded.scopes, original.scopes);

--- a/crates/symbolon/src/encrypt.rs
+++ b/crates/symbolon/src/encrypt.rs
@@ -205,10 +205,7 @@ pub(crate) fn encrypt(key: &[u8; KEY_LEN], plaintext: &[u8]) -> std::io::Result<
 /// Returns an `io::Error` if base64 decoding or AES-GCM authentication fails.
 pub(crate) fn decrypt(key: &[u8; KEY_LEN], encoded: &str) -> std::io::Result<Vec<u8>> {
     let combined = base64_decode(encoded).ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "base64 decode failed",
-        )
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "base64 decode failed")
     })?;
 
     if combined.len() < NONCE_LEN {

--- a/crates/symbolon/src/metrics.rs
+++ b/crates/symbolon/src/metrics.rs
@@ -86,7 +86,9 @@ mod tests {
     fn record_auth_attempt_increments_counter() {
         let method = "test-auth-method";
         let ok_before = AUTH_ATTEMPTS_TOTAL.with_label_values(&[method, "ok"]).get();
-        let error_before = AUTH_ATTEMPTS_TOTAL.with_label_values(&[method, "error"]).get();
+        let error_before = AUTH_ATTEMPTS_TOTAL
+            .with_label_values(&[method, "error"])
+            .get();
 
         record_auth_attempt(method, true);
         assert_eq!(
@@ -95,7 +97,9 @@ mod tests {
             "ok counter should increment by 1"
         );
         assert_eq!(
-            AUTH_ATTEMPTS_TOTAL.with_label_values(&[method, "error"]).get(),
+            AUTH_ATTEMPTS_TOTAL
+                .with_label_values(&[method, "error"])
+                .get(),
             error_before,
             "error counter should not change for successful auth"
         );
@@ -107,7 +111,9 @@ mod tests {
             "ok counter should be unchanged"
         );
         assert_eq!(
-            AUTH_ATTEMPTS_TOTAL.with_label_values(&[method, "error"]).get(),
+            AUTH_ATTEMPTS_TOTAL
+                .with_label_values(&[method, "error"])
+                .get(),
             error_before + 1,
             "error counter should increment by 1"
         );

--- a/crates/symbolon/src/store/fjall_store.rs
+++ b/crates/symbolon/src/store/fjall_store.rs
@@ -114,8 +114,8 @@ impl AuthStore {
     /// The directory and all data are deleted when the returned store is dropped.
     #[instrument]
     pub(crate) fn open_in_memory() -> Result<Self> {
-        let fdb = koina::fjall::FjallDb::open_temp(PARTITIONS)
-            .map_err(|e| storage_err(e.to_string()))?;
+        let fdb =
+            koina::fjall::FjallDb::open_temp(PARTITIONS).map_err(|e| storage_err(e.to_string()))?;
         Ok(Self::from_fjall_db(fdb))
     }
 
@@ -170,10 +170,14 @@ impl AuthStore {
     ) -> Result<()> {
         let bytes = serde_json::to_vec(value)
             .map_err(|e| storage_err(format!("fjall json encode key={key}: {e}")))?;
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut tx = self.db.write_tx();
         tx.insert(partition, key.as_bytes(), &bytes);
-        tx.commit().map_err(|e| storage_err(format!("fjall commit: {e}")))
+        tx.commit()
+            .map_err(|e| storage_err(format!("fjall commit: {e}")))
     }
 
     fn key_exists(&self, partition: &fjall::SingleWriterTxKeyspace, key: &str) -> Result<bool> {
@@ -184,7 +188,10 @@ impl AuthStore {
         if !self.key_exists(partition, key)? {
             return Ok(false);
         }
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut tx = self.db.write_tx();
         tx.remove(partition, key.as_bytes());
         tx.commit()
@@ -306,7 +313,10 @@ impl AuthStore {
         let bytes = serde_json::to_vec(&entry)
             .map_err(|e| storage_err(format!("api key json encode: {e}")))?;
 
-        let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut tx = self.db.write_tx();
         tx.insert(&api_keys, primary_key.as_bytes(), &bytes);
         tx.insert(&api_keys, hash_key.as_bytes(), record.id.as_bytes());
@@ -395,7 +405,10 @@ impl AuthStore {
         let key = format!("revoked:{jti}");
         // WHY: INSERT OR IGNORE semantics — silently skip if already present.
         if !self.key_exists(&revoked, &key)? {
-            let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _guard = self
+                .write_lock
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let mut tx = self.db.write_tx();
             tx.insert(&revoked, key.as_bytes(), expires_at.as_bytes());
             tx.commit()
@@ -438,7 +451,10 @@ impl AuthStore {
 
         let count = expired_keys.len();
         if count > 0 {
-            let _guard = self.write_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _guard = self
+                .write_lock
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let mut tx = self.db.write_tx();
             for key in &expired_keys {
                 tx.remove(&revoked, key.as_slice());

--- a/crates/symbolon/src/util.rs
+++ b/crates/symbolon/src/util.rs
@@ -22,7 +22,8 @@ pub(crate) fn days_to_date(days_since_epoch: u64) -> (u64, u64, u64) {
 const BASE64_CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 /// URL-safe base64 character set (with `-` and `_`).
-const BASE64URL_CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+const BASE64URL_CHARS: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
 /// Encode bytes to standard base64 (with `+`, `/`, and `=` padding).
 pub(crate) fn base64_encode(input: &[u8]) -> String {

--- a/crates/taxis/src/config/config_tests.rs
+++ b/crates/taxis/src/config/config_tests.rs
@@ -243,11 +243,13 @@ fn resolve_uses_defaults_for_unknown_agent() {
     let config = AletheiaConfig::default();
     let resolved = resolve_nous(&config, "unknown-agent");
     assert_eq!(
-        resolved.id.as_ref(), "unknown-agent",
+        resolved.id.as_ref(),
+        "unknown-agent",
         "resolved id should match requested agent id"
     );
     assert_eq!(
-        resolved.model.primary, Arc::<str>::from("claude-sonnet-4-6"),
+        resolved.model.primary,
+        Arc::<str>::from("claude-sonnet-4-6"),
         "unknown agent should use default primary model"
     );
     assert_eq!(
@@ -291,7 +293,8 @@ fn resolve_merges_agent_overrides() {
 
     let resolved = resolve_nous(&config, "syn");
     assert_eq!(
-        resolved.model.primary, Arc::<str>::from("claude-opus-4-6"),
+        resolved.model.primary,
+        Arc::<str>::from("claude-opus-4-6"),
         "agent override should replace primary model"
     );
     assert_eq!(
@@ -701,8 +704,7 @@ fn capacity_defaults_match_koina_consts() {
         "default max_tool_output_bytes must equal koina::defaults::MAX_OUTPUT_BYTES"
     );
     assert_eq!(
-        config.capacity.max_tool_output_bytes,
-        51_200,
+        config.capacity.max_tool_output_bytes, 51_200,
         "default max_tool_output_bytes must be 51200 (50 KiB)"
     );
     assert_eq!(
@@ -834,7 +836,10 @@ fn deployment_defaults_match_original_constants() {
     // nous::actor::INBOX_RECV_TIMEOUT = 30s
     assert_eq!(nb.inbox_recv_timeout_secs, 30, "inbox_recv_timeout_secs");
     // nous::actor::CONSECUTIVE_TIMEOUT_WARN_THRESHOLD = 3
-    assert_eq!(nb.consecutive_timeout_warn_threshold, 3, "consecutive_timeout_warn_threshold");
+    assert_eq!(
+        nb.consecutive_timeout_warn_threshold, 3,
+        "consecutive_timeout_warn_threshold"
+    );
     assert_eq!(nb.inbox_capacity, 32, "inbox_capacity");
     assert_eq!(nb.max_spawned_tasks, 8, "max_spawned_tasks");
     assert_eq!(nb.max_sessions, 1_000, "max_sessions");
@@ -843,13 +848,25 @@ fn deployment_defaults_match_original_constants() {
     // nous::manager::DEAD_THRESHOLD = 3
     assert_eq!(nb.manager_dead_threshold, 3, "manager_dead_threshold");
     // nous::manager::MAX_RESTART_BACKOFF = 300s
-    assert_eq!(nb.manager_max_restart_backoff_secs, 300, "manager_max_restart_backoff_secs");
+    assert_eq!(
+        nb.manager_max_restart_backoff_secs, 300,
+        "manager_max_restart_backoff_secs"
+    );
     // nous::manager::RESTART_DRAIN_TIMEOUT = 30s
-    assert_eq!(nb.manager_restart_drain_timeout_secs, 30, "manager_restart_drain_timeout_secs");
+    assert_eq!(
+        nb.manager_restart_drain_timeout_secs, 30,
+        "manager_restart_drain_timeout_secs"
+    );
     // nous::manager::RESTART_DECAY_WINDOW = 3600s
-    assert_eq!(nb.manager_restart_decay_window_secs, 3_600, "manager_restart_decay_window_secs");
+    assert_eq!(
+        nb.manager_restart_decay_window_secs, 3_600,
+        "manager_restart_decay_window_secs"
+    );
     // nous::manager::DEFAULT_HEALTH_INTERVAL = 30s
-    assert_eq!(nb.manager_health_interval_secs, 30, "manager_health_interval_secs");
+    assert_eq!(
+        nb.manager_health_interval_secs, 30,
+        "manager_health_interval_secs"
+    );
     // nous::manager::DEFAULT_PING_TIMEOUT = 5s
     assert_eq!(nb.manager_ping_timeout_secs, 5, "manager_ping_timeout_secs");
     // nous::manager: stuck turn detection timeout = 600s
@@ -859,44 +876,89 @@ fn deployment_defaults_match_original_constants() {
     // nous::pipeline::CYCLE_DETECTION_MAX_LEN = 10
     assert_eq!(nb.cycle_detection_max_len, 10, "cycle_detection_max_len");
     // nous::self_audit::DEFAULT_EVENT_THRESHOLD = 50
-    assert_eq!(nb.self_audit_event_threshold, 50, "self_audit_event_threshold");
+    assert_eq!(
+        nb.self_audit_event_threshold, 50,
+        "self_audit_event_threshold"
+    );
 
     let kc = KnowledgeConfig::default();
     // episteme::conflict::MAX_LLM_CALLS_PER_FACT = 3
-    assert_eq!(kc.conflict_max_llm_calls_per_fact, 3, "conflict_max_llm_calls_per_fact");
+    assert_eq!(
+        kc.conflict_max_llm_calls_per_fact, 3,
+        "conflict_max_llm_calls_per_fact"
+    );
     // episteme::conflict::INTRA_BATCH_DEDUP_THRESHOLD = 0.95
-    assert!((kc.conflict_intra_batch_dedup_threshold - 0.95).abs() < f64::EPSILON, "conflict_intra_batch_dedup_threshold");
+    assert!(
+        (kc.conflict_intra_batch_dedup_threshold - 0.95).abs() < f64::EPSILON,
+        "conflict_intra_batch_dedup_threshold"
+    );
     // episteme::conflict::CANDIDATE_DISTANCE_THRESHOLD = 0.28
-    assert!((kc.conflict_candidate_distance_threshold - 0.28).abs() < f64::EPSILON, "conflict_candidate_distance_threshold");
+    assert!(
+        (kc.conflict_candidate_distance_threshold - 0.28).abs() < f64::EPSILON,
+        "conflict_candidate_distance_threshold"
+    );
     // episteme::conflict::MAX_CANDIDATES = 5
     assert_eq!(kc.conflict_max_candidates, 5, "conflict_max_candidates");
     // episteme::decay::REINFORCEMENT_BOOST = 0.02
-    assert!((kc.decay_reinforcement_boost - 0.02).abs() < f64::EPSILON, "decay_reinforcement_boost");
+    assert!(
+        (kc.decay_reinforcement_boost - 0.02).abs() < f64::EPSILON,
+        "decay_reinforcement_boost"
+    );
     // episteme::decay::MAX_REINFORCEMENT_BONUS = 1.0
-    assert!((kc.decay_max_reinforcement_bonus - 1.0).abs() < f64::EPSILON, "decay_max_reinforcement_bonus");
+    assert!(
+        (kc.decay_max_reinforcement_bonus - 1.0).abs() < f64::EPSILON,
+        "decay_max_reinforcement_bonus"
+    );
     // episteme::decay::CROSS_AGENT_BONUS_PER_AGENT = 0.15
-    assert!((kc.decay_cross_agent_bonus_per_agent - 0.15).abs() < f64::EPSILON, "decay_cross_agent_bonus_per_agent");
+    assert!(
+        (kc.decay_cross_agent_bonus_per_agent - 0.15).abs() < f64::EPSILON,
+        "decay_cross_agent_bonus_per_agent"
+    );
     // episteme::decay::MAX_CROSS_AGENT_MULTIPLIER = 1.75
-    assert!((kc.decay_max_cross_agent_multiplier - 1.75).abs() < f64::EPSILON, "decay_max_cross_agent_multiplier");
-    assert!((kc.extraction_confidence_threshold - 0.3).abs() < f64::EPSILON, "extraction_confidence_threshold");
-    assert_eq!(kc.extraction_min_fact_length, 10, "extraction_min_fact_length");
-    assert_eq!(kc.extraction_max_fact_length, 500, "extraction_max_fact_length");
+    assert!(
+        (kc.decay_max_cross_agent_multiplier - 1.75).abs() < f64::EPSILON,
+        "decay_max_cross_agent_multiplier"
+    );
+    assert!(
+        (kc.extraction_confidence_threshold - 0.3).abs() < f64::EPSILON,
+        "extraction_confidence_threshold"
+    );
+    assert_eq!(
+        kc.extraction_min_fact_length, 10,
+        "extraction_min_fact_length"
+    );
+    assert_eq!(
+        kc.extraction_max_fact_length, 500,
+        "extraction_max_fact_length"
+    );
     // episteme::ops_facts::MIN_TOOL_CALLS = 5
     assert_eq!(kc.instinct_min_tool_calls, 5, "instinct_min_tool_calls");
 
     let pb = ProviderBehaviorConfig::default();
     // hermeneus::anthropic::client::NON_STREAMING_TIMEOUT = 120s
-    assert_eq!(pb.non_streaming_timeout_secs, 120, "non_streaming_timeout_secs");
+    assert_eq!(
+        pb.non_streaming_timeout_secs, 120,
+        "non_streaming_timeout_secs"
+    );
     // hermeneus::anthropic::error::SSE_DEFAULT_RETRY_MS = 1000
     assert_eq!(pb.sse_default_retry_ms, 1_000, "sse_default_retry_ms");
     // hermeneus::concurrency::DEFAULT_EWMA_ALPHA = 0.8
-    assert!((pb.concurrency_ewma_alpha - 0.8).abs() < f64::EPSILON, "concurrency_ewma_alpha");
+    assert!(
+        (pb.concurrency_ewma_alpha - 0.8).abs() < f64::EPSILON,
+        "concurrency_ewma_alpha"
+    );
     // hermeneus::concurrency::DEFAULT_LATENCY_THRESHOLD_SECS = 30.0
-    assert!((pb.concurrency_latency_threshold_secs - 30.0).abs() < f64::EPSILON, "concurrency_latency_threshold_secs");
+    assert!(
+        (pb.concurrency_latency_threshold_secs - 30.0).abs() < f64::EPSILON,
+        "concurrency_latency_threshold_secs"
+    );
     // hermeneus::complexity::DEFAULT_LOW_THRESHOLD = 30
     assert_eq!(pb.complexity_low_threshold, 30, "complexity_low_threshold");
     // hermeneus::complexity::DEFAULT_HIGH_THRESHOLD = 70
-    assert_eq!(pb.complexity_high_threshold, 70, "complexity_high_threshold");
+    assert_eq!(
+        pb.complexity_high_threshold, 70,
+        "complexity_high_threshold"
+    );
 
     let al = ApiLimitsConfig::default();
     // pylon::handlers::sessions::MAX_SESSION_NAME_LEN = 255
@@ -919,23 +981,44 @@ fn deployment_defaults_match_original_constants() {
     assert_eq!(al.idempotency_ttl_secs, 300, "idempotency_ttl_secs");
     // pylon::idempotency::DEFAULT_CAPACITY = 10000
     assert_eq!(al.idempotency_capacity, 10_000, "idempotency_capacity");
-    assert_eq!(al.idempotency_max_key_length, 64, "idempotency_max_key_length");
+    assert_eq!(
+        al.idempotency_max_key_length, 64,
+        "idempotency_max_key_length"
+    );
     // pylon::handlers::health::CLOCK_SKEW_LEEWAY = 30s
     assert_eq!(al.clock_skew_leeway_secs, 30, "clock_skew_leeway_secs");
     // pylon::handlers::health::EXPIRY_WARNING_THRESHOLD = 3600s
-    assert_eq!(al.expiry_warning_threshold_secs, 3_600, "expiry_warning_threshold_secs");
+    assert_eq!(
+        al.expiry_warning_threshold_secs, 3_600,
+        "expiry_warning_threshold_secs"
+    );
 
     let db = DaemonBehaviorConfig::default();
     // daemon::watchdog::BACKOFF_BASE = 2s
-    assert_eq!(db.watchdog_backoff_base_secs, 2, "watchdog_backoff_base_secs");
+    assert_eq!(
+        db.watchdog_backoff_base_secs, 2,
+        "watchdog_backoff_base_secs"
+    );
     // daemon::watchdog::BACKOFF_CAP = 300s
-    assert_eq!(db.watchdog_backoff_cap_secs, 300, "watchdog_backoff_cap_secs");
+    assert_eq!(
+        db.watchdog_backoff_cap_secs, 300,
+        "watchdog_backoff_cap_secs"
+    );
     // daemon::prosoche::ANOMALY_SAMPLE_SIZE = 15
-    assert_eq!(db.prosoche_anomaly_sample_size, 15, "prosoche_anomaly_sample_size");
+    assert_eq!(
+        db.prosoche_anomaly_sample_size, 15,
+        "prosoche_anomaly_sample_size"
+    );
     // daemon::runner::output::BRIEF_HEAD_LINES = 5
-    assert_eq!(db.runner_output_brief_head_lines, 5, "runner_output_brief_head_lines");
+    assert_eq!(
+        db.runner_output_brief_head_lines, 5,
+        "runner_output_brief_head_lines"
+    );
     // daemon::runner::output::BRIEF_TAIL_LINES = 3
-    assert_eq!(db.runner_output_brief_tail_lines, 3, "runner_output_brief_tail_lines");
+    assert_eq!(
+        db.runner_output_brief_tail_lines, 3,
+        "runner_output_brief_tail_lines"
+    );
 
     let tl = ToolLimitsConfig::default();
     // organon::builtins::filesystem::MAX_PATTERN_LENGTH = 1000
@@ -951,9 +1034,15 @@ fn deployment_defaults_match_original_constants() {
     // organon::builtins::communication::MESSAGE_MAX_LEN = 4000
     assert_eq!(tl.message_max_len, 4_000, "message_max_len");
     // organon::builtins::communication::INTER_SESSION_MAX_MESSAGE_LEN = 100000
-    assert_eq!(tl.inter_session_max_message_len, 100_000, "inter_session_max_message_len");
+    assert_eq!(
+        tl.inter_session_max_message_len, 100_000,
+        "inter_session_max_message_len"
+    );
     // organon::builtins::communication::INTER_SESSION_MAX_TIMEOUT_SECS = 300s
-    assert_eq!(tl.inter_session_max_timeout_secs, 300, "inter_session_max_timeout_secs");
+    assert_eq!(
+        tl.inter_session_max_timeout_secs, 300,
+        "inter_session_max_timeout_secs"
+    );
 
     let mc = MessagingConfig::default();
     // agora::semeion::DEFAULT_POLL_INTERVAL = 2s (2000ms)
@@ -963,7 +1052,10 @@ fn deployment_defaults_match_original_constants() {
     // agora::semeion::CIRCUIT_BREAKER_THRESHOLD = 5
     assert_eq!(mc.circuit_breaker_threshold, 5, "circuit_breaker_threshold");
     // agora::semeion::HALTED_HEALTH_CHECK_INTERVAL = 60s
-    assert_eq!(mc.halted_health_check_interval_secs, 60, "halted_health_check_interval_secs");
+    assert_eq!(
+        mc.halted_health_check_interval_secs, 60,
+        "halted_health_check_interval_secs"
+    );
     // agora::semeion::client::RPC_TIMEOUT = 10s
     assert_eq!(mc.rpc_timeout_secs, 10, "rpc_timeout_secs");
     // agora::semeion::client::HEALTH_TIMEOUT = 2s
@@ -971,7 +1063,10 @@ fn deployment_defaults_match_original_constants() {
     // agora::semeion::client::RECEIVE_TIMEOUT = 15s
     assert_eq!(mc.receive_timeout_secs, 15, "receive_timeout_secs");
     // organon::builtins::agent::DEFAULT_TIMEOUT_SECS = 300s
-    assert_eq!(mc.agent_dispatch_timeout_secs, 300, "agent_dispatch_timeout_secs");
+    assert_eq!(
+        mc.agent_dispatch_timeout_secs, 300,
+        "agent_dispatch_timeout_secs"
+    );
 }
 
 #[test]
@@ -979,47 +1074,119 @@ fn per_agent_defaults_match_original_constants() {
     let ab = AgentBehaviorDefaults::default();
 
     // Safety
-    assert_eq!(ab.safety_loop_detection_threshold, 3, "safety_loop_detection_threshold");
-    assert_eq!(ab.safety_consecutive_error_threshold, 4, "safety_consecutive_error_threshold");
+    assert_eq!(
+        ab.safety_loop_detection_threshold, 3,
+        "safety_loop_detection_threshold"
+    );
+    assert_eq!(
+        ab.safety_consecutive_error_threshold, 4,
+        "safety_consecutive_error_threshold"
+    );
     assert_eq!(ab.safety_loop_max_warnings, 2, "safety_loop_max_warnings");
-    assert_eq!(ab.safety_session_token_cap, 500_000, "safety_session_token_cap");
-    assert_eq!(ab.safety_max_consecutive_tool_only_iterations, 3, "safety_max_consecutive_tool_only_iterations");
+    assert_eq!(
+        ab.safety_session_token_cap, 500_000,
+        "safety_session_token_cap"
+    );
+    assert_eq!(
+        ab.safety_max_consecutive_tool_only_iterations, 3,
+        "safety_max_consecutive_tool_only_iterations"
+    );
 
     // Hooks
     assert!(ab.hooks_cost_control_enabled, "hooks_cost_control_enabled");
     assert_eq!(ab.hooks_turn_token_budget, 0, "hooks_turn_token_budget");
-    assert!(ab.hooks_scope_enforcement_enabled, "hooks_scope_enforcement_enabled");
-    assert!(ab.hooks_correction_hooks_enabled, "hooks_correction_hooks_enabled");
-    assert!(ab.hooks_audit_logging_enabled, "hooks_audit_logging_enabled");
+    assert!(
+        ab.hooks_scope_enforcement_enabled,
+        "hooks_scope_enforcement_enabled"
+    );
+    assert!(
+        ab.hooks_correction_hooks_enabled,
+        "hooks_correction_hooks_enabled"
+    );
+    assert!(
+        ab.hooks_audit_logging_enabled,
+        "hooks_audit_logging_enabled"
+    );
 
     // Distillation — nous::distillation constants
-    assert_eq!(ab.distillation_context_token_trigger, 120_000, "distillation_context_token_trigger");
-    assert_eq!(ab.distillation_message_count_trigger, 150, "distillation_message_count_trigger");
-    assert_eq!(ab.distillation_stale_session_days, 7, "distillation_stale_session_days");
-    assert_eq!(ab.distillation_stale_min_messages, 20, "distillation_stale_min_messages");
-    assert_eq!(ab.distillation_never_distilled_trigger, 30, "distillation_never_distilled_trigger");
-    assert_eq!(ab.distillation_legacy_min_messages, 10, "distillation_legacy_min_messages");
+    assert_eq!(
+        ab.distillation_context_token_trigger, 120_000,
+        "distillation_context_token_trigger"
+    );
+    assert_eq!(
+        ab.distillation_message_count_trigger, 150,
+        "distillation_message_count_trigger"
+    );
+    assert_eq!(
+        ab.distillation_stale_session_days, 7,
+        "distillation_stale_session_days"
+    );
+    assert_eq!(
+        ab.distillation_stale_min_messages, 20,
+        "distillation_stale_min_messages"
+    );
+    assert_eq!(
+        ab.distillation_never_distilled_trigger, 30,
+        "distillation_never_distilled_trigger"
+    );
+    assert_eq!(
+        ab.distillation_legacy_min_messages, 10,
+        "distillation_legacy_min_messages"
+    );
     // melete::distill::MAX_BACKOFF_TURNS = 8
-    assert_eq!(ab.distillation_max_backoff_turns, 8, "distillation_max_backoff_turns");
+    assert_eq!(
+        ab.distillation_max_backoff_turns, 8,
+        "distillation_max_backoff_turns"
+    );
 
     // Competence — nous::competence constants
-    assert!((ab.competence_correction_penalty - 0.05).abs() < f64::EPSILON, "competence_correction_penalty");
-    assert!((ab.competence_success_bonus - 0.02).abs() < f64::EPSILON, "competence_success_bonus");
-    assert!((ab.competence_disagreement_penalty - 0.01).abs() < f64::EPSILON, "competence_disagreement_penalty");
-    assert!((ab.competence_min_score - 0.1).abs() < f64::EPSILON, "competence_min_score");
-    assert!((ab.competence_max_score - 0.95).abs() < f64::EPSILON, "competence_max_score");
-    assert!((ab.competence_default_score - 0.5).abs() < f64::EPSILON, "competence_default_score");
-    assert!((ab.competence_escalation_failure_threshold - 0.30).abs() < f64::EPSILON, "competence_escalation_failure_threshold");
-    assert_eq!(ab.competence_escalation_min_samples, 5, "competence_escalation_min_samples");
+    assert!(
+        (ab.competence_correction_penalty - 0.05).abs() < f64::EPSILON,
+        "competence_correction_penalty"
+    );
+    assert!(
+        (ab.competence_success_bonus - 0.02).abs() < f64::EPSILON,
+        "competence_success_bonus"
+    );
+    assert!(
+        (ab.competence_disagreement_penalty - 0.01).abs() < f64::EPSILON,
+        "competence_disagreement_penalty"
+    );
+    assert!(
+        (ab.competence_min_score - 0.1).abs() < f64::EPSILON,
+        "competence_min_score"
+    );
+    assert!(
+        (ab.competence_max_score - 0.95).abs() < f64::EPSILON,
+        "competence_max_score"
+    );
+    assert!(
+        (ab.competence_default_score - 0.5).abs() < f64::EPSILON,
+        "competence_default_score"
+    );
+    assert!(
+        (ab.competence_escalation_failure_threshold - 0.30).abs() < f64::EPSILON,
+        "competence_escalation_failure_threshold"
+    );
+    assert_eq!(
+        ab.competence_escalation_min_samples, 5,
+        "competence_escalation_min_samples"
+    );
 
     // Drift — nous::drift constants
     assert_eq!(ab.drift_window_size, 20, "drift_window_size");
     assert_eq!(ab.drift_recent_size, 5, "drift_recent_size");
-    assert!((ab.drift_deviation_threshold - 2.0).abs() < f64::EPSILON, "drift_deviation_threshold");
+    assert!(
+        (ab.drift_deviation_threshold - 2.0).abs() < f64::EPSILON,
+        "drift_deviation_threshold"
+    );
     assert_eq!(ab.drift_min_samples, 8, "drift_min_samples");
 
     // Uncertainty
-    assert_eq!(ab.uncertainty_max_calibration_points, 1_000, "uncertainty_max_calibration_points");
+    assert_eq!(
+        ab.uncertainty_max_calibration_points, 1_000,
+        "uncertainty_max_calibration_points"
+    );
 
     // Skills
     assert_eq!(ab.skills_max_skills, 5, "skills_max_skills");
@@ -1032,52 +1199,127 @@ fn per_agent_defaults_match_original_constants() {
     // Planning — dianoia::stuck constants
     // dianoia::plan::DEFAULT_MAX_ITERATIONS = 10
     assert_eq!(ab.planning_max_iterations, 10, "planning_max_iterations");
-    assert_eq!(ab.planning_stuck_history_window, 20, "planning_stuck_history_window");
-    assert_eq!(ab.planning_stuck_repeated_error_threshold, 3, "planning_stuck_repeated_error_threshold");
-    assert_eq!(ab.planning_stuck_same_args_threshold, 3, "planning_stuck_same_args_threshold");
-    assert_eq!(ab.planning_stuck_alternating_threshold, 3, "planning_stuck_alternating_threshold");
-    assert_eq!(ab.planning_stuck_escalating_retry_threshold, 3, "planning_stuck_escalating_retry_threshold");
+    assert_eq!(
+        ab.planning_stuck_history_window, 20,
+        "planning_stuck_history_window"
+    );
+    assert_eq!(
+        ab.planning_stuck_repeated_error_threshold, 3,
+        "planning_stuck_repeated_error_threshold"
+    );
+    assert_eq!(
+        ab.planning_stuck_same_args_threshold, 3,
+        "planning_stuck_same_args_threshold"
+    );
+    assert_eq!(
+        ab.planning_stuck_alternating_threshold, 3,
+        "planning_stuck_alternating_threshold"
+    );
+    assert_eq!(
+        ab.planning_stuck_escalating_retry_threshold, 3,
+        "planning_stuck_escalating_retry_threshold"
+    );
 
     // Knowledge tuning — episteme constants
-    assert_eq!(ab.knowledge_instinct_min_observations, 5, "knowledge_instinct_min_observations");
-    assert!((ab.knowledge_instinct_min_success_rate - 0.80).abs() < f64::EPSILON, "knowledge_instinct_min_success_rate");
-    assert!((ab.knowledge_instinct_stability_hours - 168.0).abs() < f64::EPSILON, "knowledge_instinct_stability_hours");
+    assert_eq!(
+        ab.knowledge_instinct_min_observations, 5,
+        "knowledge_instinct_min_observations"
+    );
+    assert!(
+        (ab.knowledge_instinct_min_success_rate - 0.80).abs() < f64::EPSILON,
+        "knowledge_instinct_min_success_rate"
+    );
+    assert!(
+        (ab.knowledge_instinct_stability_hours - 168.0).abs() < f64::EPSILON,
+        "knowledge_instinct_stability_hours"
+    );
     // episteme::surprise::DEFAULT_THRESHOLD = 2.0
-    assert!((ab.knowledge_surprise_threshold - 2.0).abs() < f64::EPSILON, "knowledge_surprise_threshold");
+    assert!(
+        (ab.knowledge_surprise_threshold - 2.0).abs() < f64::EPSILON,
+        "knowledge_surprise_threshold"
+    );
     // episteme::surprise::EMA_ALPHA = 0.3
-    assert!((ab.knowledge_surprise_ema_alpha - 0.3).abs() < f64::EPSILON, "knowledge_surprise_ema_alpha");
+    assert!(
+        (ab.knowledge_surprise_ema_alpha - 0.3).abs() < f64::EPSILON,
+        "knowledge_surprise_ema_alpha"
+    );
     // episteme::rule_proposals::MIN_OBSERVATIONS = 5
-    assert_eq!(ab.knowledge_rule_min_observations, 5, "knowledge_rule_min_observations");
+    assert_eq!(
+        ab.knowledge_rule_min_observations, 5,
+        "knowledge_rule_min_observations"
+    );
     // episteme::rule_proposals::MIN_CONFIDENCE = 0.60
-    assert!((ab.knowledge_rule_min_confidence - 0.60).abs() < f64::EPSILON, "knowledge_rule_min_confidence");
+    assert!(
+        (ab.knowledge_rule_min_confidence - 0.60).abs() < f64::EPSILON,
+        "knowledge_rule_min_confidence"
+    );
     // episteme::dedup::WEIGHT_NAME = 0.4
-    assert!((ab.knowledge_dedup_weight_name - 0.4).abs() < f64::EPSILON, "knowledge_dedup_weight_name");
+    assert!(
+        (ab.knowledge_dedup_weight_name - 0.4).abs() < f64::EPSILON,
+        "knowledge_dedup_weight_name"
+    );
     // episteme::dedup::WEIGHT_EMBED = 0.3
-    assert!((ab.knowledge_dedup_weight_embed - 0.3).abs() < f64::EPSILON, "knowledge_dedup_weight_embed");
+    assert!(
+        (ab.knowledge_dedup_weight_embed - 0.3).abs() < f64::EPSILON,
+        "knowledge_dedup_weight_embed"
+    );
     // episteme::dedup::WEIGHT_TYPE = 0.2
-    assert!((ab.knowledge_dedup_weight_type - 0.2).abs() < f64::EPSILON, "knowledge_dedup_weight_type");
+    assert!(
+        (ab.knowledge_dedup_weight_type - 0.2).abs() < f64::EPSILON,
+        "knowledge_dedup_weight_type"
+    );
     // episteme::dedup::WEIGHT_ALIAS = 0.1
-    assert!((ab.knowledge_dedup_weight_alias - 0.1).abs() < f64::EPSILON, "knowledge_dedup_weight_alias");
+    assert!(
+        (ab.knowledge_dedup_weight_alias - 0.1).abs() < f64::EPSILON,
+        "knowledge_dedup_weight_alias"
+    );
     // episteme::dedup::JW_THRESHOLD = 0.85
-    assert!((ab.knowledge_dedup_jw_threshold - 0.85).abs() < f64::EPSILON, "knowledge_dedup_jw_threshold");
+    assert!(
+        (ab.knowledge_dedup_jw_threshold - 0.85).abs() < f64::EPSILON,
+        "knowledge_dedup_jw_threshold"
+    );
     // episteme::dedup::EMBED_THRESHOLD = 0.80
-    assert!((ab.knowledge_dedup_embed_threshold - 0.80).abs() < f64::EPSILON, "knowledge_dedup_embed_threshold");
+    assert!(
+        (ab.knowledge_dedup_embed_threshold - 0.80).abs() < f64::EPSILON,
+        "knowledge_dedup_embed_threshold"
+    );
 
     // Fact lifecycle — eidos::knowledge::fact constants
-    assert!((ab.fact_active_threshold - 0.7).abs() < f64::EPSILON, "fact_active_threshold");
-    assert!((ab.fact_fading_threshold - 0.3).abs() < f64::EPSILON, "fact_fading_threshold");
-    assert!((ab.fact_dormant_threshold - 0.1).abs() < f64::EPSILON, "fact_dormant_threshold");
+    assert!(
+        (ab.fact_active_threshold - 0.7).abs() < f64::EPSILON,
+        "fact_active_threshold"
+    );
+    assert!(
+        (ab.fact_fading_threshold - 0.3).abs() < f64::EPSILON,
+        "fact_fading_threshold"
+    );
+    assert!(
+        (ab.fact_dormant_threshold - 0.1).abs() < f64::EPSILON,
+        "fact_dormant_threshold"
+    );
 
     // Similarity
-    assert!((ab.similarity_threshold - 0.85).abs() < f64::EPSILON, "similarity_threshold");
+    assert!(
+        (ab.similarity_threshold - 0.85).abs() < f64::EPSILON,
+        "similarity_threshold"
+    );
 
     // Tool behavior — organon constants
     // organon::builtins::agent::MAX_DISPATCH_TASKS = 10
-    assert_eq!(ab.tool_agent_dispatch_max_tasks, 10, "tool_agent_dispatch_max_tasks");
+    assert_eq!(
+        ab.tool_agent_dispatch_max_tasks, 10,
+        "tool_agent_dispatch_max_tasks"
+    );
     // organon::builtins::memory::datalog::DEFAULT_ROW_LIMIT = 100
-    assert_eq!(ab.tool_datalog_default_row_limit, 100, "tool_datalog_default_row_limit");
+    assert_eq!(
+        ab.tool_datalog_default_row_limit, 100,
+        "tool_datalog_default_row_limit"
+    );
     // organon::builtins::memory::datalog::DEFAULT_TIMEOUT_SECS = 5.0
-    assert!((ab.tool_datalog_default_timeout_secs - 5.0).abs() < f64::EPSILON, "tool_datalog_default_timeout_secs");
+    assert!(
+        (ab.tool_datalog_default_timeout_secs - 5.0).abs() < f64::EPSILON,
+        "tool_datalog_default_timeout_secs"
+    );
     // organon::builtins::view_file::MAX_IMAGE_BYTES = 20 MiB
     assert_eq!(ab.tool_max_image_bytes, 20_971_520, "tool_max_image_bytes");
     // organon::builtins::view_file::MAX_PDF_BYTES = 32 MiB
@@ -1085,7 +1327,10 @@ fn per_agent_defaults_match_original_constants() {
 
     // Corrections
     // nous::hooks::builtins::correction::MAX_CORRECTIONS = 50
-    assert_eq!(ab.corrections_max_corrections, 50, "corrections_max_corrections");
+    assert_eq!(
+        ab.corrections_max_corrections, 50,
+        "corrections_max_corrections"
+    );
 }
 
 #[test]
@@ -1105,8 +1350,10 @@ fn resolve_nous_uses_defaults_when_no_override() {
         resolved.behavior.distillation_context_token_trigger, 120_000,
         "default behavior should be used when no per-agent override is set"
     );
-    assert!((resolved.behavior.competence_correction_penalty - 0.05).abs() < f64::EPSILON,
-        "default competence_correction_penalty must come from AgentBehaviorDefaults");
+    assert!(
+        (resolved.behavior.competence_correction_penalty - 0.05).abs() < f64::EPSILON,
+        "default competence_correction_penalty must come from AgentBehaviorDefaults"
+    );
 }
 
 #[test]
@@ -1177,30 +1424,65 @@ fn new_deployment_sections_survive_serde_roundtrip() {
     let json = serde_json::to_string(&config).expect("serialize");
     let back: AletheiaConfig = serde_json::from_str(&json).expect("deserialize");
 
-    assert_eq!(back.nous_behavior.degraded_panic_threshold, 10, "nous_behavior survives roundtrip");
-    assert_eq!(back.knowledge.conflict_max_candidates, 8, "knowledge survives roundtrip");
-    assert_eq!(back.provider_behavior.complexity_low_threshold, 25, "provider_behavior survives roundtrip");
-    assert_eq!(back.api_limits.max_history_limit, 500, "api_limits survives roundtrip");
-    assert_eq!(back.daemon_behavior.prosoche_anomaly_sample_size, 20, "daemon_behavior survives roundtrip");
-    assert_eq!(back.tool_limits.subprocess_timeout_secs, 120, "tool_limits survives roundtrip");
-    assert_eq!(back.messaging.circuit_breaker_threshold, 3, "messaging survives roundtrip");
+    assert_eq!(
+        back.nous_behavior.degraded_panic_threshold, 10,
+        "nous_behavior survives roundtrip"
+    );
+    assert_eq!(
+        back.knowledge.conflict_max_candidates, 8,
+        "knowledge survives roundtrip"
+    );
+    assert_eq!(
+        back.provider_behavior.complexity_low_threshold, 25,
+        "provider_behavior survives roundtrip"
+    );
+    assert_eq!(
+        back.api_limits.max_history_limit, 500,
+        "api_limits survives roundtrip"
+    );
+    assert_eq!(
+        back.daemon_behavior.prosoche_anomaly_sample_size, 20,
+        "daemon_behavior survives roundtrip"
+    );
+    assert_eq!(
+        back.tool_limits.subprocess_timeout_secs, 120,
+        "tool_limits survives roundtrip"
+    );
+    assert_eq!(
+        back.messaging.circuit_breaker_threshold, 3,
+        "messaging survives roundtrip"
+    );
 }
 
 #[test]
 fn agent_behavior_defaults_survive_serde_roundtrip() {
     let mut config = AletheiaConfig::default();
-    config.agents.defaults.behavior.distillation_context_token_trigger = 80_000;
-    config.agents.defaults.behavior.competence_correction_penalty = 0.08;
+    config
+        .agents
+        .defaults
+        .behavior
+        .distillation_context_token_trigger = 80_000;
+    config
+        .agents
+        .defaults
+        .behavior
+        .competence_correction_penalty = 0.08;
 
     let json = serde_json::to_string(&config).expect("serialize");
     let back: AletheiaConfig = serde_json::from_str(&json).expect("deserialize");
 
     assert_eq!(
-        back.agents.defaults.behavior.distillation_context_token_trigger, 80_000,
+        back.agents
+            .defaults
+            .behavior
+            .distillation_context_token_trigger,
+        80_000,
         "agent behavior default survives serde roundtrip"
     );
-    assert!((back.agents.defaults.behavior.competence_correction_penalty - 0.08).abs() < f64::EPSILON,
-        "competence_correction_penalty survives serde roundtrip");
+    assert!(
+        (back.agents.defaults.behavior.competence_correction_penalty - 0.08).abs() < f64::EPSILON,
+        "competence_correction_penalty survives serde roundtrip"
+    );
 }
 
 #[test]

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -7,14 +7,13 @@ mod maintenance;
 mod resolved;
 
 pub use agents::{
-    AgentBehaviorDefaults, AgentDefaults, AgentModelDefaults, AgentsConfig,
-    CachingConfig, ModelSpec, NousDefinition, RecallSettings,
-    RecallWeights,
+    AgentBehaviorDefaults, AgentDefaults, AgentModelDefaults, AgentsConfig, CachingConfig,
+    ModelSpec, NousDefinition, RecallSettings, RecallWeights,
 };
 pub use behavior::{
-    ApiLimitsConfig, CapacityConfig, DaemonBehaviorConfig, KnowledgeConfig,
-    MessagingConfig, NousBehaviorConfig, ProviderBehaviorConfig, RetrySettings,
-    TimeoutsConfig, ToolLimitsConfig, TuningConfig,
+    ApiLimitsConfig, CapacityConfig, DaemonBehaviorConfig, KnowledgeConfig, MessagingConfig,
+    NousBehaviorConfig, ProviderBehaviorConfig, RetrySettings, TimeoutsConfig, ToolLimitsConfig,
+    TuningConfig,
 };
 pub use gateway::{
     BodyLimitConfig, CorsConfig, CsrfConfig, GatewayAuthConfig, GatewayConfig,
@@ -204,8 +203,6 @@ fn default_session_pattern() -> String {
     "{source}".to_owned()
 }
 
-
-
 /// Embedding provider configuration for recall pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -283,7 +280,6 @@ impl Default for SignalAccountConfig {
         }
     }
 }
-
 
 #[cfg(test)]
 #[path = "config_tests.rs"]

--- a/crates/taxis/src/config/resolved.rs
+++ b/crates/taxis/src/config/resolved.rs
@@ -89,7 +89,10 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
         match agent.and_then(|a| a.model.as_ref()) {
             Some(spec) => (
                 Arc::from(spec.primary.as_str()),
-                spec.fallbacks.iter().map(|s| Arc::from(s.as_str())).collect(),
+                spec.fallbacks
+                    .iter()
+                    .map(|s| Arc::from(s.as_str()))
+                    .collect(),
                 spec.retries_before_fallback,
             ),
             None => (

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -176,11 +176,9 @@ pub fn generate_primary_key(path: &Path) -> Result<()> {
     rand::fill(&mut key);
 
     let hex = to_hex(&key);
-    koina::fs::write_restricted(path, hex.as_bytes()).context(
-        error::WriteConfigSnafu {
-            path: path.to_path_buf(),
-        },
-    )?;
+    koina::fs::write_restricted(path, hex.as_bytes()).context(error::WriteConfigSnafu {
+        path: path.to_path_buf(),
+    })?;
 
     Ok(())
 }
@@ -208,8 +206,7 @@ pub(crate) fn is_encrypted(value: &str) -> bool {
     reason = "kanon lint requires explicit #[must_use] on pub fns returning Result"
 )]
 pub(crate) fn encrypt_value(plaintext: &str, primary_key: &[u8; KEY_LEN]) -> Result<String> {
-    let cipher =
-        ChaCha20Poly1305::new(GenericArray::from_slice(primary_key));
+    let cipher = ChaCha20Poly1305::new(GenericArray::from_slice(primary_key));
     let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
 
     let ciphertext_with_tag = cipher
@@ -254,15 +251,12 @@ pub(crate) fn decrypt_value(encrypted: &str, primary_key: &[u8; KEY_LEN]) -> Res
 
     let (nonce_bytes, ciphertext) = payload.split_at(NONCE_LEN);
 
-    let cipher =
-        ChaCha20Poly1305::new(GenericArray::from_slice(primary_key));
+    let cipher = ChaCha20Poly1305::new(GenericArray::from_slice(primary_key));
     let nonce = GenericArray::from_slice(nonce_bytes);
 
-    let plaintext = cipher
-        .decrypt(nonce, ciphertext)
-        .map_err(|_aead_err| {
-            build_decrypt_error("decryption failed (wrong key or corrupted data)")
-        })?;
+    let plaintext = cipher.decrypt(nonce, ciphertext).map_err(|_aead_err| {
+        build_decrypt_error("decryption failed (wrong key or corrupted data)")
+    })?;
 
     String::from_utf8(plaintext)
         .map_err(|_utf8_err| build_decrypt_error("decrypted value is not valid UTF-8"))

--- a/crates/taxis/src/lib.rs
+++ b/crates/taxis/src/lib.rs
@@ -53,7 +53,13 @@ mod tests {
             cascade_name.contains("Tier"),
             "cascade module should export Tier"
         );
-        assert!(error_name.contains("Error"), "error module should export Error");
-        assert!(oikos_name.contains("Oikos"), "oikos module should export Oikos");
+        assert!(
+            error_name.contains("Error"),
+            "error module should export Error"
+        );
+        assert!(
+            oikos_name.contains("Oikos"),
+            "oikos module should export Oikos"
+        );
     }
 }

--- a/crates/taxis/src/registry.rs
+++ b/crates/taxis/src/registry.rs
@@ -115,7 +115,10 @@ pub fn specs_by_section(section: &str) -> Vec<&'static ParameterSpec> {
 /// Return specs whose `affects` field contains `outcome`.
 #[must_use]
 pub fn specs_affecting(outcome: &str) -> Vec<&'static ParameterSpec> {
-    REGISTRY.iter().filter(|s| s.affects.contains(outcome)).collect()
+    REGISTRY
+        .iter()
+        .filter(|s| s.affects.contains(outcome))
+        .collect()
 }
 
 /// Look up a single spec by its dotted key.
@@ -233,7 +236,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Comparison of distillation accuracy at different truncation points",
             direction_hint: TuningDirection::Higher,
         },
-
         // ===================================================================
         // Competence scoring
         // ===================================================================
@@ -328,7 +330,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "False-positive and false-negative escalation rates",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Knowledge — conflict resolution
         // ===================================================================
@@ -410,7 +411,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Multi-agent confidence distribution analysis",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Knowledge — dedup weights
         // ===================================================================
@@ -466,7 +466,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Embedding-match accuracy at different thresholds",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Knowledge — fact lifecycle thresholds
         // ===================================================================
@@ -509,7 +508,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Dormant fact recovery rate analysis",
             direction_hint: TuningDirection::Lower,
         },
-
         // ===================================================================
         // Tool limits
         // ===================================================================
@@ -617,7 +615,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Inter-session response time distribution",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // API limits
         // ===================================================================
@@ -686,7 +683,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Cache utilization and eviction rate analysis",
             direction_hint: TuningDirection::Higher,
         },
-
         // ===================================================================
         // Timeouts and retry
         // ===================================================================
@@ -742,7 +738,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Backoff ceiling vs. retry outcome analysis",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Safety
         // ===================================================================
@@ -785,7 +780,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Session token usage distribution",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Capacity
         // ===================================================================
@@ -815,7 +809,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Context utilization and quality at different window sizes",
             direction_hint: TuningDirection::Higher,
         },
-
         // ===================================================================
         // Nous behavior
         // ===================================================================
@@ -858,7 +851,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Time-to-detect-failure at different poll intervals",
             direction_hint: TuningDirection::Lower,
         },
-
         // ===================================================================
         // Provider behavior
         // ===================================================================
@@ -901,7 +893,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Quality and cost comparison across routing thresholds",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Messaging
         // ===================================================================
@@ -931,7 +922,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Channel error patterns and recovery times",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Daemon behavior
         // ===================================================================
@@ -961,7 +951,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Maximum downtime tolerance analysis",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Knowledge — content limits
         // ===================================================================
@@ -978,7 +967,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Fact content length distribution",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Manifest — memory entries
         // ===================================================================
@@ -995,7 +983,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Manifest size vs. recall precision analysis",
             direction_hint: TuningDirection::Contextual,
         },
-
         // ===================================================================
         // Credential — refresh threshold
         // ===================================================================

--- a/crates/taxis/src/registry_tests.rs
+++ b/crates/taxis/src/registry_tests.rs
@@ -28,7 +28,10 @@ fn all_keys_are_unique() {
 #[test]
 fn spec_by_key_finds_known_parameter() {
     let spec = spec_by_key("agents.defaults.behavior.distillationContextTokenTrigger");
-    assert!(spec.is_some(), "expected to find distillation context token trigger spec");
+    assert!(
+        spec.is_some(),
+        "expected to find distillation context token trigger spec"
+    );
     let spec = spec.unwrap();
     assert_eq!(spec.tier, ParameterTier::SelfTuning);
 }
@@ -85,10 +88,26 @@ fn bounds_are_valid_where_present() {
 fn all_specs_have_non_empty_fields() {
     for spec in all_specs() {
         assert!(!spec.key.is_empty(), "spec has empty key");
-        assert!(!spec.section.is_empty(), "spec {} has empty section", spec.key);
-        assert!(!spec.description.is_empty(), "spec {} has empty description", spec.key);
-        assert!(!spec.affects.is_empty(), "spec {} has empty affects", spec.key);
-        assert!(!spec.outcome_signal.is_empty(), "spec {} has empty outcome_signal", spec.key);
+        assert!(
+            !spec.section.is_empty(),
+            "spec {} has empty section",
+            spec.key
+        );
+        assert!(
+            !spec.description.is_empty(),
+            "spec {} has empty description",
+            spec.key
+        );
+        assert!(
+            !spec.affects.is_empty(),
+            "spec {} has empty affects",
+            spec.key
+        );
+        assert!(
+            !spec.outcome_signal.is_empty(),
+            "spec {} has empty outcome_signal",
+            spec.key
+        );
         assert!(
             !spec.evidence_required.is_empty(),
             "spec {} has empty evidence_required",

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -381,14 +381,10 @@ fn validate_capacity(value: &Value, errors: &mut Vec<String>) {
     // no more than 2M to prevent nonsensical configurations.
     if let Some(val) = value.get("opusContextTokens").and_then(Value::as_u64) {
         if val < 200_000 {
-            errors.push(
-                "capacity.opusContextTokens must be at least 200 000 tokens".to_owned(),
-            );
+            errors.push("capacity.opusContextTokens must be at least 200 000 tokens".to_owned());
         }
         if val > 2_000_000 {
-            errors.push(
-                "capacity.opusContextTokens must not exceed 2 000 000 tokens".to_owned(),
-            );
+            errors.push("capacity.opusContextTokens must not exceed 2 000 000 tokens".to_owned());
         }
     }
 }
@@ -425,9 +421,7 @@ fn validate_retry(value: &Value, errors: &mut Vec<String>) {
     if let (Some(b), Some(m)) = (base, max)
         && m < b
     {
-        errors.push(
-            "retry.backoffMaxMs must be greater than or equal to backoffBaseMs".to_owned(),
-        );
+        errors.push("retry.backoffMaxMs must be greater than or equal to backoffBaseMs".to_owned());
     }
 }
 
@@ -501,13 +495,7 @@ fn validate_nous_behavior(value: &Value, errors: &mut Vec<String>) {
 
 fn validate_knowledge(value: &Value, errors: &mut Vec<String>) {
     check_range_u64(value, "conflictMaxLlmCallsPerFact", 1, 20, errors);
-    check_range_f64(
-        value,
-        "conflictIntraBatchDedupThreshold",
-        0.5,
-        1.0,
-        errors,
-    );
+    check_range_f64(value, "conflictIntraBatchDedupThreshold", 0.5, 1.0, errors);
     check_range_f64(
         value,
         "conflictCandidateDistanceThreshold",
@@ -525,12 +513,8 @@ fn validate_knowledge(value: &Value, errors: &mut Vec<String>) {
     check_range_u64(value, "extractionMaxFactLength", 10, 10_000, errors);
 
     // INVARIANT: min length must be less than max length.
-    let min_len = value
-        .get("extractionMinFactLength")
-        .and_then(Value::as_u64);
-    let max_len = value
-        .get("extractionMaxFactLength")
-        .and_then(Value::as_u64);
+    let min_len = value.get("extractionMinFactLength").and_then(Value::as_u64);
+    let max_len = value.get("extractionMaxFactLength").and_then(Value::as_u64);
     if let (Some(min), Some(max)) = (min_len, max_len)
         && min > max
     {
@@ -544,23 +528,13 @@ fn validate_provider_behavior(value: &Value, errors: &mut Vec<String>) {
     check_range_u64(value, "nonStreamingTimeoutSecs", 10, 600, errors);
     check_range_u64(value, "sseDefaultRetryMs", 100, 60_000, errors);
     check_range_f64(value, "concurrencyEwmaAlpha", 0.0, 1.0, errors);
-    check_range_f64(
-        value,
-        "concurrencyLatencyThresholdSecs",
-        1.0,
-        300.0,
-        errors,
-    );
+    check_range_f64(value, "concurrencyLatencyThresholdSecs", 1.0, 300.0, errors);
     check_range_u64(value, "complexityLowThreshold", 0, 100, errors);
     check_range_u64(value, "complexityHighThreshold", 0, 100, errors);
 
     // INVARIANT: low threshold must be <= high threshold.
-    let low = value
-        .get("complexityLowThreshold")
-        .and_then(Value::as_u64);
-    let high = value
-        .get("complexityHighThreshold")
-        .and_then(Value::as_u64);
+    let low = value.get("complexityLowThreshold").and_then(Value::as_u64);
+    let high = value.get("complexityHighThreshold").and_then(Value::as_u64);
     if let (Some(l), Some(h)) = (low, high)
         && l > h
     {
@@ -584,12 +558,8 @@ fn validate_api_limits(value: &Value, errors: &mut Vec<String>) {
     check_range_u64(value, "idempotencyMaxKeyLength", 1, 1024, errors);
 
     // INVARIANT: default history limit must be <= max history limit.
-    let default_limit = value
-        .get("defaultHistoryLimit")
-        .and_then(Value::as_u64);
-    let max_limit = value
-        .get("maxHistoryLimit")
-        .and_then(Value::as_u64);
+    let default_limit = value.get("defaultHistoryLimit").and_then(Value::as_u64);
+    let max_limit = value.get("maxHistoryLimit").and_then(Value::as_u64);
     if let (Some(d), Some(m)) = (default_limit, max_limit)
         && d > m
     {
@@ -607,9 +577,7 @@ fn validate_daemon_behavior(value: &Value, errors: &mut Vec<String>) {
     check_range_u64(value, "runnerOutputBriefTailLines", 1, 100, errors);
 
     // INVARIANT: backoff base must be <= backoff cap.
-    let base = value
-        .get("watchdogBackoffBaseSecs")
-        .and_then(Value::as_u64);
+    let base = value.get("watchdogBackoffBaseSecs").and_then(Value::as_u64);
     let cap = value.get("watchdogBackoffCapSecs").and_then(Value::as_u64);
     if let (Some(b), Some(c)) = (base, cap)
         && b > c

--- a/crates/taxis/src/validate_tests.rs
+++ b/crates/taxis/src/validate_tests.rs
@@ -286,7 +286,8 @@ fn rejects_empty_model_primary() {
 
 #[test]
 fn rejects_empty_model_fallback() {
-    let section = json!({ "defaults": { "model": { "primary": "claude-sonnet-4-6", "fallbacks": [""] } } });
+    let section =
+        json!({ "defaults": { "model": { "primary": "claude-sonnet-4-6", "fallbacks": [""] } } });
     let result = validate_section("agents", &section);
     assert!(result.is_err(), "empty model fallback should be rejected");
     let err = result.unwrap_err();
@@ -638,7 +639,9 @@ fn validate_startup_passes_with_complete_layout() {
     // fires, so let's just verify no subdir error is in the output.
     let err = validate_startup(&config, &oikos).unwrap_err();
     assert!(
-        err.errors.iter().all(|e| !e.contains("required instance directory")),
+        err.errors
+            .iter()
+            .all(|e| !e.contains("required instance directory")),
         "no subdirectory errors should be present when layout is complete: {err:?}"
     );
 }

--- a/crates/taxis/tests/common/mod.rs
+++ b/crates/taxis/tests/common/mod.rs
@@ -4,7 +4,10 @@
 //! its own test binary; it is only reachable via `mod common;` from the
 //! real top-level test files in `tests/`.
 
-#![expect(clippy::expect_used, reason = "test fixtures use expect on setup failures")]
+#![expect(
+    clippy::expect_used,
+    reason = "test fixtures use expect on setup failures"
+)]
 #![expect(
     clippy::disallowed_methods,
     reason = "fixtures need std::fs::write to seed real file content"

--- a/crates/taxis/tests/public_api.rs
+++ b/crates/taxis/tests/public_api.rs
@@ -243,8 +243,14 @@ fn redact_scrubs_tls_key_and_cert_paths() {
     config.gateway.tls.cert_path = Some("/etc/ssl/redact-probe-cert.pem".to_owned());
 
     let redacted = redact(&config).to_string();
-    assert!(!redacted.contains("redact-probe-key.pem"), "key path leaked");
-    assert!(!redacted.contains("redact-probe-cert.pem"), "cert path leaked");
+    assert!(
+        !redacted.contains("redact-probe-key.pem"),
+        "key path leaked"
+    );
+    assert!(
+        !redacted.contains("redact-probe-cert.pem"),
+        "cert path leaked"
+    );
 }
 
 // ─── WorkspaceSchema builder API ────────────────────────────────────────

--- a/crates/taxis/tests/public_api_loader.rs
+++ b/crates/taxis/tests/public_api_loader.rs
@@ -243,7 +243,10 @@ fn write_config_creates_file_with_mode_0600() {
         let mode = meta.permissions().mode() & 0o777;
         // WHY: closes #1710 -- config file may contain signing keys and must
         // be 0600 so only the owning user can read it.
-        assert_eq!(mode, 0o600, "aletheia.toml mode should be 0600, got {mode:o}");
+        assert_eq!(
+            mode, 0o600,
+            "aletheia.toml mode should be 0600, got {mode:o}"
+        );
         Ok(())
     });
 }

--- a/crates/taxis/tests/public_api_oikos.rs
+++ b/crates/taxis/tests/public_api_oikos.rs
@@ -80,10 +80,7 @@ fn oikos_data_subpaths_are_under_data_directory() {
 fn oikos_log_subpaths_are_under_logs_directory() {
     let oikos = Oikos::from_root("/srv/instance");
     assert_eq!(oikos.logs(), PathBuf::from("/srv/instance/logs"));
-    assert_eq!(
-        oikos.traces(),
-        PathBuf::from("/srv/instance/logs/traces")
-    );
+    assert_eq!(oikos.traces(), PathBuf::from("/srv/instance/logs/traces"));
     assert_eq!(
         oikos.trace_archive(),
         PathBuf::from("/srv/instance/logs/traces/archive")
@@ -275,7 +272,10 @@ fn cascade_discover_returns_files_from_all_three_tiers() {
 
     let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
     assert!(names.contains(&"nous-only.md"), "missing nous: {names:?}");
-    assert!(names.contains(&"shared-only.md"), "missing shared: {names:?}");
+    assert!(
+        names.contains(&"shared-only.md"),
+        "missing shared: {names:?}"
+    );
     assert!(names.contains(&"theke-only.md"), "missing theke: {names:?}");
 }
 
@@ -314,7 +314,11 @@ fn cascade_resolve_returns_none_for_missing_file() {
 fn cascade_resolve_all_returns_entries_most_specific_first() {
     let (_dir, oikos) = seed_cascade_tiers();
     let entries = cascade::resolve_all(&oikos, "syn", "shadowed.md", Some("tools"));
-    assert_eq!(entries.len(), 2, "shadowed should resolve in 2 tiers: {entries:?}");
+    assert_eq!(
+        entries.len(),
+        2,
+        "shadowed should resolve in 2 tiers: {entries:?}"
+    );
     assert_eq!(entries[0].tier, Tier::Nous, "first entry is most specific");
     assert_eq!(entries[1].tier, Tier::Shared, "second entry is shared");
 }

--- a/crates/theatron/koilon/src/app/mod.rs
+++ b/crates/theatron/koilon/src/app/mod.rs
@@ -338,7 +338,13 @@ impl App {
         // WHY: The old code flattened all health-check failures to a boolean,
         // making connection-refused indistinguishable from an unhealthy server.
         // We now issue the request directly and surface the actual error.
-        match self.client.raw_client().get(format!("{}/api/health", self.config.url)).send().await {
+        match self
+            .client
+            .raw_client()
+            .get(format!("{}/api/health", self.config.url))
+            .send()
+            .await
+        {
             Ok(resp) if resp.status().is_success() => {
                 // healthy — continue
             }

--- a/crates/theatron/koilon/src/config.rs
+++ b/crates/theatron/koilon/src/config.rs
@@ -135,9 +135,9 @@ impl Config {
         // WHY: When neither CLI flag nor config file provides a URL, attempt
         // auto-discovery before falling back to the compiled default.
         // Discovery runs a blocking runtime because Config::load is sync.
-        let url = cli_url.or(file_config.url).unwrap_or_else(|| {
-            Self::try_discover().unwrap_or_else(|| DEFAULT_URL.to_string())
-        });
+        let url = cli_url
+            .or(file_config.url)
+            .unwrap_or_else(|| Self::try_discover().unwrap_or_else(|| DEFAULT_URL.to_string()));
 
         Ok(Config {
             url,

--- a/crates/theatron/koilon/src/error.rs
+++ b/crates/theatron/koilon/src/error.rs
@@ -11,9 +11,7 @@ use snafu::prelude::*;
 pub enum Error {
     /// API transport or authentication error from the HTTP client.
     #[snafu(context(false))]
-    Api {
-        source: skene::api::ApiError,
-    },
+    Api { source: skene::api::ApiError },
 
     /// Token is required but was not supplied.
     #[snafu(display("{message}"))]

--- a/crates/theatron/koilon/src/state/input.rs
+++ b/crates/theatron/koilon/src/state/input.rs
@@ -19,8 +19,7 @@ impl InputState {
     /// Trigger cursor flash on input activity.
     pub(crate) fn trigger_cursor_flash(&mut self) {
         self.cursor_flash_until = Some(
-            std::time::Instant::now()
-                + std::time::Duration::from_millis(CURSOR_FLASH_DURATION_MS),
+            std::time::Instant::now() + std::time::Duration::from_millis(CURSOR_FLASH_DURATION_MS),
         );
     }
 

--- a/crates/theatron/koilon/src/update/selection.rs
+++ b/crates/theatron/koilon/src/update/selection.rs
@@ -257,7 +257,8 @@ fn extract_urls(text: &str) -> Vec<String> {
                 .trim_end_matches(',')
                 .trim_end_matches('.');
             // SAFE: protocol detection for URL extraction from text, not endpoint construction
-            if candidate.starts_with("http://") || candidate.starts_with("https://") { // kanon:ignore SECURITY/insecure-transport -- protocol detection for URL extraction, not endpoint construction
+            if candidate.starts_with("http://") || candidate.starts_with("https://") {
+                // kanon:ignore SECURITY/insecure-transport -- protocol detection for URL extraction, not endpoint construction
                 urls.push(candidate.to_string());
                 continue;
             }
@@ -271,7 +272,8 @@ fn extract_urls(text: &str) -> Vec<String> {
             .trim_end_matches(',')
             .trim_end_matches('.');
         // SAFE: protocol detection for URL extraction from text, not endpoint construction
-        if candidate.starts_with("http://") || candidate.starts_with("https://") { // kanon:ignore SECURITY/insecure-transport -- protocol detection for URL extraction, not endpoint construction
+        if candidate.starts_with("http://") || candidate.starts_with("https://") {
+            // kanon:ignore SECURITY/insecure-transport -- protocol detection for URL extraction, not endpoint construction
             urls.push(candidate.to_string());
         }
     }

--- a/crates/theatron/koilon/src/update/sse.rs
+++ b/crates/theatron/koilon/src/update/sse.rs
@@ -92,7 +92,10 @@ pub(crate) fn check_sse_reconnect_timeout(app: &mut App) {
     app.connection.sse_disconnected_at = None;
 
     let stall_secs = stall_duration.as_secs();
-    tracing::warn!(stall_secs, "SSE stalled for {stall_secs}s — forcing reconnect");
+    tracing::warn!(
+        stall_secs,
+        "SSE stalled for {stall_secs}s — forcing reconnect"
+    );
 
     // Replace the SSE connection with a fresh one.
     app.restore_sse(Some(crate::api::sse::SseConnection::connect(
@@ -100,9 +103,9 @@ pub(crate) fn check_sse_reconnect_timeout(app: &mut App) {
         &app.config.url,
     )));
 
-    app.viewport.error_toast = Some(ErrorToast::new(
-        format!("Connection stalled for {stall_secs}s — reconnecting..."),
-    ));
+    app.viewport.error_toast = Some(ErrorToast::new(format!(
+        "Connection stalled for {stall_secs}s — reconnecting..."
+    )));
 }
 
 #[tracing::instrument(skip_all, fields(turn_count = active_turns.len()))]
@@ -339,7 +342,10 @@ mod tests {
         assert!(app.connection.sse_disconnected_at.is_none());
         // SSE connection re-established: verify via take_sse which extracts the
         // private field through the public API.
-        assert!(app.take_sse().is_some(), "SSE connection should be re-established");
+        assert!(
+            app.take_sse().is_some(),
+            "SSE connection should be re-established"
+        );
     }
 
     #[test]

--- a/crates/theatron/koilon/src/view/image.rs
+++ b/crates/theatron/koilon/src/view/image.rs
@@ -198,8 +198,7 @@ fn load_and_render_halfblocks(path: &Path, max_width: usize) -> Vec<Line<'static
 
     // Reserve 2 columns for left margin. Terminal width always fits in u32;
     // saturate at u32::MAX for the unreachable branch.
-    let avail_width =
-        u32::try_from(max_width.saturating_sub(2).max(1)).unwrap_or(u32::MAX);
+    let avail_width = u32::try_from(max_width.saturating_sub(2).max(1)).unwrap_or(u32::MAX);
     let max_pixel_h = MAX_IMAGE_HEIGHT * 2;
 
     let scale_w = f64::from(avail_width) / f64::from(orig_w);

--- a/crates/theatron/koilon/src/view/overlay/mod.rs
+++ b/crates/theatron/koilon/src/view/overlay/mod.rs
@@ -136,7 +136,8 @@ fn render_help(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
         )));
         lines.push(Line::raw(""));
         for kb in bindings {
-            let key_span = Span::styled(format!("  {:<HELP_KEY_COLUMN_WIDTH$}", kb.keys), key_style);
+            let key_span =
+                Span::styled(format!("  {:<HELP_KEY_COLUMN_WIDTH$}", kb.keys), key_style);
             // Truncate description if too long, with ellipsis
             let desc = if kb.description.len() > desc_max_width && desc_max_width > 3 {
                 format!("{}...", &kb.description[..desc_max_width.saturating_sub(3)])

--- a/crates/theatron/koilon/src/view/tab_bar.rs
+++ b/crates/theatron/koilon/src/view/tab_bar.rs
@@ -30,7 +30,9 @@ pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
     let plus_width = plus_label.len();
     let available = width.saturating_sub(separators_width + plus_width + 1); // +1 for leading space
 
-    let max_per_tab = available.checked_div(total_tabs).map_or(available, |v| v.max(3));
+    let max_per_tab = available
+        .checked_div(total_tabs)
+        .map_or(available, |v| v.max(3));
 
     let mut spans: Vec<Span> = Vec::new();
 

--- a/crates/theatron/skene/src/discovery.rs
+++ b/crates/theatron/skene/src/discovery.rs
@@ -144,10 +144,7 @@ pub async fn discover_server() -> Option<String> {
         .ok()?;
 
     let candidates = build_candidates();
-    tracing::info!(
-        count = candidates.len(),
-        "starting server discovery"
-    );
+    tracing::info!(count = candidates.len(), "starting server discovery");
 
     // WHY: tokio::time::timeout wraps the entire sequential probe loop so we
     // honour the total wall-clock budget even if individual probes are slow

--- a/crates/thesauros/src/tools/mod.rs
+++ b/crates/thesauros/src/tools/mod.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
+use indexmap::IndexMap;
 use koina::defaults::MAX_OUTPUT_BYTES;
 use koina::id::ToolName;
 use organon::process_guard::ProcessGuard;
@@ -15,7 +16,6 @@ use organon::types::{
     InputSchema, PropertyDef, PropertyType, ToolCategory, ToolContext, ToolDef, ToolInput,
     ToolResult,
 };
-use indexmap::IndexMap;
 use tracing::info;
 
 use crate::error;
@@ -38,8 +38,7 @@ impl ToolExecutor for ShellToolExecutor {
         &'a self,
         input: &'a ToolInput,
         _ctx: &'a ToolContext,
-    ) -> Pin<Box<dyn Future<Output = organon::error::Result<ToolResult>> + Send + 'a>>
-    {
+    ) -> Pin<Box<dyn Future<Output = organon::error::Result<ToolResult>> + Send + 'a>> {
         Box::pin(async {
             let json_input = serde_json::to_string(&input.arguments).unwrap_or_else(|e| {
                 tracing::debug!("failed to serialize tool arguments: {e}");

--- a/crates/thesauros/tests/public_api.rs
+++ b/crates/thesauros/tests/public_api.rs
@@ -20,10 +20,10 @@
 use std::fs;
 use std::path::PathBuf;
 
+use tempfile::TempDir;
 use thesauros::error::Error;
 use thesauros::loader::{LoadedPack, load_packs};
 use thesauros::manifest::{PackManifest, PackPropertyDef, PackToolDef, Priority};
-use tempfile::TempDir;
 
 // --- Helpers ---
 
@@ -100,7 +100,10 @@ mod manifest_serde {
 
         assert_eq!(back.name, "acme");
         assert_eq!(back.version, "2.3.1");
-        assert_eq!(back.description.as_deref(), Some("an integration-test pack"));
+        assert_eq!(
+            back.description.as_deref(),
+            Some("an integration-test pack")
+        );
 
         let ctx = back.context.first().expect("one context entry");
         assert_eq!(ctx.priority, Priority::Required);
@@ -148,8 +151,7 @@ mod manifest_serde {
         // must not appear in serialized JSON when unused, so pack.toml
         // files stay minimal and deserialization of legacy files works.
         let prop_json = r#"{"type": "string", "description": "a string"}"#;
-        let prop: PackPropertyDef =
-            serde_json::from_str(prop_json).expect("deserialize property");
+        let prop: PackPropertyDef = serde_json::from_str(prop_json).expect("deserialize property");
         assert!(prop.enum_values.is_none());
         let reserialized = serde_json::to_string(&prop).expect("serialize");
         assert!(
@@ -364,8 +366,7 @@ domains = ["healthcare", "sql"]
 
         // A random agent id with the healthcare domain should see
         // general + healthcare, but not analyst.
-        let sections =
-            pack.sections_for_agent_or_domains("hermes", &["healthcare".to_owned()]);
+        let sections = pack.sections_for_agent_or_domains("hermes", &["healthcare".to_owned()]);
         let names: Vec<&str> = sections.iter().map(|s| s.name.as_str()).collect();
         assert!(names.contains(&"general.md"));
         assert!(names.contains(&"healthcare.md"));


### PR DESCRIPTION
## Summary
- Mechanical `cargo fmt --all` across the workspace. Unblocks CI fmt check from PR #3498.
- No logic changes.

Closes #3499