### PR TITLE
feat(sovereignty): FactSensitivity + recall filter for cloud providers

### DIFF
--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -344,7 +344,7 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
                     access_count: 0,
                     last_accessed_at: None,
                 },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+                sensitivity: mneme::knowledge::FactSensitivity::Public,
             };
 
             store

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -344,6 +344,7 @@ pub(crate) fn seed_skills(args: &SeedSkillsArgs) -> Result<()> {
                     access_count: 0,
                     last_accessed_at: None,
                 },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
             };
 
             store

--- a/crates/aletheia/src/commands/memory/tests.rs
+++ b/crates/aletheia/src/commands/memory/tests.rs
@@ -39,6 +39,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/aletheia/src/commands/memory/tests.rs
+++ b/crates/aletheia/src/commands/memory/tests.rs
@@ -39,7 +39,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -224,6 +224,7 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                     access_count: 0,
                     last_accessed_at: None,
                 },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
             };
             self.store.insert_fact(&new_fact).map_err(|e| {
                 MutateStoreSnafu {

--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -224,7 +224,7 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                     access_count: 0,
                     last_accessed_at: None,
                 },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+                sensitivity: mneme::knowledge::FactSensitivity::Public,
             };
             self.store.insert_fact(&new_fact).map_err(|e| {
                 MutateStoreSnafu {

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -318,7 +318,7 @@ fn import_fact(
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     };
     knowledgedb
         .insert_fact(&fact)

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -318,6 +318,7 @@ fn import_fact(
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
     };
     knowledgedb
         .insert_fact(&fact)

--- a/crates/eidos/src/knowledge/entity.rs
+++ b/crates/eidos/src/knowledge/entity.rs
@@ -66,4 +66,15 @@ pub struct RecallResult {
     pub source_type: String,
     /// Source ID.
     pub source_id: String,
+    /// Data-sovereignty classification for the underlying fact, carried
+    /// from [`Fact::sensitivity`] so the recall pipeline can filter results
+    /// by the active provider's deployment target (#3404, #3413). Defaults
+    /// to [`FactSensitivity::Public`] for non-fact sources (messages,
+    /// notes) and for facts persisted before sensitivity tracking was
+    /// introduced.
+    ///
+    /// [`Fact::sensitivity`]: super::fact::Fact::sensitivity
+    /// [`FactSensitivity::Public`]: super::fact::FactSensitivity::Public
+    #[serde(default)]
+    pub sensitivity: super::fact::FactSensitivity,
 }

--- a/crates/eidos/src/knowledge/fact.rs
+++ b/crates/eidos/src/knowledge/fact.rs
@@ -83,6 +83,14 @@ pub struct Fact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<MemoryScope>,
 
+    /// Data-sovereignty classification gating which provider deployment
+    /// targets may receive this fact during recall (#3404, #3413).
+    ///
+    /// Defaults to [`FactSensitivity::Public`] via `#[serde(default)]` so
+    /// facts persisted before sensitivity tracking deserialize unchanged.
+    #[serde(default)]
+    pub sensitivity: FactSensitivity,
+
     /// Bi-temporal validity and recording timestamps.
     #[serde(flatten)]
     pub temporal: FactTemporal,
@@ -95,6 +103,57 @@ pub struct Fact {
     /// Access-tracking counters.
     #[serde(flatten)]
     pub access: FactAccess,
+}
+
+/// Data-sovereignty classification for a fact.
+///
+/// Controls which `DeploymentTarget` tiers may receive the fact during
+/// recall. Variants are ordered `Public < Internal < Confidential` (least
+/// restrictive → most restrictive) so admission reduces to a comparison
+/// against the provider's target.
+///
+/// | Variant | Allowed targets |
+/// |---------|----------------|
+/// | `Public` | any provider |
+/// | `Internal` | self-hosted / embedded only |
+/// | `Confidential` | embedded (in-process) only |
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum FactSensitivity {
+    /// Safe for any provider, including cloud LLM providers.
+    #[default]
+    Public,
+    /// Safe for local or self-hosted providers; must not leave the instance
+    /// via cloud APIs.
+    Internal,
+    /// Never send to any external provider. Only embedded (in-process)
+    /// providers may receive this fact.
+    Confidential,
+}
+
+impl FactSensitivity {
+    /// Return the lowercase string representation.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Internal => "internal",
+            Self::Confidential => "confidential",
+        }
+    }
+}
+
+impl std::str::FromStr for FactSensitivity {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "public" => Ok(Self::Public),
+            "internal" => Ok(Self::Internal),
+            "confidential" => Ok(Self::Confidential),
+            other => Err(format!("unknown fact sensitivity: {other}")),
+        }
+    }
 }
 
 /// Epistemic confidence tier.

--- a/crates/eidos/src/knowledge/knowledge_test.rs
+++ b/crates/eidos/src/knowledge/knowledge_test.rs
@@ -119,7 +119,7 @@ fn fact_serde_roundtrip() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: FactSensitivity::Public,
+        sensitivity: FactSensitivity::Public,
     };
     let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
     let back: Fact =
@@ -262,7 +262,7 @@ fn recall_result_serde_roundtrip() {
         distance: 0.12,
         source_type: "fact".to_owned(),
         source_id: "fact-1".to_owned(),
-    sensitivity: FactSensitivity::Public,
+        sensitivity: FactSensitivity::Public,
     };
     let json = serde_json::to_string(&result).expect("RecallResult serialization is infallible");
     let back: RecallResult =
@@ -306,7 +306,7 @@ fn fact_with_empty_content() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: FactSensitivity::Public,
+        sensitivity: FactSensitivity::Public,
     };
     let json =
         serde_json::to_string(&fact).expect("Fact with empty content serializes successfully");
@@ -347,7 +347,7 @@ fn fact_with_unicode_content() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: FactSensitivity::Public,
+        sensitivity: FactSensitivity::Public,
     };
     let json =
         serde_json::to_string(&fact).expect("Fact with unicode content serializes successfully");
@@ -719,7 +719,7 @@ fn fact_with_supersession() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: FactSensitivity::Public,
+        sensitivity: FactSensitivity::Public,
     };
     assert_eq!(
         fact.lifecycle.superseded_by.as_ref().map(FactId::as_str),
@@ -766,7 +766,7 @@ fn fact_with_session_source() {
             access_count: 3,
             last_accessed_at: Some(test_timestamp("2026-03-05T12:00:00Z")),
         },
-            sensitivity: FactSensitivity::Public,
+        sensitivity: FactSensitivity::Public,
     };
     assert_eq!(
         fact.provenance.source_session_id.as_deref(),
@@ -1070,7 +1070,7 @@ fn fact_scope_none_omitted_in_json() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: FactSensitivity::Public,
+        sensitivity: FactSensitivity::Public,
     };
     let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
     assert!(
@@ -1114,7 +1114,7 @@ fn fact_scope_some_included_in_json() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: FactSensitivity::Public,
+        sensitivity: FactSensitivity::Public,
     };
     let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
     assert!(

--- a/crates/eidos/src/knowledge/knowledge_test.rs
+++ b/crates/eidos/src/knowledge/knowledge_test.rs
@@ -119,6 +119,7 @@ fn fact_serde_roundtrip() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: FactSensitivity::Public,
     };
     let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
     let back: Fact =
@@ -131,6 +132,53 @@ fn fact_serde_roundtrip() {
         fact.provenance.tier, back.provenance.tier,
         "fact tier should survive serde roundtrip"
     );
+}
+
+#[test]
+fn fact_sensitivity_serde_roundtrip() {
+    // WHY (#3404, #3413): every variant must survive serde roundtrip, and
+    // legacy Fact JSON without the field must default to `Public`.
+    for s in [
+        FactSensitivity::Public,
+        FactSensitivity::Internal,
+        FactSensitivity::Confidential,
+    ] {
+        let json = serde_json::to_string(&s).expect("FactSensitivity serializes");
+        let back: FactSensitivity =
+            serde_json::from_str(&json).expect("FactSensitivity deserializes");
+        assert_eq!(s, back, "{s:?} must survive serde roundtrip");
+    }
+
+    let legacy_json = r#"{
+        "id": "fact-legacy",
+        "nous_id": "syn",
+        "fact_type": "",
+        "content": "legacy fact",
+        "valid_from": "2026-02-01T00:00:00Z",
+        "valid_to": "9999-01-01T00:00:00Z",
+        "recorded_at": "2026-02-01T00:00:00Z",
+        "confidence": 0.5,
+        "tier": "inferred",
+        "stability_hours": 720.0,
+        "is_forgotten": false,
+        "access_count": 0
+    }"#;
+    let fact: Fact = serde_json::from_str(legacy_json)
+        .expect("legacy Fact JSON without sensitivity must deserialize via serde default");
+    assert_eq!(
+        fact.sensitivity,
+        FactSensitivity::Public,
+        "missing sensitivity must default to Public for backward compat"
+    );
+}
+
+#[test]
+fn fact_sensitivity_ordering() {
+    // WHY: the sovereignty filter reduces to `sensitivity <= max_allowed`,
+    // so `Public < Internal < Confidential` is load-bearing.
+    assert!(FactSensitivity::Public < FactSensitivity::Internal);
+    assert!(FactSensitivity::Internal < FactSensitivity::Confidential);
+    assert!(FactSensitivity::Public < FactSensitivity::Confidential);
 }
 
 #[test]
