### PR TITLE
security(hermeneus): training opt-out, prompt cache disabled, strip CC fingerprints (#3406 #3410 #3409)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,6 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.11.0",
  "snafu",
  "tokio",
  "tower 0.5.3",

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -122,8 +122,23 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
         return registry;
     }
 
+    // #3410: translate taxis PromptCacheMode -> hermeneus PromptCacheMode.
+    // The two enums are intentionally decoupled so taxis does not depend on
+    // hermeneus, but both default to `Disabled` (sovereignty-first).
+    let prompt_cache_mode = match config.anthropic.prompt_cache_mode {
+        taxis::config::PromptCacheMode::Disabled => hermeneus::provider::PromptCacheMode::Disabled,
+        taxis::config::PromptCacheMode::Ephemeral => {
+            hermeneus::provider::PromptCacheMode::Ephemeral
+        }
+        taxis::config::PromptCacheMode::Extended => hermeneus::provider::PromptCacheMode::Extended,
+        // WHY: taxis::config::PromptCacheMode is #[non_exhaustive] to keep
+        // future additions non-breaking. Unknown variants default to the
+        // sovereignty-first policy.
+        _ => hermeneus::provider::PromptCacheMode::Disabled,
+    };
     let provider_config = ProviderConfig {
         pricing,
+        prompt_cache_mode,
         ..ProviderConfig::default()
     };
 

--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -17,7 +17,6 @@ prometheus = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
-sha2 = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hermeneus/src/anthropic/cc_profile.rs
+++ b/crates/hermeneus/src/anthropic/cc_profile.rs
@@ -1,17 +1,30 @@
-//! Claude Code profile for API request mimicry.
+//! Claude Code profile for OAuth-gated API access.
 //!
-//! Extracts version and configuration from the installed `claude` CLI binary
-//! so that hermeneus API requests match Claude Code's fingerprint. Only active
-//! when OAuth credentials are in use.
+//! Extracts version and the minimum beta-header set from the installed
+//! `claude` CLI binary so that hermeneus requests look enough like Claude
+//! Code traffic to unlock Sonnet/Opus on OAuth tokens. Only active when
+//! OAuth credentials are in use.
+//!
+//! # Sovereignty (#3409)
+//!
+//! The upstream CC format includes a per-conversation fingerprint
+//! (`SHA256(SALT + msg[4] + msg[7] + msg[20] + version)`) in both the
+//! attribution string and a persistent `X-Claude-Code-Session-Id` header,
+//! letting Anthropic correlate requests back to specific operator prompts
+//! and sessions. Aletheia stays off that attribution surface:
+//!
+//! - Attribution fingerprint replaced by the stable literal `000`.
+//! - Session-id header randomized per-request at the client layer
+//!   (see `client::build_headers`).
+//! - Per-process session UUID on this profile is removed entirely.
+//!
+//! The `cc_version`, `cc_entrypoint`, `anthropic-beta`, and `User-Agent`
+//! values are preserved because Anthropic gates Sonnet/Opus access on a
+//! well-formed attribution block and the beta set.
 
 use std::process::Command;
 
-use koina::uuid::Uuid;
 use tracing::warn;
-
-/// Fingerprint salt from CC source (constants/system.ts).
-/// Must match exactly for server-side validation.
-const FINGERPRINT_SALT: &str = "59cf53e54c78";
 
 /// Core beta headers that CC sends for non-Haiku 1P models.
 /// Derived from CC source (constants/betas.ts, utils/betas.ts).
@@ -26,14 +39,12 @@ const CORE_BETAS: &[&str] = &[
 
 /// Profile of the installed Claude Code binary.
 ///
-/// Used to make hermeneus API requests indistinguishable from Claude Code
-/// traffic when using OAuth credentials.
+/// Used to satisfy the OAuth-tier gates on Anthropic's first-party API
+/// without leaking operator-identifying fingerprints (#3409).
 #[derive(Debug, Clone)]
 pub(crate) struct CcProfile {
     /// CC version string (e.g., "2.1.92").
     pub version: String,
-    /// Persistent session ID (one per aletheia process, matches CC behavior).
-    pub session_id: Uuid,
     /// Beta headers to send (comma-joined in the `anthropic-beta` header).
     pub beta_headers: Vec<String>,
 }
@@ -52,7 +63,6 @@ impl CcProfile {
 
         Self {
             version,
-            session_id: Uuid::new_v4(),
             beta_headers,
         }
     }
@@ -69,23 +79,19 @@ impl CcProfile {
         }
     }
 
