### PR TITLE
feat: distributed tracing — propagate request_id from HTTP to nous + tools (#3384)

### DIFF
--- a/crates/organon/src/registry/mod.rs
+++ b/crates/organon/src/registry/mod.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 use indexmap::IndexMap;
 use snafu::ensure;
-use tracing::info_span;
+use tracing::{Instrument, info_span};
 
 use koina::id::ToolName;
 
@@ -106,9 +106,16 @@ impl ToolRegistry {
             tool.duration_ms = tracing::field::Empty,
             tool.status = tracing::field::Empty,
         );
-        let _guard = span.enter();
         let start = Instant::now();
-        let result = tool.executor.execute(input, ctx).await;
+        // WHY: `.instrument(span)` instead of `span.enter()` so the span context
+        // propagates correctly across `.await` points. `span.enter()` in async code
+        // keeps the span entered on the current thread even when suspended, which
+        // causes incorrect parent attribution for concurrent tasks (#3384).
+        let result = tool
+            .executor
+            .execute(input, ctx)
+            .instrument(span.clone())
+            .await;
         let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
         span.record("tool.duration_ms", duration_ms);
         match &result {

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -163,6 +163,7 @@ pub async fn send_message(
                                 input_tokens,
                                 output_tokens,
                             },
+                            request_id: Some(request_id.0.clone()),
                         },
                     ))
                     .await;
