### PR TITLE
chore(deps): upgrade qdrant-client, drop tonic 0.12 chain (#3500)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,8 +14,4 @@ ignore = [
     "RUSTSEC-2025-0141",
     # paste unmaintained — transitive via tokenizers; no safe upgrade
     "RUSTSEC-2024-0436",
-    # rustls-pemfile unmaintained — transitive via tonic/qdrant-client; tracked in follow-up issue
-    "RUSTSEC-2025-0134",
-    # rand 0.8.5 unsound with custom logger using rand::rng() — transitive via tonic/qdrant-client; tracked in follow-up issue
-    "RUSTSEC-2026-0097",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -17,14 +17,6 @@ reason = "bincode unmaintained — transitive via syntect/aletheia-tui, no safe 
 id = "RUSTSEC-2024-0436"
 reason = "paste unmaintained, transitive via tokenizers; no safe upgrade"
 
-[[advisories.ignore]]
-id = "RUSTSEC-2025-0134"
-reason = "rustls-pemfile unmaintained — transitive via tonic 0.12/qdrant-client 1.17; tracked in follow-up issue to upgrade qdrant-client when its tonic upgrades"
-
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0097"
-reason = "rand 0.8.5 unsound only when a custom logger calls rand::rng() — we don't; transitive via tonic 0.12/qdrant-client 1.17 and rust_decimal/spreadsheet-ods; tracked in follow-up issue"
-
 [licenses]
 allow = [
     "MIT",


### PR DESCRIPTION
## Summary
- qdrant-client upgraded, tonic 0.12 chain dropped
- deny.toml and audit.toml ignores cleaned

Closes #3500

🤖 Kimi okabe (v1.30.0)