### PR TITLE
feat(hermeneus): OpenAI-compatible provider for local LLMs + cloud alternatives

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -2,6 +2,20 @@
 
 too-many-arguments-threshold = 10
 
+# WHY: brand names and acronyms that appear unquoted in rustdoc. Merged with
+# clippy's built-in list (Anthropic, Rust, etc. are already known).
+doc-valid-idents = [
+    "OpenAI",
+    "llama.cpp",
+    "vLLM",
+    "vllm",
+    "Ollama",
+    "ollama",
+    "SSE",
+    "HTTP",
+    "HTTPS",
+]
+
 [[disallowed-methods]]
 path = "std::process::exit"
 reason = "use snafu errors and propagate; exit() bypasses destructors"

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -15,8 +15,8 @@ use agora::types::ChannelProvider;
 use hermeneus::anthropic::{AnthropicProvider, ProviderBehavior};
 use hermeneus::openai::{OpenAiProvider, OpenAiProviderConfig};
 use hermeneus::provider::{ProviderConfig, ProviderRegistry};
-use koina::secret::SecretString;
 use koina::credential::{CredentialProvider, CredentialSource};
+use koina::secret::SecretString;
 use mneme::embedding::{
     DegradedEmbeddingProvider, EmbeddingConfig, EmbeddingProvider, create_provider,
 };
@@ -210,24 +210,25 @@ fn register_declared_providers(registry: &mut ProviderRegistry, config: &Alethei
                     );
                     continue;
                 };