-    /// Compute the 3-character fingerprint for a given first user message.
-    ///
-    /// Algorithm: `SHA256(SALT + msg[4] + msg[7] + msg[20] + version)[:3]`
-    /// Matches CC source (`utils/fingerprint.ts`).
-    pub fn compute_fingerprint(&self, first_message_text: &str) -> String {
-        compute_fingerprint(first_message_text, &self.version)
-    }
-
-    /// Build the attribution string for the system prompt.
+    /// Build the sovereignty-scrubbed attribution string (#3409).
     ///
     /// This is NOT an HTTP header — it's a text block prepended to the system
     /// prompt array. CC embeds it as the first system block so the API can
-    /// attribute the request.
-    pub fn attribution_header(&self, first_message_text: &str) -> String {
-        let fingerprint = self.compute_fingerprint(first_message_text);
+    /// attribute the request. The 3-char slot that upstream CC fills with a
+    /// per-conversation fingerprint is pinned to `000` here so Anthropic
+    /// cannot correlate attribution back to operator prompts.
+    ///
+    /// The `first_message_text` parameter is retained for API compatibility
+    /// and ignored on purpose.
+    pub fn attribution_header(&self, _first_message_text: &str) -> String {
         format!(
-            "x-anthropic-billing-header: cc_version={version}.{fingerprint}; cc_entrypoint=cli;",
+            "x-anthropic-billing-header: cc_version={version}.000; cc_entrypoint=cli;",
             version = self.version,
         )
     }
@@ -99,39 +105,6 @@ impl CcProfile {
     pub fn beta_header_value(&self) -> String {
         self.beta_headers.join(",")
     }
-}
-
-/// Compute the 3-char fingerprint from message text and version.
-///
-/// Public for unit testing.
-pub(crate) fn compute_fingerprint(first_message_text: &str, version: &str) -> String {
-    use sha2::{Digest, Sha256};
-
-    let chars: Vec<char> = first_message_text.chars().collect();
-    let indices = [4, 7, 20];
-    let extracted: String = indices
-        .iter()
-        .map(|&i| chars.get(i).copied().unwrap_or('0'))
-        .collect();
-
-    let input = format!("{FINGERPRINT_SALT}{extracted}{version}");
-    let hash = Sha256::digest(input.as_bytes());
-    // First 3 hex chars: take 2 bytes (= 4 hex chars), then slice to 3.
-    // All chars are ASCII hex digits so the byte slice is always valid UTF-8.
-    let hex: String = hash
-        .iter()
-        .take(2)
-        .flat_map(|b| {
-            let hi = char::from_digit(u32::from(b >> 4), 16).unwrap_or('0');
-            let lo = char::from_digit(u32::from(b & 0xf), 16).unwrap_or('0');
-            [hi, lo]
-        })
-        .collect();
-    #[expect(
-        clippy::string_slice,
-        reason = "ASCII hex digits: byte slice is always on char boundary"
-    )]
-    hex[..3].to_owned()
 }
 
 /// Detect the installed Claude Code version by running `claude --version`.
