### PR TITLE
feat(systemd): Type=notify + watchdog heartbeat + STOPPING signal (#3470 #3471 #3473)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "jiff",
  "koina",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "koina",
  "organon",
@@ -1940,7 +1940,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "eidos"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "jiff",
  "serde",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "eidos",
  "fjall",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -2832,7 +2832,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "axum 0.8.8",
  "dokimion",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "fd-lock",
  "futures",
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "dianoia",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "axum 0.8.8",
  "episteme",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "base64 0.22.1",
  "energeia",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "jiff",
  "snafu",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "poiesis-core",
  "rust_xlsxwriter",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "poiesis-core",
  "ppt-rs",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "krilla",
  "poiesis-core",
@@ -5309,7 +5309,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -6641,7 +6641,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bytes",
  "compact_str",
@@ -6896,7 +6896,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -7009,7 +7009,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -7122,14 +7122,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -146,6 +146,34 @@ pub(crate) async fn run(args: Args) -> Result<()> {
 
     info!(addr = %bind_addr, "pylon listening");
 
+    // WHY: notify systemd that initialization is complete and the HTTP
+    // gateway is accepting connections. This is the authoritative READY=1
+    // for the Type=notify service — it fires after the TCP listener binds.
+    oikonomos::runner::systemd::sd_notify_ready();
+
+    // WHY: spawn a dedicated watchdog heartbeat task that sends WATCHDOG=1
+    // at half the systemd WatchdogSec interval. If the Tokio runtime
+    // deadlocks, the heartbeat stops and systemd restarts the service.
+    let watchdog_token = runtime.shutdown_token.child_token();
+    if let Some(interval) = oikonomos::runner::systemd::sd_watchdog_interval() {
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(interval);
+            loop {
+                tokio::select! {
+                    biased;
+                    () = watchdog_token.cancelled() => break,
+                    _ = tick.tick() => {
+                        oikonomos::runner::systemd::sd_notify_watchdog();
+                    }
+                }
+            }
+        });
+        info!(
+            interval_secs = interval.as_secs(),
+            "systemd watchdog heartbeat started"
+        );
+    }
+
     // WHY: Without a SIGHUP handler, the signal hits the default Unix
     // disposition (terminate), crashing the server instead of reloading (#2350).
     #[cfg(unix)]
