### PR TITLE
refactor(taxis): replace figment with owned config loader (#3447)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Desktop crate (`proskenion`) excluded from workspace — build standalone:
 - **IDs:** Newtypes (`AgentId`, `SessionId`, `NousId`). `ulid` for generation.
 - **Time:** `jiff`. **Strings:** `compact_str` for small strings.
 - **Async:** Tokio actor model (`NousActor` pattern).
-- **Config:** figment TOML cascade in `taxis`.
+- **Config:** TOML cascade in `taxis` (owned loader, no figment).
 - **Lints:** `#[expect(lint, reason = "...")]` not `#[allow]`.
 - **Visibility:** `pub(crate)` default. `pub` only for cross-crate API.
 - **Naming:** Greek names per `docs/lexicon.md`. No barrel files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Shell: [standards/SHELL.md](standards/SHELL.md)
 
 ### Config
 
-- **Rust crates:** `instance.example/config/aletheia.toml` (figment cascade: defaults → TOML → env vars)
+- **Rust crates:** `instance.example/config/aletheia.toml` (TOML cascade: defaults → TOML → env vars)
 
 ## Commands
 
@@ -40,7 +40,7 @@ Test tiers: [docs/test-tiers.md](docs/test-tiers.md)
 - **IDs:** Newtypes for all domain IDs (`AgentId`, `SessionId`, `NousId`)
 - **Time:** `jiff` for time, `ulid` for IDs, `compact_str` for small strings
 - **Async:** Tokio actor model (`NousActor` pattern)
-- **Config:** figment TOML cascade in `taxis`
+- **Config:** TOML cascade in `taxis` (owned loader, no figment)
 - **Lints:** `#[expect(lint, reason = "...")]` over `#[allow]`; every suppression justified
 - **Visibility:** `pub(crate)` by default; `pub` only for cross-crate API surface
 - **Naming:** Greek names per [standards/GNOMON.md](standards/GNOMON.md), registry at [docs/lexicon.md](docs/lexicon.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,8 +140,8 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml",
+ "toml_edit",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2061,7 +2061,7 @@ dependencies = [
  "tempfile",
  "tokenizers",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
@@ -2203,22 +2203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "figment"
-version = "0.10.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
-dependencies = [
- "atomic",
- "parking_lot",
- "pear",
- "serde",
- "tempfile",
- "toml 0.8.23",
- "uncased",
- "version_check",
 ]
 
 [[package]]
@@ -3255,12 +3239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inlinable_string"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
 name = "inotify"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,7 +3546,7 @@ dependencies = [
  "snafu",
  "syntect",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -4239,7 +4217,7 @@ dependencies = [
  "thesauros",
  "tokio",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -4429,7 +4407,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -4658,29 +4636,6 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
-]
-
-[[package]]
-name = "pear"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
-dependencies = [
- "inlinable_string",
- "pear_codegen",
- "yansi",
-]
-
-[[package]]
-name = "pear_codegen"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5059,7 +5014,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5080,19 +5035,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -6482,15 +6424,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -7015,15 +6948,15 @@ dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
  "eidos",
- "figment",
  "koina",
  "proptest",
  "rand 0.9.4",
  "serde",
  "serde_json",
  "snafu",
+ "taxis",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-test",
 ]
@@ -7142,7 +7075,7 @@ dependencies = [
  "taxis",
  "tempfile",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -7388,38 +7321,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -7433,29 +7345,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -7464,14 +7362,8 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -7745,15 +7637,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicase"
@@ -8618,15 +8501,6 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -8834,12 +8708,6 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,9 +145,6 @@ tracing-test = "0.2"
 # Metrics
 prometheus = { version = "0.14", features = ["process"] }
 
-# Config
-figment = { version = "0.10", default-features = false, features = ["toml", "env"] }
-
 # IDs
 uuid = { version = "1", default-features = false, features = ["v4", "serde"] }
 

--- a/_llm/architecture.toml
+++ b/_llm/architecture.toml
@@ -13,7 +13,7 @@ used_by = ["every other crate"]
 [[crate]]
 name = "taxis"
 layer = "foundation"
-purpose = "Config cascade: TOML + env + CLI via figment"
+purpose = "Config cascade: TOML + env via owned loader (deep-merge on serde_json::Value)"
 depends = ["koina"]
 
 [[crate]]

--- a/_llm/decisions.toml
+++ b/_llm/decisions.toml
@@ -50,8 +50,8 @@ why = "Zero C deps, embedded, WAL"
 
 [[decision]]
 area = "config"
-choice = "figment + serde"
-why = "Oikos cascade: TOML + env + CLI, hierarchical merge"
+choice = "owned toml + serde_json merge + env overlay"
+why = "Oikos cascade: defaults (serde_json::Value) → TOML → env with __ splitting. Cut 6 transitive deps including pear proc-macro combinator; ~80 lines replaced figment's 27-line surface."
 
 [[decision]]
 area = "ids"

--- a/crates/taxis/.kanon-lint-ignore
+++ b/crates/taxis/.kanon-lint-ignore
@@ -15,6 +15,12 @@ RUST/pub-visibility:src/reload.rs
 RUST/pub-visibility:src/validate.rs
 RUST/pub-visibility:src/workspace_schema.rs
 
+# WHY: test_support.rs is gated on `#[cfg(any(test, feature = "test-support"))]`
+# and exposes EnvJail to sibling integration-test binaries; its pub surface is
+# test-only and must stay pub so public_api_loader.rs can import it.
+RUST/pub-visibility:src/test_support.rs
+RUST/expect:src/test_support.rs
+
 # WHY: config_tests.rs files are test-only (included from #[cfg(test)] modules)
 # but lack their own #[cfg(test)] boundary, causing false positives for rules
 # that skip test code via the cfg(test) line marker.

--- a/crates/taxis/CLAUDE.md
+++ b/crates/taxis/CLAUDE.md
@@ -6,7 +6,7 @@ Configuration cascade and path resolution: TOML loading, oikos directory structu
 
 1. `src/config/mod.rs`: AletheiaConfig root struct and all nested config types
 2. `src/oikos.rs`: Oikos instance directory resolver (root, data, config, logs, nous, shared, theke)
-3. `src/loader.rs`: Figment-based TOML cascade: defaults -> file -> env vars, with interpolation and decryption
+3. `src/loader.rs`: TOML cascade (owned): defaults -> file -> env vars, with interpolation and decryption
 4. `src/cascade.rs`: Three-tier file discovery (nous/{id}/ -> shared/ -> theke/)
 5. `src/reload.rs`: Hot-reload classification (restart vs live update) and config diffing
 
@@ -29,8 +29,8 @@ Configuration cascade and path resolution: TOML loading, oikos directory structu
 
 ## Patterns
 
-- **Figment cascade**: Compiled defaults -> TOML file -> `ALETHEIA_*` env vars. Later wins.
-- **Env interpolation**: `${VAR:-default}` and `${VAR:?error}` syntax in TOML values, resolved before Figment.
+- **TOML cascade**: Compiled defaults -> TOML file -> `ALETHEIA_*` env vars. Later wins. Merge is a serde_json::Value deep merge; env overlay walks `ALETHEIA_*` with `__` separators.
+- **Env interpolation**: `${VAR:-default}` and `${VAR:?error}` syntax in TOML values, resolved before TOML parse.
 - **Encrypted values**: `enc:` prefix triggers AES-256-GCM decryption using `~/.config/aletheia/primary.key`.
 - **Three-tier cascade**: File lookup walks nous/{id}/ -> shared/ -> theke/. Most specific wins.
 - **Hot-reload**: Gateway port/bind/TLS/auth require restart. All other config paths are live-reloadable.
@@ -51,5 +51,5 @@ Configuration cascade and path resolution: TOML loading, oikos directory structu
 
 ## Dependencies
 
-Uses: koina, figment, serde, toml, ring
+Uses: koina, serde, serde_json, toml, chacha20poly1305, base64, rand
 Used by: nous, pylon, organon, diaporeia, agora, aletheia (binary)

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -13,23 +13,30 @@ workspace = true
 [features]
 test-core = []
 test-full = []
+# WHY: exposes the test_support module (EnvJail) for sibling integration test
+# binaries in tests/. Gated so production builds never see test helpers.
+test-support = ["dep:tempfile"]
 
 [dependencies]
 koina = { path = "../koina" }
 eidos = { path = "../eidos" }
 base64 = { workspace = true }
-figment = { workspace = true }
 rand = { workspace = true }
 chacha20poly1305 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
+# WHY: optional — only compiled in when the `test-support` feature gates the
+# EnvJail helper in. Production builds never pull tempfile.
+tempfile = { workspace = true, optional = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+# WHY: self-reference with `test-support` exposes `taxis::test_support::EnvJail`
+# to sibling integration-test binaries (tests/public_api_loader.rs etc).
+taxis = { path = ".", features = ["test-support"] }
 koina = { path = "../koina", features = ["test-support"] }
-figment = { workspace = true, features = ["test"] }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 tracing-test = { workspace = true }

--- a/crates/taxis/clippy.toml
+++ b/crates/taxis/clippy.toml
@@ -21,7 +21,7 @@ reason = "use tokio::fs for async or abstract behind a trait for testability"
 path = "std::fs::File::open"
 reason = "use tokio::fs::File::open for async or abstract behind a trait for testability"
 
-# Config is file-based (figment TOML cascade); HTTP does not belong here
+# Config is file-based (TOML cascade); HTTP does not belong here
 [[disallowed-types]]
 path = "reqwest::Client"
 reason = "taxis must not perform HTTP calls; config is file-based"

--- a/crates/taxis/src/config/config_tests.rs
+++ b/crates/taxis/src/config/config_tests.rs
@@ -827,6 +827,10 @@ fn new_sections_survive_serde_roundtrip() {
 // ─── Wave 0 (#2306): config schema for 190 behavioral constants ──────────────
 
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one assertion per pre-extraction constant; splitting would fragment the regression guard"
+)]
 fn deployment_defaults_match_original_constants() {
     let nb = NousBehaviorConfig::default();
     // nous::actor::DEGRADED_PANIC_THRESHOLD = 5
@@ -1070,6 +1074,10 @@ fn deployment_defaults_match_original_constants() {
 }
 
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one assertion per pre-extraction constant; splitting would fragment the regression guard"
+)]
 fn per_agent_defaults_match_original_constants() {
     let ab = AgentBehaviorDefaults::default();
 

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -56,10 +56,6 @@ pub fn primary_key_path() -> Option<PathBuf> {
 ///
 /// Returns an error if the file exists but cannot be read or contains
 /// invalid hex data.
-#[expect(
-    clippy::result_large_err,
-    reason = "taxis Error is inherently large due to PathBuf fields"
-)]
 #[must_use]
 #[expect(
     clippy::double_must_use,
@@ -77,10 +73,6 @@ pub fn load_primary_key(path: &Path) -> Result<Option<[u8; KEY_LEN]>> {
     parse_hex_key(hex, path)
 }
 
-#[expect(
-    clippy::result_large_err,
-    reason = "taxis Error is inherently large due to PathBuf fields"
-)]
 fn parse_hex_key(hex: &str, path: &Path) -> Result<Option<[u8; KEY_LEN]>> {
     if hex.len() != KEY_LEN * 2 {
         return Err(error::InvalidPrimaryKeySnafu {
@@ -155,10 +147,6 @@ fn to_hex(bytes: &[u8]) -> String {
 ///
 /// Returns an error if the file already exists, the directory cannot be
 /// created, or the file cannot be written.
-#[expect(
-    clippy::result_large_err,
-    reason = "taxis Error is inherently large due to PathBuf fields"
-)]
 #[must_use]
 #[expect(
     clippy::double_must_use,
@@ -196,10 +184,6 @@ pub(crate) fn is_encrypted(value: &str) -> bool {
 /// # Errors
 ///
 /// Returns an error if encryption fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "taxis Error is inherently large due to PathBuf fields"
-)]
 #[must_use]
 #[expect(
     clippy::double_must_use,
@@ -231,10 +215,6 @@ pub(crate) fn encrypt_value(plaintext: &str, primary_key: &[u8; KEY_LEN]) -> Res
 /// ChaCha20-Poly1305 tag length in bytes.
 const TAG_LEN: usize = 16;
 
-#[expect(
-    clippy::result_large_err,
-    reason = "taxis Error is inherently large due to PathBuf fields"
-)]
 pub(crate) fn decrypt_value(encrypted: &str, primary_key: &[u8; KEY_LEN]) -> Result<String> {
     let encoded = encrypted
         .strip_prefix(ENCRYPTED_PREFIX)
@@ -285,10 +265,6 @@ fn build_decrypt_error(reason: &str) -> error::Error {
 /// # Errors
 ///
 /// Returns an error if the file cannot be read/written or encryption fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "taxis Error is inherently large due to PathBuf fields"
-)]
 #[must_use]
 #[expect(
     clippy::double_must_use,
@@ -380,10 +356,6 @@ pub(crate) fn decrypt_toml_values(value: &mut toml::Value, primary_key: Option<&
 /// # Errors
 ///
 /// Returns an error if any encryption operation fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "taxis Error is inherently large due to PathBuf fields"
-)]
 pub(crate) fn encrypt_sensitive_values(
     value: &mut toml::Value,
     primary_key: &[u8; KEY_LEN],
@@ -393,10 +365,6 @@ pub(crate) fn encrypt_sensitive_values(
     Ok(count)
 }
 
-#[expect(
-    clippy::result_large_err,
-    reason = "taxis Error is inherently large due to PathBuf fields"
-)]
 fn encrypt_recursive(
     value: &mut toml::Value,
     primary_key: &[u8; KEY_LEN],

--- a/crates/taxis/src/error.rs
+++ b/crates/taxis/src/error.rs
@@ -1,7 +1,7 @@
 //! Taxis-specific errors.
 //!
 //! Covers instance root discovery, configuration file reading, and
-//! TOML/JSON/Figment parsing failures during the configuration cascade.
+//! TOML/JSON parsing failures during the configuration cascade.
 
 use std::path::PathBuf;
 
@@ -50,10 +50,27 @@ pub enum Error {
         location: snafu::Location,
     },
 
-    /// Figment configuration error.
-    #[snafu(display("configuration error: {source}"))]
-    Figment {
-        source: figment::Error,
+    /// TOML parse error during configuration loading.
+    #[snafu(display("failed to parse TOML config: {source}"))]
+    ParseToml {
+        source: toml::de::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Configuration loading failed (cascade merge or deserialisation).
+    #[snafu(display("configuration load failed: {reason}: {source}"))]
+    ConfigLoad {
+        reason: String,
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Configuration loading failed with a free-form reason.
+    #[snafu(display("configuration load failed: {reason}"))]
+    Load {
+        reason: String,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/taxis/src/interpolate.rs
+++ b/crates/taxis/src/interpolate.rs
@@ -47,10 +47,6 @@ use crate::error::{EnvVarRequiredSnafu, EnvVarUnterminatedSnafu, Result};
 /// # Ok(())
 /// # }
 /// ```
-#[expect(
-    clippy::result_large_err,
-    reason = "shared Error enum contains figment::Error; boxing would require a crate-wide change"
-)]
 #[must_use]
 #[expect(
     clippy::double_must_use,
@@ -101,10 +97,6 @@ pub fn interpolate_env_vars(content: &str) -> Result<String> {
 }
 
 /// Resolve the expression body between `${` and `}`.
-#[expect(
-    clippy::result_large_err,
-    reason = "shared Error enum contains figment::Error; boxing would require a crate-wide change"
-)]
 fn resolve_expr(expr: &str) -> Result<String> {
     if let Some(sep) = expr.find(":-") {
         #[expect(
@@ -143,15 +135,12 @@ fn resolve_expr(expr: &str) -> Result<String> {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
-#[expect(
-    clippy::result_large_err,
-    reason = "figment::Jail closures return Box<dyn Error>; test error size doesn't matter"
-)]
 mod tests {
     use super::*;
+    use crate::test_support::EnvJail;
 
-    // NOTE: All tests that touch env vars run inside figment::Jail to isolate
-    // them from the process environment and each other.
+    // NOTE: All tests that touch env vars run inside EnvJail to isolate them
+    // from the process environment and each other (serialised via a global mutex).
 
     #[test]
     fn no_placeholders_returns_content_unchanged() {
@@ -165,93 +154,73 @@ mod tests {
 
     #[test]
     fn plain_var_substitutes_value_when_set() {
-        figment::Jail::expect_with(|jail| {
-            jail.set_env("_TAX_INTERP_TEST_PORT", "9999");
-            let out = interpolate_env_vars("port = ${_TAX_INTERP_TEST_PORT}")
-                .map_err(|e| e.to_string())?;
-            assert_eq!(out, "port = 9999", "set env var should be substituted");
-            Ok(())
-        });
+        let mut jail = EnvJail::new();
+        jail.set_env("_TAX_INTERP_TEST_PORT", "9999");
+        let out = interpolate_env_vars("port = ${_TAX_INTERP_TEST_PORT}").unwrap();
+        assert_eq!(out, "port = 9999", "set env var should be substituted");
     }
 
     #[test]
     fn plain_var_substitutes_empty_when_unset() {
-        figment::Jail::expect_with(|_jail| {
-            // NOTE: _TAX_INTERP_UNSET_XYZ is not set in the jail
-            let out = interpolate_env_vars("val = ${_TAX_INTERP_UNSET_XYZ}")
-                .map_err(|e| e.to_string())?;
-            assert_eq!(out, "val = ", "unset var should substitute empty string");
-            Ok(())
-        });
+        let mut jail = EnvJail::new();
+        jail.remove_env("_TAX_INTERP_UNSET_XYZ");
+        let out = interpolate_env_vars("val = ${_TAX_INTERP_UNSET_XYZ}").unwrap();
+        assert_eq!(out, "val = ", "unset var should substitute empty string");
     }
 
     #[test]
     fn default_used_when_var_unset() {
-        figment::Jail::expect_with(|_jail| {
-            // NOTE: _TAX_INTERP_MISSING is not set in the jail
-            let out = interpolate_env_vars("port = ${_TAX_INTERP_MISSING:-18789}")
-                .map_err(|e| e.to_string())?;
-            assert_eq!(
-                out, "port = 18789",
-                "default value should be used when var is unset"
-            );
-            Ok(())
-        });
+        let mut jail = EnvJail::new();
+        jail.remove_env("_TAX_INTERP_MISSING");
+        let out = interpolate_env_vars("port = ${_TAX_INTERP_MISSING:-18789}").unwrap();
+        assert_eq!(
+            out, "port = 18789",
+            "default value should be used when var is unset"
+        );
     }
 
     #[test]
     fn default_not_used_when_var_set() {
-        figment::Jail::expect_with(|jail| {
-            jail.set_env("_TAX_INTERP_PRESENT", "42");
-            let out = interpolate_env_vars("port = ${_TAX_INTERP_PRESENT:-99}")
-                .map_err(|e| e.to_string())?;
-            assert_eq!(out, "port = 42", "set var should override default value");
-            Ok(())
-        });
+        let mut jail = EnvJail::new();
+        jail.set_env("_TAX_INTERP_PRESENT", "42");
+        let out = interpolate_env_vars("port = ${_TAX_INTERP_PRESENT:-99}").unwrap();
+        assert_eq!(out, "port = 42", "set var should override default value");
     }
 
     #[test]
     fn required_var_aborts_when_unset() {
-        figment::Jail::expect_with(|_jail| {
-            // NOTE: _TAX_INTERP_REQUIRED is not set in the jail
-            let result = interpolate_env_vars("key = ${_TAX_INTERP_REQUIRED:?API key must be set}");
-            assert!(result.is_err(), "expected an error for unset required var");
-            Ok(())
-        });
+        let mut jail = EnvJail::new();
+        jail.remove_env("_TAX_INTERP_REQUIRED");
+        let result = interpolate_env_vars("key = ${_TAX_INTERP_REQUIRED:?API key must be set}");
+        assert!(result.is_err(), "expected an error for unset required var");
     }
 
     #[test]
     fn required_var_error_contains_var_name_and_message() {
-        figment::Jail::expect_with(|_jail| {
-            // NOTE: _TAX_INTERP_REQUIRED2 is not set in the jail
-            let result =
-                interpolate_env_vars("key = ${_TAX_INTERP_REQUIRED2:?API key must be set}");
-            assert!(result.is_err(), "expected error for unset required var");
-            let msg = result.unwrap_err().to_string();
-            assert!(
-                msg.contains("_TAX_INTERP_REQUIRED2"),
-                "error should name the variable: {msg}"
-            );
-            assert!(
-                msg.contains("API key must be set"),
-                "error should include the user message: {msg}"
-            );
-            Ok(())
-        });
+        let mut jail = EnvJail::new();
+        jail.remove_env("_TAX_INTERP_REQUIRED2");
+        let result = interpolate_env_vars("key = ${_TAX_INTERP_REQUIRED2:?API key must be set}");
+        assert!(result.is_err(), "expected error for unset required var");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("_TAX_INTERP_REQUIRED2"),
+            "error should name the variable: {msg}"
+        );
+        assert!(
+            msg.contains("API key must be set"),
+            "error should include the user message: {msg}"
+        );
     }
 
     #[test]
     fn required_var_succeeds_when_set() {
-        figment::Jail::expect_with(|jail| {
-            jail.set_env("_TAX_INTERP_PRESENT2", "secret");
-            let out = interpolate_env_vars("key = ${_TAX_INTERP_PRESENT2:?must be set}")
-                .map_err(|e| e.to_string())?;
-            assert_eq!(
-                out, "key = secret",
-                "required var should substitute its value when set"
-            );
-            Ok(())
-        });
+        let mut jail = EnvJail::new();
+        jail.set_env("_TAX_INTERP_PRESENT2", "secret");
+        let out = interpolate_env_vars("key = ${_TAX_INTERP_PRESENT2:?must be set}").unwrap();
+        assert_eq!(
+            out, "key = secret",
+            "required var should substitute its value when set"
+        );
     }
 
     #[test]
@@ -266,30 +235,26 @@ mod tests {
 
     #[test]
     fn multiple_substitutions_in_one_string() {
-        figment::Jail::expect_with(|jail| {
-            jail.set_env("_TAX_INTERP_HOST", "localhost");
-            jail.set_env("_TAX_INTERP_PORT2", "8080");
-            let out = interpolate_env_vars("bind = \"${_TAX_INTERP_HOST}:${_TAX_INTERP_PORT2}\"")
-                .map_err(|e| e.to_string())?;
-            assert_eq!(
-                out, "bind = \"localhost:8080\"",
-                "multiple substitutions should all resolve"
-            );
-            Ok(())
-        });
+        let mut jail = EnvJail::new();
+        jail.set_env("_TAX_INTERP_HOST", "localhost");
+        jail.set_env("_TAX_INTERP_PORT2", "8080");
+        let out =
+            interpolate_env_vars("bind = \"${_TAX_INTERP_HOST}:${_TAX_INTERP_PORT2}\"").unwrap();
+        assert_eq!(
+            out, "bind = \"localhost:8080\"",
+            "multiple substitutions should all resolve"
+        );
     }
 
     #[test]
     fn default_value_containing_colon_is_preserved() {
-        figment::Jail::expect_with(|_jail| {
-            // The first `:-` is the operator; the rest is the default value.
-            let out = interpolate_env_vars("url = ${_TAX_INTERP_URL:-http://localhost:8080}")
-                .map_err(|e| e.to_string())?;
-            assert_eq!(
-                out, "url = http://localhost:8080",
-                "colon in default value should be preserved"
-            );
-            Ok(())
-        });
+        let mut jail = EnvJail::new();
+        jail.remove_env("_TAX_INTERP_URL");
+        // The first `:-` is the operator; the rest is the default value.
+        let out = interpolate_env_vars("url = ${_TAX_INTERP_URL:-http://localhost:8080}").unwrap();
+        assert_eq!(
+            out, "url = http://localhost:8080",
+            "colon in default value should be preserved"
+        );
     }
 }

--- a/crates/taxis/src/lib.rs
+++ b/crates/taxis/src/lib.rs
@@ -16,7 +16,7 @@ pub mod encrypt;
 pub mod error;
 /// Environment variable interpolation for TOML configuration strings.
 pub mod interpolate;
-/// Figment-based configuration loader with TOML file and environment variable cascade.
+/// Configuration loader with TOML file and environment variable cascade.
 pub mod loader;
 /// Instance directory structure and path resolution for all Aletheia subsystems.
 pub mod oikos;
@@ -28,6 +28,9 @@ pub mod redact;
 pub mod registry;
 /// Hot-reload classification: restart vs live update.
 pub mod reload;
+/// Test-only helpers (EnvJail) for unit + integration tests.
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 /// Config section validation.
 pub mod validate;
 /// Config-time validation of agent workspace directory structure.

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -1,10 +1,17 @@
-//! Figment-based configuration loading with TOML cascade.
+//! Configuration loading with TOML cascade.
+//!
+//! Resolution order (later wins):
+//! 1. Compiled defaults ([`AletheiaConfig::default()`])
+//! 2. `{oikos.config()}/aletheia.toml` (if it exists), with env-var
+//!    interpolation (`${VAR:-default}`, `${VAR:?error}`) applied first,
+//!    then `enc:` values decrypted.
+//! 3. Environment variables: `ALETHEIA_*` (e.g. `ALETHEIA_GATEWAY__PORT=9000`),
+//!    with `__` splitting nested keys and lowercasing.
 
 use std::io::Write as _;
 use std::os::unix::fs::OpenOptionsExt as _;
 
-use figment::Figment;
-use figment::providers::{Env, Format, Serialized, Toml};
+use serde_json::Value as JsonValue;
 use snafu::ResultExt;
 use tracing::{error, warn};
 
@@ -13,7 +20,7 @@ use koina::system::{FileSystem, RealSystem};
 
 use crate::config::AletheiaConfig;
 use crate::encrypt;
-use crate::error::{FigmentSnafu, Result, SerializeTomlSnafu, WriteConfigSnafu};
+use crate::error::{ConfigLoadSnafu, LoadSnafu, Result, SerializeTomlSnafu, WriteConfigSnafu};
 use crate::interpolate;
 use crate::oikos::Oikos;
 
@@ -36,10 +43,6 @@ use crate::oikos::Oikos;
 ///
 /// Returns an error if the configuration cascade produces an invalid or
 /// unextractable result.
-#[expect(
-    clippy::result_large_err,
-    reason = "figment::Error is inherently large"
-)]
 #[must_use]
 #[expect(
     clippy::double_must_use,
@@ -59,10 +62,6 @@ pub fn load_config(oikos: &Oikos) -> Result<AletheiaConfig> {
 ///
 /// Returns an error if the TOML file cannot be read.
 /// Returns an error if the configuration cascade fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "figment::Error is inherently large"
-)]
 #[must_use]
 #[expect(
     clippy::double_must_use,
@@ -72,8 +71,17 @@ pub fn load_config_with(oikos: &Oikos, fs: &impl FileSystem) -> Result<AletheiaC
     let toml_path = oikos.config().join("aletheia.toml");
     let yaml_path = oikos.config().join("aletheia.yaml");
 
-    let mut figment = Figment::new().merge(Serialized::defaults(AletheiaConfig::default()));
+    // Tier 1: compiled defaults serialized to a JSON value tree.
+    // WHY JSON: serde_json::Value is the canonical merge target — TOML deserialises
+    // cleanly into it, and the final AletheiaConfig deserialises back out of it.
+    let mut root = serde_json::to_value(AletheiaConfig::default()).map_err(|e| {
+        LoadSnafu {
+            reason: format!("serialize defaults: {e}"),
+        }
+        .build()
+    })?;
 
+    // Tier 2: TOML file (if present), interpolated + decrypted, then deep-merged.
     if fs.exists(&toml_path) {
         let bytes = fs
             .read_file(&toml_path)
@@ -83,7 +91,10 @@ pub fn load_config_with(oikos: &Oikos, fs: &impl FileSystem) -> Result<AletheiaC
         let toml_content = String::from_utf8_lossy(&bytes);
         let interpolated = interpolate::interpolate_env_vars(toml_content.as_ref())?;
         let decrypted_content = decrypt_toml_content(&interpolated)?;
-        figment = figment.merge(Toml::string(&decrypted_content));
+
+        let toml_json: JsonValue =
+            toml::from_str(&decrypted_content).context(crate::error::ParseTomlSnafu)?;
+        deep_merge(&mut root, toml_json);
     } else if fs.exists(&yaml_path) {
         warn!(
             "Found aletheia.yaml but not aletheia.toml -- run migration or rename. \
@@ -96,9 +107,107 @@ pub fn load_config_with(oikos: &Oikos, fs: &impl FileSystem) -> Result<AletheiaC
         );
     }
 
-    figment = figment.merge(Env::prefixed("ALETHEIA_").split("__"));
+    // Tier 3: environment variables, ALETHEIA_ prefix, `__` splitting nested keys.
+    apply_env_overlay(&mut root, "ALETHEIA_", "__");
 
-    figment.extract().context(FigmentSnafu)
+    serde_json::from_value::<AletheiaConfig>(root).context(ConfigLoadSnafu {
+        reason: "deserialize merged config",
+    })
+}
+
+/// Deep-merge `src` into `dst`. Objects merge by key; everything else replaces.
+fn deep_merge(dst: &mut JsonValue, src: JsonValue) {
+    match (dst, src) {
+        (JsonValue::Object(dst_map), JsonValue::Object(src_map)) => {
+            for (key, src_val) in src_map {
+                match dst_map.get_mut(&key) {
+                    Some(dst_val) => deep_merge(dst_val, src_val),
+                    None => {
+                        dst_map.insert(key, src_val);
+                    }
+                }
+            }
+        }
+        (dst_slot, src_val) => *dst_slot = src_val,
+    }
+}
+
+/// Walk `ALETHEIA_*` env vars and write each into `root`, splitting the name
+/// by `separator` to build the nested path. Keys are lowercased to match
+/// serde `rename_all = "camelCase"` output (which lowercases single words).
+///
+/// Values are parsed as: bool (`true`/`false`), integer, float (if containing
+/// `.`), otherwise string. This preserves the pre-#3447 figment autotyping
+/// contract so operators can keep writing `ALETHEIA_GATEWAY__PORT=9000` without quoting.
+fn apply_env_overlay(root: &mut JsonValue, prefix: &str, separator: &str) {
+    for (key, value) in std::env::vars() {
+        let Some(rest) = key.strip_prefix(prefix) else {
+            continue;
+        };
+        let path: Vec<String> = rest.split(separator).map(str::to_ascii_lowercase).collect();
+        if path.iter().any(String::is_empty) {
+            continue;
+        }
+        set_path(root, &path, parse_env_value(&value));
+    }
+}
+
+/// Parse an environment-variable string into a JSON scalar. Booleans, integers,
+/// floats (if containing `.`), else a string. Preserves the pre-#3447 figment
+/// autotyping contract.
+fn parse_env_value(raw: &str) -> JsonValue {
+    let trimmed = raw.trim();
+    if trimmed == "true" {
+        return JsonValue::Bool(true);
+    }
+    if trimmed == "false" {
+        return JsonValue::Bool(false);
+    }
+    if trimmed.contains('.')
+        && let Ok(f) = trimmed.parse::<f64>()
+        && let Some(n) = serde_json::Number::from_f64(f)
+    {
+        return JsonValue::Number(n);
+    }
+    if let Ok(u) = trimmed.parse::<u64>() {
+        return JsonValue::Number(serde_json::Number::from(u));
+    }
+    if let Ok(i) = trimmed.parse::<i64>() {
+        return JsonValue::Number(serde_json::Number::from(i));
+    }
+    JsonValue::String(raw.to_owned())
+}
+
+/// Drill into `root` following `path`, creating intermediate objects as needed,
+/// and set the leaf to `value`. If an intermediate slot is not an object
+/// (e.g. a previously set scalar), it is replaced with a fresh object so the
+/// env overlay always wins at the leaf.
+fn set_path(root: &mut JsonValue, path: &[String], value: JsonValue) {
+    if path.is_empty() {
+        return;
+    }
+    let mut cursor = root;
+    let last_idx = path.len() - 1;
+    for (i, segment) in path.iter().enumerate() {
+        if i == last_idx {
+            if !cursor.is_object() {
+                *cursor = JsonValue::Object(serde_json::Map::new());
+            }
+            if let Some(map) = cursor.as_object_mut() {
+                map.insert(segment.clone(), value);
+            }
+            return;
+        }
+        if !cursor.is_object() {
+            *cursor = JsonValue::Object(serde_json::Map::new());
+        }
+        let Some(map) = cursor.as_object_mut() else {
+            return;
+        };
+        cursor = map
+            .entry(segment.clone())
+            .or_insert_with(|| JsonValue::Object(serde_json::Map::new()));
+    }
 }
 
 /// Parse TOML content, decrypt any `enc:` values, and serialize back.
