### PR TITLE
fix: lazy embedding load + fjall backup mechanism (#3474 #3381)

### DIFF
--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -33,6 +33,9 @@ pub(crate) struct BackupArgs {
     /// Skip confirmation prompt when pruning
     #[arg(long)]
     pub yes: bool,
+    /// Operate on fjall knowledge store instead of SQLite session store
+    #[arg(long)]
+    pub fjall: bool,
 }
 
 pub(crate) fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<()> {
@@ -43,8 +46,13 @@ pub(crate) fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<
         export_json,
         json,
         yes,
+        fjall,
     } = args;
     let oikos = super::resolve_oikos(instance_root)?;
+
+    if fjall {
+        return run_fjall(&oikos, list, prune, keep, json, yes);
+    }
 
     let db_path = oikos.sessions_db();
     let store = SessionStore::open(&db_path).with_whatever_context(|_| {
@@ -90,6 +98,108 @@ pub(crate) fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<
         None => println!("Backup skipped: disk space critical."),
     }
 
+    Ok(())
+}
+
+/// Handle fjall knowledge store backup operations.
+fn run_fjall(
+    oikos: &taxis::oikos::Oikos,
+    list: bool,
+    prune: bool,
+    keep: usize,
+    json: bool,
+    yes: bool,
+) -> Result<()> {
+    use oikonomos::maintenance::{FjallBackup, FjallBackupConfig};
+
+    let config = FjallBackupConfig {
+        enabled: true,
+        source_dir: oikos.knowledge_db(),
+        backup_dir: oikos.backups().join("fjall"),
+        interval_hours: 24,
+        retention_count: keep,
+    };
+    let manager = FjallBackup::new(config);
+
+    if list {
+        let backups = manager
+            .list_backups()
+            .whatever_context("failed to list fjall backups")?;
+        if json {
+            let items: Vec<serde_json::Value> = backups
+                .iter()
+                .map(|b| {
+                    serde_json::json!({
+                        "name": b.name,
+                        "size_bytes": b.size_bytes,
+                        "path": b.path.to_string_lossy(),
+                    })
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&items)
+                    .whatever_context("failed to serialize backups")?
+            );
+        } else if backups.is_empty() {
+            println!("No fjall backups found.");
+        } else {
+            for b in &backups {
+                let mb = b.size_bytes / (1024 * 1024);
+                println!("{} ({mb} MB)", b.name);
+            }
+        }
+        return Ok(());
+    }
+
+    if prune {
+        let backups = manager
+            .list_backups()
+            .whatever_context("failed to list fjall backups")?;
+        let to_remove: Vec<_> = backups.iter().skip(keep).collect();
+        if to_remove.is_empty() {
+            println!(
+                "Nothing to prune: {} fjall backup(s) found, keeping {keep}.",
+                backups.len()
+            );
+            return Ok(());
+        }
+        if !yes {
+            println!("The following fjall backup(s) will be deleted:");
+            for b in &to_remove {
+                println!("  {} ({} bytes)", b.name, b.size_bytes);
+            }
+            print!("Proceed? [y/N] ");
+            std::io::Write::flush(&mut std::io::stdout())
+                .whatever_context("failed to flush stdout")?;
+            let mut input = String::new();
+            std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut input)
+                .whatever_context("failed to read confirmation")?;
+            if !input.trim().eq_ignore_ascii_case("y") {
+                println!("Aborted.");
+                return Ok(());
+            }
+        }
+        for entry in to_remove {
+            std::fs::remove_dir_all(&entry.path).whatever_context("failed to remove backup")?;
+        }
+        println!("Pruned fjall backups, kept {keep}.");
+        return Ok(());
+    }
+
+    // Default: create a new fjall backup.
+    let report = manager
+        .create_backup()
+        .whatever_context("failed to create fjall backup")?;
+    match report.backup_path {
+        Some(path) => println!(
+            "Fjall backup created: {} ({} files, {} bytes)",
+            path.display(),
+            report.files_copied,
+            report.bytes_copied,
+        ),
+        None => println!("Fjall backup skipped: knowledge store directory not found."),
+    }
     Ok(())
 }
 

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -7,7 +7,7 @@ use snafu::prelude::*;
 
 use oikonomos::maintenance::{
     AutoDreamConfig, DbMonitor, DbMonitoringConfig, DriftDetectionConfig, DriftDetector,
-    MaintenanceConfig, ProposeRulesConfig, TraceRotationConfig, TraceRotator,
+    FjallBackupConfig, MaintenanceConfig, ProposeRulesConfig, TraceRotationConfig, TraceRotator,
 };
 use oikonomos::runner::TaskRunner;
 use taxis::loader::load_config;
