### PR TITLE
refactor(poiesis-slides): replace ppt-rs with hand-rolled ZIP/XML emitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
  "base64ct",
  "blake2",
  "cpufeatures 0.2.17",
- "password-hash 0.5.0",
+ "password-hash",
 ]
 
 [[package]]
@@ -918,31 +918,11 @@ checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1337,12 +1317,6 @@ checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
 dependencies = [
  "typewit",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -2379,17 +2353,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3849,7 +3812,7 @@ dependencies = [
  "jiff",
  "koina",
  "open",
- "pulldown-cmark 0.13.3",
+ "pulldown-cmark",
  "ratatui",
  "regex",
  "reqwest 0.13.2",
@@ -4398,7 +4361,7 @@ dependencies = [
  "itertools 0.14.0",
  "js_option",
  "matrix-sdk-common",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "rand 0.8.5",
  "rmp-serde",
  "ruma",
@@ -4427,7 +4390,7 @@ dependencies = [
  "blake3",
  "chacha20poly1305",
  "hmac 0.12.1",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "rand 0.8.5",
  "rmp-serde",
  "serde",
@@ -4451,13 +4414,13 @@ dependencies = [
 name = "melete"
 version = "0.19.0"
 dependencies = [
- "fd-lock",
  "futures",
  "hermeneus",
  "jiff",
  "koina",
  "libc",
  "prometheus-client",
+ "rustix",
  "serde",
  "serde_json",
  "snafu",
@@ -5052,17 +5015,6 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
@@ -5089,18 +5041,6 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
- "password-hash 0.4.2",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "pbkdf2"
@@ -5348,8 +5288,9 @@ name = "poiesis-slides"
 version = "0.19.0"
 dependencies = [
  "poiesis-core",
- "ppt-rs",
+ "quick-xml",
  "snafu",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -5420,23 +5361,6 @@ name = "ppmd-rust"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
-
-[[package]]
-name = "ppt-rs"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea88d269703efa2b58373f5b1f5f2e59180793e81979f1448aa9a99eb60099e"
-dependencies = [
- "chrono",
- "clap",
- "pulldown-cmark 0.10.3",
- "regex",
- "syntect",
- "thiserror 1.0.69",
- "uuid",
- "xml-rs",
- "zip 0.6.6",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -5666,19 +5590,6 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
-dependencies = [
- "bitflags 2.11.0",
- "getopts",
- "memchr",
- "pulldown-cmark-escape 0.10.1",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
@@ -5686,15 +5597,9 @@ dependencies = [
  "bitflags 2.11.0",
  "getopts",
  "memchr",
- "pulldown-cmark-escape 0.11.0",
+ "pulldown-cmark-escape",
  "unicase",
 ]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
 name = "pulldown-cmark-escape"
@@ -7208,7 +7113,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "koina",
- "pulldown-cmark 0.13.3",
+ "pulldown-cmark",
  "reqwest 0.13.2",
  "rustls",
  "serde",
@@ -9044,15 +8949,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -9457,12 +9353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
-
-[[package]]
 name = "xmp-writer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9611,26 +9501,6 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2 0.4.4",
- "constant_time_eq 0.1.5",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac 0.12.1",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd 0.11.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zip"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
@@ -9651,7 +9521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "aes",
- "bzip2 0.6.1",
+ "bzip2",
  "constant_time_eq 0.3.1",
  "crc32fast",
  "deflate64",
@@ -9662,14 +9532,14 @@ dependencies = [
  "indexmap 2.14.0",
  "lzma-rust2",
  "memchr",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "ppmd-rust",
  "sha1",
  "time",
  "typed-path",
  "zeroize",
  "zopfli",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -9698,30 +9568,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/crates/poiesis/CLAUDE.md
+++ b/crates/poiesis/CLAUDE.md
@@ -30,7 +30,7 @@ Document rendering family: format-agnostic document model plus backends for PDF,
 | `OdtRenderer` | `text/src/odt.rs` | ODT backend via clean-room ZIP/XML |
 | `XlsxRenderer` | `sheet/src/xlsx.rs` | Excel backend via `rust_xlsxwriter` |
 | `OdsRenderer` | `sheet/src/ods.rs` | ODS backend via `spreadsheet-ods` |
-| `PptxRenderer` | `slides/src/pptx.rs` | PowerPoint backend via `ppt-rs` |
+| `PptxRenderer` | `slides/src/pptx.rs` | PowerPoint backend via hand-rolled ZIP/XML emitter |
 
 ## Feature flags
 
@@ -40,7 +40,7 @@ Document rendering family: format-agnostic document model plus backends for PDF,
 | `odt` | `poiesis-text` | yes | ODT output via `zip` |
 | `xlsx` | `poiesis-sheet` | yes | Excel output via `rust_xlsxwriter` |
 | `ods` | `poiesis-sheet` | yes | ODS output via `spreadsheet-ods` |
-| `pptx` | `poiesis-slides` | yes | PPTX output via `ppt-rs` |
+| `pptx` | `poiesis-slides` | yes | PPTX output via hand-rolled ZIP/XML emitter |
 
 ## Patterns
 
@@ -63,5 +63,5 @@ Document rendering family: format-agnostic document model plus backends for PDF,
 
 ## Dependencies
 
-Uses: jiff, snafu, krilla (optional), zip (optional), rust_xlsxwriter (optional), spreadsheet-ods (optional), ppt-rs (optional)
+Uses: jiff, snafu, krilla (optional), zip (optional), quick-xml (optional), rust_xlsxwriter (optional), spreadsheet-ods (optional)
 Used by: (none yet)

--- a/crates/poiesis/slides/Cargo.toml
+++ b/crates/poiesis/slides/Cargo.toml
@@ -13,11 +13,10 @@ workspace = true
 
 [dependencies]
 poiesis-core = { path = "../core" }
+quick-xml = "0.38"
 snafu = { workspace = true }
-
-# PPTX backend
-ppt-rs = { version = "0.2", optional = true }
+zip = "7"
 
 [features]
 default = ["pptx"]
-pptx = ["dep:ppt-rs"]
+pptx = []

--- a/crates/poiesis/slides/src/lib.rs
+++ b/crates/poiesis/slides/src/lib.rs
@@ -2,7 +2,7 @@
 //! poiesis-slides: PPTX presentation rendering backend.
 //!
 //! Feature flags:
-//! - `pptx` (default): `PowerPoint` PPTX output via `ppt-rs`.
+//! - `pptx` (default): `PowerPoint` PPTX output via hand-rolled ZIP/XML emitter.
 
 #[cfg(feature = "pptx")]
 pub mod pptx;

--- a/crates/poiesis/slides/src/pptx.rs
+++ b/crates/poiesis/slides/src/pptx.rs
@@ -1,26 +1,29 @@
-//! PPTX rendering backend using the `ppt-rs` crate.
+//! PPTX rendering backend — hand-rolled ZIP/XML implementation.
 //!
 //! The document content is mapped to slides using these rules:
 //! - A new [`SlideContent`] is started for each Heading block.
 //! - Paragraph and List blocks append bullet points to the current slide.
-//! - Table blocks are summarized as bullet points (one per row) since ppt-rs
-//!   table support requires pre-built table objects.
+//! - Table blocks are summarized as bullet points (one per row).
 //! - [`PageBreak`] forces a new slide even without a heading.
 //!
 //! If the document has no headings, all content lands on a single slide
 //! titled with the document metadata title.
 //!
-//! [`SlideContent`]: ppt_rs::SlideContent
 //! [`PageBreak`]: poiesis_core::Block::PageBreak
 
+use std::fmt::Write as FmtWrite;
+use std::io::Write as IoWrite;
+
 use poiesis_core::{Block, Document, Renderer, RichText};
-use ppt_rs::{SlideContent, create_pptx_with_content};
+use quick_xml::escape::escape;
 use snafu::Snafu;
+use zip::ZipWriter;
+use zip::write::SimpleFileOptions;
 
 /// Errors produced by the PPTX renderer.
 #[derive(Debug, Snafu)]
 pub enum PptxError {
-    /// `ppt-rs` returned an error while generating the presentation.
+    /// An error occurred while generating the presentation.
     #[snafu(display("PPTX error: {message}"))]
     Pptx {
         /// Human-readable error description.
@@ -102,16 +105,446 @@ impl Renderer for PptxRenderer {
 
         slides.push(current_slide);
 
-        // ppt-rs requires at least one slide.
+        // At least one slide is required.
         if slides.is_empty() {
             slides.push(SlideContent::new(&doc.metadata.title));
         }
 
-        create_pptx_with_content(&doc.metadata.title, slides).map_err(|e| PptxError::Pptx {
-            message: e.to_string(),
-        })
+        create_pptx_with_content(&doc.metadata.title, &slides)
     }
 }
+
+/// Internal slide representation.
+#[derive(Debug, Clone)]
+struct SlideContent {
+    title: String,
+    bullets: Vec<String>,
+}
+
+impl SlideContent {
+    fn new(title: &str) -> Self {
+        Self {
+            title: title.to_owned(),
+            bullets: Vec::new(),
+        }
+    }
+
+    fn add_bullet(mut self, text: &str) -> Self {
+        self.bullets.push(text.to_owned());
+        self
+    }
+}
+
+fn create_pptx_with_content(_title: &str, slides: &[SlideContent]) -> Result<Vec<u8>, PptxError> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut zip = ZipWriter::new(cursor);
+
+    write_entry(
+        &mut zip,
+        "[Content_Types].xml",
+        &build_content_types(slides),
+    )?;
+    write_entry(&mut zip, "_rels/.rels", RELS_RELS)?;
+    write_entry(
+        &mut zip,
+        "ppt/presentation.xml",
+        &build_presentation(slides),
+    )?;
+    write_entry(
+        &mut zip,
+        "ppt/_rels/presentation.xml.rels",
+        &build_presentation_rels(slides),
+    )?;
+
+    // Static template files.
+    write_entry(&mut zip, "ppt/slideLayouts/slideLayout1.xml", SLIDE_LAYOUT)?;
+    write_entry(
+        &mut zip,
+        "ppt/slideLayouts/_rels/slideLayout1.xml.rels",
+        SLIDE_LAYOUT_RELS,
+    )?;
+    write_entry(&mut zip, "ppt/slideMasters/slideMaster1.xml", SLIDE_MASTER)?;
+    write_entry(
+        &mut zip,
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels",
+        SLIDE_MASTER_RELS,
+    )?;
+    write_entry(&mut zip, "ppt/theme/theme1.xml", THEME)?;
+
+    // Dynamic slide files.
+    for (i, slide) in slides.iter().enumerate() {
+        let slide_num = i + 1;
+        write_entry(
+            &mut zip,
+            &format!("ppt/slides/slide{slide_num}.xml"),
+            &build_slide(slide),
+        )?;
+        write_entry(
+            &mut zip,
+            &format!("ppt/slides/_rels/slide{slide_num}.xml.rels"),
+            SLIDE_RELS,
+        )?;
+    }
+
+    let cursor = zip.finish().map_err(|e| PptxError::Pptx {
+        message: e.to_string(),
+    })?;
+    Ok(cursor.into_inner())
+}
+
+fn write_entry(
+    zip: &mut ZipWriter<std::io::Cursor<Vec<u8>>>,
+    name: &str,
+    content: &str,
+) -> Result<(), PptxError> {
+    zip.start_file(name, SimpleFileOptions::default())
+        .map_err(|e| PptxError::Pptx {
+            message: e.to_string(),
+        })?;
+    zip.write_all(content.as_bytes())
+        .map_err(|e| PptxError::Pptx {
+            message: e.to_string(),
+        })
+}
+
+/// Escape text for XML character data using `quick-xml`.
+fn xml_escape(s: &str) -> String {
+    format!("{}", escape(s))
+}
+
+fn build_content_types(slides: &[SlideContent]) -> String {
+    let mut overrides = String::new();
+    for i in 1..=slides.len() {
+        let _ = write!(
+            overrides,
+            r#"  <Override PartName="/ppt/slides/slide{i}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>"#,
+        );
+        overrides.push('\n');
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/ppt/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>
+  <Override PartName="/ppt/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>
+  <Override PartName="/ppt/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+{overrides}</Types>"#
+    )
+}
+
+fn build_presentation(slides: &[SlideContent]) -> String {
+    let mut slide_ids = String::new();
+    for i in 0..slides.len() {
+        let id = 256 + i;
+        let rid = i + 2; // rId2 is first slide; rId1 is slideMaster.
+        let _ = write!(slide_ids, r#"    <p:sldId id="{id}" r:id="rId{rid}"/>"#);
+        slide_ids.push('\n');
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:sldIdLst>
+{slide_ids}  </p:sldIdLst>
+  <p:sldSz cx="12192000" cy="6858000" type="screen16x9"/>
+  <p:notesSz cx="6858000" cy="9144000"/>
+</p:presentation>"#
+    )
+}
+
+fn build_presentation_rels(slides: &[SlideContent]) -> String {
+    let mut rels = String::new();
+    rels.push_str(
+        r#"  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>"#,
+    );
+    rels.push('\n');
+    for i in 0..slides.len() {
+        let rid = i + 2;
+        let _ = write!(
+            rels,
+            r#"  <Relationship Id="rId{rid}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide{slide_num}.xml"/>"#,
+            slide_num = i + 1,
+        );
+        rels.push('\n');
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+{rels}</Relationships>"#
+    )
+}
+
+fn build_slide(slide: &SlideContent) -> String {
+    let title = xml_escape(&slide.title);
+    let mut bullets_xml = String::new();
+    for bullet in &slide.bullets {
+        let text = xml_escape(bullet);
+        let _ = write!(
+            bullets_xml,
+            "          <a:p>\n\
+             <a:pPr lvl=\"0\"/>\n\
+             <a:r>\n\
+               <a:rPr lang=\"en-US\" dirty=\"0\" smtClean=\"0\"/>\n\
+               <a:t>{text}</a:t>\n\
+             </a:r>\n\
+             <a:endParaRPr lang=\"en-US\" dirty=\"0\"/>\n\
+           </a:p>\n",
+        );
+    }
+    // Emit an empty paragraph when there are no bullets so the text body is valid.
+    if bullets_xml.is_empty() {
+        bullets_xml.push_str(
+            "          <a:p>\n\
+             <a:pPr lvl=\"0\"/>\n\
+             <a:endParaRPr lang=\"en-US\" dirty=\"0\"/>\n\
+           </a:p>\n",
+        );
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:bg>
+      <p:bgRef idx="1001">
+        <a:schemeClr val="bg1"/>
+      </p:bgRef>
+    </p:bg>
+    <p:spTree>
+      <p:nvGrpSpPr>
+        <p:cNvPr id="1" name=""/>
+        <p:cNvGrpSpPr/>
+        <p:nvPr/>
+      </p:nvGrpSpPr>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="0" cy="0"/>
+          <a:chOff x="0" y="0"/>
+          <a:chExt cx="0" cy="0"/>
+        </a:xfrm>
+      </p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="2" name="Title 1"/>
+          <p:cNvSpPr txBox="1"/>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="457200" y="274638"/>
+            <a:ext cx="8236125" cy="1143000"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect">
+            <a:avLst/>
+          </a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-US" dirty="0" smtClean="0"/>
+              <a:t>{title}</a:t>
+            </a:r>
+            <a:endParaRPr lang="en-US" dirty="0"/>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="3" name="Content Placeholder 2"/>
+          <p:cNvSpPr txBox="1"/>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="457200" y="1600200"/>
+            <a:ext cx="8236125" cy="4525963"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect">
+            <a:avLst/>
+          </a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+{bullets_xml}        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>"#
+    )
+}
+
+// ------------------------------------------------------------------
+// Static OOXML template constants
+// ------------------------------------------------------------------
+
+const RELS_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>"#;
+
+const SLIDE_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+</Relationships>"#;
+
+const SLIDE_LAYOUT_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>
+</Relationships>"#;
+
+const SLIDE_MASTER_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/theme1.xml"/>
+</Relationships>"#;
+
+const SLIDE_LAYOUT: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="titleAndContent" preserve="1">
+  <p:cSld name="Title and Content">
+    <p:spTree>
+      <p:nvGrpSpPr>
+        <p:cNvPr id="1" name=""/>
+        <p:cNvGrpSpPr/>
+        <p:nvPr/>
+      </p:nvGrpSpPr>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="0" cy="0"/>
+          <a:chOff x="0" y="0"/>
+          <a:chExt cx="0" cy="0"/>
+        </a:xfrm>
+      </p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="2" name="Title 1"/>
+          <p:cNvSpPr txBox="1"/>
+          <p:nvPr phType="title"/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="457200" y="274638"/>
+            <a:ext cx="8236125" cy="1143000"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect">
+            <a:avLst/>
+          </a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:endParaRPr lang="en-US"/>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="3" name="Content Placeholder 2"/>
+          <p:cNvSpPr txBox="1"/>
+          <p:nvPr phType="body" idx="1"/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="457200" y="1600200"/>
+            <a:ext cx="8236125" cy="4525963"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect">
+            <a:avLst/>
+          </a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr lvl="0"/>
+            <a:endParaRPr lang="en-US"/>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+  <p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>
+</p:sldLayout>"#;
+
+const SLIDE_MASTER: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:bg>
+      <p:bgRef idx="1001">
+        <a:schemeClr val="bg1"/>
+      </p:bgRef>
+    </p:bg>
+    <p:spTree>
+      <p:nvGrpSpPr>
+        <p:cNvPr id="1" name=""/>
+        <p:cNvGrpSpPr/>
+        <p:nvPr/>
+      </p:nvGrpSpPr>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="0" cy="0"/>
+          <a:chOff x="0" y="0"/>
+          <a:chExt cx="0" cy="0"/>
+        </a:xfrm>
+      </p:grpSpPr>
+    </p:spTree>
+  </p:cSld>
+  <p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>
+  <p:txStyles>
+    <p:titleStyle>
+      <a:defPPr>
+        <a:defRPr lang="en-US"/>
+      </a:defPPr>
+    </p:titleStyle>
+    <p:bodyStyle>
+      <a:defPPr>
+        <a:defRPr lang="en-US"/>
+      </a:defPPr>
+    </p:bodyStyle>
+    <p:otherStyle>
+      <a:defPPr>
+        <a:defRPr lang="en-US"/>
+      </a:defPPr>
+    </p:otherStyle>
+  </p:txStyles>
+</p:sldMaster>"#;
+
+const THEME: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
+  <a:themeElements>
+    <a:clrScheme name="Office">
+      <a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>
+      <a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>
+      <a:dk2><a:srgbClr val="44546A"/></a:dk2>
+      <a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>
+      <a:accent1><a:srgbClr val="4472C4"/></a:accent1>
+      <a:accent2><a:srgbClr val="ED7D31"/></a:accent2>
+      <a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>
+      <a:accent4><a:srgbClr val="FFC000"/></a:accent4>
+      <a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>
+      <a:accent6><a:srgbClr val="70AD47"/></a:accent6>
+      <a:hlink><a:srgbClr val="0563C1"/></a:hlink>
+      <a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+    </a:clrScheme>
+    <a:fontScheme name="Office">
+      <a:majorFont><a:latin typeface="Calibri Light" panose="020F0302020204030204"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont>
+      <a:minorFont><a:latin typeface="Calibri" panose="020F0502020204030204"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont>
+    </a:fontScheme>
+    <a:fmtScheme name="Office">
+      <a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="50000"/><a:satMod val="300000"/></a:schemeClr></a:gs><a:gs pos="35000"><a:schemeClr val="phClr"><a:tint val="37000"/><a:satMod val="300000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:tint val="15000"/><a:satMod val="350000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="16200000" scaled="1"/></a:gradFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="100000"/><a:shade val="100000"/><a:satMod val="130000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:tint val="50000"/><a:satMod val="350000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="16200000" scaled="0"/></a:gradFill></a:fillStyleLst>
+      <a:lnStyleLst><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln><a:ln w="25400" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln><a:ln w="38100" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln></a:lnStyleLst>
+      <a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst><a:outerShdw blurRad="40000" dist="20000" dir="5400000" rotWithShape="0"><a:srgbClr val="000000"><a:alpha val="38000"/></a:srgbClr></a:outerShdw></a:effectLst></a:effectStyle></a:effectStyleLst>
+      <a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="40000"/><a:satMod val="350000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:tint val="100000"/><a:satMod val="350000"/></a:schemeClr></a:gs></a:gsLst><a:path path="circle"><a:fillToRect l="50000" t="-80000" r="50000" b="180000"/></a:path></a:gradFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="80000"/><a:satMod val="300000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:tint val="80000"/><a:satMod val="300000"/></a:schemeClr></a:gs></a:gsLst><a:path path="circle"><a:fillToRect l="50000" t="50000" r="50000" b="50000"/></a:path></a:gradFill></a:bgFillStyleLst>
+    </a:fmtScheme>
+  </a:themeElements>
+</a:theme>"#;
 
 #[cfg(test)]
 mod tests {
@@ -173,5 +606,13 @@ mod tests {
         let r = PptxRenderer::new();
         let bytes = r.render(&sample_doc()).expect("PPTX render failed");
         assert_eq!(&bytes[..2], b"PK", "PPTX output should be a valid ZIP");
+    }
+
+    #[test]
+    fn xml_escape_handles_special_chars() {
+        assert_eq!(
+            xml_escape("a&b<c>d\"e'f"),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
     }
 }


### PR DESCRIPTION
Closes #3449

Part of #3445

## Summary

Removes the `ppt-rs` dependency — the single worst dependency in the workspace (8+ duplicate crate pairs, unstable API). Only `crates/poiesis/slides` used it.

Replaces it with a minimal hand-rolled PPTX emitter using:
- `zip` crate (v7, already in workspace) for the archive
- `quick-xml` (already in workspace) for XML text escaping
- Hand-written OOXML parts: `[Content_Types].xml`, `_rels/.rels`, `ppt/presentation.xml`, `ppt/slideLayouts/`, `ppt/slides/slideN.xml`, plus hard-coded master/layout/theme templates based on LibreOffice defaults.

## Public API

Zero breaking changes. `PptxRenderer` still implements `Renderer`; callers are unchanged.

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --workspace --features test-core --all-targets -- -D warnings` ✅
- `cargo test -p poiesis-slides` ✅
- `grep -r "ppt_rs\|ppt-rs" crates/ Cargo.toml Cargo.lock` returns empty ✅

Gate-Passed: kanon 0.1.0