@@ -106,10 +215,6 @@ pub fn load_config_with(oikos: &Oikos, fs: &impl FileSystem) -> Result<AletheiaC
 /// Returns an error if encrypted values are found but the decryption key is
 /// missing. This prevents the server from silently starting with undecrypted
 /// `enc:` values in place of real secrets.
-#[expect(
-    clippy::result_large_err,
-    reason = "figment::Error is inherently large; boxing would require unsafe snafu workaround"
-)]
 fn decrypt_toml_content(content: &str) -> Result<String> {
     let mut value: toml::Value = match toml::from_str(content) {
         Ok(v) => v,
@@ -185,10 +290,6 @@ fn collect_encrypted_paths(value: &toml::Value, prefix: String, out: &mut Vec<St
 /// Returns an error if the config cannot be serialized to TOML.
 /// Returns an error if the config directory cannot be created or the
 /// file cannot be written.
-#[expect(
-    clippy::result_large_err,
-    reason = "figment::Error is inherently large"
-)]
 #[must_use]
 #[expect(
     clippy::double_must_use,
@@ -202,10 +303,6 @@ pub fn write_config(oikos: &Oikos, config: &AletheiaConfig) -> Result<()> {
 ///
 /// Config writes are essential (state preservation), so they always proceed.
 /// Warning and critical disk states emit tracing diagnostics.
-#[expect(
-    clippy::result_large_err,
-    reason = "figment::Error is inherently large"
-)]
 pub(crate) fn write_config_checked(
     oikos: &Oikos,
     config: &AletheiaConfig,
@@ -268,187 +365,164 @@ pub(crate) fn write_config_checked(
 
 #[cfg(test)]
 #[expect(
-    clippy::result_large_err,
-    reason = "figment::Jail closures return Box<dyn Error>; test error size doesn't matter"
+    clippy::expect_used,
+    reason = "test harness: seeding fixtures must panic loudly on setup failure"
 )]
 mod tests {
-    use super::*;
+    use koina::system::TestSystem;
 
-    // NOTE: All loader tests run inside figment::Jail to isolate env vars.
+    use super::*;
+    use crate::test_support::EnvJail;
 
     #[test]
     fn load_with_no_yaml_uses_defaults() {
-        figment::Jail::expect_with(|jail| {
-            let oikos = Oikos::from_root(jail.directory());
-            let config = load_config(&oikos).map_err(|e| e.to_string())?;
+        let jail = EnvJail::new();
+        let oikos = Oikos::from_root(jail.directory());
+        let config = load_config(&oikos).unwrap_or_else(|e| panic!("load: {e}"));
 
-            assert_eq!(
-                config.agents.defaults.model_defaults.context_tokens, 200_000,
-                "no-config default context tokens should be 200k"
-            );
-            assert_eq!(
-                config.gateway.port, 18789,
-                "no-config default port should be 18789"
-            );
-            assert_eq!(
-                config.agents.defaults.model_defaults.model.primary, "claude-sonnet-4-6",
-                "no-config default model should be sonnet"
-            );
-            Ok(())
-        });
+        assert_eq!(
+            config.agents.defaults.model_defaults.context_tokens, 200_000,
+            "no-config default context tokens should be 200k"
+        );
+        assert_eq!(
+            config.gateway.port, 18789,
+            "no-config default port should be 18789"
+        );
+        assert_eq!(
+            config.agents.defaults.model_defaults.model.primary, "claude-sonnet-4-6",
+            "no-config default model should be sonnet"
+        );
     }
 
     #[test]
     fn load_from_toml_file() {
-        figment::Jail::expect_with(|jail| {
-            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
-            jail.create_file(
-                "config/aletheia.toml",
-                "[gateway]\nport = 9999\n\n[agents.defaults]\ncontextTokens = 100000\n",
-            )?;
+        let jail = EnvJail::new();
+        jail.create_file(
+            "config/aletheia.toml",
+            "[gateway]\nport = 9999\n\n[agents.defaults]\ncontextTokens = 100000\n",
+        );
 
-            let oikos = Oikos::from_root(jail.directory());
-            let config = load_config(&oikos).map_err(|e| e.to_string())?;
+        let oikos = Oikos::from_root(jail.directory());
+        let config = load_config(&oikos).unwrap_or_else(|e| panic!("load: {e}"));
 
-            assert_eq!(
-                config.gateway.port, 9999,
-                "toml port override should take effect"
-            );
-            assert_eq!(
-                config.agents.defaults.model_defaults.context_tokens, 100_000,
-                "toml context tokens override should take effect"
-            );
-            assert_eq!(
-                config.agents.defaults.model_defaults.model.primary, "claude-sonnet-4-6",
-                "unset model should use default"
-            );
-            Ok(())
-        });
+        assert_eq!(
+            config.gateway.port, 9999,
+            "toml port override should take effect"
+        );
+        assert_eq!(
+            config.agents.defaults.model_defaults.context_tokens, 100_000,
+            "toml context tokens override should take effect"
+        );
+        assert_eq!(
+            config.agents.defaults.model_defaults.model.primary, "claude-sonnet-4-6",
+            "unset model should use default"
+        );
     }
 
     #[test]
     fn env_overrides_toml() {
-        figment::Jail::expect_with(|jail| {
-            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
-            jail.create_file("config/aletheia.toml", "[gateway]\nport = 9999\n")?;
-            jail.set_env("ALETHEIA_GATEWAY__PORT", "7777");
+        let mut jail = EnvJail::new();
+        jail.create_file("config/aletheia.toml", "[gateway]\nport = 9999\n");
+        jail.set_env("ALETHEIA_GATEWAY__PORT", "7777");
 
-            let oikos = Oikos::from_root(jail.directory());
-            let config = load_config(&oikos).map_err(|e| e.to_string())?;
+        let oikos = Oikos::from_root(jail.directory());
+        let config = load_config(&oikos).unwrap_or_else(|e| panic!("load: {e}"));
 
-            assert_eq!(
-                config.gateway.port, 7777,
-                "env var should override toml port"
-            );
-            Ok(())
-        });
+        assert_eq!(
+            config.gateway.port, 7777,
+            "env var should override toml port"
+        );
     }
 
     #[test]
     fn missing_dir_still_loads_defaults() {
-        figment::Jail::expect_with(|_jail| {
-            let oikos = Oikos::from_root("/nonexistent/path/that/does/not/exist");
-            let config = load_config(&oikos).map_err(|e| e.to_string())?;
+        let _jail = EnvJail::new();
+        let oikos = Oikos::from_root("/nonexistent/path/that/does/not/exist");
+        let config = load_config(&oikos).unwrap_or_else(|e| panic!("load: {e}"));
 
-            assert_eq!(
-                config.gateway.port, 18789,
-                "missing dir should fall back to default port"
-            );
-            assert_eq!(
-                config.agents.defaults.model_defaults.context_tokens, 200_000,
-                "missing dir should fall back to default context tokens"
-            );
-            Ok(())
-        });
+        assert_eq!(
+            config.gateway.port, 18789,
+            "missing dir should fall back to default port"
+        );
+        assert_eq!(
+            config.agents.defaults.model_defaults.context_tokens, 200_000,
+            "missing dir should fall back to default context tokens"
+        );
     }
 
     #[test]
     fn write_then_load_roundtrip() {
-        figment::Jail::expect_with(|jail| {
-            // NOTE: figment::Jail doesn't auto-create the config dir, so create it first.
-            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
+        let jail = EnvJail::new();
+        // NOTE: EnvJail doesn't auto-create the config dir, so create it first.
+        std::fs::create_dir_all(jail.directory().join("config")).expect("create config dir");
 
-            let oikos = Oikos::from_root(jail.directory());
-            let mut config = AletheiaConfig::default();
-            config.gateway.port = 9876;
+        let oikos = Oikos::from_root(jail.directory());
+        let mut config = AletheiaConfig::default();
+        config.gateway.port = 9876;
 
-            write_config(&oikos, &config).map_err(|e| e.to_string())?;
-            let loaded = load_config(&oikos).map_err(|e| e.to_string())?;
+        write_config(&oikos, &config).unwrap_or_else(|e| panic!("write: {e}"));
+        let loaded = load_config(&oikos).unwrap_or_else(|e| panic!("load: {e}"));
 
-            assert_eq!(
-                loaded.gateway.port, 9876,
-                "written port should survive roundtrip"
-            );
-            assert_eq!(
-                loaded.agents.defaults.model_defaults.context_tokens, 200_000,
-                "default context tokens should survive roundtrip"
-            );
-            Ok(())
-        });
+        assert_eq!(
+            loaded.gateway.port, 9876,
+            "written port should survive roundtrip"
+        );
+        assert_eq!(
+            loaded.agents.defaults.model_defaults.context_tokens, 200_000,
+            "default context tokens should survive roundtrip"
+        );
     }
 
     // ── load_config_with (FileSystem trait) ──────────────────────────────
 
     #[test]
     fn load_config_with_uses_in_memory_toml() {
-        figment::Jail::expect_with(|jail| {
-            use koina::system::TestSystem;
+        let jail = EnvJail::new();
+        let oikos = Oikos::from_root(jail.directory());
+        let toml_path = oikos.config().join("aletheia.toml");
 
-            let oikos = Oikos::from_root(jail.directory());
-            let toml_path = oikos.config().join("aletheia.toml");
+        let mut fs = TestSystem::new();
+        fs.add_file(toml_path, b"[gateway]\nport = 4242\n");
 
-            let mut fs = TestSystem::new();
-            fs.add_file(toml_path, b"[gateway]\nport = 4242\n");
-
-            let config = load_config_with(&oikos, &fs).map_err(|e| e.to_string())?;
-            assert_eq!(
-                config.gateway.port, 4242,
-                "in-memory toml port should be loaded"
-            );
-            Ok(())
-        });
+        let config = load_config_with(&oikos, &fs).unwrap_or_else(|e| panic!("load: {e}"));
+        assert_eq!(
+            config.gateway.port, 4242,
+            "in-memory toml port should be loaded"
+        );
     }
 
     #[test]
     fn load_config_with_uses_defaults_when_no_toml() {
-        figment::Jail::expect_with(|_jail| {
-            use koina::system::TestSystem;
+        let _jail = EnvJail::new();
+        let oikos = Oikos::from_root("/nonexistent");
+        let fs = TestSystem::new(); // empty — no files
 
-            let oikos = Oikos::from_root("/nonexistent");
-            let fs = TestSystem::new(); // empty — no files
-
-            let config = load_config_with(&oikos, &fs).map_err(|e| e.to_string())?;
-            assert_eq!(
-                config.gateway.port, 18789,
-                "empty filesystem should use default port"
-            );
-            assert_eq!(
-                config.agents.defaults.model_defaults.context_tokens, 200_000,
-                "empty filesystem should use default context tokens"
-            );
-            Ok(())
-        });
+        let config = load_config_with(&oikos, &fs).unwrap_or_else(|e| panic!("load: {e}"));
+        assert_eq!(
+            config.gateway.port, 18789,
+            "empty filesystem should use default port"
+        );
+        assert_eq!(
+            config.agents.defaults.model_defaults.context_tokens, 200_000,
+            "empty filesystem should use default context tokens"
+        );
     }
 
     #[test]
     fn load_config_with_merges_env_over_toml() {
-        figment::Jail::expect_with(|jail| {
-            use koina::system::TestSystem;
+        let mut jail = EnvJail::new();
+        jail.set_env("ALETHEIA_GATEWAY__PORT", "5555");
 
-            jail.set_env("ALETHEIA_GATEWAY__PORT", "5555");
+        let oikos = Oikos::from_root(jail.directory());
+        let toml_path = oikos.config().join("aletheia.toml");
 
-            let oikos = Oikos::from_root(jail.directory());
-            let toml_path = oikos.config().join("aletheia.toml");
+        let mut fs = TestSystem::new();
+        fs.add_file(toml_path, b"[gateway]\nport = 1111\n");
 
-            let mut fs = TestSystem::new();
-            fs.add_file(toml_path, b"[gateway]\nport = 1111\n");
-
-            let config = load_config_with(&oikos, &fs).map_err(|e| e.to_string())?;
-            assert_eq!(
-                config.gateway.port, 5555,
-                "env var should override in-memory toml port"
-            );
-            Ok(())
-        });
+        let config = load_config_with(&oikos, &fs).unwrap_or_else(|e| panic!("load: {e}"));
+        assert_eq!(
+            config.gateway.port, 5555,
+            "env var should override in-memory toml port"
+        );
     }
 }