-                let api_key = entry
-                    .api_key_env
-                    .as_deref()
-                    .and_then(|name| match std::env::var(name) {
-                        Ok(v) if !v.is_empty() => Some(SecretString::from(v)),
-                        Ok(_) => None,
-                        Err(_) => {
-                            // WHY: missing env var is expected for loopback
-                            // llama.cpp / ollama (no auth required). Log at
-                            // debug, not warn.
-                            tracing::debug!(
-                                provider = %entry.name,
-                                env = name,
-                                "api_key_env unset for OpenAI-compatible provider"
-                            );
-                            None
-                        }
-                    });
+                let api_key =
+                    entry
+                        .api_key_env
+                        .as_deref()
+                        .and_then(|name| match std::env::var(name) {
+                            Ok(v) if !v.is_empty() => Some(SecretString::from(v)),
+                            Ok(_) => None,
+                            Err(_) => {
+                                // WHY: missing env var is expected for loopback
+                                // llama.cpp / ollama (no auth required). Log at
+                                // debug, not warn.
+                                tracing::debug!(
+                                    provider = %entry.name,
+                                    env = name,
+                                    "api_key_env unset for OpenAI-compatible provider"
+                                );
+                                None
+                            }
+                        });
                 let cfg = OpenAiProviderConfig {
                     name: entry.name.clone(),
                     base_url,

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -13,7 +13,9 @@ use agora::semeion::SignalProvider;
 use agora::semeion::client::SignalClient;
 use agora::types::ChannelProvider;
 use hermeneus::anthropic::{AnthropicProvider, ProviderBehavior};
+use hermeneus::openai::{OpenAiProvider, OpenAiProviderConfig};
 use hermeneus::provider::{ProviderConfig, ProviderRegistry};
+use koina::secret::SecretString;
 use koina::credential::{CredentialProvider, CredentialSource};
 use mneme::embedding::{
     DegradedEmbeddingProvider, EmbeddingConfig, EmbeddingProvider, create_provider,
@@ -182,7 +184,102 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
         Err(e) => warn!(error = %e, "failed to init anthropic provider"),
     }
 
+    register_declared_providers(&mut registry, config);
+
     registry
+}
+
+/// Iterate `config.providers` and register each entry with the provider
+/// registry (#3424, #3414).
+///
+/// Dispatches on `ProviderKind` to pick between Anthropic, OpenAI-compatible
+/// HTTP, and the CC subprocess adapter. Anthropic entries in the declarative
+/// list are skipped — the top-level credential chain already owns the
+/// Anthropic provider so we do not double-register. Empty list (the default)
+/// is a no-op, preserving legacy single-provider behavior.
+fn register_declared_providers(registry: &mut ProviderRegistry, config: &AletheiaConfig) {
+    use taxis::config::ProviderKind;
+
+    for entry in &config.providers {
+        match entry.kind {
+            ProviderKind::OpenAiCompatible => {
+                let Some(base_url) = entry.base_url.clone() else {
+                    warn!(
+                        provider = %entry.name,
+                        "OpenAI-compatible provider missing base_url — skipping"
+                    );
+                    continue;
+                };
+                let api_key = entry
+                    .api_key_env
+                    .as_deref()
+                    .and_then(|name| match std::env::var(name) {
+                        Ok(v) if !v.is_empty() => Some(SecretString::from(v)),
+                        Ok(_) => None,
+                        Err(_) => {
+                            // WHY: missing env var is expected for loopback
+                            // llama.cpp / ollama (no auth required). Log at
+                            // debug, not warn.
+                            tracing::debug!(
+                                provider = %entry.name,
+                                env = name,
+                                "api_key_env unset for OpenAI-compatible provider"
+                            );
+                            None
+                        }
+                    });
+                let cfg = OpenAiProviderConfig {
+                    name: entry.name.clone(),
+                    base_url,
+                    api_key,
+                    models: entry.models.clone(),
+                    ..OpenAiProviderConfig::default()
+                };
+                match OpenAiProvider::new(cfg) {
+                    Ok(provider) => {
+                        info!(
+                            provider = %entry.name,
+                            target = ?entry.deployment_target,
+                            models = ?entry.models,
+                            "OpenAI-compatible provider registered"
+                        );
+                        registry.register(Box::new(provider));
+                    }
+                    Err(e) => warn!(
+                        provider = %entry.name,
+                        error = %e,
+                        "failed to init OpenAI-compatible provider"
+                    ),
+                }
+            }
+            ProviderKind::Anthropic => {
+                // Already registered via the credential-chain path above.
+                tracing::debug!(
+                    provider = %entry.name,
+                    "declarative Anthropic entry skipped — provider already registered via credential chain"
+                );
+            }
+            ProviderKind::ClaudeCode => {
+                // WHY: declarative registration of the CC adapter would
+                // duplicate the `cred_source` check above, and the binary
+                // path is already resolved by `CcProvider::new`. The
+                // credential-chain branch above handles this case.
+                tracing::debug!(
+                    provider = %entry.name,
+                    "declarative ClaudeCode entry skipped — provider already registered via credential chain"
+                );
+            }
+            // WHY: ProviderKind is #[non_exhaustive] so future additions
+            // never accidentally break the build. Unknown variants fall
+            // through to a clear operator warning.
+            _ => {
+                warn!(
+                    provider = %entry.name,
+                    "unknown provider kind in config — skipping"
+                );
+            }
+        }
+    }
 }
 
 pub(super) fn build_tool_registry(

--- a/crates/eidos/src/training.rs
+++ b/crates/eidos/src/training.rs
@@ -5,7 +5,7 @@
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-/// Default maximum shard size: 50 MiB.
+/// Default maximum shard size: 50 `MiB`.
 const DEFAULT_MAX_SHARD_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Configuration for training data capture.
@@ -21,7 +21,7 @@ pub struct TrainingConfig {
     /// Maximum size in bytes before rotating to a new shard file.
     ///
     /// When the current shard exceeds this limit, it is closed and a new
-    /// shard is started. Default: 50 MiB.
+    /// shard is started. Default: 50 `MiB`.
     #[serde(default = "default_max_shard_bytes")]
     pub max_shard_bytes: u64,
     /// Whether to redact PII and secret patterns from `user_message` and

--- a/crates/energeia/src/agent_sdk.rs
+++ b/crates/energeia/src/agent_sdk.rs
@@ -25,7 +25,7 @@ pub struct AgentSdkConfig {
     pub skip_permissions: bool,
     /// Disable MCP plugin loading.
     pub disable_plugins: bool,
-    /// Optional OAuth token for API authentication.
+    /// Optional `OAuth` token for API authentication.
     pub oauth_token: Option<String>,
     /// Optional MCP server configurations.
     pub mcp_servers: Vec<McpServerConfig>,
@@ -58,7 +58,7 @@ pub struct McpServerConfig {
 
 /// Agent SDK-based dispatch engine.
 ///
-/// WHY: Provides native Agent SDK integration with OAuth, permissions, and
+/// WHY: Provides native Agent SDK integration with `OAuth`, permissions, and
 /// plugin support, replacing the subprocess-based `HttpEngine`.
 pub struct AgentSdkEngine {
     config: AgentSdkConfig,
@@ -71,7 +71,7 @@ impl AgentSdkEngine {
     /// # Errors
     ///
     /// Returns an error if the engine cannot be initialized (e.g., binary
-    /// lookup fails, OAuth token invalid, MCP server unavailable).
+    /// lookup fails, `OAuth` token invalid, MCP server unavailable).
     pub fn new(config: AgentSdkConfig) -> Result<Self> {
         // WHY: Verify the model identifier is valid during construction.
         if config.default_model.is_empty() {

--- a/crates/energeia/src/session/events.rs
+++ b/crates/energeia/src/session/events.rs
@@ -131,7 +131,7 @@ pub(crate) async fn process_events(
 // PR URL extraction
 // ---------------------------------------------------------------------------
 
-/// Extract a GitHub pull request URL from text.
+/// Extract a `GitHub` pull request URL from text.
 ///
 /// Matches `https://github.com/{owner}/{repo}/pull/{number}` patterns.
 /// Returns the first match found.

--- a/crates/energeia/src/steward/service.rs
+++ b/crates/energeia/src/steward/service.rs
@@ -16,7 +16,7 @@ pub struct StewardConfig {
     pub once: bool,
     /// Dry-run mode: classify without executing actions.
     pub dry_run: bool,
-    /// GitHub project slug (owner/repo).
+    /// `GitHub` project slug (owner/repo).
     pub project: String,
     /// Required CI check names (empty = all checks matter).
     pub required_checks: Vec<String>,

--- a/crates/energeia/src/steward/types.rs
+++ b/crates/energeia/src/steward/types.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// A pull request representation for steward classification.
 ///
-/// WHY: Aletheia doesn't have a GitHub wrapper crate. This minimal struct
+/// WHY: Aletheia doesn't have a `GitHub` wrapper crate. This minimal struct
 /// carries the fields the steward needs for classification and merge decisions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -21,7 +21,7 @@ pub struct PullRequest {
     pub head_sha: Option<String>,
     /// State of the PR (e.g., "open", "closed").
     pub state: Option<String>,
-    /// Mergeability status from GitHub API.
+    /// Mergeability status from `GitHub` API.
     pub mergeable: Option<String>,
     /// Body/description of the PR.
     pub body: Option<String>,
@@ -53,7 +53,7 @@ impl fmt::Display for MergeMethod {
     }
 }
 
-/// A GitHub issue for observation matching.
+/// A `GitHub` issue for observation matching.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Issue {
@@ -94,9 +94,9 @@ pub struct ClassifiedPr {
     pub merge_safe: bool,
 
     /// Whether a `Gate-Passed` trailer was found in any PR commit.
-    /// WHY: Local gate enforcement replaces the verify-gate GitHub Action.
+    /// WHY: Local gate enforcement replaces the verify-gate `GitHub` Action.
     /// When CI checks are absent (minutes exhausted), this field allows the
-    /// steward to treat the PR as green without depending on GitHub CI.
+    /// steward to treat the PR as green without depending on `GitHub` CI.
     pub has_gate_trailer: bool,
 
     /// Suppression findings detected in the PR diff.
@@ -377,7 +377,7 @@ pub struct CheckRun {
     pub name: String,
 
     /// Status of the check (e.g. "completed", `in_progress`, "queued").
-    /// WHY: GitHub API uses "status" not "state" for check-runs.
+    /// WHY: `GitHub` API uses "status" not "state" for check-runs.
     #[serde(default, alias = "state")]
     pub status: String,
 

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -25,16 +25,16 @@ pub mod concurrency;
 pub mod error;
 /// Model fallback chain: retries alternative models on transient failures.
 pub mod fallback;
-/// OpenAI Chat Completions-compatible HTTP client. Bridges aletheia to any
-/// endpoint that speaks the OpenAI wire format: local llama.cpp / ollama /
-/// vllm for air-gapped operation, plus OpenAI and other cloud alternatives.
-pub mod openai;
 /// Provider health state machine (Up / Degraded / Down) with automatic recovery.
 pub mod health;
 /// Prometheus metrics for LLM request counts, latency, and token usage.
 pub mod metrics;
 /// Model constants and API configuration defaults.
 pub mod models;
+/// OpenAI Chat Completions-compatible HTTP client. Bridges aletheia to any
+/// endpoint that speaks the OpenAI wire format: local llama.cpp / ollama /
+/// vllm for air-gapped operation, plus OpenAI and other cloud alternatives.
+pub mod openai;
 /// [`LlmProvider`](provider::LlmProvider), [`ProviderConfig`](provider::ProviderConfig), and [`ProviderRegistry`](provider::ProviderRegistry).
 pub mod provider;
 /// Shared mock provider for tests across the workspace.

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -25,6 +25,10 @@ pub mod concurrency;
 pub mod error;
 /// Model fallback chain: retries alternative models on transient failures.
 pub mod fallback;
+/// OpenAI Chat Completions-compatible HTTP client. Bridges aletheia to any
+/// endpoint that speaks the OpenAI wire format: local llama.cpp / ollama /
+/// vllm for air-gapped operation, plus OpenAI and other cloud alternatives.
+pub mod openai;
 /// Provider health state machine (Up / Degraded / Down) with automatic recovery.
 pub mod health;
 /// Prometheus metrics for LLM request counts, latency, and token usage.

--- a/crates/hermeneus/src/openai/client.rs
+++ b/crates/hermeneus/src/openai/client.rs
@@ -139,13 +139,14 @@ impl OpenAiProvider {
         headers.insert("accept", HeaderValue::from_static("application/json"));
 
         if let Some(key) = &self.config.api_key {
-            let value =
-                HeaderValue::from_str(&format!("Bearer {}", key.expose_secret())).map_err(|_e| {
+            let value = HeaderValue::from_str(&format!("Bearer {}", key.expose_secret())).map_err(
+                |_e| {
                     error::AuthFailedSnafu {
                         message: "API key contains invalid header characters".to_owned(),
                     }
                     .build()
-                })?;
+                },
+            )?;
             headers.insert(reqwest::header::AUTHORIZATION, value);
         }
         Ok(headers)
@@ -194,7 +195,10 @@ impl OpenAiProvider {
             .build()
         })?;
 
-        let url = format!("{}/chat/completions", self.config.base_url.trim_end_matches('/'));
+        let url = format!(
+            "{}/chat/completions",
+            self.config.base_url.trim_end_matches('/')
+        );
 
         let mut last_error: Option<error::Error> = None;
 
@@ -233,13 +237,12 @@ impl OpenAiProvider {
                     }
                     .build()
                 })?;
-                let parsed: ChatCompletionResponse =
-                    serde_json::from_str(&text).map_err(|e| {
-                        error::ApiRequestSnafu {
-                            message: format!("failed to parse OpenAI response: {e}"),
-                        }
-                        .build()
-                    })?;
+                let parsed: ChatCompletionResponse = serde_json::from_str(&text).map_err(|e| {
+                    error::ApiRequestSnafu {
+                        message: format!("failed to parse OpenAI response: {e}"),
+                    }
+                    .build()
+                })?;
                 let resp = parsed
                     .into_response()
                     .map_err(|msg| error::ApiRequestSnafu { message: msg }.build())?;
@@ -262,22 +265,21 @@ impl OpenAiProvider {
                     0.0,
                     true,
                 );
-                crate::metrics::record_latency(
-                    &request.model,
-                    "ok",
-                    start.elapsed().as_secs_f64(),
-                );
+                crate::metrics::record_latency(&request.model, "ok", start.elapsed().as_secs_f64());
                 return Ok(resp);
             }
 
-            let err =
-                map_error_response(response, &request.model, self.credential_source()).await;
+            let err = map_error_response(response, &request.model, self.credential_source()).await;
             self.health.record_error(&err);
             if !err.is_retryable() {
                 tracing::Span::current().record("llm.retries", attempt);
                 tracing::Span::current().record(
                     "llm.status",
-                    if status == 401 { "auth_failed" } else { "error" },
+                    if status == 401 {
+                        "auth_failed"
+                    } else {
+                        "error"
+                    },
                 );
                 return Err(err);
             }
@@ -315,7 +317,10 @@ impl OpenAiProvider {
             }
             .build()
         })?;
-        let url = format!("{}/chat/completions", self.config.base_url.trim_end_matches('/'));
+        let url = format!(
+            "{}/chat/completions",
+            self.config.base_url.trim_end_matches('/')
+        );
         let headers = self.build_headers()?;
 
         let mut response = self
@@ -329,7 +334,9 @@ impl OpenAiProvider {
             .map_err(|e| map_request_error(&e))?;
 
         if !response.status().is_success() {
-            return Err(map_error_response(response, &request.model, self.credential_source()).await);
+            return Err(
+                map_error_response(response, &request.model, self.credential_source()).await,
+            );
         }
 
         let resp = parse_sse_response(&mut response, on_event).await?;

--- a/crates/hermeneus/src/openai/client.rs
+++ b/crates/hermeneus/src/openai/client.rs
@@ -1,0 +1,447 @@
+//! OpenAI-compatible HTTP client implementing [`LlmProvider`].
+//!
+//! Talks to any endpoint that exposes the OpenAI `/v1/chat/completions`
+//! surface — OpenAI itself, llama.cpp `--server`, ollama, vllm, or any
+//! compatible proxy. The wire translation lives in [`super::wire`]; this
+//! module is the transport, retry, and registration shell.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use reqwest::Client;
+use reqwest::header::{HeaderMap, HeaderValue};
+use tracing::{Instrument as _, info, info_span};
+
+use koina::secret::SecretString;
+
+use crate::anthropic::StreamEvent;
+use crate::error::{self, Result};
+use crate::health::{HealthConfig, ProviderHealthTracker};
+use crate::provider::LlmProvider;
+use crate::types::{CompletionRequest, CompletionResponse};
+
+use super::error::{map_error_response, map_request_error};
+use super::wire::{ChatCompletionRequest, ChatCompletionResponse, parse_sse_response};
+
+/// Build an HTTP client with sensible timeouts shared by Anthropic and
+/// OpenAI-compatible providers.
+fn build_http_client() -> Result<Client> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_mins(2))
+        .build()
+        .map_err(|e| {
+            error::ProviderInitSnafu {
+                message: format!("failed to build HTTP client: {e}"),
+            }
+            .build()
+        })
+}
+
+/// Configuration for an OpenAI-compatible provider instance.
+#[derive(Debug, Clone)]
+pub struct OpenAiProviderConfig {
+    /// Operator-facing label used for logs, metrics, and `name()`.
+    pub name: String,
+    /// Base URL for the target endpoint — typically ends in `/v1`. Example:
+    /// `http://127.0.0.1:8088/v1` for a local llama.cpp server. TLS is
+    /// required unless the URL is loopback.
+    pub base_url: String,
+    /// Optional bearer token for authenticated endpoints. Loopback llama.cpp
+    /// and ollama accept any value (or no auth at all); OpenAI requires a
+    /// real key.
+    pub api_key: Option<SecretString>,
+    /// Model IDs this provider advertises support for. Determines routing
+    /// in the [`ProviderRegistry`](crate::provider::ProviderRegistry).
+    pub models: Vec<String>,
+    /// Per-request timeout override. Defaults to 2 minutes (matches
+    /// Anthropic's non-streaming default).
+    pub request_timeout: Duration,
+    /// Maximum retries on transient failures (5xx, timeout, connection
+    /// reset). Defaults to 3.
+    pub max_retries: u32,
+}
+
+impl Default for OpenAiProviderConfig {
+    fn default() -> Self {
+        Self {
+            name: "openai-compatible".to_owned(),
+            base_url: "https://api.openai.com/v1".to_owned(),
+            api_key: None,
+            models: Vec::new(),
+            request_timeout: Duration::from_mins(2),
+            max_retries: 3,
+        }
+    }
+}
+
+/// Returns true when the URL is safe to use without TLS.
+fn is_loopback_url(url: &str) -> bool {
+    url.starts_with("http://localhost")
+        || url.starts_with("http://127.0.0.1")
+        || url.starts_with("http://[::1]")
+}
+
+/// OpenAI Chat Completions-compatible LLM provider.
+pub struct OpenAiProvider {
+    client: Client,
+    config: OpenAiProviderConfig,
+    /// Owned `&'static str` slice of model IDs for [`LlmProvider::supported_models`].
+    /// Leaked once at construction — the provider lives for the server lifetime.
+    model_refs: &'static [&'static str],
+    health: Arc<ProviderHealthTracker>,
+}
+
+impl OpenAiProvider {
+    /// Construct a provider from the given config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`error::Error::ProviderInit`] if the HTTP client cannot be
+    /// built or the base URL is non-loopback HTTP (credentials would be
+    /// sent in cleartext).
+    pub fn new(config: OpenAiProviderConfig) -> Result<Self> {
+        if !config.base_url.starts_with("https://") && !is_loopback_url(&config.base_url) {
+            return Err(error::ProviderInitSnafu {
+                message: format!(
+                    "OpenAI-compatible base URL must use HTTPS or loopback (got {:?})",
+                    config.base_url
+                ),
+            }
+            .build());
+        }
+
+        let client = build_http_client()?;
+        let model_refs = leak_models(&config.models);
+
+        info!(
+            provider = %config.name,
+            base_url = %config.base_url,
+            models = ?config.models,
+            authenticated = config.api_key.is_some(),
+            "OpenAI-compatible provider initialized"
+        );
+
+        Ok(Self {
+            client,
+            config,
+            model_refs,
+            health: Arc::new(ProviderHealthTracker::new(HealthConfig::default())),
+        })
+    }
+
+    fn build_headers(&self) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+        headers.insert("accept", HeaderValue::from_static("application/json"));
+
+        if let Some(key) = &self.config.api_key {
+            let value =
+                HeaderValue::from_str(&format!("Bearer {}", key.expose_secret())).map_err(|_e| {
+                    error::AuthFailedSnafu {
+                        message: "API key contains invalid header characters".to_owned(),
+                    }
+                    .build()
+                })?;
+            headers.insert(reqwest::header::AUTHORIZATION, value);
+        }
+        Ok(headers)
+    }
+
+    fn credential_source(&self) -> &'static str {
+        if self.config.api_key.is_some() {
+            "api-key"
+        } else {
+            "none"
+        }
+    }
+
+    async fn execute(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
+        let span = info_span!("llm_call",
+            llm.provider = %self.config.name,
+            llm.model = %request.model,
+            llm.duration_ms = tracing::field::Empty,
+            llm.tokens_in = tracing::field::Empty,
+            llm.tokens_out = tracing::field::Empty,
+            llm.status = tracing::field::Empty,
+            llm.retries = tracing::field::Empty,
+            llm.stream = false,
+        );
+        self.execute_inner(request).instrument(span).await
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "retry loop with span recording and metric emission at each exit point"
+    )]
+    async fn execute_inner(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
+        if let Err(health) = self.health.check_available() {
+            return Err(error::ApiRequestSnafu {
+                message: format!("provider circuit-breaker open: {health:?}"),
+            }
+            .build());
+        }
+
+        let start = Instant::now();
+        let wire = ChatCompletionRequest::from_request(request, None)?;
+        let body = serde_json::to_string(&wire).map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("failed to serialize request: {e}"),
+            }
+            .build()
+        })?;
+
+        let url = format!("{}/chat/completions", self.config.base_url.trim_end_matches('/'));
+
+        let mut last_error: Option<error::Error> = None;
+
+        for attempt in 0..=self.config.max_retries {
+            if attempt > 0 {
+                tokio::time::sleep(backoff_delay(attempt)).await;
+            }
+            let headers = self.build_headers()?;
+
+            let response = match self
+                .client
+                .post(&url)
+                .headers(headers)
+                .body(body.clone())
+                .timeout(self.config.request_timeout)
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    let err = map_request_error(&e);
+                    self.health.record_error(&err);
+                    if !err.is_retryable() {
+                        return Err(err);
+                    }
+                    last_error = Some(err);
+                    continue;
+                }
+            };
+
+            let status = response.status().as_u16();
+            if response.status().is_success() {
+                let text = response.text().await.map_err(|e| {
+                    error::ApiRequestSnafu {
+                        message: format!("failed to read response body: {e}"),
+                    }
+                    .build()
+                })?;
+                let parsed: ChatCompletionResponse =
+                    serde_json::from_str(&text).map_err(|e| {
+                        error::ApiRequestSnafu {
+                            message: format!("failed to parse OpenAI response: {e}"),
+                        }
+                        .build()
+                    })?;
+                let resp = parsed
+                    .into_response()
+                    .map_err(|msg| error::ApiRequestSnafu { message: msg }.build())?;
+                self.health.record_success();
+                tracing::Span::current().record("llm.tokens_in", resp.usage.input_tokens);
+                tracing::Span::current().record("llm.tokens_out", resp.usage.output_tokens);
+                tracing::Span::current().record("llm.status", "ok");
+                tracing::Span::current().record("llm.retries", attempt);
+                info!(
+                    provider = %self.config.name,
+                    model = %request.model,
+                    tokens_in = resp.usage.input_tokens,
+                    tokens_out = resp.usage.output_tokens,
+                    "OpenAI-compatible call complete"
+                );
+                crate::metrics::record_completion(
+                    &self.config.name,
+                    resp.usage.input_tokens,
+                    resp.usage.output_tokens,
+                    0.0,
+                    true,
+                );
+                crate::metrics::record_latency(
+                    &request.model,
+                    "ok",
+                    start.elapsed().as_secs_f64(),
+                );
+                return Ok(resp);
+            }
+
+            let err =
+                map_error_response(response, &request.model, self.credential_source()).await;
+            self.health.record_error(&err);
+            if !err.is_retryable() {
+                tracing::Span::current().record("llm.retries", attempt);
+                tracing::Span::current().record(
+                    "llm.status",
+                    if status == 401 { "auth_failed" } else { "error" },
+                );
+                return Err(err);
+            }
+            last_error = Some(err);
+        }
+
+        tracing::Span::current().record("llm.retries", self.config.max_retries);
+        tracing::Span::current().record("llm.status", "error");
+        crate::metrics::record_completion(&self.config.name, 0, 0, 0.0, false);
+        crate::metrics::record_latency(&request.model, "error", start.elapsed().as_secs_f64());
+        Err(last_error.unwrap_or_else(|| {
+            error::ApiRequestSnafu {
+                message: "request failed after all retries".to_owned(),
+            }
+            .build()
+        }))
+    }
+
+    async fn execute_streaming(
+        &self,
+        request: &CompletionRequest,
+        on_event: &mut (dyn FnMut(StreamEvent) + Send),
+    ) -> Result<CompletionResponse> {
+        if let Err(health) = self.health.check_available() {
+            return Err(error::ApiRequestSnafu {
+                message: format!("provider circuit-breaker open: {health:?}"),
+            }
+            .build());
+        }
+
+        let wire = ChatCompletionRequest::from_request(request, Some(true))?;
+        let body = serde_json::to_string(&wire).map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("failed to serialize request: {e}"),
+            }
+            .build()
+        })?;
+        let url = format!("{}/chat/completions", self.config.base_url.trim_end_matches('/'));
+        let headers = self.build_headers()?;
+
+        let mut response = self
+            .client
+            .post(&url)
+            .headers(headers)
+            .body(body)
+            .timeout(Duration::from_mins(10))
+            .send()
+            .await
+            .map_err(|e| map_request_error(&e))?;
+
+        if !response.status().is_success() {
+            return Err(map_error_response(response, &request.model, self.credential_source()).await);
+        }
+
+        let resp = parse_sse_response(&mut response, on_event).await?;
+        self.health.record_success();
+        Ok(resp)
+    }
+}
+
+/// Exponential backoff without jitter for the OpenAI retry loop.
+fn backoff_delay(attempt: u32) -> Duration {
+    let base_ms: u64 = 500;
+    let cap_ms: u64 = 30_000;
+    let delay = base_ms.saturating_mul(1_u64 << attempt.min(6));
+    Duration::from_millis(delay.min(cap_ms))
+}
+
+/// Leak a `Vec<String>` of model IDs to a `&'static [&'static str]` slice.
+///
+/// Called once at provider construction so [`LlmProvider::supported_models`]
+/// can return a borrowed static slice — the provider outlives every request
+/// in normal operation, and leaking keeps the trait signature (`&[&str]`)
+/// simple without forcing every caller into dynamic storage.
+fn leak_models(models: &[String]) -> &'static [&'static str] {
+    let leaked: Vec<&'static str> = models
+        .iter()
+        .map(|s| {
+            let boxed: Box<str> = s.clone().into_boxed_str();
+            let static_ref: &'static str = Box::leak(boxed);
+            static_ref
+        })
+        .collect();
+    Box::leak(leaked.into_boxed_slice())
+}
+
+impl std::fmt::Debug for OpenAiProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiProvider")
+            .field("name", &self.config.name)
+            .field("base_url", &self.config.base_url)
+            .field("models", &self.config.models)
+            .field("authenticated", &self.config.api_key.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl LlmProvider for OpenAiProvider {
+    fn complete<'a>(
+        &'a self,
+        request: &'a CompletionRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
+        Box::pin(self.execute(request))
+    }
+
+    fn supported_models(&self) -> &[&str] {
+        self.model_refs
+    }
+
+    fn name(&self) -> &str {
+        &self.config.name
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn complete_streaming<'a>(
+        &'a self,
+        request: &'a CompletionRequest,
+        on_event: &'a mut (dyn FnMut(StreamEvent) + Send),
+    ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
+        Box::pin(self.execute_streaming(request, on_event))
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_plain_http_to_non_loopback() {
+        let config = OpenAiProviderConfig {
+            base_url: "http://evil.example.com/v1".to_owned(),
+            ..Default::default()
+        };
+        let err = OpenAiProvider::new(config).unwrap_err();
+        assert!(err.to_string().contains("HTTPS"));
+    }
+
+    #[test]
+    fn accepts_loopback_http() {
+        let config = OpenAiProviderConfig {
+            name: "local".to_owned(),
+            base_url: "http://127.0.0.1:8088/v1".to_owned(),
+            models: vec!["qwen".to_owned()],
+            ..Default::default()
+        };
+        let provider = OpenAiProvider::new(config).unwrap();
+        assert_eq!(provider.name(), "local");
+        assert!(provider.supports_model("qwen"));
+    }
+
+    #[test]
+    fn accepts_https() {
+        let config = OpenAiProviderConfig {
+            name: "cloud".to_owned(),
+            base_url: "https://api.openai.com/v1".to_owned(),
+            models: vec!["gpt-4o".to_owned()],
+            ..Default::default()
+        };
+        let provider = OpenAiProvider::new(config).unwrap();
+        assert!(provider.supports_model("gpt-4o"));
+        assert!(!provider.supports_model("nonexistent"));
+    }
+}

--- a/crates/hermeneus/src/openai/error.rs
+++ b/crates/hermeneus/src/openai/error.rs
@@ -118,7 +118,10 @@ mod tests {
         let body = r#"{"error":{"message":"Invalid API key","type":"invalid_request_error","code":"invalid_api_key"}}"#;
         let parsed: WireErrorResponse = serde_json::from_str(body).unwrap();
         assert_eq!(parsed.error.message, "Invalid API key");
-        assert_eq!(parsed.error.error_type.as_deref(), Some("invalid_request_error"));
+        assert_eq!(
+            parsed.error.error_type.as_deref(),
+            Some("invalid_request_error")
+        );
     }
 
     #[test]

--- a/crates/hermeneus/src/openai/error.rs
+++ b/crates/hermeneus/src/openai/error.rs
@@ -1,0 +1,132 @@
+//! OpenAI-compatible error mapping to hermeneus error variants.
+//!
+//! Translates HTTP and transport errors from OpenAI-shaped endpoints
+//! (OpenAI proper, llama.cpp `--server`, ollama, vllm) into
+//! [`crate::error::Error`]. The OpenAI error envelope is simpler than
+//! Anthropic's: `{"error": {"message": ..., "type": ..., "code": ...}}`.
+
+use reqwest::Response;
+use serde::Deserialize;
+
+use crate::error::{self, ApiErrorContext};
+
+/// Wire shape of an OpenAI error response body.
+///
+/// Field set matches the documented OpenAI error envelope. Also accepted
+/// verbatim by llama.cpp / ollama / vllm since they ape the OpenAI API.
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireErrorResponse {
+    pub error: WireErrorDetail,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireErrorDetail {
+    pub message: String,
+    #[serde(default, rename = "type")]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "captured for debugging; not dispatched on yet")
+    )]
+    pub error_type: Option<String>,
+    #[serde(default)]
+    #[expect(dead_code, reason = "captured for debugging; not dispatched on yet")]
+    pub code: Option<String>,
+}
+
+/// Map an HTTP response with a non-success status to a hermeneus error.
+///
+/// Consumes the response body to extract the OpenAI-style error detail.
+/// Falls back to a synthetic `HTTP {status}` message if the body is absent
+/// or not parseable — llama.cpp in particular returns plain-text errors for
+/// some failure modes.
+#[tracing::instrument(skip_all)]
+pub(crate) async fn map_error_response(
+    response: Response,
+    model: &str,
+    credential_source: &str,
+) -> error::Error {
+    let status = response.status().as_u16();
+    let retry_after_ms = extract_retry_after(&response);
+
+    let body = response.text().await.unwrap_or_default();
+
+    let detail = serde_json::from_str::<WireErrorResponse>(&body)
+        .ok()
+        .map(|e| e.error.message);
+
+    let message = detail.unwrap_or_else(|| {
+        if body.is_empty() {
+            format!("HTTP {status}")
+        } else {
+            // WHY: bounded slice so we do not paste a multi-megabyte HTML
+            // error page into the error chain.
+            let trimmed: String = body.chars().take(512).collect();
+            format!("HTTP {status}: {trimmed}")
+        }
+    });
+
+    tracing::warn!(
+        status,
+        model,
+        credential_source,
+        "OpenAI-compatible API error response"
+    );
+
+    match status {
+        401 | 403 => error::AuthFailedSnafu { message }.build(),
+        429 => error::RateLimitedSnafu {
+            retry_after_ms: retry_after_ms.unwrap_or(1000),
+        }
+        .build(),
+        _ => error::ApiSnafu {
+            status,
+            message,
+            context: Box::new(ApiErrorContext {
+                model: model.to_owned(),
+                credential_source: credential_source.to_owned(),
+            }),
+        }
+        .build(),
+    }
+}
+
+/// Map a reqwest transport error to a hermeneus error.
+pub(crate) fn map_request_error(err: &reqwest::Error) -> error::Error {
+    error::ApiRequestSnafu {
+        message: err.to_string(),
+    }
+    .build()
+}
+
+/// Extract `retry-after` header value as milliseconds.
+fn extract_retry_after(response: &Response) -> Option<u64> {
+    response
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(|secs| secs * 1000)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_openai_error_envelope() {
+        let body = r#"{"error":{"message":"Invalid API key","type":"invalid_request_error","code":"invalid_api_key"}}"#;
+        let parsed: WireErrorResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.error.message, "Invalid API key");
+        assert_eq!(parsed.error.error_type.as_deref(), Some("invalid_request_error"));
+    }
+
+    #[test]
+    fn parses_llama_cpp_error_envelope() {
+        // llama.cpp omits `code` and `type` on some errors.
+        let body = r#"{"error":{"message":"context length exceeded"}}"#;
+        let parsed: WireErrorResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.error.message, "context length exceeded");
+        assert!(parsed.error.error_type.is_none());
+    }
+}

