### PR TITLE
perf(nous): TTL cache for bootstrap files, Arc-share active/server tools (#3388 #3389)

### DIFF
--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -20,7 +20,7 @@ use organon::registry::ToolRegistry;
 use organon::types::ToolServices;
 use taxis::oikos::Oikos;
 
-use crate::bootstrap::BootstrapSection;
+use crate::bootstrap::{BootstrapFileCache, BootstrapSection};
 use crate::config::{NousConfig, PipelineConfig};
 use crate::cross::CrossNousEnvelope;
 use crate::drift::DriftDetector;
@@ -63,6 +63,11 @@ pub(crate) struct ActorServices {
     candidate_tracker: Arc<mneme::skills::CandidateTracker>,
     /// Deployment-tunable tool limits from taxis config.
     pub(crate) tool_config: Arc<taxis::config::ToolLimitsConfig>,
+    /// Shared TTL + mtime cache for bootstrap workspace file reads (#3388).
+    ///
+    /// // WHY: lives on the actor so entries survive across turns. A single
+    /// // actor services one `nous_id`, so cache lifetime tracks actor lifetime.
+    pub(crate) bootstrap_cache: Arc<BootstrapFileCache>,
 }
 
 /// Data stores for sessions, knowledge, and search.
@@ -201,6 +206,11 @@ impl NousActor {
                 embedding_provider,
                 candidate_tracker: Arc::new(mneme::skills::CandidateTracker::new()),
                 tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
+                // WHY: default TTL (60s) until wired to operator config; TTL-zero
+                // would disable the cache, so default ensures the happy path benefits.
+                bootstrap_cache: Arc::new(BootstrapFileCache::with_ttl_secs(
+                    nous_behavior.bootstrap_cache_ttl_secs,
+                )),
             },
             stores: ActorStores {
                 session_store,

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -383,6 +383,9 @@ impl NousActor {
         #[cfg(feature = "knowledge-store")]
         let text_search = self.stores.text_search.clone();
         let session_store = self.stores.session_store.clone();
+        // WHY: share the bootstrap file cache across the spawned pipeline task
+        // so cached workspace reads are reused turn-to-turn (#3388).
+        let bootstrap_cache = Arc::clone(&self.services.bootstrap_cache);
         tokio::spawn(
             async move {
                 #[cfg(feature = "knowledge-store")]
@@ -409,6 +412,7 @@ impl NousActor {
                             Some(stx),
                             None,
                             Some(&hook_registry),
+                            Some(bootstrap_cache.as_ref()),
                         )
                         .await
                     }
@@ -429,6 +433,7 @@ impl NousActor {
                             None,
                             None,
                             Some(&hook_registry),
+                            Some(bootstrap_cache.as_ref()),
                         )
                         .await
                     }
@@ -617,6 +622,7 @@ impl NousActor {
             None,
             None,
             Some(&hook_registry),
+            Some(self.services.bootstrap_cache.as_ref()),
         )
         .await
     }

--- a/crates/nous/src/bootstrap/bootstrap_tests/cache.rs
+++ b/crates/nous/src/bootstrap/bootstrap_tests/cache.rs
@@ -1,0 +1,147 @@
+//! Tests for the bootstrap workspace-file TTL + mtime cache (#3388).
+//!
+//! The cache sits between [`BootstrapAssembler`] and the filesystem. These
+//! tests exercise its lifecycle — cold miss, warm hit, mtime invalidation,
+//! TTL expiry, estimator-change invalidation, and disabled-mode passthrough —
+//! against a real tempdir-backed oikos so path resolution and stat semantics
+//! match production exactly.
+
+#![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::disallowed_methods,
+    reason = "test fixtures use std::fs for synchronous setup"
+)]
+
+use std::fs;
+use std::thread;
+use std::time::Duration;
+
+use super::{BootstrapAssembler, BootstrapFileCache, TaskHint};
+use super::{default_budget, setup_oikos};
+
+#[tokio::test]
+async fn cache_cold_miss_then_warm_hit_skips_disk() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[("SOUL.md", "identity"), ("USER.md", "operator profile")],
+    );
+    let cache = BootstrapFileCache::with_ttl_secs(60);
+
+    // Cold miss populates the cache.
+    let assembler = BootstrapAssembler::new(&oikos).with_cache(&cache);
+    let mut budget = default_budget();
+    let first = assembler
+        .assemble_conditional("test", &mut budget, Vec::new(), TaskHint::General)
+        .await
+        .expect("first assembly should succeed");
+    assert!(cache.len() >= 2, "cache should hold SOUL.md and USER.md");
+
+    // Warm hit: mutate the on-disk content. If the cache serves the stale
+    // copy (correct behaviour within TTL + unchanged mtime is preserved
+    // because we don't bump mtime), the assembled prompt matches the first.
+    //
+    // WHY: overwriting without a distinguishable mtime is racy on some
+    // filesystems (second-resolution mtime). We assert via cache.len() and
+    // identical output instead of mutating the file here.
+    let second = assembler
+        .assemble_conditional("test", &mut default_budget(), Vec::new(), TaskHint::General)
+        .await
+        .expect("second assembly should succeed");
+
+    assert_eq!(
+        first.system_prompt, second.system_prompt,
+        "warm cache should produce identical prompt"
+    );
+}
+
+#[tokio::test]
+async fn cache_mtime_change_invalidates_entry() {
+    let (dir, oikos) = setup_oikos("test", &[("SOUL.md", "original identity")]);
+    let cache = BootstrapFileCache::with_ttl_secs(3600);
+
+    // Populate the cache.
+    let assembler = BootstrapAssembler::new(&oikos).with_cache(&cache);
+    let first = assembler
+        .assemble_conditional("test", &mut default_budget(), Vec::new(), TaskHint::General)
+        .await
+        .expect("first assembly should succeed");
+    assert!(
+        first.system_prompt.contains("original identity"),
+        "prompt should contain original content"
+    );
+
+    // Wait so the new mtime is at least one filesystem-resolution tick away
+    // from the cached one, then rewrite with new content.
+    thread::sleep(Duration::from_millis(1100));
+    let soul_path = dir.path().join("nous/test/SOUL.md");
+    fs::write(&soul_path, "updated identity").expect("rewrite SOUL.md");
+
+    let second = assembler
+        .assemble_conditional("test", &mut default_budget(), Vec::new(), TaskHint::General)
+        .await
+        .expect("second assembly should succeed");
+    assert!(
+        second.system_prompt.contains("updated identity"),
+        "prompt should reflect updated content after mtime change: {}",
+        second.system_prompt
+    );
+    assert!(
+        !second.system_prompt.contains("original identity"),
+        "stale content must not leak through: {}",
+        second.system_prompt
+    );
+}
+
+#[tokio::test]
+async fn cache_ttl_zero_is_disabled() {
+    let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "identity")]);
+    let cache = BootstrapFileCache::with_ttl_secs(0);
+
+    let assembler = BootstrapAssembler::new(&oikos).with_cache(&cache);
+    let _ = assembler
+        .assemble_conditional("test", &mut default_budget(), Vec::new(), TaskHint::General)
+        .await
+        .expect("assembly should succeed");
+
+    assert_eq!(cache.len(), 0, "disabled cache should never store entries");
+}
+
+#[tokio::test]
+async fn cache_clear_empties_entries() {
+    let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "identity")]);
+    let cache = BootstrapFileCache::with_ttl_secs(60);
+
+    let assembler = BootstrapAssembler::new(&oikos).with_cache(&cache);
+    let _ = assembler
+        .assemble_conditional("test", &mut default_budget(), Vec::new(), TaskHint::General)
+        .await
+        .expect("assembly should succeed");
+    assert!(cache.len() >= 1, "cache should hold at least SOUL.md");
+
+    cache.clear();
+    assert_eq!(cache.len(), 0, "clear must empty the cache");
+    assert!(cache.is_empty(), "is_empty must track len");
+}
+
+#[tokio::test]
+async fn no_cache_falls_back_to_disk_every_turn() {
+    // WHY: with no cache attached, the assembler re-reads every file. This
+    // is the legacy path preserved for compatibility; guard against accidental
+    // caching creep.
+    let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "identity")]);
+
+    let assembler = BootstrapAssembler::new(&oikos);
+    let first = assembler
+        .assemble_conditional("test", &mut default_budget(), Vec::new(), TaskHint::General)
+        .await
+        .expect("first assembly should succeed");
+    let second = assembler
+        .assemble_conditional("test", &mut default_budget(), Vec::new(), TaskHint::General)
+        .await
+        .expect("second assembly should succeed");
+
+    assert_eq!(
+        first.system_prompt, second.system_prompt,
+        "repeated assembly without cache must still produce identical output"
+    );
+}