--- a/crates/taxis/src/oikos.rs
+++ b/crates/taxis/src/oikos.rs
@@ -268,10 +268,6 @@ impl Oikos {
     /// # Errors
     ///
     /// Returns the first validation failure encountered.
-    #[expect(
-        clippy::result_large_err,
-        reason = "shared Error enum contains figment::Error; boxing would require a crate-wide change"
-    )]
     pub fn validate(&self) -> crate::error::Result<()> {
         use crate::error::{InstanceRootNotFoundSnafu, RequiredDirMissingSnafu};
 
@@ -309,10 +305,6 @@ impl Oikos {
     ///
     /// Returns an error if the path does not
     /// exist or is not a directory.
-    #[expect(
-        clippy::result_large_err,
-        reason = "shared Error enum contains figment::Error; boxing would require a crate-wide change"
-    )]
     pub fn validate_workspace_path(&self, workspace: &str) -> crate::error::Result<()> {
         use crate::error::WorkspacePathInvalidSnafu;
 
@@ -327,10 +319,6 @@ impl Oikos {
         Ok(())
     }
 
-    #[expect(
-        clippy::result_large_err,
-        reason = "shared Error enum contains figment::Error; boxing would require a crate-wide change"
-    )]
     fn check_writable(path: &Path) -> crate::error::Result<()> {
         use crate::error::NotWritableSnafu;
 

--- a/crates/taxis/src/reload.rs
+++ b/crates/taxis/src/reload.rs
@@ -187,7 +187,8 @@ pub struct ReloadOutcome {
 /// (the current config is unchanged).
 #[expect(
     clippy::result_large_err,
-    reason = "figment::Error is inherently large"
+    reason = "ReloadError wraps taxis Error which carries PathBuf fields; \
+              boxing would require a crate-wide change"
 )]
 pub fn prepare_reload(
     oikos: &Oikos,
@@ -254,12 +255,9 @@ fn diff_values(old: &Value, new: &Value, prefix: String, changes: &mut Vec<Confi
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::result_large_err,
-    reason = "figment::Jail closures return Box<dyn Error>; test error size doesn't matter"
-)]
 mod tests {
     use super::*;
+    use crate::test_support::EnvJail;
 
     #[test]
     fn gateway_port_requires_restart() {
@@ -416,132 +414,112 @@ mod tests {
 
     #[test]
     fn prepare_reload_succeeds_with_valid_config() {
-        figment::Jail::expect_with(|jail| {
-            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
-            jail.create_file(
-                "config/aletheia.toml",
-                "[agents.defaults]\nthinkingBudget = 20000\n",
-            )?;
+        let jail = EnvJail::new();
+        jail.create_file(
+            "config/aletheia.toml",
+            "[agents.defaults]\nthinkingBudget = 20000\n",
+        );
 
-            let oikos = Oikos::from_root(jail.directory());
-            let current = AletheiaConfig::default();
+        let oikos = Oikos::from_root(jail.directory());
+        let current = AletheiaConfig::default();
 
-            let outcome = prepare_reload(&oikos, &current).map_err(|e| e.to_string())?;
-            assert!(
-                !outcome.diff.is_empty(),
-                "thinkingBudget change should produce a diff"
-            );
-            assert_eq!(
-                outcome
-                    .new_config
-                    .agents
-                    .defaults
-                    .model_defaults
-                    .thinking_budget,
-                20_000,
-                "new config should have updated value"
-            );
-            assert!(
-                outcome.diff.cold_changes().is_empty(),
-                "agent defaults are hot-reloadable"
-            );
-            Ok(())
-        });
+        let outcome = prepare_reload(&oikos, &current).unwrap_or_else(|e| panic!("reload: {e}"));
+        assert!(
+            !outcome.diff.is_empty(),
+            "thinkingBudget change should produce a diff"
+        );
+        assert_eq!(
+            outcome
+                .new_config
+                .agents
+                .defaults
+                .model_defaults
+                .thinking_budget,
+            20_000,
+            "new config should have updated value"
+        );
+        assert!(
+            outcome.diff.cold_changes().is_empty(),
+            "agent defaults are hot-reloadable"
+        );
     }
 
     #[test]
     fn prepare_reload_rejects_invalid_config() {
-        figment::Jail::expect_with(|jail| {
-            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
-            // WHY: maxToolIterations=0 is rejected by the validator (must be 1..=10000).
-            jail.create_file(
-                "config/aletheia.toml",
-                "[agents.defaults]\nmaxToolIterations = 0\n",
-            )?;
+        let jail = EnvJail::new();
+        // WHY: maxToolIterations=0 is rejected by the validator (must be 1..=10000).
+        jail.create_file(
+            "config/aletheia.toml",
+            "[agents.defaults]\nmaxToolIterations = 0\n",
+        );
 
-            let oikos = Oikos::from_root(jail.directory());
-            let current = AletheiaConfig::default();
+        let oikos = Oikos::from_root(jail.directory());
+        let current = AletheiaConfig::default();
 
-            let result = prepare_reload(&oikos, &current);
-            assert!(result.is_err(), "invalid config should be rejected");
-            Ok(())
-        });
+        let result = prepare_reload(&oikos, &current);
+        assert!(result.is_err(), "invalid config should be rejected");
     }
 
     #[test]
     fn prepare_reload_preserves_current_on_rejection() {
-        figment::Jail::expect_with(|jail| {
-            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
-            jail.create_file(
-                "config/aletheia.toml",
-                "[agents.defaults]\nmaxToolIterations = 0\n",
-            )?;
+        let jail = EnvJail::new();
+        jail.create_file(
+            "config/aletheia.toml",
+            "[agents.defaults]\nmaxToolIterations = 0\n",
+        );
 
-            let oikos = Oikos::from_root(jail.directory());
-            let current = AletheiaConfig::default();
-            let original_budget = current.agents.defaults.model_defaults.thinking_budget;
+        let oikos = Oikos::from_root(jail.directory());
+        let current = AletheiaConfig::default();
+        let original_budget = current.agents.defaults.model_defaults.thinking_budget;
 
-            let _ = prepare_reload(&oikos, &current);
+        let _ = prepare_reload(&oikos, &current);
 
-            assert_eq!(
-                current.agents.defaults.model_defaults.thinking_budget, original_budget,
-                "current config must not be modified on rejection"
-            );
-            Ok(())
-        });
+        assert_eq!(
+            current.agents.defaults.model_defaults.thinking_budget, original_budget,
+            "current config must not be modified on rejection"
+        );
     }
 
     #[test]
     fn prepare_reload_cold_values_appear_in_diff() {
-        figment::Jail::expect_with(|jail| {
-            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
-            jail.create_file(
-                "config/aletheia.toml",
-                "[gateway]\nport = 9999\n\n[agents.defaults]\nthinkingBudget = 20000\n",
-            )?;
+        let jail = EnvJail::new();
+        jail.create_file(
+            "config/aletheia.toml",
+            "[gateway]\nport = 9999\n\n[agents.defaults]\nthinkingBudget = 20000\n",
+        );
 
-            let oikos = Oikos::from_root(jail.directory());
-            let current = AletheiaConfig::default();
+        let oikos = Oikos::from_root(jail.directory());
+        let current = AletheiaConfig::default();
 
-            let outcome = prepare_reload(&oikos, &current).map_err(|e| e.to_string())?;
+        let outcome = prepare_reload(&oikos, &current).unwrap_or_else(|e| panic!("reload: {e}"));
 
-            let cold = outcome.diff.cold_changes();
-            assert!(
-                cold.iter().any(|c| c.path.contains("gateway.port")),
-                "gateway.port should appear as a cold change"
-            );
+        let cold = outcome.diff.cold_changes();
+        assert!(
+            cold.iter().any(|c| c.path.contains("gateway.port")),
+            "gateway.port should appear as a cold change"
+        );
 
-            let hot = outcome.diff.hot_changes();
-            assert!(
-                hot.iter().any(|c| c.path.contains("thinkingBudget")),
-                "thinkingBudget should appear as a hot change"
-            );
-            Ok(())
-        });
+        let hot = outcome.diff.hot_changes();
+        assert!(
+            hot.iter().any(|c| c.path.contains("thinkingBudget")),
+            "thinkingBudget should appear as a hot change"
+        );
     }
 
     #[test]
     fn prepare_reload_no_changes_when_config_identical() {
-        figment::Jail::expect_with(|jail| {
-            std::fs::create_dir_all(jail.directory().join("config")).map_err(|e| e.to_string())?;
-            let default_toml =
-                toml::to_string(&AletheiaConfig::default()).map_err(|e| e.to_string())?;
-            #[expect(
-                clippy::disallowed_methods,
-                reason = "taxis config operations are CLI-invoked and require synchronous filesystem access"
-            )]
-            std::fs::write(jail.directory().join("config/aletheia.toml"), default_toml)
-                .map_err(|e| e.to_string())?;
+        let jail = EnvJail::new();
+        let default_toml = toml::to_string(&AletheiaConfig::default())
+            .unwrap_or_else(|e| panic!("serialize default: {e}"));
+        jail.create_file("config/aletheia.toml", &default_toml);
 
-            let oikos = Oikos::from_root(jail.directory());
-            let current = AletheiaConfig::default();
+        let oikos = Oikos::from_root(jail.directory());
+        let current = AletheiaConfig::default();
 
-            let outcome = prepare_reload(&oikos, &current).map_err(|e| e.to_string())?;
-            assert!(
-                outcome.diff.is_empty(),
-                "identical config should produce empty diff"
-            );
-            Ok(())
-        });
+        let outcome = prepare_reload(&oikos, &current).unwrap_or_else(|e| panic!("reload: {e}"));
+        assert!(
+            outcome.diff.is_empty(),
+            "identical config should produce empty diff"
+        );
     }
 }

