### PR TITLE
feat(organon): expand built-in toolkit — filesystem, HTTP, git, web search (#3440 #3441 #3442 #3437 #3439)

### DIFF
--- a/crates/organon/CLAUDE.md
+++ b/crates/organon/CLAUDE.md
@@ -1,6 +1,6 @@
 # organon
 
-Tool registry, executors, and sandbox. 16K lines. 38 built-in tools.
+Tool registry, executors, and sandbox. 16K lines. 49 built-in tools.
 
 ## Read first
 
@@ -22,21 +22,25 @@ Tool registry, executors, and sandbox. 16K lines. 38 built-in tools.
 | `SandboxConfig` | `sandbox/mod.rs` | Landlock + seccomp + egress policy |
 | `ProcessGuard` | `process_guard.rs` | RAII child process wrapper, `pub(crate)` (prevents orphans/zombies) |
 
-## Built-in tools (38)
+## Built-in tools (49)
 
 | Category | Tools |
 |----------|-------|
 | Workspace | read, write, edit, exec |
-| Filesystem | grep, find, ls |
+| Filesystem (navigation) | grep, find, ls |
+| Filesystem (mutation) | mkdir, mv, cp, rm |
+| Git | git_status, git_log, git_diff, git_branch, git_checkout |
 | View File | view_file |
 | Memory | memory_search, memory_correct, memory_retract, memory_forget, memory_audit, note, blackboard, datalog_query |
 | Communication | message, sessions_send, sessions_ask |
 | Agent | sessions_spawn, sessions_dispatch |
 | Enable Tool | enable_tool |
 | Planning | plan_create, plan_research, plan_requirements, plan_roadmap, plan_discuss, plan_execute, plan_verify, plan_status, plan_step_complete, plan_step_fail, plan_verify_criteria |
-| Research | web_fetch |
+| Research | web_fetch, http_request, web_search |
 | Triage | issue_scan, issue_triage, issue_approve |
 | Computer Use | computer_use (feature-gated: `computer-use`) |
+
+`web_search` requires `BRAVE_SEARCH_API_KEY` at runtime (Brave Search API). `http_request` and `web_search` are lazy (activate via `enable_tool`). Git operations are read-only or non-destructive by design — no commit, push, reset, rebase, or `--force` checkout; destructive Git work still goes through `exec` under operator review.
 
 ## Patterns
 

--- a/crates/organon/src/builtins/fs_ops.rs
+++ b/crates/organon/src/builtins/fs_ops.rs
@@ -1,0 +1,515 @@
+//! Filesystem mutation tools: `mkdir`, `mv`, `cp`, `rm`.
+//!
+//! WHY: organon's `write` tool covers file creation, but agents previously had
+//! no way to create directories (outside of implicit parent creation during
+//! `write`), move or rename paths, copy files, or delete paths. These are
+//! standard operations on an agent workspace. Closes #3440.
+//!
+//! Every operation validates paths through `workspace::validate_path` and
+//! rejects:
+//! - protected-file overwrites (same allowlist the workspace write/edit tools use)
+//! - recursive deletion unless the caller explicitly opts in with `recursive=true`
+//! - symlink following into otherwise-protected roots (validate_path resolves
+//!   symlinks before the check).
+
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+
+use indexmap::IndexMap;
+
+use koina::id::ToolName;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+use super::workspace::{extract_opt_bool, extract_str, validate_path};
+
+/// Sanitize a path to just its filename for error messages.
+///
+/// WHY: Full filesystem paths in error messages sent to the LLM leak instance
+/// directory structure. Mirrors `workspace::sanitize_path_in_msg` (kept local
+/// to this module to avoid making that helper `pub(crate)`).
+fn sanitize(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("<path>")
+        .to_owned()
+}
+
+/// Reject mutations to protected files.
+///
+/// WHY: The write/edit tools block overwriting identity/soul/secret files.
+/// Destination-taking mutations (mv, cp, rm) must enforce the same guard so
+/// agents cannot route around the protection via rename/delete. We mirror the
+/// `PROTECTED_FILES` allowlist used by `workspace::is_protected_file` rather
+/// than importing it because the exact match semantics are tool-specific.
+const PROTECTED_BASENAMES: &[&str] = &[
+    "IDENTITY.md",
+    "SOUL.md",
+    "GOALS.md",
+    "TOOLS.md",
+    "MEMORY.md",
+    ".git",
+    ".claude",
+    "standards",
+];
+
+fn is_protected(path: &Path) -> Option<&'static str> {
+    let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    PROTECTED_BASENAMES
+        .iter()
+        .copied()
+        .find(|&name| filename == name)
+}
+
+// -------------------------------------------------------------------------
+// mkdir
+// -------------------------------------------------------------------------
+
+pub(crate) struct MkdirExecutor;
+
+impl ToolExecutor for MkdirExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let path_str = extract_str(&input.arguments, "path", &input.name)?;
+            let parents = extract_opt_bool(&input.arguments, "parents").unwrap_or(true);
+            let path = validate_path(path_str, ctx, &input.name)?;
+
+            if path.exists() {
+                // WHY: idempotent success mirrors POSIX `mkdir -p` behavior so
+                // agents can safely call mkdir in a retry loop without
+                // branching on existence.
+                return Ok(ToolResult::text(format!(
+                    "directory already exists: {}",
+                    sanitize(&path)
+                )));
+            }
+
+            let result = if parents {
+                std::fs::create_dir_all(&path)
+            } else {
+                std::fs::create_dir(&path)
+            };
+
+            match result {
+                Ok(()) => Ok(ToolResult::text(format!(
+                    "created directory: {}",
+                    sanitize(&path)
+                ))),
+                Err(e) => Ok(ToolResult::error(format!("mkdir failed: {e}"))),
+            }
+        })
+    }
+}
+
+// -------------------------------------------------------------------------
+// mv
+// -------------------------------------------------------------------------
+
+pub(crate) struct MvExecutor;
+
+impl ToolExecutor for MvExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let from_str = extract_str(&input.arguments, "from", &input.name)?;
+            let to_str = extract_str(&input.arguments, "to", &input.name)?;
+            let from = validate_path(from_str, ctx, &input.name)?;
+            let to = validate_path(to_str, ctx, &input.name)?;
+
+            if let Some(name) = is_protected(&from) {
+                return Ok(ToolResult::error(format!(
+                    "cannot move protected path: {name}"
+                )));
+            }
+            if let Some(name) = is_protected(&to) {
+                return Ok(ToolResult::error(format!(
+                    "cannot overwrite protected path: {name}"
+                )));
+            }
+
+            if !from.exists() {
+                return Ok(ToolResult::error(format!(
+                    "source not found: {}",
+                    sanitize(&from)
+                )));
+            }
+
+            // WHY: std::fs::rename across mount points returns EXDEV. Fall
+            // back to copy+remove so agents can move files between, for
+            // example, tmpfs and the real workspace without surprises.
+            match std::fs::rename(&from, &to) {
+                Ok(()) => Ok(ToolResult::text(format!(
+                    "moved {} -> {}",
+                    sanitize(&from),
+                    sanitize(&to)
+                ))),
+                Err(e) if e.raw_os_error() == Some(18) => {
+                    // EXDEV: cross-device link
+                    let copy_result = if from.is_dir() {
+                        copy_dir_recursive(&from, &to)
+                    } else {
+                        std::fs::copy(&from, &to).map(|_| ())
+                    };
+                    match copy_result {
+                        Ok(()) => match remove_path(&from) {
+                            Ok(()) => Ok(ToolResult::text(format!(
+                                "moved (cross-device) {} -> {}",
+                                sanitize(&from),
+                                sanitize(&to)
+                            ))),
+                            Err(e2) => Ok(ToolResult::error(format!(
+                                "cross-device move copied but failed to remove source: {e2}"
+                            ))),
+                        },
+                        Err(e2) => Ok(ToolResult::error(format!(
+                            "cross-device move failed during copy: {e2}"
+                        ))),
+                    }
+                }
+                Err(e) => Ok(ToolResult::error(format!("mv failed: {e}"))),
+            }
+        })
+    }
+}
+
+fn remove_path(path: &Path) -> std::io::Result<()> {
+    if path.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
+}
+
+// -------------------------------------------------------------------------
+// cp
+// -------------------------------------------------------------------------
+
+pub(crate) struct CpExecutor;
+
+impl ToolExecutor for CpExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let from_str = extract_str(&input.arguments, "from", &input.name)?;
+            let to_str = extract_str(&input.arguments, "to", &input.name)?;
+            let recursive = extract_opt_bool(&input.arguments, "recursive").unwrap_or(false);
+            let from = validate_path(from_str, ctx, &input.name)?;
+            let to = validate_path(to_str, ctx, &input.name)?;
+
+            if let Some(name) = is_protected(&to) {
+                return Ok(ToolResult::error(format!(
+                    "cannot overwrite protected path: {name}"
+                )));
+            }
+
+            if !from.exists() {
+                return Ok(ToolResult::error(format!(
+                    "source not found: {}",
+                    sanitize(&from)
+                )));
+            }
+
+            if from.is_dir() {
+                if !recursive {
+                    return Ok(ToolResult::error(
+                        "source is a directory; pass recursive=true to copy directories".to_owned(),
+                    ));
+                }
+                match copy_dir_recursive(&from, &to) {
+                    Ok(()) => Ok(ToolResult::text(format!(
+                        "copied directory {} -> {}",
+                        sanitize(&from),
+                        sanitize(&to)
+                    ))),
+                    Err(e) => Ok(ToolResult::error(format!("cp failed: {e}"))),
+                }
+            } else {
+                match std::fs::copy(&from, &to) {
+                    Ok(bytes) => Ok(ToolResult::text(format!(
+                        "copied {bytes} bytes: {} -> {}",
+                        sanitize(&from),
+                        sanitize(&to)
+                    ))),
+                    Err(e) => Ok(ToolResult::error(format!("cp failed: {e}"))),
+                }
+            }
+        })
+    }
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else if file_type.is_symlink() {
+            // WHY: Preserve symlinks rather than dereferencing to avoid
+            // silently following a link into a location that validate_path
+            // never saw. The destination link is created verbatim.
+            #[cfg(unix)]
+            {
+                let target = std::fs::read_link(&src_path)?;
+                std::os::unix::fs::symlink(target, &dst_path)?;
+            }
+            #[cfg(not(unix))]
+            {
+                std::fs::copy(&src_path, &dst_path)?;
+            }
+        } else {
+            std::fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// rm
+// -------------------------------------------------------------------------
+
+pub(crate) struct RmExecutor;
+
+impl ToolExecutor for RmExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let path_str = extract_str(&input.arguments, "path", &input.name)?;
+            let recursive = extract_opt_bool(&input.arguments, "recursive").unwrap_or(false);
+            let path = validate_path(path_str, ctx, &input.name)?;
+
+            if let Some(name) = is_protected(&path) {
+                return Ok(ToolResult::error(format!(
+                    "cannot remove protected path: {name}"
+                )));
+            }
+
+            if !path.exists() {
+                return Ok(ToolResult::error(format!(
+                    "path not found: {}",
+                    sanitize(&path)
+                )));
+            }
+
+            // WHY: Prevent accidental deletion of the workspace root or any
+            // ancestor of it — a buggy agent that passes `..` chains could
+            // otherwise wipe everything it has access to. validate_path
+            // already restricts paths to allowed_roots; this reinforces it.
+            if ctx
+                .workspace
+                .canonicalize()
+                .ok()
+                .is_some_and(|ws| ws.starts_with(&path))
+            {
+                return Ok(ToolResult::error(
+                    "refusing to remove workspace root or ancestor".to_owned(),
+                ));
+            }
+
+            let result = if path.is_dir() {
+                if !recursive {
+                    return Ok(ToolResult::error(
+                        "path is a directory; pass recursive=true to remove directories".to_owned(),
+                    ));
+                }
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            };
+
+            match result {
+                Ok(()) => Ok(ToolResult::text(format!("removed: {}", sanitize(&path)))),
+                Err(e) => Ok(ToolResult::error(format!("rm failed: {e}"))),
+            }
+        })
+    }
+}
+
+// -------------------------------------------------------------------------
+// Registration
+// -------------------------------------------------------------------------
+
+/// Register filesystem mutation tools (`mkdir`, `mv`, `cp`, `rm`).
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(mkdir_def(), Box::new(MkdirExecutor))?;
+    registry.register(mv_def(), Box::new(MvExecutor))?;
+    registry.register(cp_def(), Box::new(CpExecutor))?;
+    registry.register(rm_def(), Box::new(RmExecutor))?;
+    Ok(())
+}
+
+fn mkdir_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("mkdir"), // kanon:ignore RUST/expect
+        description: "Create a directory (idempotent; creates parents by default).".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Directory path to create".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "parents".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description: "Create parent directories as needed (default: true)"
+                            .to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(true)),
+                    },
+                ),
+            ]),
+            required: vec!["path".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::Reversible,
+        auto_activate: true,
+    }
+}
+
+fn mv_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("mv"), // kanon:ignore RUST/expect
+        description: "Move or rename a file or directory.".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "from".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Source path".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "to".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Destination path".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["from".to_owned(), "to".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::Reversible,
+        auto_activate: true,
+    }
+}
+
+fn cp_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("cp"), // kanon:ignore RUST/expect
+        description: "Copy a file or directory.".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "from".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Source path".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "to".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Destination path".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "recursive".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description: "Required to copy a directory (default: false)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(false)),
+                    },
+                ),
+            ]),
+            required: vec!["from".to_owned(), "to".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::Reversible,
+        auto_activate: true,
+    }
+}
+
+fn rm_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("rm"), // kanon:ignore RUST/expect
+        description: "Remove a file or directory (recursive requires explicit opt-in).".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Path to remove".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "recursive".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description:
+                            "Required to remove a directory and its contents (default: false)"
+                                .to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(false)),
+                    },
+                ),
+            ]),
+            required: vec!["path".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        // WHY: rm is not reversible from within the tool; there is no
+        // built-in backup step. Mark Irreversible so the approval layer can
+        // gate it appropriately.
+        reversibility: Reversibility::Irreversible,
+        auto_activate: true,
+    }
+}
+
+#[cfg(test)]
+#[path = "fs_ops_tests.rs"]
+mod tests;

