### PR TITLE
fix: validate auth_mode=none writes, add nous shutdown timeout (#3383 #3382)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7035,6 +7035,7 @@ dependencies = [
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]
@@ -7683,6 +7684,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ zeroize = { version = "1", default-features = false, features = ["std"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-appender = { version = "0.2", default-features = false }
+tracing-test = "0.2"
 
 # Metrics
 prometheus = { version = "0.14", features = ["process"] }

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -30,6 +30,16 @@ use crate::config::{NousConfig, PipelineConfig};
 use crate::handle::NousHandle;
 use crate::message::{ActorHealth, NousStatus};
 
+/// Result of waiting for a single actor task during `shutdown_all`.
+enum ShutdownOutcome {
+    /// Actor exited its run loop cleanly within the shutdown budget.
+    Clean,
+    /// Actor task panicked; the captured message is carried for logging.
+    Panicked(String),
+    /// Actor did not finish its current turn in time and was aborted.
+    TimedOut,
+}
+
 struct ActorEntry {
     handle: NousHandle,
     /// Wrapped in `Mutex<Option<_>>` so `shutdown_readonly` can take the handle
@@ -568,14 +578,35 @@ impl NousManager {
         statuses
     }
 
-    /// Gracefully shut down all actors.
+    /// Gracefully shut down all actors, bounded by `shutdown_timeout_secs`.
+    ///
+    /// Sends a `Shutdown` message to each actor and awaits their join handles
+    /// up to `nous_behavior.shutdown_timeout_secs`. Any actor still running
+    /// when the budget expires is aborted via [`JoinHandle::abort`] so the
+    /// process can exit. Per-actor shutdown durations are logged, and actors
+    /// that hit the timeout are logged at `warn!`. (#3382)
     ///
     /// # Cancel safety
     ///
     /// Not cancel-safe. If cancelled after draining actors but before joining
     /// them, actor tasks may be leaked. Only call from shutdown paths.
     pub async fn shutdown_all(&mut self) {
-        info!(count = self.actors.len(), "shutting down all actors");
+        let timeout = Duration::from_secs(self.nous_behavior.shutdown_timeout_secs);
+        self.shutdown_all_with_timeout(timeout).await;
+    }
+
+    /// Gracefully shut down all actors with an explicit timeout.
+    ///
+    /// Equivalent to [`Self::shutdown_all`] but takes the timeout as an
+    /// argument instead of reading it from `nous_behavior`. Useful for tests
+    /// and for callers that need a different budget (e.g. a fast-path shutdown
+    /// triggered by SIGKILL-like signals).
+    pub async fn shutdown_all_with_timeout(&mut self, timeout: Duration) {
+        info!(
+            count = self.actors.len(),
+            timeout_secs = timeout.as_secs(),
+            "shutting down all actors"
+        );
 
         if let Some(ref router) = self.router {
             for id in self.actors.keys() {
@@ -605,19 +636,68 @@ impl NousManager {
             }
         }
 
-        let mut join_set: JoinSet<(String, Result<(), tokio::task::JoinError>)> = JoinSet::new();
+        // WHY: wrap each join in a timed future so we can log per-actor
+        // shutdown duration and force-abort any actor that overruns the
+        // shared budget. The budget is shared across all actors: a single
+        // actor that takes `timeout` seconds exhausts the pool, and any
+        // actor not yet drained is aborted.
+        let shutdown_start = std::time::Instant::now();
+        let mut join_set: JoinSet<(String, Duration, ShutdownOutcome)> = JoinSet::new();
         for (id, join_opt) in joins {
             if let Some(join) = join_opt {
-                join_set.spawn(async move { (id, join.await) });
+                join_set.spawn(async move {
+                    let started = std::time::Instant::now();
+                    // WHY: `JoinHandle` supports `abort_handle` so the timed
+                    // branch can cancel the task if the join overruns.
+                    let abort = join.abort_handle();
+                    let join_result = tokio::time::timeout(timeout, join).await;
+                    let elapsed = started.elapsed();
+                    match join_result {
+                        Ok(Ok(())) => (id, elapsed, ShutdownOutcome::Clean),
+                        Ok(Err(e)) => (id, elapsed, ShutdownOutcome::Panicked(e.to_string())),
+                        Err(_) => {
+                            abort.abort();
+                            (id, elapsed, ShutdownOutcome::TimedOut)
+                        }
+                    }
+                });
             }
         }
         while let Some(result) = join_set.join_next().await {
-            if let Ok((id, Err(e))) = result {
-                warn!(nous_id = %id, error = %e, "actor task panicked");
+            match result {
+                Ok((id, elapsed, ShutdownOutcome::Clean)) => {
+                    debug!(
+                        nous_id = %id,
+                        shutdown_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+                        "actor stopped cleanly"
+                    );
+                }
+                Ok((id, elapsed, ShutdownOutcome::Panicked(err))) => {
+                    warn!(
+                        nous_id = %id,
+                        shutdown_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+                        error = %err,
+                        "actor task panicked"
+                    );
+                }
+                Ok((id, elapsed, ShutdownOutcome::TimedOut)) => {
+                    warn!(
+                        nous_id = %id,
+                        shutdown_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+                        timeout_secs = timeout.as_secs(),
+                        "actor did not finish current turn within shutdown timeout — aborted"
+                    );
+                }
+                Err(e) => {
+                    warn!(error = %e, "shutdown tracker task failed");
+                }
             }
         }
 
-        info!("all actors stopped");
+        info!(
+            elapsed_ms = u64::try_from(shutdown_start.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "all actors stopped"
+        );
     }
 
     /// Cancel all actors and wait for them to drain, bounded by a timeout.

--- a/crates/nous/src/manager_tests.rs
+++ b/crates/nous/src/manager_tests.rs
@@ -450,6 +450,92 @@ async fn check_health_busy_actor_reports_alive() {
     );
 }
 
+/// `shutdown_all` must honour `shutdown_timeout_secs`: an actor whose task
+/// outlives the timeout is aborted via `JoinHandle::abort` and `shutdown_all`
+/// returns within `timeout + slack`. (#3382)
+#[tokio::test]
+async fn shutdown_all_timeout_aborts_stuck_actor() {
+    let (_dir, oikos) = make_oikos();
+    let mut mgr = make_manager(oikos);
+
+    // Spawn a real actor so the manager sees a normal ActorEntry.
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
+
+    // Swap the actor's join handle for a task that sleeps far longer than
+    // the shutdown budget. This simulates an actor blocked on a long-running
+    // turn: its run loop cannot observe the Shutdown message or cancel token
+    // until the sleep returns.
+    let blocking_join: JoinHandle<()> = tokio::spawn(async {
+        // WHY: 1 hour sleep stands in for a stuck turn; if the shutdown
+        // timeout path fails to abort it the test hangs for an hour.
+        tokio::time::sleep(Duration::from_hours(1)).await;
+    });
+    let blocking_abort = blocking_join.abort_handle();
+    {
+        let entry = mgr.actors.get("syn").expect("actor registered");
+        let mut guard = entry
+            .join
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Drop the real join handle; we don't need it for this test — the
+        // real actor is still alive, which is fine: it stops when the manager
+        // drops at end of test.
+        if let Some(original) = guard.take() {
+            original.abort();
+        }
+        *guard = Some(blocking_join);
+    }
+
+    let timeout = Duration::from_millis(250);
+    let started = std::time::Instant::now();
+    mgr.shutdown_all_with_timeout(timeout).await;
+    let elapsed = started.elapsed();
+
+    // Hard upper bound: must not take longer than timeout + 2s slack. Task
+    // scheduling + teardown adds a small amount over the raw timeout, but a
+    // failure to abort would leave the test hanging for 3600s.
+    assert!(
+        elapsed < timeout + Duration::from_secs(2),
+        "shutdown_all took {elapsed:?}, expected < {:?}",
+        timeout + Duration::from_secs(2)
+    );
+    // The stuck task must have been aborted.
+    assert!(
+        blocking_abort.is_finished(),
+        "stuck actor task should have been aborted by shutdown timeout"
+    );
+    assert_eq!(
+        mgr.count(),
+        0,
+        "manager should have zero actors after shutdown"
+    );
+}
+
+/// `shutdown_all` with a normal actor (no stuck turn) completes well within
+/// the configured budget and does not abort the task. Regression guard
+/// against the timeout path accidentally aborting healthy shutdowns. (#3382)
+#[tokio::test]
+async fn shutdown_all_completes_cleanly_under_budget() {
+    let (_dir, oikos) = make_oikos();
+    let mut mgr = make_manager(oikos);
+
+    mgr.spawn(syn_config(), PipelineConfig::default())
+        .await
+        .expect("spawn");
+
+    let started = std::time::Instant::now();
+    mgr.shutdown_all_with_timeout(Duration::from_secs(5)).await;
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "healthy shutdown took {elapsed:?}, expected well under 5s budget"
+    );
+    assert_eq!(mgr.count(), 0, "manager should be empty after shutdown");
+}
+
 #[test]
 fn backoff_calculation() {
     let max_secs = taxis::config::NousBehaviorConfig::default().manager_max_restart_backoff_secs;

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -135,6 +135,11 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         AletheiaConfig::default()
     });
 
+    // WHY: Emit a loud warning when authentication is disabled so operators
+    // see the consequence in every log aggregator, not just buried in the
+    // gateway config. (#3383)
+    taxis::validate::warn_if_auth_disabled(&aletheia_config);
+
     #[cfg(feature = "knowledge-store")]
     let knowledge_store = nous_manager.knowledge_store().cloned();
 

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -32,3 +32,4 @@ koina = { path = "../koina", features = ["test-support"] }
 figment = { workspace = true, features = ["test"] }
 proptest = { workspace = true }
 tempfile = { workspace = true }
+tracing-test = { workspace = true }

--- a/crates/taxis/src/config/behavior.rs
+++ b/crates/taxis/src/config/behavior.rs
@@ -199,6 +199,14 @@ pub struct NousBehaviorConfig {
     /// // TTL is a backstop rather than the primary freshness mechanism.
     /// // Set to 0 to disable the cache.
     pub bootstrap_cache_ttl_secs: u64,
+    /// Maximum seconds `NousManager::shutdown_all` waits for actors to finish
+    /// their current turn before aborting their tasks. Default: 30.
+    ///
+    /// WHY: Without a timeout, a long-running turn (e.g. a stuck LLM call or
+    /// deadlocked tool) blocks graceful shutdown indefinitely. When the
+    /// timeout expires, remaining actor tasks are aborted via
+    /// `JoinHandle::abort()` so the process can exit. (#3382)
+    pub shutdown_timeout_secs: u64,
 }
 
 impl Default for NousBehaviorConfig {
@@ -223,6 +231,7 @@ impl Default for NousBehaviorConfig {
             cycle_detection_max_len: 10,
             self_audit_event_threshold: 50,
             bootstrap_cache_ttl_secs: 60,
+            shutdown_timeout_secs: 30,
         }
     }
 }

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -243,16 +243,31 @@ fn validate_agents(value: &Value, errors: &mut Vec<String>) {
 
 const VALID_AUTH_MODES: &[&str] = &["none", "token", "jwt"];
 
+/// Environment variable operators must set to `1` in order to accept a config
+/// write that sets `gateway.auth.mode = "none"`.
+///
+/// WHY: Disabling authentication removes all access control from the HTTP API.
+/// Requiring an explicit opt-in prevents a remote PUT /api/v1/config/gateway
+/// from silently turning off auth. (#3383)
+pub const ALLOW_AUTH_NONE_ENV: &str = "ALETHEIA_ALLOW_AUTH_NONE";
+
 fn validate_gateway(value: &Value, errors: &mut Vec<String>) {
     check_port(value, "port", "port", errors);
 
     if let Some(auth) = value.get("auth")
         && let Some(mode) = auth.get("mode").and_then(Value::as_str)
-        && !VALID_AUTH_MODES.contains(&mode)
     {
-        errors.push(format!(
-            "gateway.auth.mode '{mode}' is invalid; must be one of: none, token, jwt"
-        ));
+        if !VALID_AUTH_MODES.contains(&mode) {
+            errors.push(format!(
+                "gateway.auth.mode '{mode}' is invalid; must be one of: none, token, jwt"
+            ));
+        } else if mode == "none" && !auth_none_opt_in_enabled() {
+            errors.push(format!(
+                "gateway.auth.mode = \"none\" disables all authentication and is \
+                 rejected by default; set the environment variable {ALLOW_AUTH_NONE_ENV}=1 \
+                 on the server process to opt in (intended for local dev only)"
+            ));
+        }
     }
 
     if let Some(cors) = value.get("cors") {
@@ -261,6 +276,33 @@ fn validate_gateway(value: &Value, errors: &mut Vec<String>) {
 
     if let Some(body_limit) = value.get("bodyLimit") {
         check_positive_u64(body_limit, "maxBytes", errors);
+    }
+}
+
+/// Return `true` when the operator has set `ALETHEIA_ALLOW_AUTH_NONE=1`.
+///
+/// This is the single gate that permits writing `auth_mode = "none"` through
+/// the config API. Reading a TOML file at startup with `auth_mode = "none"` is
+/// accepted regardless (operators have filesystem-level control of the file),
+/// but a loud warning is emitted via [`warn_if_auth_disabled`].
+#[must_use]
+pub fn auth_none_opt_in_enabled() -> bool {
+    std::env::var(ALLOW_AUTH_NONE_ENV).is_ok_and(|v| v == "1")
+}
+
+/// Emit a loud startup warning when authentication is disabled.
+///
+/// Called after the initial config load. Emits a single `warn!` event with the
+/// prefix `SECURITY: auth disabled` so operators running with `auth_mode = "none"`
+/// — even intentionally — see the consequence in every log aggregator. (#3383)
+pub fn warn_if_auth_disabled(config: &AletheiaConfig) {
+    if config.gateway.auth.mode == "none" {
+        tracing::warn!(
+            auth_mode = "none",
+            "SECURITY: auth disabled — all endpoints are unauthenticated; \
+             requests are served as role '{}'",
+            config.gateway.auth.none_role,
+        );
     }
 }
 
@@ -507,6 +549,7 @@ fn validate_nous_behavior(value: &Value, errors: &mut Vec<String>) {
     check_range_u64(value, "managerMaxRestartBackoffSecs", 1, 86_400, errors);
     check_range_u64(value, "managerRestartDrainTimeoutSecs", 1, 600, errors);
     check_range_u64(value, "managerRestartDecayWindowSecs", 60, 86_400, errors);
+    check_range_u64(value, "shutdownTimeoutSecs", 1, 3600, errors);
 }
 
 fn validate_knowledge(value: &Value, errors: &mut Vec<String>) {

--- a/crates/taxis/src/validate_tests.rs
+++ b/crates/taxis/src/validate_tests.rs
@@ -140,13 +140,78 @@ fn rejects_invalid_auth_mode() {
 
 #[test]
 fn accepts_valid_auth_modes() {
-    for mode in &["none", "token", "jwt"] {
+    for mode in &["token", "jwt"] {
         let section = json!({ "auth": { "mode": mode } });
         assert!(
             validate_section("gateway", &section).is_ok(),
             "mode '{mode}' should be valid"
         );
     }
+}
+
+/// Serialises tests that mutate `ALETHEIA_ALLOW_AUTH_NONE`. Cargo runs tests
+/// within a binary in parallel threads, and `std::env` is process-wide, so
+/// without a mutex the opt-in gate flips under another test's feet.
+static AUTH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// `auth.mode = "none"` is rejected by default: disabling authentication
+/// must be an explicit opt-in so a config PUT cannot silently remove access
+/// control. (#3383)
+#[test]
+fn auth_mode_none_env_gate() {
+    let _guard = AUTH_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    #[expect(
+        unsafe_code,
+        reason = "std::env::{set_var,remove_var} require unsafe in edition 2024; serialised via AUTH_ENV_LOCK"
+    )]
+    // SAFETY: `AUTH_ENV_LOCK` serialises all tests in this module that mutate
+    // ALLOW_AUTH_NONE_ENV; no other test in the crate touches this var.
+    unsafe {
+        std::env::remove_var(crate::validate::ALLOW_AUTH_NONE_ENV);
+    }
+
+    // Without opt-in: reject, and point the operator at the env var.
+    let section = json!({ "auth": { "mode": "none" } });
+    let rejected = validate_section("gateway", &section);
+    assert!(
+        rejected.is_err(),
+        "auth_mode = none must be rejected without env opt-in"
+    );
+    let err = rejected.unwrap_err();
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| e.contains(crate::validate::ALLOW_AUTH_NONE_ENV)),
+        "error should mention the env-var opt-in: {err:?}"
+    );
+
+    // With opt-in: accept.
+    #[expect(
+        unsafe_code,
+        reason = "std::env::set_var requires unsafe in edition 2024; serialised via AUTH_ENV_LOCK"
+    )]
+    // SAFETY: `AUTH_ENV_LOCK` held for the duration of this test.
+    unsafe {
+        std::env::set_var(crate::validate::ALLOW_AUTH_NONE_ENV, "1");
+    }
+    let accepted = validate_section("gateway", &section);
+
+    #[expect(
+        unsafe_code,
+        reason = "std::env::remove_var requires unsafe in edition 2024; serialised via AUTH_ENV_LOCK"
+    )]
+    // SAFETY: Cleanup so later tests see an unset var.
+    unsafe {
+        std::env::remove_var(crate::validate::ALLOW_AUTH_NONE_ENV);
+    }
+
+    assert!(
+        accepted.is_ok(),
+        "auth_mode = none must be accepted with env opt-in: {accepted:?}"
+    );
 }
 
 #[test]