--- a/crates/taxis/src/test_support.rs
+++ b/crates/taxis/src/test_support.rs
@@ -1,0 +1,132 @@
+//! Test helpers for env-var isolation and temp-dir fixtures.
+//!
+//! `EnvJail` replaces `figment::Jail` after the figment removal (#3447): it
+//! provides a serialised, RAII-scoped fixture that captures any env vars the
+//! test touches and restores them on drop, alongside a fresh temp directory.
+//!
+//! Because `std::env::set_var` is process-wide and Cargo runs tests within a
+//! binary in parallel threads, all jails lock a single global mutex for the
+//! lifetime of the jail. Tests inside a jail are effectively serialised.
+
+#![cfg(any(test, feature = "test-support"))]
+#![expect(
+    clippy::expect_used,
+    reason = "test helper: failure to create a temp dir or hold a lock is a test harness bug"
+)]
+#![expect(
+    unsafe_code,
+    reason = "std::env::{set_var,remove_var} are unsafe in edition 2024; serialised via the jail lock"
+)]
+#![expect(
+    clippy::disallowed_methods,
+    reason = "test helper: std::fs::write seeds real files inside the jail's temp dir"
+)]
+
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use tempfile::TempDir;
+
+/// Global lock that serialises jail scopes. Cargo runs tests in parallel
+/// threads and `std::env` is process-wide, so without this lock one jail's
+/// env mutations would bleed into another.
+static LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII fixture that owns a fresh temp directory and restores any env vars
+/// it set (or cleared) when it is dropped.
+///
+/// WHY: replaces `figment::Jail` after #3447 (figment replacement). The jail
+/// protects a test's env-var mutations from leaking to sibling tests.
+pub struct EnvJail {
+    _lock: MutexGuard<'static, ()>,
+    dir: TempDir,
+    saved: HashMap<OsString, Option<OsString>>,
+    canonical_dir: PathBuf,
+}
+
+impl EnvJail {
+    /// Create a fresh jail with its own temp directory and env-var scope.
+    ///
+    /// Blocks until the process-wide jail lock is acquired.
+    #[must_use]
+    pub fn new() -> Self {
+        let lock = LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        let dir = TempDir::new().expect("create jail temp dir");
+        let canonical_dir = dir
+            .path()
+            .canonicalize()
+            .expect("canonicalize jail temp dir");
+        Self {
+            _lock: lock,
+            dir,
+            saved: HashMap::new(),
+            canonical_dir,
+        }
+    }
+
+    /// Return the jail's working directory.
+    #[must_use]
+    pub fn directory(&self) -> &Path {
+        &self.canonical_dir
+    }
+
+    /// Set an env var for the duration of the jail. The original value (or
+    /// absence) is restored when the jail is dropped.
+    pub fn set_env<K: AsRef<str>, V: AsRef<str>>(&mut self, key: K, value: V) {
+        let key = key.as_ref();
+        let key_os = OsString::from(key);
+        if !self.saved.contains_key(OsStr::new(key)) {
+            self.saved.insert(key_os.clone(), std::env::var_os(key));
+        }
+        // SAFETY: the global LOCK held by `_lock` serialises all EnvJail scopes,
+        // and no test outside an EnvJail mutates env vars we care about.
+        unsafe {
+            std::env::set_var(key_os, value.as_ref());
+        }
+    }
+
+    /// Remove an env var for the duration of the jail. The original value is
+    /// restored when the jail is dropped.
+    pub fn remove_env<K: AsRef<str>>(&mut self, key: K) {
+        let key = key.as_ref();
+        let key_os = OsString::from(key);
+        if !self.saved.contains_key(OsStr::new(key)) {
+            self.saved.insert(key_os.clone(), std::env::var_os(key));
+        }
+        // SAFETY: serialised via LOCK held by `_lock`.
+        unsafe {
+            std::env::remove_var(key_os);
+        }
+    }
+
+    /// Create a file inside the jail's directory. Parents are created as
+    /// needed. Panics on I/O failure because this is test-harness code.
+    pub fn create_file<P: AsRef<Path>>(&self, rel: P, contents: &str) {
+        let full = self.dir.path().join(rel.as_ref());
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dirs");
+        }
+        std::fs::write(&full, contents).expect("write jail file");
+    }
+}
+
+impl Default for EnvJail {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for EnvJail {
+    fn drop(&mut self) {
+        for (key, original) in self.saved.drain() {
+            match original {
+                // SAFETY: the jail lock is still held until the MutexGuard in
+                // `_lock` is dropped, which happens after this loop completes.
+                Some(val) => unsafe { std::env::set_var(&key, val) },
+                None => unsafe { std::env::remove_var(&key) },
+            }
+        }
+    }
+}

--- a/crates/taxis/tests/public_api_loader.rs
+++ b/crates/taxis/tests/public_api_loader.rs
@@ -5,10 +5,6 @@
 
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 #![expect(clippy::expect_used, reason = "test assertions")]
-#![expect(
-    clippy::result_large_err,
-    reason = "figment::Jail::expect_with closures return a boxed dynamic error; test error size is irrelevant"
-)]
 
 mod common;
 