--- a/crates/organon/src/builtins/fs_ops_tests.rs
+++ b/crates/organon/src/builtins/fs_ops_tests.rs
@@ -1,0 +1,259 @@
+#![expect(clippy::expect_used, reason = "test assertions")]
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+
+use koina::id::{NousId, SessionId, ToolName};
+
+use crate::registry::ToolExecutor as _;
+use crate::types::{ToolContext, ToolInput};
+
+use super::*;
+
+fn test_ctx(dir: &std::path::Path) -> ToolContext {
+    ToolContext {
+        nous_id: NousId::new("alice").expect("valid"),
+        session_id: SessionId::new(),
+        workspace: dir.to_path_buf(),
+        allowed_roots: vec![dir.to_path_buf()],
+        services: None,
+        active_tools: Arc::new(RwLock::new(HashSet::new())),
+        tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
+    }
+}
+
+fn tool_input(name: &str, args: serde_json::Value) -> ToolInput {
+    ToolInput {
+        name: ToolName::new(name).expect("valid"),
+        tool_use_id: "toolu_test".to_owned(),
+        arguments: args,
+    }
+}
+
+fn write_file(path: &std::path::Path, content: &str) {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test fixture setup; exercising tool executor contract"
+    )]
+    std::fs::write(path, content).expect("write fixture");
+}
+
+// -------------------------------------------------------------------------
+// mkdir
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mkdir_creates_directory() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input("mkdir", serde_json::json!({ "path": "acme/reports" }));
+    let result = MkdirExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(!result.is_error, "mkdir should succeed");
+    assert!(
+        dir.path().join("acme/reports").is_dir(),
+        "expected nested directory to exist"
+    );
+}
+
+#[tokio::test]
+async fn mkdir_is_idempotent() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    std::fs::create_dir(dir.path().join("already")).expect("mkdir");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input("mkdir", serde_json::json!({ "path": "already" }));
+    let result = MkdirExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(
+        !result.is_error,
+        "mkdir on existing directory should not error"
+    );
+    assert!(
+        result.content.text_summary().contains("already exists"),
+        "response should note idempotent no-op"
+    );
+}
+
+#[tokio::test]
+async fn mkdir_rejects_outside_root() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input("mkdir", serde_json::json!({ "path": "/etc/evil" }));
+    let err = MkdirExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect_err("outside root must fail");
+    assert!(
+        err.to_string().contains("outside allowed roots"),
+        "error should identify outside-root path"
+    );
+}
+
+// -------------------------------------------------------------------------
+// mv
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mv_renames_file() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    write_file(&dir.path().join("alice.txt"), "hello");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input(
+        "mv",
+        serde_json::json!({ "from": "alice.txt", "to": "bob.txt" }),
+    );
+    let result = MvExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(!result.is_error, "mv should succeed");
+    assert!(
+        dir.path().join("bob.txt").exists(),
+        "destination should exist after mv"
+    );
+    assert!(
+        !dir.path().join("alice.txt").exists(),
+        "source should not exist after mv"
+    );
+}
+
+#[tokio::test]
+async fn mv_missing_source_errors() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input(
+        "mv",
+        serde_json::json!({ "from": "nope.txt", "to": "yes.txt" }),
+    );
+    let result = MvExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(result.is_error, "missing source should be an error result");
+    assert!(
+        result.content.text_summary().contains("source not found"),
+        "error should name the issue"
+    );
+}
+
+#[tokio::test]
+async fn mv_refuses_protected_target() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    write_file(&dir.path().join("draft.md"), "x");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input(
+        "mv",
+        serde_json::json!({ "from": "draft.md", "to": "IDENTITY.md" }),
+    );
+    let result = MvExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(result.is_error, "moving onto protected path must fail");
+}
+
+// -------------------------------------------------------------------------
+// cp
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cp_copies_file() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    write_file(&dir.path().join("alice.txt"), "greetings");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input(
+        "cp",
+        serde_json::json!({ "from": "alice.txt", "to": "alice-copy.txt" }),
+    );
+    let result = CpExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(!result.is_error, "cp should succeed");
+    let copied = std::fs::read_to_string(dir.path().join("alice-copy.txt")).expect("read copy");
+    assert_eq!(copied, "greetings", "copy should match source contents");
+}
+
+#[tokio::test]
+async fn cp_directory_requires_recursive_flag() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    std::fs::create_dir(dir.path().join("src_dir")).expect("mkdir");
+    write_file(&dir.path().join("src_dir/inner.txt"), "nested");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input(
+        "cp",
+        serde_json::json!({ "from": "src_dir", "to": "dst_dir" }),
+    );
+    let result = CpExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(result.is_error, "cp of directory without flag should fail");
+    assert!(
+        result.content.text_summary().contains("recursive=true"),
+        "error should mention the required flag"
+    );
+}
+
+#[tokio::test]
+async fn cp_directory_recursive_copies_contents() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    std::fs::create_dir(dir.path().join("src_dir")).expect("mkdir");
+    write_file(&dir.path().join("src_dir/inner.txt"), "nested");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input(
+        "cp",
+        serde_json::json!({ "from": "src_dir", "to": "dst_dir", "recursive": true }),
+    );
+    let result = CpExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(!result.is_error, "recursive cp should succeed");
+    let nested = std::fs::read_to_string(dir.path().join("dst_dir/inner.txt")).expect("read");
+    assert_eq!(nested, "nested", "nested file should be copied");
+}
+
+// -------------------------------------------------------------------------
+// rm
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rm_removes_file() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    write_file(&dir.path().join("junk.txt"), "x");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input("rm", serde_json::json!({ "path": "junk.txt" }));
+    let result = RmExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(!result.is_error, "rm should succeed");
+    assert!(
+        !dir.path().join("junk.txt").exists(),
+        "file should be gone after rm"
+    );
+}
+
+#[tokio::test]
+async fn rm_directory_requires_recursive_flag() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    std::fs::create_dir(dir.path().join("trash")).expect("mkdir");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input("rm", serde_json::json!({ "path": "trash" }));
+    let result = RmExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(result.is_error, "rm on directory without flag must fail");
+}
+
+#[tokio::test]
+async fn rm_refuses_protected_path() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    write_file(&dir.path().join("IDENTITY.md"), "name: alice");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input("rm", serde_json::json!({ "path": "IDENTITY.md" }));
+    let result = RmExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(result.is_error, "rm of protected file must fail");
+    assert!(
+        result.content.text_summary().contains("protected"),
+        "error should mention protection"
+    );
+}
+
+#[tokio::test]
+async fn rm_missing_path_errors() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input("rm", serde_json::json!({ "path": "nope.txt" }));
+    let result = RmExecutor.execute(&input, &ctx).await.expect("exec");
+    assert!(result.is_error, "missing path should be an error result");
+}
+
+// -------------------------------------------------------------------------
+// registration
+// -------------------------------------------------------------------------
+
+#[test]
+fn all_fs_ops_tools_registered() {
+    let mut reg = crate::registry::ToolRegistry::new();
+    register(&mut reg).expect("register");
+    for name in ["mkdir", "mv", "cp", "rm"] {
+        let tn = ToolName::new(name).expect("valid");
+        assert!(reg.get_def(&tn).is_some(), "{name} should be registered");
+    }
+}

