### PR TITLE
fix(ci): silence krites test clippy warnings with scoped #[expect] attrs

### DIFF
--- a/crates/krites/src/data/functions/math/mod.rs
+++ b/crates/krites/src/data/functions/math/mod.rs
@@ -11,17 +11,16 @@
     clippy::float_cmp,
     reason = "exact equality for integer-representable float check — not accumulated arithmetic"
 )]
-#![expect(
-    clippy::enum_glob_use,
-    reason = "DataValue::* glob import is scoped to function body for pattern matching"
-)]
-
 use super::arg;
 use crate::data::error::*;
 type Result<T> = DataResult<T>;
 use crate::data::value::{DataValue, Num, Vector};
 
 pub(crate) fn ensure_same_value_type(a: &DataValue, b: &DataValue) -> Result<()> {
+    #[allow(
+        clippy::enum_glob_use,
+        reason = "DataValue::* glob import is scoped to function body for pattern matching; expectation cannot be expressed reliably across lib and lib-test compilations"
+    )]
     use DataValue::*;
     if !matches!(
         (a, b),

--- a/crates/krites/src/data/mod.rs
+++ b/crates/krites/src/data/mod.rs
@@ -4,9 +4,9 @@
 //! expression evaluation ([`expr`]), scalar functions ([`functions`]),
 //! aggregation operators ([`aggr`]), relation metadata ([`relation`]),
 //! binary key encoding ([`memcmp`]), and the Datalog program AST ([`program`]).
-#![expect(
+#![allow(
     clippy::wildcard_imports,
-    reason = "error selectors and re-exports used pervasively across data module"
+    reason = "error selectors and re-exports used pervasively across data module; expectation cannot be expressed because the lint fires only on the lib build, not lib-test"
 )]
 pub(crate) mod aggr;
 pub(crate) mod error;

--- a/crates/krites/src/data/tests/exprs.rs
+++ b/crates/krites/src/data/tests/exprs.rs
@@ -1,5 +1,9 @@
 //! Tests for expression evaluation.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
 use crate::{DataValue, DbInstance};
 
 #[test]

--- a/crates/krites/src/data/tests/functions/arithmetic.rs
+++ b/crates/krites/src/data/tests/functions/arithmetic.rs
@@ -1,5 +1,17 @@
 //! Tests for arithmetic, comparison, boolean, and bit operations.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::unreadable_literal,
+    reason = "test: numeric literals mirror tested bit-patterns and arithmetic inputs verbatim; adding `_` separators would obscure the test intent"
+)]
+#![expect(
+    clippy::too_many_lines,
+    reason = "test covers many arithmetic ops in a single readable sequence"
+)]
+#![expect(
+    clippy::float_cmp,
+    reason = "test compares exact-arithmetic floats against known-exact expected values"
+)]
 use std::f64::consts::{E, PI};
 
 use crate::data::functions::*;

--- a/crates/krites/src/data/tests/functions/collections.rs
+++ b/crates/krites/src/data/tests/functions/collections.rs
@@ -1,5 +1,13 @@
 //! Tests for predicates, collection operations, geographic functions, and UUIDs.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::too_many_lines,
+    reason = "test covers many collection ops in a single readable sequence"
+)]
+#![expect(
+    clippy::float_cmp,
+    reason = "test compares exact-arithmetic floats against known-exact expected values"
+)]
 use std::f64::consts::PI;
 
 use crate::data::functions::*;

--- a/crates/krites/src/data/tests/functions/type_conversion.rs
+++ b/crates/krites/src/data/tests/functions/type_conversion.rs
@@ -1,5 +1,9 @@
 //! Tests for type conversion, coalesce, and range functions.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape DataValue::List results"
+)]
 use serde_json::json;
 
 use crate::DbInstance;

--- a/crates/krites/src/data/tests/json.rs
+++ b/crates/krites/src/data/tests/json.rs
@@ -1,5 +1,9 @@
 //! Tests for JSON round-tripping.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::unnecessary_fallible_conversions,
+    reason = "test exercises fallible conversion paths explicitly"
+)]
 use serde_json::json;
 
 use crate::data::json::JsonValue;

--- a/crates/krites/src/data/tests/memcmp.rs
+++ b/crates/krites/src/data/tests/memcmp.rs
@@ -1,5 +1,13 @@
 //! Tests for memory-comparable encoding.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-size encoding buffers"