@@ -16,214 +12,206 @@ use taxis::config::AletheiaConfig;
 use taxis::loader::{load_config, write_config};
 use taxis::oikos::Oikos;
 use taxis::reload::{prepare_reload, restart_prefixes};
+use taxis::test_support::EnvJail;
 
-use common::{make_valid_instance, write_toml};
+use common::write_toml;
+
+// WHY: EnvJail owns a tempdir and a process-wide lock. Integration tests use
+// the jail's own directory (seeded with config/, data/, nous/) rather than a
+// separate TempDir so env-var scopes are always serialised.
+fn seed_instance(jail: &EnvJail) -> &std::path::Path {
+    let root = jail.directory();
+    std::fs::create_dir_all(root.join("config")).expect("create config dir");
+    std::fs::create_dir_all(root.join("data")).expect("create data dir");
+    std::fs::create_dir_all(root.join("nous")).expect("create nous dir");
+    root
+}
 
 // ─── TOML loading: cascade (defaults → file → env) ──────────────────────
 
 #[test]
 fn load_config_returns_defaults_when_no_toml_present() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        let oikos = Oikos::from_root(dir.path());
-        let config = load_config(&oikos).map_err(|e| e.to_string())?;
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    let oikos = Oikos::from_root(root);
+    let config = load_config(&oikos).unwrap();
 