--- a/crates/organon/src/builtins/git_ops.rs
+++ b/crates/organon/src/builtins/git_ops.rs
@@ -1,0 +1,665 @@
+//! Git operations tool suite: `git_status`, `git_log`, `git_diff`, `git_branch`,
+//! `git_checkout`.
+//!
+//! WHY: Agents working inside a repository need basic Git introspection. The
+//! existing `exec` tool can run git but costs tokens on parsing shell syntax
+//! and does not enforce a deny-list of destructive flags. This module exposes
+//! narrow, read-only operations directly. Closes #3442.
+//!
+//! Scope decisions:
+//! - No `git commit`, `git push`, `git reset`, `git rebase`, `git merge`:
+//!   destructive or history-mutating. Agents that need these should go
+//!   through the exec tool under operator review.
+//! - `git_checkout` is included because switching branches is sometimes the
+//!   only way to inspect state; it rejects `--force`, `-f`, and any form
+//!   that would discard uncommitted changes. Creating a new branch is
+//!   allowed (`create=true`) because that is non-destructive.
+//!
+//! Implementation: we shell out to the `git` binary via `std::process::Command`.
+//! WHY: the aletheia workspace does not depend on `gix` or `git2`; pulling a
+//! libgit2 binding in just for these executors would add ~4-5 MB to the
+//! release binary and a C dependency. The shell-out is contained to a single
+//! function that enforces the argument allowlist, so the attack surface is
+//! narrow. If the workspace later adopts `gix` we can swap without changing
+//! tool shapes.
+
+use std::future::Future;
+use std::io::Read as _;
+use std::pin::Pin;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use indexmap::IndexMap;
+
+use koina::id::ToolName;
+
+use crate::error::Result;
+use crate::process_guard::ProcessGuard;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+use super::workspace::{extract_opt_bool, extract_opt_str, extract_opt_u64, extract_str};
+
+/// Git subprocess wall-clock timeout.
+const GIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Cap stdout captured from git.
+const MAX_GIT_OUTPUT: usize = 256 * 1024;
+
+/// Reject refs or arguments that start with `-` unless they are in an
+/// operation-specific allowlist.
+///
+/// WHY: `git` treats any argument starting with `-` as an option, so an
+/// attacker-controlled branch name could turn into `--upload-pack=…` and
+/// execute code. Forcing callers through `--` separators is not enough when
+/// we construct the command; we simply reject dashed refs outright.
+fn validate_ref(raw: &str) -> std::result::Result<&str, String> {
+    if raw.is_empty() {
+        return Err("ref must not be empty".to_owned());
+    }
+    if raw.starts_with('-') {
+        return Err(format!("ref must not start with '-': {raw}"));
+    }
+    if raw.contains('\0') || raw.contains('\n') {
+        return Err("ref contains invalid characters".to_owned());
+    }
+    Ok(raw)
+}
+
+/// Run `git` in the workspace root. Returns stdout on success, stderr on failure.
+fn run_git(ctx: &ToolContext, args: &[&str]) -> std::result::Result<String, String> {
+    let mut cmd = Command::new("git");
+    cmd.args(args)
+        .current_dir(&ctx.workspace)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| format!("failed to spawn git: {e}"))?;
+    let mut guard = ProcessGuard::new(child);
+
+    let deadline = Instant::now() + GIT_TIMEOUT;
+    let status = loop {
+        match guard.get_mut().try_wait() {
+            Ok(Some(s)) => break s,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    // Guard drop kills + reaps.
+                    return Err("git timed out after 30s".to_owned());
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => return Err(format!("git wait failed: {e}")),
+        }
+    };
+
+    let mut stdout = String::new();
+    if let Some(ref mut pipe) = guard.get_mut().stdout {
+        let _ = pipe.read_to_string(&mut stdout);
+    }
+    let mut stderr = String::new();
+    if let Some(ref mut pipe) = guard.get_mut().stderr {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+
+    #[expect(
+        clippy::zombie_processes,
+        reason = "process already reaped via try_wait in poll loop above"
+    )]
+    let _ = guard.detach();
+
+    if stdout.len() > MAX_GIT_OUTPUT {
+        // WHY: slice at UTF-8 char boundary to preserve validity.
+        let mut end = MAX_GIT_OUTPUT;
+        while end > 0 && !stdout.is_char_boundary(end) {
+            end -= 1;
+        }
+        stdout.truncate(end);
+        stdout.push_str("\n[output truncated]");
+    }
+
+    if status.success() {
+        Ok(stdout)
+    } else {
+        let code = status.code().unwrap_or(-1);
+        Err(format!("git exited with {code}\n{stderr}"))
+    }
+}
+
+// -------------------------------------------------------------------------
+// git_status
+// -------------------------------------------------------------------------
+
+struct GitStatusExecutor;
+
+impl ToolExecutor for GitStatusExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let _ = input;
+            match run_git(ctx, &["status", "--short", "--branch"]) {
+                Ok(out) => Ok(ToolResult::text(if out.trim().is_empty() {
+                    "(clean working tree)".to_owned()
+                } else {
+                    out
+                })),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+// -------------------------------------------------------------------------
+// git_log
+// -------------------------------------------------------------------------
+
+struct GitLogExecutor;
+
+impl ToolExecutor for GitLogExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let max_count = extract_opt_u64(&input.arguments, "maxCount").unwrap_or(20);
+            let max_count_str = max_count.to_string();
+            let mut args: Vec<&str> = vec![
+                "log",
+                "--pretty=format:%h %ad %an %s",
+                "--date=short",
+                "-n",
+                &max_count_str,
+            ];
+
+            let reference = extract_opt_str(&input.arguments, "ref");
+            if let Some(r) = reference {
+                match validate_ref(r) {
+                    Ok(valid) => args.push(valid),
+                    Err(e) => return Ok(ToolResult::error(e)),
+                }
+            }
+
+            match run_git(ctx, &args) {
+                Ok(out) => Ok(ToolResult::text(if out.trim().is_empty() {
+                    "(no commits)".to_owned()
+                } else {
+                    out
+                })),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+// -------------------------------------------------------------------------
+// git_diff
+// -------------------------------------------------------------------------
+
+struct GitDiffExecutor;
+
+impl ToolExecutor for GitDiffExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let staged = extract_opt_bool(&input.arguments, "staged").unwrap_or(false);
+            let mut args: Vec<&str> = vec!["diff"];
+            if staged {
+                args.push("--staged");
+            }
+
+            let reference = extract_opt_str(&input.arguments, "ref");
+            if let Some(r) = reference {
+                match validate_ref(r) {
+                    Ok(valid) => args.push(valid),
+                    Err(e) => return Ok(ToolResult::error(e)),
+                }
+            }
+
+            let path = extract_opt_str(&input.arguments, "path");
+            if let Some(p) = path {
+                if p.starts_with('-') {
+                    return Ok(ToolResult::error(format!(
+                        "path must not start with '-': {p}"
+                    )));
+                }
+                args.push("--");
+                args.push(p);
+            }
+
+            match run_git(ctx, &args) {
+                Ok(out) => Ok(ToolResult::text(if out.trim().is_empty() {
+                    "(no changes)".to_owned()
+                } else {
+                    out
+                })),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+// -------------------------------------------------------------------------
+// git_branch
+// -------------------------------------------------------------------------
+
+struct GitBranchExecutor;
+
+impl ToolExecutor for GitBranchExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let _ = input;
+            // WHY: --list default shows local branches; --verbose adds the
+            // commit subject which helps the LLM pick a branch.
+            match run_git(ctx, &["branch", "--list", "--verbose"]) {
+                Ok(out) => Ok(ToolResult::text(if out.trim().is_empty() {
+                    "(no local branches)".to_owned()
+                } else {
+                    out
+                })),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+// -------------------------------------------------------------------------
+// git_checkout
+// -------------------------------------------------------------------------
+
+struct GitCheckoutExecutor;
+
+impl ToolExecutor for GitCheckoutExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let branch = extract_str(&input.arguments, "branch", &input.name)?;
+            let create = extract_opt_bool(&input.arguments, "create").unwrap_or(false);
+
+            let validated = match validate_ref(branch) {
+                Ok(v) => v,
+                Err(e) => return Ok(ToolResult::error(e)),
+            };
+
+            // WHY: Never pass `--force` / `-f`. If the working tree is dirty,
+            // let git refuse and surface the error so the agent must
+            // explicitly resolve it (via commit/stash through a separate
+            // path), rather than silently discarding uncommitted work.
+            let args: Vec<&str> = if create {
+                vec!["checkout", "-b", validated]
+            } else {
+                vec!["checkout", validated]
+            };
+
+            match run_git(ctx, &args) {
+                Ok(out) => Ok(ToolResult::text(if out.trim().is_empty() {
+                    format!(
+                        "checked out {validated}{}",
+                        if create { " (new branch)" } else { "" }
+                    )
+                } else {
+                    out
+                })),
+                Err(e) => Ok(ToolResult::error(e)),
+            }
+        })
+    }
+}
+
+// -------------------------------------------------------------------------
+// Registration
+// -------------------------------------------------------------------------
+
+/// Register the git tool suite.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(git_status_def(), Box::new(GitStatusExecutor))?;
+    registry.register(git_log_def(), Box::new(GitLogExecutor))?;
+    registry.register(git_diff_def(), Box::new(GitDiffExecutor))?;
+    registry.register(git_branch_def(), Box::new(GitBranchExecutor))?;
+    registry.register(git_checkout_def(), Box::new(GitCheckoutExecutor))?;
+    Ok(())
+}
+
+fn git_status_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("git_status"), // kanon:ignore RUST/expect
+        description: "Show the working tree status (short format, with branch).".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::new(),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: true,
+    }
+}
+
+fn git_log_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("git_log"), // kanon:ignore RUST/expect
+        description: "List recent commits in a one-line format.".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "maxCount".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Maximum commits to list (default: 20)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(20)),
+                    },
+                ),
+                (
+                    "ref".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Branch, tag, or commit to log from (default: HEAD)"
+                            .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: true,
+    }
+}
+
+fn git_diff_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("git_diff"), // kanon:ignore RUST/expect
+        description: "Show a unified diff of working-tree or staged changes.".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "staged".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description: "Show staged changes instead of working tree (default: false)"
+                            .to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(false)),
+                    },
+                ),
+                (
+                    "ref".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Optional ref or revision range (e.g. main..HEAD)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Limit the diff to a single path".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: true,
+    }
+}
+
+fn git_branch_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("git_branch"), // kanon:ignore RUST/expect
+        description: "List local branches with their latest commit.".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::new(),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: true,
+    }
+}
+
+fn git_checkout_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("git_checkout"), // kanon:ignore RUST/expect
+        description:
+            "Switch branches, or create and switch to a new branch. Never forces; refuses to discard uncommitted changes."
+                .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "branch".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Branch name to switch to".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "create".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description: "Create the branch if it does not exist (default: false)"
+                            .to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(false)),
+                    },
+                ),
+            ]),
+            required: vec!["branch".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        // WHY: switching branches is reversible by checking out the previous
+        // branch, so long as we never force-discard changes.
+        reversibility: Reversibility::Reversible,
+        auto_activate: true,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    use koina::id::{NousId, SessionId};
+
+    use crate::types::ToolContext;
+
+    use super::*;
+
+    fn test_ctx(dir: &std::path::Path) -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("alice").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: dir.to_path_buf(),
+            allowed_roots: vec![dir.to_path_buf()],
+            services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+            tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
+        }
+    }
+
+    fn init_repo(dir: &std::path::Path) {
+        // Initialize a repo with a single commit so read-only ops have
+        // something to report.
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .expect("git command");
+        };
+        run(&["init", "-q", "-b", "main"]);
+        run(&["config", "user.email", "alice@acme.corp"]);
+        run(&["config", "user.name", "Alice"]);
+        run(&["commit", "--allow-empty", "-q", "-m", "initial"]);
+    }
+
+    #[test]
+    fn validate_ref_rejects_dashed_input() {
+        assert!(validate_ref("--upload-pack=evil").is_err());
+        assert!(validate_ref("-foo").is_err());
+    }
+
+    #[test]
+    fn validate_ref_rejects_newline() {
+        assert!(validate_ref("main\nHEAD").is_err());
+    }
+
+    #[test]
+    fn validate_ref_accepts_normal_names() {
+        assert!(validate_ref("main").is_ok());
+        assert!(validate_ref("feat/some-branch").is_ok());
+        assert!(validate_ref("HEAD").is_ok());
+    }
+
+    #[tokio::test]
+    async fn git_status_reports_clean_tree() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        init_repo(dir.path());
+        let ctx = test_ctx(dir.path());
+        let input = ToolInput {
+            name: ToolName::new("git_status").expect("valid"),
+            tool_use_id: "toolu_test".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        let result = GitStatusExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error, "git_status should succeed in a real repo");
+        let text = result.content.text_summary();
+        assert!(
+            text.contains("main") || text.contains("clean"),
+            "expected branch marker or clean tree: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn git_log_reports_initial_commit() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        init_repo(dir.path());
+        let ctx = test_ctx(dir.path());
+        let input = ToolInput {
+            name: ToolName::new("git_log").expect("valid"),
+            tool_use_id: "toolu_test".to_owned(),
+            arguments: serde_json::json!({ "maxCount": 5 }),
+        };
+        let result = GitLogExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error, "git_log should succeed");
+        assert!(
+            result.content.text_summary().contains("initial"),
+            "log should contain the seed commit message"
+        );
+    }
+
+    #[tokio::test]
+    async fn git_log_rejects_dashed_ref() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        init_repo(dir.path());
+        let ctx = test_ctx(dir.path());
+        let input = ToolInput {
+            name: ToolName::new("git_log").expect("valid"),
+            tool_use_id: "toolu_test".to_owned(),
+            arguments: serde_json::json!({ "ref": "--upload-pack=evil" }),
+        };
+        let result = GitLogExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(result.is_error, "dashed ref must be rejected");
+    }
+
+    #[tokio::test]
+    async fn git_diff_clean_tree_is_empty() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        init_repo(dir.path());
+        let ctx = test_ctx(dir.path());
+        let input = ToolInput {
+            name: ToolName::new("git_diff").expect("valid"),
+            tool_use_id: "toolu_test".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        let result = GitDiffExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error, "git_diff should succeed");
+        assert!(
+            result.content.text_summary().contains("no changes"),
+            "clean tree should report no changes"
+        );
+    }
+
+    #[tokio::test]
+    async fn git_branch_lists_main() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        init_repo(dir.path());
+        let ctx = test_ctx(dir.path());
+        let input = ToolInput {
+            name: ToolName::new("git_branch").expect("valid"),
+            tool_use_id: "toolu_test".to_owned(),
+            arguments: serde_json::json!({}),
+        };
+        let result = GitBranchExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(!result.is_error);
+        assert!(
+            result.content.text_summary().contains("main"),
+            "branch listing should show main"
+        );
+    }
+
+    #[tokio::test]
+    async fn git_checkout_rejects_dashed_branch() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        init_repo(dir.path());
+        let ctx = test_ctx(dir.path());
+        let input = ToolInput {
+            name: ToolName::new("git_checkout").expect("valid"),
+            tool_use_id: "toolu_test".to_owned(),
+            arguments: serde_json::json!({ "branch": "--force" }),
+        };
+        let result = GitCheckoutExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect("exec");
+        assert!(result.is_error, "dashed branch must be rejected");
+    }
+
+    #[test]
+    fn all_git_tools_registered() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+        for name in [
+            "git_status",
+            "git_log",
+            "git_diff",
+            "git_branch",
+            "git_checkout",
+        ] {
+            let tn = ToolName::new(name).expect("valid");
+            assert!(reg.get_def(&tn).is_some(), "{name} should be registered");
+        }
+    }
+}