+)]
+#![expect(
+    clippy::unreadable_literal,
+    reason = "test: numeric literals mirror tested bit patterns verbatim"
+)]
 use uuid::Uuid;
 
 use crate::data::memcmp::{MemCmpEncoder, decode_bytes};

--- a/crates/krites/src/data/tests/proptest_memcmp.rs
+++ b/crates/krites/src/data/tests/proptest_memcmp.rs
@@ -4,7 +4,6 @@
 //! deserializes, and verifies equality. Also tests rmp-serde round-trips
 //! and sort-order preservation.
 #![expect(clippy::expect_used, reason = "test assertions")]
-#![expect(clippy::indexing_slicing, reason = "test data with known structure")]
 
 use std::collections::BTreeSet;
 

--- a/crates/krites/src/data/tests/validity.rs
+++ b/crates/krites/src/data/tests/validity.rs
@@ -1,5 +1,13 @@
 //! Tests for temporal validity ranges.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
+#![expect(
+    clippy::too_many_lines,
+    reason = "test covers end-to-end validity flow in one readable sequence"
+)]
 use std::env;
 
 use serde_json::json;

--- a/crates/krites/src/data/tests/values.rs
+++ b/crates/krites/src/data/tests/values.rs
@@ -1,5 +1,13 @@
 //! Tests for core value type.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-size encoding buffers"
+)]
+#![expect(
+    clippy::unreadable_literal,
+    reason = "test: numeric literals mirror tested bit patterns verbatim"
+)]
 use std::collections::{BTreeMap, HashMap};
 use std::mem::size_of;
 

--- a/crates/krites/src/fixed_rule/algos/louvain.rs
+++ b/crates/krites/src/fixed_rule/algos/louvain.rs
@@ -360,6 +360,11 @@ fn louvain_step(
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::as_conversions,
+    reason = "test: node indices fit in u32 for small fixed graphs"
+)]
 mod tests {
     use crate::fixed_rule::csr::CsrBuilder;
 

--- a/crates/krites/src/fixed_rule/algos/shortest_path_bfs.rs
+++ b/crates/krites/src/fixed_rule/algos/shortest_path_bfs.rs
@@ -151,6 +151,10 @@ impl FixedRule for ShortestPathBFS {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
 mod tests {
     use crate::data::value::DataValue;
 

--- a/crates/krites/src/fixed_rule/csr/mod.rs
+++ b/crates/krites/src/fixed_rule/csr/mod.rs
@@ -204,6 +204,10 @@ impl CsrBuilder<()> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape CSR offset/target arrays"
+)]
 mod tests {
     use super::*;
 

--- a/crates/krites/src/fixed_rule/mod.rs
+++ b/crates/krites/src/fixed_rule/mod.rs
@@ -18,17 +18,17 @@ use crate::data::tuple::TupleIter;
 use crate::data::value::DataValue;
 use crate::error::InternalResult as Result;
 #[cfg(feature = "graph-algo")]
-#[expect(
+#[allow(
     clippy::wildcard_imports,
-    reason = "graph algorithm registry re-exports all algo types for registration"
+    reason = "graph algorithm registry re-exports all algo types for registration; expectation cannot be expressed reliably across lib and lib-test compilations"
 )]
 use crate::fixed_rule::algos::*;
 #[cfg(feature = "graph-algo")]
 use crate::fixed_rule::csr::{CsrBuilder, DirectedCsrGraph};
 use crate::fixed_rule::error::InvalidInputSnafu;
-#[expect(
+#[allow(
     clippy::wildcard_imports,
-    reason = "utility rule registry re-exports all utility types for registration"
+    reason = "utility rule registry re-exports all utility types for registration; expectation cannot be expressed reliably across lib and lib-test compilations"
 )]
 use crate::fixed_rule::utilities::*;
 use crate::parse::SourceSpan;

--- a/crates/krites/src/fixed_rule/tests/centrality_spanning.rs
+++ b/crates/krites/src/fixed_rule/tests/centrality_spanning.rs
@@ -1,6 +1,14 @@
 //! Centrality and spanning tree tests: `DegreeCentrality`, MST, `LabelProp`, `PageRank`, `RandomWalk`.
 #![cfg(test)]
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
+#![expect(
+    clippy::as_conversions,
+    reason = "test: graph node counts fit well within target numeric ranges"
+)]
 use crate::DbInstance;
 use crate::data::value::DataValue;
 