@@ -283,6 +284,7 @@ pub async fn send_message(
             // body, even if the turn fails before producing any content events.
             let event = SseEvent::MessageStart {
                 status: "accepted".to_owned(),
+                request_id: Some(request_id_str.clone()),
             };
             let seq = record_sse_event(&buf_handle_task, &event).await;
             let _ = tx.send((seq, event)).await;
@@ -305,7 +307,13 @@ pub async fn send_message(
             };
             match result {
                 Ok(result) => {
-                    emit_turn_result_events_buffered(&tx, &buf_handle_task, &result).await;
+                    emit_turn_result_events_buffered(
+                        &tx,
+                        &buf_handle_task,
+                        &result,
+                        Some(&request_id_str),
+                    )
+                    .await;
                     buf_handle_task.mark_completed().await;
 
                     // NOTE: Store the turn summary so cache-hit replays return real data.
@@ -345,6 +353,7 @@ pub async fn send_message(
                             input_tokens: 0,
                             output_tokens: 0,
                         },
+                        request_id: Some(request_id_str.clone()),
                     };
                     let seq = record_sse_event(&buf_handle_task, &event).await;
                     let _ = tx.send((seq, event)).await;
@@ -491,6 +500,7 @@ pub async fn stream_turn(
         session_id: session_id.clone(),
         nous_id: agent_id.clone(),
         turn_id: turn_id.clone(),
+        request_id: Some(request_id.0.clone()),
     };
     let seq = record_webchat_event(&buf_handle, &start_event).await;
     let _ = webchat_tx.send((seq, start_event)).await;
@@ -914,10 +924,14 @@ fn redact_secrets(msg: &str) -> String {
 ///
 /// WHY(#3276): Each event is recorded in the turn buffer before being sent
 /// to the client channel, so events survive client disconnection.
+///
+/// WHY(#3384): `request_id` is threaded through so `message_complete` carries it
+/// for distributed tracing correlation on the client side.
 async fn emit_turn_result_events_buffered(
     tx: &mpsc::Sender<(u64, SseEvent)>,
     buf: &TurnBufferHandle,
     result: &TurnResult,
+    request_id: Option<&str>,
 ) {
     if !result.content.is_empty() {
         let event = SseEvent::TextDelta {
@@ -953,6 +967,7 @@ async fn emit_turn_result_events_buffered(
             input_tokens: result.usage.input_tokens,
             output_tokens: result.usage.output_tokens,
         },
+        request_id: request_id.map(ToOwned::to_owned),
     };
     let seq = record_sse_event(buf, &event).await;
     let _ = tx.send((seq, event)).await;

--- a/crates/pylon/src/handlers/sessions/streaming_tests.rs
+++ b/crates/pylon/src/handlers/sessions/streaming_tests.rs
@@ -395,6 +395,7 @@ fn sse_event_message_complete_serializes_correctly() {
             input_tokens: 100,
             output_tokens: 200,
         },
+        request_id: Some("req-456".to_owned()),
     };
     let result = sse_event_to_axum_with_id((3, event)).expect("infallible");
     drop(result);

--- a/crates/pylon/src/pagination.rs
+++ b/crates/pylon/src/pagination.rs
@@ -79,6 +79,10 @@ impl<T: Serialize> PaginatedResponse<T> {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: vec/JSON indices valid after asserting len or known structure"
+)]
 mod tests {
     use super::*;
 

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -361,6 +361,10 @@ fn apply_security_headers(router: Router, security: &SecurityConfig) -> Router {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: serde_json::Value Index returns Null for absent keys, never panics"
+)]
 mod tests {
     use super::*;
     use crate::security::{CorsConfig, CsrfConfig, RateLimitConfig, TlsConfig};

--- a/crates/pylon/src/stream.rs
+++ b/crates/pylon/src/stream.rs
@@ -10,7 +10,12 @@ use utoipa::ToSchema;
 pub(crate) enum SseEvent {
     /// Acknowledgment that the message was accepted and a turn is starting.
     #[serde(rename = "message_start")]
-    MessageStart { status: String },
+    MessageStart {
+        status: String,
+        /// Per-request correlation ID for distributed tracing across the pipeline.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+    },
 
     /// Incremental text output from the assistant.
     #[serde(rename = "text_delta")]
@@ -48,6 +53,9 @@ pub(crate) enum SseEvent {
     MessageComplete {
         stop_reason: String,
         usage: UsageData,
+        /// Per-request correlation ID for distributed tracing across the pipeline.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
     },
 
     /// An error occurred during the turn.
@@ -101,6 +109,9 @@ pub(crate) enum WebchatEvent {
         session_id: String,
         nous_id: String,
         turn_id: String,
+        /// Per-request correlation ID for distributed tracing across the pipeline.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
     },
     /// Incremental extended-thinking output.
     #[serde(rename = "thinking_delta")]

--- a/crates/pylon/src/tests/sse_events.rs
+++ b/crates/pylon/src/tests/sse_events.rs
@@ -47,6 +47,7 @@ fn sse_event_type_message_complete() {
             input_tokens: 10,
             output_tokens: 5,
         },
+        request_id: None,
     };
     assert_eq!(event.event_type(), "message_complete");
 }
@@ -79,12 +80,14 @@ fn sse_event_message_complete_serialization() {
             input_tokens: 100,
             output_tokens: 50,
         },
+        request_id: Some("req-789".to_owned()),
     };
     let json = serde_json::to_value(&event).unwrap();
     assert_eq!(json["type"], "message_complete");
     assert_eq!(json["stop_reason"], "end_turn");
     assert_eq!(json["usage"]["input_tokens"], 100);
     assert_eq!(json["usage"]["output_tokens"], 50);
+    assert_eq!(json["request_id"], "req-789");
 }
 
 #[test]
@@ -121,6 +124,7 @@ fn tui_event_message_start_type() {
         session_id: "s1".to_owned(),
         nous_id: "syn".to_owned(),
         turn_id: "t1".to_owned(),
+        request_id: None,
     };
     assert_eq!(event.event_type(), "message_start");
 }
@@ -196,12 +200,14 @@ fn tui_event_message_start_serialization() {
         session_id: "s1".to_owned(),
         nous_id: "syn".to_owned(),
         turn_id: "t1".to_owned(),
+        request_id: Some("req-abc".to_owned()),
     };
     let json = serde_json::to_value(&event).unwrap();
     assert_eq!(json["type"], "message_start");
     assert_eq!(json["session_id"], "s1");
     assert_eq!(json["nous_id"], "syn");
     assert_eq!(json["turn_id"], "t1");
+    assert_eq!(json["request_id"], "req-abc");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- request_id now flows through SSE events (MessageStart, MessageComplete, WebchatEvent)
- Fixed organon tool_execute: span.enter() → .instrument() for correct async propagation
- Full chain: HTTP middleware → pylon span → NousMessage::Turn{span} → actor pipeline → tool execution

Closes #3384

🤖 Generated with [Claude Code](https://claude.com/claude-code)