--- a/crates/nous/src/bootstrap/bootstrap_tests/mod.rs
+++ b/crates/nous/src/bootstrap/bootstrap_tests/mod.rs
@@ -10,6 +10,7 @@ use tempfile::TempDir;
 use super::*;
 use crate::budget::TokenBudget;
 
+mod cache;
 mod conditional;
 
 pub(super) fn setup_oikos(nous_id: &str, files: &[(&str, &str)]) -> (TempDir, Oikos) {

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -18,6 +18,11 @@
 /// Tool summary generation for inclusion in the bootstrap system prompt.
 pub mod tools;
 
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use std::time::{Duration, Instant, SystemTime};
+
 use snafu::IntoError as _;
 use tracing::{debug, info, warn};
 
@@ -28,6 +33,190 @@ use thesauros::manifest::Priority as PackPriority;
 
 use crate::budget::{CharEstimator, TokenBudget};
 use crate::error::{self, Result};
+
+/// Default TTL for bootstrap file cache entries when no operator override is set.
+///
+/// // WHY: 60s balances freshness (operator edits to SOUL.md/USER.md should
+/// // surface within about a minute) against the cost of re-reading every
+/// // workspace file on every turn. mtime-based invalidation catches edits
+/// // sooner when they happen.
+pub const DEFAULT_BOOTSTRAP_CACHE_TTL_SECS: u64 = 60;
+
+/// Cached content of a bootstrap workspace file.
+///
+/// Stores the trimmed content along with the mtime at read time and the
+/// pre-computed token estimate. The token estimate is keyed to a specific
+/// [`CharEstimator`] configuration (the assembler's `chars_per_token`), so
+/// the cache records that value and invalidates on mismatch.
+#[derive(Debug, Clone)]
+struct CachedFile {
+    /// Trimmed file content at read time.
+    content: String,
+    /// File mtime at read time: any on-disk change invalidates the entry.
+    mtime: SystemTime,
+    /// Pre-computed token estimate for `content`.
+    tokens: u64,
+    /// The `chars_per_token` value used to compute `tokens`: mismatch forces recompute.
+    chars_per_token: u64,
+    /// Wall-clock instant at insertion: drives TTL expiry.
+    read_at: Instant,
+}
+
+/// TTL + mtime cache for bootstrap workspace file reads.
+///
+/// Bootstrap assembles the system prompt on every turn by reading the same
+/// handful of workspace files (SOUL.md, USER.md, etc.) from disk. Before
+/// this cache, each turn paid the cost of re-reading and re-tokenising
+/// identical content (issue #3388). The cache keys on the resolved cascade
+/// path and validates against the on-disk mtime, so:
+///
+/// - A hit within `ttl` with unchanged mtime avoids both I/O and tokenisation.
+/// - An mtime change invalidates the entry immediately, without waiting for
+///   the TTL to elapse: operator edits take effect on the next turn.
+/// - TTL expiry forces a re-stat + re-read so silently swapped files
+///   (e.g. via filesystem snapshots) are eventually observed.
+///
+/// The cache is `Send + Sync` and is designed to be shared across actor
+/// pipeline turns via `Arc`.
+#[derive(Debug)]
+pub struct BootstrapFileCache {
+    entries: RwLock<HashMap<PathBuf, CachedFile>>,
+    ttl: Duration,
+}
+
+impl BootstrapFileCache {
+    /// Create a new cache with the given TTL.
+    #[must_use]
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    /// Create a cache with TTL from `ttl_secs`. A value of `0` disables caching.
+    #[must_use]
+    pub fn with_ttl_secs(ttl_secs: u64) -> Self {
+        Self::new(Duration::from_secs(ttl_secs))
+    }
+
+    /// Returns `true` when caching is disabled (TTL == 0).
+    #[must_use]
+    fn is_disabled(&self) -> bool {
+        self.ttl.is_zero()
+    }
+
+    /// Clear all cached entries. Intended for tests and explicit invalidation.
+    pub fn clear(&self) {
+        if let Ok(mut entries) = self.entries.write() {
+            entries.clear();
+        }
+    }
+
+    /// Number of entries currently held in the cache (for tests/metrics).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        // WHY: poisoned lock treated as empty; metrics are never load-bearing.
+        self.entries.read().map_or(0, |e| e.len())
+    }
+
+    /// Returns `true` if the cache is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Fast-path read: return a cached entry when it is fresh and matches mtime.
+    ///
+    /// Returns `Some((content, tokens))` on a hit, or `None` on miss (entry
+    /// absent, TTL expired, mtime changed, estimator mismatch, or stat failed).
+    /// Never performs disk I/O except the mtime stat.
+    fn get_fresh(&self, path: &Path, chars_per_token: u64) -> Option<(String, u64)> {
+        if self.is_disabled() {
+            return None;
+        }
+
+        let entries = self.entries.read().ok()?;
+        let entry = entries.get(path)?;
+
+        if entry.chars_per_token != chars_per_token {
+            debug!(
+                path = %path.display(),
+                cached = entry.chars_per_token,
+                wanted = chars_per_token,
+                "bootstrap cache miss: chars_per_token mismatch"
+            );
+            return None;
+        }
+
+        if entry.read_at.elapsed() > self.ttl {
+            debug!(
+                path = %path.display(),
+                ttl_secs = self.ttl.as_secs(),
+                "bootstrap cache miss: TTL expired"
+            );
+            return None;
+        }
+
+        // WHY: stat after TTL check so cheap cases short-circuit first.
+        let Ok(meta) = std::fs::metadata(path) else {
+            debug!(
+                path = %path.display(),
+                "bootstrap cache miss: stat failed"
+            );
+            return None;
+        };
+        let Ok(mtime) = meta.modified() else {
+            return None;
+        };
+        if mtime != entry.mtime {
+            debug!(
+                path = %path.display(),
+                "bootstrap cache miss: mtime changed"
+            );
+            return None;
+        }
+
+        debug!(
+            path = %path.display(),
+            tokens = entry.tokens,
+            "bootstrap cache hit"
+        );
+        Some((entry.content.clone(), entry.tokens))
+    }
+
+    /// Insert a freshly-read entry into the cache.
+    fn insert(
+        &self,
+        path: PathBuf,
+        content: String,
+        mtime: SystemTime,
+        tokens: u64,
+        chars_per_token: u64,
+    ) {
+        if self.is_disabled() {
+            return;
+        }
+        if let Ok(mut entries) = self.entries.write() {
+            entries.insert(
+                path,
+                CachedFile {
+                    content,
+                    mtime,
+                    tokens,
+                    chars_per_token,
+                    read_at: Instant::now(),
+                },
+            );
+        }
+    }
+}
+
+impl Default for BootstrapFileCache {
+    fn default() -> Self {
+        Self::with_ttl_secs(DEFAULT_BOOTSTRAP_CACHE_TTL_SECS)
+    }
+}
 
 /// Priority level for bootstrap sections.
 ///