--- a/crates/krites/src/fixed_rule/tests/connectivity_misc.rs
+++ b/crates/krites/src/fixed_rule/tests/connectivity_misc.rs
@@ -1,6 +1,20 @@
 //! Connectivity and misc tests: SCC, CC, `TopSort`, Clustering, KSP, Louvain, `KCore`.
 #![cfg(test)]
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
+#![expect(
+    clippy::mutable_key_type,
+    reason = "test uses BTreeSet<DataValue>; interior mutability is not exercised in DataValue keys here"
+)]
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::as_conversions,
+    reason = "test: small graph sizes fit target numeric ranges"
+)]
 use crate::DbInstance;
 use crate::data::value::DataValue;
 

--- a/crates/krites/src/fixed_rule/tests/path_algorithms.rs
+++ b/crates/krites/src/fixed_rule/tests/path_algorithms.rs
@@ -1,6 +1,10 @@
 //! Path and traversal algorithm tests: Dijkstra, BFS, DFS, A*, centrality.
 #![cfg(test)]
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
 use crate::DbInstance;
 use crate::data::value::DataValue;
 

--- a/crates/krites/src/fixed_rule/tests/proptest_algos.rs
+++ b/crates/krites/src/fixed_rule/tests/proptest_algos.rs
@@ -9,8 +9,11 @@
 #![expect(clippy::expect_used, reason = "test assertions")]
 #![expect(clippy::indexing_slicing, reason = "test data with known structure")]
 #![expect(
-    clippy::cast_precision_loss,
-    reason = "small graph sizes -- precision loss irrelevant"
+    clippy::as_conversions,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "test: small proptest graph sizes fit target numeric ranges"
 )]
 
 use proptest::prelude::*;

--- a/crates/krites/src/fixed_rule/utilities/rrf.rs
+++ b/crates/krites/src/fixed_rule/utilities/rrf.rs
@@ -136,6 +136,14 @@ fn rank_to_output(rank: usize) -> i64 {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape rank/score maps"
+)]
+#[expect(
+    clippy::float_cmp,
+    reason = "test compares exact-arithmetic floats against known-exact expected values"
+)]
 mod tests {
     use super::*;
 

--- a/crates/krites/src/fts/indexing.rs
+++ b/crates/krites/src/fts/indexing.rs
@@ -698,6 +698,14 @@ impl SessionTx<'_> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::as_conversions,
+    reason = "test: BM25 score arithmetic uses small known integer-to-float casts"
+)]
+#[expect(
+    clippy::float_cmp,
+    reason = "test compares exact-arithmetic floats against known-exact expected values"
+)]
 mod tests {
     use super::bm25_compute_score;
     use crate::data::program::FtsScoreKind;

--- a/crates/krites/src/fts/tokenizer/alphanum_only.rs
+++ b/crates/krites/src/fts/tokenizer/alphanum_only.rs
@@ -46,6 +46,10 @@ impl TokenStream for AlphaNumOnlyFilterStream<'_> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-length token vectors"
+)]
 mod tests {
     use crate::fts::tokenizer::tests::assert_token;
     use crate::fts::tokenizer::{AlphaNumOnlyFilter, SimpleTokenizer, TextAnalyzer, Token};

--- a/crates/krites/src/fts/tokenizer/ascii_folding_filter/tests/foldings_a_i.rs
+++ b/crates/krites/src/fts/tokenizer/ascii_folding_filter/tests/foldings_a_i.rs
@@ -1,4 +1,8 @@
 //! ASCII folding tests for letters A through I.
+#![expect(
+    clippy::too_many_lines,
+    reason = "test covers all folding rules for letters A-I in a single readable table"
+)]
 
 use super::folding_using_raw_tokenizer_helper;
 

--- a/crates/krites/src/fts/tokenizer/ascii_folding_filter/tests/foldings_j_s.rs
+++ b/crates/krites/src/fts/tokenizer/ascii_folding_filter/tests/foldings_j_s.rs
@@ -1,4 +1,8 @@
 //! ASCII folding tests for letters J through S.
+#![expect(
+    clippy::too_many_lines,
+    reason = "test covers all folding rules for letters J-S in a single readable table"
+)]
 
 use super::folding_using_raw_tokenizer_helper;
 

--- a/crates/krites/src/fts/tokenizer/ascii_folding_filter/tests/foldings_num_sym.rs
+++ b/crates/krites/src/fts/tokenizer/ascii_folding_filter/tests/foldings_num_sym.rs
@@ -1,4 +1,8 @@
 //! ASCII folding tests for numbers and symbols.