@@ -156,45 +129,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fingerprint_matches_cc_implementation() {
-        // Test case: message "Say 'hello' in one word. Nothing else."
-        // Indices [4, 7]: ' ' (space at 4), 'l' (at 7), 'l' (at 20)
-        let msg = "Say 'hello' in one word. Nothing else.";
-        let version = "2.1.92";
-        let fp = compute_fingerprint(msg, version);
-        assert_eq!(fp.len(), 3, "fingerprint must be 3 hex chars");
-
-        // Verify: SHA256("59cf53e54c78" + "'lo" + "2.1.92")
-        // msg[4] = '\'' (apostrophe after "Say ")
-        // msg[7] = 'l'  (in "hello")
-        // msg[20] = 'o' (in "word")
-        // Wait let me recount: S(0)a(1)y(2) (3)'(4)h(5)e(6)l(7)l(8)o(9)'(10) (11)i(12)n(13) (14)o(15)n(16)e(17) (18)w(19)o(20)
-        // msg[4] = 'h', msg[7] = 'o', msg[20] = 'r'
-        // No wait — the Python probe used this same message and got "ea9"
-        // Let me just verify it matches
-        assert_eq!(fp, "ea9", "fingerprint must match CC output");
-    }
-
-    #[test]
-    fn fingerprint_short_message() {
-        // Message shorter than index 20 → uses '0' for missing chars
-        let msg = "Hi";
-        let version = "2.1.92";
-        let fp = compute_fingerprint(msg, version);
-        assert_eq!(fp.len(), 3);
-    }
-
-    #[test]
-    fn fingerprint_empty_message() {
-        let fp = compute_fingerprint("", "2.1.92");
-        assert_eq!(fp.len(), 3);
-    }
-
-    #[test]
     fn attribution_header_format() {
         let profile = CcProfile {
             version: "2.1.92".to_owned(),
-            session_id: Uuid::new_v4(),
             beta_headers: vec![],
         };
         let header = profile.attribution_header("Say 'hello' in one word. Nothing else.");
@@ -202,11 +139,31 @@ mod tests {
         assert!(header.ends_with("; cc_entrypoint=cli;"));
     }
 
+    /// Sovereignty (#3409): attribution must NOT vary with the user's
+    /// first-message content. The upstream fingerprint is replaced by `000`
+    /// so Anthropic cannot correlate attribution back to operator prompts.
+    #[test]
+    fn attribution_header_strips_operator_fingerprint() {
+        let profile = CcProfile {
+            version: "2.1.92".to_owned(),
+            beta_headers: vec![],
+        };
+        let first = profile.attribution_header("first message with distinctive content");
+        let second = profile.attribution_header("entirely different wording here");
+        assert_eq!(
+            first, second,
+            "attribution must not fingerprint operator content"
+        );
+        assert!(
+            first.contains(".000;"),
+            "fingerprint slot must be stable placeholder, got: {first}"
+        );
+    }
+
     #[test]
     fn user_agent_format() {
         let profile = CcProfile {
             version: "2.1.92".to_owned(),
-            session_id: Uuid::new_v4(),
             beta_headers: vec![],
         };
         assert_eq!(profile.user_agent(), "claude-cli/2.1.92 (user, cli)");

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -16,7 +16,7 @@ use koina::secret::SecretString;
 
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};
-use crate::provider::{LlmProvider, ModelPricing, ProviderConfig};
+use crate::provider::{LlmProvider, ModelPricing, PromptCacheMode, ProviderConfig};
 use crate::types::{CompletionRequest, CompletionResponse};
 
 use super::stream::{StreamAccumulator, StreamEvent, parse_sse_response};
@@ -52,6 +52,10 @@ pub struct AnthropicProvider {
     cc_profile: Option<super::cc_profile::CcProfile>,
     /// Per-request timeout for non-streaming completions.
     non_streaming_timeout: Duration,
+    /// Prompt cache policy (#3410). When `Disabled`, all `cache_control`
+    /// markers are scrubbed before the wire request is built so operator
+    /// content never enters Anthropic's prompt cache.
+    prompt_cache_mode: PromptCacheMode,
 }
 
 /// Static credential provider for backward-compatible `from_config()`.
@@ -78,6 +82,18 @@ impl CredentialProvider for StaticCredentialProvider {
 
 /// Per-request timeout for non-streaming completions.
 const NON_STREAMING_TIMEOUT: Duration = Duration::from_mins(2);
+
+/// HTTP headers sent on every outbound Anthropic request to opt out of
+/// using operator traffic for model training (#3406).
+///
+/// Anthropic has not publicly documented a single canonical header name for
+/// per-request training opt-out, so we send both the hyphenated
+/// `anthropic-disable-training` form and an `anthropic-training-opt-out`
+/// alias. Both are harmless no-ops if the server ignores them and either
+/// may match the accepted name once verified. The constant lives here so
+/// the follow-up verification issue has a single call site to update.
+const ANTHROPIC_TRAINING_OPTOUT_HEADERS: &[&str] =
+    &["anthropic-disable-training", "anthropic-training-opt-out"];
 
 /// Per-request timeout for streaming completions. Generous because actual stall
 /// detection is handled by the SSE parser's idle timeout; this is a safety net
@@ -159,6 +175,7 @@ impl AnthropicProvider {
             health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
             cc_profile: None, // API key mode — no mimicry needed
             non_streaming_timeout: NON_STREAMING_TIMEOUT,
+            prompt_cache_mode: config.prompt_cache_mode,
         };
         // TODO(#2178): add allow_insecure config field
         if !provider.base_url.starts_with("https://") && !is_loopback_url(&provider.base_url) {
@@ -211,6 +228,7 @@ impl AnthropicProvider {
             health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
             cc_profile,
             non_streaming_timeout: NON_STREAMING_TIMEOUT,
+            prompt_cache_mode: config.prompt_cache_mode,
         };
         // TODO(#2178): add allow_insecure config field
         if !provider.base_url.starts_with("https://") && !is_loopback_url(&provider.base_url) {
@@ -297,7 +315,8 @@ impl AnthropicProvider {
         let start = Instant::now();
         let mut ttft: Option<std::time::Duration> = None;
 
-        let request = &self.maybe_prepend_oauth_identity(request);
+        let scrubbed = self.apply_prompt_cache_policy(request);
+        let request = &self.maybe_prepend_oauth_identity(&scrubbed);
         let attribution = self.compute_attribution(request);
         let wire = WireRequest::from_request(request, Some(true), attribution.as_deref())
             .context(error::ParseResponseSnafu)?;
@@ -639,9 +658,14 @@ impl AnthropicProvider {
                         .build()
                     })?,
                 );
+                // WHY (#3409): `X-Claude-Code-Session-Id` is stable per-process
+                // in upstream CC and lets Anthropic correlate requests back to
+                // a single operator session. Send a fresh random UUID on every
+                // call instead so the header still satisfies any server-side
+                // presence checks without leaking session identity.
                 headers.insert(
                     "X-Claude-Code-Session-Id",
-                    HeaderValue::from_str(&profile.session_id.to_string()).map_err(|_e| {
+                    HeaderValue::from_str(&koina::uuid::uuid_v4()).map_err(|_e| {
                         error::AuthFailedSnafu {
                             message: "session id contains invalid characters".to_owned(),
                         }
@@ -685,7 +709,38 @@ impl AnthropicProvider {
             })?,
         );
         headers.insert("content-type", HeaderValue::from_static("application/json"));
+        // WHY (#3406): sovereignty default — always opt out of Anthropic using
+        // our traffic for model training. API customers already have this by
+        // contract, but we belt-and-suspenders the header so any future policy
+        // shift or misrouted request still carries an explicit refusal.
+        //
+        // Anthropic has not publicly documented a single canonical header name
+        // for per-request training opt-out. The value `anthropic-training-opt-out`
+        // is a defensive placeholder pending verification against Anthropic's
+        // API reference; see the follow-up issue noted in the PR body.
+        for name in ANTHROPIC_TRAINING_OPTOUT_HEADERS {
+            headers.insert(*name, HeaderValue::from_static("true"));
+        }
         Ok(headers)
+    }
+
+    /// Apply the operator's prompt cache policy (#3410).
+    ///
+    /// When [`PromptCacheMode::Disabled`] (the sovereignty default), every
+    /// `cache_*` flag is zeroed before the wire request is built so the
+    /// serializer in [`super::wire::WireRequest::from_request`] emits no
+    /// `cache_control` markers. Operators who opt in to `Ephemeral` or
+    /// `Extended` keep the caller-provided flags untouched.
+    fn apply_prompt_cache_policy(&self, request: &CompletionRequest) -> CompletionRequest {
+        if matches!(self.prompt_cache_mode, PromptCacheMode::Disabled) {
+            let mut scrubbed = request.clone();
+            scrubbed.cache_system = false;
+            scrubbed.cache_tools = false;
+            scrubbed.cache_turns = false;
+            scrubbed
+        } else {
+            request.clone()
+        }
     }
 
     async fn execute_with_retry(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
@@ -728,7 +783,8 @@ impl AnthropicProvider {
         // WHY: Anthropic gates Sonnet/Opus access on OAuth tokens behind a system
         // prompt identity check. Without the CC identity prefix, only Haiku-tier
         // models are available. This matches what Claude Code itself sends.
-        let request = &self.maybe_prepend_oauth_identity(request);
+        let scrubbed = self.apply_prompt_cache_policy(request);
+        let request = &self.maybe_prepend_oauth_identity(&scrubbed);
         let attribution = self.compute_attribution(request);
         let wire = WireRequest::from_request(request, None, attribution.as_deref())
             .context(error::ParseResponseSnafu)?;

--- a/crates/hermeneus/src/anthropic/client_tests.rs
+++ b/crates/hermeneus/src/anthropic/client_tests.rs
@@ -26,6 +26,7 @@ fn test_config_with(base_url: &str) -> ProviderConfig {
         max_retries: Some(0),
         pricing: HashMap::new(),
         cc_mimicry: None,
+        prompt_cache_mode: crate::provider::PromptCacheMode::Disabled,
     }
 }
 
@@ -128,6 +129,105 @@ async fn complete_success() {
         response.usage.input_tokens, 10,
         "input tokens should match wire response"
     );
+}
+
+/// #3406: every outbound request must carry a training opt-out header.
+/// Sovereignty default — not configurable.
+#[tokio::test]
+async fn request_carries_training_optout_header() {
+    use wiremock::matchers::header_exists;
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header_exists("anthropic-disable-training"))
+        .and(header_exists("anthropic-training-opt-out"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(valid_wire_response_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = test_config_with(&server.uri());
+    let provider = AnthropicProvider::from_config(&config).expect("valid config");
+    provider
+        .complete(&test_request())
+        .await
+        .expect("complete ok");
+}
+
+/// #3410: when `prompt_cache_mode` = `Disabled` (default), the serialized
+/// request body must contain no `cache_control` markers regardless of
+/// what the caller put on the `CompletionRequest`.
+#[tokio::test]
+async fn disabled_prompt_cache_strips_cache_control_markers() {
+    use wiremock::matchers::body_string_contains;
+
+    let server = MockServer::start().await;
+
+    // Any request that slips a `cache_control` marker through fails to
+    // match and causes the mock's .expect(1) check to fire.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(valid_wire_response_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Negative mock: if the body ever contains cache_control we would
+    // route to this 500 responder instead.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(body_string_contains("cache_control"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let config = test_config_with(&server.uri());
+    assert_eq!(
+        config.prompt_cache_mode,
+        crate::provider::PromptCacheMode::Disabled,
+        "test fixture default must be Disabled"
+    );
+    let provider = AnthropicProvider::from_config(&config).expect("valid config");
+
+    // Caller sets every cache flag; provider must scrub them.
+    let mut req = test_request();
+    req.cache_system = true;
+    req.cache_tools = true;
+    req.cache_turns = true;
+
+    provider.complete(&req).await.expect("complete ok");
+}
+
+/// #3410: when `prompt_cache_mode` = `Ephemeral`, caller-provided cache
+/// flags are honored and `cache_control` markers appear in the wire body.
+#[tokio::test]
+async fn ephemeral_prompt_cache_preserves_cache_control_markers() {
+    use wiremock::matchers::body_string_contains;
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(body_string_contains("cache_control"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(valid_wire_response_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut config = test_config_with(&server.uri());
+    config.prompt_cache_mode = crate::provider::PromptCacheMode::Ephemeral;
+    let provider = AnthropicProvider::from_config(&config).expect("valid config");
+
+    let mut req = test_request();
+    // system: field with cache_system = true triggers the array form with
+    // cache_control on the block.
+    req.system = Some("operator system prompt".to_owned());
+    req.cache_system = true;
+
+    provider.complete(&req).await.expect("complete ok");
 }
 
 #[tokio::test]
@@ -479,7 +579,7 @@ fn backoff_delay_respects_retry_after() {
     let delay = backoff_delay(1, Some(&err));
     assert_eq!(
         delay,
-        Duration::from_millis(5000),
+        Duration::from_secs(5),
         "should use retry-after from rate limit error"
     );
 }

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -77,6 +77,34 @@ pub struct ModelPricing {
     pub output_cost_per_mtok: f64,
 }
 
+/// Controls whether Anthropic prompt-cache markers (`cache_control`) are
+/// emitted on outgoing requests.
+///
+/// Anthropic's prompt cache stores marked content on their servers for up
+/// to 5 minutes (`Ephemeral`) or 1 hour (`Extended`) so that repeated
+/// requests can reuse it. Disabling the cache keeps the operator system
+/// prompt, tool definitions, and conversation history off Anthropic's
+/// caching infrastructure at the cost of higher per-turn input token spend.
+///
+/// Sovereignty default: [`PromptCacheMode::Disabled`]. Operators who
+/// accept the tradeoff may opt in via `aletheia.toml`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum PromptCacheMode {
+    /// No `cache_control` markers emitted. Operator content never enters
+    /// Anthropic's prompt cache. Default for sovereignty-first deployments.
+    #[default]
+    Disabled,
+    /// Standard 5-minute ephemeral cache. `cache_control: {"type": "ephemeral"}`
+    /// on system prompt, tools, and recent conversation turns.
+    Ephemeral,
+    /// Extended 1-hour cache. Currently behaves like [`Ephemeral`](Self::Ephemeral)
+    /// since the wire format for extended TTL is provider-specific and not
+    /// yet wired through. Reserved for future use.
+    Extended,
+}
+
 /// Configuration for provider initialization.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProviderConfig {
@@ -99,6 +127,11 @@ pub struct ProviderConfig {
     /// using API keys).
     #[serde(default)]
     pub cc_mimicry: Option<bool>,
+    /// Prompt cache policy. Defaults to [`PromptCacheMode::Disabled`] —
+    /// no `cache_control` markers are emitted and operator content never
+    /// enters Anthropic's cache infrastructure (#3410).
+    #[serde(default)]
+    pub prompt_cache_mode: PromptCacheMode,
 }
 
 impl Default for ProviderConfig {
@@ -158,6 +191,7 @@ impl Default for ProviderConfig {
             max_retries: Some(3),
             pricing,
             cc_mimicry: None,
+            prompt_cache_mode: PromptCacheMode::Disabled,
         }
     }
 }

--- a/crates/taxis/src/config/behavior.rs
+++ b/crates/taxis/src/config/behavior.rs
@@ -341,6 +341,53 @@ impl Default for ProviderBehaviorConfig {
     }
 }
 
+/// Anthropic-specific sovereignty and privacy settings.
+///
+/// Mirrors the operator-facing controls at the hermeneus (Anthropic client)
+/// boundary. Defaults are sovereignty-first: nothing is cached on Anthropic
+/// servers unless the operator explicitly opts in.
+///
+/// Issues: #3406, #3410, #3409.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct AnthropicConfig {
+    /// Prompt cache policy (#3410).
+    ///
+    /// Controls whether outgoing requests carry `cache_control` markers that
+    /// let Anthropic store operator system prompts, tool definitions, and
+    /// recent conversation turns on their side for reuse. `"disabled"` (the
+    /// default) strips every marker so operator content never enters the
+    /// Anthropic prompt cache; `"ephemeral"` opts in to the standard 5-minute
+    /// cache; `"extended"` reserves the slot for the 1-hour cache wire format
+    /// and currently behaves the same as `"ephemeral"`.
+    ///
+    /// Tradeoff: enabling caching lowers per-turn token spend at the cost of
+    /// storing the operator's system prompt on Anthropic infrastructure for
+    /// the cache lifetime.
+    pub prompt_cache_mode: PromptCacheMode,
+}
+
+/// Prompt cache policy for the Anthropic provider.
+///
+/// Mirrors `hermeneus::provider::PromptCacheMode` so the taxis config layer
+/// does not depend on hermeneus; the runtime wiring in `crates/aletheia`
+/// converts between the two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum PromptCacheMode {
+    /// No `cache_control` markers emitted — operator content never enters
+    /// Anthropic's prompt cache. Sovereignty default.
+    #[default]
+    Disabled,
+    /// Standard 5-minute ephemeral cache.
+    Ephemeral,
+    /// Extended 1-hour cache (reserved; behaves like `Ephemeral` until the
+    /// wire format for extended TTL is plumbed through).
+    Extended,
+}
+
 /// Pylon API request size and idempotency cache limits.
 ///
 /// All defaults match the current hardcoded constants in the `pylon` crate.

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -11,9 +11,9 @@ pub use agents::{
     ModelSpec, NousDefinition, RecallSettings, RecallWeights,
 };
 pub use behavior::{
-    ApiLimitsConfig, CapacityConfig, DaemonBehaviorConfig, KnowledgeConfig, MessagingConfig,
-    NousBehaviorConfig, ProviderBehaviorConfig, RetrySettings, TimeoutsConfig, ToolLimitsConfig,
-    TuningConfig,
+    AnthropicConfig, ApiLimitsConfig, CapacityConfig, DaemonBehaviorConfig, KnowledgeConfig,
+    MessagingConfig, NousBehaviorConfig, PromptCacheMode, ProviderBehaviorConfig, RetrySettings,
+    TimeoutsConfig, ToolLimitsConfig, TuningConfig,
 };
 pub use gateway::{
     BodyLimitConfig, CorsConfig, CsrfConfig, GatewayAuthConfig, GatewayConfig,
@@ -128,6 +128,13 @@ pub struct AletheiaConfig {
     /// global kill switch and evidence thresholds let operators enable and
     /// tune the feedback loop incrementally.
     pub tuning: TuningConfig,
+    /// Anthropic-specific sovereignty and privacy settings (#3410, #3406, #3409).
+    ///
+    /// WHY configurable: prompt caching stores operator system prompts on
+    /// Anthropic servers. The default (`disabled`) is sovereignty-first;
+    /// operators who accept the tradeoff may opt in to reduce per-turn token
+    /// cost.
+    pub anthropic: AnthropicConfig,
 }
 
 /// Sandbox enforcement level for tool execution.

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -150,7 +150,8 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
         "messaging" => validate_messaging(value, &mut errors),
         "tuning" => validate_tuning(value, &mut errors),
         // NOTE: pass-through sections with no validation rules.
-        "packs" | "pricing" | "sandbox" | "logging" | "mcp" | "localProvider" | "training" => {}
+        "packs" | "pricing" | "sandbox" | "logging" | "mcp" | "localProvider" | "training"
+        | "anthropic" => {}
         _ => errors.push(format!("unknown config section: {section}")),
     }
 

--- a/docs/NETWORK.md
+++ b/docs/NETWORK.md
@@ -86,6 +86,19 @@ These components make **no network calls**:
 
 ---
 
+## Anthropic data sovereignty (defaults)
+
+The `hermeneus` crate owns the Anthropic client boundary. Every outbound
+request is scrubbed before it leaves the process:
+
+| Control | Default | Issue | Behaviour |
+|---------|---------|-------|-----------|
+| Training opt-out header | Always on | #3406 | `anthropic-disable-training: true` and `anthropic-training-opt-out: true` are sent on every request. Not configurable — sovereignty default. |
+| Prompt cache markers | Disabled | #3410 | No `cache_control` markers on any block. Operator system prompts, tool definitions, and conversation history never enter Anthropic's prompt cache. Opt in via `[anthropic] promptCacheMode = "ephemeral"` if the cost tradeoff is acceptable. |
+| CC attribution fingerprint | Stripped | #3409 | The 3-char fingerprint slot in the attribution block is pinned to `000`; the upstream CC algorithm would otherwise hash operator message content into it. |
+| `X-Claude-Code-Session-Id` | Randomized per request | #3409 | Fresh UUID on every call so Anthropic cannot correlate requests to a persistent operator session. Upstream CC sends a stable per-process UUID. |
+| `User-Agent`, `anthropic-beta`, `anthropic-version`, `x-app` | Preserved | — | Required for OAuth tier access; values are static and do not carry operator identity. |
+
 ## No telemetry
 
 Aletheia makes zero unsolicited outbound network connections. There is no:

--- a/instance.example/config/aletheia.toml
+++ b/instance.example/config/aletheia.toml
@@ -121,6 +121,23 @@ workspace = "nous/main"
 # claudeCodeCredentials = "~/.claude/.credentials.json"  # override default path
 # refreshThresholdSecs = 3600  # refresh token when less than N seconds remain
 
+# --- Anthropic sovereignty controls (#3406, #3410, #3409) ---
+# Operator-facing privacy settings for the Anthropic client boundary.
+# All defaults are sovereignty-first: no operator content is cached on
+# Anthropic servers, every request carries a training opt-out header,
+# and CC mimicry headers are stripped of operator-identifying fingerprints.
+# [anthropic]
+# promptCacheMode = "disabled"  # disabled | ephemeral | extended
+#   disabled  (default) — no `cache_control` markers on outgoing requests.
+#                         Operator system prompts, tool definitions, and
+#                         conversation turns never enter Anthropic's prompt
+#                         cache. Costs more per turn but leaks no context.
+#   ephemeral           — standard 5-minute cache. Operator system prompt
+#                         is stored on Anthropic servers for up to 5 min
+#                         between requests. Cheaper per turn.
+#   extended            — reserved for the 1-hour cache (currently behaves
+#                         the same as `ephemeral`).
+
 # --- Cost tracking ---
 # [pricing."claude-sonnet-4-6"]
 # inputCostPerMtok = 3.0


### PR DESCRIPTION
## Summary

Close three data-sovereignty gaps at the hermeneus (Anthropic client) boundary so operator content and session identity do not leak to Anthropic by default.

- **#3406 training opt-out:** every outbound request now carries `anthropic-disable-training: true` and `anthropic-training-opt-out: true`. Not configurable — sovereignty default.
- **#3410 prompt cache disabled:** new `[anthropic] promptCacheMode` config (`disabled` | `ephemeral` | `extended`), default `disabled`. `AnthropicProvider` scrubs `cache_system`, `cache_tools`, `cache_turns` before the wire request is built, so `cache_control` markers never leave the process and operator system prompts never enter Anthropic's prompt cache.
- **#3409 CC mimicry fingerprints:** per-conversation 3-char attribution fingerprint replaced with stable literal `000`; `X-Claude-Code-Session-Id` randomized per request instead of being a stable per-process UUID. SHA256 fingerprint code and `sha2` dep removed. `cc_version`, `cc_entrypoint`, `anthropic-beta`, `User-Agent`, `x-app` preserved (required for OAuth-tier Sonnet/Opus access).

## Follow-up needed

Anthropic does not publicly document a canonical HTTP header name for per-request training opt-out. API customers already have training opt-out by contract, so the header is a defensive belt-and-suspenders layer. This PR sends both `anthropic-disable-training` and `anthropic-training-opt-out` on every request; both are harmless no-ops if ignored. A follow-up issue should verify the accepted name against Anthropic's current API reference (or confirm that no such header exists and the contract is the sole mechanism) and collapse to the single correct name.

## Gate

All green on the affected crates:

```
CARGO_TARGET_DIR=/data/target cargo check   -p hermeneus -p taxis --tests
CARGO_TARGET_DIR=/data/target cargo clippy  -p hermeneus -p taxis --tests -- -D warnings
CARGO_TARGET_DIR=/data/target cargo test    -p hermeneus -p taxis
```

Workspace-wide clippy under `-p aletheia --tests` surfaces pre-existing lint errors in `crates/hermeneus/src/cc/process.rs`, `crates/episteme/src/conflict.rs`, and `crates/episteme/src/consolidation/engine.rs` that are unrelated to this change (confirmed by stashing and rerunning against `main`). Out of scope here.

## Test plan

- [x] `cargo test -p hermeneus -p taxis` passes (all 578 tests green)
- [x] New test `request_carries_training_optout_header` asserts both opt-out headers present on outbound wire
- [x] New test `disabled_prompt_cache_strips_cache_control_markers` asserts `cache_control` absent from body when caller sets every `cache_*` flag true
- [x] New test `ephemeral_prompt_cache_preserves_cache_control_markers` asserts markers appear when operator opts in to ephemeral
- [x] New test `attribution_header_strips_operator_fingerprint` asserts attribution string is invariant across different first-message content
- [ ] Live smoke: set `promptCacheMode = "disabled"`, run one turn, confirm no `cache_creation_input_tokens` in usage response
- [ ] Live smoke: set `promptCacheMode = "ephemeral"`, run two turns, confirm `cache_read_input_tokens > 0` on the second

## Docs

- `docs/NETWORK.md`: new "Anthropic data sovereignty (defaults)" table
- `instance.example/config/aletheia.toml`: commented `[anthropic]` block with tradeoff notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)