### PR TITLE
fix(ci): unblock PR CI — deny args + advisories + graphe dead code

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,4 +14,8 @@ ignore = [
     "RUSTSEC-2025-0141",
     # paste unmaintained — transitive via tokenizers; no safe upgrade
     "RUSTSEC-2024-0436",
+    # rustls-pemfile 2.x unmaintained — transitive via qdrant-client → tonic 0.12. Blocked on qdrant-client → tonic 0.13+
+    "RUSTSEC-2025-0134",
+    # rand 0.8 unsound only with custom logger using rand::rng() — not our usage. Transitive via qdrant-client → tonic 0.12 + spreadsheet-ods + phf
+    "RUSTSEC-2026-0097",
 ]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false # PROJECT: security hardening — never expose token to steps
-      - uses: EmbarkStudios/cargo-deny-action@30f817c6f72275c6d54dc744fbca09ebc958599f # v2.0.14
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
         with:
           # WHY: run every check explicitly so a schema regression in one
           # section can't silently disable the others. cargo-deny expects

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,10 +42,12 @@ jobs:
           persist-credentials: false # PROJECT: security hardening — never expose token to steps
       - uses: EmbarkStudios/cargo-deny-action@30f817c6f72275c6d54dc744fbca09ebc958599f # v2.0.14
         with:
-          command: check
           # WHY: run every check explicitly so a schema regression in one
-          # section can't silently disable the others.
-          arguments: --all-features advisories licenses bans sources
+          # section can't silently disable the others. cargo-deny expects
+          # the check subcommand followed by space-separated check names;
+          # `arguments:` passes post-subcommand flags only.
+          command: check advisories licenses bans sources
+          arguments: --all-features
 
   cargo-audit:
     # WHY: cargo-deny's advisories check overlaps but uses a different code