+#![expect(
+    clippy::too_many_lines,
+    reason = "test covers all folding rules for numbers and symbols in a single readable table"
+)]
 
 use super::folding_using_raw_tokenizer_helper;
 

--- a/crates/krites/src/fts/tokenizer/ascii_folding_filter/tests/foldings_t_z.rs
+++ b/crates/krites/src/fts/tokenizer/ascii_folding_filter/tests/foldings_t_z.rs
@@ -1,4 +1,8 @@
 //! ASCII folding tests for letters T through Z.
+#![expect(
+    clippy::too_many_lines,
+    reason = "test covers all folding rules for letters T-Z in a single readable table"
+)]
 
 use super::folding_using_raw_tokenizer_helper;
 

--- a/crates/krites/src/fts/tokenizer/lower_caser.rs
+++ b/crates/krites/src/fts/tokenizer/lower_caser.rs
@@ -55,6 +55,10 @@ impl TokenStream for LowerCaserTokenStream<'_> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-length token vectors"
+)]
 mod tests {
     use crate::fts::tokenizer::tests::assert_token;
     use crate::fts::tokenizer::{LowerCaser, SimpleTokenizer, TextAnalyzer, Token};

--- a/crates/krites/src/fts/tokenizer/ngram_tokenizer.rs
+++ b/crates/krites/src/fts/tokenizer/ngram_tokenizer.rs
@@ -262,6 +262,12 @@ fn utf8_codepoint_width(b: u8) -> usize {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::as_conversions,
+    reason = "test: byte values are bounded to u8 range by construction"
+)]
 mod tests {
 
     use super::{CodepointFrontiers, StutteringIterator, utf8_codepoint_width};

--- a/crates/krites/src/fts/tokenizer/raw_tokenizer.rs
+++ b/crates/krites/src/fts/tokenizer/raw_tokenizer.rs
@@ -45,6 +45,10 @@ impl TokenStream for RawTokenStream {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-length token vectors"
+)]
 mod tests {
     use crate::fts::tokenizer::tests::assert_token;
     use crate::fts::tokenizer::{RawTokenizer, TextAnalyzer, Token};

--- a/crates/krites/src/fts/tokenizer/remove_long.rs
+++ b/crates/krites/src/fts/tokenizer/remove_long.rs
@@ -57,6 +57,10 @@ impl TokenStream for RemoveLongFilterStream<'_> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-length token vectors"
+)]
 mod tests {
     use crate::fts::tokenizer::tests::assert_token;
     use crate::fts::tokenizer::{RemoveLongFilter, SimpleTokenizer, TextAnalyzer, Token};

--- a/crates/krites/src/fts/tokenizer/simple_tokenizer.rs
+++ b/crates/krites/src/fts/tokenizer/simple_tokenizer.rs
@@ -61,6 +61,10 @@ impl TokenStream for SimpleTokenStream<'_> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-length token vectors"
+)]
 mod tests {
     use crate::fts::tokenizer::tests::assert_token;
     use crate::fts::tokenizer::{SimpleTokenizer, TextAnalyzer, Token};

--- a/crates/krites/src/fts/tokenizer/stemmer.rs
+++ b/crates/krites/src/fts/tokenizer/stemmer.rs
@@ -32,9 +32,9 @@ pub(crate) enum Language {
 
 impl Language {
     fn algorithm(self) -> Algorithm {
-        #[expect(
+        #[allow(
             clippy::enum_glob_use,
-            reason = "local import for concise match arms in Language-to-Algorithm mapping"
+            reason = "local import for concise match arms in Language-to-Algorithm mapping; expectation cannot be expressed reliably across lib and lib-test compilations"
         )]
         use self::Language::*;
         match self {

--- a/crates/krites/src/fts/tokenizer/stop_word_filter/mod.rs
+++ b/crates/krites/src/fts/tokenizer/stop_word_filter/mod.rs
@@ -146,6 +146,10 @@ impl TokenStream for StopWordFilterStream<'_> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-length token vectors"
+)]
 mod tests {
     use crate::fts::tokenizer::tests::assert_token;
     use crate::fts::tokenizer::{SimpleTokenizer, StopWordFilter, TextAnalyzer, Token};

--- a/crates/krites/src/fts/tokenizer/tokenized_string.rs
+++ b/crates/krites/src/fts/tokenizer/tokenized_string.rs
@@ -1,4 +1,15 @@
 //! Pre-tokenized string wrapper.
+#![cfg_attr(
+    test,
+    expect(
+        clippy::indexing_slicing,
+        clippy::as_conversions,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap,
+        reason = "test-only module: indices and casts bounded by fixed small token streams"
+    )
+)]
 
 #[cfg(test)]
 use std::cmp::Ordering;

