### PR TITLE
feat(sovereignty): prompt audit log — operator visibility into outbound LLM requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4698,6 +4698,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "snafu",
  "taxis",
  "tempfile",

--- a/crates/aletheia/src/cli.rs
+++ b/crates/aletheia/src/cli.rs
@@ -19,6 +19,7 @@ use crate::commands::eval_embeddings::EvalEmbeddingsArgs;
 use crate::commands::health::HealthArgs;
 use crate::commands::maintenance;
 use crate::commands::memory;
+use crate::commands::prompt_audit;
 use crate::commands::repl::ReplArgs;
 use crate::commands::session_export::SessionExportArgs;
 use crate::commands::tls;
@@ -70,6 +71,11 @@ pub(crate) enum Command {
     Maintenance {
         #[command(subcommand)]
         action: maintenance::Action,
+    },
+    /// Inspect the prompt audit log (outbound LLM requests)
+    PromptAudit {
+        #[command(subcommand)]
+        action: prompt_audit::Action,
     },
     /// Knowledge graph inspection and maintenance
     Memory {

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -7,7 +7,8 @@ use snafu::prelude::*;
 
 use oikonomos::maintenance::{
     AutoDreamConfig, DbMonitor, DbMonitoringConfig, DriftDetectionConfig, DriftDetector,
-    FjallBackupConfig, MaintenanceConfig, ProposeRulesConfig, TraceRotationConfig, TraceRotator,
+    FjallBackupConfig, MaintenanceConfig, ProposeRulesConfig, PromptAuditRetentionConfig,
+    PromptAuditRotator, TraceRotationConfig, TraceRotator,
 };
 use oikonomos::runner::TaskRunner;
 use taxis::loader::load_config;
@@ -40,7 +41,7 @@ pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()>
         None => Oikos::discover(),
     };
     let config = load_config(&oikos).whatever_context("failed to load config")?;
-    let maint = build_config(&oikos, &config.maintenance);
+    let maint = build_config(&oikos, &config.maintenance, &config.prompt_audit);
 
     match action {
         Action::Status { json } => {
@@ -71,6 +72,7 @@ pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()>
                     "drift-detection",
                     "db-monitor",
                     "fjall-backup",
+                    "prompt-audit-rotation",
                 ]
             } else {
                 vec![task.as_str()]
@@ -147,6 +149,15 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
                 None => println!("fjall-backup: skipped (source directory not found)"),
             }
         }
+        "prompt-audit-rotation" => {
+            let report = PromptAuditRotator::new(maint.prompt_audit.clone())
+                .prune()
+                .whatever_context("prompt audit rotation failed")?;
+            println!(
+                "prompt-audit-rotation: {} files pruned, {} bytes freed",
+                report.files_pruned, report.bytes_freed
+            );
+        }
         "self-audit" => {
             use nous::self_audit::{AuditTrigger, CheckContext, SelfAuditor};
             let mut auditor = SelfAuditor::new();
@@ -167,7 +178,7 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
             }
         }
         other => whatever!(
-            "unknown task: {other}. Valid: trace-rotation, drift-detection, db-monitor, fjall-backup, self-audit, all"
+            "unknown task: {other}. Valid: trace-rotation, drift-detection, db-monitor, fjall-backup, prompt-audit-rotation, self-audit, all"
         ),
     }
     Ok(())