-        let default = AletheiaConfig::default();
-        assert_eq!(
-            config.gateway.port, default.gateway.port,
-            "no toml should preserve default port"
-        );
-        assert_eq!(
-            config.embedding.dimension, default.embedding.dimension,
-            "no toml should preserve default dimension"
-        );
-        Ok(())
-    });
+    let default = AletheiaConfig::default();
+    assert_eq!(
+        config.gateway.port, default.gateway.port,
+        "no toml should preserve default port"
+    );
+    assert_eq!(
+        config.embedding.dimension, default.embedding.dimension,
+        "no toml should preserve default dimension"
+    );
 }
 
 #[test]
 fn load_config_applies_gateway_port_override_from_toml() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        write_toml(dir.path(), "[gateway]\nport = 4242\n");
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    write_toml(root, "[gateway]\nport = 4242\n");
 
-        let oikos = Oikos::from_root(dir.path());
-        let config = load_config(&oikos).map_err(|e| e.to_string())?;
-        assert_eq!(config.gateway.port, 4242);
-        Ok(())
-    });
+    let oikos = Oikos::from_root(root);
+    let config = load_config(&oikos).unwrap();
+    assert_eq!(config.gateway.port, 4242);
 }
 
 #[test]
 fn load_config_nested_override_preserves_unrelated_defaults() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        write_toml(dir.path(), "[gateway]\nport = 9999\n");
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    write_toml(root, "[gateway]\nport = 9999\n");
 
-        let oikos = Oikos::from_root(dir.path());
-        let config = load_config(&oikos).map_err(|e| e.to_string())?;
-        assert_eq!(config.gateway.port, 9999);
-        // WHY: contract -- overriding one field must not wipe out defaults
-        // for other fields in the same section or sibling sections.
-        assert_eq!(config.gateway.bind, "localhost");
-        assert_eq!(config.embedding.provider, "candle");
-        Ok(())
-    });
+    let oikos = Oikos::from_root(root);
+    let config = load_config(&oikos).unwrap();
+    assert_eq!(config.gateway.port, 9999);
+    // WHY: contract -- overriding one field must not wipe out defaults
+    // for other fields in the same section or sibling sections.
+    assert_eq!(config.gateway.bind, "localhost");
+    assert_eq!(config.embedding.provider, "candle");
 }
 
 #[test]
 fn load_config_env_var_overrides_toml_value() {
-    figment::Jail::expect_with(|jail| {
-        let dir = make_valid_instance();
-        write_toml(dir.path(), "[gateway]\nport = 1111\n");
-        jail.set_env("ALETHEIA_GATEWAY__PORT", "2222");
+    let mut jail = EnvJail::new();
+    let root = seed_instance(&jail).to_path_buf();
+    write_toml(&root, "[gateway]\nport = 1111\n");
+    jail.set_env("ALETHEIA_GATEWAY__PORT", "2222");
 
-        let oikos = Oikos::from_root(dir.path());
-        let config = load_config(&oikos).map_err(|e| e.to_string())?;
-        assert_eq!(config.gateway.port, 2222);
-        Ok(())
-    });
+    let oikos = Oikos::from_root(&root);
+    let config = load_config(&oikos).unwrap();
+    assert_eq!(config.gateway.port, 2222);
 }
 
 #[test]
 fn load_config_parses_camel_case_keys() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        // WHY: taxis uses #[serde(rename_all = "camelCase")] everywhere;
-        // TOML keys must be camelCase even though Rust fields are snake_case.
-        write_toml(
-            dir.path(),
-            "[embedding]\nprovider = \"mock\"\ndimension = 512\n",
-        );
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    // WHY: taxis uses #[serde(rename_all = "camelCase")] everywhere;
+    // TOML keys must be camelCase even though Rust fields are snake_case.
+    write_toml(
+        root,
+        "[embedding]\nprovider = \"mock\"\ndimension = 512\n",
+    );
 
-        let oikos = Oikos::from_root(dir.path());
-        let config = load_config(&oikos).map_err(|e| e.to_string())?;
-        assert_eq!(config.embedding.provider, "mock");
-        assert_eq!(config.embedding.dimension, 512);
-        Ok(())
-    });
+    let oikos = Oikos::from_root(root);
+    let config = load_config(&oikos).unwrap();
+    assert_eq!(config.embedding.provider, "mock");
+    assert_eq!(config.embedding.dimension, 512);
 }
 
 #[test]
 fn load_config_rejects_encrypted_value_when_primary_key_is_missing() {
-    figment::Jail::expect_with(|jail| {
-        let dir = make_valid_instance();
-        // WHY: the loader must never silently pass an encrypted value
-        // through as plaintext. Closes a class of "silent crypto failure"
-        // bugs where the server starts with enc: strings in memory.
-        write_toml(
-            dir.path(),
-            "[gateway.auth]\nsigningKey = \"enc:dGVzdA==\"\n",
-        );
-        jail.set_env("ALETHEIA_PRIMARY_KEY", "/nonexistent/path-missing-key.key");
+    let mut jail = EnvJail::new();
+    let root = seed_instance(&jail).to_path_buf();
+    // WHY: the loader must never silently pass an encrypted value
+    // through as plaintext. Closes a class of "silent crypto failure"
+    // bugs where the server starts with enc: strings in memory.
+    write_toml(
+        &root,
+        "[gateway.auth]\nsigningKey = \"enc:dGVzdA==\"\n",
+    );
+    jail.set_env("ALETHEIA_PRIMARY_KEY", "/nonexistent/path-missing-key.key");
 
-        let oikos = Oikos::from_root(dir.path());
-        let err = load_config(&oikos).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("encrypted") || msg.contains("decrypt"),
-            "error should mention encryption/decryption, got: {msg}"
-        );
-        Ok(())
-    });
+    let oikos = Oikos::from_root(&root);
+    let err = load_config(&oikos).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("encrypted") || msg.contains("decrypt"),
+        "error should mention encryption/decryption, got: {msg}"
+    );
 }
 
 // ─── Env var interpolation via the loader ──────────────────────────────
 
 #[test]
 fn interpolate_applies_default_when_env_var_unset() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        // NOTE: _TAXIS_TEST_UNSET_PORT_A is not set in the jail
