### PR TITLE
refactor: canonical Tokio graceful shutdown — TaskTracker + CancellationToken (#3472)

### DIFF
--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -33,7 +33,7 @@ pub(crate) struct BackupArgs {
     /// Skip confirmation prompt when pruning
     #[arg(long)]
     pub yes: bool,
-    /// Operate on fjall knowledge store instead of SQLite session store
+    /// Operate on fjall knowledge store instead of `SQLite` session store
     #[arg(long)]
     pub fjall: bool,
 }
@@ -102,6 +102,10 @@ pub(crate) fn run(instance_root: Option<&PathBuf>, args: &BackupArgs) -> Result<
 }
 
 /// Handle fjall knowledge store backup operations.
+#[expect(
+    clippy::fn_params_excessive_bools,
+    reason = "1:1 pass-through of CLI flags from clap; grouping into a struct adds no clarity"
+)]
 fn run_fjall(
     oikos: &taxis::oikos::Oikos,
     list: bool,

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -59,7 +59,7 @@ pub(crate) async fn run(args: Args) -> Result<()> {
 
     let oikos_arc = Arc::new(oikos);
 
-    let mut runtime = RuntimeBuilder::production(Arc::clone(&oikos_arc), config.clone())
+    let runtime = RuntimeBuilder::production(Arc::clone(&oikos_arc), config.clone())
         .build()
         .await?;
 
@@ -197,7 +197,8 @@ pub(crate) async fn run(args: Args) -> Result<()> {
     // 1. HTTP server has stopped accepting new requests (axum graceful_shutdown).
     // 2. Root token is cancelled: daemon tasks observe it and exit their loops.
     // 2a. Drain SIGHUP handler (observes shutdown token).
-    // 3. Wait for system daemon to finish in-flight maintenance work.
+    // 3. Close TaskTracker + wait with timeout: all tracked background tasks
+    //    (system daemon, per-agent daemon runners, lazy init) drain cleanly.
     // 4. Drain nous actors with a timeout, flushing fjall WAL and other state.
     // 5. Drop AppState (session store, registries).
 
@@ -224,10 +225,20 @@ pub(crate) async fn run(args: Args) -> Result<()> {
         }
     }
 
-    while let Some(result) = runtime.daemon_handles.join_next().await {
-        match result {
-            Ok(()) => {}
-            Err(e) => warn!(error = %e, "system daemon panicked during shutdown"),
+    // WHY: close() prevents new tasks from being spawned; wait() resolves
+    // when every tracked task has completed. The timeout ensures we don't
+    // hang indefinitely on a stuck daemon.
+    runtime.task_tracker.close();
+    tokio::select! {
+        () = runtime.task_tracker.wait() => {
+            info!("all tracked tasks drained");
+        }
+        () = tokio::time::sleep(shutdown_timeout) => {
+            warn!(
+                remaining = runtime.task_tracker.len(),
+                timeout_secs = shutdown_timeout.as_secs(),
+                "tracked task drain timed out"
+            );
         }
     }
 

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -5,8 +5,8 @@ use std::time::Instant;
 
 use snafu::prelude::*;
 use tokio::sync::Mutex;
-use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tracing::{Instrument, error, info, warn};
 
 use agora::types::ChannelProvider;
@@ -54,7 +54,10 @@ pub(crate) struct Runtime {
         reason = "accessible for callers that need direct NousManager access"
     )]
     pub nous_manager: Arc<NousManager>,
-    pub daemon_handles: JoinSet<()>,
+    /// Tracks all long-running background tasks (daemons, per-agent runners,
+    /// lazy init jobs). On shutdown: close the tracker, then `wait()` with a
+    /// timeout so every task gets a chance to drain cleanly.
+    pub task_tracker: TaskTracker,
     pub shutdown_token: CancellationToken,
 }
 
@@ -240,6 +243,7 @@ impl RuntimeBuilder {
     )]
     pub(crate) async fn build(self) -> Result<Runtime> {
         let shutdown_token = CancellationToken::new();
+        let task_tracker = TaskTracker::new();
 
         info!(root = %self.oikos.root().display(), "instance discovered");
 
@@ -389,7 +393,7 @@ impl RuntimeBuilder {
             let lazy = Arc::new(LazyEmbeddingProvider::new(self.config.embedding.clone()));
             // Spawn background init so the model loads without blocking startup.
             let lazy_clone = Arc::clone(&lazy);
-            tokio::spawn(async move {
+            task_tracker.spawn(async move {
                 lazy_clone.get().await;
             });
             lazy
@@ -622,9 +626,6 @@ impl RuntimeBuilder {
             info!(count = nous_manager.count(), "nous actors spawned");
         }
 
-        // Daemon handles collector
-        let mut daemon_handles: JoinSet<()> = JoinSet::new();
-
         if self.daemons {
             // System maintenance daemon
             let maintenance_config =
@@ -642,7 +643,7 @@ impl RuntimeBuilder {
             }
 
             daemon_runner.register_maintenance_tasks();
-            daemon_handles.spawn(
+            task_tracker.spawn(
                 async move {
                     daemon_runner.run().await;
                 }
@@ -694,7 +695,7 @@ impl RuntimeBuilder {
                     ..oikonomos::schedule::TaskDef::default()
                 });
                 let daemon_span = tracing::info_span!("daemon", nous.id = %agent_def.id);
-                tokio::spawn(
+                task_tracker.spawn(
                     async move {
                         runner.run().await;
                     }
@@ -742,7 +743,7 @@ impl RuntimeBuilder {
         Ok(Runtime {
             state,
             nous_manager,
-            daemon_handles,
+            task_tracker,
             shutdown_token,
         })
     }

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -126,14 +126,13 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
     // The two enums are intentionally decoupled so taxis does not depend on
     // hermeneus, but both default to `Disabled` (sovereignty-first).
     let prompt_cache_mode = match config.anthropic.prompt_cache_mode {
-        taxis::config::PromptCacheMode::Disabled => hermeneus::provider::PromptCacheMode::Disabled,
         taxis::config::PromptCacheMode::Ephemeral => {
             hermeneus::provider::PromptCacheMode::Ephemeral
         }
         taxis::config::PromptCacheMode::Extended => hermeneus::provider::PromptCacheMode::Extended,
         // WHY: taxis::config::PromptCacheMode is #[non_exhaustive] to keep
-        // future additions non-breaking. Unknown variants default to the
-        // sovereignty-first policy.
+        // future additions non-breaking. Unknown/Disabled variants default to
+        // the sovereignty-first policy.
         _ => hermeneus::provider::PromptCacheMode::Disabled,
     };
     let provider_config = ProviderConfig {

--- a/crates/hermeneus/src/cc/process.rs
+++ b/crates/hermeneus/src/cc/process.rs
@@ -106,6 +106,10 @@ pub(crate) struct CcOutput {
 ///
 /// # Errors
 /// Returns errors on spawn failure, timeout, or if CC reports an error result.
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential process lifecycle: spawn, feed stdin, wait, parse — splitting obscures the flow"
+)]
 #[tracing::instrument(skip_all)]
 pub(crate) async fn run_completion(
     cc_binary: &PathBuf,

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -94,10 +94,6 @@ pub enum ServerError {
 /// until the OS delivers a shutdown signal; dropping it at that point skips the
 /// SIGHUP-handler drain and `shutdown_readonly` call, which may leave actor tasks
 /// running until the runtime exits.
-#[expect(
-    clippy::expect_used,
-    reason = "startup-time invariants: default nous spawn and signal handlers are not recoverable errors"
-)]
 pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
     let oikos = Oikos::from_root(&config.instance_path);
     oikos.validate().context(ValidationSnafu)?;


### PR DESCRIPTION
## Summary
- Replace JoinSet with TaskTracker for all long-running tasks (embedding init, daemon runners)
- Shutdown: cancel token → tracker.close() → wait with timeout → log remaining on timeout
- Drive-by clippy fixes in hermeneus, pylon, aletheia (blocking gate)

Closes #3472

🤖 Generated with [Claude Code](https://claude.com/claude-code)