@@ -179,6 +190,7 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
 pub(crate) fn build_config(
     oikos: &Oikos,
     settings: &taxis::config::MaintenanceSettings,
+    prompt_audit: &taxis::config::PromptAuditSettings,
 ) -> MaintenanceConfig {
     MaintenanceConfig {
         trace_rotation: TraceRotationConfig {
@@ -219,6 +231,14 @@ pub(crate) fn build_config(
             retention_count: settings.backup.backup_retention_count,
         },
         propose_rules: ProposeRulesConfig::default(),
+        prompt_audit: PromptAuditRetentionConfig {
+            enabled: prompt_audit.enabled,
+            log_dir: prompt_audit
+                .log_dir
+                .clone()
+                .unwrap_or_else(|| oikos.logs().join("prompt-audit")),
+            retention_days: prompt_audit.retention_days,
+        },
         cron: oikonomos::cron::CronConfig {
             evolution: oikonomos::cron::CronEvolutionConfig {
                 enabled: settings.cron_tasks.evolution.enabled,

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -7,8 +7,8 @@ use snafu::prelude::*;
 
 use oikonomos::maintenance::{
     AutoDreamConfig, DbMonitor, DbMonitoringConfig, DriftDetectionConfig, DriftDetector,
-    FjallBackupConfig, MaintenanceConfig, ProposeRulesConfig, PromptAuditRetentionConfig,
-    PromptAuditRotator, TraceRotationConfig, TraceRotator,
+    FjallBackupConfig, MaintenanceConfig, PromptAuditRetentionConfig, PromptAuditRotator,
+    ProposeRulesConfig, TraceRotationConfig, TraceRotator,
 };
 use oikonomos::runner::TaskRunner;
 use taxis::loader::load_config;

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod eval_embeddings;
 pub(crate) mod health;
 pub(crate) mod maintenance;
 pub(crate) mod memory;
+pub(crate) mod prompt_audit;
 pub(crate) mod repl;
 pub(crate) mod server;
 pub(crate) mod session_export;
@@ -72,6 +73,9 @@ pub(crate) async fn dispatch(cmd: Command, instance_root: Option<&PathBuf>) -> R
         Command::Backup(a) => backup::run(instance_root, &a).map_err(Into::into),
         Command::Maintenance { action } => {
             maintenance::run(action, instance_root).map_err(Into::into)
+        }
+        Command::PromptAudit { action } => {
+            prompt_audit::run(action, instance_root).map_err(Into::into)
         }
         Command::Memory { url, action } => memory::run(action, &url, instance_root)
             .await

--- a/crates/aletheia/src/commands/prompt_audit.rs
+++ b/crates/aletheia/src/commands/prompt_audit.rs
@@ -1,0 +1,211 @@
+//! `aletheia prompt-audit`: operator-visible record of outbound LLM requests (#3411).
+//!
+//! The audit log lives at `{instance}/logs/prompt-audit/YYYY-MM-DD.jsonl` as
+//! append-only JSONL. These commands let operators inspect that log without
+//! writing JSON-parsing one-liners.
+
+use std::path::{Path, PathBuf};
+
+use clap::Subcommand;
+use snafu::prelude::*;
+
+use nous::audit::PromptAuditRecord;
+use taxis::loader::load_config;
+use taxis::oikos::Oikos;
+
+use crate::error::Result;
+
+#[derive(Debug, Clone, Subcommand)]
+pub(crate) enum Action {
+    /// List audit records (newest first)
+    List {
+        /// Only show records at or after this date (YYYY-MM-DD).
+        #[arg(long)]
+        since: Option<String>,
+        /// Only show records for this nous id.
+        #[arg(long)]
+        nous: Option<String>,
+        /// Maximum records to print. Default: 50.
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+        /// Emit JSON instead of the human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show the full record for a specific turn timestamp
+    Show {
+        /// Record timestamp (RFC3339, e.g. 2026-04-16T12:00:00Z).
+        timestamp: String,
+    },
+}
+
+pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
+    let oikos = match instance_root {
+        Some(root) => Oikos::from_root(root),
+        None => Oikos::discover(),
+    };
+    let config = load_config(&oikos).whatever_context("failed to load config")?;
+    let log_dir = config
+        .prompt_audit
+        .log_dir
+        .clone()
+        .unwrap_or_else(|| oikos.logs().join("prompt-audit"));
+
+    match action {
+        Action::List {
+            since,
+            nous,
+            limit,
+            json,
+        } => list_records(&log_dir, since.as_deref(), nous.as_deref(), limit, json),
+        Action::Show { timestamp } => show_record(&log_dir, &timestamp),
+    }
+}
+
+fn list_records(
+    log_dir: &Path,
+    since: Option<&str>,
+    nous: Option<&str>,
+    limit: usize,
+    json: bool,
+) -> Result<()> {
+    if !log_dir.exists() {
+        println!("no audit log directory at {}", log_dir.display());
+        return Ok(());
+    }
+
+    let mut files: Vec<_> = std::fs::read_dir(log_dir)
+        .whatever_context("failed to read audit log directory")?
+        .filter_map(std::result::Result::ok)
+        .filter(|e| {
+            e.path()
+                .extension()
+                .and_then(|x| x.to_str())
+                .is_some_and(|s| s == "jsonl")
+        })
+        .collect();
+    // WHY: sort descending by filename (YYYY-MM-DD). Newest day first.
+    files.sort_by_key(|e| std::cmp::Reverse(e.file_name()));
+
+    if let Some(since) = since {
+        files.retain(|e| {
+            e.file_name()
+                .to_str()
+                .and_then(|n| n.strip_suffix(".jsonl"))
+                .is_some_and(|d| d >= since)
+        });
+    }
+
+    let mut records: Vec<PromptAuditRecord> = Vec::new();
+    for entry in files {
+        let content = std::fs::read_to_string(entry.path())
+            .whatever_context("failed to read audit log file")?;
+        // WHY: iterate lines in reverse so newest-within-day comes first.
+        for line in content.lines().rev() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<PromptAuditRecord>(line) {
+                Ok(rec) => {
+                    if let Some(id) = nous
+                        && rec.nous_id != id
+                    {
+                        continue;
+                    }
+                    records.push(rec);
+                    if records.len() >= limit {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping malformed audit record");
+                }
+            }
+        }
+        if records.len() >= limit {
+            break;
+        }
+    }
+
+    if json {
+        let out = serde_json::to_string_pretty(&records)
+            .whatever_context("failed to serialize records")?;
+        println!("{out}");
+    } else if records.is_empty() {
+        println!("no audit records matched");
+    } else {
+        println!(
+            "{:<26} {:<10} {:<12} {:<32} {:<6} {:>7}",
+            "timestamp", "nous", "provider", "model", "tools", "tokens"
+        );
+        println!("{}", "-".repeat(100));
+        for r in &records {
+            let model = shorten(&r.model, 32);
+            println!(
+                "{:<26} {:<10} {:<12} {:<32} {:<6} {:>7}",
+                r.timestamp.to_string(),
+                shorten(&r.nous_id, 10),
+                shorten(&r.provider, 12),
+                model,
+                r.tool_names.len(),
+                r.token_count_estimate
+            );
+        }
+    }
+    Ok(())
+}
+
+fn show_record(log_dir: &Path, timestamp: &str) -> Result<()> {
+    if !log_dir.exists() {
+        snafu::whatever!("no audit log directory at {}", log_dir.display());
+    }
+
+    let target: jiff::Timestamp = timestamp
+        .parse()
+        .whatever_context("invalid timestamp (expected RFC3339, e.g. 2026-04-16T12:00:00Z)")?;
+
+    // WHY: timestamp format matches the day the record was written, so open
+    // the matching day file directly rather than scanning every day.
+    let date = target.to_zoned(jiff::tz::TimeZone::UTC).date();
+    let path = log_dir.join(format!("{date}.jsonl"));
+    if !path.exists() {
+        snafu::whatever!("no audit log for {date}");
+    }
+
+    let content =
+        std::fs::read_to_string(&path).whatever_context("failed to read audit log file")?;
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let rec: PromptAuditRecord = match serde_json::from_str(line) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "skipping malformed record");
+                continue;
+            }
+        };
+        if rec.timestamp == target {
+            let out =
+                serde_json::to_string_pretty(&rec).whatever_context("serialize record")?;
+            println!("{out}");
+            return Ok(());
+        }
+    }
+
+    snafu::whatever!("no record at {timestamp}");
+}
+
+fn shorten(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_owned()
+    } else {
+        let keep = max.saturating_sub(1);
+        let end = s.floor_char_boundary(keep);
+        // WHY: `.get(..end)` cannot panic even if `end` somehow falls outside
+        // the char boundary; falling back to the full string keeps the
+        // human-readable output correct rather than aborting the list.
+        let prefix = s.get(..end).unwrap_or(s);
+        format!("{prefix}…")
+    }
+}

--- a/crates/aletheia/src/commands/prompt_audit.rs
+++ b/crates/aletheia/src/commands/prompt_audit.rs
@@ -186,8 +186,7 @@ fn show_record(log_dir: &Path, timestamp: &str) -> Result<()> {
             }
         };
         if rec.timestamp == target {
-            let out =
-                serde_json::to_string_pretty(&rec).whatever_context("serialize record")?;
+            let out = serde_json::to_string_pretty(&rec).whatever_context("serialize record")?;
             println!("{out}");
             return Ok(());
         }

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -556,6 +556,20 @@ impl RuntimeBuilder {
         #[cfg(feature = "recall")]
         let knowledge_store_for_daemon = knowledge_store.clone();
 
+        // WHY(#3411): shared prompt audit log written once per turn across
+        // all actors. Path defaults to `{instance}/logs/prompt-audit/` when
+        // the operator hasn't set an explicit `log_dir` in config.
+        let audit_log_dir = self
+            .config
+            .prompt_audit
+            .log_dir
+            .clone()
+            .unwrap_or_else(|| self.oikos.logs().join("prompt-audit"));
+        let audit_log = Arc::new(nous::audit::PromptAuditLog::new(
+            audit_log_dir,
+            self.config.prompt_audit.enabled,
+        ));
+
         let mut nous_manager = NousManager::new(
             Arc::clone(&provider_registry),
             Arc::clone(&tool_registry),
@@ -569,7 +583,8 @@ impl RuntimeBuilder {
             Some(Arc::clone(&cross_router)),
             Some(tool_services),
             self.config.nous_behavior.clone(),
-        );
+        )
+        .with_audit_log(Arc::clone(&audit_log));
 
         // Spawn nous actors
         {
@@ -638,8 +653,11 @@ impl RuntimeBuilder {
 
         if self.daemons {
             // System maintenance daemon
-            let maintenance_config =
-                maintenance::build_config(&self.oikos, &self.config.maintenance);
+            let maintenance_config = maintenance::build_config(
+                &self.oikos,
+                &self.config.maintenance,
+                &self.config.prompt_audit,
+            );
             let daemon_token = shutdown_token.child_token();
             let mut daemon_runner =
                 TaskRunner::new("system", daemon_token).with_maintenance(maintenance_config);

--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -386,6 +386,32 @@ pub(crate) async fn execute_builtin(
                 )),
             })
         }