@@ -165,12 +193,17 @@ pub(crate) async fn run(args: Args) -> Result<()> {
         .whatever_context("server error")?;
 
     // INVARIANT: Drain ordering must follow this sequence:
+    // 0. Notify systemd that shutdown has begun (STOPPING=1).
     // 1. HTTP server has stopped accepting new requests (axum graceful_shutdown).
     // 2. Root token is cancelled: daemon tasks observe it and exit their loops.
     // 2a. Drain SIGHUP handler (observes shutdown token).
     // 3. Wait for system daemon to finish in-flight maintenance work.
     // 4. Drain nous actors with a timeout, flushing fjall WAL and other state.
     // 5. Drop AppState (session store, registries).
+
+    // WHY: notify systemd that graceful shutdown has begun so it does not
+    // treat the drain period as a hang and send SIGKILL prematurely.
+    oikonomos::runner::systemd::sd_notify_stopping();
 
     info!("shutting down");
 

--- a/crates/daemon/src/runner/lifecycle.rs
+++ b/crates/daemon/src/runner/lifecycle.rs
@@ -7,9 +7,7 @@ use tracing::Instrument;
 use crate::execution::execute_action;
 use crate::schedule::Schedule;
 
-use super::systemd::{
-    sd_notify_ready, sd_notify_stopping, sd_notify_watchdog, sd_watchdog_interval,
-};
+use super::systemd::{sd_notify_watchdog, sd_watchdog_interval};
 use super::{InFlightTask, TaskRunner};
 
 impl TaskRunner {
@@ -31,9 +29,6 @@ impl TaskRunner {
         self.restore_state();
 
         self.check_missed_cron_catchup();
-
-        // WHY: send READY=1 to systemd after initialization is complete.
-        sd_notify_ready();
 
         let mut interval = tokio::time::interval(Duration::from_secs(1));
 
@@ -65,9 +60,6 @@ impl TaskRunner {
                 }
             }
         }
-
-        // WHY: send STOPPING=1 to systemd before cleanup.
-        sd_notify_stopping();
 
         // WHY: abort all in-flight tasks on shutdown to prevent leaked work
         // after the runner exits. Without this, spawned tasks continue running

--- a/crates/daemon/src/runner/mod.rs
+++ b/crates/daemon/src/runner/mod.rs
@@ -34,7 +34,8 @@ mod lifecycle;
 mod output;
 mod persistence;
 mod registration;
-mod systemd;
+/// Systemd notify integration for daemon lifecycle signaling.
+pub mod systemd;
 mod tracking;
 pub(crate) use output::truncate_output;
 

--- a/crates/daemon/src/runner/systemd.rs
+++ b/crates/daemon/src/runner/systemd.rs
@@ -8,19 +8,19 @@ use koina::system::{Environment, RealSystem};
 ///
 /// WHY: systemd `Type=notify` services need this to know initialization is
 /// complete. No-op if `$NOTIFY_SOCKET` is not SET.
-pub(super) fn sd_notify_ready() {
+pub fn sd_notify_ready() {
     sd_notify("READY=1");
 }
 
 /// Send `WATCHDOG=1` to systemd.
 ///
 /// WHY: `WatchdogSec` integration enables automatic restart on hang.
-pub(super) fn sd_notify_watchdog() {
+pub fn sd_notify_watchdog() {
     sd_notify("WATCHDOG=1");
 }
 
 /// Send `STOPPING=1` to systemd before shutdown cleanup.
-pub(super) fn sd_notify_stopping() {
+pub fn sd_notify_stopping() {
     sd_notify("STOPPING=1");
 }
 
@@ -28,7 +28,7 @@ pub(super) fn sd_notify_stopping() {
 ///
 /// Returns `None` if the variable is not SET or unparseable. The recommended
 /// notification interval is half the watchdog timeout.
-pub(super) fn sd_watchdog_interval() -> Option<Duration> {
+pub fn sd_watchdog_interval() -> Option<Duration> {
     let usec_str = RealSystem.var("WATCHDOG_USEC")?;
     let usec: u64 = usec_str.parse().ok()?;
     // WHY: notify at half the watchdog interval to avoid races.

--- a/instance.example/services/aletheia.service
+++ b/instance.example/services/aletheia.service
@@ -4,11 +4,16 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-# WHY: Type=exec waits for the exec() call to succeed before marking the
-# service as started, catching binary-not-found immediately. The ExecStartPost
-# readiness probe then polls the health endpoint so dependents and `systemctl
-# start` only return once the HTTP gateway is actually accepting connections.
-Type=exec
+# WHY: Type=notify lets the binary signal READY=1 after the HTTP gateway
+# binds and starts accepting connections. systemctl start blocks until
+# the notification arrives, replacing the old ExecStartPost health-probe
+# polling loop. The binary also sends STOPPING=1 at shutdown start so
+# systemd knows drain is in progress.
+Type=notify
+# WHY: WatchdogSec enables automatic restart if the Tokio runtime
+# deadlocks. The binary sends WATCHDOG=1 every 15s (half the interval).
+# If two consecutive heartbeats are missed, systemd restarts the service.
+WatchdogSec=30
 Environment=RUST_BACKTRACE=1
 # WARNING: Do not put secrets (API keys, tokens) directly in this file.
 # Use the EnvironmentFile below instead. Unit files are world-readable.
@@ -17,16 +22,6 @@ Environment=RUST_BACKTRACE=1
 EnvironmentFile=-%h/aletheia/instance/config/env  # CUSTOMIZE: path to your instance config/env
 # %h expands to the user's home directory at runtime.
 ExecStart=%h/.local/bin/aletheia -r %h/aletheia/instance  # CUSTOMIZE: binary and instance paths
-# Readiness probe: poll the health endpoint until the gateway is listening.
-# Retries every 0.5s for up to 15s (30 attempts). Adjust URL if using a
-# non-default port or bind address.
-ExecStartPost=/bin/sh -c '\
-  url="${ALETHEIA_HEALTH_URL:-http://localhost:18789/api/health}"; \
-  i=0; while [ "$i" -lt 30 ]; do \
-    if curl -sf --max-time 2 "$url" >/dev/null 2>&1; then exit 0; fi; \
-    sleep 0.5; i=$((i+1)); \
-  done; \
-  echo "aletheia health endpoint not reachable after 15s" >&2; exit 1'
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- Type=notify with READY=1 after TCP bind (removes ExecStartPost health probe)
- WatchdogSec=30 with WATCHDOG=1 heartbeat every 15s (detects Tokio deadlocks)
- STOPPING=1 sent at shutdown start before drain sequence
- Daemon systemd module promoted to pub for binary crate access

Closes #3470
Closes #3471
Closes #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)