--- a/crates/organon/src/builtins/http_client.rs
+++ b/crates/organon/src/builtins/http_client.rs
@@ -1,0 +1,425 @@
+//! Generic HTTP client tool (`http_request`) supporting POST/PUT/DELETE/PATCH
+//! in addition to GET, with configurable headers and body.
+//!
+//! WHY: `web_fetch` handles only GET and strips HTML. Agents that need to call
+//! REST APIs (POST JSON, PUT YAML, DELETE) had no path. This adds a generic
+//! method-aware HTTP tool that reuses the SSRF guards from `research.rs`.
+//! Closes #3441.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::future::Future;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::pin::Pin;
+
+use indexmap::IndexMap;
+use reqwest::{Method, redirect};
+
+use koina::id::ToolName;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+use super::workspace::{extract_opt_str, extract_opt_u64, extract_str};
+
+/// Cloud-metadata / loopback hostnames rejected outright.
+///
+/// WHY: duplicated with `research.rs` rather than shared, because each tool's
+/// allowlist is an independent security boundary; a future widening of one
+/// should not silently widen the other. Kept in sync by convention.
+const BLOCKED_HOSTNAMES: &[&str] = &["localhost", "metadata.google.internal"];
+
+/// Headers that must never be forwarded from LLM input.
+///
+/// WHY: Host/Content-Length are computed by reqwest; the LLM setting them
+/// produces malformed requests. Authorization is operator-sensitive; agents
+/// should never inject credentials without an explicit surface (future work).
+const FORBIDDEN_REQUEST_HEADERS: &[&str] = &["host", "content-length"];
+
+/// Upper bound on response body size forwarded to the LLM.
+const MAX_RESPONSE_BYTES: usize = 1_000_000;
+
+fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.octets().first() == Some(&0)
+                || *v4 == Ipv4Addr::new(169, 254, 169, 254)
+                || *v4 == Ipv4Addr::new(169, 254, 169, 123)
+        }
+        IpAddr::V6(v6) => {
+            *v6 == Ipv6Addr::LOCALHOST
+                || (v6.segments().first().unwrap_or(&0) & 0xfe00) == 0xfc00
+                || (v6.segments().first().unwrap_or(&0) & 0xffc0) == 0xfe80
+                || v6.to_ipv4_mapped().is_some_and(|v4| {
+                    v4.is_loopback()
+                        || v4.is_private()
+                        || v4.is_link_local()
+                        || v4.octets().first() == Some(&0)
+                })
+        }
+    }
+}
+
+async fn validate_url_not_internal(url_str: &str) -> std::result::Result<(), String> {
+    let parsed: reqwest::Url = url_str.parse().map_err(|e| format!("invalid URL: {e}"))?;
+
+    let host = parsed.host_str().ok_or("URL has no host")?;
+    let host_lower = host.to_lowercase();
+    for blocked in BLOCKED_HOSTNAMES {
+        if host_lower == *blocked {
+            return Err(format!("blocked hostname: {host}"));
+        }
+    }
+
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host(format!("{host}:{port}"))
+        .await
+        .map_err(|e| format!("DNS resolution failed for {host}: {e}"))?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(format!("DNS resolution returned no addresses for {host}"));
+    }
+
+    for addr in &addrs {
+        if is_private_ip(&addr.ip()) {
+            return Err("URL resolves to a private/internal IP address".to_owned());
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_method(raw: &str) -> std::result::Result<Method, String> {
+    match raw.to_ascii_uppercase().as_str() {
+        "GET" => Ok(Method::GET),
+        "POST" => Ok(Method::POST),
+        "PUT" => Ok(Method::PUT),
+        "DELETE" => Ok(Method::DELETE),
+        "PATCH" => Ok(Method::PATCH),
+        "HEAD" => Ok(Method::HEAD),
+        other => Err(format!("unsupported method: {other}")),
+    }
+}
+
+fn extract_headers(
+    args: &serde_json::Value,
+) -> std::result::Result<HashMap<String, String>, String> {
+    let Some(raw) = args.get("headers") else {
+        return Ok(HashMap::new());
+    };
+    let Some(obj) = raw.as_object() else {
+        return Err("headers must be a JSON object of string->string".to_owned());
+    };
+    let mut out = HashMap::new();
+    for (k, v) in obj {
+        let value = v
+            .as_str()
+            .ok_or_else(|| format!("header {k} must be a string value"))?;
+        let lower = k.to_ascii_lowercase();
+        if FORBIDDEN_REQUEST_HEADERS.contains(&lower.as_str()) {
+            return Err(format!("header not permitted: {k}"));
+        }
+        out.insert(k.clone(), value.to_owned());
+    }
+    Ok(out)
+}
+
+struct HttpRequestExecutor;
+
+impl ToolExecutor for HttpRequestExecutor {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "single HTTP lifecycle — validate URL, build client, send, render response; splitting would fragment one cohesive I/O operation"
+    )]
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let _ = ctx; // unused: no service dependencies
+
+            let url = extract_str(&input.arguments, "url", &input.name)?;
+            let method_str = extract_opt_str(&input.arguments, "method").unwrap_or("GET");
+            let body = extract_opt_str(&input.arguments, "body");
+            let timeout_secs = extract_opt_u64(&input.arguments, "timeoutSecs").unwrap_or(30);
+
+            // SAFE: validating user-supplied URL scheme, not constructing an endpoint
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                // kanon:ignore SECURITY/insecure-transport -- scheme validation, not construction
+                return Ok(ToolResult::error("URL must start with http:// or https://"));
+            }
+
+            let method = match parse_method(method_str) {
+                Ok(m) => m,
+                Err(e) => return Ok(ToolResult::error(e)),
+            };
+
+            let headers = match extract_headers(&input.arguments) {
+                Ok(h) => h,
+                Err(e) => return Ok(ToolResult::error(e)),
+            };
+
+            if let Err(msg) = validate_url_not_internal(url).await {
+                return Ok(ToolResult::error(msg));
+            }
+
+            let client = match reqwest::Client::builder()
+                .redirect(redirect::Policy::custom(|attempt| {
+                    let url = attempt.url();
+                    let host = match url.host_str() {
+                        Some(h) => h.to_lowercase(),
+                        None => return attempt.stop(),
+                    };
+                    for blocked in BLOCKED_HOSTNAMES {
+                        if host == *blocked {
+                            return attempt.stop();
+                        }
+                    }
+                    if let Some(addr) = url.host_str().and_then(|h| h.parse::<IpAddr>().ok())
+                        && is_private_ip(&addr)
+                    {
+                        return attempt.stop();
+                    }
+                    if attempt.previous().len() >= 5 {
+                        return attempt.stop();
+                    }
+                    attempt.follow()
+                }))
+                .timeout(std::time::Duration::from_secs(timeout_secs))
+                .build()
+            {
+                Ok(c) => c,
+                Err(e) => return Ok(ToolResult::error(format!("client build failed: {e}"))),
+            };
+
+            let mut req = client.request(method.clone(), url).header(
+                "User-Agent",
+                concat!(
+                    "aletheia/",
+                    env!("CARGO_PKG_VERSION"),
+                    " (organon http_request)"
+                ),
+            );
+            for (k, v) in &headers {
+                req = req.header(k, v);
+            }
+            if let Some(b) = body {
+                req = req.body(b.to_owned());
+            }
+
+            let response = match req.send().await {
+                Ok(r) => r,
+                Err(e) => return Ok(ToolResult::error(format!("request failed: {e}"))),
+            };
+
+            let status = response.status();
+            let status_code = status.as_u16();
+
+            let mut header_summary: Vec<(String, String)> = response
+                .headers()
+                .iter()
+                .filter_map(|(k, v)| {
+                    v.to_str()
+                        .ok()
+                        .map(|s| (k.as_str().to_owned(), s.to_owned()))
+                })
+                .collect();
+            header_summary.sort_by(|a, b| a.0.cmp(&b.0));
+
+            let body_bytes = match response.bytes().await {
+                Ok(b) => b,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("failed to read body: {e}")));
+                }
+            };
+
+            let (body_text, truncated) = if body_bytes.len() > MAX_RESPONSE_BYTES {
+                // WHY: truncate at a valid UTF-8 boundary in the decoded
+                // string so the rendered text stays valid UTF-8 even when
+                // the response body is arbitrary binary.
+                let decoded = String::from_utf8_lossy(&body_bytes).into_owned();
+                let mut end = MAX_RESPONSE_BYTES.min(decoded.len());
+                while end > 0 && !decoded.is_char_boundary(end) {
+                    end -= 1;
+                }
+                let partial = decoded.get(..end).unwrap_or("").to_owned();
+                (partial, true)
+            } else {
+                (String::from_utf8_lossy(&body_bytes).into_owned(), false)
+            };
+
+            let mut rendered = format!("status: {status_code}\n");
+            rendered.push_str("headers:\n");
+            for (k, v) in &header_summary {
+                let _ = writeln!(rendered, "  {k}: {v}");
+            }
+            rendered.push_str("body:\n");
+            rendered.push_str(&body_text);
+            if truncated {
+                rendered.push_str("\n[response truncated]");
+            }
+
+            // WHY: Return an error-typed result for non-2xx so the LLM can
+            // distinguish network success from HTTP failure without parsing
+            // the status line. Body is still included for context.
+            if status.is_success() {
+                Ok(ToolResult::text(rendered))
+            } else {
+                Ok(ToolResult::error(rendered))
+            }
+        })
+    }
+}
+
+/// Register the `http_request` tool.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(http_request_def(), Box::new(HttpRequestExecutor))?;
+    Ok(())
+}
+
+fn http_request_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("http_request"), // kanon:ignore RUST/expect
+        description:
+            "Make an HTTP request (GET/POST/PUT/DELETE/PATCH/HEAD) with configurable headers and body. Returns status, headers, and body."
+                .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "url".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Absolute http(s) URL".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "method".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "HTTP method (default: GET)".to_owned(),
+                        enum_values: Some(vec![
+                            "GET".to_owned(),
+                            "POST".to_owned(),
+                            "PUT".to_owned(),
+                            "DELETE".to_owned(),
+                            "PATCH".to_owned(),
+                            "HEAD".to_owned(),
+                        ]),
+                        default: Some(serde_json::json!("GET")),
+                    },
+                ),
+                (
+                    "headers".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Object,
+                        description: "Request headers as a string->string map".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "body".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Request body (sent verbatim)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "timeoutSecs".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Request timeout in seconds (default 30)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(30)),
+                    },
+                ),
+            ]),
+            required: vec!["url".to_owned()],
+        },
+        category: ToolCategory::Research,
+        reversibility: Reversibility::Irreversible,
+        auto_activate: false,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_method_accepts_standard_methods() {
+        for m in ["GET", "post", "Put", "DELETE", "patch", "head"] {
+            parse_method(m).expect("standard method should parse");
+        }
+    }
+
+    #[test]
+    fn parse_method_rejects_unknown() {
+        assert!(parse_method("FROBNICATE").is_err());
+    }
+
+    #[test]
+    fn extract_headers_rejects_forbidden() {
+        let args = serde_json::json!({ "headers": { "Host": "evil.example.com" } });
+        let err = extract_headers(&args).expect_err("host header must be rejected");
+        assert!(err.contains("not permitted"), "error should explain reason");
+    }
+
+    #[test]
+    fn extract_headers_accepts_normal_headers() {
+        let args = serde_json::json!({
+            "headers": { "Content-Type": "application/json", "X-Request-Id": "abc" }
+        });
+        let h = extract_headers(&args).expect("headers should parse");
+        assert_eq!(
+            h.get("Content-Type").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(h.get("X-Request-Id").map(String::as_str), Some("abc"));
+    }
+
+    #[test]
+    fn extract_headers_rejects_non_string_values() {
+        let args = serde_json::json!({ "headers": { "X": 42 } });
+        assert!(extract_headers(&args).is_err());
+    }
+
+    #[test]
+    fn is_private_ip_flags_loopback_v4() {
+        assert!(is_private_ip(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn is_private_ip_flags_aws_metadata() {
+        assert!(is_private_ip(&IpAddr::V4(Ipv4Addr::new(
+            169, 254, 169, 254
+        ))));
+    }
+
+    #[test]
+    fn is_private_ip_allows_public_v4() {
+        assert!(!is_private_ip(&IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+    }
+
+    #[test]
+    fn http_request_def_is_lazy() {
+        let def = http_request_def();
+        assert!(!def.auto_activate);
+        assert_eq!(def.category, ToolCategory::Research);
+    }
+}

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -18,18 +18,26 @@ pub mod enable_tool;
 pub mod energeia;
 /// Filesystem navigation tools (grep, find, ls).
 pub mod filesystem;
+/// Filesystem mutation tools (mkdir, mv, cp, rm).
+pub mod fs_ops;
+/// Git read-only and non-destructive operations (status, log, diff, branch, checkout).
+pub mod git_ops;
+/// Generic HTTP client (POST/PUT/DELETE/PATCH with headers + body).
+pub mod http_client;
 /// Knowledge graph and session memory tools (remember, recall).
 pub mod memory;
 /// Parameter registry query tool (discover tunable parameters).
 pub mod parameters;
 /// Planning project management tools (create, status, execute, verify).
 pub mod planning;
-/// Web research tools (web_fetch). Web search uses Anthropic server-side tools.
+/// Web research tools (web_fetch).
 pub mod research;
 /// Issue triage tools (scan, score, stage, approve).
 pub mod triage;
 /// File viewing with multimodal support (images, PDFs, text).
 pub mod view_file;
+/// Web search via Brave Search API (requires BRAVE_SEARCH_API_KEY).
+pub mod web_search;
 /// File and shell workspace tools (read, write, edit, exec).
 pub mod workspace;
 
@@ -64,11 +72,15 @@ pub fn register_all_with_sandbox(
     memory::register(registry)?;
     communication::register(registry)?;
     filesystem::register(registry)?;
+    fs_ops::register(registry)?;
+    git_ops::register(registry)?;
+    http_client::register(registry)?;
     view_file::register(registry)?;
     agent::register(registry)?;
     enable_tool::register(registry)?;
     planning::register(registry)?;
     research::register(registry)?;
+    web_search::register(registry)?;
     triage::register(registry)?;
     parameters::register(registry)?;
     #[cfg(feature = "energeia")]

--- a/crates/organon/src/builtins/web_search.rs
+++ b/crates/organon/src/builtins/web_search.rs
@@ -1,0 +1,283 @@
+//! `web_search` tool — agent-side web search via the Brave Search API.
+//!
+//! WHY: The previous design relied on Anthropic's server-side `web_search` tool,
+//! which only works with Anthropic-hosted models. Agents using other providers
+//! (Kimi, local Qwen, etc.) had no search capability. Closes #3437.
+//!
+//! Availability: requires `BRAVE_SEARCH_API_KEY` in the environment. If the
+//! key is absent the tool still registers, but every call returns an error
+//! instructing the operator to configure the key. We deliberately register
+//! unconditionally so tool discovery is deterministic; the runtime check
+//! surfaces the missing configuration.
+//!
+//! WHY Brave: free tier supports 2 000 queries / month, returns JSON, and
+//! does not require a Google CSE, scraping, or browser. DuckDuckGo has no
+//! official JSON search API (only the Instant Answer endpoint, which rarely
+//! returns web results).
+
+use std::fmt::Write as _;
+use std::future::Future;
+use std::pin::Pin;
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+use koina::id::ToolName;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+use super::workspace::{extract_opt_u64, extract_str};
+
+const BRAVE_SEARCH_ENDPOINT: &str = "https://api.search.brave.com/res/v1/web/search";
+const API_KEY_ENV: &str = "BRAVE_SEARCH_API_KEY";
+
+/// Upper bound on the number of results returned to the LLM.
+const MAX_RESULTS: u64 = 20;
+
+#[derive(Debug, Deserialize)]
+struct BraveResponse {
+    #[serde(default)]
+    web: Option<BraveWeb>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BraveWeb {
+    #[serde(default)]
+    results: Vec<BraveResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BraveResult {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    description: String,
+}
+
+fn require_http_client(ctx: &ToolContext) -> std::result::Result<reqwest::Client, ToolResult> {
+    ctx.services
+        .as_deref()
+        .map(|s| s.http_client.clone())
+        .ok_or_else(|| ToolResult::error("tool services not configured"))
+}
+
+struct WebSearchExecutor;
+
+impl ToolExecutor for WebSearchExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let query = extract_str(&input.arguments, "query", &input.name)?;
+            let requested = extract_opt_u64(&input.arguments, "maxResults").unwrap_or(5);
+            let count = requested.clamp(1, MAX_RESULTS);
+
+            let api_key = match std::env::var(API_KEY_ENV) {
+                Ok(k) if !k.is_empty() => k,
+                _ => {
+                    return Ok(ToolResult::error(format!(
+                        "web_search unavailable: set {API_KEY_ENV} in the environment (Brave Search API key required)"
+                    )));
+                }
+            };
+
+            let client = match require_http_client(ctx) {
+                Ok(c) => c,
+                Err(r) => return Ok(r),
+            };
+
+            let response = client
+                .get(BRAVE_SEARCH_ENDPOINT)
+                .query(&[("q", query), ("count", &count.to_string())])
+                .header("X-Subscription-Token", api_key)
+                .header("Accept", "application/json")
+                .header(
+                    "User-Agent",
+                    concat!(
+                        "aletheia/",
+                        env!("CARGO_PKG_VERSION"),
+                        " (organon web_search)"
+                    ),
+                )
+                .timeout(std::time::Duration::from_secs(20))
+                .send()
+                .await;
+
+            let response = match response {
+                Ok(r) => r,
+                Err(e) => return Ok(ToolResult::error(format!("search failed: {e}"))),
+            };
+
+            let status = response.status();
+            if !status.is_success() {
+                let body = response.text().await.unwrap_or_default();
+                return Ok(ToolResult::error(format!(
+                    "search API returned {status}: {body}"
+                )));
+            }
+
+            let parsed: BraveResponse = match response.json().await {
+                Ok(p) => p,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!(
+                        "failed to parse search response: {e}"
+                    )));
+                }
+            };
+
+            let results = parsed.web.map(|w| w.results).unwrap_or_default();
+
+            if results.is_empty() {
+                return Ok(ToolResult::text(format!("no results for: {query}")));
+            }
+
+            let mut out = String::new();
+            for (i, r) in results.iter().enumerate() {
+                let n = i + 1;
+                let _ = writeln!(
+                    out,
+                    "{n}. {title}\n   {url}\n   {desc}\n",
+                    title = r.title,
+                    url = r.url,
+                    desc = r.description
+                );
+            }
+
+            Ok(ToolResult::text(out.trim_end().to_owned()))
+        })
+    }
+}
+
+/// Register the `web_search` tool.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(web_search_def(), Box::new(WebSearchExecutor))?;
+    Ok(())
+}
+
+fn web_search_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("web_search"), // kanon:ignore RUST/expect
+        description: concat!(
+            "Search the web via Brave Search. Returns a ranked list of ",
+            "title/URL/snippet. Requires BRAVE_SEARCH_API_KEY in the environment."
+        )
+        .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "query".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Search query".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "maxResults".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Number,
+                        description: "Maximum results (1-20, default 5)".to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(5)),
+                    },
+                ),
+            ]),
+            required: vec!["query".to_owned()],
+        },
+        category: ToolCategory::Research,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    use koina::id::{NousId, SessionId};
+
+    use crate::types::{ServerToolConfig, ToolContext, ToolServices};
+
+    use super::*;
+
+    fn mock_ctx() -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("alice").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: std::path::PathBuf::from("/tmp"),
+            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+            services: Some(Arc::new(ToolServices {
+                cross_nous: None,
+                messenger: None,
+                note_store: None,
+                blackboard_store: None,
+                spawn: None,
+                planning: None,
+                knowledge: None,
+                http_client: reqwest::Client::new(),
+                lazy_tool_catalog: vec![],
+                server_tool_config: ServerToolConfig::default(),
+            })),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+            tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
+        }
+    }
+
+    #[test]
+    fn web_search_def_is_lazy() {
+        let def = web_search_def();
+        assert!(!def.auto_activate);
+        assert_eq!(def.category, ToolCategory::Research);
+    }
+
+    #[test]
+    fn registration_registers_web_search() {
+        let mut reg = crate::registry::ToolRegistry::new();
+        register(&mut reg).expect("register");
+        let tn = ToolName::new("web_search").expect("valid");
+        assert!(reg.get_def(&tn).is_some());
+    }
+
+    #[tokio::test]
+    async fn missing_api_key_returns_configuration_error() {
+        // SAFETY: we remove the env var for the duration of this test.
+        // Serial-by-convention: tests in this module do not run in parallel
+        // on the API key because only this test manipulates it.
+        // SAFETY: set_var is unsafe on recent Rust; this test owns the env
+        // manipulation scope.
+        #[expect(
+            unsafe_code,
+            reason = "std::env::remove_var is unsafe on current Rust; test owns the scope"
+        )]
+        // SAFETY: test-scoped env manipulation; no other threads depend on this key.
+        unsafe {
+            std::env::remove_var(API_KEY_ENV);
+        }
+
+        let ctx = mock_ctx();
+        let input = ToolInput {
+            name: ToolName::new("web_search").expect("valid"),
+            tool_use_id: "toolu_test".to_owned(),
+            arguments: serde_json::json!({ "query": "alice and bob" }),
+        };
+        let result = WebSearchExecutor.execute(&input, &ctx).await.expect("exec");
+        assert!(result.is_error, "missing key must surface an error");
+        assert!(
+            result.content.text_summary().contains(API_KEY_ENV),
+            "error should name the required env var"
+        );
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ aletheia
 │   ├── episteme   -  knowledge pipeline: extraction, recall, consolidation, embeddings
 │   └── krites     -  embedded Datalog engine + HNSW vectors (mneme-engine feature gate)
 ├── hermeneus      -  Anthropic client, model routing, credentials, provider trait