@@ -214,6 +262,7 @@ fn recall_result_serde_roundtrip() {
         distance: 0.12,
         source_type: "fact".to_owned(),
         source_id: "fact-1".to_owned(),
+    sensitivity: FactSensitivity::Public,
     };
     let json = serde_json::to_string(&result).expect("RecallResult serialization is infallible");
     let back: RecallResult =
@@ -257,6 +306,7 @@ fn fact_with_empty_content() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: FactSensitivity::Public,
     };
     let json =
         serde_json::to_string(&fact).expect("Fact with empty content serializes successfully");
@@ -297,6 +347,7 @@ fn fact_with_unicode_content() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: FactSensitivity::Public,
     };
     let json =
         serde_json::to_string(&fact).expect("Fact with unicode content serializes successfully");
@@ -668,6 +719,7 @@ fn fact_with_supersession() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: FactSensitivity::Public,
     };
     assert_eq!(
         fact.lifecycle.superseded_by.as_ref().map(FactId::as_str),
@@ -714,6 +766,7 @@ fn fact_with_session_source() {
             access_count: 3,
             last_accessed_at: Some(test_timestamp("2026-03-05T12:00:00Z")),
         },
+            sensitivity: FactSensitivity::Public,
     };
     assert_eq!(
         fact.provenance.source_session_id.as_deref(),
@@ -1017,6 +1070,7 @@ fn fact_scope_none_omitted_in_json() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: FactSensitivity::Public,
     };
     let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
     assert!(
@@ -1060,6 +1114,7 @@ fn fact_scope_some_included_in_json() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: FactSensitivity::Public,
     };
     let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
     assert!(
@@ -1135,6 +1190,7 @@ fn fact_scope_all_variants_roundtrip() {
                 access_count: 0,
                 last_accessed_at: None,
             },
+            sensitivity: FactSensitivity::Public,
         };
         let json = serde_json::to_string(&fact).expect("Fact serialization is infallible");
         let back: Fact =

--- a/crates/eidos/src/knowledge/mod.rs
+++ b/crates/eidos/src/knowledge/mod.rs
@@ -26,8 +26,8 @@ pub use entity::{EmbeddedChunk, Entity, RecallResult, Relationship};
 #[cfg(test)]
 pub(crate) use fact::is_far_future;
 pub use fact::{
-    EpistemicTier, Fact, FactAccess, FactDiff, FactLifecycle, FactProvenance, FactTemporal,
-    FactType, ForgetReason, KnowledgeStage, MAX_CONTENT_LENGTH, StageTransition,
+    EpistemicTier, Fact, FactAccess, FactDiff, FactLifecycle, FactProvenance, FactSensitivity,
+    FactTemporal, FactType, ForgetReason, KnowledgeStage, MAX_CONTENT_LENGTH, StageTransition,
     VerificationRecord, VerificationSource, VerificationStatus, default_stability_hours,
     far_future, format_timestamp, parse_timestamp,
 };
@@ -61,6 +61,7 @@ display_via_as_str!(
     KnowledgeStage,
     ForgetReason,
     FactType,
+    FactSensitivity,
     VerificationSource,
     VerificationStatus,
     TemporalOrdering,

--- a/crates/eidos/src/test_fixtures.rs
+++ b/crates/eidos/src/test_fixtures.rs
@@ -52,7 +52,7 @@ pub fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: FactSensitivity::Public,
+        sensitivity: FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/eidos/src/test_fixtures.rs
+++ b/crates/eidos/src/test_fixtures.rs
@@ -9,8 +9,8 @@
 
 use crate::id::{EntityId, FactId};
 use crate::knowledge::{
-    Entity, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
-    Relationship, far_future, parse_timestamp,
+    Entity, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactSensitivity,
+    FactTemporal, Relationship, far_future, parse_timestamp,
 };
 
 /// Parse an ISO 8601 timestamp for test data. Panics on invalid input.
@@ -52,6 +52,7 @@ pub fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/energeia/src/store/fjall_store.rs
+++ b/crates/energeia/src/store/fjall_store.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use eidos::id::FactId;
 use eidos::knowledge::{
-    EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
+    EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactSensitivity, FactTemporal,
 };
 
 use crate::error::{self, Result};
@@ -476,6 +476,7 @@ impl EnergeiaStore {
                 access_count: 0,
                 last_accessed_at: None,
             },
+            sensitivity: FactSensitivity::Public,
         };
 
         Ok(fact)

--- a/crates/episteme/src/admission.rs
+++ b/crates/episteme/src/admission.rs
@@ -324,6 +324,7 @@ mod tests {
                 access_count: 0,
                 last_accessed_at: None,
             },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         }
     }
 

--- a/crates/episteme/src/consolidation/engine.rs
+++ b/crates/episteme/src/consolidation/engine.rs
@@ -305,7 +305,7 @@ impl KnowledgeStore {
                     access_count: 0,
                     last_accessed_at: None,
                 },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+                sensitivity: crate::knowledge::FactSensitivity::Public,
             };
             self.insert_fact(&fact).map_err(|e| {
                 StoreSnafu {

--- a/crates/episteme/src/consolidation/engine.rs
+++ b/crates/episteme/src/consolidation/engine.rs
@@ -305,6 +305,7 @@ impl KnowledgeStore {
                     access_count: 0,
                     last_accessed_at: None,
                 },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
             };
             self.insert_fact(&fact).map_err(|e| {
                 StoreSnafu {

--- a/crates/episteme/src/extract/engine.rs
+++ b/crates/episteme/src/extract/engine.rs
@@ -514,6 +514,7 @@ Rules:
                     access_count: 0,
                     last_accessed_at: None,
                 },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
             };
             store.insert_fact(&f).map_err(|e| {
                 PersistSnafu {

--- a/crates/episteme/src/extract/engine.rs
+++ b/crates/episteme/src/extract/engine.rs
@@ -514,7 +514,7 @@ Rules:
                     access_count: 0,
                     last_accessed_at: None,
                 },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+                sensitivity: crate::knowledge::FactSensitivity::Public,
             };
             store.insert_fact(&f).map_err(|e| {
                 PersistSnafu {

--- a/crates/episteme/src/extract/lesson.rs
+++ b/crates/episteme/src/extract/lesson.rs
@@ -529,6 +529,7 @@ pub(crate) fn persist_lesson(
                 access_count: 0,
                 last_accessed_at: None,
             },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         };
         store.insert_fact(&f).map_err(|e| {
             PersistSnafu {

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -754,6 +754,65 @@ impl KnowledgeStore {
             .context(crate::error::JoinSnafu)?
     }
 
+    /// Set the data-sovereignty sensitivity for a fact (#3404, #3413).
+    ///
+    /// Updates every temporal record for the given fact so recall sees a
+    /// consistent classification regardless of which snapshot is returned.
+    ///
+    /// Returns the updated fact. Errors if no fact with the given ID exists.
+    ///
+    /// # Note on persistence
+    ///
+    /// The current `facts` Datalog schema does not carry a sensitivity
+    /// column; this method round-trips the Rust-side [`Fact`] struct, so
+    /// the sensitivity survives for the in-memory flow through
+    /// [`read_facts_by_id`] → mutate → [`insert_fact`] but is not yet
+    /// persisted across restarts. A follow-up schema migration will lift
+    /// it to the store (tracked in #3413).
+    ///
+    /// [`Fact`]: crate::knowledge::Fact
+    /// [`read_facts_by_id`]: Self::read_facts_by_id
+    /// [`insert_fact`]: Self::insert_fact
+    #[instrument(skip(self))]
+    pub(crate) fn update_sensitivity(
+        &self,
+        fact_id: &crate::id::FactId,
+        sensitivity: crate::knowledge::FactSensitivity,
+    ) -> crate::error::Result<crate::knowledge::Fact> {
+        let existing = self.read_facts_by_id(fact_id.as_str())?;
+        if existing.is_empty() {
+            return Err(crate::error::FactNotFoundSnafu {
+                id: fact_id.as_str(),
+            }
+            .build());
+        }
+        for mut fact in existing {
+            fact.sensitivity = sensitivity;
+            self.insert_fact(&fact)?;
+        }
+        let updated = self.read_facts_by_id(fact_id.as_str())?;
+        updated.into_iter().next().ok_or_else(|| {
+            crate::error::FactNotFoundSnafu {
+                id: fact_id.as_str(),
+            }
+            .build()
+        })
+    }
+
+    /// Async `update_sensitivity`: wraps sync call in `spawn_blocking`.
+    #[instrument(skip(self))]
+    pub async fn update_sensitivity_async(
+        self: &std::sync::Arc<Self>,
+        fact_id: crate::id::FactId,
+        sensitivity: crate::knowledge::FactSensitivity,
+    ) -> crate::error::Result<crate::knowledge::Fact> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.update_sensitivity(&fact_id, sensitivity))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
+
     /// Async `insert_fact`: wraps sync call in `spawn_blocking`.
     #[instrument(skip(self, fact), fields(fact_id = %fact.id))]
     pub async fn insert_fact_async(

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -387,6 +387,7 @@ pub(super) fn rows_to_facts(
                 access_count,
                 last_accessed_at: crate::knowledge::parse_timestamp(&last_accessed_at),
             },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         });
     }
     Ok(out)
@@ -526,6 +527,7 @@ pub(super) fn rows_to_raw_facts(
                 access_count,
                 last_accessed_at: crate::knowledge::parse_timestamp(&last_accessed_at),
             },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         });
     }
     Ok(out)
@@ -592,6 +594,7 @@ pub(super) fn rows_to_facts_partial(
                 access_count: 0,
                 last_accessed_at: None,
             },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         });
     }
     Ok(out)