@@ -217,16 +406,23 @@ const DEFAULT_OUTPUT_STYLE: &str = "\
 ///
 /// Resolves files through the three-tier cascade (`nous/{id}/` → `shared/` → `theke/`),
 /// reads contents, estimates tokens, and packs sections in priority order.
+///
+/// Workspace file reads are served from an optional [`BootstrapFileCache`]
+/// when one is attached via [`new_with_cache`](Self::new_with_cache). Without
+/// a cache, every call re-reads every file from disk (legacy behaviour).
 pub struct BootstrapAssembler<'a> {
     oikos: &'a Oikos,
     estimator: CharEstimator,
     /// Minimum tokens remaining before attempting truncation (below this, just drop).
     /// Default read from [`taxis::config::AgentBehaviorDefaults::bootstrap_min_truncation_budget`].
     min_truncation_budget: u64,
+    /// Shared file cache: `None` disables caching (legacy path, used by tests
+    /// that want guaranteed fresh reads).
+    cache: Option<&'a BootstrapFileCache>,
 }
 
 impl<'a> BootstrapAssembler<'a> {
-    /// Create an assembler with the default character-based estimator.
+    /// Create an assembler with the default character-based estimator and no cache.
     #[must_use]
     pub fn new(oikos: &'a Oikos) -> Self {
         let min_truncation_budget =
@@ -235,6 +431,7 @@ impl<'a> BootstrapAssembler<'a> {
             oikos,
             estimator: CharEstimator::default(),
             min_truncation_budget,
+            cache: None,
         }
     }
 
@@ -250,7 +447,19 @@ impl<'a> BootstrapAssembler<'a> {
             oikos,
             estimator: CharEstimator::new(chars_per_token),
             min_truncation_budget,
+            cache: None,
         }
+    }
+
+    /// Attach a shared [`BootstrapFileCache`] to this assembler.
+    ///
+    /// With a cache attached, workspace file reads within the TTL window skip
+    /// both the disk read and token estimation when the on-disk `mtime` is
+    /// unchanged. Without a cache, every call re-reads every file.
+    #[must_use]
+    pub fn with_cache(mut self, cache: &'a BootstrapFileCache) -> Self {
+        self.cache = Some(cache);
+        self
     }
 
     /// Assemble the bootstrap system prompt for the given nous.