+        BuiltinTask::PromptAuditRotation => {
+            let config = maintenance
+                .map(|m| m.prompt_audit.clone())
+                .unwrap_or_default();
+            let report = tokio::task::spawn_blocking(move || {
+                let _span = tracing::info_span!("prompt_audit_rotation").entered();
+                crate::maintenance::PromptAuditRotator::new(config).prune()
+            })
+            .await
+            .context(error::BlockingJoinSnafu {
+                context: "prompt audit rotation",
+            })??;
+
+            tracing::info!(
+                files_pruned = report.files_pruned,
+                bytes_freed = report.bytes_freed,
+                "maintenance: prompt audit rotation complete"
+            );
+            Ok(ExecutionResult {
+                success: true,
+                output: Some(format!(
+                    "{} files pruned, {} bytes freed",
+                    report.files_pruned, report.bytes_freed
+                )),
+            })
+        }
         BuiltinTask::RetentionExecution => {
             let Some(executor) = retention_executor else {
                 tracing::info!("retention execution skipped — no executor configured");
@@ -560,7 +586,8 @@ async fn execute_knowledge_task(
             | BuiltinTask::LessonExtraction
             | BuiltinTask::SelfPrompt
             | BuiltinTask::ProposeRules
-            | BuiltinTask::FjallBackup => {
+            | BuiltinTask::FjallBackup
+            | BuiltinTask::PromptAuditRotation => {
                 unreachable!("non-knowledge task routed to execute_knowledge_task")
             }
         }?;

--- a/crates/daemon/src/maintenance/mod.rs
+++ b/crates/daemon/src/maintenance/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod drift_detection;
 pub mod fjall_backup;
 /// Knowledge graph maintenance bridge trait and report types.
 pub(crate) mod knowledge;
+/// Prompt audit log retention pruning (#3411).
+pub(crate) mod prompt_audit_rotation;
 /// Data retention policy execution trait and summary types.
 pub(crate) mod retention;
 /// Trace file rotation, gzip compression, and archive pruning.
@@ -20,6 +22,9 @@ pub use drift_detection::{DriftDetectionConfig, DriftDetector, DriftReport};
 pub use fjall_backup::{FjallBackup, FjallBackupConfig, FjallBackupReport};
 pub use knowledge::{
     AutoDreamConfig, KnowledgeMaintenanceConfig, KnowledgeMaintenanceExecutor, MaintenanceReport,
+};
+pub use prompt_audit_rotation::{
+    PromptAuditRetentionConfig, PromptAuditRetentionReport, PromptAuditRotator,
 };
 pub use retention::{RetentionConfig, RetentionExecutor, RetentionSummary};
 pub use trace_rotation::{RotationReport, TraceRotationConfig, TraceRotator};
@@ -67,4 +72,6 @@ pub struct MaintenanceConfig {
     pub cron: crate::cron::CronConfig,
     /// Rule proposal generation from observed patterns.
     pub propose_rules: ProposeRulesConfig,
+    /// Prompt audit log retention pruning (#3411).
+    pub prompt_audit: PromptAuditRetentionConfig,
 }

--- a/crates/daemon/src/maintenance/prompt_audit_rotation.rs
+++ b/crates/daemon/src/maintenance/prompt_audit_rotation.rs
@@ -1,0 +1,227 @@
+//! Prompt audit log retention (#3411).
+//!
+//! Prunes daily JSONL files older than `retention_days`. The audit log itself
+//! is append-only and rotates per-day by filename (`YYYY-MM-DD.jsonl`); this
+//! task enforces the retention window.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::error;
+
+/// Configuration for prompt audit log retention.
+#[derive(Debug, Clone)]
+pub struct PromptAuditRetentionConfig {
+    /// Whether pruning is active.
+    pub enabled: bool,
+    /// Directory holding daily JSONL files.
+    pub log_dir: PathBuf,
+    /// Files older than this many days are deleted.
+    pub retention_days: u32,
+}
+
+impl Default for PromptAuditRetentionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            log_dir: PathBuf::from("logs/prompt-audit"),
+            retention_days: 90,
+        }
+    }
+}
+
+/// Outcome of a retention run.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PromptAuditRetentionReport {
+    /// Number of daily files deleted.
+    pub files_pruned: u32,
+    /// Total bytes freed.
+    pub bytes_freed: u64,
+}
+
+/// Prunes prompt-audit daily files past the retention window.
+pub struct PromptAuditRotator {
+    config: PromptAuditRetentionConfig,
+}
+
+impl PromptAuditRotator {
+    /// Create a rotator with the given configuration.
+    #[must_use]
+    pub fn new(config: PromptAuditRetentionConfig) -> Self {
+        Self { config }
+    }
+
+    /// Run retention. Delete any `*.jsonl` file whose mtime is older than
+    /// `retention_days`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the log directory cannot be read or a file cannot
+    /// be deleted. Missing log directory is treated as an empty report, not
+    /// an error, so operators can enable the feature before any requests
+    /// have been logged.
+    pub fn prune(&self) -> error::Result<PromptAuditRetentionReport> {
+        if !self.config.enabled {
+            return Ok(PromptAuditRetentionReport::default());
+        }
+        if !self.config.log_dir.exists() {
+            return Ok(PromptAuditRetentionReport::default());
+        }
+
+        let now = SystemTime::now();
+        let max_age =
+            std::time::Duration::from_secs(u64::from(self.config.retention_days) * 86_400);
+
+        let dir = fs::read_dir(&self.config.log_dir).context(error::MaintenanceIoSnafu {
+            context: format!(
+                "reading prompt audit dir {}",
+                self.config.log_dir.display()
+            ),
+        })?;
+
+        let mut report = PromptAuditRetentionReport::default();
+
+        for entry in dir {
+            let entry = entry.context(error::MaintenanceIoSnafu {
+                context: "reading prompt audit directory entry",
+            })?;
+            let path = entry.path();
+            if path.is_dir() {
+                continue;
+            }
+            // WHY: only prune `*.jsonl` files — leave any accidental sidecar
+            // files alone so operators can drop notes or reports next to the
+            // log directory without the daemon deleting them.
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+
+            let metadata = entry.metadata().context(error::MaintenanceIoSnafu {
+                context: format!("reading metadata for {}", path.display()),
+            })?;
+            let modified = metadata.modified().context(error::MaintenanceIoSnafu {
+                context: format!("reading mtime for {}", path.display()),
+            })?;
+
+            let age = now.duration_since(modified).unwrap_or_default();
+            if age > max_age {
+                let size = metadata.len();
+                fs::remove_file(&path).context(error::MaintenanceIoSnafu {
+                    context: format!("pruning {}", path.display()),
+                })?;
+                report.files_pruned += 1;
+                report.bytes_freed += size;
+                tracing::debug!(path = %path.display(), "pruned prompt audit file");
+            }
+        }
+
+        Ok(report)
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    fn write_fixture(path: &std::path::Path, content: &str) {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test fixture: synchronous write in non-async test context"
+        )]
+        fs::write(path, content).expect("write");
+        let mut perms = fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o644);
+        fs::set_permissions(path, perms).unwrap();
+    }
+
+    /// Set a file's mtime to `days_ago` days in the past.
+    ///
+    /// WHY: tests rely on rewriting mtime to simulate aging without waiting.
+    /// MSRV 1.94 provides `File::set_modified`.
+    fn set_old_mtime(path: &std::path::Path, days_ago: u64) {
+        let age = std::time::Duration::from_secs(days_ago * 86_400);
+        let mtime = SystemTime::now()
+            .checked_sub(age)
+            .expect("subtract duration");
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open for mtime");
+        file.set_modified(mtime).expect("set mtime");
+    }
+
+    #[test]
+    fn disabled_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = PromptAuditRetentionConfig {
+            enabled: false,
+            log_dir: tmp.path().to_path_buf(),
+            retention_days: 1,
+        };
+        let path = tmp.path().join("2020-01-01.jsonl");
+        write_fixture(&path, "{}\n");
+        set_old_mtime(&path, 365);
+
+        let report = PromptAuditRotator::new(config).prune().unwrap();
+        assert_eq!(report.files_pruned, 0);
+        assert!(path.exists(), "disabled rotator must not touch files");
+    }
+
+    #[test]
+    fn missing_dir_is_empty_report() {
+        let config = PromptAuditRetentionConfig {
+            enabled: true,
+            log_dir: PathBuf::from("/tmp/does-not-exist-xyz-prompt-audit-12345"),
+            retention_days: 90,
+        };
+        let report = PromptAuditRotator::new(config).prune().unwrap();
+        assert_eq!(report.files_pruned, 0);
+    }
+
+    #[test]
+    fn old_files_pruned_recent_kept() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = PromptAuditRetentionConfig {
+            enabled: true,
+            log_dir: tmp.path().to_path_buf(),
+            retention_days: 7,
+        };
+
+        let old = tmp.path().join("2020-01-01.jsonl");
+        let recent = tmp.path().join("2026-04-15.jsonl");
+        write_fixture(&old, "{}\n");
+        write_fixture(&recent, "{}\n");
+        set_old_mtime(&old, 365);
+        set_old_mtime(&recent, 1);
+
+        let report = PromptAuditRotator::new(config).prune().unwrap();
+        assert_eq!(report.files_pruned, 1);
+        assert!(!old.exists(), "old file must be pruned");
+        assert!(recent.exists(), "recent file must be kept");
+    }
+
+    #[test]
+    fn non_jsonl_files_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = PromptAuditRetentionConfig {
+            enabled: true,
+            log_dir: tmp.path().to_path_buf(),
+            retention_days: 1,
+        };
+        let note = tmp.path().join("README.txt");
+        write_fixture(&note, "operator notes\n");
+        set_old_mtime(&note, 365);
+
+        let report = PromptAuditRotator::new(config).prune().unwrap();
+        assert_eq!(report.files_pruned, 0, "non-jsonl file must be skipped");
+        assert!(note.exists(), "non-jsonl file must remain");
+    }
+}