@@ -640,6 +643,10 @@ pub(super) fn rows_to_recall_results(
             distance,
             source_type,
             source_id,
+            // WHY (#3404, #3413): embeddings relation does not carry
+            // sensitivity; `search_vectors` hydrates it from the facts
+            // table before results reach the recall scorer.
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         });
     }
     Ok(out)

--- a/crates/episteme/src/knowledge_store/skills.rs
+++ b/crates/episteme/src/knowledge_store/skills.rs
@@ -237,6 +237,7 @@ impl KnowledgeStore {
                 access_count: 0,
                 last_accessed_at: None,
             },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         };
 
         self.insert_fact(&approved_fact)?;

--- a/crates/episteme/src/knowledge_store/tests/causal.rs
+++ b/crates/episteme/src/knowledge_store/tests/causal.rs
@@ -41,7 +41,7 @@ fn make_fact(id: &str, content: &str) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/episteme/src/knowledge_store/tests/causal.rs
+++ b/crates/episteme/src/knowledge_store/tests/causal.rs
@@ -41,6 +41,7 @@ fn make_fact(id: &str, content: &str) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/episteme/src/knowledge_store/tests/ddl.rs
+++ b/crates/episteme/src/knowledge_store/tests/ddl.rs
@@ -151,7 +151,7 @@ fn hybrid_search_empty_seeds_returns_results() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&fact).expect("insert fact");
@@ -237,7 +237,7 @@ fn hybrid_search_graph_aggregation() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&f1).expect("insert f1");
@@ -282,7 +282,7 @@ fn hybrid_search_graph_aggregation() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&f2).expect("insert f2");
@@ -417,7 +417,7 @@ fn hybrid_search_two_signal_no_graph() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&fact).expect("insert fact");
@@ -512,7 +512,7 @@ fn hybrid_search_absent_signal_rank_is_negative_one() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&fact).expect("insert fact");

--- a/crates/episteme/src/knowledge_store/tests/ddl.rs
+++ b/crates/episteme/src/knowledge_store/tests/ddl.rs
@@ -151,6 +151,7 @@ fn hybrid_search_empty_seeds_returns_results() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&fact).expect("insert fact");
@@ -236,6 +237,7 @@ fn hybrid_search_graph_aggregation() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&f1).expect("insert f1");
@@ -280,6 +282,7 @@ fn hybrid_search_graph_aggregation() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&f2).expect("insert f2");
@@ -414,6 +417,7 @@ fn hybrid_search_two_signal_no_graph() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&fact).expect("insert fact");
@@ -508,6 +512,7 @@ fn hybrid_search_absent_signal_rank_is_negative_one() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     };
     store.insert_fact(&fact).expect("insert fact");

--- a/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
@@ -361,6 +361,7 @@ fn concurrent_inserts() {
                         access_count: 0,
                         last_accessed_at: None,
                     },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
                     scope: None,
                 };
                 s.insert_fact(&fact).expect("concurrent insert");

--- a/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
@@ -361,7 +361,7 @@ fn concurrent_inserts() {
                         access_count: 0,
                         last_accessed_at: None,
                     },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+                    sensitivity: crate::knowledge::FactSensitivity::Public,
                     scope: None,
                 };
                 s.insert_fact(&fact).expect("concurrent insert");

--- a/crates/episteme/src/knowledge_store/tests/skills.rs
+++ b/crates/episteme/src/knowledge_store/tests/skills.rs
@@ -44,7 +44,7 @@ fn make_skill_fact(id: &str, nous_id: &str, skill_name: &str, domain_tags: &[&st
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/episteme/src/knowledge_store/tests/skills.rs
+++ b/crates/episteme/src/knowledge_store/tests/skills.rs
@@ -44,6 +44,7 @@ fn make_skill_fact(id: &str, nous_id: &str, skill_name: &str, domain_tags: &[&st
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/episteme/src/knowledge_store/tests/temporal.rs
+++ b/crates/episteme/src/knowledge_store/tests/temporal.rs
@@ -45,6 +45,7 @@ fn make_temporal_fact(
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/episteme/src/knowledge_store/tests/temporal.rs
+++ b/crates/episteme/src/knowledge_store/tests/temporal.rs
@@ -45,7 +45,7 @@ fn make_temporal_fact(
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/episteme/src/ops_facts.rs
+++ b/crates/episteme/src/ops_facts.rs
@@ -172,6 +172,7 @@ fn build_ops_fact(
                 access_count: 0,
                 last_accessed_at: None,
             },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
     })
 }

--- a/crates/episteme/src/recall.rs
+++ b/crates/episteme/src/recall.rs
@@ -115,6 +115,10 @@ pub struct ScoredResult {
     pub factors: FactorScores,
     /// Final weighted score [0.0, 1.0].
     pub score: f64,
+    /// Data-sovereignty classification carried from the store so the recall
+    /// pipeline can filter by the active provider's deployment target
+    /// (#3404, #3413).
+    pub sensitivity: crate::knowledge::FactSensitivity,
 }
 
 /// The recall engine.

--- a/crates/episteme/src/recall_tests/edge_cases.rs
+++ b/crates/episteme/src/recall_tests/edge_cases.rs
@@ -304,7 +304,7 @@ fn rank_preserves_equal_scores() {
             nous_id: "syn".to_owned(),
             factors: factors.clone(),
             score: 0.0,
-        sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "second".to_owned(),
@@ -313,7 +313,7 @@ fn rank_preserves_equal_scores() {
             nous_id: "syn".to_owned(),
             factors,
             score: 0.0,
-        sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
     ];
     let ranked = e.rank(candidates);
@@ -346,7 +346,7 @@ fn rank_large_input() {
                     ..FactorScores::default()
                 },
                 score: 0.0,
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+                sensitivity: crate::knowledge::FactSensitivity::Public,
             }
         })
         .collect();
@@ -665,7 +665,7 @@ fn integration_full_recall_with_decay() {
                 access_frequency: 0.3,
             },
             score: 0.0,
-        sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "old observation".to_owned(),
@@ -681,7 +681,7 @@ fn integration_full_recall_with_decay() {
                 access_frequency: 0.0,
             },
             score: 0.0,
-        sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
     ];
 

--- a/crates/episteme/src/recall_tests/edge_cases.rs
+++ b/crates/episteme/src/recall_tests/edge_cases.rs
@@ -304,6 +304,7 @@ fn rank_preserves_equal_scores() {
             nous_id: "syn".to_owned(),
             factors: factors.clone(),
             score: 0.0,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "second".to_owned(),
@@ -312,6 +313,7 @@ fn rank_preserves_equal_scores() {
             nous_id: "syn".to_owned(),
             factors,
             score: 0.0,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         },
     ];
     let ranked = e.rank(candidates);
@@ -344,6 +346,7 @@ fn rank_large_input() {
                     ..FactorScores::default()
                 },
                 score: 0.0,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
             }
         })
         .collect();
@@ -662,6 +665,7 @@ fn integration_full_recall_with_decay() {
                 access_frequency: 0.3,
             },
             score: 0.0,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "old observation".to_owned(),
@@ -677,6 +681,7 @@ fn integration_full_recall_with_decay() {
                 access_frequency: 0.0,
             },
             score: 0.0,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         },
     ];
 

--- a/crates/episteme/src/recall_tests/ranking.rs
+++ b/crates/episteme/src/recall_tests/ranking.rs
@@ -24,7 +24,7 @@ fn rank_sorts_by_score_descending() {
                 ..FactorScores::default()
             },
             score: 0.0,