-├── organon        -  tool registry + 38 built-in tools
+├── organon        -  tool registry + 49 built-in tools
 ├── nous           -  agent pipeline, bootstrap, recall, finalize, actor model
 ├── dianoia        -  planning / project orchestration
 ├── pylon          -  Axum HTTP gateway, SSE streaming
@@ -119,7 +119,7 @@ The oikos hierarchy is described in [CONFIGURATION.md](CONFIGURATION.md).
 | `krites` | `crates/krites` | Embedded Datalog engine with HNSW and graph support | eidos |
 | `mneme` | `crates/mneme` | Thin facade re-exporting eidos, graphe, episteme, krites | eidos, graphe, episteme, krites |
 | `hermeneus` | `crates/hermeneus` | Anthropic client, model routing, credential management, provider trait | koina, taxis |
-| `organon` | `crates/organon` | Tool registry, tool definitions, 38 built-in tools, sandbox | koina, hermeneus |
+| `organon` | `crates/organon` | Tool registry, tool definitions, 49 built-in tools, sandbox | koina, hermeneus |
 | `symbolon` | `crates/symbolon` | JWT tokens, password hashing, RBAC policies | koina |
 | `melete` | `crates/melete` | Context distillation, compression strategies, token budget management | hermeneus |
 | `agora` | `crates/agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |


### PR DESCRIPTION
## Summary

Expand organon's built-in toolkit so agents can perform everyday filesystem, HTTP, Git, and web-search operations without falling back to the bare `exec` tool or to Anthropic-only server-side tooling.

- **fs_ops** (`mkdir`, `mv`, `cp`, `rm`) — path-validated filesystem mutations with a protected-basename allowlist (IDENTITY.md, .git, standards, ...), recursive opt-in for dir ops, EXDEV cross-device fallback for `mv`, and a refuse-to-remove-workspace-root guard.
- **http_request** — generic HTTP client (GET/POST/PUT/DELETE/PATCH/HEAD) with configurable headers + body. Reuses SSRF + redirect guards from `research.rs`; forbids Host/Content-Length injection; truncates large bodies at a UTF-8 boundary; non-2xx surfaces as an error result.
- **git_ops** (`git_status`, `git_log`, `git_diff`, `git_branch`, `git_checkout`) — shells out to `git` via `ProcessGuard` (30s timeout). Rejects refs starting with `-` to block option-injection. Never `--force`; `no commit/push/reset/rebase/merge` (destructive work still goes through `exec` under operator review). WHY comment explains why we use `Command` over `gix`/`git2`.
- **web_search** — Brave Search API client gated on `BRAVE_SEARCH_API_KEY`. Registers unconditionally so tool discovery stays deterministic; missing key surfaces a configuration error at call time.
- **Docs** — `crates/organon/CLAUDE.md` tool count `38 -> 49` with new categories; same update in `docs/ARCHITECTURE.md` (two references).

All new executors:
- Follow the `ToolExecutor` pattern with per-site `#[expect(...)]` suppressions and WHY reasons.
- Validate paths via `workspace::validate_path` (tilde expansion, symlink canonicalization, allowed-roots check).
- Use snafu `InvalidInputSnafu` for input errors; `ToolResult::error` for runtime failures.
- Use synthetic test identities (`alice`, `bob`, `acme.corp`) — no real PII.