--- a/crates/hermeneus/src/openai/mod.rs
+++ b/crates/hermeneus/src/openai/mod.rs
@@ -52,5 +52,8 @@ pub use client::{OpenAiProvider, OpenAiProviderConfig};
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(clippy::expect_used, reason = "test assertions")]
-#[expect(clippy::indexing_slicing, reason = "test: indices asserted valid by construction")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: indices asserted valid by construction"
+)]
 mod tests;

--- a/crates/hermeneus/src/openai/mod.rs
+++ b/crates/hermeneus/src/openai/mod.rs
@@ -1,0 +1,56 @@
+// WHY: the `OpenAI` brand name and related proper nouns (llama.cpp,
+// ollama, vllm) pervade the docs of this module. clippy::doc_markdown
+// flags bare CamelCase as missing backticks. Backticks would visually
+// muddle the rustdoc-rendered prose and are not appropriate for a
+// brand, so the lint is opted out at the module root only.
+#![allow(clippy::doc_markdown)]
+
+//! OpenAI Chat Completions-compatible LLM provider.
+//!
+//! Talks to any endpoint that exposes the OpenAI `/v1/chat/completions`
+//! wire format — OpenAI itself, llama.cpp `--server`, ollama, vllm, or a
+//! compatible proxy. Intended primary use: local LLMs for air-gapped
+//! operation (#3414) and non-Anthropic cloud alternatives (#3424).
+//!
+//! # Feature negotiation
+//!
+//! Maps Anthropic concepts onto OpenAI where possible and degrades
+//! gracefully where not. See [`wire::request`] for the full mapping table.
+//! Highlights:
+//!
+//! - `system` top-level prompt → first `{role: "system"}` message.
+//! - `ContentBlock::ToolUse` ↔ assistant `tool_calls[]`.
+//! - `ContentBlock::ToolResult` → `{role: "tool", tool_call_id: ...}`.
+//! - `thinking` budget → dropped, warning logged.
+//! - `cache_control` markers → dropped, warning logged.
+//! - `server_tools` → rejected with a clear error.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use hermeneus::openai::{OpenAiProvider, OpenAiProviderConfig};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let provider = OpenAiProvider::new(OpenAiProviderConfig {
+//!     name: "local-qwen".to_owned(),
+//!     base_url: "http://127.0.0.1:8088/v1".to_owned(),
+//!     api_key: None,
+//!     models: vec!["Qwen3.5-35B-A3B-Q8_0".to_owned()],
+//!     ..OpenAiProviderConfig::default()
+//! })?;
+//! # let _ = provider;
+//! # Ok(())
+//! # }
+//! ```
+
+mod client;
+mod error;
+mod wire;
+
+pub use client::{OpenAiProvider, OpenAiProviderConfig};
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(clippy::indexing_slicing, reason = "test: indices asserted valid by construction")]
+mod tests;