--- a/crates/daemon/src/maintenance/prompt_audit_rotation.rs
+++ b/crates/daemon/src/maintenance/prompt_audit_rotation.rs
@@ -77,10 +77,7 @@ impl PromptAuditRotator {
             std::time::Duration::from_secs(u64::from(self.config.retention_days) * 86_400);
 
         let dir = fs::read_dir(&self.config.log_dir).context(error::MaintenanceIoSnafu {
-            context: format!(
-                "reading prompt audit dir {}",
-                self.config.log_dir.display()
-            ),
+            context: format!("reading prompt audit dir {}", self.config.log_dir.display()),
         })?;
 
         let mut report = PromptAuditRetentionReport::default();

--- a/crates/daemon/src/runner/registration.rs
+++ b/crates/daemon/src/runner/registration.rs
@@ -124,6 +124,19 @@ impl TaskRunner {
             );
         }
 
+        if config.prompt_audit.enabled {
+            // WHY: daily cadence matches the log's per-day filenames; pruning
+            // more often wastes IO. Fires at 02:00 UTC to avoid overlapping
+            // with trace rotation (03:00) and drift detection (04:00).
+            self.register_builtin(
+                "prompt-audit-rotation",
+                "Prompt audit log retention",
+                Schedule::Cron("0 0 2 * * *".to_owned()),
+                BuiltinTask::PromptAuditRotation,
+                true,
+            );
+        }
+
         self.register_cron_tasks(&config.cron);
     }
 

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -134,6 +134,8 @@ pub enum BuiltinTask {
     ProposeRules,
     /// Periodic file-level backup of the fjall knowledge store.
     FjallBackup,
+    /// Prune prompt audit log daily files past the retention window (#3411).
+    PromptAuditRotation,
 }
 
 impl Schedule {

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -37,6 +37,7 @@ prometheus-client = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -68,6 +68,12 @@ pub(crate) struct ActorServices {
     /// // WHY: lives on the actor so entries survive across turns. A single
     /// // actor services one `nous_id`, so cache lifetime tracks actor lifetime.
     pub(crate) bootstrap_cache: Arc<BootstrapFileCache>,
+    /// Prompt audit log: one record per outbound LLM request (#3411).
+    ///
+    /// // WHY: shared across all actors so the per-day JSONL file handle is
+    /// // reused instead of re-opening per turn. `None` when the feature is
+    /// // disabled in taxis config.
+    pub(crate) audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
 }
 
 /// Data stores for sessions, knowledge, and search.
@@ -171,6 +177,7 @@ impl NousActor {
         active_turn: Arc<AtomicBool>,
         turn_started_at_ms: Arc<AtomicU64>,
         nous_behavior: taxis::config::NousBehaviorConfig,
+        audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
     ) -> Self {
         #[cfg(feature = "knowledge-store")]
         let skill_loader = knowledge_store
@@ -211,6 +218,7 @@ impl NousActor {
                 bootstrap_cache: Arc::new(BootstrapFileCache::with_ttl_secs(
                     nous_behavior.bootstrap_cache_ttl_secs,
                 )),
+                audit_log,
             },
             stores: ActorStores {
                 session_store,

--- a/crates/nous/src/actor/spawn.rs
+++ b/crates/nous/src/actor/spawn.rs
@@ -52,6 +52,7 @@ pub(crate) fn spawn(
     cross_rx: Option<mpsc::Receiver<CrossNousEnvelope>>,
     cancel: CancellationToken,
     nous_behavior: taxis::config::NousBehaviorConfig,
+    audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
 ) -> (
     NousHandle,
     tokio::task::JoinHandle<()>,
@@ -85,6 +86,7 @@ pub(crate) fn spawn(
         Arc::clone(&active_turn),
         Arc::clone(&turn_started_at_ms),
         nous_behavior,
+        audit_log,
     );
 
     let span = tracing::info_span!("nous_actor", nous.id = %id);
@@ -161,6 +163,7 @@ pub fn spawn_for_daemon(
         None, // WHY: daemon-spawned children don't use cross-nous messaging
         cancel,
         taxis::config::NousBehaviorConfig::default(),
+        None, // WHY: daemon child agents share the parent's audit log via binary crate wiring
     )
 }
 

--- a/crates/nous/src/actor/tests.rs
+++ b/crates/nous/src/actor/tests.rs
@@ -70,6 +70,7 @@ fn spawn_test_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile::Tem
         None,
         CancellationToken::new(),
         taxis::config::NousBehaviorConfig::default(),
+        None,
     );
     (handle, join, dir)
 }
@@ -373,6 +374,7 @@ fn spawn_panicking_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile
         None,
         CancellationToken::new(),
         taxis::config::NousBehaviorConfig::default(),
+        None,
     );
     (handle, join, dir)
 }
@@ -545,6 +547,7 @@ fn spawn_test_actor_with_store(
         None,
         CancellationToken::new(),
         taxis::config::NousBehaviorConfig::default(),
+        None,
     );
     (handle, join, dir)
 }
@@ -588,6 +591,7 @@ fn make_test_actor(
         active_turn,
         turn_started_at_ms,
         taxis::config::NousBehaviorConfig::default(),
+        None,
     );
     (actor, tx, dir)
 }

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -386,6 +386,7 @@ impl NousActor {
         // WHY: share the bootstrap file cache across the spawned pipeline task
         // so cached workspace reads are reused turn-to-turn (#3388).
         let bootstrap_cache = Arc::clone(&self.services.bootstrap_cache);
+        let audit_log = self.services.audit_log.clone();
         tokio::spawn(
             async move {
                 #[cfg(feature = "knowledge-store")]
@@ -413,6 +414,7 @@ impl NousActor {
                             None,
                             Some(&hook_registry),
                             Some(bootstrap_cache.as_ref()),
+                            audit_log.as_deref(),
                         )
                         .await
                     }
@@ -434,6 +436,7 @@ impl NousActor {
                             None,
                             Some(&hook_registry),
                             Some(bootstrap_cache.as_ref()),
+                            audit_log.as_deref(),
                         )
                         .await
                     }
@@ -623,6 +626,7 @@ impl NousActor {
             None,
             Some(&hook_registry),
             Some(self.services.bootstrap_cache.as_ref()),
+            self.services.audit_log.as_deref(),
         )
         .await
     }