@@ -643,6 +708,41 @@ fn validate_startup_passes_with_complete_layout() {
             .iter()
             .all(|e| !e.contains("required instance directory")),
         "no subdirectory errors should be present when layout is complete: {err:?}"
+    );
+}
+
+// --- Auth-disabled startup warning (#3383) ---
+
+/// When `gateway.auth.mode = "none"`, `warn_if_auth_disabled` must emit a
+/// single `warn!` event prefixed `SECURITY: auth disabled` so operators see
+/// the disabled state in every log aggregator.
+#[test]
+#[tracing_test::traced_test]
+fn warn_if_auth_disabled_emits_security_warning() {
+    let mut config = AletheiaConfig::default();
+    config.gateway.auth.mode = "none".to_owned();
+
+    crate::validate::warn_if_auth_disabled(&config);
+
+    assert!(
+        logs_contain("SECURITY: auth disabled"),
+        "warn should carry the SECURITY prefix so log aggregators surface it"
+    );
+    assert!(
+        logs_contain("WARN"),
+        "warning must be at warn level, not info"
+    );
+}
+
+/// When `gateway.auth.mode != "none"`, no warning is emitted.
+#[test]
+#[tracing_test::traced_test]
+fn warn_if_auth_disabled_silent_when_auth_enabled() {
+    let config = AletheiaConfig::default(); // default: mode = "token"
+    crate::validate::warn_if_auth_disabled(&config);
+    assert!(
+        !logs_contain("SECURITY: auth disabled"),
+        "no warning should fire when auth is enabled"
     );
 }
 


### PR DESCRIPTION
## Summary
- Config PUT rejects `auth_mode=none` unless `ALETHEIA_ALLOW_AUTH_NONE=1` (422 + clear error)
- Startup warns when auth is disabled
- `NousManager::shutdown_all` now has a configurable timeout (default 30s); stuck actors are aborted

Closes #3383
Closes #3382

## Test plan
- [x] `cargo check -p nous -p pylon -p taxis --tests` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)