--- a/crates/krites/src/fts/tokenizer/whitespace_tokenizer.rs
+++ b/crates/krites/src/fts/tokenizer/whitespace_tokenizer.rs
@@ -61,6 +61,10 @@ impl TokenStream for WhitespaceTokenStream<'_> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-length token vectors"
+)]
 mod tests {
     use crate::fts::tokenizer::tests::assert_token;
     use crate::fts::tokenizer::{TextAnalyzer, Token, WhitespaceTokenizer};

--- a/crates/krites/src/query/compile.rs
+++ b/crates/krites/src/query/compile.rs
@@ -9,7 +9,6 @@
     clippy::semicolon_if_nothing_returned,
     clippy::too_many_lines,
     clippy::unnecessary_semicolon,
-    clippy::wildcard_imports,
     reason = "engine-internal query compiler — casts, indexing, and result size are structural"
 )]
 

--- a/crates/krites/src/query/eval.rs
+++ b/crates/krites/src/query/eval.rs
@@ -13,7 +13,6 @@
     clippy::semicolon_if_nothing_returned,
     clippy::too_many_arguments,
     clippy::too_many_lines,
-    clippy::wildcard_imports,
     reason = "engine-internal query evaluator — pass-by-value for Poison, indexing on validated bounds"
 )]
 

--- a/crates/krites/src/query/logical.rs
+++ b/crates/krites/src/query/logical.rs
@@ -4,7 +4,6 @@
     clippy::redundant_closure_for_method_calls,
     clippy::result_large_err,
     clippy::semicolon_if_nothing_returned,
-    clippy::wildcard_imports,
     reason = "engine-internal logical plan — match arms kept explicit for clarity"
 )]
 

--- a/crates/krites/src/query/magic.rs
+++ b/crates/krites/src/query/magic.rs
@@ -20,7 +20,6 @@
     clippy::result_large_err,
     clippy::semicolon_if_nothing_returned,
     clippy::too_many_lines,
-    clippy::wildcard_imports,
     reason = "engine-internal magic sets rewrite — complex transformation with many intermediate collections"
 )]
 
@@ -675,6 +674,10 @@ impl NormalFormInlineRule {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
 mod tests {
     use serde_json::json;
 

--- a/crates/krites/src/query/mod.rs
+++ b/crates/krites/src/query/mod.rs
@@ -22,6 +22,10 @@
 //! All errors propagate through [`QueryError`](error::QueryError) with
 //! `snafu::Location` tracking. The error type covers compilation, evaluation,
 //! stratification, graph traversal, type mismatches, and access control.
+#![allow(
+    clippy::wildcard_imports,
+    reason = "snafu error selectors are imported via glob across query submodules — scoped to engine internals; expectation cannot be expressed because the lint fires only on the lib build, not lib-test"
+)]
 pub(crate) mod compile;
 pub(crate) mod error;
 pub(crate) mod eval;

--- a/crates/krites/src/query/ra/join.rs
+++ b/crates/krites/src/query/ra/join.rs
@@ -20,7 +20,6 @@
     clippy::result_large_err,
     clippy::semicolon_if_nothing_returned,
     clippy::single_match_else,
-    clippy::wildcard_imports,
     reason = "engine-internal join operators -- indexing validated by join_indices, mutable keys are Symbol"
 )]
 

--- a/crates/krites/src/query/ra/mod.rs
+++ b/crates/krites/src/query/ra/mod.rs
@@ -25,7 +25,6 @@
     clippy::too_many_lines,
     clippy::unnecessary_semicolon,
     clippy::unnecessary_wraps,
-    clippy::wildcard_imports,
     reason = "engine-internal relational algebra -- match arms kept explicit, result size structural"
 )]
 

--- a/crates/krites/src/query/ra/project.rs
+++ b/crates/krites/src/query/ra/project.rs
@@ -7,7 +7,6 @@
 #![expect(
     clippy::iter_not_returning_iterator,
     clippy::result_large_err,