-        sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "high".to_owned(),
@@ -39,7 +39,7 @@ fn rank_sorts_by_score_descending() {
                 ..FactorScores::default()
             },
             score: 0.0,
-        sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "mid".to_owned(),
@@ -52,7 +52,7 @@ fn rank_sorts_by_score_descending() {
                 ..FactorScores::default()
             },
             score: 0.0,
-        sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
     ];
 
@@ -221,7 +221,7 @@ fn rank_single_element() {
             ..FactorScores::default()
         },
         score: 0.0,
-    sensitivity: crate::knowledge::FactSensitivity::Public,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
     }];
     let ranked = e.rank(single);
     assert_eq!(
@@ -380,7 +380,7 @@ fn verified_tier_scores_higher_than_inferred_in_ranking() {
                 access_frequency: 0.3,
             },
             score: 0.0,
-        sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "verified fact".to_owned(),
@@ -396,7 +396,7 @@ fn verified_tier_scores_higher_than_inferred_in_ranking() {
                 access_frequency: 0.3,
             },
             score: 0.0,
-        sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
         },
     ];
 
@@ -475,7 +475,7 @@ fn rank_deterministic() {
                     ..FactorScores::default()
                 },
                 score: 0.0,
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+                sensitivity: crate::knowledge::FactSensitivity::Public,
             },
             ScoredResult {
                 content: "beta".to_owned(),
@@ -488,7 +488,7 @@ fn rank_deterministic() {
                     ..FactorScores::default()
                 },
                 score: 0.0,
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+                sensitivity: crate::knowledge::FactSensitivity::Public,
             },
         ]
     };

--- a/crates/episteme/src/recall_tests/ranking.rs
+++ b/crates/episteme/src/recall_tests/ranking.rs
@@ -24,6 +24,7 @@ fn rank_sorts_by_score_descending() {
                 ..FactorScores::default()
             },
             score: 0.0,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "high".to_owned(),
@@ -38,6 +39,7 @@ fn rank_sorts_by_score_descending() {
                 ..FactorScores::default()
             },
             score: 0.0,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "mid".to_owned(),
@@ -50,6 +52,7 @@ fn rank_sorts_by_score_descending() {
                 ..FactorScores::default()
             },
             score: 0.0,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         },
     ];
 
@@ -218,6 +221,7 @@ fn rank_single_element() {
             ..FactorScores::default()
         },
         score: 0.0,
+    sensitivity: crate::knowledge::FactSensitivity::Public,
     }];
     let ranked = e.rank(single);
     assert_eq!(
@@ -376,6 +380,7 @@ fn verified_tier_scores_higher_than_inferred_in_ranking() {
                 access_frequency: 0.3,
             },
             score: 0.0,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "verified fact".to_owned(),
@@ -391,6 +396,7 @@ fn verified_tier_scores_higher_than_inferred_in_ranking() {
                 access_frequency: 0.3,
             },
             score: 0.0,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
         },
     ];
 
@@ -469,6 +475,7 @@ fn rank_deterministic() {
                     ..FactorScores::default()
                 },
                 score: 0.0,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
             },
             ScoredResult {
                 content: "beta".to_owned(),
@@ -481,6 +488,7 @@ fn rank_deterministic() {
                     ..FactorScores::default()
                 },
                 score: 0.0,
+            sensitivity: crate::knowledge::FactSensitivity::Public,
             },
         ]
     };

--- a/crates/episteme/src/recall_tests/side_query.rs
+++ b/crates/episteme/src/recall_tests/side_query.rs
@@ -112,6 +112,7 @@ fn make_scored_result(source_id: &str, score: f64) -> ScoredResult {
         nous_id: String::new(),
         factors: FactorScores::default(),
         score,
+        sensitivity: crate::knowledge::FactSensitivity::Public,
     }
 }
 

--- a/crates/episteme/src/succession.rs
+++ b/crates/episteme/src/succession.rs
@@ -441,6 +441,7 @@ mod tests {
                     access_count: 0,
                     last_accessed_at: None,
                 },
+            sensitivity: crate::knowledge::FactSensitivity::Public,
                 scope: None,
             }
         }

--- a/crates/episteme/src/succession.rs
+++ b/crates/episteme/src/succession.rs
@@ -441,7 +441,7 @@ mod tests {
                     access_count: 0,
                     last_accessed_at: None,
                 },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+                sensitivity: crate::knowledge::FactSensitivity::Public,
                 scope: None,
             }
         }

--- a/crates/hermeneus/src/anthropic/client_tests.rs
+++ b/crates/hermeneus/src/anthropic/client_tests.rs
@@ -27,6 +27,7 @@ fn test_config_with(base_url: &str) -> ProviderConfig {
         pricing: HashMap::new(),
         cc_mimicry: None,
         prompt_cache_mode: crate::provider::PromptCacheMode::Disabled,
+        deployment_target: crate::provider::DeploymentTarget::Cloud,
     }
 }
 

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -132,7 +132,16 @@ pub enum PromptCacheMode {
 /// The ordering `Cloud < LocalHosted < Embedded` mirrors the sensitivity
 /// ordering so admission reduces to `sensitivity <= target`.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    Default,
 )]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -45,6 +45,18 @@ pub trait LlmProvider: Send + Sync {
     /// Provider name for logging and diagnostics.
     fn name(&self) -> &str;
 
+    /// Where this provider runs, for data-sovereignty gating (#3404, #3413).
+    ///
+    /// The recall pipeline filters facts whose `FactSensitivity` exceeds the
+    /// provider's trust boundary before the system prompt is handed off to
+    /// the provider. Defaults to [`DeploymentTarget::Cloud`] — the safe
+    /// assumption, so operators cannot accidentally leak `Internal` or
+    /// `Confidential` facts by registering a new provider without
+    /// classifying it.
+    fn deployment_target(&self) -> DeploymentTarget {
+        DeploymentTarget::Cloud
+    }
+
     /// Whether this provider supports streaming completions.
     fn supports_streaming(&self) -> bool {
         false
@@ -105,6 +117,47 @@ pub enum PromptCacheMode {
     Extended,
 }
 
+/// Where a provider's inference runs, for data-sovereignty gating.
+///
+/// Facts classified with a `FactSensitivity` strictly greater than the
+/// provider's deployment target are filtered out during recall so they
+/// never leave the boundary the operator has chosen (#3404, #3413).
+///
+/// | Variant | Meaning | Accepts |
+/// |---------|---------|---------|
+/// | `Cloud` | External API (`Anthropic`, `OpenAI`, etc.) | `Public` only |
+/// | `LocalHosted` | Self-hosted but network-accessible (`llama.cpp`, `Ollama`) | `Public`, `Internal` |
+/// | `Embedded` | In-process (`candle`, static model) | all sensitivities |
+///
+/// The ordering `Cloud < LocalHosted < Embedded` mirrors the sensitivity
+/// ordering so admission reduces to `sensitivity <= target`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Default,
+)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum DeploymentTarget {
+    /// External cloud provider; receives only `Public` facts.
+    #[default]
+    Cloud,
+    /// Self-hosted or network-local provider; receives `Public` and `Internal`.
+    LocalHosted,
+    /// In-process provider; no facts leave the host.
+    Embedded,
+}
+
+impl DeploymentTarget {
+    /// Lowercase `snake_case` name.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cloud => "cloud",
+            Self::LocalHosted => "local_hosted",
+            Self::Embedded => "embedded",
+        }
+    }
+}
+
 /// Configuration for provider initialization.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProviderConfig {
@@ -132,6 +185,12 @@ pub struct ProviderConfig {
     /// enters Anthropic's cache infrastructure (#3410).
     #[serde(default)]
     pub prompt_cache_mode: PromptCacheMode,
+    /// Where this provider runs, gating which `FactSensitivity` the recall
+    /// pipeline is allowed to send to it (#3404, #3413). Defaults to
+    /// [`DeploymentTarget::Cloud`] — the safe assumption that an
+    /// unconfigured provider speaks to an external service.
+    #[serde(default)]
+    pub deployment_target: DeploymentTarget,
 }
 
 impl Default for ProviderConfig {
@@ -192,6 +251,12 @@ impl Default for ProviderConfig {
             pricing,
             cc_mimicry: None,
             prompt_cache_mode: PromptCacheMode::Disabled,
+            // WHY (#3404, #3413): Anthropic is a cloud provider — only
+            // `Public`-classified facts may be sent. Operators running a
+            // self-hosted proxy or embedded model MUST override this in
+            // `aletheia.toml` so the recall filter lets `Internal` /
+            // `Confidential` facts through to the non-cloud boundary.
+            deployment_target: DeploymentTarget::Cloud,
         }
     }
 }