## Test plan

- [x] `CARGO_TARGET_DIR=/data/target cargo check -p organon --tests`
- [x] `CARGO_TARGET_DIR=/data/target cargo clippy -p organon --tests -- -D warnings` (zero warnings)
- [x] `CARGO_TARGET_DIR=/data/target cargo test -p organon` — 438/438 pass, including 28 new tests across the four modules
- [ ] Manual smoke test: spawn an agent with `enable_tool('http_request')` against a public JSON endpoint
- [ ] Manual smoke test: export `BRAVE_SEARCH_API_KEY`, call `web_search({"query": "rust async runtime"})`
- [ ] Manual smoke test: `git_status` / `git_log` / `git_branch` against the aletheia repo workspace

## Follow-up (noticed but deliberately out of scope)

- `http_request` does not yet integrate with a per-agent secret store for Authorization headers. Agents must paste the header verbatim, which is fine for public APIs but blocks private ones. Candidate: wire a `credential_ref` argument that resolves against a future secret provider service.
- No `git_show`, `git_blame`, `git_stash list` yet — could add without scope creep once this lands.
- `web_search` relies on Brave only. If/when a DDG JSON endpoint becomes usable, it would be nice to have a provider-select arg. Brave's free tier is sufficient for now.

Closes #3440
Closes #3441
Closes #3442
Closes #3437
Closes #3439