-    clippy::wildcard_imports,
     reason = "engine-internal unification RA -- iter returns TupleIter (boxed trait)"
 )]
 

--- a/crates/krites/src/query/ra/search.rs
+++ b/crates/krites/src/query/ra/search.rs
@@ -10,7 +10,6 @@
     clippy::indexing_slicing,
     clippy::iter_not_returning_iterator,
     clippy::result_large_err,
-    clippy::wildcard_imports,
     reason = "engine-internal search RA -- indexing on bind_idx validated during compilation"
 )]
 

--- a/crates/krites/src/query/reorder.rs
+++ b/crates/krites/src/query/reorder.rs
@@ -4,7 +4,6 @@
     clippy::result_large_err,
     clippy::semicolon_if_nothing_returned,
     clippy::too_many_lines,
-    clippy::wildcard_imports,
     reason = "engine-internal join reordering — complex pattern matching over atom types"
 )]
 

--- a/crates/krites/src/query/stored/extractors.rs
+++ b/crates/krites/src/query/stored/extractors.rs
@@ -4,7 +4,6 @@
     clippy::explicit_iter_loop,
     clippy::indexing_slicing,
     clippy::result_large_err,
-    clippy::wildcard_imports,
     reason = "engine-internal data extractors — indexing validated by make_extractor callers"
 )]
 

--- a/crates/krites/src/query/stored/mutation.rs
+++ b/crates/krites/src/query/stored/mutation.rs
@@ -15,7 +15,6 @@
     clippy::type_complexity,
     clippy::unnecessary_semicolon,
     clippy::unused_self,
-    clippy::wildcard_imports,
     reason = "engine-internal mutation — many arguments required for trigger/callback propagation"
 )]
 

--- a/crates/krites/src/query/stored/validation.rs
+++ b/crates/krites/src/query/stored/validation.rs
@@ -14,7 +14,6 @@
     clippy::similar_names,
     clippy::too_many_arguments,
     clippy::too_many_lines,
-    clippy::wildcard_imports,
     reason = "engine-internal validation — many arguments for trigger/callback propagation"
 )]
 

--- a/crates/krites/src/query/stratify.rs
+++ b/crates/krites/src/query/stratify.rs
@@ -18,7 +18,6 @@
     clippy::redundant_closure_for_method_calls,
     clippy::result_large_err,
     clippy::too_many_lines,
-    clippy::wildcard_imports,
     reason = "engine-internal stratification — complex graph analysis with BTreeMap defaults"
 )]
 

--- a/crates/krites/src/runtime/hnsw/put.rs
+++ b/crates/krites/src/runtime/hnsw/put.rs
@@ -590,11 +590,7 @@ impl SessionTx<'_> {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    clippy::cast_precision_loss,
-    reason = "test assertions and test-only numeric casts"
-)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
     use crate::DbInstance;
 

--- a/crates/krites/src/runtime/minhash_lsh.rs
+++ b/crates/krites/src/runtime/minhash_lsh.rs
@@ -447,6 +447,10 @@ impl HashValues {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::float_cmp,
+    reason = "test compares exact-arithmetic floats against known-exact expected values"
+)]
 mod test {
     use super::*;
 

--- a/crates/krites/src/runtime/tests/basic_queries.rs
+++ b/crates/krites/src/runtime/tests/basic_queries.rs
@@ -1,5 +1,9 @@
 //! Basic query tests: limits, aggregation, conditions, classical logic.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
 use serde_json::json;
 use tracing::debug;
 

--- a/crates/krites/src/runtime/tests/imperative.rs
+++ b/crates/krites/src/runtime/tests/imperative.rs
@@ -1,5 +1,9 @@
 //! Tests for imperative scripts, parser edge cases, deletions, and returning relations.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
 use std::collections::BTreeMap;
 
 use serde_json::json;

--- a/crates/krites/src/runtime/tests/indexing.rs
+++ b/crates/krites/src/runtime/tests/indexing.rs
@@ -1,5 +1,9 @@
 //! Tests for vector indexing, FTS indexing, LSH indexing, and insertions.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
 use std::collections::BTreeMap;
 
 use crate::DbInstance;

--- a/crates/krites/src/runtime/tests/triggers_callbacks.rs
+++ b/crates/krites/src/runtime/tests/triggers_callbacks.rs
@@ -1,5 +1,21 @@
 //! Tests for triggers, callbacks, updates, indexes, and multi-transaction behavior.
 #![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "test assertions: index into known-shape NamedRows results"
+)]
+#![expect(
+    clippy::default_trait_access,
+    reason = "tests use `Default::default()` idiomatically for script option structs"
+)]
+#![expect(
+    clippy::similar_names,
+    reason = "tests use parallel binding names (tx_a/tx_b, rx_a/rx_b) for clarity"
+)]
+#![expect(
+    clippy::items_after_statements,
+    reason = "test helper fns are defined near their first use for readability"
+)]
 use std::collections::BTreeMap;
 use std::time::Duration;
 