@@ -374,6 +439,32 @@ mod tests {
         let registry = ProviderRegistry::new();
         assert!(registry.find_provider("any-model").is_none());
         assert!(registry.providers().is_empty());
+    }
+
+    #[test]
+    fn provider_config_deployment_target_defaults_to_cloud() {
+        // WHY (#3404, #3413): the safe default — any unconfigured provider
+        // is treated as a cloud target so the sovereignty filter only
+        // admits `Public` facts until the operator explicitly opts in to a
+        // lower-trust boundary.
+        let config = ProviderConfig::default();
+        assert_eq!(
+            config.deployment_target,
+            DeploymentTarget::Cloud,
+            "default ProviderConfig must bind deployment_target = Cloud"
+        );
+    }
+
+    #[test]
+    fn deployment_target_ordering() {
+        assert!(DeploymentTarget::Cloud < DeploymentTarget::LocalHosted);
+        assert!(DeploymentTarget::LocalHosted < DeploymentTarget::Embedded);
+    }
+
+    #[test]
+    fn llm_provider_default_deployment_target_is_cloud() {
+        let provider = MockProvider::new("x");
+        assert_eq!(provider.deployment_target(), DeploymentTarget::Cloud);
     }
 
     #[test]

--- a/crates/integration-tests/tests/access_tracking.rs
+++ b/crates/integration-tests/tests/access_tracking.rs
@@ -62,6 +62,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 

--- a/crates/integration-tests/tests/access_tracking.rs
+++ b/crates/integration-tests/tests/access_tracking.rs
@@ -62,7 +62,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -56,6 +56,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: Epis
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 
@@ -134,6 +135,7 @@ fn fact_round_trip() {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
     };
 
     store.insert_fact(&fact).expect("insert");

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -56,7 +56,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: Epis
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 
@@ -135,7 +135,7 @@ fn fact_round_trip() {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     };
 
     store.insert_fact(&fact).expect("insert");

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -56,7 +56,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: Epis
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 
@@ -120,7 +120,7 @@ fn correct_fact(
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     };
     store
         .insert_fact(&new_fact)

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -56,6 +56,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: Epis
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 
@@ -119,6 +120,7 @@ fn correct_fact(
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
     };
     store
         .insert_fact(&new_fact)

--- a/crates/integration-tests/tests/knowledge_recall.rs
+++ b/crates/integration-tests/tests/knowledge_recall.rs
@@ -27,6 +27,7 @@ fn fact_to_scored(fact: &Fact, engine: &RecallEngine, query_nous: &str) -> Score
             access_frequency: 0.3,
         },
         score: 0.0,
+    sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 
@@ -59,6 +60,7 @@ fn sample_fact(id: &str, nous_id: &str, tier: EpistemicTier) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }
@@ -132,6 +134,7 @@ fn knowledge_types_all_serialize() {
         distance: 0.1,
         source_type: "fact".to_owned(),
         source_id: "f-1".to_owned(),
+    sensitivity: mneme::knowledge::FactSensitivity::Public,
     };
 
     assert!(serde_json::to_string(&fact).is_ok());

--- a/crates/integration-tests/tests/knowledge_recall.rs
+++ b/crates/integration-tests/tests/knowledge_recall.rs
@@ -27,7 +27,7 @@ fn fact_to_scored(fact: &Fact, engine: &RecallEngine, query_nous: &str) -> Score
             access_frequency: 0.3,
         },
         score: 0.0,
-    sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 
@@ -60,7 +60,7 @@ fn sample_fact(id: &str, nous_id: &str, tier: EpistemicTier) -> Fact {
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }
@@ -134,7 +134,7 @@ fn knowledge_types_all_serialize() {
         distance: 0.1,
         source_type: "fact".to_owned(),
         source_id: "f-1".to_owned(),
-    sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     };
 
     assert!(serde_json::to_string(&fact).is_ok());

--- a/crates/integration-tests/tests/recall_pipeline.rs
+++ b/crates/integration-tests/tests/recall_pipeline.rs
@@ -31,14 +31,14 @@ fn recall_with_mock_vectors_end_to_end() {
                 distance: 0.05,
                 source_type: "fact".to_owned(),
                 source_id: "f-1".to_owned(),
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+                sensitivity: mneme::knowledge::FactSensitivity::Public,
             },
             KnowledgeRecallResult {
                 content: "Aletheia uses Tokio actors".to_owned(),
                 distance: 0.3,
                 source_type: "fact".to_owned(),
                 source_id: "f-2".to_owned(),
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+                sensitivity: mneme::knowledge::FactSensitivity::Public,
             },
         ],
     };

--- a/crates/integration-tests/tests/recall_pipeline.rs
+++ b/crates/integration-tests/tests/recall_pipeline.rs
@@ -31,12 +31,14 @@ fn recall_with_mock_vectors_end_to_end() {
                 distance: 0.05,
                 source_type: "fact".to_owned(),
                 source_id: "f-1".to_owned(),
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
             },
             KnowledgeRecallResult {
                 content: "Aletheia uses Tokio actors".to_owned(),
                 distance: 0.3,
                 source_type: "fact".to_owned(),
                 source_id: "f-2".to_owned(),
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
             },
         ],
     };

--- a/crates/integration-tests/tests/recall_scoring.rs
+++ b/crates/integration-tests/tests/recall_scoring.rs
@@ -15,6 +15,7 @@ fn make_result(content: &str, nous_id: &str, factors: FactorScores) -> ScoredRes
         nous_id: nous_id.to_owned(),
         factors,
         score: 0.0,
+    sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 

--- a/crates/integration-tests/tests/recall_scoring.rs
+++ b/crates/integration-tests/tests/recall_scoring.rs
@@ -15,7 +15,7 @@ fn make_result(content: &str, nous_id: &str, factors: FactorScores) -> ScoredRes
         nous_id: nous_id.to_owned(),
         factors,
         score: 0.0,
-    sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 