--- a/crates/nous/src/audit.rs
+++ b/crates/nous/src/audit.rs
@@ -1,0 +1,377 @@
+//! Prompt audit log: operator-visible record of every outbound LLM request.
+//!
+//! Append-only JSONL log at `{instance}/logs/prompt-audit/YYYY-MM-DD.jsonl`.
+//! Rotated daily based on the UTC calendar date of the record timestamp.
+//!
+//! # Sovereignty contract
+//!
+//! The operator owns this system and must be able to audit what it sends to
+//! external LLM providers. To keep the audit surface small and avoid turning
+//! the log into a second copy of user content, the record schema only stores:
+//!
+//! - Identifiers (nous/session/turn/request)
+//! - Provider + model
+//! - A **hash** of the system prompt (not the content)
+//! - The system prompt's byte length
+//! - Message count + token estimate
+//! - Fact IDs included via recall (not fact content)
+//! - Fact IDs filtered out by sensitivity policy (deferred to #3404)
+//! - Tool names (not tool inputs)
+//!
+//! Never logged: system prompt content, user message text, tool call
+//! arguments. The hash lets operators correlate audit records with a known
+//! prompt without storing the prompt itself.
+//!
+//! # Retention
+//!
+//! Daily files are pruned by
+//! `oikonomos::maintenance::prompt_audit_rotation::PromptAuditRotator`,
+//! configured via `taxis::config::PromptAuditSettings::retention_days`.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use jiff::Timestamp;
+use jiff::civil::Date;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use snafu::{ResultExt, Snafu};
+use tracing::{debug, warn};
+
+/// Errors from prompt audit log operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+#[expect(
+    missing_docs,
+    reason = "snafu error variant fields (source, path) are self-documenting via display format"
+)]
+pub enum PromptAuditError {
+    /// Failed to create the audit log directory.
+    #[snafu(display("failed to create prompt audit directory {}: {source}", path.display()))]
+    CreateDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Failed to open the daily JSONL file for appending.
+    #[snafu(display("failed to open prompt audit file {}: {source}", path.display()))]
+    OpenFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Failed to serialize a record to JSON.
+    #[snafu(display("failed to serialize prompt audit record: {source}"))]
+    Serialize { source: serde_json::Error },
+
+    /// Failed to write a record to the JSONL file.
+    #[snafu(display("failed to write prompt audit record to {}: {source}", path.display()))]
+    WriteRecord {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+/// Result alias for prompt audit operations.
+pub type Result<T> = std::result::Result<T, PromptAuditError>;
+
+/// Deployment target classification for a request.
+///
+/// WHY(stub): #3404 will introduce a proper `DeploymentTarget` enum shared with
+/// eidos/hermeneus for the fact sensitivity recall filter. Until then, the
+/// audit log carries a simple string default of `"cloud"` so the schema is
+/// stable and the follow-up PR only has to swap the field type.
+pub type DeploymentTarget = String;
+
+/// Sensitivity classification of a fact that was filtered from recall.
+///
+/// WHY(stub): Same as [`DeploymentTarget`] — #3404 owns the canonical enum.
+/// The audit log keeps the field in the schema now so `PromptAuditRecord` is
+/// stable; the filtered-facts vector defaults to empty until the filter lands.
+pub type FactSensitivity = String;
+
+/// A single fact that was filtered out by the sensitivity policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilteredFact {
+    /// Fact identifier from the knowledge store.
+    pub id: String,
+    /// Sensitivity tier that caused the filter to exclude the fact.
+    pub sensitivity: FactSensitivity,
+}
+
+/// One append-only audit record per outbound `CompletionRequest`.
+///
+/// See module docs for the sovereignty contract on what is and is not logged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptAuditRecord {
+    /// When the request was assembled (UTC).
+    pub timestamp: Timestamp,
+    /// Nous agent identifier (e.g. `"syn"`).
+    pub nous_id: String,
+    /// Session identifier.
+    pub session_id: String,
+    /// Turn identifier (ULID). Stable across actor restarts for a given turn.
+    pub turn_id: String,
+    /// LLM provider name (`"anthropic"`, `"cc"`, etc.).
+    pub provider: String,
+    /// Deployment target (cloud/local/…). See [`DeploymentTarget`].
+    pub deployment_target: DeploymentTarget,
+    /// Model identifier passed to the provider.
+    pub model: String,
+    /// SHA-256 of the system prompt (hex). Empty string when no system prompt.
+    pub system_prompt_hash: String,
+    /// Byte length of the system prompt.
+    pub system_prompt_bytes: usize,
+    /// Number of conversation messages in the request.
+    pub message_count: usize,
+    /// Rough token count estimate for the request.
+    pub token_count_estimate: u32,
+    /// Fact IDs whose content was included in the recall section.
+    pub fact_ids_included: Vec<String>,
+    /// Facts excluded from recall by the sensitivity filter (#3404).
+    #[serde(default)]
+    pub fact_ids_filtered: Vec<FilteredFact>,
+    /// Names of tools exposed to the model for this request.
+    pub tool_names: Vec<String>,
+    /// Request identifier propagated from pylon middleware (#3384).
+    #[serde(default)]
+    pub request_id: Option<String>,
+}
+
+/// Compute the SHA-256 hex digest of a system prompt.
+///
+/// Returns the empty string for `None` so the JSON field stays a consistent
+/// string type across records.
+#[must_use]
+pub fn hash_system_prompt(prompt: Option<&str>) -> String {
+    match prompt {
+        Some(s) => {
+            let mut hasher = Sha256::new();
+            hasher.update(s.as_bytes());
+            let digest = hasher.finalize();
+            let mut out = String::with_capacity(digest.len() * 2);
+            for byte in &digest {
+                use std::fmt::Write;
+                // kanon:ignore RUST/expect — write! on String is infallible.
+                let _ = write!(out, "{byte:02x}");
+            }
+            out
+        }
+        None => String::new(),
+    }
+}
+
+/// Append-only prompt audit log with daily rotation.
+///
+/// # Threading
+///
+/// Cloneable by sharing the same `Arc<Mutex<...>>` via [`PromptAuditLog::clone`].
+/// Internal state is guarded by a `Mutex`; contention is negligible because
+/// each write is a serialize + append of a few KB.
+#[derive(Debug)]
+pub struct PromptAuditLog {
+    inner: Mutex<PromptAuditLogInner>,
+    /// Whether logging is active. When `false`, [`PromptAuditLog::log_request`]
+    /// is a no-op that does not touch the filesystem.
+    enabled: bool,
+    log_dir: PathBuf,
+}
+
+#[derive(Debug)]
+struct PromptAuditLogInner {
+    /// Currently open day file and its calendar date.
+    current: Option<(Date, File)>,
+}
+
+impl PromptAuditLog {
+    /// Create a new audit log writing to `log_dir`.
+    ///
+    /// The directory is created lazily on first write. `enabled = false`
+    /// returns a log handle that drops every record — useful for operators
+    /// who want to disable the feature via config without threading
+    /// `Option<PromptAuditLog>` through the pipeline.
+    #[must_use]
+    pub fn new(log_dir: PathBuf, enabled: bool) -> Self {
+        Self {
+            inner: Mutex::new(PromptAuditLogInner { current: None }),
+            enabled,
+            log_dir,
+        }
+    }
+
+    /// Return the log directory.
+    #[must_use]
+    pub fn log_dir(&self) -> &Path {
+        &self.log_dir
+    }
+
+    /// Return whether logging is active.
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Append a record to today's JSONL file.
+    ///
+    /// Rotation happens on the calendar-date transition of `record.timestamp`.
+    /// A record at 23:59 on day N goes in `N.jsonl`; a record at 00:01 on
+    /// day N+1 goes in `N+1.jsonl` even if the previous file is still open.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory cannot be created, the file cannot
+    /// be opened, or the serialized line cannot be written. Callers in the
+    /// pipeline should log the error and continue; audit failure must not
+    /// break the turn.
+    pub fn log_request(&self, record: &PromptAuditRecord) -> Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        let record_date = record.timestamp.to_zoned(jiff::tz::TimeZone::UTC).date();
+        let json = serde_json::to_string(record).context(SerializeSnafu)?;
+
+        // WHY: a poisoned mutex means a panic occurred while holding the
+        // audit lock. Rather than propagate, recover the inner state and
+        // continue: the audit log is observational and must not block a
+        // turn. `.unwrap_or_else` with `into_inner` is the canonical
+        // non-panicking recovery pattern.
+        let mut inner = self.inner.lock().unwrap_or_else(|poisoned| {
+            warn!("prompt audit mutex poisoned; recovering inner state");
+            poisoned.into_inner()
+        });
+
+        let needs_rotation = match inner.current.as_ref() {
+            Some((d, _)) => *d != record_date,
+            None => true,
+        };
+
+        if needs_rotation {
+            if !self.log_dir.exists() {
+                std::fs::create_dir_all(&self.log_dir).context(CreateDirSnafu {
+                    path: self.log_dir.clone(),
+                })?;
+            }
+            let path = self.log_dir.join(format!("{record_date}.jsonl"));
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .context(OpenFileSnafu { path: path.clone() })?;
+            debug!(path = %path.display(), "rotated prompt audit log");
+            inner.current = Some((record_date, file));
+        }
+
+        // SAFETY: `needs_rotation` guarantees `current` is `Some` here.
+        #[expect(
+            clippy::expect_used,
+            reason = "current is Some: either it already was, or we just set it in the rotation branch above"
+        )]
+        let (_, file) = inner
+            .current
+            .as_mut()
+            .expect("current file populated above");
+
+        let path = self.log_dir.join(format!("{record_date}.jsonl"));
+        writeln!(file, "{json}").context(WriteRecordSnafu { path: path.clone() })?;
+        file.flush().context(WriteRecordSnafu { path })?;
+        Ok(())
+    }
+}
+
+/// Build a [`PromptAuditRecord`] from the assembled pipeline context.
+///
+/// Called once per pipeline turn, right before the execute stage hands the
+/// request to hermeneus. Never touches the system prompt content — the
+/// hash and length are the only signal that leave this function.
+///
+/// WHY(stub): `deployment_target` defaults to `"cloud"` and
+/// `fact_ids_filtered` is always empty until #3404 lands the `FactSensitivity`
+/// enum and recall-time filter. At that point this helper will read the
+/// filtered-facts list directly from `PipelineContext::recall_result`.
+pub(crate) fn build_audit_record(
+    ctx: &crate::pipeline::PipelineContext,
+    session: &crate::session::SessionState,
+    config: &crate::config::NousConfig,
+    providers: &hermeneus::provider::ProviderRegistry,
+    tools: &organon::registry::ToolRegistry,
+    tool_ctx: &organon::types::ToolContext,
+) -> PromptAuditRecord {
+    let system_prompt = ctx.system_prompt.as_deref();
+    let system_prompt_bytes = system_prompt.map_or(0, str::len);
+
+    // WHY: resolve provider from the configured model so the log reports the
+    // real route, not just the model alias. `"unknown"` keeps the log
+    // writeable when the provider is mid-reconfiguration.
+    let provider_name = providers
+        .find_provider(&config.generation.model)
+        .map_or_else(|| "unknown".to_owned(), |p| p.name().to_owned());
+
+    // WHY: tool name list mirrors the filter in execute::resolve_active_server_tools
+    // so the audit reflects what the model will actually see this turn.
+    let active_snapshot = tool_ctx
+        .active_tools
+        .read()
+        .map_or_else(|poisoned| poisoned.into_inner().clone(), |g| g.clone());
+    let mut tool_names: Vec<String> = tools
+        .to_hermeneus_tools_filtered(&active_snapshot)
+        .into_iter()
+        .map(|td| td.name)
+        .collect();
+    if let Some(allowlist) = &config.tool_allowlist {
+        tool_names.retain(|n| allowlist.iter().any(|a| a == n));
+    }
+
+    let fact_ids_included = ctx
+        .recall_result
+        .as_ref()
+        .map(|r| r.fact_ids.clone())
+        .unwrap_or_default();
+
+    // WHY: token estimate uses the same per-message estimate the pipeline
+    // already computed, plus the system-prompt byte length divided by a
+    // conservative chars-per-token heuristic. Matches the order-of-magnitude
+    // figure operators see in the tracing spans.
+    #[expect(
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        clippy::as_conversions,
+        reason = "i64→u32: per-message token estimates are positive and fit in u32 for practical turns"
+    )]
+    let msg_tokens: u32 = ctx
+        .messages
+        .iter()
+        .map(|m| m.token_estimate.max(0) as u32)
+        .sum();
+    let cpt = usize::try_from(config.generation.chars_per_token.max(1)).unwrap_or(4);
+    let sys_tokens = u32::try_from(system_prompt_bytes / cpt).unwrap_or(u32::MAX);
+    let token_count_estimate = msg_tokens.saturating_add(sys_tokens);
+
+    PromptAuditRecord {
+        timestamp: Timestamp::now(),
+        nous_id: session.nous_id.clone(),
+        session_id: session.id.clone(),
+        turn_id: session.turn_id.to_string(),
+        provider: provider_name,
+        deployment_target: "cloud".to_owned(),
+        model: config.generation.model.clone(),
+        system_prompt_hash: hash_system_prompt(system_prompt),
+        system_prompt_bytes,
+        message_count: ctx.messages.len(),
+        token_count_estimate,
+        fact_ids_included,
+        // TODO(#3404): populate from sensitivity filter when it lands.
+        fact_ids_filtered: Vec::new(),
+        tool_names,
+        // TODO(#3384 follow-up): thread request_id from pylon middleware
+        // through PipelineInput once the extraction path reaches nous.
+        request_id: None,
+    }
+}
+
+#[cfg(test)]
+#[path = "audit_tests.rs"]
+mod tests;

