### PR TITLE
docs: add 'at a glance' + 'depth' sections to all CLAUDE.md files (#3485)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # CLAUDE.md
 
+## At a glance
+
+Repo-level conventions for AI coding agents working on Aletheia. Key crates: aletheia, nous, pylon, mneme. Entry point: `crates/aletheia/src/main.rs`.
+
+## Depth
+
 Build the system you'd trust to run without you.
 
 Project conventions for AI coding agents working on this codebase.

--- a/crates/agora/CLAUDE.md
+++ b/crates/agora/CLAUDE.md
@@ -1,5 +1,11 @@
 # agora
 
+## At a glance
+
+Channel registry and Signal provider for external messaging. Depends on koina and taxis. Entry point: `src/lib.rs` (ChannelListener, ChannelRegistry, MessageRouter).
+
+## Depth
+
 Channel registry and provider implementations for external messaging (Signal). 3K lines.
 
 ## Read first

--- a/crates/aletheia/CLAUDE.md
+++ b/crates/aletheia/CLAUDE.md
@@ -1,5 +1,11 @@
 # aletheia
 
+## At a glance
+
+Binary entrypoint and service wiring for the Aletheia runtime. Depends on nous, pylon, mneme, and organon. Entry point: `src/main.rs` (Cli, main).
+
+## Depth
+
 Binary entrypoint: CLI, server startup, service wiring, and adapter glue. 8.9K lines.
 
 ## Read first

--- a/crates/daemon/CLAUDE.md
+++ b/crates/daemon/CLAUDE.md
@@ -1,5 +1,11 @@
 # daemon (oikonomos)
 
+## At a glance
+
+Per-nous background task runner with cron scheduling and maintenance. Depends on koina and episteme. Entry point: `src/lib.rs` (TaskRunner, ProsocheCheck, Watchdog).
+
+## Depth
+
 Per-nous background task runner: cron scheduling, maintenance services, prosoche attention, watchdog. 6K lines.
 
 ## Read first

--- a/crates/dianoia/CLAUDE.md
+++ b/crates/dianoia/CLAUDE.md
@@ -1,5 +1,11 @@
 # dianoia
 
+## At a glance
+
+Planning and project orchestration via multi-phase state machines. Depends on koina. Entry point: `src/lib.rs` (Project, ProjectWorkspace).
+
+## Depth
+
 Planning and project orchestration: multi-phase state machine with workspace persistence. 5.4K lines.
 
 ## Read first

--- a/crates/diaporeia/CLAUDE.md
+++ b/crates/diaporeia/CLAUDE.md
@@ -1,5 +1,11 @@
 # diaporeia
 
+## At a glance
+
+MCP server interface for external AI agents. Depends on koina, taxis, nous, and mneme. Entry point: `src/lib.rs` (DiaporeiaServer, DiaporeiaState).
+
+## Depth
+
 MCP server interface for external AI agents via the Model Context Protocol. 1.5K lines.
 
 ## Read first

--- a/crates/eidos/CLAUDE.md
+++ b/crates/eidos/CLAUDE.md
@@ -1,5 +1,11 @@
 # eidos
 
+## At a glance
+
+Shared knowledge types for the memory layer. Zero internal dependencies. Entry point: `src/lib.rs` (Fact, Entity, Relationship).
+
+## Depth
+
 Shared knowledge types for the memory layer. 1.6K lines. Zero internal dependencies.
 
 ## Read first

--- a/crates/energeia/CLAUDE.md
+++ b/crates/energeia/CLAUDE.md
@@ -1,5 +1,11 @@
 # energeia
 
+## At a glance
+
+Dispatch orchestration for plan execution. Depends on koina, eidos, and hermeneus. Entry point: `src/lib.rs` (DispatchEngine, QaGate).
+
+## Depth
+
 Dispatch orchestration: actualization of plans into execution. Absorbs kanon's phronesis dispatch system into aletheia.
 
 ## Read first

--- a/crates/episteme/CLAUDE.md
+++ b/crates/episteme/CLAUDE.md
@@ -1,5 +1,11 @@
 # episteme
 
+## At a glance
+
+Knowledge pipeline: extraction, recall, and embeddings. Depends on eidos, graphe, and koina. Entry point: `src/lib.rs` (ExtractionEngine, RecallEngine).
+
+## Depth
+
 Knowledge pipeline: extraction, recall, conflict detection, consolidation, embeddings, skills. 34K lines.
 
 ## Read first

--- a/crates/eval/CLAUDE.md
+++ b/crates/eval/CLAUDE.md
@@ -1,5 +1,11 @@
 # eval (dokimion)
 
+## At a glance
+
+Behavioral eval framework for scenario-based API testing. Depends on koina. Entry point: `src/lib.rs` (Scenario, ScenarioRunner).
+
+## Depth
+
 Behavioral eval framework: scenario-based API testing against a live Aletheia instance. 4.9K lines.
 
 ## Read first

--- a/crates/graphe/CLAUDE.md
+++ b/crates/graphe/CLAUDE.md
@@ -1,5 +1,11 @@
 # graphe
 
+## At a glance
+
+Session persistence layer with fjall-backed store. Depends on eidos and koina. Entry point: `src/lib.rs` (SessionStore, Session, Message).
+
+## Depth
+
 Session persistence layer: fjall-backed session/message store with agent portability types. ~2K lines after rusqlite removal (#3446).
 
 ## Read first

--- a/crates/hermeneus/CLAUDE.md
+++ b/crates/hermeneus/CLAUDE.md
@@ -1,5 +1,11 @@
 # hermeneus
 
+## At a glance
+
+Anthropic LLM client with streaming, retries, and cost tracking. Depends on koina. Entry point: `src/lib.rs` (LlmProvider, AnthropicProvider).
+
+## Depth
+
 Anthropic LLM client with streaming, retries, fallback, health tracking, and cost estimation. 10.5K lines.
 
 ## Read first

--- a/crates/integration-tests/CLAUDE.md
+++ b/crates/integration-tests/CLAUDE.md
@@ -1,5 +1,11 @@
 # integration-tests
 
+## At a glance
+
+Cross-crate integration test suite for end-to-end pipelines. Depends on dokimion, mneme, nous, and pylon. Entry point: `tests/end_to_end.rs`.
+
+## Depth
+
 Cross-crate integration test suite exercising multi-crate pipelines end-to-end. 5.7K lines. No library code (test-only crate).
 
 ## Read first

--- a/crates/koina/CLAUDE.md
+++ b/crates/koina/CLAUDE.md
@@ -1,5 +1,11 @@
 # koina
 
+## At a glance
+
+Core types, errors, and tracing shared by every Aletheia crate. Zero internal dependencies. Entry point: `src/lib.rs` (NousId, SessionId, RealSystem).
+
+## Depth
+
 Core types, errors, tracing, and system abstractions shared by every Aletheia crate. 4K lines. Zero internal dependencies.
 
 ## Read first

--- a/crates/krites/CLAUDE.md
+++ b/crates/krites/CLAUDE.md
@@ -1,5 +1,11 @@
 # krites
 
+## At a glance
+
+Embedded Datalog engine with HNSW vector search and graph algorithms. Depends on eidos. Entry point: `src/lib.rs` (Db, DataValue, FixedRule).
+
+## Depth
+
 Embedded Datalog engine with HNSW vector search, full-text search, and graph algorithms. 55K lines. Embedded Datalog engine for Aletheia knowledge graph.
 
 ## Read first

--- a/crates/melete/CLAUDE.md
+++ b/crates/melete/CLAUDE.md
@@ -1,5 +1,11 @@
 # melete
 
+## At a glance
+
+Context distillation engine for conversation history compression. Depends on hermeneus and koina. Entry point: `src/lib.rs` (DistillEngine, DistillConfig).
+
+## Depth
+
 Context distillation engine: compresses conversation history via LLM-driven summarization. 5.2K lines.
 
 ## Read first

--- a/crates/mneme/CLAUDE.md
+++ b/crates/mneme/CLAUDE.md
@@ -1,5 +1,11 @@
 # mneme
 
+## At a glance
+
+Curated facade re-exporting memory and session types from sub-crates. Depends on eidos, graphe, and episteme. Entry point: `src/lib.rs` (SessionStore, KnowledgeStore).
+
+## Depth
+
 Curated facade re-exporting from four decomposed sub-crates. ~270 lines of glue code.
 
 ## Facade justification (#3243)

--- a/crates/nous/CLAUDE.md
+++ b/crates/nous/CLAUDE.md
@@ -1,5 +1,11 @@
 # nous
 
+## At a glance
+
+Agent session pipeline: bootstrap, recall, execute, finalize. Depends on koina, mneme, hermeneus, and organon. Entry point: `src/lib.rs` (NousActor, NousManager).
+
+## Depth
+
 Agent session pipeline: bootstrap, recall, execute, finalize. 22K lines. The agent runtime.
 
 ## Read first

--- a/crates/organon/CLAUDE.md
+++ b/crates/organon/CLAUDE.md
@@ -1,5 +1,11 @@
 # organon
 
+## At a glance
+
+Tool registry, executors, and sandbox for built-in tools. Depends on koina, hermeneus, and taxis. Entry point: `src/lib.rs` (ToolRegistry, ToolExecutor).
+
+## Depth
+
 Tool registry, executors, and sandbox. 16K lines. 49 built-in tools.
 
 ## Read first

--- a/crates/poiesis/CLAUDE.md
+++ b/crates/poiesis/CLAUDE.md
@@ -1,5 +1,11 @@
 # poiesis
 
+## At a glance
+
+Document rendering family: format-agnostic model plus PDF, ODT, XLSX, ODS, and PPTX backends. Zero internal dependencies. Entry point: `core/src/lib.rs` (Document, Renderer).
+
+## Depth
+
 Document rendering family: format-agnostic document model plus backends for PDF, ODT, XLSX, ODS, and PPTX. ~1.7K lines.
 
 ## Read first

--- a/crates/pylon/CLAUDE.md
+++ b/crates/pylon/CLAUDE.md
@@ -1,5 +1,11 @@
 # pylon
 
+## At a glance
+
+HTTP gateway with Axum handlers, SSE streaming, and auth. Depends on koina, taxis, nous, and mneme. Entry point: `src/lib.rs` (AppState, router, server).
+
+## Depth
+
 HTTP gateway: Axum handlers, SSE streaming, auth middleware, rate limiting. 11K lines.
 
 ## Read first

--- a/crates/symbolon/CLAUDE.md
+++ b/crates/symbolon/CLAUDE.md
@@ -1,5 +1,11 @@
 # symbolon
 
+## At a glance
+
+Authentication and authorization: JWT sessions, API keys, and RBAC. Depends on koina. Entry point: `src/lib.rs` (AuthService, JwtManager).
+
+## Depth
+
 Authentication and authorization: JWT sessions, API keys, Argon2id passwords, OAuth credential refresh, RBAC. 5.3K lines.
 
 ## Read first

--- a/crates/taxis/CLAUDE.md
+++ b/crates/taxis/CLAUDE.md
@@ -1,5 +1,11 @@
 # taxis
 
+## At a glance
+
+Configuration cascade and path resolution for Aletheia. Depends on koina and eidos. Entry point: `src/lib.rs` (AletheiaConfig, Oikos, loader).
+
+## Depth
+
 Configuration cascade and path resolution: TOML loading, oikos directory structure, env interpolation, hot-reload. 8.2K lines.
 
 ## Read first

--- a/crates/theatron/CLAUDE.md
+++ b/crates/theatron/CLAUDE.md
@@ -1,5 +1,11 @@
 # theatron
 
+## At a glance
+
+Presentation umbrella re-exporting skene types for UI consumers. Depends on skene. Entry point: `src/lib.rs` (ApiClient, StreamEvent).
+
+## Depth
+
 Presentation umbrella grouping the three UI crates: core (shared infrastructure), tui (terminal), desktop (Dioxus). 86K lines total across sub-crates; no individual sub-crate exceeds the 50K budget.
 
 ## Sub-crates

--- a/crates/theatron/koilon/CLAUDE.md
+++ b/crates/theatron/koilon/CLAUDE.md
@@ -1,5 +1,11 @@
 # koilon
 
+## At a glance
+
+Ratatui terminal dashboard for Aletheia. Depends on skene and koina. Entry point: `src/main.rs` (run_tui).
+
+## Depth
+
 Ratatui terminal dashboard for Aletheia: chat, planning, memory, metrics, ops views. 37K lines.
 
 ## Read first

--- a/crates/theatron/proskenion/CLAUDE.md
+++ b/crates/theatron/proskenion/CLAUDE.md
@@ -1,5 +1,11 @@
 # proskenion
 
+## At a glance
+
+Dioxus desktop application for Aletheia. Depends on skene. Entry point: `src/main.rs` (proskenion::run).
+
+## Depth
+
 Dioxus desktop application for Aletheia: chat, planning, memory, metrics, ops, and file views. 45K lines.
 
 ## Read first

--- a/crates/theatron/skene/CLAUDE.md
+++ b/crates/theatron/skene/CLAUDE.md
@@ -1,5 +1,11 @@
 # skene
 
+## At a glance
+
+Shared API client, types, SSE parser, and streaming for UIs. Depends on koina. Entry point: `src/lib.rs` (ApiClient, StreamEvent).
+
+## Depth
+
 Shared API client, types, SSE parser, and streaming infrastructure for Aletheia UIs. 3K lines.
 
 ## Read first

--- a/crates/thesauros/CLAUDE.md
+++ b/crates/thesauros/CLAUDE.md
@@ -1,5 +1,11 @@
 # thesauros
 
+## At a glance
+
+Domain pack loader for external knowledge, tools, and config overlays. Depends on koina and organon. Entry point: `src/lib.rs` (PackManifest, LoadedPack).
+
+## Depth
+
 Domain pack loader: parses pack.toml manifests, resolves context files, registers pack-declared tools. 2.1K lines.
 
 ## Read first

--- a/fuzz/CLAUDE.md
+++ b/fuzz/CLAUDE.md
@@ -1,5 +1,11 @@
 # fuzz
 
+## At a glance
+
+Fuzz testing workspace for parsing and serialization surfaces. Depends on hermeneus, nous, koina, and mneme. Entry point: `fuzz_targets/fuzz_tool_dispatch.rs`.
+
+## Depth
+
 Fuzz testing workspace for Aletheia. Separate Cargo workspace that links against crate APIs to exercise parsing and serialization surfaces with arbitrary input.
 
 ## Structure


### PR DESCRIPTION
Reopens work from closed PR #3571 (rebased onto new main after #3566 merged).

## Summary
- Adds `## At a glance` (50 tokens, novice audience) + `## Depth` (existing content) sections to all 29 CLAUDE.md files
- Supports the documentation ladder pattern — L1 agents can use a crate from at-a-glance alone; L4 agents get the full context

Closes #3485.

## Test plan
- [x] All 29 CLAUDE.md files have both sections
- [x] At-a-glance derived from src/lib.rs + Cargo.toml (not invented)
- [x] Existing content preserved under Depth