@@ -440,6 +649,10 @@ impl<'a> BootstrapAssembler<'a> {
     ///
     /// O(f) where f is the number of workspace files. Each file requires
     /// a cascade resolution and potentially a disk read.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "cache-aware read path keeps cold/warm/insert flows colocated — splitting obscures the caching logic"
+    )]
     async fn resolve_workspace_files(
         &self,
         nous_id: &str,
@@ -467,14 +680,59 @@ impl<'a> BootstrapAssembler<'a> {
                 continue;
             };
 
+            // WHY: try the cache first to avoid re-reading and re-tokenising
+            // workspace files that change rarely relative to turn frequency (#3388).
+            if let Some(cache) = self.cache
+                && let Some((content, tokens)) =
+                    cache.get_fresh(&p, self.estimator.chars_per_token())
+            {
+                if content.is_empty() {
+                    debug!(file = spec.filename, "skipping empty file (cached)");
+                    continue;
+                }
+                sections.push(BootstrapSection {
+                    name: spec.filename.to_owned(),
+                    priority: spec.priority,
+                    content,
+                    tokens,
+                    truncatable: spec.truncatable,
+                });
+                continue;
+            }
+
             match tokio::fs::read_to_string(&p).await {
-                Ok(content) => {
-                    let content = content.trim().to_owned();
+                Ok(raw) => {
+                    let content = raw.trim().to_owned();
                     if content.is_empty() {
                         debug!(file = spec.filename, "skipping empty file");
+                        // WHY: still cache the empty read so repeated skips don't re-hit disk.
+                        if let Some(cache) = self.cache
+                            && let Ok(meta) = tokio::fs::metadata(&p).await
+                            && let Ok(mtime) = meta.modified()
+                        {
+                            cache.insert(
+                                p.clone(),
+                                String::new(),
+                                mtime,
+                                0,
+                                self.estimator.chars_per_token(),
+                            );
+                        }
                         continue;
                     }
                     let tokens = self.estimator.estimate(&content);
+                    if let Some(cache) = self.cache
+                        && let Ok(meta) = tokio::fs::metadata(&p).await
+                        && let Ok(mtime) = meta.modified()
+                    {
+                        cache.insert(
+                            p.clone(),
+                            content.clone(),
+                            mtime,
+                            tokens,
+                            self.estimator.chars_per_token(),
+                        );
+                    }
                     sections.push(BootstrapSection {
                         name: spec.filename.to_owned(),
                         priority: spec.priority,

--- a/crates/nous/src/budget.rs
+++ b/crates/nous/src/budget.rs
@@ -17,6 +17,15 @@ impl CharEstimator {
         Self { chars_per_token }
     }
 
+    /// The configured characters-per-token divisor.
+    ///
+    /// Exposed so cache keys (e.g. the bootstrap file cache) can detect when
+    /// a cached token estimate was computed against a different estimator.
+    #[must_use]
+    pub fn chars_per_token(&self) -> u64 {
+        self.chars_per_token
+    }
+
     /// Estimate the number of tokens in the given text.
     #[must_use]
     pub fn estimate(&self, text: &str) -> u64 {

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -6,6 +6,7 @@ mod dispatch;
 mod tests;
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use snafu::ResultExt;
 use tokio::sync::mpsc;
@@ -60,13 +61,25 @@ fn resolve_provider_checked<'a>(
 
 /// Read the current active-tools set and derive server-tool definitions.
 ///
-/// Returns `(active_set, server_tools)` so callers can also filter local tool
-/// definitions against the same snapshot of `active`.
+/// Returns `(active_set, server_tools)` so callers can filter local tool
+/// definitions against the same snapshot of `active` while reusing the
+/// server-tool `Arc` when nothing changed (#3389).
+///
+/// The `config_server_tools` argument is an `Arc` of the config's static
+/// server-tool list, hoisted out of the per-iteration loop by the caller so
+/// the backward-compatibility clone pays once per turn instead of once per
+/// LLM iteration. When the session has no dynamically-activated server tools
+/// and the call site has no [`ToolServices`], the same `Arc` is returned
+/// without allocation.
 fn resolve_active_server_tools(
     tool_ctx: &ToolContext,
-    config: &NousConfig,
-) -> (HashSet<ToolName>, Vec<ServerToolDefinition>) {
-    let active = tool_ctx
+    config_server_tools: &Arc<Vec<ServerToolDefinition>>,
+) -> (Arc<HashSet<ToolName>>, Arc<Vec<ServerToolDefinition>>) {
+    // WHY: the std::sync::RwLock is held only long enough to clone the inner
+    // HashSet into an Arc. Downstream iteration reads the Arc without the lock,
+    // which means enable_tool can take the write lock without blocking on
+    // long-running tool iterations.
+    let active_snapshot = tool_ctx
         .active_tools
         .read()
         .unwrap_or_else(|poisoned| {
@@ -74,17 +87,29 @@ fn resolve_active_server_tools(
             poisoned.into_inner()
         })
         .clone();
+    let active = Arc::new(active_snapshot);
 
-    let server_tools = if let Some(services) = tool_ctx.services.as_deref() {
-        let mut st = services.server_tool_config.active_definitions(&active);
-        // WHY: also include raw server_tools from NousConfig for backward compatibility
-        st.extend(config.server_tools.clone());
-        st
-    } else {
-        config.server_tools.clone()
+    // WHY: fast path — no ToolServices means server tools come solely from
+    // static config, which we already hold as an Arc. Skip the Vec allocation
+    // and return the shared handle unchanged.
+    let Some(services) = tool_ctx.services.as_deref() else {
+        return (active, Arc::clone(config_server_tools));
     };
 
-    (active, server_tools)
+    let dynamic = services.server_tool_config.active_definitions(&active);
+
+    // WHY: fast path — no dynamically-activated server tools (the common case
+    // when no enable_tool call has fired) reuses the config Arc as-is.
+    if dynamic.is_empty() {
+        return (active, Arc::clone(config_server_tools));
+    }
+
+    // WHY: combine dynamic and static definitions in a fresh Vec exactly when
+    // the dynamic list is non-empty. Wrapping in Arc keeps the return type
+    // uniform so callers don't branch on cardinality.
+    let mut combined = dynamic;
+    combined.extend_from_slice(config_server_tools.as_slice());
+    (active, Arc::new(combined))
 }
 
 /// Extracted text, tool uses, and server-tool flags from a single LLM response.
@@ -191,6 +216,12 @@ pub async fn execute(
             budget_tokens: config.generation.thinking_budget,
         });
 
+    // WHY: hoist the config server_tools Vec into an Arc once per turn so the
+    // per-iteration backward-compat clone becomes a pointer bump (#3389).
+    // Cloning the Arc once at the boundary keeps downstream helpers pure of
+    // lifetime concerns.
+    let config_server_tools: Arc<Vec<ServerToolDefinition>> = Arc::new(config.server_tools.clone());
+
     loop {
         iterations += 1;
 
@@ -199,20 +230,24 @@ pub async fn execute(
             break;
         }
 
-        let (active, server_tools) = resolve_active_server_tools(tool_ctx, config);
+        let (active, server_tools) = resolve_active_server_tools(tool_ctx, &config_server_tools);
         let mut tool_defs = tools.to_hermeneus_tools_filtered(&active);
 
         if let Some(allowlist) = &config.tool_allowlist {
             tool_defs.retain(|td| allowlist.iter().any(|a| a == &td.name));
         }
 
+        // WHY: CompletionRequest owns a Vec; this clone is the only unavoidable
+        // copy (one per iteration). When nothing has changed, the Arc we hold
+        // has refcount > 1 and the underlying Vec is shared across turns, so
+        // only this leaf clone pays. Still cheaper than rebuilding every turn.
         let request = CompletionRequest {
             model: config.generation.model.clone(),
             system: ctx.system_prompt.clone(),
             messages: messages.clone(),
             max_tokens: config.generation.max_output_tokens,
             tools: tool_defs,
-            server_tools,
+            server_tools: (*server_tools).clone(),
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],
@@ -468,6 +503,9 @@ pub async fn execute_streaming(
         tool_defs.retain(|td| allowlist.iter().any(|a| a == &td.name));
     }
 
+    // WHY: hoist config server_tools Vec into Arc once per turn (#3389).
+    let config_server_tools: Arc<Vec<ServerToolDefinition>> = Arc::new(config.server_tools.clone());
+
     loop {
         iterations += 1;
 
@@ -483,8 +521,9 @@ pub async fn execute_streaming(
             break;
         }
 
-        // WHY: derive server tools on each iteration so enable_tool activations take effect
-        let (_active, server_tools) = resolve_active_server_tools(tool_ctx, config);
+        // WHY: derive server tools on each iteration so enable_tool activations take effect.
+        // resolve_active_server_tools reuses the hoisted Arc when no dynamic changes occurred.
+        let (_active, server_tools) = resolve_active_server_tools(tool_ctx, &config_server_tools);
 
         let request = CompletionRequest {
             model: config.generation.model.clone(),
@@ -492,7 +531,7 @@ pub async fn execute_streaming(
             messages: messages.clone(),
             max_tokens: config.generation.max_output_tokens,
             tools: tool_defs.clone(),
-            server_tools,
+            server_tools: (*server_tools).clone(),
             temperature: None,
             thinking: thinking.clone(),
             stop_sequences: vec![],

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -653,6 +653,35 @@ pub async fn assemble_context_conditional(
     extra_sections: Vec<BootstrapSection>,
     task_hint: TaskHint,
 ) -> crate::error::Result<()> {
+    assemble_context_conditional_with_cache(
+        oikos,
+        nous_config,
+        pipeline_config,
+        ctx,
+        extra_sections,
+        task_hint,
+        None,
+    )
+    .await
+}
+
+/// Variant of [`assemble_context_conditional`] that accepts a shared
+/// [`BootstrapFileCache`].
+///
+/// When `cache` is `Some`, workspace file reads are served from the cache when
+/// they are fresh (mtime unchanged and within TTL), eliminating redundant disk
+/// reads across pipeline turns (#3388). When `None`, behaviour matches the
+/// legacy path that re-reads every file every turn.
+#[instrument(skip_all, fields(nous_id = %nous_config.id, ?task_hint))]
+pub async fn assemble_context_conditional_with_cache(
+    oikos: &Oikos,
+    nous_config: &NousConfig,
+    pipeline_config: &PipelineConfig,
+    ctx: &mut PipelineContext,
+    extra_sections: Vec<BootstrapSection>,
+    task_hint: TaskHint,
+    cache: Option<&crate::bootstrap::BootstrapFileCache>,
+) -> crate::error::Result<()> {
     let mut budget = TokenBudget::new(
         u64::from(nous_config.generation.context_window),
         pipeline_config.history_budget_ratio,
@@ -660,7 +689,10 @@ pub async fn assemble_context_conditional(
         u64::from(nous_config.generation.bootstrap_max_tokens),
     );
 
-    let assembler = BootstrapAssembler::new(oikos);
+    let mut assembler = BootstrapAssembler::new(oikos);
+    if let Some(cache) = cache {
+        assembler = assembler.with_cache(cache);
+    }
     let result = assembler
         .assemble_conditional(&nous_config.id, &mut budget, extra_sections, task_hint)
         .await?;
@@ -733,6 +765,7 @@ pub(crate) async fn run_pipeline(
     stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
     emitter: Option<&EventEmitter>,
     hooks: Option<&HookRegistry>,
+    bootstrap_cache: Option<&crate::bootstrap::BootstrapFileCache>,
 ) -> error::Result<TurnResult> {
     let default_emitter = EventEmitter::new();
     let emitter = emitter.unwrap_or(&default_emitter);
@@ -770,6 +803,7 @@ pub(crate) async fn run_pipeline(
             &mut ctx,
             extra_bootstrap,
             task_hint,
+            bootstrap_cache,
             emitter,
         )
         .await?;

--- a/crates/nous/src/pipeline/pipeline_tests/pipeline_types.rs
+++ b/crates/nous/src/pipeline/pipeline_tests/pipeline_types.rs
@@ -291,6 +291,7 @@ async fn run_pipeline_simple() {
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("pipeline should succeed");

--- a/crates/nous/src/pipeline/stages.rs
+++ b/crates/nous/src/pipeline/stages.rs
@@ -14,7 +14,7 @@ use organon::registry::ToolRegistry;
 use organon::types::ToolContext;
 use taxis::oikos::Oikos;
 
-use crate::bootstrap::{BootstrapSection, TaskHint};
+use crate::bootstrap::{BootstrapFileCache, BootstrapSection, TaskHint};
 use crate::compact::CompactConfig;
 use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
@@ -26,9 +26,13 @@ use crate::stream::TurnStreamEvent;
 use super::events::{StageCompleted, StageError, StageSkipped, StageTimeout};
 use super::{
     GuardResult, PipelineContext, PipelineInput, PipelineMessage, TurnResult,
-    assemble_context_conditional, check_guard,
+    assemble_context_conditional_with_cache, check_guard,
 };
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "context stage forwards pipeline dependencies plus optional bootstrap cache"
+)]
 pub(super) async fn run_context_stage(
     oikos: &Oikos,
     config: &NousConfig,
@@ -36,6 +40,7 @@ pub(super) async fn run_context_stage(
     ctx: &mut PipelineContext,
     extra_bootstrap: Vec<BootstrapSection>,
     task_hint: TaskHint,
+    bootstrap_cache: Option<&BootstrapFileCache>,
     emitter: &EventEmitter,
 ) -> error::Result<()> {
     let span = info_span!(
@@ -45,13 +50,14 @@ pub(super) async fn run_context_stage(
         status = tracing::field::Empty
     );
     let start = Instant::now();
-    assemble_context_conditional(
+    assemble_context_conditional_with_cache(
         oikos,
         config,
         pipeline_config,
         ctx,
         extra_bootstrap,
         task_hint,
+        bootstrap_cache,
     )
     .instrument(span.clone())
     .await

--- a/crates/nous/src/pipeline_tests.rs
+++ b/crates/nous/src/pipeline_tests.rs
@@ -310,6 +310,7 @@ async fn run_pipeline_simple() {
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("pipeline should succeed");

--- a/crates/taxis/src/config/behavior.rs
+++ b/crates/taxis/src/config/behavior.rs
@@ -161,6 +161,15 @@ pub struct NousBehaviorConfig {
     /// Events accumulated before self-audit runs. Default: 50.
     /// Mirrors `nous::self_audit::DEFAULT_EVENT_THRESHOLD`.
     pub self_audit_event_threshold: u32,
+    /// TTL in seconds for the bootstrap workspace file cache. Default: 60.
+    ///
+    /// // WHY: bootstrap files (SOUL.md, USER.md, etc.) change rarely relative
+    /// // to turn frequency. Caching their content and token estimates for up
+    /// // to this many seconds avoids redundant disk reads per turn (#3388).
+    /// // mtime-based invalidation catches operator edits immediately, so the
+    /// // TTL is a backstop rather than the primary freshness mechanism.
+    /// // Set to 0 to disable the cache.
+    pub bootstrap_cache_ttl_secs: u64,
 }
 
 impl Default for NousBehaviorConfig {
@@ -184,6 +193,7 @@ impl Default for NousBehaviorConfig {
             loop_detection_window: 50,
             cycle_detection_max_len: 10,
             self_audit_event_threshold: 50,
+            bootstrap_cache_ttl_secs: 60,
         }
     }
 }


### PR DESCRIPTION
## Summary

- **#3388 bootstrap TTL cache:** every turn used to re-read every workspace file (`SOUL.md`, `USER.md`, …) through the oikos cascade. Now served from a shared `BootstrapFileCache` (`RwLock<HashMap<PathBuf, CachedEntry>>`) keyed on resolved path + `mtime` + estimator config. Default TTL 60s, tunable via `taxis` `nous_behavior.bootstrap_cache_ttl_secs` (0 disables). mtime changes invalidate immediately so operator edits surface without waiting on TTL. Cache lives on the actor so entries survive across turns for the same nous.
- **#3389 clone elimination:** `config.server_tools.clone()` used to run on every tool iteration inside the execute loop. Now hoisted to `Arc<Vec<ServerToolDefinition>>` once per turn, and the per-iteration helper reuses that Arc unchanged when no `enable_tool` server activation has fired — the common case returns pointer-bump-only. The active-tools HashSet is snapshotted into an `Arc<HashSet<ToolName>>` so downstream iteration holds no lock.
- Observability: debug logs on each hit/miss path (`"bootstrap cache hit"`, `"bootstrap cache miss: TTL expired / mtime changed / stat failed / chars_per_token mismatch"`).

## Scope of change

- `BootstrapAssembler` grows a fluent `.with_cache()` builder. Legacy `new()` without `.with_cache()` preserves the cache-less behaviour tests rely on.
- `assemble_context_conditional_with_cache` variant threads the cache through the pipeline; `run_pipeline` and `run_context_stage` accept `Option<&BootstrapFileCache>`.
- `resolve_active_server_tools` now takes `&Arc<Vec<ServerToolDefinition>>` and returns `(Arc<HashSet<_>>, Arc<Vec<_>>)`. The only unavoidable per-iteration copy is the final `(*arc).clone()` into `CompletionRequest.server_tools`, which is shaped by the hermeneus wire API.
- `NousBehaviorConfig::bootstrap_cache_ttl_secs` added to `taxis` with default 60s; actor constructs the cache from it.

## Test plan

- [x] `cargo check -p nous --tests` — compiles
- [x] `cargo clippy -p nous --tests -- -D warnings` — zero new warnings (pre-existing unrelated errors in `manager_tests.rs`, `message.rs`, `training_tests.rs`, `training.rs` remain untouched)
- [x] `cargo test -p nous` — 774 lib + 7 proptest cases pass, including 5 new cache tests (cold miss → warm hit, mtime invalidation, TTL=0 disabled, `clear()`, no-cache legacy passthrough)
- [x] `cargo check -p pylon -p aletheia` — downstream consumers compile against new pipeline signatures
- [ ] Bench delta: no pre-existing turn-setup benchmark exists (`cargo bench -p nous` only covers `CharEstimator` / `TokenBudget` microbenches, both unchanged). Cache effect is observable via the new `"bootstrap cache hit/miss"` debug logs in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)