@@ -66,7 +66,12 @@ pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()>
         }
         Action::Run { task, verbose } => {
             let tasks: Vec<&str> = if task == "all" {
-                vec!["trace-rotation", "drift-detection", "db-monitor"]
+                vec![
+                    "trace-rotation",
+                    "drift-detection",
+                    "db-monitor",
+                    "fjall-backup",
+                ]
             } else {
                 vec![task.as_str()]
             };
@@ -126,6 +131,22 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
                 );
             }
         }
+        "fjall-backup" => {
+            let manager = oikonomos::maintenance::FjallBackup::new(maint.fjall_backup.clone());
+            let report = manager
+                .create_backup()
+                .whatever_context("fjall backup failed")?;
+            match report.backup_path {
+                Some(path) => println!(
+                    "fjall-backup: {} files copied ({} bytes) to {}, {} old backups pruned",
+                    report.files_copied,
+                    report.bytes_copied,
+                    path.display(),
+                    report.backups_pruned,
+                ),
+                None => println!("fjall-backup: skipped (source directory not found)"),
+            }
+        }
         "self-audit" => {
             use nous::self_audit::{AuditTrigger, CheckContext, SelfAuditor};
             let mut auditor = SelfAuditor::new();
@@ -146,7 +167,7 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
             }
         }
         other => whatever!(
-            "unknown task: {other}. Valid: trace-rotation, drift-detection, db-monitor, self-audit, all"
+            "unknown task: {other}. Valid: trace-rotation, drift-detection, db-monitor, fjall-backup, self-audit, all"
         ),
     }
     Ok(())