--- a/crates/hermeneus/src/openai/tests.rs
+++ b/crates/hermeneus/src/openai/tests.rs
@@ -1,0 +1,280 @@
+//! Integration-style tests for the OpenAI-compatible provider.
+//!
+//! Uses `wiremock` to stand up an in-process HTTP server, then exercises
+//! the full request/response path. Focused on behaviors that cross the
+//! wire module boundary (the per-module unit tests already cover JSON
+//! translation in isolation).
+
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::openai::{OpenAiProvider, OpenAiProviderConfig};
+use crate::provider::{LlmProvider, ProviderRegistry};
+use crate::types::{
+    CompletionRequest, Content, ContentBlock, Message, Role, StopReason, ThinkingConfig,
+    ToolDefinition,
+};
+
+fn mock_provider(server: &MockServer, models: Vec<String>) -> OpenAiProvider {
+    let cfg = OpenAiProviderConfig {
+        name: "test-openai".to_owned(),
+        base_url: format!("{}/v1", server.uri()),
+        api_key: None,
+        models,
+        ..OpenAiProviderConfig::default()
+    };
+    OpenAiProvider::new(cfg).expect("mock provider construct")
+}
+
+fn basic_request(model: &str) -> CompletionRequest {
+    CompletionRequest {
+        model: model.to_owned(),
+        system: Some("You are helpful.".to_owned()),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("hi".to_owned()),
+        }],
+        max_tokens: 64,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn non_streaming_text_round_trip() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chatcmpl-1",
+            "model": "qwen",
+            "choices": [{
+                "message": { "role": "assistant", "content": "hello back" },
+                "finish_reason": "stop",
+                "index": 0
+            }],
+            "usage": { "prompt_tokens": 6, "completion_tokens": 2, "total_tokens": 8 }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = mock_provider(&server, vec!["qwen".to_owned()]);
+    let resp = provider
+        .complete(&basic_request("qwen"))
+        .await
+        .expect("completion succeeds");
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+    assert_eq!(resp.usage.input_tokens, 6);
+    match &resp.content[0] {
+        ContentBlock::Text { text, .. } => assert_eq!(text, "hello back"),
+        other => panic!("expected Text, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn tool_use_round_trip_maps_both_directions() {
+    let server = MockServer::start().await;
+
+    // Server returns a tool_calls response.
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chatcmpl-tool",
+            "model": "qwen",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_7",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\":\"Paris\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls",
+                "index": 0
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = mock_provider(&server, vec!["qwen".to_owned()]);
+    let request = CompletionRequest {
+        model: "qwen".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("weather in Paris?".to_owned()),
+        }],
+        max_tokens: 64,
+        tools: vec![ToolDefinition {
+            name: "get_weather".to_owned(),
+            description: "Fetch weather".to_owned(),
+            input_schema: serde_json::json!({"type": "object"}),
+            disable_passthrough: None,
+        }],
+        ..Default::default()
+    };
+
+    let resp = provider.complete(&request).await.expect("completion");
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+    match &resp.content[0] {
+        ContentBlock::ToolUse { id, name, input } => {
+            assert_eq!(id, "call_7");
+            assert_eq!(name, "get_weather");
+            assert_eq!(input["city"], "Paris");
+        }
+        other => panic!("expected ToolUse, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn thinking_budget_is_dropped_without_breaking_request() {
+    let server = MockServer::start().await;
+
+    // Server echoes any valid request — we just want to verify the
+    // outbound body omits any thinking field.
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        // WHY: matching the absence of a string is cumbersome with wiremock;
+        // instead we assert the payload shape via `body_string_contains` on
+        // a known field to prove the request reached the server.
+        .and(body_string_contains("\"model\":\"qwen\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chatcmpl-thinking",
+            "model": "qwen",
+            "choices": [{
+                "message": { "role": "assistant", "content": "ok" },
+                "finish_reason": "stop",
+                "index": 0
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = mock_provider(&server, vec!["qwen".to_owned()]);
+    let mut req = basic_request("qwen");
+    req.thinking = Some(ThinkingConfig {
+        enabled: true,
+        budget_tokens: 1024,
+    });
+    let resp = provider.complete(&req).await.expect("completion succeeds");
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+}
+
+#[tokio::test]
+async fn auth_header_sent_when_api_key_present() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(wiremock::matchers::header(
+            "authorization",
+            "Bearer sk-test-key",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chatcmpl-auth",
+            "model": "qwen",
+            "choices": [{
+                "message": { "role": "assistant", "content": "authed" },
+                "finish_reason": "stop",
+                "index": 0
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cfg = OpenAiProviderConfig {
+        name: "authed".to_owned(),
+        base_url: format!("{}/v1", server.uri()),
+        api_key: Some(koina::secret::SecretString::from("sk-test-key")),
+        models: vec!["qwen".to_owned()],
+        ..OpenAiProviderConfig::default()
+    };
+    let provider = OpenAiProvider::new(cfg).expect("construct");
+    let resp = provider.complete(&basic_request("qwen")).await.expect("ok");
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+}
+
+#[tokio::test]
+async fn server_tools_request_is_rejected_before_transport() {
+    let server = MockServer::start().await;
+    let provider = mock_provider(&server, vec!["qwen".to_owned()]);
+    let request = CompletionRequest {
+        model: "qwen".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("search the web".to_owned()),
+        }],
+        max_tokens: 64,
+        server_tools: vec![crate::types::ServerToolDefinition {
+            tool_type: "web_search_20250305".to_owned(),
+            name: "web_search".to_owned(),
+            max_uses: Some(3),
+            allowed_domains: None,
+            blocked_domains: None,
+            user_location: None,
+        }],
+        ..Default::default()
+    };
+    let err = provider.complete(&request).await.unwrap_err();
+    assert!(err.to_string().contains("server-side tools"));
+}
+
+#[tokio::test]
+async fn air_gapped_registry_routes_to_local_provider() {
+    // Air-gapped mode is emergent: register only a local OpenAI-compatible
+    // provider, verify a turn completes without any external traffic.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "air-gapped-1",
+            "model": "Qwen3.5-35B-A3B-Q8_0",
+            "choices": [{
+                "message": { "role": "assistant", "content": "local only" },
+                "finish_reason": "stop",
+                "index": 0
+            }],
+            "usage": { "prompt_tokens": 8, "completion_tokens": 3, "total_tokens": 11 }
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = OpenAiProvider::new(OpenAiProviderConfig {
+        name: "local-qwen".to_owned(),
+        base_url: format!("{}/v1", server.uri()),
+        api_key: None,
+        models: vec!["Qwen3.5-35B-A3B-Q8_0".to_owned()],
+        ..OpenAiProviderConfig::default()
+    })
+    .expect("construct");
+
+    let mut registry = ProviderRegistry::new();
+    registry.register(Box::new(provider));
+
+    // No Anthropic provider registered — the registry must still resolve.
+    let resolved = registry
+        .find_provider("Qwen3.5-35B-A3B-Q8_0")
+        .expect("local provider routes");
+    assert_eq!(resolved.name(), "local-qwen");
+
+    let req = CompletionRequest {
+        model: "Qwen3.5-35B-A3B-Q8_0".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("ping".to_owned()),
+        }],
+        max_tokens: 32,
+        ..Default::default()
+    };
+    let resp = resolved.complete(&req).await.expect("air-gapped turn");
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+    match &resp.content[0] {
+        ContentBlock::Text { text, .. } => assert_eq!(text, "local only"),
+        other => panic!("expected Text, got {other:?}"),
+    }
+}

--- a/crates/hermeneus/src/openai/wire/mod.rs
+++ b/crates/hermeneus/src/openai/wire/mod.rs
@@ -1,0 +1,14 @@
+//! Wire types for the OpenAI Chat Completions API.
+//!
+//! Split by direction: [`request`] serializes outgoing requests,
+//! [`response`] deserializes non-streaming responses, [`stream`] parses
+//! incremental SSE deltas. Kept crate-private — callers go through
+//! [`super::client::OpenAiProvider`].
+
+pub(crate) mod request;
+pub(crate) mod response;
+pub(crate) mod stream;
+
+pub(crate) use request::ChatCompletionRequest;
+pub(crate) use response::ChatCompletionResponse;
+pub(crate) use stream::parse_sse_response;

--- a/crates/hermeneus/src/openai/wire/request.rs
+++ b/crates/hermeneus/src/openai/wire/request.rs
@@ -1,0 +1,582 @@
+//! Translate [`CompletionRequest`] into the OpenAI Chat Completions wire format.
+//!
+//! Maps Anthropic-native concepts onto OpenAI equivalents, dropping fields
+//! the target API cannot express:
+//!
+//! | Anthropic concept        | OpenAI mapping                         |
+//! |--------------------------|----------------------------------------|
+//! | `system` top-level       | `{role: "system"}` message prepended   |
+//! | `ContentBlock::Text`     | assistant/user `content` string        |
+//! | `ContentBlock::ToolUse`  | assistant message `tool_calls[]`       |
+//! | `ContentBlock::ToolResult` | `{role: "tool", tool_call_id: ...}`  |
+//! | `ContentBlock::Thinking` | dropped (warn at build time)           |
+//! | `ToolDefinition`         | `{type: "function", function: {...}}`  |
+//! | `ToolChoice`             | `{type: "function"} | "auto" | "any"`  |
+//! | `cache_control`          | dropped (warn at build time)           |
+//! | `server_tools`           | rejected (returns error)               |
+
+use serde::Serialize;
+
+use crate::error::{self, Result};
+use crate::types::{
+    CompletionRequest, Content, ContentBlock, Message, Role, ToolChoice, ToolResultContent,
+};
+
+/// Top-level OpenAI Chat Completions request body.
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatCompletionRequest<'a> {
+    pub model: &'a str,
+    pub messages: Vec<ChatMessage>,
+    pub max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub stop: Vec<&'a str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ChatTool<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<&'a str>,
+}
+
+/// Single chat message. `role` is `"system" | "user" | "assistant" | "tool"`.
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatMessage {
+    pub role: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ChatToolCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub call_type: &'static str,
+    pub function: ChatFunctionCall,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatFunctionCall {
+    pub name: String,
+    /// OpenAI requires `arguments` to be a **JSON-encoded string**, not
+    /// the raw object — matches `json.dumps(...)` on the Python side.
+    pub arguments: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatTool<'a> {
+    #[serde(rename = "type")]
+    pub tool_type: &'static str,
+    pub function: ChatFunctionDef<'a>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ChatFunctionDef<'a> {
+    pub name: &'a str,
+    pub description: &'a str,
+    pub parameters: &'a serde_json::Value,
+}
+
+impl<'a> ChatCompletionRequest<'a> {
+    /// Build an OpenAI-format request from a hermeneus [`CompletionRequest`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request carries features the OpenAI wire
+    /// format cannot express and that would silently change behavior
+    /// (currently: `server_tools` — the caller must route these through an
+    /// Anthropic provider).
+    pub(crate) fn from_request(
+        req: &'a CompletionRequest,
+        stream: Option<bool>,
+    ) -> Result<Self> {
+        if !req.server_tools.is_empty() {
+            return Err(error::ProviderInitSnafu {
+                message: "OpenAI-compatible providers do not support server-side tools \
+                          (web_search, code_execution). Route these requests to an \
+                          Anthropic provider, or remove the server_tools from the \
+                          request."
+                    .to_owned(),
+            }
+            .build());
+        }
+
+        // Thinking: the OpenAI Chat Completions wire format has no equivalent
+        // concept. The model is never given a separate thinking budget, so the
+        // request is sent verbatim and the operator's budget_tokens is dropped.
+        if let Some(thinking) = &req.thinking
+            && thinking.enabled
+        {
+            tracing::warn!(
+                budget_tokens = thinking.budget_tokens,
+                "thinking budget set on request routed to OpenAI-compatible provider; \
+                 dropping (no OpenAI equivalent for extended thinking)"
+            );
+        }
+
+        if req.cache_system || req.cache_tools || req.cache_turns {
+            tracing::warn!(
+                cache_system = req.cache_system,
+                cache_tools = req.cache_tools,
+                cache_turns = req.cache_turns,
+                "prompt-cache flags set on request routed to OpenAI-compatible provider; \
+                 dropping (no OpenAI equivalent for cache_control markers)"
+            );
+        }
+
+        if req.citations.is_some() {
+            tracing::debug!(
+                "citations config set on request routed to OpenAI-compatible provider; \
+                 ignored (no OpenAI equivalent)"
+            );
+        }
+
+        let mut messages: Vec<ChatMessage> = Vec::with_capacity(req.messages.len() + 1);
+
+        // Prepend system message. Anthropic carries `system` at the top level;
+        // OpenAI expects it as the first message with role="system".
+        if let Some(system) = req.system.as_deref()
+            && !system.is_empty()
+        {
+            messages.push(ChatMessage {
+                role: "system",
+                content: Some(system.to_owned()),
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            });
+        }
+
+        for msg in &req.messages {
+            translate_message(msg, &mut messages);
+        }
+
+        let tools: Vec<ChatTool<'a>> = req
+            .tools
+            .iter()
+            .map(|t| ChatTool {
+                tool_type: "function",
+                function: ChatFunctionDef {
+                    name: &t.name,
+                    description: &t.description,
+                    parameters: &t.input_schema,
+                },
+            })
+            .collect();
+
+        let tool_choice = req.tool_choice.as_ref().map(translate_tool_choice);
+
+        let stop: Vec<&str> = req.stop_sequences.iter().map(String::as_str).collect();
+
+        let user = req
+            .metadata
+            .as_ref()
+            .and_then(|m| m.user_id.as_deref());
+
+        Ok(Self {
+            model: &req.model,
+            messages,
+            max_tokens: req.max_tokens,
+            temperature: req.temperature,
+            stop,
+            tools,
+            tool_choice,
+            stream,
+            user,
+        })
+    }
+}
+
+/// Translate one hermeneus [`Message`] into one or more [`ChatMessage`]s.
+///
+/// Messages with mixed content (text + `tool_use` + `tool_result`) expand
+/// into multiple chat messages: OpenAI requires each tool result to live
+/// in its own `role: "tool"` message correlated by `tool_call_id`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one function per Anthropic role keeps the wire mapping readable in one place"
+)]
+#[expect(
+    clippy::collapsible_match,
+    reason = "nested if lets read more clearly here than a combined match guard"
+)]
+fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
+    match msg.role {
+        Role::System => {
+            // System messages inside the messages vec (rather than at top
+            // level) get merged as plain system prefaces.
+            out.push(ChatMessage {
+                role: "system",
+                content: Some(msg.content.text()),
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            });
+        }
+        Role::User => {
+            // User messages with tool_result blocks split into one
+            // `role: "tool"` per result, plus any remaining text as a
+            // follow-up user message.
+            match &msg.content {
+                Content::Text(text) => {
+                    out.push(ChatMessage {
+                        role: "user",
+                        content: Some(text.clone()),
+                        tool_calls: Vec::new(),
+                        tool_call_id: None,
+                    });
+                }
+                Content::Blocks(blocks) => {
+                    let mut text_parts: Vec<String> = Vec::new();
+                    for block in blocks {
+                        match block {
+                            ContentBlock::Text { text, .. } => {
+                                if !text.is_empty() {
+                                    text_parts.push(text.clone());
+                                }
+                            }
+                            ContentBlock::ToolResult {
+                                tool_use_id,
+                                content,
+                                ..
+                            } => {
+                                out.push(ChatMessage {
+                                    role: "tool",
+                                    content: Some(tool_result_to_string(content)),
+                                    tool_calls: Vec::new(),
+                                    tool_call_id: Some(tool_use_id.clone()),
+                                });
+                            }
+                            // Thinking / server-side blocks have no inbound
+                            // user-side equivalent; skip.
+                            _ => {}
+                        }
+                    }
+                    if !text_parts.is_empty() {
+                        out.push(ChatMessage {
+                            role: "user",
+                            content: Some(text_parts.join("\n")),
+                            tool_calls: Vec::new(),
+                            tool_call_id: None,
+                        });
+                    }
+                }
+            }
+        }
+        Role::Assistant => {
+            // Assistant messages coalesce text + tool_use into a single
+            // message with `content` and `tool_calls`.
+            let mut text_parts: Vec<String> = Vec::new();
+            let mut tool_calls: Vec<ChatToolCall> = Vec::new();
+            match &msg.content {
+                Content::Text(text) => {
+                    text_parts.push(text.clone());
+                }
+                Content::Blocks(blocks) => {
+                    for block in blocks {
+                        match block {
+                            ContentBlock::Text { text, .. } => {
+                                if !text.is_empty() {
+                                    text_parts.push(text.clone());
+                                }
+                            }
+                            ContentBlock::ToolUse { id, name, input } => {
+                                // WHY: OpenAI requires arguments as a JSON
+                                // *string*, not object. Round-trip through
+                                // serde_json::to_string to encode.
+                                let arguments = serde_json::to_string(input)
+                                    .unwrap_or_else(|_| "{}".to_owned());
+                                tool_calls.push(ChatToolCall {
+                                    id: id.clone(),
+                                    call_type: "function",
+                                    function: ChatFunctionCall {
+                                        name: name.clone(),
+                                        arguments,
+                                    },
+                                });
+                            }
+                            // WHY: thinking blocks and server-side blocks
+                            // have no OpenAI equivalent; skipped silently
+                            // (thinking is warned once at request build
+                            // time, server_tools is rejected outright).
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            let content = if text_parts.is_empty() {
+                None
+            } else {
+                Some(text_parts.join("\n"))
+            };
+            // OpenAI rejects assistant messages where both `content` and
+            // `tool_calls` are empty. Synthesize a single space to keep
+            // the payload valid — matches openai-python behavior.
+            let content = if content.is_none() && tool_calls.is_empty() {
+                Some(String::new())
+            } else {
+                content
+            };
+            out.push(ChatMessage {
+                role: "assistant",
+                content,
+                tool_calls,
+                tool_call_id: None,
+            });
+        }
+    }
+}
+
+fn tool_result_to_string(content: &ToolResultContent) -> String {
+    match content {
+        ToolResultContent::Text(s) => s.clone(),
+        ToolResultContent::Blocks(_) => {
+            // OpenAI tool role accepts only text content; collapse via the
+            // existing summary helper (images / documents become tags).
+            content.text_summary()
+        }
+    }
+}
+
+fn translate_tool_choice(choice: &ToolChoice) -> serde_json::Value {
+    match choice {
+        ToolChoice::Auto => serde_json::Value::String("auto".to_owned()),
+        // OpenAI uses "required" to force any tool; Anthropic calls this "any".
+        ToolChoice::Any => serde_json::Value::String("required".to_owned()),
+        ToolChoice::Tool { name } => serde_json::json!({
+            "type": "function",
+            "function": { "name": name }
+        }),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::indexing_slicing, reason = "test: indices asserted valid by construction")]
+mod tests {
+    use super::*;
+    use crate::types::{
+        CompletionRequest, Content, ContentBlock, Message, Role, ThinkingConfig, ToolDefinition,
+        ToolResultContent,
+    };
+
+    #[test]
+    fn system_prompt_becomes_first_system_message() {
+        let req = CompletionRequest {
+            model: "qwen".to_owned(),
+            system: Some("You are a helpful assistant.".to_owned()),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 128,
+            ..Default::default()
+        };
+        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+        assert_eq!(wire.messages.len(), 2);
+        assert_eq!(wire.messages[0].role, "system");
+        assert_eq!(
+            wire.messages[0].content.as_deref(),
+            Some("You are a helpful assistant.")
+        );
+        assert_eq!(wire.messages[1].role, "user");
+    }
+
+    #[test]
+    fn tool_definitions_map_to_function_tools() {
+        let req = CompletionRequest {
+            model: "qwen".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("use a tool".to_owned()),
+            }],
+            max_tokens: 128,
+            tools: vec![ToolDefinition {
+                name: "get_weather".to_owned(),
+                description: "Fetch weather for a city".to_owned(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": { "city": { "type": "string" } }
+                }),
+                disable_passthrough: None,
+            }],
+            ..Default::default()
+        };
+        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+        assert_eq!(wire.tools.len(), 1);
+        let tool = &wire.tools[0];
+        assert_eq!(tool.tool_type, "function");
+        assert_eq!(tool.function.name, "get_weather");
+    }
+
+    #[test]
+    fn assistant_tool_use_block_becomes_tool_calls() {
+        let req = CompletionRequest {
+            model: "qwen".to_owned(),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: Content::Text("call get_weather".to_owned()),
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Blocks(vec![
+                        ContentBlock::Text {
+                            text: "Sure".to_owned(),
+                            citations: None,
+                        },
+                        ContentBlock::ToolUse {
+                            id: "call_1".to_owned(),
+                            name: "get_weather".to_owned(),
+                            input: serde_json::json!({ "city": "Paris" }),
+                        },
+                    ]),
+                },
+            ],
+            max_tokens: 128,
+            ..Default::default()
+        };
+        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+        let assistant = wire
+            .messages
+            .iter()
+            .find(|m| m.role == "assistant")
+            .unwrap();
+        assert_eq!(assistant.tool_calls.len(), 1);
+        assert_eq!(assistant.tool_calls[0].id, "call_1");
+        assert_eq!(assistant.tool_calls[0].function.name, "get_weather");
+        assert!(assistant.tool_calls[0].function.arguments.contains("Paris"));
+    }
+
+    #[test]
+    fn user_tool_result_block_becomes_role_tool_message() {
+        let req = CompletionRequest {
+            model: "qwen".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Blocks(vec![ContentBlock::ToolResult {
+                    tool_use_id: "call_1".to_owned(),
+                    content: ToolResultContent::Text("sunny".to_owned()),
+                    is_error: None,
+                }]),
+            }],
+            max_tokens: 128,
+            ..Default::default()
+        };
+        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+        let tool_msg = wire.messages.iter().find(|m| m.role == "tool").unwrap();
+        assert_eq!(tool_msg.tool_call_id.as_deref(), Some("call_1"));
+        assert_eq!(tool_msg.content.as_deref(), Some("sunny"));
+    }
+
+    #[test]
+    fn thinking_block_is_dropped_and_warned() {
+        let req = CompletionRequest {
+            model: "qwen".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 128,
+            thinking: Some(ThinkingConfig {
+                enabled: true,
+                budget_tokens: 1024,
+            }),
+            ..Default::default()
+        };
+        // No thinking field in the wire request; confirm it serializes.
+        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+        let json = serde_json::to_string(&wire).unwrap();
+        assert!(!json.contains("thinking"));
+        assert!(!json.contains("budget_tokens"));
+    }
+
+    #[test]
+    fn server_tools_rejected_with_clear_error() {
+        let req = CompletionRequest {
+            model: "qwen".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 128,
+            server_tools: vec![crate::types::ServerToolDefinition {
+                tool_type: "web_search_20250305".to_owned(),
+                name: "web_search".to_owned(),
+                max_uses: Some(3),
+                allowed_domains: None,
+                blocked_domains: None,
+                user_location: None,
+            }],
+            ..Default::default()
+        };
+        let err = ChatCompletionRequest::from_request(&req, None).unwrap_err();
+        assert!(err.to_string().contains("server-side tools"));
+    }
+
+    #[test]
+    fn cache_flags_dropped_without_error() {
+        let req = CompletionRequest {
+            model: "qwen".to_owned(),
+            system: Some("sys".to_owned()),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 128,
+            cache_system: true,
+            cache_tools: true,
+            cache_turns: true,
+            ..Default::default()
+        };
+        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+        let json = serde_json::to_string(&wire).unwrap();
+        assert!(!json.contains("cache_control"));
+    }
+
+    #[test]
+    fn tool_choice_any_maps_to_required() {
+        let req = CompletionRequest {
+            model: "qwen".to_owned(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hi".to_owned()),
+            }],
+            max_tokens: 128,
+            tool_choice: Some(ToolChoice::Any),
+            ..Default::default()
+        };
+        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+        assert_eq!(
+            wire.tool_choice,
+            Some(serde_json::Value::String("required".to_owned()))
+        );
+    }
+
+    #[test]
+    fn tool_arguments_serialized_as_json_string() {
+        let req = CompletionRequest {
+            model: "qwen".to_owned(),
+            messages: vec![Message {
+                role: Role::Assistant,
+                content: Content::Blocks(vec![ContentBlock::ToolUse {
+                    id: "c1".to_owned(),
+                    name: "f".to_owned(),
+                    input: serde_json::json!({ "x": 1 }),
+                }]),
+            }],
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+        let tc = &wire.messages[0].tool_calls[0];
+        // arguments must be a JSON-encoded string containing the object.
+        let parsed: serde_json::Value = serde_json::from_str(&tc.function.arguments).unwrap();
+        assert_eq!(parsed["x"], 1);
+    }
+}

