### PR TITLE
fix(pylon): SSE client recovery — progressive persistence + Last-Event-ID reconnection (#3276)

### DIFF
--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -736,6 +736,7 @@ impl RuntimeBuilder {
             #[cfg(feature = "recall")]
             knowledge_store,
             embedding_provider: Some(Arc::clone(&embedding_provider)),
+            turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
         });
 
         Ok(Runtime {

--- a/crates/integration-tests/tests/cross_crate_pipeline.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline.rs
@@ -285,6 +285,7 @@ impl TestHarness {
             #[cfg(feature = "knowledge-store")]
             knowledge_store: None,
             embedding_provider: None,
+            turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
         });
 
         Self {

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -199,6 +199,7 @@ impl TestHarness {
             #[cfg(feature = "knowledge-store")]
             knowledge_store: None,
             embedding_provider: None,
+            turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
         });
 
         Self {

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -119,6 +119,7 @@ async fn start_test_server() -> (String, String, tempfile::TempDir) {
         #[cfg(feature = "knowledge-store")]
         knowledge_store: None,
         embedding_provider: None,
+        turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
     });
 
     let router = build_router(

--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -4,7 +4,7 @@
 pub(crate) mod streaming;
 pub(crate) mod types;
 
-pub use streaming::{events, send_message, stream_turn};
+pub use streaming::{events, reconnect_turn, send_message, stream_turn};
 
 use types::{
     CreateSessionRequest, HistoryMessage, HistoryParams, HistoryResponse, ListSessionsParams,

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -10,7 +10,7 @@ use axum::response::sse::{Event, KeepAlive, Sse};
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::{IntervalStream, ReceiverStream};
-use tracing::{Instrument, instrument, warn};
+use tracing::{Instrument, debug, instrument, warn};
 
 use hermeneus::anthropic::StreamEvent as LlmStreamEvent;
 use nous::pipeline::TurnResult;
@@ -29,6 +29,7 @@ use crate::idempotency::LookupResult;
 use crate::middleware::RequestId;
 use crate::state::SessionsState;
 use crate::stream::{SseEvent, TurnOutcome, UsageData, WebchatEvent};
+use crate::turn_buffer::TurnBufferHandle;
 
 use super::types::{SendMessageRequest, StreamTurnRequest};
 use super::{find_session, resolve_session};
@@ -149,19 +150,25 @@ pub async fn send_message(
                 )]
                 let output_tokens = cached["output_tokens"].as_u64().unwrap_or(0);
 
-                let (tx, rx) = mpsc::channel::<SseEvent>(1);
+                // WHY(#3276): Use (seq, event) pair for type-compatibility with
+                // the normal streaming path. Idempotency replays use seq=0 since
+                // they are not recoverable turns.
+                let (tx, rx) = mpsc::channel::<(u64, SseEvent)>(1);
                 let _ = tx
-                    .send(SseEvent::MessageComplete {
-                        stop_reason,
-                        usage: UsageData {
-                            input_tokens,
-                            output_tokens,
+                    .send((
+                        0,
+                        SseEvent::MessageComplete {
+                            stop_reason,
+                            usage: UsageData {
+                                input_tokens,
+                                output_tokens,
+                            },
                         },
-                    })
+                    ))
                     .await;
                 drop(tx);
                 let stream = GuardedStream {
-                    inner: ReceiverStream::new(rx).map(sse_event_to_axum),
+                    inner: ReceiverStream::new(rx).map(sse_event_to_axum_with_id),
                     _guard: AbortOnDrop(tokio::spawn(
                         async {}.instrument(tracing::info_span!("idempotent_noop")),
                     )),
@@ -242,11 +249,21 @@ pub async fn send_message(
     }
 
     let session_key = session.session_key.clone();
-    let (tx, rx) = mpsc::channel::<SseEvent>(32);
+    // WHY(#3276): channel carries (seq, event) pairs so the stream mapper can
+    // set the SSE `id:` field for Last-Event-ID client recovery.
+    let (tx, rx) = mpsc::channel::<(u64, SseEvent)>(32);
     let sid = session_id.clone();
 
     let idem_key = idempotency_key.clone();
     let idem_cache = Arc::clone(&state.idempotency_cache);
+
+    // WHY(#3276): Create a turn buffer for this turn so events survive disconnection.
+    let turn_id = koina::ulid::Ulid::new().to_string();
+    let turn_buf = state
+        .turn_buffer_registry
+        .get_or_create(&session_id, &turn_id)
+        .await;
+    let buf_handle = TurnBufferHandle::new(turn_buf);
 
     let request_id_str = request_id.0.clone();
     let turn_span = tracing::info_span!(
@@ -255,18 +272,20 @@ pub async fn send_message(
         session.key = %session_key,
         nous.id = %session.nous_id,
         request_id = %request_id,
+        turn_id = %turn_id,
         idempotency_key = idempotency_key.as_deref().unwrap_or(""),
     );
     let shutdown_token = state.shutdown.child_token();
+    let buf_handle_task = buf_handle.clone();
     let turn_handle = tokio::spawn(
         async move {
             // WHY(#2113): Emit an immediate acknowledgment so the client never sees an empty
             // body, even if the turn fails before producing any content events.
-            let _ = tx
-                .send(SseEvent::MessageStart {
-                    status: "accepted".to_owned(),
-                })
-                .await;
+            let event = SseEvent::MessageStart {
+                status: "accepted".to_owned(),
+            };
+            let seq = record_sse_event(&buf_handle_task, &event).await;
+            let _ = tx.send((seq, event)).await;
 
             // WHY: cancel the in-flight turn when the server shuts down so Axum's graceful
             // shutdown can drain open SSE connections rather than hanging indefinitely (#1723).
@@ -280,12 +299,14 @@ pub async fn send_message(
                 r = turn_fut => r,
                 () = shutdown_token.cancelled() => {
                     tracing::info!("shutdown: cancelling in-flight SSE turn");
+                    buf_handle_task.mark_failed().await;
                     return;
                 }
             };
             match result {
                 Ok(result) => {
-                    emit_turn_result_events(&tx, &result).await;
+                    emit_turn_result_events_buffered(&tx, &buf_handle_task, &result).await;
+                    buf_handle_task.mark_completed().await;
 
                     // NOTE: Store the turn summary so cache-hit replays return real data.
                     if let Some(ref key) = idem_key {
@@ -309,24 +330,25 @@ pub async fn send_message(
                     }
 
                     let (err_code, err_message) = turn_error_info(&err);
-                    let _ = tx
-                        .send(SseEvent::Error {
-                            code: err_code,
-                            message: err_message,
-                            request_id: Some(request_id_str.clone()),
-                        })
-                        .await;
+                    let event = SseEvent::Error {
+                        code: err_code,
+                        message: err_message,
+                        request_id: Some(request_id_str.clone()),
+                    };
+                    let seq = record_sse_event(&buf_handle_task, &event).await;
+                    let _ = tx.send((seq, event)).await;
                     // WHY: Always send a completion marker so the client knows the
                     // stream is finished, even on error paths.
-                    let _ = tx
-                        .send(SseEvent::MessageComplete {
-                            stop_reason: "error".to_owned(),
-                            usage: UsageData {
-                                input_tokens: 0,
-                                output_tokens: 0,
-                            },
-                        })
-                        .await;
+                    let event = SseEvent::MessageComplete {
+                        stop_reason: "error".to_owned(),
+                        usage: UsageData {
+                            input_tokens: 0,
+                            output_tokens: 0,
+                        },
+                    };
+                    let seq = record_sse_event(&buf_handle_task, &event).await;
+                    let _ = tx.send((seq, event)).await;
+                    buf_handle_task.mark_failed().await;
                 }
             }
         }
@@ -336,7 +358,7 @@ pub async fn send_message(
     // WHY: Wrap the stream so the turn task is aborted when the client disconnects.
     // Without this, a disconnected client leaves the LLM inference running.
     let stream = GuardedStream {
-        inner: ReceiverStream::new(rx).map(sse_event_to_axum),
+        inner: ReceiverStream::new(rx).map(sse_event_to_axum_with_id),
         _guard: AbortOnDrop(turn_handle),
     };
 
@@ -454,16 +476,24 @@ pub async fn stream_turn(
 
     let webchat_request_id = request_id.0.clone();
     let turn_id = koina::ulid::Ulid::new().to_string();
-    let (webchat_tx, webchat_rx) = mpsc::channel::<WebchatEvent>(32);
+    // WHY(#3276): channel carries (seq, event) pairs for Last-Event-ID support.
+    let (webchat_tx, webchat_rx) = mpsc::channel::<(u64, WebchatEvent)>(32);
     let (nous_tx, mut nous_rx) = mpsc::channel::<TurnStreamEvent>(64);
 
-    let _ = webchat_tx
-        .send(WebchatEvent::MessageStart {
-            session_id: session_id.clone(),
-            nous_id: agent_id.clone(),
-            turn_id,
-        })
+    // WHY(#3276): Create a turn buffer so events survive client disconnection.
+    let turn_buf = state
+        .turn_buffer_registry
+        .get_or_create(&session_id, &turn_id)
         .await;
+    let buf_handle = TurnBufferHandle::new(turn_buf);
+
+    let start_event = WebchatEvent::MessageStart {
+        session_id: session_id.clone(),
+        nous_id: agent_id.clone(),
+        turn_id: turn_id.clone(),
+    };
+    let seq = record_webchat_event(&buf_handle, &start_event).await;
+    let _ = webchat_tx.send((seq, start_event)).await;
 
     let sid = session_id;
     let aid = agent_id;
@@ -474,12 +504,14 @@ pub async fn stream_turn(
         session.key = %session_key,
         nous.id = %aid,
         request_id = %request_id,
+        turn_id = %turn_id,
     );
 
     // WHY: Returns a JoinHandle so the turn task can wait for all deltas to drain
     // before emitting turn_complete (prevents the race where turn_complete
     // arrives at the TUI before the final text_delta events).
     let bridge_tx = webchat_tx.clone();
+    let bridge_buf = buf_handle.clone();
     let bridge_handle = tokio::spawn(
         async move {
             while let Some(event) = nous_rx.recv().await {
@@ -514,7 +546,8 @@ pub async fn stream_turn(
                     },
                     _ => continue,
                 };
-                if bridge_tx.send(webchat_event).await.is_err() {
+                let seq = record_webchat_event(&bridge_buf, &webchat_event).await;
+                if bridge_tx.send((seq, webchat_event)).await.is_err() {
                     break;
                 }
             }
@@ -523,6 +556,7 @@ pub async fn stream_turn(
     );
 
     let shutdown_token = state.shutdown.child_token();
+    let buf_handle_task = buf_handle.clone();
     let stream_turn_handle = tokio::spawn(
         async move {
             // WHY: cancel the in-flight turn when the server shuts down so Axum's graceful
@@ -538,6 +572,7 @@ pub async fn stream_turn(
                 r = turn_fut => r,
                 () = shutdown_token.cancelled() => {
                     tracing::info!("shutdown: cancelling in-flight streaming turn");
+                    buf_handle_task.mark_failed().await;
                     return;
                 }
             };
@@ -548,50 +583,52 @@ pub async fn stream_turn(
                     // seeing turn_complete before the final text_delta events.
                     let _ = bridge_handle.await;
 
-                    let _ = webchat_tx
-                        .send(WebchatEvent::MessageComplete {
-                            outcome: TurnOutcome {
-                                text: result.content.clone(),
-                                nous_id: aid,
-                                session_id: sid.clone(),
-                                model,
-                                tool_calls: result.tool_calls.len(),
-                                input_tokens: result.usage.input_tokens,
-                                output_tokens: result.usage.output_tokens,
-                                cache_read_tokens: result.usage.cache_read_tokens,
-                                cache_write_tokens: result.usage.cache_write_tokens,
-                            },
-                        })
-                        .await;
+                    let event = WebchatEvent::MessageComplete {
+                        outcome: TurnOutcome {
+                            text: result.content.clone(),
+                            nous_id: aid,
+                            session_id: sid.clone(),
+                            model,
+                            tool_calls: result.tool_calls.len(),
+                            input_tokens: result.usage.input_tokens,
+                            output_tokens: result.usage.output_tokens,
+                            cache_read_tokens: result.usage.cache_read_tokens,
+                            cache_write_tokens: result.usage.cache_write_tokens,
+                        },
+                    };
+                    let seq = record_webchat_event(&buf_handle_task, &event).await;
+                    let _ = webchat_tx.send((seq, event)).await;
+                    buf_handle_task.mark_completed().await;
                 }
                 Err(err) => {
                     // WHY: Log full error internally; span carries session/nous context (#844).
                     tracing::error!(error = %err, "streaming turn failed");
                     let _ = bridge_handle.await;
                     let (_, err_message) = turn_error_info(&err);
-                    let _ = webchat_tx
-                        .send(WebchatEvent::Error {
-                            message: err_message,
-                            request_id: Some(webchat_request_id.clone()),
-                        })
-                        .await;
+                    let event = WebchatEvent::Error {
+                        message: err_message,
+                        request_id: Some(webchat_request_id.clone()),
+                    };
+                    let seq = record_webchat_event(&buf_handle_task, &event).await;
+                    let _ = webchat_tx.send((seq, event)).await;
                     // WHY: Always send a completion marker so the TUI knows the stream
                     // is finished, even on error paths.
-                    let _ = webchat_tx
-                        .send(WebchatEvent::MessageComplete {
-                            outcome: TurnOutcome {
-                                text: String::new(),
-                                nous_id: aid,
-                                session_id: sid,
-                                model,
-                                tool_calls: 0,
-                                input_tokens: 0,
-                                output_tokens: 0,
-                                cache_read_tokens: 0,
-                                cache_write_tokens: 0,
-                            },
-                        })
-                        .await;
+                    let event = WebchatEvent::MessageComplete {
+                        outcome: TurnOutcome {
+                            text: String::new(),
+                            nous_id: aid,
+                            session_id: sid,
+                            model,
+                            tool_calls: 0,
+                            input_tokens: 0,
+                            output_tokens: 0,
+                            cache_read_tokens: 0,
+                            cache_write_tokens: 0,
+                        },
+                    };
+                    let seq = record_webchat_event(&buf_handle_task, &event).await;
+                    let _ = webchat_tx.send((seq, event)).await;
+                    buf_handle_task.mark_failed().await;
                 }
             }
         }
@@ -600,15 +637,21 @@ pub async fn stream_turn(
 
     // WHY: Abort streaming turn task when the client disconnects.
     let stream = GuardedStream {
-        inner: ReceiverStream::new(webchat_rx).map(|event| match serde_json::to_string(&event) {
-            Ok(data) => Ok(Event::default().event(event.event_type()).data(data)),
-            Err(e) => {
-                warn!(error = %e, "failed to serialize SSE event");
-                // WHY: Use the WebchatEvent::Error shape so the fallback event has the
-                // same structure as all other error events in the stream (#3160).
-                Ok(Event::default()
-                    .event("error")
-                    .data(r#"{"type":"error","message":"serialization failed"}"#))
+        inner: ReceiverStream::new(webchat_rx).map(|(seq, event)| {
+            match serde_json::to_string(&event) {
+                Ok(data) => Ok(Event::default()
+                    .event(event.event_type())
+                    .data(data)
+                    .id(seq.to_string())),
+                Err(e) => {
+                    warn!(error = %e, "failed to serialize SSE event");
+                    // WHY: Use the WebchatEvent::Error shape so the fallback event has the
+                    // same structure as all other error events in the stream (#3160).
+                    Ok(Event::default()
+                        .event("error")
+                        .data(r#"{"type":"error","message":"serialization failed"}"#)
+                        .id(seq.to_string()))
+                }
             }
         }),
         _guard: AbortOnDrop(stream_turn_handle),
@@ -656,28 +699,29 @@ pub async fn events(
     )
 }
 
-/// Convert an [`SseEvent`] into an Axum SSE [`Event`].
+/// Convert a `(seq, SseEvent)` pair into an Axum SSE [`Event`] with `id:` field.
 ///
-/// Used as a named function (not closure) so that both the idempotency-replay
-/// path and the normal streaming path produce the same `impl Stream` type.
+/// WHY(#3276): The SSE `id:` field enables `Last-Event-ID` on reconnection.
+/// The client's `EventSource` automatically sends `Last-Event-ID: N` when
+/// reconnecting, and the server replays events from `N+1` onward.
 #[expect(
     clippy::unnecessary_wraps,
     reason = "Result<_, Infallible> required by Stream<Item = Result<Event, Infallible>>"
 )]
-#[expect(
-    clippy::needless_pass_by_value,
-    reason = "owned value received from Stream::map"
-)]
-fn sse_event_to_axum(event: SseEvent) -> Result<Event, Infallible> {
+fn sse_event_to_axum_with_id((seq, event): (u64, SseEvent)) -> Result<Event, Infallible> {
     match serde_json::to_string(&event) {
-        Ok(data) => Ok(Event::default().event(event.event_type()).data(data)),
+        Ok(data) => Ok(Event::default()
+            .event(event.event_type())
+            .data(data)
+            .id(seq.to_string())),
         Err(e) => {
             warn!(error = %e, "failed to serialize SSE event");
-            // WHY: Use the SseEvent::Error variant so the fallback event has the same
-            // shape as all other error events in the stream (#3160).
-            Ok(Event::default().event("error").data(
-                r#"{"type":"error","code":"serialization_error","message":"serialization failed"}"#,
-            ))
+            Ok(Event::default()
+                .event("error")
+                .data(
+                    r#"{"type":"error","code":"serialization_error","message":"serialization failed"}"#,
+                )
+                .id(seq.to_string()))
         }
     }
 }
@@ -866,47 +910,177 @@ fn redact_secrets(msg: &str) -> String {
     SECRET_PATTERN.replace_all(msg, "[REDACTED]").into_owned()
 }
 
-/// Emit turn result as individual SSE events to a single client channel.
+/// Emit turn result as individual SSE events with buffer recording.
 ///
-/// Each SSE endpoint serves exactly one client: there is no multi-subscriber
-/// broadcast. Serialization happens once at the stream boundary (`ReceiverStream::map`).
-async fn emit_turn_result_events(tx: &mpsc::Sender<SseEvent>, result: &TurnResult) {
+/// WHY(#3276): Each event is recorded in the turn buffer before being sent
+/// to the client channel, so events survive client disconnection.
+async fn emit_turn_result_events_buffered(
+    tx: &mpsc::Sender<(u64, SseEvent)>,
+    buf: &TurnBufferHandle,
+    result: &TurnResult,
+) {
     if !result.content.is_empty() {
-        let _ = tx
-            .send(SseEvent::TextDelta {
-                text: result.content.clone(),
-            })
-            .await;
+        let event = SseEvent::TextDelta {
+            text: result.content.clone(),
+        };
+        let seq = record_sse_event(buf, &event).await;
+        let _ = tx.send((seq, event)).await;
     }
 
     for tc in &result.tool_calls {
-        let _ = tx
-            .send(SseEvent::ToolUse {
-                id: tc.id.clone(),
-                name: tc.name.clone(),
-                input: tc.input.clone(),
-            })
-            .await;
+        let event = SseEvent::ToolUse {
+            id: tc.id.clone(),
+            name: tc.name.clone(),
+            input: tc.input.clone(),
+        };
+        let seq = record_sse_event(buf, &event).await;
+        let _ = tx.send((seq, event)).await;
+
         if let Some(ref result_content) = tc.result {
-            let _ = tx
-                .send(SseEvent::ToolResult {
-                    tool_use_id: tc.id.clone(),
-                    content: result_content.clone(),
-                    is_error: tc.is_error,
-                })
-                .await;
+            let event = SseEvent::ToolResult {
+                tool_use_id: tc.id.clone(),
+                content: result_content.clone(),
+                is_error: tc.is_error,
+            };
+            let seq = record_sse_event(buf, &event).await;
+            let _ = tx.send((seq, event)).await;
         }
     }
 
-    let _ = tx
-        .send(SseEvent::MessageComplete {
-            stop_reason: result.stop_reason.clone(),
-            usage: UsageData {
-                input_tokens: result.usage.input_tokens,
-                output_tokens: result.usage.output_tokens,
-            },
-        })
-        .await;
+    let event = SseEvent::MessageComplete {
+        stop_reason: result.stop_reason.clone(),
+        usage: UsageData {
+            input_tokens: result.usage.input_tokens,
+            output_tokens: result.usage.output_tokens,
+        },
+    };
+    let seq = record_sse_event(buf, &event).await;
+    let _ = tx.send((seq, event)).await;
+}
+
+/// Record an [`SseEvent`] to the turn buffer. Returns the assigned sequence number.
+async fn record_sse_event(buf: &TurnBufferHandle, event: &SseEvent) -> u64 {
+    let event_type = event.event_type().to_owned();
+    let data = serde_json::to_string(event).unwrap_or_default();
+    buf.record(&event_type, &data).await
+}
+
+/// Record a [`WebchatEvent`] to the turn buffer. Returns the assigned sequence number.
+async fn record_webchat_event(buf: &TurnBufferHandle, event: &WebchatEvent) -> u64 {
+    let event_type = event.event_type().to_owned();
+    let data = serde_json::to_string(event).unwrap_or_default();
+    buf.record(&event_type, &data).await
+}
+
+/// Reconnect to a turn's SSE event stream.
+///
+/// Supports `Last-Event-ID` header for resuming from the last received event.
+/// If the turn is still running, replays missed events then streams live events.
+/// If the turn completed or failed, replays all events after `Last-Event-ID`.
+///
+/// Returns 404 if the turn buffer has expired or was never created.
+#[utoipa::path(
+    get,
+    path = "/api/v1/sessions/{session_id}/turns/{turn_id}/events",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("turn_id" = String, Path, description = "Turn ID (from message_start event)"),
+        ("Last-Event-ID" = Option<String>, Header, description = "Last received event sequence number for reconnection"),
+    ),
+    responses(
+        (status = 200, description = "SSE event stream (replay + live)", content_type = "text/event-stream"),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+        (status = 404, description = "Turn not found or expired", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+/// # Cancel safety
+///
+/// Cancel-safe. Axum handler; cancellation drops the future with no
+/// side effects beyond not returning a response.
+#[instrument(skip(state, _claims, headers))]
+pub async fn reconnect_turn(
+    State(state): State<SessionsState>,
+    _claims: Claims,
+    headers: axum::http::HeaderMap,
+    axum::extract::Path((session_id, turn_id)): axum::extract::Path<(String, String)>,
+) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    // WHY: Parse Last-Event-ID from the standard SSE reconnection header.
+    let last_event_id: u64 = headers
+        .get("last-event-id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    debug!(
+        session_id = %session_id,
+        turn_id = %turn_id,
+        last_event_id,
+        "SSE reconnection request"
+    );
+
+    let buf = state
+        .turn_buffer_registry
+        .get(&session_id, &turn_id)
+        .await
+        .ok_or_else(|| {
+            crate::error::SessionNotFoundSnafu {
+                id: format!("{session_id}/turn/{turn_id}"),
+            }
+            .build()
+        })?;
+
+    let handle = TurnBufferHandle::new(buf);
+    let (tx, rx) = mpsc::channel::<Result<Event, Infallible>>(32);
+
+    tokio::spawn(async move {
+        // Phase 1: Replay buffered events after last_event_id.
+        let (events, state) = handle.events_after(last_event_id).await;
+        for event in events {
+            let sse_event = Event::default()
+                .event(event.event_type)
+                .data(event.data)
+                .id(event.seq.to_string());
+            if tx.send(Ok(sse_event)).await.is_err() {
+                return;
+            }
+        }
+
+        // Phase 2: If turn is still running, stream live events.
+        if state == crate::turn_buffer::TurnState::Running {
+            let notify = handle.notify_handle().await;
+            let mut last_seq = last_event_id;
+            // WHY: update last_seq to include events already replayed
+            let (replayed, _) = handle.events_after(0).await;
+            if let Some(last) = replayed.last() {
+                last_seq = last_seq.max(last.seq);
+            }
+
+            loop {
+                notify.notified().await;
+                let (new_events, new_state) = handle.events_after(last_seq).await;
+                for event in &new_events {
+                    let sse_event = Event::default()
+                        .event(event.event_type.clone())
+                        .data(event.data.clone())
+                        .id(event.seq.to_string());
+                    if tx.send(Ok(sse_event)).await.is_err() {
+                        return;
+                    }
+                    last_seq = event.seq;
+                }
+                if new_state != crate::turn_buffer::TurnState::Running {
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok(Sse::new(ReceiverStream::new(rx)).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("ping"),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/pylon/src/handlers/sessions/streaming_tests.rs
+++ b/crates/pylon/src/handlers/sessions/streaming_tests.rs
@@ -362,7 +362,7 @@ fn redact_strips_bearer_token() {
 }
 
 // ─────────────────────────────────────────────────────────
-// sse_event_to_axum — serialization
+// sse_event_to_axum_with_id — serialization
 // ─────────────────────────────────────────────────────────
 
 #[test]
@@ -370,7 +370,7 @@ fn sse_event_text_delta_serializes_correctly() {
     let event = SseEvent::TextDelta {
         text: "hello world".to_owned(),
     };
-    let result = sse_event_to_axum(event).expect("infallible");
+    let result = sse_event_to_axum_with_id((1, event)).expect("infallible");
     // We can't directly inspect axum::response::sse::Event fields, but we
     // can verify the conversion doesn't panic and produces *something*.
     drop(result);
@@ -383,7 +383,7 @@ fn sse_event_error_serializes_correctly() {
         message: "something broke".to_owned(),
         request_id: Some("req-abc".to_owned()),
     };
-    let result = sse_event_to_axum(event).expect("infallible");
+    let result = sse_event_to_axum_with_id((2, event)).expect("infallible");
     drop(result);
 }
 
@@ -396,6 +396,6 @@ fn sse_event_message_complete_serializes_correctly() {
             output_tokens: 200,
         },
     };
-    let result = sse_event_to_axum(event).expect("infallible");
+    let result = sse_event_to_axum_with_id((3, event)).expect("infallible");
     drop(result);
 }

--- a/crates/pylon/src/lib.rs
+++ b/crates/pylon/src/lib.rs
@@ -29,6 +29,8 @@ pub mod server;
 pub mod state;
 /// SSE event types for streaming agent responses to clients.
 pub mod stream;
+/// In-memory turn event buffer for SSE client recovery after connection drops.
+pub mod turn_buffer;
 
 #[cfg(test)]
 mod tests;

--- a/crates/pylon/src/openapi.rs
+++ b/crates/pylon/src/openapi.rs
@@ -33,6 +33,7 @@ use koina::http::CONTENT_TYPE_JSON;
         crate::handlers::sessions::streaming::send_message,
         crate::handlers::sessions::streaming::stream_turn,
         crate::handlers::sessions::streaming::events,
+        crate::handlers::sessions::streaming::reconnect_turn,
         crate::handlers::sessions::history,
         crate::handlers::nous::list,
         crate::handlers::nous::get_status,

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -71,6 +71,11 @@ pub fn build_router_with(
         )
         .route("/sessions/{id}/name", axum::routing::put(sessions::rename))
         .route("/sessions/{id}/messages", post(sessions::send_message))
+        // WHY(#3276): reconnect to an in-flight or recently-completed turn's SSE stream.
+        .route(
+            "/sessions/{session_id}/turns/{turn_id}/events",
+            get(sessions::reconnect_turn),
+        )
         .route("/sessions/{id}/history", get(sessions::history))
         .route("/events", get(sessions::events))
         .route("/nous", get(nous::list))
@@ -122,6 +127,10 @@ pub fn build_router_with(
         .route("/metrics", get(metrics::expose));
 
     router = router.fallback(fallback_handler);
+
+    // WHY(#3276): Spawn turn buffer reaper to clean up expired turn buffers.
+    // Must happen before `with_state` consumes the Arc.
+    crate::turn_buffer::spawn_reaper(Arc::clone(&state.turn_buffer_registry), shutdown.clone());
 
     // WHY: Bind state before merging extra routes. This converts
     // Router<Arc<AppState>> to Router<()> so the extra Router<()> from

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -164,6 +164,7 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         // WHY: pylon's standalone server does not configure embeddings; the
         // aletheia binary owns the embedding pipeline. Health reports "warn".
         embedding_provider: None,
+        turn_buffer_registry: Arc::new(crate::turn_buffer::TurnBufferRegistry::new()),
     });
 
     #[cfg(unix)]

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -19,6 +19,7 @@ use taxis::config::AletheiaConfig;
 use taxis::oikos::Oikos;
 
 use crate::idempotency::IdempotencyCache;
+use crate::turn_buffer::TurnBufferRegistry;
 
 /// Shared state for all Axum handlers, held behind `Arc` in the router.
 pub struct AppState {
@@ -60,6 +61,11 @@ pub struct AppState {
     /// `None` only when the pylon-only standalone server builds state without
     /// a configured embedding pipeline.
     pub embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
+    /// Per-turn event buffer registry for SSE client recovery (#3276).
+    ///
+    /// Shared between streaming handlers (which record events) and the
+    /// reconnect handler (which replays them).
+    pub turn_buffer_registry: Arc<TurnBufferRegistry>,
 }
 
 impl AppState {
@@ -182,6 +188,8 @@ pub struct SessionsState {
     pub idempotency_cache: Arc<IdempotencyCache>,
     /// Runtime configuration for API limit reads.
     pub config: Arc<tokio::sync::RwLock<AletheiaConfig>>,
+    /// Per-turn event buffer registry for SSE client recovery (#3276).
+    pub turn_buffer_registry: Arc<TurnBufferRegistry>,
 }
 
 impl FromRef<Arc<AppState>> for SessionsState {
@@ -193,6 +201,7 @@ impl FromRef<Arc<AppState>> for SessionsState {
             shutdown: state.shutdown.clone(),
             idempotency_cache: Arc::clone(&state.idempotency_cache),
             config: Arc::clone(&state.config),
+            turn_buffer_registry: Arc::clone(&state.turn_buffer_registry),
         }
     }
 }

--- a/crates/pylon/src/tests/auth.rs
+++ b/crates/pylon/src/tests/auth.rs
@@ -146,6 +146,7 @@ async fn app_auth_disabled() -> (axum::Router, tempfile::TempDir) {
         #[cfg(feature = "knowledge-store")]
         knowledge_store: None,
         embedding_provider: state.embedding_provider.clone(),
+        turn_buffer_registry: Arc::clone(&state.turn_buffer_registry),
     });
     (build_router(state, &test_security_config()), dir)
 }

--- a/crates/pylon/src/tests/helpers.rs
+++ b/crates/pylon/src/tests/helpers.rs
@@ -163,6 +163,7 @@ bind = "localhost"
         #[cfg(feature = "knowledge-store")]
         knowledge_store: None,
         embedding_provider: None,
+        turn_buffer_registry: Arc::new(crate::turn_buffer::TurnBufferRegistry::new()),
     });
 
     (state, dir)

--- a/crates/pylon/src/turn_buffer.rs
+++ b/crates/pylon/src/turn_buffer.rs
@@ -1,0 +1,426 @@
+//! In-memory turn event buffer for SSE client recovery.
+//!
+//! Each active turn gets a [`TurnBuffer`] that records every SSE event with a
+//! monotonic sequence ID. When a client reconnects with `Last-Event-ID: N`,
+//! the server replays events from `N+1` onward.
+//!
+//! Buffers are held in a [`TurnBufferRegistry`] keyed by `(session_id, turn_id)`.
+//! Completed turns are retained for a configurable TTL (default 5 minutes) so
+//! that late reconnects can still recover. A background reaper task prunes
+//! expired entries.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::{Mutex, Notify};
+use tracing::{debug, warn};
+
+/// Default time-to-live for completed turn buffers before they are reaped.
+const DEFAULT_COMPLETED_TTL: Duration = Duration::from_mins(5);
+
+/// Maximum events retained per turn buffer to bound memory usage.
+const MAX_EVENTS_PER_TURN: usize = 10_000;
+
+/// A single buffered SSE event with its sequence ID.
+#[derive(Debug, Clone)]
+pub(crate) struct BufferedEvent {
+    /// Monotonic sequence number (1-based).
+    pub seq: u64,
+    /// SSE event type name (e.g. `text_delta`, `message_complete`).
+    pub event_type: String,
+    /// Serialized JSON payload.
+    pub data: String,
+}
+
+/// Turn completion state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TurnState {
+    /// Turn is still executing; new events may arrive.
+    Running,
+    /// Turn completed successfully.
+    Completed,
+    /// Turn failed with an error.
+    Failed,
+}
+
+/// Per-turn event buffer.
+///
+/// Internally synchronized via `Mutex` so multiple producers (the streaming
+/// task) and consumers (reconnecting clients) can access it concurrently.
+pub(crate) struct TurnBuffer {
+    events: Vec<BufferedEvent>,
+    next_seq: u64,
+    state: TurnState,
+    /// When the turn completed or failed (for TTL-based reaping).
+    finished_at: Option<Instant>,
+    /// Notified whenever a new event is appended. Reconnecting clients
+    /// wait on this to receive live events after replaying the backlog.
+    notify: Arc<Notify>,
+}
+
+impl TurnBuffer {
+    fn new() -> Self {
+        Self {
+            events: Vec::new(),
+            next_seq: 1,
+            state: TurnState::Running,
+            finished_at: None,
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Append an event and return its assigned sequence number.
+    fn push(&mut self, event_type: String, data: String) -> u64 {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+
+        if self.events.len() < MAX_EVENTS_PER_TURN {
+            self.events.push(BufferedEvent {
+                seq,
+                event_type,
+                data,
+            });
+        } else if self.events.len() == MAX_EVENTS_PER_TURN {
+            warn!(
+                seq,
+                "turn buffer reached max capacity ({MAX_EVENTS_PER_TURN}), dropping new events"
+            );
+        }
+
+        self.notify.notify_waiters();
+        seq
+    }
+
+    /// Mark the turn as completed or failed.
+    fn finish(&mut self, state: TurnState) {
+        self.state = state;
+        self.finished_at = Some(Instant::now());
+        self.notify.notify_waiters();
+    }
+
+    /// Get all events with sequence > `after_seq`.
+    fn events_after(&self, after_seq: u64) -> Vec<BufferedEvent> {
+        self.events
+            .iter()
+            .filter(|e| e.seq > after_seq)
+            .cloned()
+            .collect()
+    }
+}
+
+/// Key for looking up a turn buffer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TurnKey {
+    session_id: String,
+    turn_id: String,
+}
+
+/// Registry of active and recently-completed turn buffers.
+///
+/// Held in `SessionsState` as `Arc<TurnBufferRegistry>`.
+pub struct TurnBufferRegistry {
+    buffers: Mutex<HashMap<TurnKey, Arc<Mutex<TurnBuffer>>>>,
+    completed_ttl: Duration,
+}
+
+impl Default for TurnBufferRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TurnBufferRegistry {
+    /// Create a new registry with the default completed-turn TTL.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            buffers: Mutex::new(HashMap::new()),
+            completed_ttl: DEFAULT_COMPLETED_TTL,
+        }
+    }
+
+    /// Create or retrieve the buffer for a turn. Returns a handle that the
+    /// streaming handler uses to record events.
+    pub(crate) async fn get_or_create(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+    ) -> Arc<Mutex<TurnBuffer>> {
+        let key = TurnKey {
+            session_id: session_id.to_owned(),
+            turn_id: turn_id.to_owned(),
+        };
+        let mut map = self.buffers.lock().await;
+        Arc::clone(
+            map.entry(key)
+                .or_insert_with(|| Arc::new(Mutex::new(TurnBuffer::new()))),
+        )
+    }
+
+    /// Look up an existing buffer (for reconnection). Returns `None` if
+    /// the turn was never registered or has already been reaped.
+    pub(crate) async fn get(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+    ) -> Option<Arc<Mutex<TurnBuffer>>> {
+        let key = TurnKey {
+            session_id: session_id.to_owned(),
+            turn_id: turn_id.to_owned(),
+        };
+        let map = self.buffers.lock().await;
+        map.get(&key).cloned()
+    }
+
+    /// Remove expired completed/failed turn buffers.
+    pub async fn reap_expired(&self) {
+        let mut map = self.buffers.lock().await;
+        let before = map.len();
+        let ttl = self.completed_ttl;
+
+        let mut to_remove = Vec::new();
+        for (key, buffer) in map.iter() {
+            let buf = buffer.lock().await;
+            if let Some(finished_at) = buf.finished_at
+                && finished_at.elapsed() > ttl
+            {
+                to_remove.push(key.clone());
+            }
+        }
+
+        for key in &to_remove {
+            map.remove(key);
+        }
+
+        let removed = to_remove.len();
+        if removed > 0 {
+            debug!(
+                removed,
+                remaining = before - removed,
+                "reaped expired turn buffers"
+            );
+        }
+    }
+}
+
+/// Handle for a streaming handler to record events into a turn buffer.
+///
+/// Wraps `Arc<Mutex<TurnBuffer>>` with convenience methods.
+#[derive(Clone)]
+pub(crate) struct TurnBufferHandle {
+    inner: Arc<Mutex<TurnBuffer>>,
+}
+
+impl TurnBufferHandle {
+    /// Create a handle from a buffer reference.
+    pub fn new(buffer: Arc<Mutex<TurnBuffer>>) -> Self {
+        Self { inner: buffer }
+    }
+
+    /// Record an SSE event. Returns the assigned sequence number.
+    pub async fn record(&self, event_type: &str, data: &str) -> u64 {
+        let mut buf = self.inner.lock().await;
+        buf.push(event_type.to_owned(), data.to_owned())
+    }
+
+    /// Mark the turn as completed.
+    pub async fn mark_completed(&self) {
+        let mut buf = self.inner.lock().await;
+        buf.finish(TurnState::Completed);
+    }
+
+    /// Mark the turn as failed.
+    pub async fn mark_failed(&self) {
+        let mut buf = self.inner.lock().await;
+        buf.finish(TurnState::Failed);
+    }
+
+    /// Get the notify handle for live-streaming to reconnecting clients.
+    pub async fn notify_handle(&self) -> Arc<Notify> {
+        let buf = self.inner.lock().await;
+        Arc::clone(&buf.notify)
+    }
+
+    /// Get events after a given sequence number, plus the current turn state.
+    pub async fn events_after(&self, after_seq: u64) -> (Vec<BufferedEvent>, TurnState) {
+        let buf = self.inner.lock().await;
+        (buf.events_after(after_seq), buf.state.clone())
+    }
+}
+
+/// Spawn a background task that periodically reaps expired turn buffers.
+///
+/// Runs every 60 seconds until the shutdown token is cancelled.
+pub(crate) fn spawn_reaper(
+    registry: Arc<TurnBufferRegistry>,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_mins(1));
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    registry.reap_expired().await;
+                }
+                () = shutdown.cancelled() => {
+                    debug!("turn buffer reaper shutting down");
+                    return;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: indices validated by assertions"
+)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn buffer_records_events_with_monotonic_seq() {
+        let registry = TurnBufferRegistry::new();
+        let buf = registry.get_or_create("ses-1", "turn-1").await;
+        let handle = TurnBufferHandle::new(buf);
+
+        let seq1 = handle.record("text_delta", r#"{"text":"hello"}"#).await;
+        let seq2 = handle.record("text_delta", r#"{"text":" world"}"#).await;
+        let seq3 = handle
+            .record("message_complete", r#"{"stop_reason":"end_turn"}"#)
+            .await;
+
+        assert_eq!(seq1, 1);
+        assert_eq!(seq2, 2);
+        assert_eq!(seq3, 3);
+    }
+
+    #[tokio::test]
+    async fn events_after_returns_subset() {
+        let registry = TurnBufferRegistry::new();
+        let buf = registry.get_or_create("ses-1", "turn-1").await;
+        let handle = TurnBufferHandle::new(buf);
+
+        handle.record("text_delta", r#"{"text":"a"}"#).await;
+        handle.record("text_delta", r#"{"text":"b"}"#).await;
+        handle.record("text_delta", r#"{"text":"c"}"#).await;
+
+        let (events, state) = handle.events_after(1).await;
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].seq, 2);
+        assert_eq!(events[1].seq, 3);
+        assert_eq!(state, TurnState::Running);
+    }
+
+    #[tokio::test]
+    async fn events_after_zero_returns_all() {
+        let registry = TurnBufferRegistry::new();
+        let buf = registry.get_or_create("ses-1", "turn-1").await;
+        let handle = TurnBufferHandle::new(buf);
+
+        handle.record("text_delta", r#"{"text":"a"}"#).await;
+        handle.record("text_delta", r#"{"text":"b"}"#).await;
+
+        let (events, _) = handle.events_after(0).await;
+        assert_eq!(events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn mark_completed_sets_state() {
+        let registry = TurnBufferRegistry::new();
+        let buf = registry.get_or_create("ses-1", "turn-1").await;
+        let handle = TurnBufferHandle::new(buf);
+
+        handle.record("message_complete", "{}").await;
+        handle.mark_completed().await;
+
+        let (_, state) = handle.events_after(0).await;
+        assert_eq!(state, TurnState::Completed);
+    }
+
+    #[tokio::test]
+    async fn mark_failed_sets_state() {
+        let registry = TurnBufferRegistry::new();
+        let buf = registry.get_or_create("ses-1", "turn-1").await;
+        let handle = TurnBufferHandle::new(buf);
+
+        handle.mark_failed().await;
+
+        let (_, state) = handle.events_after(0).await;
+        assert_eq!(state, TurnState::Failed);
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_unknown_turn() {
+        let registry = TurnBufferRegistry::new();
+        let result = registry.get("ses-1", "unknown").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_returns_existing_buffer() {
+        let registry = TurnBufferRegistry::new();
+        let _ = registry.get_or_create("ses-1", "turn-1").await;
+        let result = registry.get("ses-1", "turn-1").await;
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn reap_removes_expired_buffers() {
+        let registry = TurnBufferRegistry {
+            buffers: Mutex::new(HashMap::new()),
+            // WHY: use zero TTL so the buffer expires immediately for testing
+            completed_ttl: Duration::from_secs(0),
+        };
+
+        let buf = registry.get_or_create("ses-1", "turn-1").await;
+        let handle = TurnBufferHandle::new(buf);
+        handle.mark_completed().await;
+
+        // Small delay so elapsed > 0
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        registry.reap_expired().await;
+        assert!(registry.get("ses-1", "turn-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn reap_keeps_running_buffers() {
+        let registry = TurnBufferRegistry {
+            buffers: Mutex::new(HashMap::new()),
+            completed_ttl: Duration::from_secs(0),
+        };
+
+        let _ = registry.get_or_create("ses-1", "turn-1").await;
+        // Buffer is still Running (not completed)
+
+        registry.reap_expired().await;
+        assert!(
+            registry.get("ses-1", "turn-1").await.is_some(),
+            "running buffers must not be reaped"
+        );
+    }
+
+    #[tokio::test]
+    async fn buffer_caps_at_max_events() {
+        let registry = TurnBufferRegistry::new();
+        let buf = registry.get_or_create("ses-1", "turn-1").await;
+        let handle = TurnBufferHandle::new(buf);
+
+        // Push MAX + 10 events
+        for i in 0..(MAX_EVENTS_PER_TURN + 10) {
+            handle
+                .record("text_delta", &format!(r#"{{"text":"event-{i}"}}"#))
+                .await;
+        }
+
+        let (events, _) = handle.events_after(0).await;
+        assert_eq!(
+            events.len(),
+            MAX_EVENTS_PER_TURN,
+            "buffer must cap at MAX_EVENTS_PER_TURN"
+        );
+    }
+}

--- a/crates/pylon/tests/public_api.rs
+++ b/crates/pylon/tests/public_api.rs
@@ -190,6 +190,7 @@ impl TestEnvBuilder {
             #[cfg(feature = "knowledge-store")]
             knowledge_store: None,
             embedding_provider: None,
+            turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
         });
 
         TestEnv { state, _tmp: tmp }


### PR DESCRIPTION
## Summary

- Add `TurnBufferRegistry` — per-turn in-memory event buffer that records every SSE event with a monotonic sequence ID, surviving client disconnection
- Both `send_message` and `stream_turn` handlers now record events to the buffer and attach `id:` fields to SSE events for `Last-Event-ID` support
- New `GET /api/v1/sessions/{session_id}/turns/{turn_id}/events` reconnect endpoint: replays missed events from `Last-Event-ID+1`, then streams live events if the turn is still running
- Background reaper task prunes completed turn buffers after 5-minute TTL

## Design choices

- **In-memory only**: Turn buffers live in RAM, not SQLite. This keeps the hot path fast and avoids write amplification. The 5-minute TTL after completion is sufficient for reconnection — turns that completed hours ago are recoverable from the session store via the history endpoint.
- **Max 10K events per buffer**: Bounds memory usage at ~10MB per active turn in the worst case (large tool outputs). Events beyond the cap are dropped with a warning.
- **Sequence IDs on all SSE events**: Both the `send_message` (REST API) and `stream_turn` (TUI/webchat) protocols now emit `id:` fields. Existing clients that don't use `Last-Event-ID` are unaffected.
- **Reconnect replays then streams**: If the turn is still running, the reconnect handler replays buffered events then enters a live notification loop. If completed/failed, it replays all remaining events and closes.

## Test plan

- [x] 10 new unit tests for `TurnBufferRegistry` (buffer recording, event replay, state transitions, reaping, capacity cap)
- [x] `cargo check -p pylon -p nous -p graphe --tests` passes
- [x] `cargo clippy -p pylon -- -D warnings` clean (pre-existing `server.rs` issue only)
- [x] `cargo test -p pylon` — 388 passed, 2 pre-existing health test failures
- [ ] Manual test: connect to stream, kill client mid-turn, reconnect with `Last-Event-ID`

Closes #3276

🤖 Generated with [Claude Code](https://claude.com/claude-code)