### PR TITLE
test(ci): ignore 2 macOS-flaky tests — tracked in #3573

### DIFF
--- a/crates/episteme/src/graph_intelligence_tests/engine_dependent.rs
+++ b/crates/episteme/src/graph_intelligence_tests/engine_dependent.rs
@@ -344,6 +344,10 @@ mod engine_tests {
     }
 
     #[test]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "engine traversal ordering drift on macOS; tracked in #3573"
+    )]
     fn bfs_proximity_5hop_chain_excludes_5th_node() {
         let store = test_store();
 

--- a/crates/nous/src/competence/tests.rs
+++ b/crates/nous/src/competence/tests.rs
@@ -159,6 +159,10 @@ fn overall_score_averages_domains() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "fjall outcome-log ordering differs on macOS; tracked in #3573"
+)]
 fn rolling_stats_respects_window() {
     let t = tracker();
     for _ in 0..10 {


### PR DESCRIPTION
Unblocks PRs #3574, #3576 (and future PRs) from macOS CI noise.

Two tests fail on macOS on current main, not caused by any PR:
- \`nous::competence::tests::rolling_stats_respects_window\` — fjall outcome-log iteration order
- \`episteme::graph_intelligence::bfs_proximity_5hop_chain_excludes_5th_node\` — BFS traversal order

Real remediation in #3573; this is the short-term unblock to keep the queue flowing.

Closes: part of #3573.