--- a/crates/graphe/src/metrics.rs
+++ b/crates/graphe/src/metrics.rs
@@ -80,9 +80,14 @@ pub(crate) fn record_session_created(nous_id: &str, session_type: &str) {
 
 /// Record a backup operation duration.
 ///
-/// Only compiled when the `sqlite` feature is enabled — the only call site
-/// (`backup::create_backup`) lives behind that feature gate.
-
+/// Currently unused: the only call site (`backup::create_backup`) was removed
+/// along with rusqlite in #3446. Retained — together with `BACKUP_DURATION_SECONDS`
+/// and its registration — so fjall-based backup work can re-attach to the same
+/// metric name without a schema migration.
+#[expect(
+    dead_code,
+    reason = "reserved for fjall backup work; call site removed in #3446"
+)]
 pub(crate) fn record_backup_duration(duration_secs: f64, success: bool) {
     let status = if success { "ok" } else { "error" };
     BACKUP_DURATION_SECONDS

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,14 @@ reason = "bincode unmaintained — transitive via syntect/aletheia-tui, no safe 
 id = "RUSTSEC-2024-0436"
 reason = "paste unmaintained, transitive via tokenizers; no safe upgrade"
 
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0134"
+reason = "rustls-pemfile 2.x unmaintained — transitive via qdrant-client → tonic 0.12. Blocked until qdrant-client upgrades tonic to 0.13+"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0097"
+reason = "rand 0.8 unsound only with custom logger using rand::rng() — not our usage. Transitive via qdrant-client → tonic 0.12 + spreadsheet-ods + phf. Blocked on upstream migrations to rand 0.9+"
+
 [licenses]
 allow = [
     "MIT",

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ allow = [
     "MPL-2.0",              # option-ext, smartstring
     "LGPL-3.0-or-later",    # priority-queue
     "CDLA-Permissive-2.0",  # webpki-roots, webpki-root-certs
+    "bzip2-1.0.6",          # libbz2-rs-sys (via zip 7.x), standalone bzip2 license
 ]
 confidence-threshold = 0.8
 
@@ -130,16 +131,14 @@ skip = [
     { name = "rand_core", version = "=0.6.4" },
     { name = "rand_core", version = "=0.9.5" },
 
-<<<<<<< HEAD
     # WHY: procfs (prometheus metrics client) pins rustix 0.38.
     # Blocked until prometheus/procfs upgrades to rustix 1.x.
     # (See also windows-sys 0.59 skip above — same dep chain.)
     { name = "rustix", version = "=0.38.44" },
-=======
+
     # WHY: toml 0.8 (figment dependency) uses serde_spanned 0.6; toml 1.x uses 1.x.
     # Same root cause as the toml/toml_datetime skips below.
     { name = "serde_spanned", version = "=0.6.9" },
->>>>>>> 3a90f5307 (refactor: migrate from prometheus to prometheus-client (drops protobuf) (#3444))
 
     # WHY: various transitive deps have not yet migrated to thiserror v2.
     # Blocked until upstream crates release versions using thiserror 2.x.

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,10 @@ id = "RUSTSEC-2026-0097"
 reason = "rand 0.8 unsound only with custom logger using rand::rng() — not our usage. Transitive via qdrant-client → tonic 0.12 + spreadsheet-ods + phf. Blocked on upstream migrations to rand 0.9+"
 
 [licenses]
+# WHY: `version = 2` enables modern SPDX 3.x parsing so "AGPL-3.0-or-later" /
+# "LGPL-3.0-or-later" are accepted as bare license identifiers. Without this,
+# the legacy parser rejects them with "expected a <bare-gnu-license>".
+version = 2
 allow = [
     "MIT",
     "Apache-2.0",


### PR DESCRIPTION
## Summary

Three independent CI failures that have been blocking every PR since ~April 14-16. All pre-existing on main; fixed together so the next PR doesn't have to re-learn them.

1. **cargo-deny-action argument order.** Workflow passed `command: check` + `arguments: --all-features advisories licenses bans sources`, which the action composes as `--all-features advisories licenses bans sources check`. cargo-deny doesn't accept `advisories` as a top-level subcommand, so CI emitted `unrecognized subcommand 'advisories'`. Fix: move the check list into `command:` and leave only `--all-features` in `arguments:`.

2. **New RustSec advisories denied by cargo audit + cargo deny.** Both come through `qdrant-client → tonic 0.12`, plus transitive use elsewhere:
   - `RUSTSEC-2025-0134` (rustls-pemfile unmaintained)
   - `RUSTSEC-2026-0097` (rand 0.8 unsound w/ custom `rand::rng()` logger — not our usage pattern)
   
   Blocked on qdrant-client upgrading tonic. Added to both `deny.toml` and `.cargo/audit.toml` ignore lists with WHY citations.

3. **`graphe::record_backup_duration` flagged as dead code under `-D warnings`.** Call site (`backup::create_backup`) was removed with rusqlite in #3446. Metric name retained for future fjall backup work; added `#[expect(dead_code, reason=...)]`.

4. **`deny.toml` merge conflict** from #3444 resolved (kept both skip entries; they target independent dep chains).

5. **`bzip2-1.0.6` license** added to allowlist: `libbz2-rs-sys` (via `zip 7.x` from #3448).

## Verification

```
cargo deny check          → advisories ok, bans ok, licenses ok, sources ok
cargo audit               → 0 denied warnings
cargo check -p graphe     → clean under -D warnings
```

## Unblocks

- #3559, #3560, #3561, #3562 (Wave 3 Sovereignty — all 4 blocked by same CI issues)
- #3558 (Wave 7 proskenion)
- All future PRs

## Test plan

- [x] `cargo deny check` passes locally
- [x] `cargo audit` passes locally
- [x] `cargo check -p graphe` passes under `-D warnings`
- [ ] CI cargo deny passes on this PR
- [ ] CI cargo audit passes on this PR
- [ ] CI check+clippy+test passes on this PR