@@ -189,6 +210,13 @@ pub(crate) fn build_config(
         knowledge_maintenance: oikonomos::maintenance::KnowledgeMaintenanceConfig {
             enabled: settings.knowledge_maintenance_enabled,
             auto_dream: AutoDreamConfig::default(),
+        },
+        fjall_backup: FjallBackupConfig {
+            enabled: settings.backup.enabled,
+            source_dir: oikos.knowledge_db(),
+            backup_dir: oikos.backups().join("fjall"),
+            interval_hours: settings.backup.backup_interval_hours,
+            retention_count: settings.backup.backup_retention_count,
         },
         propose_rules: ProposeRulesConfig::default(),
         cron: oikonomos::cron::CronConfig {

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -379,9 +379,20 @@ impl RuntimeBuilder {
 
         let tool_registry = Arc::new(tool_registry);
 
-        // Embedding provider
-        let embedding_provider = if self.embedding {
-            create_embedding_provider(&self.config.embedding)
+        // Embedding provider — lazy initialization (#3474)
+        //
+        // WHY: the embedding model download/load can be slow or fail. Loading
+        // synchronously here blocks the HTTP gateway from binding. Wrapping in
+        // `LazyEmbeddingProvider` lets the gateway start immediately and defers
+        // the real init to first use.
+        let embedding_provider: Arc<dyn mneme::embedding::EmbeddingProvider> = if self.embedding {
+            let lazy = Arc::new(LazyEmbeddingProvider::new(self.config.embedding.clone()));
+            // Spawn background init so the model loads without blocking startup.
+            let lazy_clone = Arc::clone(&lazy);
+            tokio::spawn(async move {
+                lazy_clone.get().await;
+            });
+            lazy
         } else {
             Arc::new(DegradedEmbeddingProvider::new(
                 self.config.embedding.dimension,
@@ -746,6 +757,6 @@ mod tool_adapters;
 #[cfg(feature = "recall")]
 use setup::open_knowledge_store;
 use setup::{
-    build_provider_registry, build_signal_provider, build_tool_registry, create_embedding_provider,
+    LazyEmbeddingProvider, build_provider_registry, build_signal_provider, build_tool_registry,
     start_inbound_dispatch,
 };

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -216,34 +216,131 @@ pub(super) fn build_tool_registry(
     Ok(registry)
 }
 
-pub(super) fn create_embedding_provider(
-    settings: &EmbeddingSettings,
-) -> Arc<dyn EmbeddingProvider> {
-    let embedding_config = EmbeddingConfig {
-        provider: settings.provider.clone(),
-        model: settings.model.clone(),
-        dimension: Some(settings.dimension),
-        api_key: None,
-    };
-    match create_provider(&embedding_config) {
-        Ok(p) => {
-            info!(
-                provider = %settings.provider,
-                dim = settings.dimension,
-                "embedding provider created"
-            );
-            Arc::from(p)
-        }
-        Err(e) => {
-            warn!(
-                error = %e,
-                provider = %settings.provider,
-                "embedding provider failed to load: starting in degraded mode \
-                 (recall and vector search unavailable)"
-            );
-            Arc::new(DegradedEmbeddingProvider::new(settings.dimension))
+/// Lazily-initialized embedding provider.
+///
+/// WHY (#3474): the embedding model download and initialization can be slow
+/// (network fetch, model load) or fail transiently. Loading synchronously
+/// during server startup blocks the HTTP gateway from accepting health
+/// checks, making the server appear dead. This wrapper defers the real
+/// initialization to first use so the gateway can bind immediately.
+pub(crate) struct LazyEmbeddingProvider {
+    inner: tokio::sync::OnceCell<Arc<dyn EmbeddingProvider>>,
+    /// Fallback provider returned before initialization completes.
+    degraded: DegradedEmbeddingProvider,
+    settings: EmbeddingSettings,
+    dimension: usize,
+}
+
+impl LazyEmbeddingProvider {
+    pub(crate) fn new(settings: EmbeddingSettings) -> Self {
+        let dimension = settings.dimension;
+        Self {
+            inner: tokio::sync::OnceCell::new(),
+            degraded: DegradedEmbeddingProvider::new(dimension),
+            settings,
+            dimension,
         }
     }
+
+    /// Returns the underlying provider, initializing on first call.
+    ///
+    /// If initialization fails, stores a `DegradedEmbeddingProvider` so
+    /// subsequent calls do not retry a broken init path.
+    pub(crate) async fn get(&self) -> &Arc<dyn EmbeddingProvider> {
+        self.inner
+            .get_or_init(|| async {
+                let embedding_config = EmbeddingConfig {
+                    provider: self.settings.provider.clone(),
+                    model: self.settings.model.clone(),
+                    dimension: Some(self.settings.dimension),
+                    api_key: None,
+                };
+                #[expect(
+                    clippy::as_conversions,
+                    reason = "coercion to dyn EmbeddingProvider trait object: required for OnceCell<Arc<dyn Trait>>"
+                )]
+                match create_provider(&embedding_config) {
+                    Ok(p) => {
+                        info!(
+                            provider = %self.settings.provider,
+                            dim = self.settings.dimension,
+                            "embedding provider initialized (lazy)"
+                        );
+                        Arc::from(p) as Arc<dyn EmbeddingProvider>
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            provider = %self.settings.provider,
+                            "embedding provider failed to load: degraded mode \
+                             (recall and vector search unavailable)"
+                        );
+                        Arc::new(DegradedEmbeddingProvider::new(self.settings.dimension))
+                            as Arc<dyn EmbeddingProvider>
+                    }
+                }
+            })
+            .await
+    }
+
+    /// Returns `true` if the provider has been initialized and is NOT degraded.
+    #[expect(
+        dead_code,
+        reason = "diagnostic helper for callers that need to check provider readiness"
+    )]
+    fn is_ready(&self) -> bool {
+        self.inner
+            .get()
+            .is_some_and(|p| !mneme::embedding::is_degraded_provider(p.as_ref()))
+    }
+
+    /// Returns `true` if initialization has started (provider present, degraded or not).
+    #[expect(
+        dead_code,
+        reason = "diagnostic helper for callers that need to check init status"
+    )]
+    fn is_initialized(&self) -> bool {
+        self.inner.get().is_some()
+    }
+}
+
+impl EmbeddingProvider for LazyEmbeddingProvider {
+    fn embed(&self, text: &str) -> std::result::Result<Vec<f32>, mneme::embedding::EmbeddingError> {
+        match self.inner.get() {
+            Some(provider) => provider.embed(text),
+            // WHY: before init completes, delegate to the degraded provider
+            // which returns a descriptive error for callers that need embeddings.
+            None => self.degraded.embed(text),
+        }
+    }
+
+    fn embed_batch(
+        &self,
+        texts: &[&str],
+    ) -> std::result::Result<Vec<Vec<f32>>, mneme::embedding::EmbeddingError> {
+        match self.inner.get() {
+            Some(provider) => provider.embed_batch(texts),
+            None => self.degraded.embed_batch(texts),
+        }
+    }
+
+    fn dimension(&self) -> usize {
+        self.inner.get().map_or(self.dimension, |p| p.dimension())
+    }
+
+    fn model_name(&self) -> &str {
+        match self.inner.get() {
+            Some(provider) => provider.model_name(),
+            None => LazyEmbeddingProvider::LOADING_MODEL_NAME,
+        }
+    }
+}
+
+impl LazyEmbeddingProvider {
+    /// Sentinel model name reported while the provider is still loading.
+    ///
+    /// Health checks use this to report `"degraded: embedding-loading"`.
+    pub(crate) const LOADING_MODEL_NAME: &'static str = "embedding-loading";
 }
 
 #[cfg(feature = "recall")]

--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -359,6 +359,33 @@ pub(crate) async fn execute_builtin(
                 ),
             })
         }