--- a/crates/nous/src/audit_tests.rs
+++ b/crates/nous/src/audit_tests.rs
@@ -1,0 +1,168 @@
+//! Tests for the prompt audit log.
+
+#![expect(clippy::unwrap_used, reason = "test assertions")]
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+use std::fs;
+
+use jiff::civil::date;
+use jiff::{Timestamp, ToSpan};
+
+use super::*;
+
+fn make_record(ts: Timestamp, id: &str) -> PromptAuditRecord {
+    PromptAuditRecord {
+        timestamp: ts,
+        nous_id: "syn".to_owned(),
+        session_id: "ses-1".to_owned(),
+        turn_id: id.to_owned(),
+        provider: "anthropic".to_owned(),
+        deployment_target: "cloud".to_owned(),
+        model: "claude-opus-4-20250514".to_owned(),
+        system_prompt_hash: hash_system_prompt(Some("hello system")),
+        system_prompt_bytes: "hello system".len(),
+        message_count: 2,
+        token_count_estimate: 42,
+        fact_ids_included: vec!["fact:1".to_owned(), "fact:2".to_owned()],
+        fact_ids_filtered: vec![],
+        tool_names: vec!["read".to_owned(), "write".to_owned()],
+        request_id: Some("req-abc".to_owned()),
+    }
+}
+
+#[test]
+fn hash_system_prompt_is_sha256_hex() {
+    // WHY: canonical SHA-256 of "hello" (ASCII, no trailing newline) keeps the
+    // hash format contract tied to a stable reference. If this ever changes,
+    // operators need to know — existing audit logs would become unreadable.
+    let h = hash_system_prompt(Some("hello"));
+    assert_eq!(
+        h,
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
+}
+
+#[test]
+fn hash_system_prompt_none_is_empty() {
+    assert_eq!(hash_system_prompt(None), "");
+}
+
+#[test]
+fn record_serialization_roundtrip() {
+    let ts = "2026-04-16T12:00:00Z".parse::<Timestamp>().unwrap();
+    let record = make_record(ts, "turn-1");
+    let json = serde_json::to_string(&record).expect("serialize");
+    let decoded: PromptAuditRecord = serde_json::from_str(&json).expect("decode");
+    assert_eq!(decoded.nous_id, "syn");
+    assert_eq!(decoded.fact_ids_included.len(), 2);
+    assert_eq!(decoded.tool_names, vec!["read", "write"]);
+    assert_eq!(decoded.request_id.as_deref(), Some("req-abc"));
+    assert_eq!(decoded.system_prompt_bytes, 12);
+}
+
+#[test]
+fn disabled_log_is_noop() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = PromptAuditLog::new(dir.path().to_path_buf(), false);
+    let ts = "2026-04-16T12:00:00Z".parse::<Timestamp>().unwrap();
+    log.log_request(&make_record(ts, "t1")).expect("noop ok");
+    // WHY: disabled log must not create any files, so operators can turn the
+    // feature off without leaving empty directories behind.
+    let entries = fs::read_dir(dir.path()).unwrap().count();
+    assert_eq!(entries, 0, "disabled log should not create files");
+}
+
+#[test]
+fn log_appends_record() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = PromptAuditLog::new(dir.path().join("prompt-audit"), true);
+    let ts = "2026-04-16T12:00:00Z".parse::<Timestamp>().unwrap();
+    log.log_request(&make_record(ts, "t1")).expect("write");
+    log.log_request(&make_record(ts, "t2")).expect("write");
+
+    let path = dir.path().join("prompt-audit").join("2026-04-16.jsonl");
+    let content = fs::read_to_string(&path).expect("read");
+    let lines: Vec<_> = content.lines().collect();
+    assert_eq!(lines.len(), 2, "two records written as JSONL");
+    for line in &lines {
+        let _: PromptAuditRecord = serde_json::from_str(line).expect("valid JSONL");
+    }
+}
+
+#[test]
+fn daily_rotation_boundary() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = PromptAuditLog::new(dir.path().to_path_buf(), true);
+
+    // 23:59 on 2026-04-16 → 2026-04-16.jsonl
+    let t_late = "2026-04-16T23:59:00Z".parse::<Timestamp>().unwrap();
+    // 00:01 on 2026-04-17 → 2026-04-17.jsonl
+    let t_next = "2026-04-17T00:01:00Z".parse::<Timestamp>().unwrap();
+
+    log.log_request(&make_record(t_late, "late")).unwrap();
+    log.log_request(&make_record(t_next, "next")).unwrap();
+
+    let d1 = dir.path().join("2026-04-16.jsonl");
+    let d2 = dir.path().join("2026-04-17.jsonl");
+    assert!(d1.exists(), "late record goes in day N file");
+    assert!(d2.exists(), "next record goes in day N+1 file");
+
+    let c1 = fs::read_to_string(&d1).unwrap();
+    let c2 = fs::read_to_string(&d2).unwrap();
+    assert_eq!(c1.lines().count(), 1);
+    assert_eq!(c2.lines().count(), 1);
+    assert!(c1.contains("\"turn_id\":\"late\""));
+    assert!(c2.contains("\"turn_id\":\"next\""));
+}
+
+#[test]
+fn log_does_not_contain_system_prompt_content() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = PromptAuditLog::new(dir.path().to_path_buf(), true);
+    let ts = "2026-04-16T12:00:00Z".parse::<Timestamp>().unwrap();
+
+    let sentinel = "SECRET_SOUL_MD_CONTENT_DO_NOT_LEAK";
+    let mut record = make_record(ts, "t1");
+    record.system_prompt_hash = hash_system_prompt(Some(sentinel));
+    record.system_prompt_bytes = sentinel.len();
+    log.log_request(&record).expect("write");
+
+    let path = dir.path().join("2026-04-16.jsonl");
+    let content = fs::read_to_string(&path).unwrap();
+    // WHY: the sovereignty contract is that system prompt content is hashed,
+    // not logged. If the sentinel ever appears in the log, the contract is
+    // broken.
+    assert!(
+        !content.contains(sentinel),
+        "log must not contain system prompt content"
+    );
+    assert!(
+        content.contains(&hash_system_prompt(Some(sentinel))),
+        "log must contain the hash"
+    );
+}
+
+#[test]
+fn rotation_after_seven_days() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = PromptAuditLog::new(dir.path().to_path_buf(), true);
+
+    let base = date(2026, 4, 10).at(12, 0, 0, 0).in_tz("UTC").unwrap();
+    for i in 0..7 {
+        let ts = base.checked_add(i.days()).unwrap().timestamp();
+        log.log_request(&make_record(ts, &format!("turn-{i}")))
+            .unwrap();
+    }
+
+    let files: Vec<_> = fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(std::result::Result::ok)
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| {
+            std::path::Path::new(n)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
+        })
+        .collect();
+    assert_eq!(files.len(), 7, "one file per day");
+}

