### PR TITLE
feat(energeia): add HealthCheck pipeline stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,7 +2163,9 @@ dependencies = [
  "parking_lot",
  "prometheus-client",
  "regex",
+ "reqwest 0.13.2",
  "rmp-serde",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2172,6 +2174,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -2379,17 +2382,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4451,13 +4443,13 @@ dependencies = [
 name = "melete"
 version = "0.19.0"
 dependencies = [
- "fd-lock",
  "futures",
  "hermeneus",
  "jiff",
  "koina",
  "libc",
  "prometheus-client",
+ "rustix",
  "serde",
  "serde_json",
  "snafu",
@@ -9038,15 +9030,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crates/energeia/Cargo.toml
+++ b/crates/energeia/Cargo.toml
@@ -24,6 +24,7 @@ regex = { workspace = true }
 fjall = { version = "3", optional = true }
 jiff = { workspace = true, features = ["serde"] }
 parking_lot = { version = "0.12", default-features = false }
+reqwest = { workspace = true }
 rmp-serde = "1.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -34,5 +35,7 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+rustls = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["process", "io-util", "test-util"] }
+wiremock = { workspace = true }

--- a/crates/energeia/src/pipeline/context.rs
+++ b/crates/energeia/src/pipeline/context.rs
@@ -79,6 +79,24 @@ pub(crate) struct PipelineContext {
     // --- Set by post-processing stage ---
     /// Final aggregate result, set by post-processing.
     pub(crate) result: Option<DispatchResult>,
+
+    // --- Health-check stage configuration ---
+    /// Primary backend health endpoint URL. `None` skips the HTTP probe.
+    ///
+    /// OpenAI-compatible backends: `<base_url>/v1/models`.
+    /// Anthropic: omit — the stage skips gracefully when `None`.
+    pub(crate) health_endpoint: Option<String>,
+    /// Fallback backend health endpoint URL.
+    ///
+    /// If the primary probe fails with a transient error (timeout, connection
+    /// refused), the stage retries against this URL before failing the dispatch.
+    pub(crate) fallback_health_endpoint: Option<String>,
+    /// Timeout for each HTTP probe. Defaults to 5 seconds.
+    pub(crate) health_probe_timeout: std::time::Duration,
+    /// Latency recorded by the health-check stage (milliseconds).
+    ///
+    /// Set on the first successful probe; `None` if the stage was skipped.
+    pub(crate) health_probe_latency_ms: Option<u64>,
 }
 
 impl PipelineContext {
@@ -119,6 +137,10 @@ impl PipelineContext {
             correctives: Vec::new(),
             aborted: false,
             result: None,
+            health_endpoint: None,
+            fallback_health_endpoint: None,
+            health_probe_timeout: std::time::Duration::from_secs(5),
+            health_probe_latency_ms: None,
         }
     }
 

--- a/crates/energeia/src/pipeline/health_check.rs
+++ b/crates/energeia/src/pipeline/health_check.rs
@@ -1,0 +1,462 @@
+// WHY: Health-check stage verifies the target LLM backend is reachable before
+// spawning dispatch sessions. Running this before execution means unreachable-
+// backend failures surface immediately with a clear [health_check] error rather
+// than only after sessions time out. The probe is intentionally lightweight:
+// one GET to /v1/models (OpenAI-compatible) with a 5s timeout. Providers that
+// don't expose a health endpoint are skipped gracefully via None.
+
+use std::time::Instant;
+
+use snafu::ResultExt as _;
+
+use crate::error::{EngineSnafu, PreflightSnafu};
+use crate::pipeline::PipelineStage;
+use crate::pipeline::context::PipelineContext;
+use crate::pipeline::error::{PipelineError, StageSnafu};
+
+// ---------------------------------------------------------------------------
+// HealthCheckStage
+// ---------------------------------------------------------------------------
+
+/// Health-check stage: probe the target LLM backend before execution.
+///
+/// Runs between preparation and execution. If `ctx.health_endpoint` is `None`
+/// the stage passes immediately — providers without a health endpoint are
+/// skipped gracefully.
+///
+/// Probe rules:
+/// - Timeout: `ctx.health_probe_timeout` (default 5 s).
+/// - Transient failure (timeout, connection refused, 5xx): retry once against
+///   `ctx.fallback_health_endpoint` if set; otherwise fail with a
+///   `[health_check]` `PipelineError`.
+/// - Permanent failure (4xx): fail immediately, no retry.
+/// - Success: record latency in `ctx.health_probe_latency_ms`.
+pub(crate) struct HealthCheckStage;
+
+impl PipelineStage for HealthCheckStage {
+    fn name(&self) -> &'static str {
+        "health_check"
+    }
+
+    async fn run(&self, ctx: &mut PipelineContext) -> Result<(), PipelineError> {
+        let Some(ref endpoint) = ctx.health_endpoint.clone() else {
+            // No endpoint configured — skip gracefully.
+            tracing::debug!("health_check: no endpoint configured, skipping probe");
+            return Ok(());
+        };
+
+        let timeout = ctx.health_probe_timeout;
+        let client = build_client(timeout).context(StageSnafu { stage: self.name() })?;
+
+        match probe(&client, endpoint).await {
+            ProbeOutcome::Ok { latency_ms } => {
+                tracing::info!(latency_ms, endpoint, "health_check: backend reachable");
+                ctx.health_probe_latency_ms = Some(latency_ms);
+                Ok(())
+            }
+            ProbeOutcome::PermanentFailure { status } => PreflightSnafu {
+                reason: format!(
+                    "backend health probe returned {status} (permanent failure): {endpoint}"
+                ),
+            }
+            .fail()
+            .context(StageSnafu { stage: self.name() }),
+            ProbeOutcome::TransientFailure { detail } => {
+                tracing::warn!(
+                    %detail,
+                    endpoint,
+                    "health_check: primary probe failed (transient), trying fallback"
+                );
+
+                // Try fallback if configured.
+                let Some(ref fallback) = ctx.fallback_health_endpoint.clone() else {
+                    return EngineSnafu {
+                        detail: format!(
+                            "backend health probe failed (transient) and no fallback configured: {detail}"
+                        ),
+                    }
+                    .fail()
+                    .context(StageSnafu { stage: self.name() });
+                };
+
+                match probe(&client, fallback).await {
+                    ProbeOutcome::Ok { latency_ms } => {
+                        tracing::info!(
+                            latency_ms,
+                            fallback_endpoint = %fallback,
+                            "health_check: fallback backend reachable"
+                        );
+                        ctx.health_probe_latency_ms = Some(latency_ms);
+                        Ok(())
+                    }
+                    ProbeOutcome::PermanentFailure { status } => {
+                        PreflightSnafu {
+                            reason: format!(
+                                "fallback health probe returned {status} (permanent failure): {fallback}"
+                            ),
+                        }
+                        .fail()
+                        .context(StageSnafu { stage: self.name() })
+                    }
+                    ProbeOutcome::TransientFailure { detail: fb_detail } => {
+                        EngineSnafu {
+                            detail: format!(
+                                "both primary and fallback health probes failed: primary={detail}; fallback={fb_detail}"
+                            ),
+                        }
+                        .fail()
+                        .context(StageSnafu { stage: self.name() })
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal probe helpers
+// ---------------------------------------------------------------------------
+
+/// Outcome of a single HTTP probe.
+enum ProbeOutcome {
+    /// Backend responded with 2xx; latency recorded.
+    Ok { latency_ms: u64 },
+    /// Backend responded with 4xx — do not retry.
+    PermanentFailure { status: u16 },
+    /// Connection error, timeout, or 5xx — may be transient.
+    TransientFailure { detail: String },
+}
+
+/// Build a `reqwest::Client` with the given request timeout.
+fn build_client(timeout: std::time::Duration) -> crate::error::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .build()
+        .map_err(|e| {
+            EngineSnafu {
+                detail: format!("failed to build HTTP client for health probe: {e}"),
+            }
+            .build()
+        })
+}
+
+/// Send a GET request to `url` and classify the outcome.
+async fn probe(client: &reqwest::Client, url: &str) -> ProbeOutcome {
+    let t0 = Instant::now();
+    match client.get(url).send().await {
+        Ok(resp) => {
+            let latency_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);
+            let status = resp.status().as_u16();
+            if resp.status().is_success() {
+                ProbeOutcome::Ok { latency_ms }
+            } else if resp.status().is_client_error() {
+                // 4xx: permanent failure (auth, not-found, etc.)
+                ProbeOutcome::PermanentFailure { status }
+            } else {
+                // 5xx or unexpected: treat as transient
+                ProbeOutcome::TransientFailure {
+                    detail: format!("HTTP {status}"),
+                }
+            }
+        }
+        Err(e) => {
+            // Connection refused, timeout, DNS failure — all transient.
+            ProbeOutcome::TransientFailure {
+                detail: e.to_string(),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use std::sync::Arc;
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::mock::MockEngine;
+    use crate::orchestrator::OrchestratorConfig;
+    use crate::pipeline::PipelineStage as _;
+    use crate::pipeline::context::PipelineContext;
+    use crate::prompt::PromptSpec;
+    use crate::qa::QaGate;
+    use crate::types::{DispatchSpec, MechanicalIssue, QaResult, QaVerdict};
+
+    use super::HealthCheckStage;
+
+    // ---------------------------------------------------------------------------
+    // Test helpers
+    // ---------------------------------------------------------------------------
+
+    struct AlwaysPassQa;
+
+    impl QaGate for AlwaysPassQa {
+        fn evaluate<'a>(
+            &'a self,
+            prompt: &'a crate::qa::PromptSpec,
+            pr_number: u64,
+            _diff: &'a str,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = crate::error::Result<QaResult>> + Send + 'a>,
+        > {
+            use jiff::Timestamp;
+            Box::pin(async move {
+                Ok(QaResult {
+                    prompt_number: prompt.prompt_number,
+                    pr_number,
+                    verdict: QaVerdict::Pass,
+                    criteria_results: vec![],
+                    mechanical_issues: vec![],
+                    cost_usd: 0.0,
+                    evaluated_at: Timestamp::now(),
+                    semantic_evaluated: false,
+                })
+            })
+        }
+
+        fn mechanical_check(
+            &self,
+            _diff: &str,
+            _prompt: &crate::qa::PromptSpec,
+        ) -> Vec<MechanicalIssue> {
+            vec![]
+        }
+    }
+
+    fn make_context() -> PipelineContext {
+        let engine = Arc::new(MockEngine::new(vec![]));
+        let qa = Arc::new(AlwaysPassQa);
+        let spec = DispatchSpec::new("acme".to_owned(), vec![1]);
+        let prompts = vec![PromptSpec {
+            number: 1,
+            description: "test".to_owned(),
+            depends_on: vec![],
+            acceptance_criteria: vec![],
+            blast_radius: vec![],
+            body: "do the thing".to_owned(),
+        }];
+        PipelineContext::new(
+            spec,
+            prompts,
+            engine,
+            qa,
+            OrchestratorConfig::default(),
+            #[cfg(feature = "storage-fjall")]
+            None,
+        )
+    }
+
+    // ---------------------------------------------------------------------------
+    // Shared TLS provider initialiser
+    // ---------------------------------------------------------------------------
+
+    fn init_tls() {
+        // WHY: reqwest uses rustls-no-provider; tests must install a crypto
+        // provider before the first HTTPS request. Ignoring the error is safe —
+        // it means the provider was already installed (e.g. by a parallel test).
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Happy-path probe succeeds
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn probe_success_records_latency() {
+        init_tls();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "list",
+                "data": [{"id": "qwen3", "object": "model"}]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut ctx = make_context();
+        ctx.health_endpoint = Some(format!("{}/v1/models", server.uri()));
+
+        HealthCheckStage
+            .run(&mut ctx)
+            .await
+            .expect("probe should succeed");
+
+        assert!(
+            ctx.health_probe_latency_ms.is_some(),
+            "latency should be recorded on success"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // 5xx retries once, falls over to fallback
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn transient_5xx_retries_fallback() {
+        init_tls();
+        // Primary returns 503 (transient).
+        let primary = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&primary)
+            .await;
+
+        // Fallback returns 200.
+        let fallback = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "list",
+                "data": []
+            })))
+            .expect(1)
+            .mount(&fallback)
+            .await;
+
+        let mut ctx = make_context();
+        ctx.health_endpoint = Some(format!("{}/v1/models", primary.uri()));
+        ctx.fallback_health_endpoint = Some(format!("{}/v1/models", fallback.uri()));
+
+        HealthCheckStage
+            .run(&mut ctx)
+            .await
+            .expect("fallback probe should succeed");
+
+        assert!(ctx.health_probe_latency_ms.is_some());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Timeout fails if no fallback configured
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn timeout_fails_without_fallback() {
+        init_tls();
+        // Bind a port that accepts TCP connections but never responds.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Keep the listener alive so connect() succeeds and the timeout is what
+        // triggers failure, not immediate connection refused.
+        let _listener = listener;
+
+        let mut ctx = make_context();
+        ctx.health_endpoint = Some(format!("http://{}:{}/v1/models", addr.ip(), addr.port()));
+        ctx.health_probe_timeout = std::time::Duration::from_millis(200);
+
+        let err = HealthCheckStage
+            .run(&mut ctx)
+            .await
+            .expect_err("should fail on timeout with no fallback");
+
+        assert_eq!(err.stage(), "health_check");
+        assert!(
+            err.to_string().contains("health_check"),
+            "stage name in error: {err}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Timeout succeeds with fallback
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn timeout_succeeds_with_fallback() {
+        init_tls();
+        // Primary: listener that stalls (timeout triggers).
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _listener = listener;
+
+        // Fallback: real mock server that returns 200.
+        let fallback = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "list",
+                "data": []
+            })))
+            .expect(1)
+            .mount(&fallback)
+            .await;
+
+        let mut ctx = make_context();
+        ctx.health_endpoint = Some(format!("http://{}:{}/v1/models", addr.ip(), addr.port()));
+        ctx.fallback_health_endpoint = Some(format!("{}/v1/models", fallback.uri()));
+        ctx.health_probe_timeout = std::time::Duration::from_millis(200);
+
+        HealthCheckStage
+            .run(&mut ctx)
+            .await
+            .expect("fallback should succeed after primary timeout");
+
+        assert!(ctx.health_probe_latency_ms.is_some());
+    }
+
+    // ---------------------------------------------------------------------------
+    // 4xx fails immediately (no retry)
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn permanent_4xx_fails_immediately() {
+        init_tls();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(401))
+            // Expect exactly 1 call — no fallback should be attempted.
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut ctx = make_context();
+        ctx.health_endpoint = Some(format!("{}/v1/models", server.uri()));
+
+        let err = HealthCheckStage
+            .run(&mut ctx)
+            .await
+            .expect_err("should fail on 401");
+
+        assert_eq!(err.stage(), "health_check");
+        assert!(
+            err.to_string().contains("health_check"),
+            "stage name in error: {err}"
+        );
+        assert!(
+            err.to_string().contains("401"),
+            "status code in error: {err}"
+        );
+
+        // Verify wiremock received exactly 1 request (no retry).
+        server.verify().await;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Skips gracefully when no endpoint configured
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn skips_when_no_endpoint_configured() {
+        let mut ctx = make_context();
+        // health_endpoint is None by default — stage should pass without touching network.
+        HealthCheckStage
+            .run(&mut ctx)
+            .await
+            .expect("stage should pass when no endpoint is configured");
+
+        assert!(
+            ctx.health_probe_latency_ms.is_none(),
+            "no latency should be recorded when probe was skipped"
+        );
+    }
+}

--- a/crates/energeia/src/pipeline/mod.rs
+++ b/crates/energeia/src/pipeline/mod.rs
@@ -1,10 +1,11 @@
-// WHY: The 4-stage pipeline (preparation → execution → post-processing) is the
-// foundation of Wave 4. Each stage is a named, independently testable unit with
-// a uniform interface. The DispatchPipeline driver wires them in order and
-// surfaces which stage failed when an error occurs.
+// WHY: The dispatch pipeline (preparation → health_check → execution →
+// post-processing) executes each stage in order. Each stage is a named,
+// independently testable unit with a uniform interface. The DispatchPipeline
+// driver wires them in order and surfaces which stage failed when an error
+// occurs.
 //
-// Follow-up stages (health-check, QA-gate, record, validate — #3458–#3461)
-// will slot into this structure without touching the driver.
+// Remaining Wave 4 follow-up stages: QA-gate (#3459), validate (#3460),
+// record (#3461).
 
 use crate::pipeline::context::PipelineContext;
 use crate::pipeline::error::PipelineError;
@@ -15,6 +16,8 @@ pub(crate) mod context;
 pub(crate) mod error;
 /// Stage 2: drive frontier group loop, collect session outcomes.
 pub(crate) mod execution;
+/// Stage 1b: probe target backend reachability before spawning sessions.
+pub(crate) mod health_check;
 /// Stage 3: record metrics, assemble result, finish store record.
 pub(crate) mod post_processing;
 /// Stage 1: validate inputs, build DAG, compute frontier, initialise shared state.
@@ -22,6 +25,7 @@ pub(crate) mod preparation;
 
 // Re-export stage implementations for use by the orchestrator.
 pub(crate) use execution::ExecutionStage;
+pub(crate) use health_check::HealthCheckStage;
 pub(crate) use post_processing::PostProcessingStage;
 pub(crate) use preparation::PreparationStage;
 
@@ -62,10 +66,12 @@ pub(crate) struct DispatchPipeline {
 }
 
 impl Default for DispatchPipeline {
-    /// Build the standard 3-stage pipeline: preparation → execution → post-processing.
+    /// Build the standard 4-stage pipeline:
+    /// preparation → `health_check` → execution → post-processing.
     fn default() -> Self {
         Self::new(vec![
             Box::new(PreparationStage),
+            Box::new(HealthCheckStage),
             Box::new(ExecutionStage),
             Box::new(PostProcessingStage),
         ])


### PR DESCRIPTION
## Summary

- Adds `HealthCheckStage` to `crates/energeia/src/pipeline/health_check.rs` implementing `PipelineStage`
- Stage runs between `Preparation` and `Execution` — probes the target LLM backend via HTTP GET before any sessions spawn
- Slots into the scaffold from merged PR #3576 without changing existing stages' behaviour

## Behaviour

- **Endpoint**: `ctx.health_endpoint` (OpenAI-compatible: `/v1/models`). `None` → skip gracefully (Anthropic CLI backend, any provider without a health endpoint)
- **Timeout**: 5 s default, configurable via `ctx.health_probe_timeout`
- **Transient failure** (timeout, connection refused, 5xx): retry once against `ctx.fallback_health_endpoint` if set; otherwise fail with `[health_check] PipelineError`
- **Permanent failure** (4xx): fail immediately, no retry
- **Success**: latency recorded in `ctx.health_probe_latency_ms`
- snafu errors with `stage: "health_check"` identification throughout

## Test plan

6 new wiremock-backed tests in `health_check.rs`:

- [ ] `probe_success_records_latency` — happy path, 200 response, latency recorded
- [ ] `transient_5xx_retries_fallback` — primary 503, fallback 200, stage passes
- [ ] `timeout_fails_without_fallback` — stalling listener, no fallback, stage fails `[health_check]`
- [ ] `timeout_succeeds_with_fallback` — stalling primary, fallback 200, stage passes
- [ ] `permanent_4xx_fails_immediately` — 401, single request (wiremock `.expect(1)`), no fallback attempted
- [ ] `skips_when_no_endpoint_configured` — `health_endpoint = None`, no network calls, stage passes

All existing energeia tests continue to pass (464 total). All three gates pass:
```
cargo fmt --check          ✓
cargo clippy -D warnings   ✓
cargo test -p energeia     ✓  464 passed
```

Closes #3458
Part of #3453
Followup stages: #3459 #3460 #3461

🤖 Generated with [Claude Code](https://claude.com/claude-code)