+        BuiltinTask::FjallBackup => {
+            let config = maintenance
+                .map(|m| m.fjall_backup.clone())
+                .unwrap_or_default();
+            let report = tokio::task::spawn_blocking(move || {
+                let _span = tracing::info_span!("fjall_backup").entered();
+                crate::maintenance::FjallBackup::new(config).create_backup()
+            })
+            .await
+            .context(error::BlockingJoinSnafu {
+                context: "fjall backup",
+            })??;
+
+            tracing::info!(
+                files = report.files_copied,
+                bytes = report.bytes_copied,
+                pruned = report.backups_pruned,
+                "maintenance: fjall backup complete"
+            );
+            Ok(ExecutionResult {
+                success: true,
+                output: Some(format!(
+                    "{} files copied ({} bytes), {} old backups pruned",
+                    report.files_copied, report.bytes_copied, report.backups_pruned
+                )),
+            })
+        }
         BuiltinTask::RetentionExecution => {
             let Some(executor) = retention_executor else {
                 tracing::info!("retention execution skipped — no executor configured");
@@ -532,7 +559,8 @@ async fn execute_knowledge_task(
             | BuiltinTask::OpsFactExtraction
             | BuiltinTask::LessonExtraction
             | BuiltinTask::SelfPrompt
-            | BuiltinTask::ProposeRules => {
+            | BuiltinTask::ProposeRules
+            | BuiltinTask::FjallBackup => {
                 unreachable!("non-knowledge task routed to execute_knowledge_task")
             }
         }?;

--- a/crates/daemon/src/maintenance/fjall_backup.rs
+++ b/crates/daemon/src/maintenance/fjall_backup.rs
@@ -1,0 +1,361 @@
+//! Fjall knowledge store backup: periodic file-level copy to timestamped directory.
+//!
+//! WHY (#3381): the fjall knowledge store has no built-in backup mechanism.
+//! If the fjall DB files are corrupted or the machine dies, all session and
+//! knowledge data is lost. This module implements periodic file-level backups
+//! with configurable retention.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use snafu::ResultExt;
+use tracing::{info, warn};
+
+use crate::error;
+
+/// Configuration for fjall knowledge store backups.
+#[derive(Debug, Clone)]
+pub struct FjallBackupConfig {
+    /// Whether periodic fjall backups are enabled.
+    pub enabled: bool,
+    /// Path to the fjall knowledge store data directory.
+    pub source_dir: PathBuf,
+    /// Directory where timestamped backups are stored.
+    pub backup_dir: PathBuf,
+    /// Hours between automatic backups.
+    pub interval_hours: u64,
+    /// Maximum number of backup snapshots to retain.
+    pub retention_count: usize,
+}
+
+impl Default for FjallBackupConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            source_dir: PathBuf::from("data/knowledge.fjall"),
+            backup_dir: PathBuf::from("data/backups/fjall"),
+            interval_hours: 24,
+            retention_count: 7,
+        }
+    }
+}
+
+/// Outcome of a fjall backup run.
+#[derive(Debug, Clone, Default)]
+pub struct FjallBackupReport {
+    /// Path to the created backup directory.
+    pub backup_path: Option<PathBuf>,
+    /// Total bytes copied.
+    pub bytes_copied: u64,
+    /// Number of files copied.
+    pub files_copied: u32,
+    /// Number of old backups pruned.
+    pub backups_pruned: u32,
+}
+
+/// A single backup entry found on disk.
+#[derive(Debug, Clone)]
+pub struct BackupEntry {
+    /// Directory name (timestamp-based).
+    pub name: String,
+    /// Full path to the backup directory.
+    pub path: PathBuf,
+    /// When the backup was created (from directory mtime).
+    pub created: SystemTime,
+    /// Total size of the backup in bytes.
+    pub size_bytes: u64,
+}
+
+/// Manages fjall knowledge store backups.
+pub struct FjallBackup {
+    config: FjallBackupConfig,
+}
+
+impl FjallBackup {
+    /// Create a new backup manager with the given configuration.
+    #[must_use]
+    pub fn new(config: FjallBackupConfig) -> Self {
+        Self { config }
+    }
+
+    /// Create a backup by copying the fjall data directory to a timestamped subdirectory.
+    ///
+    /// The backup directory name uses ISO 8601 format: `YYYYMMDD-HHMMSS`.
+    /// After creating the backup, old backups beyond `retention_count` are pruned.
+    pub fn create_backup(&self) -> error::Result<FjallBackupReport> {
+        if !self.config.source_dir.exists() {
+            info!(
+                source = %self.config.source_dir.display(),
+                "fjall backup skipped: source directory does not exist"
+            );
+            return Ok(FjallBackupReport::default());
+        }
+
+        fs::create_dir_all(&self.config.backup_dir).context(error::MaintenanceIoSnafu {
+            context: format!(
+                "creating fjall backup dir {}",
+                self.config.backup_dir.display()
+            ),
+        })?;
+
+        // WHY: include subsecond precision to avoid collisions when backups
+        // are triggered in rapid succession (e.g., tests or manual runs).
+        let timestamp = jiff::Zoned::now().strftime("%Y%m%d-%H%M%S%.3f").to_string();
+        let backup_path = self.config.backup_dir.join(&timestamp);
+
+        let (bytes_copied, files_copied) =
+            copy_dir_recursive(&self.config.source_dir, &backup_path)?;
+
+        info!(
+            backup = %backup_path.display(),
+            files = files_copied,
+            bytes = bytes_copied,
+            "fjall backup created"
+        );
+
+        let backups_pruned = self.prune_old_backups()?;
+
+        Ok(FjallBackupReport {
+            backup_path: Some(backup_path),
+            bytes_copied,
+            files_copied,
+            backups_pruned,
+        })
+    }
+
+    /// List existing backups, newest first.
+    pub fn list_backups(&self) -> error::Result<Vec<BackupEntry>> {
+        if !self.config.backup_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut entries = Vec::new();
+        let dir = fs::read_dir(&self.config.backup_dir).context(error::MaintenanceIoSnafu {
+            context: format!(
+                "reading fjall backup dir {}",
+                self.config.backup_dir.display()
+            ),
+        })?;
+
+        for entry in dir {
+            let entry = entry.context(error::MaintenanceIoSnafu {
+                context: "reading backup entry",
+            })?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let metadata = entry.metadata().context(error::MaintenanceIoSnafu {
+                context: format!("reading backup metadata: {}", path.display()),
+            })?;
+            let created = metadata.modified().context(error::MaintenanceIoSnafu {
+                context: format!("reading backup mtime: {}", path.display()),
+            })?;
+            let size_bytes = dir_size(&path);
+            let name = entry.file_name().to_string_lossy().into_owned();
+            entries.push(BackupEntry {
+                name,
+                path,
+                created,
+                size_bytes,
+            });
+        }
+
+        // Sort newest first.
+        entries.sort_by_key(|e| std::cmp::Reverse(e.created));
+        Ok(entries)
+    }
+
+    /// Remove old backups beyond the configured retention count.
+    fn prune_old_backups(&self) -> error::Result<u32> {
+        let entries = self.list_backups()?;
+        let mut pruned = 0u32;
+
+        // Keep the newest `retention_count` entries, remove the rest.
+        for entry in entries.into_iter().skip(self.config.retention_count) {
+            if let Err(e) = fs::remove_dir_all(&entry.path) {
+                warn!(
+                    path = %entry.path.display(),
+                    error = %e,
+                    "failed to remove old fjall backup"
+                );
+            } else {
+                pruned += 1;
+            }
+        }
+
+        if pruned > 0 {
+            info!(pruned, "pruned old fjall backups");
+        }
+
+        Ok(pruned)
+    }
+}
+
+/// Recursively copy a directory. Returns `(bytes_copied, files_copied)`.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> error::Result<(u64, u32)> {
+    fs::create_dir_all(dst).context(error::MaintenanceIoSnafu {
+        context: format!("creating backup dir {}", dst.display()),
+    })?;
+
+    let mut total_bytes = 0u64;
+    let mut total_files = 0u32;
+
+    let entries = fs::read_dir(src).context(error::MaintenanceIoSnafu {
+        context: format!("reading source dir {}", src.display()),
+    })?;
+
+    for entry in entries {
+        let entry = entry.context(error::MaintenanceIoSnafu {
+            context: "reading directory entry",
+        })?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if src_path.is_dir() {
+            let (bytes, files) = copy_dir_recursive(&src_path, &dst_path)?;
+            total_bytes += bytes;
+            total_files += files;
+        } else {
+            let bytes = fs::copy(&src_path, &dst_path).context(error::MaintenanceIoSnafu {
+                context: format!("copying {} to {}", src_path.display(), dst_path.display()),
+            })?;
+            total_bytes += bytes;
+            total_files += 1;
+        }
+    }
+
+    Ok((total_bytes, total_files))
+}
+
+/// Calculate total size of a directory tree.
+fn dir_size(path: &Path) -> u64 {
+    let mut total = 0u64;
+    if let Ok(entries) = fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                total += dir_size(&path);
+            } else if let Ok(metadata) = entry.metadata() {
+                total += metadata.len();
+            }
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    fn write_fixture(path: impl AsRef<Path>, content: &str) {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test fixture: synchronous write in non-async test context"
+        )]
+        fs::write(path.as_ref(), content).expect("write fixture");
+        let mut perms = fs::metadata(path.as_ref())
+            .expect("read fixture metadata")
+            .permissions();
+        perms.set_mode(0o644);
+        fs::set_permissions(path.as_ref(), perms).expect("set fixture permissions");
+    }
+
+    #[test]
+    fn create_backup_copies_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let source = tmp.path().join("knowledge.fjall");
+        let backup_dir = tmp.path().join("backups");
+        fs::create_dir_all(&source).unwrap();
+        write_fixture(source.join("data.sst"), "sst data");
+        write_fixture(source.join("manifest"), "manifest data");
+
+        let config = FjallBackupConfig {
+            enabled: true,
+            source_dir: source,
+            backup_dir: backup_dir.clone(),
+            interval_hours: 24,
+            retention_count: 7,
+        };
+
+        let manager = FjallBackup::new(config);
+        let report = manager.create_backup().expect("backup succeeds");
+
+        assert!(report.backup_path.is_some());
+        assert_eq!(report.files_copied, 2);
+        assert!(report.bytes_copied > 0);
+
+        let backups = manager.list_backups().expect("list succeeds");
+        assert_eq!(backups.len(), 1);
+    }
+
+    #[test]
+    fn prune_respects_retention_count() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let source = tmp.path().join("knowledge.fjall");
+        let backup_dir = tmp.path().join("backups");
+        fs::create_dir_all(&source).unwrap();
+        write_fixture(source.join("data"), "data");
+
+        let config = FjallBackupConfig {
+            enabled: true,
+            source_dir: source,
+            backup_dir: backup_dir.clone(),
+            interval_hours: 24,
+            retention_count: 2,
+        };
+
+        let manager = FjallBackup::new(config);
+
+        // Create 4 backups.
+        for _ in 0..4 {
+            manager.create_backup().expect("backup succeeds");
+            // Small sleep to ensure distinct timestamps.
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let backups = manager.list_backups().expect("list succeeds");
+        assert_eq!(backups.len(), 2, "should keep only 2 backups");
+    }
+
+    #[test]
+    fn nonexistent_source_returns_empty_report() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = FjallBackupConfig {
+            source_dir: tmp.path().join("nonexistent"),
+            backup_dir: tmp.path().join("backups"),
+            ..FjallBackupConfig::default()
+        };
+
+        let manager = FjallBackup::new(config);
+        let report = manager.create_backup().expect("should not error");
+        assert!(report.backup_path.is_none());
+        assert_eq!(report.files_copied, 0);
+    }
+
+    #[test]
+    fn list_empty_backup_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = FjallBackupConfig {
+            backup_dir: tmp.path().join("nonexistent-backups"),
+            ..FjallBackupConfig::default()
+        };
+
+        let manager = FjallBackup::new(config);
+        let backups = manager.list_backups().expect("list succeeds");
+        assert!(backups.is_empty());
+    }
+
+    #[test]
+    fn default_config_values() {
+        let config = FjallBackupConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.interval_hours, 24);
+        assert_eq!(config.retention_count, 7);
+    }
+}