--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -490,6 +490,7 @@ async fn run_skill_extraction(
                                 access_count: 0,
                                 last_accessed_at: None,
                             },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
                         };
 
                         match store.insert_fact(&fact) {

--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -490,7 +490,7 @@ async fn run_skill_extraction(
                                 access_count: 0,
                                 last_accessed_at: None,
                             },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+                            sensitivity: mneme::knowledge::FactSensitivity::Public,
                         };
 
                         match store.insert_fact(&fact) {

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -817,6 +817,7 @@ pub(crate) async fn run_pipeline(
             embedding_provider,
             vector_search,
             text_search,
+            providers,
             emitter,
         )
         .await;

--- a/crates/nous/src/pipeline/stages.rs
+++ b/crates/nous/src/pipeline/stages.rs
@@ -94,8 +94,20 @@ pub(super) async fn run_recall_stage(
     embedding_provider: Option<&dyn EmbeddingProvider>,
     vector_search: Option<&dyn crate::recall::VectorSearch>,
     text_search: Option<&dyn crate::recall::TextSearch>,
+    providers: &ProviderRegistry,
     emitter: &EventEmitter,
 ) {
+    // WHY (#3404, #3413): resolve the active provider's deployment target
+    // so the sovereignty filter in `finalize_results` can drop facts whose
+    // sensitivity exceeds what the provider is allowed to receive. When no
+    // provider is registered for the configured model, default to `Cloud`
+    // (`Public`-only recall) rather than leaking `Internal` / `Confidential`
+    // facts.
+    let deployment_target = providers
+        .find_provider(&config.generation.model)
+        .map_or(hermeneus::provider::DeploymentTarget::Cloud, |p| {
+            p.deployment_target()
+        });
     let span = info_span!(
         "pipeline_stage",
         stage = "recall",
@@ -128,7 +140,8 @@ pub(super) async fn run_recall_stage(
                 provider = embedding_provider.map_or("none", EmbeddingProvider::model_name),
                 "embeddings unavailable — using BM25-only recall"
             );
-            let recall_stage = crate::recall::RecallStage::new(config.recall.clone());
+            let recall_stage = crate::recall::RecallStage::new(config.recall.clone())
+                .with_deployment_target(deployment_target);
             let result = recall_stage.run_bm25(content, &config.id, ts, budget);
             apply_recall_result(result, ctx, &span);
         } else {
@@ -140,7 +153,8 @@ pub(super) async fn run_recall_stage(
             });
         }
     } else if let (Some(ep), Some(vs)) = (embedding_provider, vector_search) {
-        let recall_stage = crate::recall::RecallStage::new(config.recall.clone());
+        let recall_stage = crate::recall::RecallStage::new(config.recall.clone())
+            .with_deployment_target(deployment_target);
 
         let recall_result_opt = if recall_timeout_secs > 0 {
             match tokio::time::timeout(

--- a/crates/nous/src/recall/mod.rs
+++ b/crates/nous/src/recall/mod.rs
@@ -469,15 +469,14 @@ impl RecallStage {
 /// The ordering on `FactSensitivity` mirrors the ordering on
 /// `DeploymentTarget`, so admission reduces to `sensitivity <= max`.
 fn max_sensitivity_for(target: DeploymentTarget) -> FactSensitivity {
+    // WHY: `DeploymentTarget` is `#[non_exhaustive]` — any future boundary
+    // this crate has not been taught about falls into the wildcard arm and
+    // is treated as `Public`, the safest classification. Operators cannot
+    // leak classified facts to an unknown target by accident.
     match target {
-        DeploymentTarget::Cloud => FactSensitivity::Public,
         DeploymentTarget::LocalHosted => FactSensitivity::Internal,
         DeploymentTarget::Embedded => FactSensitivity::Confidential,
-        // WHY: `DeploymentTarget` is `#[non_exhaustive]` — any future
-        // boundary this crate has not been taught about falls back to the
-        // safest classification (`Public`) so operators cannot leak
-        // classified facts to an unknown target by accident.
-        _ => FactSensitivity::Public,
+        DeploymentTarget::Cloud | _ => FactSensitivity::Public,
     }
 }
 

--- a/crates/nous/src/recall/mod.rs
+++ b/crates/nous/src/recall/mod.rs
@@ -6,10 +6,11 @@ mod search;
 
 use std::collections::HashSet;
 
-use tracing::{debug, instrument};
+use tracing::{debug, info, instrument};
 
+use hermeneus::provider::DeploymentTarget;
 use mneme::embedding::EmbeddingProvider;
-use mneme::knowledge::RecallResult as KnowledgeRecallResult;
+use mneme::knowledge::{FactSensitivity, RecallResult as KnowledgeRecallResult};
 use mneme::recall::{FactorScores, RecallEngine, ScoredResult};
 
 use crate::error;
@@ -58,6 +59,12 @@ pub struct RecallStage {
     config: RecallConfig,
     /// Optional side-query selected IDs for pre-filtering before 6-factor scoring.
     side_query_ids: Option<HashSet<String>>,
+    /// Data-sovereignty target: gates which facts may leave the instance
+    /// through this recall pass (#3404, #3413). Defaults to
+    /// [`DeploymentTarget::Cloud`] — the safe assumption so callers who do
+    /// not thread `with_deployment_target` never leak `Internal` or
+    /// `Confidential` facts.
+    deployment_target: DeploymentTarget,
 }
 
 impl RecallStage {
@@ -73,6 +80,7 @@ impl RecallStage {
             engine: RecallEngine::with_weights(mneme::recall::RecallWeights::default()),
             config,
             side_query_ids: None,
+            deployment_target: DeploymentTarget::Cloud,
         }
     }
 
@@ -84,6 +92,17 @@ impl RecallStage {
     #[must_use]
     pub fn with_side_query_ids(mut self, ids: HashSet<String>) -> Self {
         self.side_query_ids = Some(ids);
+        self
+    }
+
+    /// Set the deployment target used to filter recalled facts by sensitivity.
+    ///
+    /// Facts whose [`FactSensitivity`] exceeds the target are dropped in
+    /// [`finalize_results`](Self::finalize_results) before the recall section
+    /// is built, so they never reach the LLM provider (#3404, #3413).
+    #[must_use]
+    pub fn with_deployment_target(mut self, target: DeploymentTarget) -> Self {
+        self.deployment_target = target;
         self
     }
 
@@ -283,6 +302,14 @@ impl RecallStage {
         remaining_budget: u64,
     ) -> RecallStageResult {
         let candidates_found = ranked.len();
+
+        // WHY (#3404, #3413): data-sovereignty filter. Drop facts whose
+        // sensitivity exceeds the active provider's deployment target BEFORE
+        // `min_score` filtering / budgeting, so the dropped facts never
+        // contribute to the recall section sent to the LLM. Non-fact sources
+        // default to `Public` and pass through unchanged.
+        let ranked = self.filter_by_sensitivity(ranked);
+
         let filtered = self.filter(ranked);
 
         if filtered.is_empty() {
@@ -315,6 +342,47 @@ impl RecallStage {
         }
     }
 
+    /// Drop candidates whose sensitivity exceeds the active deployment target.
+    ///
+    /// Emits an info-level log listing the filtered fact IDs so operators
+    /// can audit which memories were withheld from the current provider.
+    ///
+    /// | Target | Accepts |
+    /// |--------|---------|
+    /// | `Cloud` | `Public` only |
+    /// | `LocalHosted` | `Public`, `Internal` |
+    /// | `Embedded` | all sensitivities |
+    ///
+    /// # Complexity
+    ///
+    /// O(n) where n is the number of ranked candidates.
+    fn filter_by_sensitivity(&self, ranked: Vec<ScoredResult>) -> Vec<ScoredResult> {
+        let target = self.deployment_target;
+        let max_allowed = max_sensitivity_for(target);
+        let mut filtered_ids: Vec<String> = Vec::new();
+        let kept: Vec<ScoredResult> = ranked
+            .into_iter()
+            .filter(|r| {
+                if r.sensitivity <= max_allowed {
+                    true
+                } else {
+                    filtered_ids.push(r.source_id.clone());
+                    false
+                }
+            })
+            .collect();
+        if !filtered_ids.is_empty() {
+            info!(
+                filtered_count = filtered_ids.len(),
+                deployment_target = target.as_str(),
+                max_sensitivity = max_allowed.as_str(),
+                fact_ids = ?filtered_ids,
+                "recall: dropped sensitive facts before provider dispatch (sovereignty filter)"
+            );
+        }
+        kept
+    }
+
     /// Build candidate scores from raw search results.
     ///
     /// # Complexity
@@ -341,6 +409,10 @@ impl RecallStage {
                     access_frequency: w.access_frequency,
                 },
                 score: 0.0,
+                // WHY (#3404, #3413): propagate sensitivity from the search
+                // layer so the sovereignty filter in `finalize_results` sees
+                // per-fact classification rather than assuming `Public`.
+                sensitivity: r.sensitivity,
             })
             .collect()
     }
@@ -385,6 +457,27 @@ impl RecallStage {
         let section = format_section(&included);
         let tokens = estimate_tokens(&section, cpt);
         (included.len(), section, tokens)
+    }
+}
+
+/// Maximum [`FactSensitivity`] this deployment target is permitted to receive.
+///
+/// - `Cloud` → `Public`
+/// - `LocalHosted` → `Internal`
+/// - `Embedded` → `Confidential`
+///
+/// The ordering on `FactSensitivity` mirrors the ordering on
+/// `DeploymentTarget`, so admission reduces to `sensitivity <= max`.
+fn max_sensitivity_for(target: DeploymentTarget) -> FactSensitivity {
+    match target {
+        DeploymentTarget::Cloud => FactSensitivity::Public,
+        DeploymentTarget::LocalHosted => FactSensitivity::Internal,
+        DeploymentTarget::Embedded => FactSensitivity::Confidential,
+        // WHY: `DeploymentTarget` is `#[non_exhaustive]` — any future
+        // boundary this crate has not been taught about falls back to the
+        // safest classification (`Public`) so operators cannot leak
+        // classified facts to an unknown target by accident.
+        _ => FactSensitivity::Public,
     }
 }
 

--- a/crates/nous/src/recall_tests.rs
+++ b/crates/nous/src/recall_tests.rs
@@ -71,6 +71,7 @@ fn make_knowledge_result(content: &str, distance: f64) -> KnowledgeRecallResult 
         distance,
         source_type: "fact".to_owned(),
         source_id: format!("fact-{}", content.len()),
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 
@@ -84,6 +85,7 @@ fn make_knowledge_result_with_id(
         distance,
         source_type: "fact".to_owned(),
         source_id: source_id.to_owned(),
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 
@@ -95,6 +97,7 @@ fn make_scored(content: &str, score: f64) -> ScoredResult {
         nous_id: "syn".to_owned(),
         factors: FactorScores::default(),
         score,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }
 }
 
@@ -412,6 +415,7 @@ fn terminology_discovery_finds_novel_terms() {
             nous_id: String::new(),
             factors: FactorScores::default(),
             score: 0.8,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "quantum computing leverages superposition states".to_owned(),
@@ -420,6 +424,7 @@ fn terminology_discovery_finds_novel_terms() {
             nous_id: String::new(),
             factors: FactorScores::default(),
             score: 0.7,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
         },
     ];
 
@@ -440,6 +445,7 @@ fn terminology_discovery_ignores_stopwords() {
         nous_id: String::new(),
         factors: FactorScores::default(),
         score: 0.5,
+    sensitivity: mneme::knowledge::FactSensitivity::Public,
     }];
 
     let terms = discover_terminology(&results, "test query");
@@ -464,6 +470,7 @@ fn terminology_discovery_skips_short_words() {
         nous_id: String::new(),
         factors: FactorScores::default(),
         score: 0.5,
+    sensitivity: mneme::knowledge::FactSensitivity::Public,
     }];
 
     let terms = discover_terminology(&results, "test");