--- a/crates/nous/src/lib.rs
+++ b/crates/nous/src/lib.rs
@@ -5,6 +5,8 @@
 pub(crate) mod actor;
 /// Trait adapters bridging organon tool traits to mneme SessionStore.
 pub mod adapters;
+/// Prompt audit log: operator-visible record of every outbound LLM request (#3411).
+pub mod audit;
 /// System prompt assembly from workspace files and domain packs.
 pub mod bootstrap;
 /// Token and wall-clock time budget tracking for pipeline stages.

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -89,6 +89,8 @@ pub struct NousManager {
     cancel: CancellationToken,
     /// Deployment-level behavioral configuration (health intervals, restart limits).
     nous_behavior: taxis::config::NousBehaviorConfig,
+    /// Prompt audit log shared across all actors (#3411).
+    audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
 }
 
 impl NousManager {
@@ -129,7 +131,18 @@ impl NousManager {
             ready_rx,
             cancel: CancellationToken::new(),
             nous_behavior,
+            audit_log: None,
         }
+    }
+
+    /// Attach a prompt audit log to the manager (#3411).
+    ///
+    /// All subsequently spawned actors share this log handle. Call once at
+    /// startup before spawning any agents.
+    #[must_use]
+    pub fn with_audit_log(mut self, audit_log: Arc<crate::audit::PromptAuditLog>) -> Self {
+        self.audit_log = Some(audit_log);
+        self
     }
 
     /// Signal that all actors are spawned and the system is ready for inbound messages.