-        write_toml(
-            dir.path(),
-            "[gateway]\nport = ${_TAXIS_TEST_UNSET_PORT_A:-4242}\n",
-        );
+    let mut jail = EnvJail::new();
+    let root = seed_instance(&jail).to_path_buf();
+    // NOTE: _TAXIS_TEST_UNSET_PORT_A is not set in the jail
+    jail.remove_env("_TAXIS_TEST_UNSET_PORT_A");
+    write_toml(
+        &root,
+        "[gateway]\nport = ${_TAXIS_TEST_UNSET_PORT_A:-4242}\n",
+    );
 
-        let oikos = Oikos::from_root(dir.path());
-        let config = load_config(&oikos).map_err(|e| e.to_string())?;
-        assert_eq!(
-            config.gateway.port, 4242,
-            "default from :-syntax should apply when var is unset"
-        );
-        Ok(())
-    });
+    let oikos = Oikos::from_root(&root);
+    let config = load_config(&oikos).unwrap();
+    assert_eq!(
+        config.gateway.port, 4242,
+        "default from :-syntax should apply when var is unset"
+    );
 }
 
 #[test]
 fn interpolate_substitutes_env_var_value_when_set() {
-    figment::Jail::expect_with(|jail| {
-        let dir = make_valid_instance();
-        jail.set_env("_TAXIS_TEST_SET_PORT_B", "7777");
-        write_toml(
-            dir.path(),
-            "[gateway]\nport = ${_TAXIS_TEST_SET_PORT_B:-1111}\n",
-        );
+    let mut jail = EnvJail::new();
+    let root = seed_instance(&jail).to_path_buf();
+    jail.set_env("_TAXIS_TEST_SET_PORT_B", "7777");
+    write_toml(
+        &root,
+        "[gateway]\nport = ${_TAXIS_TEST_SET_PORT_B:-1111}\n",
+    );
 
-        let oikos = Oikos::from_root(dir.path());
-        let config = load_config(&oikos).map_err(|e| e.to_string())?;
-        assert_eq!(config.gateway.port, 7777);
-        Ok(())
-    });
+    let oikos = Oikos::from_root(&root);
+    let config = load_config(&oikos).unwrap();
+    assert_eq!(config.gateway.port, 7777);
 }
 
 #[test]
 fn interpolate_required_var_missing_aborts_load_with_user_message() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        // NOTE: _TAXIS_TEST_REQ_C is not set
-        write_toml(
-            dir.path(),
-            "[gateway.auth]\nnoneRole = \"${_TAXIS_TEST_REQ_C:?missing required role}\"\n",
-        );
+    let mut jail = EnvJail::new();
+    let root = seed_instance(&jail).to_path_buf();
+    // NOTE: _TAXIS_TEST_REQ_C is not set
+    jail.remove_env("_TAXIS_TEST_REQ_C");
+    write_toml(
+        &root,
+        "[gateway.auth]\nnoneRole = \"${_TAXIS_TEST_REQ_C:?missing required role}\"\n",
+    );
 
-        let oikos = Oikos::from_root(dir.path());
-        let err = load_config(&oikos).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("_TAXIS_TEST_REQ_C"),
-            "error should name the unset var: {msg}"
-        );
-        assert!(
-            msg.contains("missing required role"),
-            "error should include user-supplied message: {msg}"
-        );
-        Ok(())
-    });
+    let oikos = Oikos::from_root(&root);
+    let err = load_config(&oikos).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("_TAXIS_TEST_REQ_C"),
+        "error should name the unset var: {msg}"
+    );
+    assert!(
+        msg.contains("missing required role"),
+        "error should include user-supplied message: {msg}"
+    );
 }
 
 // ─── write_config + load_config roundtrip ──────────────────────────────
 
 #[test]
 fn write_then_load_preserves_gateway_port_override() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        let oikos = Oikos::from_root(dir.path());
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    let oikos = Oikos::from_root(root);
 
-        let mut config = AletheiaConfig::default();
-        config.gateway.port = 13_131;
+    let mut config = AletheiaConfig::default();
+    config.gateway.port = 13_131;
 
-        write_config(&oikos, &config).map_err(|e| e.to_string())?;
-        let loaded = load_config(&oikos).map_err(|e| e.to_string())?;
-        assert_eq!(loaded.gateway.port, 13_131);
-        Ok(())
-    });
+    write_config(&oikos, &config).unwrap();
+    let loaded = load_config(&oikos).unwrap();
+    assert_eq!(loaded.gateway.port, 13_131);
 }
 
 #[test]
 fn write_then_load_preserves_embedding_dimension_override() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        let oikos = Oikos::from_root(dir.path());
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    let oikos = Oikos::from_root(root);
 
-        let mut config = AletheiaConfig::default();
-        config.embedding.dimension = 1024;
+    let mut config = AletheiaConfig::default();
+    config.embedding.dimension = 1024;
 
-        write_config(&oikos, &config).map_err(|e| e.to_string())?;
-        let loaded = load_config(&oikos).map_err(|e| e.to_string())?;
-        assert_eq!(loaded.embedding.dimension, 1024);
-        Ok(())
-    });
+    write_config(&oikos, &config).unwrap();
+    let loaded = load_config(&oikos).unwrap();
+    assert_eq!(loaded.embedding.dimension, 1024);
 }
 
 #[test]
@@ -231,24 +219,22 @@ fn write_then_load_preserves_embedding_dimension_override() {
 fn write_config_creates_file_with_mode_0600() {
     use std::os::unix::fs::PermissionsExt;
 
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        let oikos = Oikos::from_root(dir.path());
-        let config = AletheiaConfig::default();
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    let oikos = Oikos::from_root(root);
+    let config = AletheiaConfig::default();
 
-        write_config(&oikos, &config).map_err(|e| e.to_string())?;
+    write_config(&oikos, &config).unwrap();
 
-        let toml_path = dir.path().join("config").join("aletheia.toml");
-        let meta = std::fs::metadata(&toml_path).expect("stat config file");
-        let mode = meta.permissions().mode() & 0o777;
-        // WHY: closes #1710 -- config file may contain signing keys and must
-        // be 0600 so only the owning user can read it.
-        assert_eq!(
-            mode, 0o600,
-            "aletheia.toml mode should be 0600, got {mode:o}"
-        );
-        Ok(())
-    });
+    let toml_path = root.join("config").join("aletheia.toml");
+    let meta = std::fs::metadata(&toml_path).expect("stat config file");
+    let mode = meta.permissions().mode() & 0o777;
+    // WHY: closes #1710 -- config file may contain signing keys and must
+    // be 0600 so only the owning user can read it.
+    assert_eq!(
+        mode, 0o600,
+        "aletheia.toml mode should be 0600, got {mode:o}"
+    );
 }
 
 // ─── Hot-reload classification ──────────────────────────────────────────
@@ -270,43 +256,39 @@ fn restart_prefixes_lists_channels() {
 
 #[test]
 fn prepare_reload_classifies_gateway_port_change_as_cold() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        write_toml(dir.path(), "[gateway]\nport = 7890\n");
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    write_toml(root, "[gateway]\nport = 7890\n");
 
-        let oikos = Oikos::from_root(dir.path());
-        let current = AletheiaConfig::default();
-        let outcome = prepare_reload(&oikos, &current).map_err(|e| e.to_string())?;
+    let oikos = Oikos::from_root(root);
+    let current = AletheiaConfig::default();
+    let outcome = prepare_reload(&oikos, &current).unwrap();
 
-        assert!(
-            outcome
-                .diff
-                .cold_changes()
-                .iter()
-                .any(|c| c.path.contains("gateway.port")),
-            "gateway.port should appear as a cold change"
-        );
-        Ok(())
-    });
+    assert!(
+        outcome
+            .diff
+            .cold_changes()
+            .iter()
+            .any(|c| c.path.contains("gateway.port")),
+        "gateway.port should appear as a cold change"
+    );
 }
 
 #[test]
 fn prepare_reload_rejects_invalid_config_and_preserves_current() {
-    figment::Jail::expect_with(|_jail| {
-        let dir = make_valid_instance();
-        // WHY: maxToolIterations = 0 is rejected by the validator.
-        write_toml(dir.path(), "[agents.defaults]\nmaxToolIterations = 0\n");
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    // WHY: maxToolIterations = 0 is rejected by the validator.
+    write_toml(root, "[agents.defaults]\nmaxToolIterations = 0\n");
 
-        let oikos = Oikos::from_root(dir.path());
-        let current = AletheiaConfig::default();
-        let original = current.agents.defaults.max_tool_iterations;
+    let oikos = Oikos::from_root(root);
+    let current = AletheiaConfig::default();
+    let original = current.agents.defaults.max_tool_iterations;
 
-        let result = prepare_reload(&oikos, &current);
-        assert!(result.is_err(), "invalid config should fail prepare_reload");
-        assert_eq!(
-            current.agents.defaults.max_tool_iterations, original,
-            "current config must be preserved on rejection"
-        );
-        Ok(())
-    });
+    let result = prepare_reload(&oikos, &current);
+    assert!(result.is_err(), "invalid config should fail prepare_reload");
+    assert_eq!(
+        current.agents.defaults.max_tool_iterations, original,
+        "current config must be preserved on rejection"
+    );
 }