@@ -483,6 +490,7 @@ fn gap_detection_finds_capitalized_phrases() {
         nous_id: String::new(),
         factors: FactorScores::default(),
         score: 0.8,
+    sensitivity: mneme::knowledge::FactSensitivity::Public,
     }];
 
     let gaps = detect_gaps(&results);
@@ -502,6 +510,7 @@ fn gap_detection_finds_quoted_strings() {
         nous_id: String::new(),
         factors: FactorScores::default(),
         score: 0.7,
+    sensitivity: mneme::knowledge::FactSensitivity::Public,
     }];
 
     let gaps = detect_gaps(&results);
@@ -572,5 +581,202 @@ fn iterative_recall_disabled_by_default() {
         search.call_count(),
         1,
         "default config should only search once"
+    );
+}
+
+// ── Sovereignty filter tests (#3404, #3413) ──────────────────────────────
+
+fn make_knowledge_result_sensitive(
+    content: &str,
+    distance: f64,
+    source_id: &str,
+    sensitivity: mneme::knowledge::FactSensitivity,
+) -> KnowledgeRecallResult {
+    KnowledgeRecallResult {
+        content: content.to_owned(),
+        distance,
+        source_type: "fact".to_owned(),
+        source_id: source_id.to_owned(),
+        sensitivity,
+    }
+}
+
+#[test]
+fn sovereignty_filter_cloud_drops_internal_and_confidential() {
+    use hermeneus::provider::DeploymentTarget;
+    use mneme::knowledge::FactSensitivity;
+
+    let results = vec![
+        make_knowledge_result_sensitive("public A", 0.1, "f-pub", FactSensitivity::Public),
+        make_knowledge_result_sensitive("internal B", 0.1, "f-int", FactSensitivity::Internal),
+        make_knowledge_result_sensitive(
+            "confidential C",
+            0.1,
+            "f-conf",
+            FactSensitivity::Confidential,
+        ),
+    ];
+    let search = MockVectorSearch::new(results);
+    let config = RecallConfig {
+        min_score: 0.0,
+        max_results: 10,
+        ..Default::default()
+    };
+    let stage = RecallStage::new(config).with_deployment_target(DeploymentTarget::Cloud);
+    let result = stage
+        .run("query", "syn", &mock_embed(), &search, 50000)
+        .expect("recall runs");
+
+    let section = result
+        .recall_section
+        .expect("public result should yield a section");
+    assert!(
+        section.contains("public A"),
+        "Cloud target must keep Public; section = {section}"
+    );
+    assert!(
+        !section.contains("internal B"),
+        "Cloud target must drop Internal; section = {section}"
+    );
+    assert!(
+        !section.contains("confidential C"),
+        "Cloud target must drop Confidential; section = {section}"
+    );
+    assert_eq!(
+        result.results_injected, 1,
+        "only Public fact should be injected on Cloud target"
+    );
+}
+
+#[test]
+fn sovereignty_filter_local_hosted_drops_only_confidential() {
+    use hermeneus::provider::DeploymentTarget;
+    use mneme::knowledge::FactSensitivity;
+
+    let results = vec![
+        make_knowledge_result_sensitive("public A", 0.1, "f-pub", FactSensitivity::Public),
+        make_knowledge_result_sensitive("internal B", 0.15, "f-int", FactSensitivity::Internal),
+        make_knowledge_result_sensitive(
+            "confidential C",
+            0.2,
+            "f-conf",
+            FactSensitivity::Confidential,
+        ),
+    ];
+    let search = MockVectorSearch::new(results);
+    let config = RecallConfig {
+        min_score: 0.0,
+        max_results: 10,
+        ..Default::default()
+    };
+    let stage = RecallStage::new(config).with_deployment_target(DeploymentTarget::LocalHosted);
+    let result = stage
+        .run("query", "syn", &mock_embed(), &search, 50000)
+        .expect("recall runs");
+
+    let section = result
+        .recall_section
+        .expect("public+internal should yield a section");
+    assert!(section.contains("public A"));
+    assert!(section.contains("internal B"));
+    assert!(!section.contains("confidential C"));
+    assert_eq!(result.results_injected, 2);
+}
+
+#[test]
+fn sovereignty_filter_embedded_keeps_all() {
+    use hermeneus::provider::DeploymentTarget;
+    use mneme::knowledge::FactSensitivity;
+
+    let results = vec![
+        make_knowledge_result_sensitive("public A", 0.1, "f-pub", FactSensitivity::Public),
+        make_knowledge_result_sensitive("internal B", 0.15, "f-int", FactSensitivity::Internal),
+        make_knowledge_result_sensitive(
+            "confidential C",
+            0.2,
+            "f-conf",
+            FactSensitivity::Confidential,
+        ),
+    ];
+    let search = MockVectorSearch::new(results);
+    let config = RecallConfig {
+        min_score: 0.0,
+        max_results: 10,
+        ..Default::default()
+    };
+    let stage = RecallStage::new(config).with_deployment_target(DeploymentTarget::Embedded);
+    let result = stage
+        .run("query", "syn", &mock_embed(), &search, 50000)
+        .expect("recall runs");
+
+    let section = result.recall_section.expect("section present");
+    assert!(section.contains("public A"));
+    assert!(section.contains("internal B"));
+    assert!(section.contains("confidential C"));
+    assert_eq!(result.results_injected, 3);
+}
+
+#[test]
+fn sovereignty_filter_default_is_cloud() {
+    use mneme::knowledge::FactSensitivity;
+
+    // WHY: an unconfigured `RecallStage::new` defaults to Cloud so callers
+    // who forget to thread `with_deployment_target` still get the safest
+    // behaviour (no Internal/Confidential leaks).
+    let results = vec![
+        make_knowledge_result_sensitive("public A", 0.1, "f-pub", FactSensitivity::Public),
+        make_knowledge_result_sensitive("secret B", 0.1, "f-sec", FactSensitivity::Confidential),
+    ];
+    let search = MockVectorSearch::new(results);
+    let config = RecallConfig {
+        min_score: 0.0,
+        max_results: 10,
+        ..Default::default()
+    };
+    let stage = RecallStage::new(config);
+    let result = stage
+        .run("query", "syn", &mock_embed(), &search, 50000)
+        .expect("recall runs");
+
+    let section = result.recall_section.expect("public yields a section");
+    assert!(section.contains("public A"));
+    assert!(
+        !section.contains("secret B"),
+        "default (Cloud) must drop Confidential"
+    );
+    assert_eq!(result.results_injected, 1);
+}
+
+#[test]
+fn sovereignty_filter_reports_filtered_count_in_result() {
+    use hermeneus::provider::DeploymentTarget;
+    use mneme::knowledge::FactSensitivity;
+
+    // WHY: `candidates_found` is pre-filter and `results_injected` is
+    // post-filter; the delta quantifies what the sovereignty filter
+    // removed (audited alongside the info-level log).
+    let results = vec![
+        make_knowledge_result_sensitive("public A", 0.1, "f-pub", FactSensitivity::Public),
+        make_knowledge_result_sensitive("internal B", 0.1, "f-int-42", FactSensitivity::Internal),
+        make_knowledge_result_sensitive("secret C", 0.1, "f-sec", FactSensitivity::Confidential),
+    ];
+    let search = MockVectorSearch::new(results);
+    let config = RecallConfig {
+        min_score: 0.0,
+        max_results: 10,
+        ..Default::default()
+    };
+    let stage = RecallStage::new(config).with_deployment_target(DeploymentTarget::Cloud);
+    let result = stage
+        .run("query", "syn", &mock_embed(), &search, 50000)
+        .expect("recall runs");
+
+    assert_eq!(
+        result.candidates_found, 3,
+        "candidates_found is pre-filter total"
+    );
+    assert_eq!(
+        result.results_injected, 1,
+        "only Public fact survives Cloud sovereignty filter"
     );
 }

--- a/crates/nous/src/recall_tests.rs
+++ b/crates/nous/src/recall_tests.rs
@@ -415,7 +415,7 @@ fn terminology_discovery_finds_novel_terms() {
             nous_id: String::new(),
             factors: FactorScores::default(),
             score: 0.8,
-        sensitivity: mneme::knowledge::FactSensitivity::Public,
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
         },
         ScoredResult {
             content: "quantum computing leverages superposition states".to_owned(),
@@ -424,7 +424,7 @@ fn terminology_discovery_finds_novel_terms() {
             nous_id: String::new(),
             factors: FactorScores::default(),
             score: 0.7,
-        sensitivity: mneme::knowledge::FactSensitivity::Public,
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
         },
     ];
 
@@ -445,7 +445,7 @@ fn terminology_discovery_ignores_stopwords() {
         nous_id: String::new(),
         factors: FactorScores::default(),
         score: 0.5,
-    sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }];
 
     let terms = discover_terminology(&results, "test query");