--- a/crates/daemon/src/maintenance/mod.rs
+++ b/crates/daemon/src/maintenance/mod.rs
@@ -6,6 +6,8 @@ use koina::system::{Environment, RealSystem};
 pub(crate) mod db_monitor;
 /// Instance drift detection: compare a live instance against the example template.
 pub(crate) mod drift_detection;
+/// Fjall knowledge store file-level backup with timestamped snapshots.
+pub mod fjall_backup;
 /// Knowledge graph maintenance bridge trait and report types.
 pub(crate) mod knowledge;
 /// Data retention policy execution trait and summary types.
@@ -15,6 +17,7 @@ pub(crate) mod trace_rotation;
 
 pub use db_monitor::{DbInfo, DbMonitor, DbMonitoringConfig, DbSizeReport, DbStatus};
 pub use drift_detection::{DriftDetectionConfig, DriftDetector, DriftReport};
+pub use fjall_backup::{FjallBackup, FjallBackupConfig, FjallBackupReport};
 pub use knowledge::{
     AutoDreamConfig, KnowledgeMaintenanceConfig, KnowledgeMaintenanceExecutor, MaintenanceReport,
 };
@@ -58,6 +61,8 @@ pub struct MaintenanceConfig {
     pub retention: RetentionConfig,
     /// Knowledge graph maintenance settings.
     pub knowledge_maintenance: KnowledgeMaintenanceConfig,
+    /// Fjall knowledge store backup settings.
+    pub fjall_backup: FjallBackupConfig,
     /// Cron task configuration (evolution, reflection, graph cleanup).
     pub cron: crate::cron::CronConfig,
     /// Rule proposal generation from observed patterns.

--- a/crates/daemon/src/runner/registration.rs
+++ b/crates/daemon/src/runner/registration.rs
@@ -102,6 +102,16 @@ impl TaskRunner {
             false,
         );
 
+        if config.fjall_backup.enabled {
+            self.register_builtin(
+                "fjall-backup",
+                "Fjall knowledge store backup",
+                Schedule::Interval(Duration::from_hours(config.fjall_backup.interval_hours)),
+                BuiltinTask::FjallBackup,
+                true,
+            );
+        }
+
         if config.propose_rules.enabled {
             // WHY: weekly cadence balances freshness with noise — daily would flood
             // the operator with near-identical proposals.

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -132,6 +132,8 @@ pub enum BuiltinTask {
     SelfPrompt,
     /// Analyze recent session observations and write candidate lint rule proposals.
     ProposeRules,
+    /// Periodic file-level backup of the fjall knowledge store.
+    FjallBackup,
 }
 
 impl Schedule {

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -187,8 +187,8 @@ pub mod consolidation {
 /// [`create_provider`](embedding::create_provider)
 pub mod embedding {
     pub use episteme::embedding::{
-        DegradedEmbeddingProvider, EmbeddingConfig, EmbeddingProvider, create_provider,
-        is_degraded_provider,
+        DegradedEmbeddingProvider, EmbeddingConfig, EmbeddingError, EmbeddingProvider,
+        create_provider, is_degraded_provider,
     };
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -230,10 +230,18 @@ fn check_provider_reachability(state: &HealthState) -> HealthCheck {
     }
 }
 
-/// Check embedding provider status. Reports `"warn"` with
-/// `"degraded: no-embeddings"` when the real provider failed to load at
-/// startup and the server is running BM25-only (#3380).
+/// Check embedding provider status.
+///
+/// Reports:
+/// - `"pass"` when the real provider is loaded and healthy
+/// - `"warn"` with `"degraded: embedding-loading"` while the lazy provider
+///   is still initializing (#3474)
+/// - `"warn"` with `"degraded: no-embeddings"` when the real provider failed
+///   to load and the server is running BM25-only (#3380)
 fn check_embedding_provider(state: &HealthState) -> HealthCheck {
+    /// Sentinel model name emitted by `LazyEmbeddingProvider` while still loading.
+    const LOADING_MODEL_NAME: &str = "embedding-loading";
+
     let Some(provider) = state.embedding_provider.as_ref() else {
         return HealthCheck {
             name: "embedding_provider",
@@ -241,7 +249,20 @@ fn check_embedding_provider(state: &HealthState) -> HealthCheck {
             message: Some("no embedding provider configured".to_owned()),
         };
     };
-    if mneme::embedding::is_degraded_provider(provider.as_ref()) {
+
+    let model_name = provider.model_name();
+
+    if model_name == LOADING_MODEL_NAME {
+        HealthCheck {
+            name: "embedding_provider",
+            status: "warn",
+            message: Some(
+                "degraded: embedding-loading (model initializing — \
+                 recall unavailable until load completes)"
+                    .to_owned(),
+            ),
+        }
+    } else if mneme::embedding::is_degraded_provider(provider.as_ref()) {
         HealthCheck {
             name: "embedding_provider",
             status: "warn",

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -30,6 +30,8 @@ pub struct MaintenanceSettings {
     pub watchdog: WatchdogSettings,
     /// Periodic cron task settings (evolution, reflection, graph cleanup).
     pub cron_tasks: CronTaskSettings,
+    /// Fjall knowledge store backup settings.
+    pub backup: BackupSettings,
 }
 
 /// Trace file rotation settings.
@@ -435,6 +437,29 @@ impl Default for WatchdogSettings {
             heartbeat_timeout_secs: 60,
             check_interval_secs: 10,
             max_restarts: 5,
+        }
+    }
+}
+
+/// Fjall knowledge store periodic backup settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct BackupSettings {
+    /// Whether automatic fjall backups are enabled.
+    pub enabled: bool,
+    /// Hours between automatic backups.
+    pub backup_interval_hours: u64,
+    /// Maximum number of backup snapshots to retain.
+    pub backup_retention_count: usize,
+}
+
+impl Default for BackupSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            backup_interval_hours: 24,
+            backup_retention_count: 7,
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Lazy embedding init (#3474)**: Embedding model download/load is deferred to first use via `tokio::sync::OnceCell` in a new `LazyEmbeddingProvider` wrapper. The HTTP gateway binds immediately and health checks report `"degraded: embedding-loading"` until the model is ready. Background `tokio::spawn` triggers init on startup so the model loads without blocking.

- **Fjall backup mechanism (#3381)**: File-level periodic backup of the fjall knowledge store directory to timestamped snapshots with configurable retention. New `BuiltinTask::FjallBackup` wired into daemon maintenance scheduler. CLI support via `aletheia backup --fjall` (create/list/prune). Config: `maintenance.backup.backupIntervalHours = 24`, `maintenance.backup.backupRetentionCount = 7`.

### Files changed

| Crate | File | Change |
|-------|------|--------|
| aletheia | `runtime/setup.rs` | `LazyEmbeddingProvider` with `OnceCell` + degraded fallback |
| aletheia | `runtime/mod.rs` | Spawn background embedding init, use lazy provider |
| pylon | `handlers/health.rs` | Report "embedding-loading" state in health check |
| mneme | `lib.rs` | Re-export `EmbeddingError` for external trait impls |
| oikonomos | `maintenance/fjall_backup.rs` | New: `FjallBackup`, `FjallBackupConfig`, file copy + prune |
| oikonomos | `schedule.rs` | `BuiltinTask::FjallBackup` variant |
| oikonomos | `execution.rs` | Dispatch handler for fjall backup task |
| oikonomos | `runner/registration.rs` | Register fjall-backup in maintenance tasks |
| taxis | `config/maintenance.rs` | `BackupSettings` (interval, retention) |
| aletheia | `commands/maintenance.rs` | Wire fjall backup config + `fjall-backup` CLI task |
| aletheia | `commands/backup.rs` | `--fjall` flag for create/list/prune |

## Test plan

- [x] `cargo check -p aletheia -p graphe -p oikonomos --tests` passes
- [x] `cargo clippy -p aletheia -p oikonomos -p mneme -p taxis -p pylon -- -D warnings` clean (pre-existing hermeneus/graphe test issues excluded)
- [x] 5 new unit tests for fjall backup (create, prune retention, nonexistent source, empty list, defaults)
- [ ] Manual: start server, verify `/api/health` shows `"degraded: embedding-loading"` before model loads, then `"pass"` after
- [ ] Manual: `aletheia backup --fjall` creates timestamped copy of knowledge.fjall
- [ ] Manual: `aletheia backup --fjall --list` shows backup entries
- [ ] Manual: `aletheia maintenance run fjall-backup` runs backup via daemon path

Closes #3474
Closes #3381

🤖 Generated with [Claude Code](https://claude.com/claude-code)