--- a/crates/theatron/proskenion/deny.toml
+++ b/crates/theatron/proskenion/deny.toml
@@ -144,8 +144,8 @@ skip = [
     # (See also windows-sys 0.59 skip above — same dep chain.)
     { name = "rustix", version = "=0.38.44" },
 
-    # WHY: toml 0.8 (figment dependency) uses serde_spanned 0.6; toml 1.x uses 1.x.
-    # Same root cause as the toml/toml_datetime skips below.
+    # WHY: transitive toml 0.8 (from dioxus/tauri tooling chain) uses serde_spanned 0.6;
+    # the application layer uses toml 1.x. Same root cause as the toml skips below.
     { name = "serde_spanned", version = "=0.6.9" },
 
     # WHY: various transitive deps have not yet migrated to thiserror v2.
@@ -153,8 +153,8 @@ skip = [
     { name = "thiserror", version = "=1.0.69" },
     { name = "thiserror-impl", version = "=1.0.69" },
 
-    # WHY: figment 0.10 (config cascade library in taxis) pins toml 0.8.
-    # Workspace and taxis proper use toml 1.x. Blocked until figment uses toml 1.0+.
+    # WHY: dioxus/tauri tooling chain still pulls in toml 0.8; the application
+    # layer uses toml 1.x. Blocked until upstream UI stack upgrades to toml 1.x.
     { name = "toml", version = "=0.8.23" },
     { name = "toml_datetime", version = "=0.6.11" },
 

--- a/deny.toml
+++ b/deny.toml
@@ -143,23 +143,10 @@ skip = [
     # (See also windows-sys 0.59 skip above — same dep chain.)
     { name = "rustix", version = "=0.38.44" },
 
-    # WHY: toml 0.8 (figment dependency) uses serde_spanned 0.6; toml 1.x uses 1.x.
-    # Same root cause as the toml/toml_datetime skips below.
-    { name = "serde_spanned", version = "=0.6.9" },
-
     # WHY: various transitive deps have not yet migrated to thiserror v2.
     # Blocked until upstream crates release versions using thiserror 2.x.
     { name = "thiserror", version = "=1.0.69" },
     { name = "thiserror-impl", version = "=1.0.69" },
-
-    # WHY: figment 0.10 (config cascade library in taxis) pins toml 0.8.
-    # Workspace and taxis proper use toml 1.x. Blocked until figment uses toml 1.0+.
-    { name = "toml", version = "=0.8.23" },
-    { name = "toml_datetime", version = "=0.6.11" },
-
-    # WHY: toml_edit pins winnow 0.7.
-    # Canonical: winnow 1.0 (toml 1.x). Blocked until toml_edit updates.
-    { name = "winnow", version = "=0.7.15" },
 ]
 
 [sources]

--- a/docs/ARCHITECTURE-GUIDE.md
+++ b/docs/ARCHITECTURE-GUIDE.md
@@ -75,7 +75,7 @@ Crates are organized in layers. Lower layers know nothing about higher layers.
 
 ### Low (depends on koina)
 
-- **taxis**: configuration and paths. Loads the YAML config cascade (figment), resolves the oikos instance directory structure.
+- **taxis**: configuration and paths. Loads the TOML config cascade (owned loader: defaults → TOML → env), resolves the oikos instance directory structure.
 - **hermeneus**: LLM provider abstraction. The Anthropic streaming client lives here. Handles retries, cost tracking, model routing.
 - **symbolon**: authentication: JWT tokens, bearer validation, RBAC. Depends on koina; uses its own SQLite for token storage.
 - **mneme**: memory engine. SQLite session store, embedded Datalog engine for knowledge graphs and vector search, candle for local embeddings, LLM-driven fact extraction.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,7 +112,7 @@ The oikos hierarchy is described in [CONFIGURATION.md](CONFIGURATION.md).
 | Crate | Directory | Domain | Depends On |
 |-------|-----------|--------|------------|
 | `koina` | `crates/koina` | Errors (snafu), tracing, fs utilities, safe wrappers | nothing (leaf) |
-| `taxis` | `crates/taxis` | Config loading (figment TOML cascade), path resolution, oikos hierarchy | koina |
+| `taxis` | `crates/taxis` | Config loading (owned TOML cascade), path resolution, oikos hierarchy | koina |
 | `eidos` | `crates/eidos` | Shared knowledge types: Fact, Entity, Relationship, EpistemicTier | nothing (leaf) |
 | `graphe` | `crates/graphe` | SQLite session store: WAL, migrations, retention, backup, export/import | eidos, koina |
 | `episteme` | `crates/episteme` | Knowledge pipeline: extraction, recall, consolidation, embedding provider | eidos, koina, graphe, krites (opt) |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,7 +2,7 @@
 
 **File:** `instance/config/aletheia.toml`
 
-Loaded by the `taxis` crate using figment with a three-layer cascade:
+Loaded by the `taxis` crate using an owned TOML loader with a three-layer cascade:
 
 1. Compiled defaults (`AletheiaConfig::default()`)
 2. TOML file (if present)

--- a/docs/TECHNOLOGY.md
+++ b/docs/TECHNOLOGY.md
@@ -20,7 +20,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module boundaries, [PROJECT.md](PROJE
 | Memory | Direct (no abstraction) | KnowledgeStore (embedded engine) | ~50 LOC replaces the library |
 | Sessions | rusqlite + bundled | better-sqlite3 | WAL mode, no native addon |
 | Encryption | XChaCha20Poly1305 | None (plaintext) | Planned: per-message encryption at rest. Not yet implemented. |
-| Config | figment + serde + validator | Zod | figment handles oikos cascade natively (TOML + env + CLI, hierarchical merge). By Rocket author. |
+| Config | toml + serde_json + serde | Zod | Owned cascade loader in taxis: deep-merge on serde_json::Value (defaults → TOML → env). ~80 lines, no proc-macro parser combinator overhead. |
 | IDs | ulid + uuid | uuid | ulid for time-sorted data (sessions, messages, memories) - lexicographic sort = natural ordering. uuid v4 for non-temporal. |
 | Errors | snafu + anyhow | AletheiaError hierarchy | snafu for library/mid-level enums (context wrapping, Location-based virtual stack traces, multiple variants from same source type - GreptimeDB pattern). anyhow for application entry. |
 | Logging | tracing + Langfuse | tslog | Spans, layers, OpenTelemetry. Langfuse for LLM-specific traces. |
@@ -80,7 +80,7 @@ Lean dependency count. See `Cargo.toml` workspace members and `[workspace.depend
 | Crate | Key Dependencies |
 |-------|-----------------|
 | **koina** | snafu, tracing, tracing-subscriber |
-| **taxis** | koina, figment, serde, serde_json, snafu, tracing |
+| **taxis** | koina, serde, serde_json, toml, snafu, tracing, chacha20poly1305, base64 |
 | **mneme** | koina, snafu, serde, tracing, ulid, rusqlite (sqlite), candle-core/nn/transformers (embed-candle), jiff, hnsw_rs, fjall |
 | **hermeneus** | koina, taxis, reqwest, serde_json, tokio |
 | **organon** | koina, taxis, hermeneus, tokio, gix, extrasafe, chromiumoxide |

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -44,7 +44,7 @@ cargo build --release
 
 ## Config compatibility
 
-The config system uses figment with `serde(default)` on all structs. New config fields added in newer versions automatically get their compiled defaults; no manual migration needed for minor versions.
+The config system uses an owned TOML loader with `serde(default)` on all structs. New config fields added in newer versions automatically get their compiled defaults; no manual migration needed for minor versions.
 
 Both `snake_case` and `camelCase` field names work via serde's `rename_all = "camelCase"`.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -338,8 +338,8 @@ collection coherent; ordered structure. Aristotle used *taxis* for the organizat
 distinguishes a well-ordered army from a mob. In rhetoric, it refers to the arrangement of
 arguments.
 
-**In this codebase.** The configuration loading and path resolution crate. Implements a
-figment cascade (defaults → TOML → environment variables), resolves the `Oikos` instance
+**In this codebase.** The configuration loading and path resolution crate. Implements an
+owned TOML cascade (defaults → TOML → environment variables), resolves the `Oikos` instance
 directory layout, and exposes `AletheiaConfig` to the rest of the system.
 
 **Crate.** `taxis` (low layer) - config and path resolution.

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -31,7 +31,7 @@
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
-| **Taxis** | τάξις | "config" | The arrangement that makes a collection coherent, Aristotle's word for ordered structure. Config loading (figment TOML cascade), path resolution, oikos hierarchy. |
+| **Taxis** | τάξις | "config" | The arrangement that makes a collection coherent, Aristotle's word for ordered structure. Config loading (owned TOML cascade), path resolution, oikos hierarchy. |
 | **Hermeneus** | ἑρμηνεύς | "provider" | Hermes' art of carrying meaning across worlds. Anthropic client, model routing, credential management. The translation layer between nous and LLM backends. |
 | **Mneme** | μνήμη | "memory" | Memory as active faculty, the Muse's gift, not passive storage. Facade re-exporting eidos, krites, graphe, episteme. |
 | **Eidos** | εἶδος | "types" | The visible form: what makes a Fact a Fact, a Session a Session. Shared memory types, IDs, error definitions. |

--- a/instance.example/nous/_default/MEMORY.md
+++ b/instance.example/nous/_default/MEMORY.md
@@ -9,7 +9,7 @@ Keep this file lean. Delete entries that are no longer relevant. Move entries th
 - Runtime: Aletheia v0.13.11 (self-hosted, single binary, Rust)
 - Source: https://github.com/forkwright/aletheia
 - Standing order: log bugs and improvements as issues on the repo
-- Config: instance/config/aletheia.toml (TOML, figment cascade)
+- Config: instance/config/aletheia.toml (TOML cascade: defaults → file → env)
 - CLI: `aletheia --help` for full reference
 
 ## Operator

--- a/planning/research/mcp-client.md
+++ b/planning/research/mcp-client.md
@@ -135,7 +135,7 @@ The SDK abstracts JSON-RPC framing, lifecycle management, and transport details.
 
 ### 7. configuration system
 
-**Framework**: figment (defaults, TOML file, environment variables). All config types in `crates/taxis/src/config.rs`.
+**Framework**: owned TOML cascade (defaults, TOML file, environment variables) in `crates/taxis/src/loader.rs`. All config types in `crates/taxis/src/config.rs`.
 
 **Existing MCP config**: `McpConfig` with `rate_limit` sub-struct (for server rate limiting). This is the natural extension point for client configuration.
 

--- a/standards/RUST.md
+++ b/standards/RUST.md
@@ -1042,7 +1042,7 @@ Rust-specific framework choices and conventions:
 **Preferred:**
 - `snafu` (errors), `tokio` (async), `tracing` (logging), `serde` (serialization)
 - `jiff` (time), `ulid` (IDs), `compact_str` (small strings)
-- `figment` (config), `rusqlite` (SQLite)
+- `toml` + `serde_json` (config merge — no figment; see crates/taxis/src/loader.rs), `rusqlite` (SQLite)
 - `secrecy` (secret values), `subtle` (constant-time comparison)
 - `std::sync::LazyLock` (lazy statics)
 - `tokio_util::sync::CancellationToken` (shutdown coordination)


### PR DESCRIPTION
## Summary

- taxis used only 3 figment features (merge defaults, merge TOML, merge env with `__` splitting); replaced with an owned ~80-line loader that deep-merges on `serde_json::Value`: defaults → TOML → env overlay.
- Env autotyping (bool, int, float, string) preserved so `ALETHEIA_*=...` operator contract is unchanged.
- Tests migrated from `figment::Jail` to a new owned `EnvJail` helper in `crates/taxis/src/test_support.rs` (process-wide mutex, captures + restores env vars, owns a tempdir).

## Transitive dep reduction

`cargo tree -p taxis` unique packages: **143 → 121** (22 fewer).
Unique crates dropped from the workspace lockfile: `figment`, `pear`, `pear_codegen`, `inlinable_string`, `proc-macro2-diagnostics`, `uncased`, `yansi`, plus the parallel toml 0.8 / winnow 0.7 / serde_spanned 0.6 chain figment pinned.
Kills the `pear` proc-macro parser-combinator build cost.

## Acceptance

- `cargo tree -p figment --workspace` → not found
- `cargo tree -p pear` → not found
- `cargo check -p taxis --tests` → ok
- `cargo clippy -p taxis --tests -- -D warnings` → clean
- `cargo test -p taxis` → 291 pass (222 lib + 25 + 16 + 26 + 2 doc)
- kanon lint: 16 pre-existing violations unchanged; no new violations introduced

## Test plan

- [x] `cargo check -p taxis --tests`
- [x] `cargo clippy -p taxis --tests -- -D warnings`
- [x] `cargo test -p taxis`
- [x] `cargo test -p taxis --features test-core`
- [x] `cargo check --workspace` (dependents still compile)

Closes #3447