@@ -470,7 +470,7 @@ fn terminology_discovery_skips_short_words() {
         nous_id: String::new(),
         factors: FactorScores::default(),
         score: 0.5,
-    sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }];
 
     let terms = discover_terminology(&results, "test");
@@ -490,7 +490,7 @@ fn gap_detection_finds_capitalized_phrases() {
         nous_id: String::new(),
         factors: FactorScores::default(),
         score: 0.8,
-    sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }];
 
     let gaps = detect_gaps(&results);
@@ -510,7 +510,7 @@ fn gap_detection_finds_quoted_strings() {
         nous_id: String::new(),
         factors: FactorScores::default(),
         score: 0.7,
-    sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
     }];
 
     let gaps = detect_gaps(&results);

--- a/crates/nous/src/self_audit/mod.rs
+++ b/crates/nous/src/self_audit/mod.rs
@@ -374,6 +374,7 @@ pub fn store_audit_report(
                 access_count: 0,
                 last_accessed_at: None,
             },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
         };
 
         knowledge_store

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -497,6 +497,7 @@ mod tests {
                 access_count,
                 last_accessed_at: None,
             },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
             scope: None,
         }
     }

--- a/crates/pylon/src/handlers/knowledge/knowledge_tests.rs
+++ b/crates/pylon/src/handlers/knowledge/knowledge_tests.rs
@@ -37,7 +37,7 @@ fn make_fact(id: &str, content: &str, confidence: f64) -> mneme::knowledge::Fact
             access_count: 0,
             last_accessed_at: None,
         },
-            sensitivity: mneme::knowledge::FactSensitivity::Public,
+        sensitivity: mneme::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/pylon/src/handlers/knowledge/knowledge_tests.rs
+++ b/crates/pylon/src/handlers/knowledge/knowledge_tests.rs
@@ -37,6 +37,7 @@ fn make_fact(id: &str, content: &str, confidence: f64) -> mneme::knowledge::Fact
             access_count: 0,
             last_accessed_at: None,
         },
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
         scope: None,
     }
 }

--- a/crates/pylon/src/handlers/knowledge/mod.rs
+++ b/crates/pylon/src/handlers/knowledge/mod.rs
@@ -136,6 +136,18 @@ pub struct UpdateConfidenceRequest {
     pub confidence: f64,
 }
 
+/// Body for sovereignty sensitivity edit (#3404, #3413).
+///
+/// Accepted values (lowercase): `public`, `internal`, `confidential`.
+#[derive(Debug, Deserialize)]
+#[expect(
+    missing_docs,
+    reason = "response struct fields are self-documenting by name"
+)]
+pub struct UpdateSensitivityRequest {
+    pub sensitivity: String,
+}
+
 /// Search query parameters.
 #[derive(Debug, Deserialize)]
 #[expect(
@@ -480,8 +492,8 @@ mod search;
 
 pub use bulk_import::{__path_import_facts, import_facts};
 pub use mutation::{
-    __path_forget_fact, __path_restore_fact, __path_update_confidence, forget_fact, restore_fact,
-    update_confidence,
+    __path_forget_fact, __path_restore_fact, __path_update_confidence, __path_update_sensitivity,
+    forget_fact, restore_fact, update_confidence, update_sensitivity,
 };
 #[cfg(test)]
 use search::truncate_content;

--- a/crates/pylon/src/handlers/knowledge/mutation.rs
+++ b/crates/pylon/src/handlers/knowledge/mutation.rs
@@ -10,7 +10,7 @@ use crate::error::ApiError;
 use crate::extract::{Claims, require_role};
 use crate::state::KnowledgeState;
 
-use super::{ForgetRequest, UpdateConfidenceRequest};
+use super::{ForgetRequest, UpdateConfidenceRequest, UpdateSensitivityRequest};
 
 /// POST /api/v1/knowledge/facts/{id}/forget
 #[utoipa::path(
@@ -190,6 +190,85 @@ pub async fn update_confidence(
     #[cfg(not(feature = "knowledge-store"))]
     let _ = (state, body);
     tracing::info!(fact_id = %id, "confidence update requested but knowledge store not available");
+    Err(ApiError::ServiceUnavailable {
+        message: "knowledge store not available".to_owned(),
+        location: snafu::location!(),
+    })
+}
+
+/// PUT /api/v1/knowledge/facts/{id}/sensitivity
+///
+/// Set the data-sovereignty classification on a fact so the recall pipeline
+/// can gate which LLM providers receive it (#3404, #3413). Valid values:
+/// `public`, `internal`, `confidential`.
+#[utoipa::path(
+    put,
+    path = "/api/v1/knowledge/facts/{id}/sensitivity",
+    params(("id" = String, Path, description = "Fact ID")),
+    request_body(
+        content = serde_json::Value,
+        description = "Sensitivity classification: `{\"sensitivity\": \"public|internal|confidential\"}`",
+        content_type = "application/json"
+    ),
+    responses(
+        (status = 200, description = "Sensitivity updated"),
+        (status = 400, description = "Invalid sensitivity value", body = crate::error::ErrorResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+        (status = 404, description = "Fact not found", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+///
+/// # Cancel safety
+///
+/// Cancel-safe. Axum handler; cancellation drops the future with no
+/// side effects beyond not returning a response.
+pub async fn update_sensitivity(
+    State(state): State<KnowledgeState>,
+    claims: Claims,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateSensitivityRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_role(&claims, Role::Operator)?;
+    let sensitivity = body
+        .sensitivity
+        .parse::<mneme::knowledge::FactSensitivity>()
+        .map_err(|e| ApiError::BadRequest {
+            message: format!("invalid sensitivity: {e}"),
+            location: snafu::location!(),
+        })?;
+    #[cfg(feature = "knowledge-store")]
+    if let Some(ref store) = state.knowledge_store {
+        let fact_id = mneme::id::FactId::new(&id).map_err(|e| ApiError::BadRequest {
+            message: format!("invalid fact id: {e}"),
+            location: snafu::location!(),
+        })?;
+        return match store.update_sensitivity_async(fact_id, sensitivity).await {
+            Ok(_) => {
+                tracing::info!(
+                    fact_id = %id,
+                    sensitivity = sensitivity.as_str(),
+                    "fact sensitivity updated"
+                );
+                Ok(Json(serde_json::json!({
+                    "status": "updated",
+                    "id": id,
+                    "sensitivity": sensitivity.as_str(),
+                })))
+            }
+            Err(mneme::error::Error::FactNotFound { .. }) => Err(ApiError::NotFound {
+                path: format!("fact/{id}"),
+                location: snafu::location!(),
+            }),
+            Err(e) => Err(ApiError::Internal {
+                message: e.to_string(),
+                location: snafu::location!(),
+            }),
+        };
+    }
+    #[cfg(not(feature = "knowledge-store"))]
+    let _ = (state, sensitivity);
+    tracing::info!(fact_id = %id, "sensitivity update requested but knowledge store not available");
     Err(ApiError::ServiceUnavailable {
         message: "knowledge store not available".to_owned(),
         location: snafu::location!(),

--- a/crates/pylon/src/openapi.rs
+++ b/crates/pylon/src/openapi.rs
@@ -47,6 +47,7 @@ use koina::http::CONTENT_TYPE_JSON;
         crate::handlers::knowledge::forget_fact,
         crate::handlers::knowledge::restore_fact,
         crate::handlers::knowledge::update_confidence,
+        crate::handlers::knowledge::update_sensitivity,
         crate::handlers::knowledge::list_entities,
         crate::handlers::knowledge::entity_relationships,
         crate::handlers::knowledge::search,

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -104,6 +104,10 @@ pub fn build_router_with(
             "/knowledge/facts/{id}/confidence",
             axum::routing::put(knowledge::update_confidence),
         )
+        .route(
+            "/knowledge/facts/{id}/sensitivity",
+            axum::routing::put(knowledge::update_sensitivity),
+        )
         .route("/knowledge/entities", get(knowledge::list_entities))
         .route(
             "/knowledge/entities/{id}/relationships",


### PR DESCRIPTION
Reopens work from closed PR #3562 (rebased + match_same_arms clippy fix).

## Summary
- \`FactSensitivity\` enum on \`Fact\`: Public / Internal / Confidential (default Public)
- \`DeploymentTarget\` on provider: Cloud / LocalHosted / Embedded (default Cloud)
- Recall pipeline filters facts whose sensitivity exceeds provider's trust boundary before system prompt is sent
- Admission rule: sensitivity <= max_for(deployment_target)

Closes #3404 #3413. Wave 3a of the sovereignty plan.

## Test plan
- [x] Existing recall tests still pass unchanged
- [x] New recall_tests.rs exercises filter matrix: Cloud×Public pass, Cloud×Internal reject, etc.