--- a/crates/hermeneus/src/openai/wire/request.rs
+++ b/crates/hermeneus/src/openai/wire/request.rs
@@ -93,10 +93,7 @@ impl<'a> ChatCompletionRequest<'a> {
     /// format cannot express and that would silently change behavior
     /// (currently: `server_tools` — the caller must route these through an
     /// Anthropic provider).
-    pub(crate) fn from_request(
-        req: &'a CompletionRequest,
-        stream: Option<bool>,
-    ) -> Result<Self> {
+    pub(crate) fn from_request(req: &'a CompletionRequest, stream: Option<bool>) -> Result<Self> {
         if !req.server_tools.is_empty() {
             return Err(error::ProviderInitSnafu {
                 message: "OpenAI-compatible providers do not support server-side tools \
@@ -174,10 +171,7 @@ impl<'a> ChatCompletionRequest<'a> {
 
         let stop: Vec<&str> = req.stop_sequences.iter().map(String::as_str).collect();
 
-        let user = req
-            .metadata
-            .as_ref()
-            .and_then(|m| m.user_id.as_deref());
+        let user = req.metadata.as_ref().and_then(|m| m.user_id.as_deref());
 
         Ok(Self {
             model: &req.model,
@@ -357,7 +351,10 @@ fn translate_tool_choice(choice: &ToolChoice) -> serde_json::Value {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
-#[expect(clippy::indexing_slicing, reason = "test: indices asserted valid by construction")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: indices asserted valid by construction"
+)]
 mod tests {
     use super::*;
     use crate::types::{

--- a/crates/hermeneus/src/openai/wire/response.rs
+++ b/crates/hermeneus/src/openai/wire/response.rs
@@ -154,7 +154,10 @@ fn map_finish_reason(reason: &str) -> StopReason {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
-#[expect(clippy::indexing_slicing, reason = "test: indices asserted valid by construction")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: indices asserted valid by construction"
+)]
 mod tests {
     use super::*;
 

--- a/crates/hermeneus/src/openai/wire/response.rs
+++ b/crates/hermeneus/src/openai/wire/response.rs
@@ -1,0 +1,282 @@
+//! Parse OpenAI Chat Completions responses into [`CompletionResponse`].
+//!
+//! Maps `finish_reason` → [`StopReason`] and `tool_calls` → structured
+//! [`ContentBlock::ToolUse`]. The OpenAI response shape is stable across
+//! OpenAI proper, llama.cpp, ollama, and vllm.
+
+use serde::Deserialize;
+
+use crate::types::{CompletionResponse, ContentBlock, StopReason, Usage};
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatCompletionResponse {
+    pub id: String,
+    pub model: String,
+    pub choices: Vec<ChatChoice>,
+    #[serde(default)]
+    pub usage: Option<ChatUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatChoice {
+    pub message: ChatChoiceMessage,
+    #[serde(default)]
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatChoiceMessage {
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub tool_calls: Vec<ChatChoiceToolCall>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatChoiceToolCall {
+    pub id: String,
+    #[expect(
+        dead_code,
+        reason = "OpenAI always sets type=function for now; kept for forward compatibility"
+    )]
+    #[serde(default, rename = "type")]
+    pub call_type: Option<String>,
+    pub function: ChatChoiceFunctionCall,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatChoiceFunctionCall {
+    pub name: String,
+    /// JSON-encoded string of arguments — decoded into a
+    /// [`serde_json::Value`] when building the [`ContentBlock::ToolUse`].
+    #[serde(default)]
+    pub arguments: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChatUsage {
+    #[serde(default)]
+    pub prompt_tokens: u64,
+    #[serde(default)]
+    pub completion_tokens: u64,
+    // OpenAI does not expose cache-tier tokens; leave zero.
+}
+
+impl ChatCompletionResponse {
+    /// Convert a successful OpenAI response into the Anthropic-shaped
+    /// [`CompletionResponse`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string when the response contains no choices (the
+    /// OpenAI API guarantees at least one but we defend against a degenerate
+    /// server).
+    pub(crate) fn into_response(self) -> Result<CompletionResponse, String> {
+        let Self {
+            id,
+            model,
+            choices,
+            usage,
+        } = self;
+
+        let mut choices_iter = choices.into_iter();
+        let choice = choices_iter
+            .next()
+            .ok_or_else(|| "OpenAI response had no choices".to_owned())?;
+
+        let finish_reason = choice.finish_reason.as_deref().unwrap_or("stop");
+        let stop_reason = map_finish_reason(finish_reason);
+
+        let mut content: Vec<ContentBlock> = Vec::new();
+
+        if let Some(text) = choice.message.content
+            && !text.is_empty()
+        {
+            content.push(ContentBlock::Text {
+                text,
+                citations: None,
+            });
+        }
+
+        for call in choice.message.tool_calls {
+            // WHY: arguments is a JSON-encoded string on the wire. An empty
+            // string means the tool takes no input — map to an empty object.
+            let input: serde_json::Value = if call.function.arguments.is_empty() {
+                serde_json::json!({})
+            } else {
+                serde_json::from_str(&call.function.arguments)
+                    .unwrap_or(serde_json::Value::String(call.function.arguments.clone()))
+            };
+            content.push(ContentBlock::ToolUse {
+                id: call.id,
+                name: call.function.name,
+                input,
+            });
+        }
+
+        let usage = usage
+            .map(|u| Usage {
+                input_tokens: u.prompt_tokens,
+                output_tokens: u.completion_tokens,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+            })
+            .unwrap_or_default();
+
+        Ok(CompletionResponse {
+            id,
+            model,
+            stop_reason,
+            content,
+            usage,
+        })
+    }
+}
+
+/// Map OpenAI's `finish_reason` to our [`StopReason`].
+///
+/// OpenAI values: `stop`, `length`, `tool_calls`, `function_call` (legacy),
+/// `content_filter`.
+fn map_finish_reason(reason: &str) -> StopReason {
+    match reason {
+        "length" => StopReason::MaxTokens,
+        "tool_calls" | "function_call" => StopReason::ToolUse,
+        "stop" | "content_filter" | "" => StopReason::EndTurn,
+        other => {
+            tracing::debug!(
+                reason = other,
+                "unknown OpenAI finish_reason; treating as end_turn"
+            );
+            StopReason::EndTurn
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::indexing_slicing, reason = "test: indices asserted valid by construction")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_response_round_trips() {
+        let body = r#"{
+            "id": "chatcmpl-123",
+            "model": "qwen",
+            "choices": [{
+                "message": { "role": "assistant", "content": "hello" },
+                "finish_reason": "stop",
+                "index": 0
+            }],
+            "usage": { "prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8 }
+        }"#;
+        let parsed: ChatCompletionResponse = serde_json::from_str(body).unwrap();
+        let resp = parsed.into_response().unwrap();
+        assert_eq!(resp.id, "chatcmpl-123");
+        assert_eq!(resp.stop_reason, StopReason::EndTurn);
+        assert_eq!(resp.usage.input_tokens, 5);
+        assert_eq!(resp.usage.output_tokens, 3);
+        assert_eq!(resp.content.len(), 1);
+        match &resp.content[0] {
+            ContentBlock::Text { text, .. } => assert_eq!(text, "hello"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_call_response_becomes_tool_use_block() {
+        let body = r#"{
+            "id": "chatcmpl-tool",
+            "model": "qwen",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_42",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\":\"Austin\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls",
+                "index": 0
+            }]
+        }"#;
+        let parsed: ChatCompletionResponse = serde_json::from_str(body).unwrap();
+        let resp = parsed.into_response().unwrap();
+        assert_eq!(resp.stop_reason, StopReason::ToolUse);
+        assert_eq!(resp.content.len(), 1);
+        match &resp.content[0] {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "call_42");
+                assert_eq!(name, "get_weather");
+                assert_eq!(input["city"], "Austin");
+            }
+            other => panic!("expected ToolUse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn length_finish_reason_maps_to_max_tokens() {
+        let body = r#"{
+            "id": "chatcmpl-long",
+            "model": "qwen",
+            "choices": [{
+                "message": { "role": "assistant", "content": "..." },
+                "finish_reason": "length",
+                "index": 0
+            }]
+        }"#;
+        let parsed: ChatCompletionResponse = serde_json::from_str(body).unwrap();
+        let resp = parsed.into_response().unwrap();
+        assert_eq!(resp.stop_reason, StopReason::MaxTokens);
+    }
+
+    #[test]
+    fn response_with_no_usage_defaults_to_zero() {
+        let body = r#"{
+            "id": "chatcmpl-no-usage",
+            "model": "qwen",
+            "choices": [{
+                "message": { "role": "assistant", "content": "ok" },
+                "finish_reason": "stop",
+                "index": 0
+            }]
+        }"#;
+        let parsed: ChatCompletionResponse = serde_json::from_str(body).unwrap();
+        let resp = parsed.into_response().unwrap();
+        assert_eq!(resp.usage.input_tokens, 0);
+        assert_eq!(resp.usage.output_tokens, 0);
+    }
+
+    #[test]
+    fn empty_arguments_string_becomes_empty_object() {
+        let body = r#"{
+            "id": "x",
+            "model": "m",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "c",
+                        "type": "function",
+                        "function": { "name": "f", "arguments": "" }
+                    }]
+                },
+                "finish_reason": "tool_calls",
+                "index": 0
+            }]
+        }"#;
+        let parsed: ChatCompletionResponse = serde_json::from_str(body).unwrap();
+        let resp = parsed.into_response().unwrap();
+        match &resp.content[0] {
+            ContentBlock::ToolUse { input, .. } => {
+                assert!(input.as_object().is_some_and(serde_json::Map::is_empty));
+            }
+            other => panic!("expected ToolUse, got {other:?}"),
+        }
+    }
+}

--- a/crates/hermeneus/src/openai/wire/stream.rs
+++ b/crates/hermeneus/src/openai/wire/stream.rs
@@ -121,9 +121,7 @@ impl OpenAiStreamAccumulator {
             self.model = model;
             // Emit a MessageStart so the accumulator contract matches the
             // Anthropic provider — downstream code expects one per stream.
-            on_event(StreamEvent::MessageStart {
-                usage: self.usage,
-            });
+            on_event(StreamEvent::MessageStart { usage: self.usage });
         }
 
         if let Some(usage) = chunk.usage {
@@ -158,13 +156,14 @@ impl OpenAiStreamAccumulator {
 
         // Tool-call deltas → buffered, partial_json emitted per increment.
         for tc in choice.delta.tool_calls {
-            let pending = self.tool_calls.entry(tc.index).or_insert_with(|| {
-                PendingToolCall {
+            let pending = self
+                .tool_calls
+                .entry(tc.index)
+                .or_insert_with(|| PendingToolCall {
                     id: String::new(),
                     name: String::new(),
                     arguments: String::new(),
-                }
-            });
+                });
             if let Some(id) = tc.id
                 && !id.is_empty()
             {
@@ -180,9 +179,7 @@ impl OpenAiStreamAccumulator {
                     && !args.is_empty()
                 {
                     pending.arguments.push_str(&args);
-                    on_event(StreamEvent::InputJsonDelta {
-                        partial_json: args,
-                    });
+                    on_event(StreamEvent::InputJsonDelta { partial_json: args });
                 }
             }
         }
@@ -231,10 +228,7 @@ impl OpenAiStreamAccumulator {
             });
         }
 
-        on_event(StreamEvent::MessageStop {
-            stop_reason,
-            usage,
-        });
+        on_event(StreamEvent::MessageStop { stop_reason, usage });
 
         CompletionResponse {
             id,
@@ -325,7 +319,10 @@ pub(crate) async fn parse_sse_response(
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
-#[expect(clippy::indexing_slicing, reason = "test: indices asserted valid by construction")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: indices asserted valid by construction"
+)]
 mod tests {
     use super::*;
 

--- a/crates/hermeneus/src/openai/wire/stream.rs
+++ b/crates/hermeneus/src/openai/wire/stream.rs
@@ -1,0 +1,393 @@
+//! Parse OpenAI Chat Completions SSE streams into hermeneus stream events.
+//!
+//! OpenAI streams `data: {chunk}` lines terminated by `data: [DONE]`. Each
+//! chunk carries incremental `delta` fields that mirror the non-streaming
+//! `message` shape. This module accumulates them into a
+//! [`CompletionResponse`] while emitting [`StreamEvent`]s for live UI.
+
+use std::collections::BTreeMap;
+
+use reqwest::Response;
+use serde::Deserialize;
+
+use crate::anthropic::StreamEvent;
+use crate::error::{self, Result};
+use crate::types::{CompletionResponse, ContentBlock, StopReason, Usage};
+
+#[derive(Debug, Deserialize)]
+struct ChatStreamChunk {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    choices: Vec<ChatStreamChoice>,
+    #[serde(default)]
+    usage: Option<ChatStreamUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatStreamChoice {
+    delta: ChatStreamDelta,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ChatStreamDelta {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<ChatStreamToolCallDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatStreamToolCallDelta {
+    #[serde(default)]
+    index: u32,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<ChatStreamFunctionDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatStreamFunctionDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatStreamUsage {
+    #[serde(default)]
+    prompt_tokens: u64,
+    #[serde(default)]
+    completion_tokens: u64,
+}
+
+/// Accumulator for an OpenAI SSE stream.
+///
+/// Mirrors the Anthropic `StreamAccumulator` surface so the caller's
+/// `on_event` callback receives the same `StreamEvent` variants regardless
+/// of provider.
+pub(crate) struct OpenAiStreamAccumulator {
+    id: String,
+    model: String,
+    text_buf: String,
+    /// Pending tool calls indexed by their `index` field — OpenAI streams
+    /// tool calls in interleaved deltas, each tagged by a stable position.
+    tool_calls: BTreeMap<u32, PendingToolCall>,
+    stop_reason: StopReason,
+    usage: Usage,
+    /// Tracks whether a text block has been announced via
+    /// `ContentBlockStart` — used to suppress duplicate start events across
+    /// chunks.
+    text_block_open: bool,
+}
+
+struct PendingToolCall {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+impl OpenAiStreamAccumulator {
+    pub(crate) fn new() -> Self {
+        Self {
+            id: String::new(),
+            model: String::new(),
+            text_buf: String::new(),
+            tool_calls: BTreeMap::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            text_block_open: false,
+        }
+    }
+
+    fn process_chunk<F: FnMut(StreamEvent) + ?Sized>(
+        &mut self,
+        chunk: ChatStreamChunk,
+        on_event: &mut F,
+    ) {
+        if let Some(id) = chunk.id
+            && self.id.is_empty()
+        {
+            self.id = id;
+        }
+        if let Some(model) = chunk.model
+            && self.model.is_empty()
+        {
+            self.model = model;
+            // Emit a MessageStart so the accumulator contract matches the
+            // Anthropic provider — downstream code expects one per stream.
+            on_event(StreamEvent::MessageStart {
+                usage: self.usage,
+            });
+        }
+
+        if let Some(usage) = chunk.usage {
+            self.usage.input_tokens = usage.prompt_tokens;
+            self.usage.output_tokens = usage.completion_tokens;
+        }
+
+        for choice in chunk.choices {
+            self.apply_delta(choice, on_event);
+        }
+    }
+
+    fn apply_delta<F: FnMut(StreamEvent) + ?Sized>(
+        &mut self,
+        choice: ChatStreamChoice,
+        on_event: &mut F,
+    ) {
+        // Text delta → TextDelta event + append to buffer.
+        if let Some(text) = choice.delta.content
+            && !text.is_empty()
+        {
+            if !self.text_block_open {
+                on_event(StreamEvent::ContentBlockStart {
+                    index: 0,
+                    block_type: "text".to_owned(),
+                });
+                self.text_block_open = true;
+            }
+            self.text_buf.push_str(&text);
+            on_event(StreamEvent::TextDelta { text });
+        }
+
+        // Tool-call deltas → buffered, partial_json emitted per increment.
+        for tc in choice.delta.tool_calls {
+            let pending = self.tool_calls.entry(tc.index).or_insert_with(|| {
+                PendingToolCall {
+                    id: String::new(),
+                    name: String::new(),
+                    arguments: String::new(),
+                }
+            });
+            if let Some(id) = tc.id
+                && !id.is_empty()
+            {
+                pending.id = id;
+            }
+            if let Some(func) = tc.function {
+                if let Some(name) = func.name
+                    && !name.is_empty()
+                {
+                    pending.name = name;
+                }
+                if let Some(args) = func.arguments
+                    && !args.is_empty()
+                {
+                    pending.arguments.push_str(&args);
+                    on_event(StreamEvent::InputJsonDelta {
+                        partial_json: args,
+                    });
+                }
+            }
+        }
+
+        if let Some(reason) = choice.finish_reason {
+            self.stop_reason = map_finish_reason(&reason);
+        }
+    }
+
+    pub(crate) fn finish<F: FnMut(StreamEvent) + ?Sized>(
+        self,
+        on_event: &mut F,
+    ) -> CompletionResponse {
+        let Self {
+            id,
+            model,
+            text_buf,
+            tool_calls,
+            stop_reason,
+            usage,
+            text_block_open,
+        } = self;
+
+        if text_block_open {
+            on_event(StreamEvent::ContentBlockStop { index: 0 });
+        }
+
+        let mut content: Vec<ContentBlock> = Vec::new();
+        if !text_buf.is_empty() {
+            content.push(ContentBlock::Text {
+                text: text_buf,
+                citations: None,
+            });
+        }
+        for (_, tc) in tool_calls {
+            let input: serde_json::Value = if tc.arguments.is_empty() {
+                serde_json::json!({})
+            } else {
+                serde_json::from_str(&tc.arguments)
+                    .unwrap_or(serde_json::Value::String(tc.arguments.clone()))
+            };
+            content.push(ContentBlock::ToolUse {
+                id: tc.id,
+                name: tc.name,
+                input,
+            });
+        }
+
+        on_event(StreamEvent::MessageStop {
+            stop_reason,
+            usage,
+        });
+
+        CompletionResponse {
+            id,
+            model,
+            stop_reason,
+            content,
+            usage,
+        }
+    }
+}
+
+fn map_finish_reason(reason: &str) -> StopReason {
+    match reason {
+        "length" => StopReason::MaxTokens,
+        "tool_calls" | "function_call" => StopReason::ToolUse,
+        _ => StopReason::EndTurn,
+    }
+}
+
+/// Parse an OpenAI SSE stream from a `reqwest::Response`, emitting
+/// [`StreamEvent`]s and returning the finalized [`CompletionResponse`].
+#[tracing::instrument(skip_all)]
+pub(crate) async fn parse_sse_response(
+    response: &mut Response,
+    on_event: &mut (dyn FnMut(StreamEvent) + Send),
+) -> Result<CompletionResponse> {
+    let mut accumulator = OpenAiStreamAccumulator::new();
+    let mut line_buf: Vec<u8> = Vec::with_capacity(256);
+    let mut current_data = String::new();
+    let mut done = false;
+
+    loop {
+        let chunk = response.chunk().await.map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("stream read error: {e}"),
+            }
+            .build()
+        })?;
+        let Some(bytes) = chunk else { break };
+
+        for &byte in &bytes {
+            if byte == b'\n' {
+                let line_cow = String::from_utf8_lossy(&line_buf);
+                let line = line_cow.trim_end_matches('\r');
+                if line.is_empty() {
+                    if !current_data.is_empty() {
+                        if current_data.trim() == "[DONE]" {
+                            done = true;
+                        } else {
+                            match serde_json::from_str::<ChatStreamChunk>(&current_data) {
+                                Ok(chunk) => accumulator.process_chunk(chunk, on_event),
+                                Err(e) => {
+                                    return Err(error::ApiRequestSnafu {
+                                        message: format!("stream parse error: {e}"),
+                                    }
+                                    .build());
+                                }
+                            }
+                        }
+                    }
+                    current_data.clear();
+                } else if let Some(data) = line.strip_prefix("data: ") {
+                    if !current_data.is_empty() {
+                        current_data.push('\n');
+                    }
+                    current_data.push_str(data);
+                } else if let Some(data) = line.strip_prefix("data:") {
+                    // llama.cpp emits `data:{...}` without the space.
+                    if !current_data.is_empty() {
+                        current_data.push('\n');
+                    }
+                    current_data.push_str(data);
+                }
+                // Ignore comments, empty `:` lines, event:, id:, retry:
+                line_buf.clear();
+            } else {
+                line_buf.push(byte);
+            }
+        }
+
+        if done {
+            break;
+        }
+    }
+
+    Ok(accumulator.finish(on_event))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::indexing_slicing, reason = "test: indices asserted valid by construction")]
+mod tests {
+    use super::*;
+
+    fn process_chunks(chunks: &[&str]) -> (Vec<StreamEvent>, CompletionResponse) {
+        let mut acc = OpenAiStreamAccumulator::new();
+        let mut events = Vec::new();
+        for chunk_json in chunks {
+            let chunk: ChatStreamChunk = serde_json::from_str(chunk_json).unwrap();
+            acc.process_chunk(chunk, &mut |e| events.push(e));
+        }
+        let resp = acc.finish(&mut |e| events.push(e));
+        (events, resp)
+    }
+
+    #[test]
+    fn accumulates_text_deltas() {
+        let (events, resp) = process_chunks(&[
+            r#"{"id":"x","model":"m","choices":[{"index":0,"delta":{"content":"Hel"}}]}"#,
+            r#"{"id":"x","choices":[{"index":0,"delta":{"content":"lo"}}]}"#,
+            r#"{"id":"x","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+        ]);
+        match &resp.content[0] {
+            ContentBlock::Text { text, .. } => assert_eq!(text, "Hello"),
+            _ => panic!("expected Text"),
+        }
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, StreamEvent::TextDelta { text } if text == "Hel")),
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, StreamEvent::TextDelta { text } if text == "lo")),
+        );
+    }
+
+    #[test]
+    fn accumulates_tool_call_deltas() {
+        let (_, resp) = process_chunks(&[
+            r#"{"id":"x","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"f","arguments":"{\"a\":"}}]}}]}"#,
+            r#"{"id":"x","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"1}"}}]}}]}"#,
+            r#"{"id":"x","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#,
+        ]);
+        assert_eq!(resp.stop_reason, StopReason::ToolUse);
+        match &resp.content[0] {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "c1");
+                assert_eq!(name, "f");
+                assert_eq!(input["a"], 1);
+            }
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn usage_propagates_when_present() {
+        let (_, resp) = process_chunks(&[
+            r#"{"id":"x","model":"m","choices":[{"index":0,"delta":{"content":"hi"}}]}"#,
+            r#"{"id":"x","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":1}}"#,
+        ]);
+        assert_eq!(resp.usage.input_tokens, 4);
+        assert_eq!(resp.usage.output_tokens, 1);
+    }
+}

--- a/crates/taxis/src/config/behavior/mod.rs
+++ b/crates/taxis/src/config/behavior/mod.rs
@@ -17,7 +17,10 @@ pub use jwt::JwtSettings;
 pub use knowledge::KnowledgeConfig;
 pub use messaging::MessagingConfig;
 pub use nous::NousBehaviorConfig;
-pub use provider::{AnthropicConfig, PromptCacheMode, ProviderBehaviorConfig};
+pub use provider::{
+    AnthropicConfig, DeploymentTarget, LlmProviderConfig, PromptCacheMode, ProviderBehaviorConfig,
+    ProviderKind,
+};
 pub use timeouts::{CapacityConfig, RetrySettings, TimeoutsConfig};
 pub use tools::ToolLimitsConfig;
 pub use tuning::TuningConfig;

--- a/crates/taxis/src/config/behavior/provider.rs
+++ b/crates/taxis/src/config/behavior/provider.rs
@@ -88,3 +88,84 @@ pub enum PromptCacheMode {
     /// wire format for extended TTL is plumbed through).
     Extended,
 }
+
+/// Where a provider's traffic terminates — used to classify data sensitivity
+/// and sovereignty posture for routing decisions (#3414, #3424).
+///
+/// The factsensitivity filter and air-gapped mode use this to decide whether
+/// a given turn may be sent to a given provider: cloud endpoints receive only
+/// the facts the operator has explicitly allowed to leave the machine, while
+/// locally-hosted and embedded providers are trusted with everything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum DeploymentTarget {
+    /// Third-party cloud API (e.g., api.anthropic.com, api.openai.com).
+    /// Facts marked sensitive are filtered before the request is sent.
+    #[default]
+    Cloud,
+    /// Self-hosted endpoint reachable over the local network (e.g., a
+    /// colocated llama.cpp server on the same subnet). Trusted with
+    /// operator-sensitive content but not with personally-identifiable data.
+    LocalHosted,
+    /// Runs on the same machine as aletheia (loopback llama.cpp / ollama
+    /// / vllm). Trusted with every fact the operator would trust to disk.
+    Embedded,
+}
+
+/// Which concrete provider implementation to instantiate at startup.
+///
+/// Matches on this in `crates/aletheia/src/runtime/setup.rs` to pick between
+/// the Anthropic HTTP client, OpenAI-compatible HTTP client, or the CC
+/// subprocess adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum ProviderKind {
+    /// Anthropic Messages API native client.
+    Anthropic,
+    /// `OpenAI` Chat Completions-compatible HTTP client. Works with
+    /// `OpenAI`, llama.cpp, ollama, vllm, and any other server exposing the
+    /// same wire format.
+    OpenAiCompatible,
+    /// Claude Code subprocess adapter (delegates to the `claude` CLI).
+    /// Requires the `cc-provider` feature flag on hermeneus.
+    ClaudeCode,
+}
+
+/// Per-provider configuration entry. One of these is produced for every
+/// `[[providers]]` table in `aletheia.toml`.
+///
+/// The full set of entries lives on `AletheiaConfig::providers`. At startup
+/// `build_provider_registry` iterates the vector and dispatches on
+/// [`kind`](Self::kind) to build the corresponding concrete provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LlmProviderConfig {
+    /// Operator-facing label for logs and diagnostics (e.g., `"local-qwen"`,
+    /// `"anthropic-cloud"`). Must be unique across the provider list.
+    pub name: String,
+    /// Which concrete provider implementation to instantiate.
+    #[serde(rename = "providerType")]
+    pub kind: ProviderKind,
+    /// HTTP base URL override. Required for OpenAI-compatible providers
+    /// (e.g., `http://127.0.0.1:8088/v1` for local llama.cpp). Optional for
+    /// Anthropic (defaults to `https://api.anthropic.com`). Ignored for
+    /// the Claude Code subprocess adapter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// Environment variable name holding the API key. Read at startup via
+    /// `std::env::var`. Optional for loopback / embedded providers that do
+    /// not require authentication.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_env: Option<String>,
+    /// Where this provider's traffic terminates. Drives the
+    /// factsensitivity filter (#3414) and air-gapped mode.
+    #[serde(default)]
+    pub deployment_target: DeploymentTarget,
+    /// Model identifiers this provider advertises support for. Used by the
+    /// provider registry for routing: the first provider in list order that
+    /// claims the requested model wins.
+    #[serde(default)]
+    pub models: Vec<String>,
+}

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -11,9 +11,10 @@ pub use agents::{
     ModelSpec, NousDefinition, RecallSettings, RecallWeights,
 };
 pub use behavior::{
-    AnthropicConfig, ApiLimitsConfig, CapacityConfig, DaemonBehaviorConfig, JwtSettings,
-    KnowledgeConfig, MessagingConfig, NousBehaviorConfig, PromptCacheMode, ProviderBehaviorConfig,
-    RetrySettings, TimeoutsConfig, ToolLimitsConfig, TuningConfig,
+    AnthropicConfig, ApiLimitsConfig, CapacityConfig, DaemonBehaviorConfig, DeploymentTarget,
+    JwtSettings, KnowledgeConfig, LlmProviderConfig, MessagingConfig, NousBehaviorConfig,
+    PromptCacheMode, ProviderBehaviorConfig, ProviderKind, RetrySettings, TimeoutsConfig,
+    ToolLimitsConfig, TuningConfig,
 };
 pub use gateway::{
     BodyLimitConfig, CorsConfig, CsrfConfig, GatewayAuthConfig, GatewayConfig,
@@ -142,6 +143,17 @@ pub struct AletheiaConfig {
     /// typical NTP drift; operators on tightly synchronized hosts may
     /// lower this, and those behind mis-synced proxies may raise it.
     pub jwt: JwtSettings,
+    /// LLM provider definitions (#3424, #3414).
+    ///
+    /// Ordered list of backends — the provider registry routes each request
+    /// to the first entry that claims the requested model. Empty by default
+    /// for backward compatibility: when empty, the runtime falls back to the
+    /// legacy single-Anthropic setup driven by [`Self::anthropic`] and the
+    /// top-level credential chain. Populate this to enable OpenAI-compatible
+    /// endpoints (local llama.cpp/ollama/vllm, other cloud APIs) or to
+    /// declare explicit deployment targets for the factsensitivity filter.
+    #[serde(default)]
+    pub providers: Vec<LlmProviderConfig>,
 }
 
 /// Sandbox enforcement level for tool execution.

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -150,6 +150,7 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
         "messaging" => validate_messaging(value, &mut errors),
         "tuning" => validate_tuning(value, &mut errors),
         "jwt" => validate_jwt(value, &mut errors),
+        "providers" => validate_providers(value, &mut errors),
         // NOTE: pass-through sections with no validation rules.
         "packs" | "pricing" | "sandbox" | "logging" | "mcp" | "localProvider" | "training"
         | "anthropic" => {}
@@ -679,6 +680,69 @@ fn validate_tuning(value: &Value, errors: &mut Vec<String>) {
         errors.push(format!(
             "tuning.significanceThreshold must be between 0.1 and 10.0, got {threshold}"
         ));
+    }
+}
+
+/// Validate the [`LlmProviderConfig`](crate::config::LlmProviderConfig) list
+/// (#3424, #3414).
+///
+/// Rejects entries with empty names, unknown provider kinds, OpenAI-compatible
+/// entries missing a base URL, or duplicate provider names.
+fn validate_providers(value: &Value, errors: &mut Vec<String>) {
+    let Some(entries) = value.as_array() else {
+        // WHY: missing or empty provider list is a valid config — the
+        // legacy single-Anthropic path remains the default.
+        return;
+    };
+
+    let mut seen_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for (i, entry) in entries.iter().enumerate() {
+        match entry.get("name").and_then(Value::as_str) {
+            None | Some("") => {
+                errors.push(format!("providers[{i}].name must not be empty"));
+            }
+            Some(name) => {
+                if !seen_names.insert(name) {
+                    errors.push(format!(
+                        "providers[{i}].name '{name}' is duplicated (names must be unique)"
+                    ));
+                }
+            }
+        }
+
+        match entry.get("providerType").and_then(Value::as_str) {
+            None | Some("") => {
+                errors.push(format!(
+                    "providers[{i}].providerType must be one of: anthropic, openai-compatible, claude-code"
+                ));
+            }
+            Some(kind) => {
+                if !matches!(kind, "anthropic" | "openai-compatible" | "claude-code") {
+                    errors.push(format!(
+                        "providers[{i}].providerType '{kind}' is not recognized (expected one of: anthropic, openai-compatible, claude-code)"
+                    ));
+                }
+                // OpenAI-compatible requires baseUrl.
+                if kind == "openai-compatible"
+                    && entry
+                        .get("baseUrl")
+                        .and_then(Value::as_str)
+                        .is_none_or(str::is_empty)
+                {
+                    errors.push(format!(
+                        "providers[{i}].baseUrl is required for providerType = openai-compatible"
+                    ));
+                }
+            }
+        }
+
+        if let Some(target) = entry.get("deploymentTarget").and_then(Value::as_str)
+            && !matches!(target, "cloud" | "localhosted" | "embedded")
+        {
+            errors.push(format!(
+                "providers[{i}].deploymentTarget '{target}' is not recognized (expected one of: cloud, localhosted, embedded)"
+            ));
+        }
     }
 }
 

--- a/docs/AIR-GAPPED.md
+++ b/docs/AIR-GAPPED.md
@@ -1,0 +1,115 @@
+# Air-gapped operation
+
+> Status: supported via the OpenAI-compatible provider (#3414, #3424).
+
+Aletheia has no air-gapped mode flag. The capability emerges from config: remove
+every cloud provider from `[[providers]]`, declare one or more local
+OpenAI-compatible providers, and the runtime never opens an outbound connection
+the operator did not authorize.
+
+This document covers the required local LLM stack, a reference `aletheia.toml`
+fragment, and the feature set that drops when no Anthropic provider is
+registered.
+
+## Required local LLM stack
+
+Any server speaking OpenAI's `/v1/chat/completions` wire format works. The
+OpenAI adapter has been tested against:
+
+| Server      | Status        | Notes                                           |
+|-------------|---------------|-------------------------------------------------|
+| llama.cpp   | recommended   | `llama-server --host 127.0.0.1 --port 8088`     |
+| ollama      | supported     | `ollama serve` — default endpoint `/v1`         |
+| vllm        | supported     | `vllm serve MODEL --port 8000`                  |
+
+The adapter tolerates llama.cpp's quirks (missing `code` / `type` on errors,
+SSE lines that omit the space after `data:`) so no server-side workaround is
+needed.
+
+## Recommended model
+
+Qwen3.5-35B-A3B-Q8_0 on a workstation-class GPU (24 GB VRAM minimum) gives
+parity with Haiku-tier cloud models for most agent tasks. Smaller operators
+can run Qwen3.5-8B-Q8_0 on consumer hardware with a quality cost.
+
+The exact model is not prescriptive — anything that exposes function calling
+over the OpenAI wire format will route correctly.
+
+## Example config
+
+```toml
+# No [[providers]] entry with providerType = "anthropic" → no cloud egress.
+
+[[providers]]
+name = "local-qwen"
+providerType = "openai-compatible"
+baseUrl = "http://127.0.0.1:8088/v1"
+deploymentTarget = "embedded"
+# `apiKeyEnv` is optional; loopback llama.cpp accepts unauthenticated clients.
+models = ["Qwen3.5-35B-A3B-Q8_0"]
+```
+
+For a mixed cloud + local deployment, keep the Anthropic entry and add the
+local one; the provider registry routes each request to the first entry that
+claims the requested model, so model IDs must be unique.
+
+```toml
+[[providers]]
+name = "anthropic"
+providerType = "anthropic"
+deploymentTarget = "cloud"
+apiKeyEnv = "ANTHROPIC_API_KEY"
+models = ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"]
+
+[[providers]]
+name = "local-qwen"
+providerType = "openai-compatible"
+baseUrl = "http://127.0.0.1:8088/v1"
+deploymentTarget = "embedded"
+models = ["Qwen3.5-35B-A3B-Q8_0"]
+```
+
+## Feature set in air-gapped mode
+
+Three Anthropic-native features have no OpenAI equivalent and are disabled
+for requests routed to OpenAI-compatible providers:
+
+| Feature                | Behavior                                            |
+|------------------------|-----------------------------------------------------|
+| `cache_control` markers| Dropped. One warning per request carrying the flag. |
+| `thinking` budget      | Dropped. One warning per request with `enabled=true`. |
+| Server-side tools      | Request is rejected outright with a clear error.    |
+
+Everything else maps cleanly: system prompts, tool definitions, multi-turn
+tool_use / tool_result conversations, streaming deltas, stop reasons.
+
+## Deployment targets and factsensitivity
+
+The `deploymentTarget` field on each provider entry classifies where the
+traffic terminates. The factsensitivity filter (W3-1) reads this to decide
+which facts are allowed to flow to which provider:
+
+| Target       | Trust level                                                    |
+|--------------|----------------------------------------------------------------|
+| `cloud`      | Public-only. Facts marked sensitive are filtered before send.  |
+| `localhosted`| Operator-trusted. Sensitive content flows, PII does not.       |
+| `embedded`   | Fully trusted. Every fact the operator would trust to disk.    |
+
+Air-gapped deployments should mark every provider `embedded` (same host) or
+`localhosted` (same subnet). Keeping a `cloud` entry alongside is supported
+and does not compromise the local-only path — the router picks based on the
+requested model ID, not on trust level.
+
+## Observability
+
+Per-provider metrics carry the `name` from the config entry as the
+`provider` label. With two providers registered, Prometheus queries can
+split cost, latency, and error rate by name — useful for operators who want
+to prove that a given model never hit the cloud entry.
+
+## Related issues
+
+- #3424 — OpenAI-compatible provider (this feature)
+- #3414 — Air-gapped mode (this document)
+- #3410 — Prompt cache sovereignty default (already disabled)
+- W3-1 — FactSensitivity filter (consumes `deploymentTarget`)


### PR DESCRIPTION
Reopens work from closed PR #3559 (rebased onto new main + clippy docs-backticks fixes).

## Summary
- Full OpenAI Chat Completions adapter in \`crates/hermeneus/src/openai/\`
- Works for local LLMs (llama.cpp, vllm, ollama), OpenAI API, and compatible clouds
- Graceful capability degradation (missing thinking/cache omitted, never crashes)
- Adds \`DeploymentTarget\` to ProviderConfig (Cloud / LocalHosted / Embedded)
- Docs: \`docs/AIR-GAPPED.md\` deployment guide

Closes #3424 #3414. Wave 3c of the sovereignty plan.