--- a/crates/krites/src/storage/fjall_backend.rs
+++ b/crates/krites/src/storage/fjall_backend.rs
@@ -524,6 +524,14 @@ impl Iterator for CollectedSkipIterator {
     clippy::indexing_slicing,
     reason = "test assertions on collections with known length"
 )]
+#[expect(
+    clippy::default_trait_access,
+    reason = "tests use `Default::default()` idiomatically for script option structs"
+)]
+#[expect(
+    clippy::result_large_err,
+    reason = "tests return InternalResult which carries rich context; size is intentional"
+)]
 mod tests {
     use std::collections::BTreeMap;
     use std::sync::Arc;


### PR DESCRIPTION
## Summary

Silences ~370 clippy errors in `crates/krites/` test code that surface under `--all-targets -D warnings`. All suppressions are scoped to the tightest level that matches the lint's actual firing site, with explicit `reason = "..."` strings.

This is the final blocker for PR #3566 — and unblocks CI for all currently open PRs once #3566 lands.

## Lint categories addressed

| Lint | Count | Suppression strategy |
|------|------:|---------------------|
| `indexing_slicing` | 244 | File/module-level `#[expect]` on test files (test assertions index into known-shape NamedRows / token vectors / CSR offset+target arrays / etc.) |
| `default_trait_access` | 26 | Module-level — tests use `Default::default()` idiomatically for script option structs |
| `as_conversions`, `cast_*` | 33 | Module-level — small graph fixtures fit target numeric ranges |
| `unreadable_literal` | 15 | File-level — bit-pattern literals mirror tested values verbatim |
| `result_large_err` | 9 | Module-level — `InternalResult` size is intentional |
| `too_many_lines` | 7 | File-level — ASCII-folding tables and end-to-end test sequences kept readable |
| `float_cmp` | 7 | Module-level — exact-arithmetic float comparisons |
| `mutable_key_type` | 3 | Module-level — `BTreeSet<DataValue>` keys do not exercise interior mutability |
| `similar_names` | 3 | Module-level — parallel binding names (e.g. `tx_a`/`tx_b`) |
| `items_after_statements` | 2 | Module-level — test helper fns near first use |
| `unnecessary_fallible_conversions` | 1 | File-level — test exercises fallible path explicitly |

## Other fixes

Also resolves pre-existing `unfulfilled_lint_expectation` issues that become errors under `-D warnings`:

- `runtime/hnsw/put.rs:595` — removed unused `cast_precision_loss` from the test-module `#[expect]` (lint never fired).
- Stale `clippy::wildcard_imports` entries removed from existing module-level `#[expect]` blocks across `query/`, `data/`, `fixed_rule/`, and `fts/tokenizer/stemmer.rs`.
- Where the `wildcard_imports` lint genuinely fires only on the lib build (not lib-test) due to compilation-pass differences, the suppression is converted to `#[allow(... reason = "...")]` with the limitation documented.
- Added `#![allow(clippy::wildcard_imports)]` at `query/mod.rs` to cover snafu error-selector glob imports across the query submodule tree.

## Stacking

Branched from and stacked on `fix/integration-tests-on-main`. **Do not rebase onto `main`.**

Pre-existing issues in other crates (`melete::distill_tests::extraction_integration::context_parse:431` indexing, `hermeneus::cc::process_tests:20` unfulfilled lint expectation, `data::tests::json::bot_to_json_returns_error` test panic) are unrelated to this scope and exist on the base branch.

## Test plan

- [ ] `CARGO_TARGET_DIR=/data/target cargo clippy -p krites --features storage-fjall --all-targets -- -D warnings` — passes (verified locally)
- [ ] `CARGO_TARGET_DIR=/data/target cargo fmt --check --all` — passes (verified locally)
- [ ] CI passes once #3566 lands and this rebases against the new base