### PR TITLE
security: scrub exec tool env, fix cleartext logging/transmission alerts (#3374)

### DIFF
--- a/crates/aletheia/src/commands/credential.rs
+++ b/crates/aletheia/src/commands/credential.rs
@@ -66,7 +66,9 @@ pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Resu
                 };
                 println!("Source:        file ({})", cred_path.display());
                 println!("Type:          {cred_type}");
-                // SAFETY: token_preview redacts to first 4 + last 3 chars only (7 of ~100+)
+                // CodeQL: cleartext-logging false positive — token_preview() redacts
+                // to first 4 + last 3 chars only (7 of ~100+ char token). This is
+                // standard practice for credential status display (cf. `gh auth status`).
                 println!(
                     "Token:         {}",
                     token_preview(cred.token.expose_secret())
@@ -103,7 +105,9 @@ pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Resu
                     found_any = true;
                     println!("Source:        keyring (OS)");
                     println!("Type:          static API key");
-                    // SAFETY: token_preview redacts to first 4 + last 3 chars only (7 of ~100+)
+                    // CodeQL: cleartext-logging false positive — token_preview() redacts
+                    // to first 4 + last 3 chars only (7 of ~100+ char token). Same
+                    // masking as the file credential display above.
                     println!(
                         "Token:         {}",
                         token_preview(cred.secret.expose_secret())

--- a/crates/aletheia/src/commands/session_export.rs
+++ b/crates/aletheia/src/commands/session_export.rs
@@ -105,12 +105,11 @@ async fn fetch_session(
         );
     }
     let url = format!("{base_url}{API_V1}/sessions/{session_id}");
-    // SAFETY: cleartext transmission risk is mitigated. The CLI default is
+    // CodeQL: cleartext-transmission false positive. The CLI default is
     // localhost (http://127.0.0.1:18789) which never leaves the machine. The
-    // guard above (lines 97-106) logs a warning when the operator overrides
-    // --url to a non-HTTPS, non-localhost target, making the risk explicit.
-    // This is a local operator tool, not a library API — the operator controls
-    // the URL and accepts the risk when pointing at a remote HTTP endpoint.
+    // guard above logs a tracing::warn when the operator overrides --url to a
+    // non-HTTPS, non-localhost target, making the risk explicit. This is a
+    // local operator tool, not a library API — the operator controls the URL.
     let resp = client.get(&url).send().await.map_err(|e| {
         if e.is_connect() {
             crate::error::Error::msg(format!(
@@ -150,9 +149,8 @@ async fn fetch_history(
         );
     }
     let url = format!("{base_url}{API_V1}/sessions/{session_id}/history");
-    // SAFETY: cleartext transmission risk is mitigated — see the identical
-    // comment in `fetch_session` above. The non-HTTPS guard on lines 137-145
-    // warns when the operator targets a remote HTTP endpoint.
+    // CodeQL: cleartext-transmission false positive — same mitigation as
+    // `fetch_session` above: localhost default + tracing::warn on non-HTTPS.
     let resp = client
         .get(&url)
         .send()

--- a/crates/episteme/src/consolidation/engine.rs
+++ b/crates/episteme/src/consolidation/engine.rs
@@ -24,7 +24,9 @@ use crate::knowledge_store::KnowledgeStore;
 /// should never be negative). When detected, a warning is logged with the
 /// raw value and the function returns 0 for operational continuity.
 fn i64_as_usize(v: i64) -> usize {
-    if let Ok(n) = v.try_into() { n } else {
+    if let Ok(n) = v.try_into() {
+        n
+    } else {
         // WHY: negative counts are a data corruption indicator — surface it
         // via logging rather than silently defaulting.
         tracing::warn!(

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -807,7 +807,7 @@ impl AnthropicProvider {
                 headers.insert("idempotency-key", val);
             }
 
-            // SAFETY: cleartext transmission is impossible here. Both constructors
+            // CodeQL: cleartext-transmission false positive. Both constructors
             // (`from_config` and `with_credential_provider`) reject non-HTTPS base
             // URLs unless the target is loopback (localhost / 127.0.0.1). The
             // `base_url` field is immutable after construction, so by the time we

--- a/crates/hermeneus/src/cc/process_tests.rs
+++ b/crates/hermeneus/src/cc/process_tests.rs
@@ -484,9 +484,8 @@ async fn read_stream_rejects_oversized_output_by_bytes() {
     // WHY: A CC subprocess that outputs more than MAX_OUTPUT_BYTES must be
     // rejected with a clear error, not allowed to grow unbounded to OOM.
     let big_text = "x".repeat(MAX_OUTPUT_BYTES + 1);
-    let event = format!(
-        r#"{{"type":"assistant","message":{{"type":"text","text":"{big_text}"}}}}"#
-    );
+    let event =
+        format!(r#"{{"type":"assistant","message":{{"type":"text","text":"{big_text}"}}}}"#);
     let buf = stream_buf(&[&event]);
     let err = read_stream(buf.as_slice()).await.unwrap_err();
     let msg = err.to_string();
@@ -500,9 +499,8 @@ async fn read_stream_rejects_oversized_output_by_bytes() {
 async fn read_stream_with_callback_rejects_oversized_output() {
     // WHY: The streaming variant must enforce the same size limits.
     let big_text = "x".repeat(MAX_OUTPUT_BYTES + 1);
-    let event = format!(
-        r#"{{"type":"assistant","message":{{"type":"text","text":"{big_text}"}}}}"#
-    );
+    let event =
+        format!(r#"{{"type":"assistant","message":{{"type":"text","text":"{big_text}"}}}}"#);
     let buf = stream_buf(&[&event]);
     let mut on_delta = |_: &str| {};
     let err = read_stream_with_callback(buf.as_slice(), &mut on_delta)
@@ -519,12 +517,9 @@ async fn read_stream_with_callback_rejects_oversized_output() {
 async fn read_stream_accepts_output_within_limits() {
     // WHY: Output within the byte limit must succeed normally.
     let text = "x".repeat(1000);
-    let event = format!(
-        r#"{{"type":"assistant","message":{{"type":"text","text":"{text}"}}}}"#
-    );
-    let result_event = format!(
-        r#"{{"type":"result","subtype":"success","result":"{text}","is_error":false}}"#
-    );
+    let event = format!(r#"{{"type":"assistant","message":{{"type":"text","text":"{text}"}}}}"#);
+    let result_event =
+        format!(r#"{{"type":"result","subtype":"success","result":"{text}","is_error":false}}"#);
     let buf = stream_buf(&[&event, &result_event]);
     let output = read_stream(buf.as_slice()).await.unwrap();
     assert_eq!(output.result_text, text);

--- a/crates/koina/tests/public_api.rs
+++ b/crates/koina/tests/public_api.rs
@@ -187,12 +187,14 @@ mod uuid {
         let s = uuid_v4();
         let chars: Vec<char> = s.chars().collect();
         // Index after first 8 hex + first hyphen + 4 hex + second hyphen = 14
-        // codequality:ignore — test-generated UUID, not a credential or sensitive value
+        // CodeQL: cleartext-logging false positive — `s` is a freshly generated random
+        // UUID v4 from uuid_v4(), not a credential, password, or sensitive value.
+        // The assert message includes it for test failure diagnostics only.
         assert_eq!(
             chars[14], '4',
             "UUID v4 version marker should be '4' at position 14, got: {s}"
         );
-        // codequality:ignore — test-generated UUID, not a credential or sensitive value
+        // CodeQL: cleartext-logging false positive — same as above; random UUID, not a secret.
         assert!(
             matches!(chars[19], '8' | '9' | 'a' | 'b'),
             "UUID v4 variant should be 8/9/a/b at position 19, got: {s}"

--- a/crates/krites/src/fts/tokenizer/mod.rs
+++ b/crates/krites/src/fts/tokenizer/mod.rs
@@ -56,9 +56,6 @@ pub(crate) mod tests {
             token.offset_from, from,
             "expected offset_from {from} but {token:?}"
         );
-        assert_eq!(
-            token.offset_to, to,
-            "expected offset_to {to} but {token:?}"
-        );
+        assert_eq!(token.offset_to, to, "expected offset_to {to} but {token:?}");
     }
 }

--- a/crates/krites/src/runtime/hnsw/put.rs
+++ b/crates/krites/src/runtime/hnsw/put.rs
@@ -463,6 +463,9 @@ impl SessionTx<'_> {
                 .into());
             }
             if current >= warn_threshold {
+                // CodeQL: cleartext-logging false positive — index_name, current,
+                // and max_cap are internal HNSW metadata (table name and integer
+                // counters), not credentials or user-supplied sensitive data.
                 warn!(
                     index = %manifest.index_name,
                     current,

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -545,11 +545,38 @@ fn parse_command_args(command: &str) -> std::result::Result<(String, Vec<String>
     Ok((program, args))
 }
 
+/// WHY: The parent process holds API keys (`ANTHROPIC_API_KEY`,
+/// `ANTHROPIC_AUTH_TOKEN`, `ALETHEIA_*`, etc.) in its environment. Without
+/// clearing, any child process spawned by the exec tool inherits these secrets,
+/// enabling exfiltration via prompt injection (e.g., `exec env | grep API`).
+/// The Landlock sandbox restricts filesystem access but NOT env var reading —
+/// env vars are process state, not filesystem objects.
+///
+/// We clear the entire environment and re-add only variables needed for basic
+/// process operation. Operators needing additional variables should add them to
+/// the `SandboxConfig` allowlist. Closes #3374.
+const SAFE_ENV_VARS: &[&str] = &[
+    "PATH",
+    "HOME",
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "USER",
+    "SHELL",
+    "TMPDIR",
+    "XDG_RUNTIME_DIR",
+    "TZ",
+];
+
 struct ExecExecutor {
     sandbox: crate::sandbox::SandboxConfig,
 }
 
 impl ToolExecutor for ExecExecutor {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "env sanitization (#3374) + sandbox + rlimit setup in a single spawn sequence; splitting obscures the security-critical ordering"
+    )]
     fn execute<'a>(
         &'a self,
         input: &'a ToolInput,
@@ -577,6 +604,15 @@ impl ToolExecutor for ExecExecutor {
                 .current_dir(&ctx.workspace)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
+
+            // WHY: Clear inherited environment to prevent API key exfiltration.
+            // See SAFE_ENV_VARS constant for rationale. Closes #3374.
+            cmd.env_clear();
+            for &var in SAFE_ENV_VARS {
+                if let Some(val) = std::env::var_os(var) {
+                    cmd.env(var, val);
+                }
+            }
 
             // WHY: Apply process resource limits before sandbox to constrain fork-bombs
             // and runaway CPU usage. RLIMIT_NPROC caps child process count;

--- a/crates/organon/src/builtins/workspace_tests/path_ops.rs
+++ b/crates/organon/src/builtins/workspace_tests/path_ops.rs
@@ -488,3 +488,80 @@ async fn test_write_append_creates_file_when_absent() {
         "append mode should create the file with the provided content"
     );
 }
+
+/// WHY: Validates the fix for #3374 — the exec tool must clear the parent
+/// environment before spawning so API keys cannot be exfiltrated via prompt
+/// injection (e.g., `exec env | grep ANTHROPIC`).
+#[tokio::test]
+async fn exec_env_does_not_leak_api_keys() {
+    // Inject a fake API key into the parent environment for this test.
+    // SAFETY: this is single-threaded test code; the env var is removed
+    // in the assertion below regardless of outcome.
+    #[expect(
+        unsafe_code,
+        reason = "set_var requires unsafe in Rust 2024; test-only, single-threaded"
+    )]
+    unsafe {
+        std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-test-secret-key-value");
+        std::env::set_var("ALETHEIA_TOKEN", "aletheia-test-secret-token");
+    }
+
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input("exec", serde_json::json!({ "command": "env" }));
+    let result = ExecExecutor {
+        sandbox: crate::sandbox::SandboxConfig::disabled(),
+    }
+    .execute(&input, &ctx)
+    .await
+    .expect("execute");
+
+    // Clean up injected vars (best-effort; test failure is still valid).
+    #[expect(
+        unsafe_code,
+        reason = "remove_var requires unsafe in Rust 2024; test cleanup"
+    )]
+    unsafe {
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("ALETHEIA_TOKEN");
+    }
+
+    let output = result.content.text_summary();
+    assert!(
+        !output.contains("sk-ant-test-secret-key-value"),
+        "child process must not inherit ANTHROPIC_API_KEY from parent environment"
+    );
+    assert!(
+        !output.contains("aletheia-test-secret-token"),
+        "child process must not inherit ALETHEIA_TOKEN from parent environment"
+    );
+    assert!(
+        !output.contains("ANTHROPIC_API_KEY"),
+        "child process env must not contain the ANTHROPIC_API_KEY variable name"
+    );
+    assert!(
+        !output.contains("ALETHEIA_TOKEN"),
+        "child process env must not contain the ALETHEIA_TOKEN variable name"
+    );
+}
+
+/// Validates that the `SAFE_ENV_VARS` allowlist is effective -- PATH should be
+/// present in the child environment so basic commands work.
+#[tokio::test]
+async fn exec_env_preserves_safe_vars() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let ctx = test_ctx(dir.path());
+    let input = tool_input("exec", serde_json::json!({ "command": "env" }));
+    let result = ExecExecutor {
+        sandbox: crate::sandbox::SandboxConfig::disabled(),
+    }
+    .execute(&input, &ctx)
+    .await
+    .expect("execute");
+
+    let output = result.content.text_summary();
+    assert!(
+        output.contains("PATH="),
+        "child process should inherit PATH from the safe env allowlist"
+    );
+}

--- a/crates/pylon/src/pagination.rs
+++ b/crates/pylon/src/pagination.rs
@@ -105,7 +105,13 @@ mod tests {
     #[test]
     fn from_vec_with_cursor_skips_past_it() {
         let items: Vec<String> = (0..10).map(|i| format!("item-{i}")).collect();
-        let resp = PaginatedResponse::from_vec(items, 3, Some("item-2"), std::clone::Clone::clone, Some(10));
+        let resp = PaginatedResponse::from_vec(
+            items,
+            3,
+            Some("item-2"),
+            std::clone::Clone::clone,
+            Some(10),
+        );
         assert_eq!(resp.items.len(), 3);
         assert_eq!(resp.items[0], "item-3");
         assert!(resp.has_more);
@@ -124,7 +130,13 @@ mod tests {
     #[test]
     fn from_vec_cursor_not_found_returns_all() {
         let items: Vec<String> = (0..3).map(|i| format!("item-{i}")).collect();
-        let resp = PaginatedResponse::from_vec(items, 10, Some("nonexistent"), std::clone::Clone::clone, None);
+        let resp = PaginatedResponse::from_vec(
+            items,
+            10,
+            Some("nonexistent"),
+            std::clone::Clone::clone,
+            None,
+        );
         assert_eq!(resp.items.len(), 3);
         assert!(!resp.has_more);
     }


### PR DESCRIPTION
## Summary

- **Exec tool env leak (#3374):** Child processes spawned by the `exec` tool now start with a clean environment (`cmd.env_clear()`) and only inherit safe variables from a constant allowlist (`SAFE_ENV_VARS`): PATH, HOME, TERM, LANG, LC_ALL, USER, SHELL, TMPDIR, XDG_RUNTIME_DIR, TZ. Prevents exfiltration of `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ALETHEIA_*`, etc. via prompt injection.
- **CodeQL alerts:** 7 cleartext-logging/transmission alerts reviewed; all false positives, suppressed with justification comments.
- **Tests:** Two new tests verify API keys are absent from child env and safe vars (PATH) are preserved.

## CodeQL alert disposition

| # | Location | Alert | Verdict | Reason |
|---|----------|-------|---------|--------|
| 1 | `krites/runtime/hnsw/put.rs` | cleartext-logging | **False positive** | Logs index name and integer counters (internal HNSW metadata), not credentials or PII |
| 2 | `koina/tests/public_api.rs:190,194` | cleartext-logging | **False positive** | Test-generated random UUID in assert message, not a credential |
| 3 | `hermeneus/anthropic/client.rs:755` | cleartext-transmission | **False positive** | Constructors reject non-HTTPS base URLs unless loopback; scheme validated before any request |
| 4 | `aletheia/commands/credential.rs:69` | cleartext-logging | **False positive** | `token_preview()` redacts to first 4 + last 3 chars only (7 of ~100+) |
| 5 | `aletheia/commands/credential.rs:105` | cleartext-logging | **False positive** | Same `token_preview()` masking as above |
| 6 | `aletheia/commands/session_export.rs:109` | cleartext-transmission | **False positive** | CLI default is localhost; tracing::warn guard on non-HTTPS/non-localhost override |
| 7 | `aletheia/commands/session_export.rs:150` | cleartext-transmission | **False positive** | Same localhost guard as fetch_session |

## Test plan

- [x] `cargo check -p organon -p krites -p koina -p hermeneus -p aletheia --tests` passes
- [x] `cargo clippy -p organon --tests -- -D warnings` passes (krites has pre-existing clippy failures; hermeneus cc/process.rs too_many_lines is pre-existing when compiled via aletheia)
- [x] `cargo test -p organon` passes (440 tests, including 2 new)
- [x] `exec_env_does_not_leak_api_keys`: sets `ANTHROPIC_API_KEY` and `ALETHEIA_TOKEN` in parent, verifies child `env` output contains neither
- [x] `exec_env_preserves_safe_vars`: verifies child `env` output contains `PATH=`

Closes #3374

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>