@@ -241,6 +254,7 @@ impl NousManager {
             cross_rx,
             child_cancel,
             self.nous_behavior.clone(),
+            self.audit_log.clone(),
         );
 
         info!(nous_id = %id, "actor spawned");

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -766,6 +766,7 @@ pub(crate) async fn run_pipeline(
     emitter: Option<&EventEmitter>,
     hooks: Option<&HookRegistry>,
     bootstrap_cache: Option<&crate::bootstrap::BootstrapFileCache>,
+    audit_log: Option<&crate::audit::PromptAuditLog>,
 ) -> error::Result<TurnResult> {
     let default_emitter = EventEmitter::new();
     let emitter = emitter.unwrap_or(&default_emitter);
@@ -847,6 +848,28 @@ pub(crate) async fn run_pipeline(
                 hook_registry.run_before_query(&mut query_ctx).await
             {
                 return Err(error::GuardRejectedSnafu { reason }.build());
+            }
+        }
+
+        // WHY(#3411): write one prompt audit record per pipeline turn, after
+        // hooks have finished mutating context but before execute hands the
+        // CompletionRequest to hermeneus. Writing here keeps the audit
+        // surface at one record per outbound request even though execute may
+        // loop with tool-use iterations — the system prompt, tool list, and
+        // fact set are determined by the pipeline, not the tool loop. Audit
+        // failures are logged and never propagate: the log is observational
+        // and must not block a turn.
+        if let Some(log) = audit_log {
+            let record = crate::audit::build_audit_record(
+                &ctx,
+                &input.session,
+                config,
+                providers,
+                tools,
+                tool_ctx,
+            );
+            if let Err(e) = log.log_request(&record) {
+                tracing::warn!(error = %e, "prompt audit log write failed — continuing turn");
             }
         }
 

--- a/crates/nous/src/pipeline/pipeline_tests/pipeline_types.rs
+++ b/crates/nous/src/pipeline/pipeline_tests/pipeline_types.rs
@@ -292,6 +292,7 @@ async fn run_pipeline_simple() {
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("pipeline should succeed");

--- a/crates/nous/src/recall/mod.rs
+++ b/crates/nous/src/recall/mod.rs
@@ -40,6 +40,10 @@ pub struct RecallStageResult {
     pub tokens_consumed: u64,
     /// The formatted recall section (appended to system prompt).
     pub recall_section: Option<String>,
+    /// Source IDs of facts whose content was injected into the recall
+    /// section. Used by the prompt audit log (#3411) so operators can see
+    /// which stored facts were included in each outbound request.
+    pub fact_ids: Vec<String>,
 }
 
 impl RecallStageResult {
@@ -49,6 +53,7 @@ impl RecallStageResult {
             results_injected: 0,
             tokens_consumed: 0,
             recall_section: None,
+            fact_ids: Vec::new(),
         }
     }
 }
@@ -321,7 +326,8 @@ impl RecallStage {
         }
 
         let budget = remaining_budget.min(self.config.max_recall_tokens);
-        let (results_injected, section, tokens) = self.format_within_budget(&filtered, budget);
+        let (results_injected, section, tokens, fact_ids) =
+            self.format_within_budget(&filtered, budget);
 
         debug!(
             candidates_found,
@@ -339,6 +345,7 @@ impl RecallStage {
             } else {
                 Some(section)
             },
+            fact_ids,
         }
     }
 
@@ -432,11 +439,19 @@ impl RecallStage {
 
     /// Format results within the token budget.
     ///
+    /// Returns the included count, rendered section, total tokens consumed,
+    /// and the source IDs of the included facts (used by the prompt audit
+    /// log in #3411 to identify which facts were surfaced).
+    ///
     /// # Complexity
     ///
     /// O(n²) where n is the number of results, due to repeated token estimation
     /// for each incremental addition to the output.
-    fn format_within_budget(&self, results: &[ScoredResult], budget: u64) -> (usize, String, u64) {
+    fn format_within_budget(
+        &self,
+        results: &[ScoredResult],
+        budget: u64,
+    ) -> (usize, String, u64, Vec<String>) {
         let cpt = self.config.chars_per_token;
         let mut included = Vec::with_capacity(results.len());
 
@@ -451,12 +466,13 @@ impl RecallStage {
         }
 
         if included.is_empty() {
-            return (0, String::new(), 0);
+            return (0, String::new(), 0, Vec::new());
         }
 
         let section = format_section(&included);
         let tokens = estimate_tokens(&section, cpt);
-        (included.len(), section, tokens)
+        let fact_ids = included.iter().map(|r| r.source_id.clone()).collect();
+        (included.len(), section, tokens, fact_ids)
     }
 }
 

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -174,6 +174,7 @@ impl SpawnService for SpawnServiceImpl {
                     None,
                     ephemeral_cancel,
                     taxis::config::NousBehaviorConfig::default(),
+                    None,
                 );
 
                 info!(session_key = %session_key, "ephemeral actor started");

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -519,6 +519,43 @@ impl Default for CronTaskEntry {
     }
 }
 
+/// Prompt audit log configuration (#3411).
+///
+/// Controls the operator-visible append-only JSONL log of every outbound
+/// LLM `CompletionRequest`. See `nous::audit` for the record schema and
+/// sovereignty contract on what is (and is not) logged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct PromptAuditSettings {
+    /// Whether outbound requests are recorded. Default: `true`.
+    ///
+    /// WHY default-on: this is a sovereignty feature — operators need
+    /// visibility into what the system sends to external providers without
+    /// opting in. The log stores hashes and IDs, not content, so the cost
+    /// of enabling it is small.
+    pub enabled: bool,
+    /// Directory for daily JSONL files. When `None`, resolves to
+    /// `{instance}/logs/prompt-audit/` at startup.
+    pub log_dir: Option<PathBuf>,
+    /// Days to retain JSONL files before the daemon prunes them.
+    pub retention_days: u32,
+    /// Whether the IDs of facts filtered by the sensitivity policy (#3404)
+    /// are included in each record. Default: `true`.
+    pub include_filtered_ids: bool,
+}
+
+impl Default for PromptAuditSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            log_dir: None,
+            retention_days: 90,
+            include_filtered_ids: true,
+        }
+    }
+}
+
 /// MCP server configuration.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -23,8 +23,9 @@ pub use gateway::{
 pub use maintenance::{
     CircuitBreakerSettings, CredentialConfig, CronTaskEntry, CronTaskSettings,
     DbMonitoringSettings, DiskSpaceSettings, DriftDetectionSettings, LoggingSettings,
-    MaintenanceSettings, McpConfig, McpRateLimitConfig, RedactionSettings, RetentionSettings,
-    SandboxSettings, SqliteRecoverySettings, TraceRotationSettings, WatchdogSettings,
+    MaintenanceSettings, McpConfig, McpRateLimitConfig, PromptAuditSettings, RedactionSettings,
+    RetentionSettings, SandboxSettings, SqliteRecoverySettings, TraceRotationSettings,
+    WatchdogSettings,
 };
 pub use resolved::{
     AgentCapabilities, ResolvedModelConfig, ResolvedNousConfig, TokenLimits, resolve_nous,
@@ -154,6 +155,13 @@ pub struct AletheiaConfig {
     /// declare explicit deployment targets for the factsensitivity filter.
     #[serde(default)]
     pub providers: Vec<LlmProviderConfig>,
+    /// Prompt audit log: operator visibility into outbound LLM requests (#3411).
+    ///
+    /// WHY configurable: operators can disable the log or tune retention and
+    /// filtered-ID inclusion. Default is on with 90-day retention because
+    /// the log is a sovereignty feature — operators should be able to see
+    /// what the system sent out without opting in.
+    pub prompt_audit: PromptAuditSettings,
 }
 
 /// Sandbox enforcement level for tool execution.

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -153,7 +153,7 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
         "providers" => validate_providers(value, &mut errors),
         // NOTE: pass-through sections with no validation rules.
         "packs" | "pricing" | "sandbox" | "logging" | "mcp" | "localProvider" | "training"
-        | "anthropic" => {}
+        | "anthropic" | "promptAudit" => {}
         _ => errors.push(format!("unknown config section: {section}")),
     }
 


### PR DESCRIPTION
Reopens work from closed PR #3561 (rebased onto new main after #3566 merged).

## Summary
- Append-only JSONL log at \`{instance}/logs/prompt-audit/\` of every outbound LLM request
- Records: timestamp, nous_id, provider, deployment target, prompt hash, fact IDs included/filtered, token count
- Daily rotation via daemon maintenance task
- Operator CLI: \`aletheia prompt-audit\` subcommand

Closes #3411. Wave 3b of the sovereignty plan.