### PR TITLE
refactor(workspace): replace base64 crate with koina::base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,7 +1915,6 @@ name = "diaporeia"
 version = "0.19.0"
 dependencies = [
  "axum 0.8.8",
- "base64 0.22.1",
  "hermeneus",
  "http",
  "koina",
@@ -3805,7 +3804,6 @@ name = "koilon"
 version = "0.19.0"
 dependencies = [
  "arboard",
- "base64 0.22.1",
  "clap",
  "compact_str",
  "crossterm",
@@ -3843,6 +3841,7 @@ dependencies = [
  "fjall",
  "jiff",
  "prometheus-client",
+ "proptest",
  "rand 0.9.4",
  "regex",
  "rustix",
@@ -3942,7 +3941,6 @@ name = "krites"
 version = "0.19.0"
 dependencies = [
  "aho-corasick",
- "base64 0.22.1",
  "bytemuck",
  "compact_str",
  "crossbeam",
@@ -3951,6 +3949,7 @@ dependencies = [
  "fjall",
  "itertools 0.14.0",
  "jiff",
+ "koina",
  "loom",
  "lru",
  "ndarray",
@@ -4955,7 +4954,6 @@ dependencies = [
 name = "organon"
 version = "0.19.0"
 dependencies = [
- "base64 0.22.1",
  "energeia",
  "fjall",
  "hermeneus",
@@ -7502,7 +7500,6 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 name = "taxis"
 version = "0.19.0"
 dependencies = [
- "base64 0.22.1",
  "chacha20poly1305",
  "eidos",
  "koina",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,6 @@ disallowed_methods = "deny"
 disallowed_types = "deny"
 
 [workspace.dependencies]
-base64 = { version = "0.22", default-features = false, features = ["std"] }
 rayon = { version = "1", default-features = false }
 
 # Error handling

--- a/crates/diaporeia/Cargo.toml
+++ b/crates/diaporeia/Cargo.toml
@@ -49,9 +49,6 @@ snafu = { workspace = true }
 # Observability
 tracing = { workspace = true }
 
-# Base64 for JWT payload decoding
-base64 = { workspace = true }
-
 # HTTP types for accessing request extensions
 http = { workspace = true }
 

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -86,13 +86,8 @@ fn parse_role_from_token(token: &str) -> Option<Role> {
 }
 
 /// Base64 decode with URL-safe alphabet and no padding.
-fn base64_decode_urlsafe(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    use base64::{Engine, alphabet, engine::GeneralPurpose};
-    let engine = GeneralPurpose::new(
-        &alphabet::URL_SAFE,
-        base64::engine::GeneralPurposeConfig::new(),
-    );
-    engine.decode(input.trim_end_matches('='))
+fn base64_decode_urlsafe(input: &str) -> Result<Vec<u8>, koina::base64::DecodeError> {
+    koina::base64::decode_url_safe_no_pad(input)
 }
 
 /// Check if the caller has operator-level access or above.

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -38,6 +38,7 @@ prometheus-client = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
 criterion = { workspace = true }
 tempfile = { workspace = true }
+proptest = { workspace = true }
 
 # WHY: ID generation is on every session/turn/observation hot path. Track
 # regressions in the internal ULID/UUID implementations against external

--- a/crates/koina/src/base64.rs
+++ b/crates/koina/src/base64.rs
@@ -1,0 +1,456 @@
+//! RFC 4648 base64 encoding and decoding.
+//!
+//! Provides standard (padded) and URL-safe (no-pad) variants.
+//! No SIMD, no streaming — straightforward iterator-based implementation.
+
+use snafu::Snafu;
+
+/// Errors that can occur during base64 decoding.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum DecodeError {
+    /// Input contained a character not in the base64 alphabet.
+    #[snafu(display("invalid base64 character: {ch} at position {position}"))]
+    InvalidChar {
+        /// The offending character.
+        ch: char,
+        /// Byte position in the input string.
+        position: usize,
+        #[snafu(implicit)]
+        /// Source location captured by snafu.
+        location: snafu::Location,
+    },
+    /// Input length is not valid for base64.
+    #[snafu(display("invalid base64 length: {length}"))]
+    InvalidLength {
+        /// The length of the input.
+        length: usize,
+        #[snafu(implicit)]
+        /// Source location captured by snafu.
+        location: snafu::Location,
+    },
+    /// Padding is malformed or absent where required.
+    #[snafu(display("invalid base64 padding"))]
+    InvalidPadding {
+        #[snafu(implicit)]
+        /// Source location captured by snafu.
+        location: snafu::Location,
+    },
+}
+
+/// Standard base64 alphabet (with `+` and `/`).
+const STANDARD_ALPHABET: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// URL-safe base64 alphabet (with `-` and `_`).
+const URL_SAFE_ALPHABET: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+/// Encode bytes to standard base64 (with `+`, `/`, and `=` padding).
+#[must_use]
+pub fn encode(input: &[u8]) -> String {
+    encode_with_alphabet(input, STANDARD_ALPHABET, true)
+}
+
+/// Decode standard base64 (with `+`, `/`, `=` padding).
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] if the input contains invalid characters,
+/// has an invalid length, or has malformed padding.
+pub fn decode(input: &str) -> Result<Vec<u8>, DecodeError> {
+    decode_inner(input, false, true)
+}
+
+/// Encode bytes to URL-safe base64 (with `-`, `_`, no padding).
+///
+/// Used for JWT segments and PKCE verifiers.
+#[must_use]
+pub fn encode_url_safe_no_pad(input: &[u8]) -> String {
+    encode_with_alphabet(input, URL_SAFE_ALPHABET, false)
+}
+
+/// Decode URL-safe base64 (with `-`, `_`, no padding required).
+///
+/// Leniently accepts `+` and `/` as aliases for `-` and `_`, and strips
+/// any trailing `=` padding, so callers that receive mildly malformed
+/// inputs do not fail unnecessarily.
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] if the input contains invalid characters
+/// or has an invalid length.
+pub fn decode_url_safe_no_pad(input: &str) -> Result<Vec<u8>, DecodeError> {
+    decode_inner(input, true, false)
+}
+
+/// Encode with a given alphabet and optional padding.
+fn encode_with_alphabet(input: &[u8], alphabet: &[u8; 64], pad: bool) -> String {
+    let mut out = String::with_capacity(input.len().saturating_mul(4).div_ceil(3));
+
+    let mut chunks = input.chunks_exact(3);
+    for chunk in &mut chunks {
+        let [b0, b1, b2] = *chunk else {
+            #[expect(
+                clippy::unreachable,
+                reason = "chunks_exact(3) yields only full-length chunks; remainder is handled separately"
+            )]
+            {
+                unreachable!("chunks_exact(3) chunk must have len 3")
+            }
+        };
+        let b = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+        out.push(sextet_to_char(alphabet, b >> 18));
+        out.push(sextet_to_char(alphabet, b >> 12));
+        out.push(sextet_to_char(alphabet, b >> 6));
+        out.push(sextet_to_char(alphabet, b));
+    }
+
+    let remainder = chunks.remainder();
+    match *remainder {
+        [] => {}
+        [b0] => {
+            let b = u32::from(b0) << 16;
+            out.push(sextet_to_char(alphabet, b >> 18));
+            out.push(sextet_to_char(alphabet, b >> 12));
+            if pad {
+                out.push('=');
+                out.push('=');
+            }
+        }
+        [b0, b1] => {
+            let b = (u32::from(b0) << 16) | (u32::from(b1) << 8);
+            out.push(sextet_to_char(alphabet, b >> 18));
+            out.push(sextet_to_char(alphabet, b >> 12));
+            out.push(sextet_to_char(alphabet, b >> 6));
+            if pad {
+                out.push('=');
+            }
+        }
+        #[expect(
+            clippy::unreachable,
+            reason = "chunks_exact(3) guarantees remainder().len() ∈ {0, 1, 2}; only 3 arms reachable"
+        )]
+        _ => unreachable!("chunks_exact(3) remainder cannot exceed 2"),
+    }
+
+    out
+}
+
+/// Map a 6-bit sextet to a character in the given alphabet.
+fn sextet_to_char(alphabet: &[u8; 64], six_bits: u32) -> char {
+    #[expect(
+        clippy::as_conversions,
+        reason = "six_bits & 0x3F is always 0-63, fits in usize"
+    )]
+    let idx = (six_bits & 0x3F) as usize;
+    // INVARIANT: `six_bits & 0x3F` is always 0-63, so the index is always in bounds.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "six_bits & 0x3F is always in 0..64"
+    )]
+    char::from(alphabet[idx])
+}
+
+/// Decode base64 with configurable alphabet and padding requirements.
+fn decode_inner(
+    input: &str,
+    allow_url_safe: bool,
+    require_pad: bool,
+) -> Result<Vec<u8>, DecodeError> {
+    let bytes = input.as_bytes();
+
+    // Locate the end of actual data (before any trailing '=').
+    let data_end = bytes.iter().rposition(|&b| b != b'=').map_or(0, |i| i + 1);
+    let padding_len = bytes.len().saturating_sub(data_end);
+
+    if require_pad {
+        if !bytes.len().is_multiple_of(4) {
+            return InvalidLengthSnafu {
+                length: bytes.len(),
+            }
+            .fail();
+        }
+        if padding_len > 2 {
+            return InvalidPaddingSnafu.fail();
+        }
+    } else if data_end % 4 == 1 {
+        // No-pad mode: 1 mod 4 can never represent a valid number of bytes.
+        return InvalidLengthSnafu { length: data_end }.fail();
+    }
+
+    let mut out = Vec::with_capacity(data_end.saturating_mul(3).div_ceil(4));
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+
+    for (pos, &b) in bytes.iter().enumerate().take(data_end) {
+        let v = char_to_sextet(b, allow_url_safe).ok_or_else(|| {
+            InvalidCharSnafu {
+                ch: char::from(b),
+                position: pos,
+            }
+            .build()
+        })?;
+        buf = (buf << 6) | u32::from(v);
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(u8::try_from((buf >> bits) & 0xFF).unwrap_or(0));
+        }
+    }
+
+    // Validate that any leftover bits in the final sextet are zero.
+    if bits > 0 {
+        let mask = (1u32 << bits) - 1;
+        if (buf & mask) != 0 {
+            return InvalidPaddingSnafu.fail();
+        }
+    }
+
+    Ok(out)
+}
+
+/// Map a single base64 character to its 6-bit value.
+fn char_to_sextet(b: u8, allow_url_safe: bool) -> Option<u8> {
+    match b {
+        b'A'..=b'Z' => Some(b - b'A'),
+        b'a'..=b'z' => Some(b - b'a' + 26),
+        b'0'..=b'9' => Some(b - b'0' + 52),
+        b'+' => Some(62),
+        b'/' => Some(63),
+        b'-' if allow_url_safe => Some(62),
+        b'_' if allow_url_safe => Some(63),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    // ── RFC 4648 test vectors (section 10) ─────────────────────────────
+
+    #[test]
+    fn rfc4648_empty() {
+        assert_eq!(encode(b""), "");
+        assert_eq!(decode("").unwrap(), b"");
+    }
+
+    #[test]
+    fn rfc4648_f() {
+        assert_eq!(encode(b"f"), "Zg==");
+        assert_eq!(decode("Zg==").unwrap(), b"f");
+    }
+
+    #[test]
+    fn rfc4648_fo() {
+        assert_eq!(encode(b"fo"), "Zm8=");
+        assert_eq!(decode("Zm8=").unwrap(), b"fo");
+    }
+
+    #[test]
+    fn rfc4648_foo() {
+        assert_eq!(encode(b"foo"), "Zm9v");
+        assert_eq!(decode("Zm9v").unwrap(), b"foo");
+    }
+
+    #[test]
+    fn rfc4648_foob() {
+        assert_eq!(encode(b"foob"), "Zm9vYg==");
+        assert_eq!(decode("Zm9vYg==").unwrap(), b"foob");
+    }
+
+    #[test]
+    fn rfc4648_fooba() {
+        assert_eq!(encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(decode("Zm9vYmE=").unwrap(), b"fooba");
+    }
+
+    #[test]
+    fn rfc4648_foobar() {
+        assert_eq!(encode(b"foobar"), "Zm9vYmFy");
+        assert_eq!(decode("Zm9vYmFy").unwrap(), b"foobar");
+    }
+
+    // ── URL-safe no-pad vectors ───────────────────────────────────────
+
+    #[test]
+    fn url_safe_empty() {
+        assert_eq!(encode_url_safe_no_pad(b""), "");
+        assert_eq!(decode_url_safe_no_pad("").unwrap(), b"");
+    }
+
+    #[test]
+    fn url_safe_f() {
+        assert_eq!(encode_url_safe_no_pad(b"f"), "Zg");
+        assert_eq!(decode_url_safe_no_pad("Zg").unwrap(), b"f");
+    }
+
+    #[test]
+    fn url_safe_fo() {
+        assert_eq!(encode_url_safe_no_pad(b"fo"), "Zm8");
+        assert_eq!(decode_url_safe_no_pad("Zm8").unwrap(), b"fo");
+    }
+
+    #[test]
+    fn url_safe_foo() {
+        assert_eq!(encode_url_safe_no_pad(b"foo"), "Zm9v");
+        assert_eq!(decode_url_safe_no_pad("Zm9v").unwrap(), b"foo");
+    }
+
+    #[test]
+    fn url_safe_foob() {
+        assert_eq!(encode_url_safe_no_pad(b"foob"), "Zm9vYg");
+        assert_eq!(decode_url_safe_no_pad("Zm9vYg").unwrap(), b"foob");
+    }
+
+    #[test]
+    fn url_safe_fooba() {
+        assert_eq!(encode_url_safe_no_pad(b"fooba"), "Zm9vYmE");
+        assert_eq!(decode_url_safe_no_pad("Zm9vYmE").unwrap(), b"fooba");
+    }
+
+    #[test]
+    fn url_safe_foobar() {
+        assert_eq!(encode_url_safe_no_pad(b"foobar"), "Zm9vYmFy");
+        assert_eq!(decode_url_safe_no_pad("Zm9vYmFy").unwrap(), b"foobar");
+    }
+
+    #[test]
+    fn url_safe_replaces_special_chars() {
+        // Bytes that would produce + or / in standard base64.
+        let input: &[u8] = &[0xfb, 0xff, 0xfe];
+        let encoded = encode_url_safe_no_pad(input);
+        assert!(!encoded.contains('+'));
+        assert!(!encoded.contains('/'));
+        assert!(!encoded.contains('='));
+        assert_eq!(decode_url_safe_no_pad(&encoded).unwrap(), input);
+    }
+
+    #[test]
+    fn url_safe_lenient_with_standard_chars() {
+        // URL-safe decoder should accept + and / as well.
+        let input = b"test";
+        let encoded = encode(input);
+        assert_eq!(decode_url_safe_no_pad(&encoded).unwrap(), input);
+    }
+
+    #[test]
+    fn url_safe_lenient_with_padding() {
+        // URL-safe decoder should strip trailing = padding.
+        assert_eq!(decode_url_safe_no_pad("Zg==").unwrap(), b"f");
+        assert_eq!(decode_url_safe_no_pad("Zm8=").unwrap(), b"fo");
+    }
+
+    #[test]
+    fn url_safe_known_jwt_header() {
+        let decoded = decode_url_safe_no_pad("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9").unwrap();
+        assert_eq!(decoded, br#"{"alg":"HS256","typ":"JWT"}"#);
+    }
+
+    // ── Error cases ───────────────────────────────────────────────────
+
+    #[test]
+    fn decode_invalid_char() {
+        // Valid length (8), invalid character in the middle.
+        assert!(matches!(
+            decode("Zm9vYg@="),
+            Err(DecodeError::InvalidChar { .. })
+        ));
+        // Valid length for no-pad (7), invalid character at end.
+        assert!(matches!(
+            decode_url_safe_no_pad("Zm9vYg@"),
+            Err(DecodeError::InvalidChar { .. })
+        ));
+    }
+
+    #[test]
+    fn decode_wrong_length() {
+        // "a" is 1 char — not a multiple of 4 for standard, and 1 mod 4 for no-pad.
+        assert!(matches!(
+            decode("a"),
+            Err(DecodeError::InvalidLength { .. })
+        ));
+        assert!(matches!(
+            decode_url_safe_no_pad("a"),
+            Err(DecodeError::InvalidLength { .. })
+        ));
+    }
+
+    #[test]
+    fn decode_bad_padding() {
+        // "abc==" is 5 chars — not a multiple of 4.
+        assert!(matches!(
+            decode("abc=="),
+            Err(DecodeError::InvalidLength { .. })
+        ));
+        // "abcde" is 5 chars — not a multiple of 4.
+        assert!(matches!(
+            decode("abcde"),
+            Err(DecodeError::InvalidLength { .. })
+        ));
+        // "ab==" has 2 data chars; the 4 trailing bits of the second char must be zero.
+        // 'b' = 27 = 0b011011; last 4 bits = 0b1011 = 11 ≠ 0, so InvalidPadding.
+        assert!(matches!(
+            decode("ab=="),
+            Err(DecodeError::InvalidPadding { .. })
+        ));
+    }
+
+    #[test]
+    fn decode_url_safe_bad_length() {
+        // 1 mod 4 is always invalid for no-pad.
+        assert!(matches!(
+            decode_url_safe_no_pad("a"),
+            Err(DecodeError::InvalidLength { .. })
+        ));
+        // 2 chars with non-zero leftover bits.
+        assert!(matches!(
+            decode_url_safe_no_pad("ab"),
+            Err(DecodeError::InvalidPadding { .. })
+        ));
+    }
+
+    // ── Roundtrip property test (proptest) ────────────────────────────
+
+    #[test]
+    fn roundtrip_standard() {
+        let input = b"The quick brown fox jumps over the lazy dog.";
+        let encoded = encode(input);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn roundtrip_url_safe() {
+        let input = b"The quick brown fox jumps over the lazy dog.";
+        let encoded = encode_url_safe_no_pad(input);
+        let decoded = decode_url_safe_no_pad(&encoded).unwrap();
+        assert_eq!(decoded, input);
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "proptest assertions")]
+mod proptests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn prop_roundtrip_standard(data: Vec<u8>) {
+            let encoded = encode(&data);
+            let decoded = decode(&encoded).unwrap();
+            prop_assert_eq!(decoded, data);
+        }
+
+        #[test]
+        fn prop_roundtrip_url_safe(data: Vec<u8>) {
+            let encoded = encode_url_safe_no_pad(&data);
+            let decoded = decode_url_safe_no_pad(&encoded).unwrap();
+            prop_assert_eq!(decoded, data);
+        }
+    }
+}

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -5,6 +5,8 @@
 //! Imports nothing from other Aletheia crates. Contains only types, error definitions,
 //! and tracing initialization.
 
+/// RFC 4648 base64 encoding and decoding (standard and URL-safe variants).
+pub mod base64;
 /// Setup-time cleanup registration via RAII guards ([`cleanup::CleanupGuard`], [`cleanup::CleanupRegistry`]).
 pub mod cleanup;
 /// Credential provider trait for dynamic API key resolution.

--- a/crates/krites/Cargo.toml
+++ b/crates/krites/Cargo.toml
@@ -18,6 +18,7 @@ test-core = ["storage-fjall"]
 test-full = []
 
 [dependencies]
+koina = { path = "../koina" }
 eidos = { path = "../eidos" }
 
 jiff = { workspace = true, features = ["serde"] }
@@ -48,7 +49,6 @@ regex = { workspace = true }
 sha2 = { workspace = true, default-features = false }
 either = { version = "1", default-features = false }
 rand = { workspace = true }
-base64 = { workspace = true }
 uuid = { workspace = true, features = ["v1", "serde"] }
 pest = "2.8"
 pest_derive = "2.8"

--- a/crates/krites/src/data/functions/string.rs
+++ b/crates/krites/src/data/functions/string.rs
@@ -3,10 +3,9 @@
     clippy::as_conversions,
     reason = "string function casts (CompactString as &str) are safe coercions"
 )]
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
 use compact_str::CompactString;
 use itertools::Itertools;
+use koina::base64;
 use snafu::ResultExt;
 use unicode_normalization::UnicodeNormalization;
 
@@ -216,7 +215,7 @@ pub(crate) fn op_unicode_normalize(args: &[DataValue]) -> Result<DataValue> {
 pub(crate) fn op_encode_base64(args: &[DataValue]) -> Result<DataValue> {
     match arg(args, 0)? {
         DataValue::Bytes(b) => {
-            let s = STANDARD.encode(b);
+            let s = base64::encode(b);
             Ok(DataValue::from(s))
         }
         _ => TypeMismatchSnafu {
@@ -230,7 +229,7 @@ pub(crate) fn op_encode_base64(args: &[DataValue]) -> Result<DataValue> {
 pub(crate) fn op_decode_base64(args: &[DataValue]) -> Result<DataValue> {
     match arg(args, 0)? {
         DataValue::Str(s) => {
-            let b = STANDARD.decode(s).map_err(|e| {
+            let b = base64::decode(s).map_err(|e| {
                 EncodingFailedSnafu {
                     message: format!("Data is not properly encoded: {e}"),
                 }

--- a/crates/krites/src/data/functions/vector.rs
+++ b/crates/krites/src/data/functions/vector.rs
@@ -12,8 +12,7 @@
     reason = "op_vec handles multiple input types and vector element types"
 )]
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
+use koina::base64;
 use rand::Rng;
 
 use super::arg;
@@ -140,7 +139,7 @@ pub(crate) fn op_vec(args: &[DataValue]) -> Result<DataValue> {
             }
         },
         DataValue::Str(s) => {
-            let bytes = STANDARD.decode(s).map_err(|_e| {
+            let bytes = base64::decode(s).map_err(|_e| {
                 EncodingFailedSnafu {
                     message: "Data is not base64 encoded",
                 }

--- a/crates/krites/src/data/json.rs
+++ b/crates/krites/src/data/json.rs
@@ -1,6 +1,5 @@
 //! JSON serialization and deserialization for data values.
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
+use koina::base64;
 pub(crate) use serde_json::Value as JsonValue;
 use serde_json::json;
 
@@ -71,7 +70,7 @@ impl From<DataValue> for JsonValue {
                 }
             }
             DataValue::Str(t) => JsonValue::String(t.into()),
-            DataValue::Bytes(bytes) => JsonValue::String(STANDARD.encode(bytes)),
+            DataValue::Bytes(bytes) => JsonValue::String(base64::encode(&bytes)),
             DataValue::List(l) => JsonValue::Array(l.into_iter().map(JsonValue::from).collect()),
             DataValue::Bot => panic!("found bottom"),
             DataValue::Set(l) => JsonValue::Array(l.into_iter().map(JsonValue::from).collect()),

--- a/crates/krites/src/data/relation.rs
+++ b/crates/krites/src/data/relation.rs
@@ -26,11 +26,10 @@
 use std::cmp::Reverse;
 use std::fmt::{Display, Formatter};
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
 use compact_str::CompactString;
 use itertools::Itertools;
 use jiff::Timestamp;
+use koina::base64;
 use serde_json::json;
 
 use super::error::*;
@@ -240,7 +239,7 @@ impl NullableColType {
             ColType::Bytes => match data {
                 d @ DataValue::Bytes(_) => d,
                 DataValue::Str(s) => {
-                    let b = STANDARD.decode(s).map_err(|e| {
+                    let b = base64::decode(&s).map_err(|e| {
                         EncodingFailedSnafu {
                             message: format!("cannot decode string as base64-encoded bytes: {e}"),
                         }
@@ -314,7 +313,7 @@ impl NullableColType {
                     }
                 }
                 DataValue::Str(s) => {
-                    let bytes = STANDARD.decode(s).map_err(|_| make_err())?;
+                    let bytes = base64::decode(s).map_err(|_| make_err())?;
                     match eltype {
                         VecElementType::F32 => {
                             let floats: &[f32] =

--- a/crates/krites/src/data/value.rs
+++ b/crates/krites/src/data/value.rs
@@ -34,9 +34,8 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
 use compact_str::CompactString;
+use koina::base64;
 use ndarray::Array1;
 use ordered_float::OrderedFloat;
 use regex::Regex;
@@ -721,7 +720,7 @@ impl Display for DataValue {
             DataValue::Num(n) => write!(f, "{n}"),
             DataValue::Str(s) => write!(f, "{s:?}"),
             DataValue::Bytes(b) => {
-                let bs = STANDARD.encode(b);
+                let bs = base64::encode(b);
                 write!(f, "decode_base64({bs:?})")
             }
             DataValue::Uuid(u) => {

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -29,7 +29,6 @@ energeia = { path = "../energeia", optional = true, features = [
 hermeneus = { path = "../hermeneus" }
 koina = { path = "../koina" }
 taxis = { path = "../taxis" }
-base64 = { workspace = true }
 indexmap = { workspace = true }
 jiff = { workspace = true }
 prometheus-client = { workspace = true }

--- a/crates/organon/src/builtins/computer_use/sandbox.rs
+++ b/crates/organon/src/builtins/computer_use/sandbox.rs
@@ -137,10 +137,7 @@ pub(super) fn execute_sandboxed_action(
     let change_description = describe_change(action, diff_region.as_ref());
 
     // Encode post-action frame for return.
-    let frame_base64 = Some(base64::Engine::encode(
-        &base64::engine::general_purpose::STANDARD,
-        &after_bytes,
-    ));
+    let frame_base64 = Some(koina::base64::encode(&after_bytes));
 
     // Clean up temp files.
     let _ = std::fs::remove_file(&before_path);

--- a/crates/organon/src/builtins/view_file.rs
+++ b/crates/organon/src/builtins/view_file.rs
@@ -4,8 +4,8 @@ use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
 
-use base64::Engine as _;
 use indexmap::IndexMap;
+use koina::base64;
 
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
@@ -162,7 +162,7 @@ fn execute_by_kind(
                 Ok(b) => b,
                 Err(e) => return ToolResult::error(format!("read failed: {e}")),
             };
-            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            let encoded = base64::encode(&bytes);
             ToolResult::blocks(vec![
                 ToolResultBlock::Image {
                     source: ImageSource {
@@ -197,7 +197,7 @@ fn execute_by_kind(
                 Ok(b) => b,
                 Err(e) => return ToolResult::error(format!("read failed: {e}")),
             };
-            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            let encoded = base64::encode(&bytes);
             ToolResult::blocks(vec![
                 ToolResultBlock::Document {
                     source: DocumentSource {

--- a/crates/symbolon/src/credential_tests.rs
+++ b/crates/symbolon/src/credential_tests.rs
@@ -213,32 +213,7 @@ fn env_provider_with_source_forces_oauth() {
 /// signature is unused (no verification is performed).
 fn make_test_oauth_token(exp_secs: u64) -> String {
     fn base64url_encode(input: &[u8]) -> String {
-        const TABLE: &[u8; 64] =
-            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-        // SAFETY: index is masked to 0..=63 by & 0x3F, TABLE has exactly 64 elements
-        fn lookup(table: &[u8; 64], idx: u32) -> char {
-            char::from(
-                *table
-                    .get(usize::try_from(idx).unwrap_or(0))
-                    .unwrap_or(&b'A'),
-            )
-        }
-        let mut out = String::new();
-        for chunk in input.chunks(3) {
-            let b0 = u32::from(*chunk.first().unwrap_or(&0));
-            let b1 = u32::from(*chunk.get(1).unwrap_or(&0));
-            let b2 = u32::from(*chunk.get(2).unwrap_or(&0));
-            let n = (b0 << 16) | (b1 << 8) | b2;
-            out.push(lookup(TABLE, (n >> 18) & 0x3F));
-            out.push(lookup(TABLE, (n >> 12) & 0x3F));
-            if chunk.len() > 1 {
-                out.push(lookup(TABLE, (n >> 6) & 0x3F));
-            }
-            if chunk.len() > 2 {
-                out.push(lookup(TABLE, n & 0x3F));
-            }
-        }
-        out
+        koina::base64::encode_url_safe_no_pad(input)
     }
 
     let payload_json = format!(r#"{{"exp":{exp_secs}}}"#);

--- a/crates/symbolon/src/util.rs
+++ b/crates/symbolon/src/util.rs
@@ -18,26 +18,19 @@ pub(crate) fn days_to_date(days_since_epoch: u64) -> (u64, u64, u64) {
     (y, m, d)
 }
 
-/// Standard base64 character set (with `+` and `/`).
-const BASE64_CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-/// URL-safe base64 character set (with `-` and `_`).
-const BASE64URL_CHARS: &[u8; 64] =
-    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-
 /// Encode bytes to standard base64 (with `+`, `/`, and `=` padding).
 pub(crate) fn base64_encode(input: &[u8]) -> String {
-    base64_encode_with_alphabet(input, BASE64_CHARS, true)
+    koina::base64::encode(input)
 }
 
 /// Decode standard base64 (with `+`, `/`, `=` padding).
 pub(crate) fn base64_decode(s: &str) -> Option<Vec<u8>> {
-    base64_decode_with_alphabet(s, false)
+    koina::base64::decode(s).ok()
 }
 
 /// Encode bytes to base64url (with `-`, `_`, no padding).
 pub(crate) fn base64url_encode(input: &[u8]) -> String {
-    base64_encode_with_alphabet(input, BASE64URL_CHARS, false)
+    koina::base64::encode_url_safe_no_pad(input)
 }
 
 /// Decode base64url-encoded string (with `-`, `_`, no padding required).
@@ -46,114 +39,7 @@ pub(crate) fn base64url_encode(input: &[u8]) -> String {
 /// dedicated crate for this ~30-line function. Base64url differs from standard
 /// Base64 only in the `+`/`-` and `/`/`_` substitutions and the omission of `=` padding.
 pub(crate) fn base64url_decode(s: &str) -> Option<Vec<u8>> {
-    base64_decode_with_alphabet(s, true)
-}
-
-/// Look up a base64 sextet (0-63) in a 64-entry alphabet.
-///
-/// INVARIANT: callers mask inputs with `& 0x3F` (range 0-63) before calling;
-/// the alphabet is a fixed 64-byte array, so the index is always in bounds.
-/// The `unwrap_or(b'A')` branch is mathematically unreachable but avoids a
-/// panic path and keeps the function total.
-fn base64_sextet(alphabet: &[u8; 64], six_bits: u32) -> char {
-    let idx = (six_bits & 0x3F).to_le_bytes();
-    // INVARIANT: `six_bits & 0x3F` fits in u8, so idx[0] is the whole index.
-    let byte = idx.first().copied().unwrap_or(0);
-    char::from(alphabet.get(usize::from(byte)).copied().unwrap_or(b'A'))
-}
-
-/// Internal: encode with a given alphabet and optional padding.
-fn base64_encode_with_alphabet(input: &[u8], alphabet: &[u8; 64], pad: bool) -> String {
-    let mut out = String::with_capacity((input.len() * 4).div_ceil(3) + if pad { 4 } else { 0 });
-
-    let mut chunks = input.chunks_exact(3);
-    for chunk in &mut chunks {
-        // INVARIANT: chunks_exact(3) guarantees every yielded chunk has len == 3.
-        let [b0, b1, b2] = *chunk else {
-            #[expect(
-                clippy::unreachable,
-                reason = "chunks_exact(3) yields only full-length chunks; remainder is handled separately"
-            )]
-            {
-                unreachable!("chunks_exact(3) chunk must have len 3")
-            }
-        };
-        let b = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
-        out.push(base64_sextet(alphabet, b >> 18));
-        out.push(base64_sextet(alphabet, b >> 12));
-        out.push(base64_sextet(alphabet, b >> 6));
-        out.push(base64_sextet(alphabet, b));
-    }
-
-    let remainder = chunks.remainder();
-    match *remainder {
-        [] => {}
-        [b0] => {
-            let b = u32::from(b0) << 16;
-            out.push(base64_sextet(alphabet, b >> 18));
-            out.push(base64_sextet(alphabet, b >> 12));
-            if pad {
-                out.push('=');
-                out.push('=');
-            }
-        }
-        [b0, b1] => {
-            let b = (u32::from(b0) << 16) | (u32::from(b1) << 8);
-            out.push(base64_sextet(alphabet, b >> 18));
-            out.push(base64_sextet(alphabet, b >> 12));
-            out.push(base64_sextet(alphabet, b >> 6));
-            if pad {
-                out.push('=');
-            }
-        }
-        // INVARIANT: chunks_exact(3).remainder() always has len ∈ {0, 1, 2}.
-        #[expect(
-            clippy::unreachable,
-            reason = "chunks_exact(3) guarantees remainder().len() ∈ {0, 1, 2}; only 3 arms reachable"
-        )]
-        _ => unreachable!("chunks_exact(3) remainder cannot exceed 2"),
-    }
-
-    out
-}
-
-/// Internal: decode with support for both standard and URL-safe alphabets.
-fn base64_decode_with_alphabet(s: &str, url_safe: bool) -> Option<Vec<u8>> {
-    /// Map a single base64/base64url character to its 6-bit value.
-    fn char_val(b: u8, url_safe: bool) -> Option<u8> {
-        match b {
-            b'A'..=b'Z' => Some(b - b'A'),
-            b'a'..=b'z' => Some(b - b'a' + 26),
-            b'0'..=b'9' => Some(b - b'0' + 52),
-            b'-' => Some(62),
-            b'_' => Some(63),
-            b'+' if !url_safe => Some(62),
-            b'/' if !url_safe => Some(63),
-            b'=' => Some(0), // NOTE: padding treated as zero bits
-            _ => None,
-        }
-    }
-
-    let bytes = s.as_bytes();
-    let end = bytes.iter().rposition(|&b| b != b'=').map_or(0, |i| i + 1);
-    let bytes = bytes.get(..end).unwrap_or(bytes); // SAFETY: end <= bytes.len() by construction from rposition
-
-    let mut out = Vec::with_capacity(bytes.len() * 6 / 8 + 1);
-    let mut buf: u32 = 0;
-    let mut bits: u32 = 0;
-
-    for &b in bytes {
-        let v = char_val(b, url_safe)?;
-        buf = (buf << 6) | u32::from(v);
-        bits += 6;
-        if bits >= 8 {
-            bits -= 8;
-            // SAFETY: bits is 0-7 after decrement, buf >> bits lowest 8 bits are the decoded byte
-            out.push(u8::try_from((buf >> bits) & 0xFF).unwrap_or(0));
-        }
-    }
-
-    Some(out)
+    koina::base64::decode_url_safe_no_pad(s).ok()
 }
 
 /// Extract the `exp` (expiry, seconds since epoch) claim from a dot-segmented token.

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -20,7 +20,6 @@ test-support = ["dep:tempfile"]
 [dependencies]
 koina = { path = "../koina" }
 eidos = { path = "../eidos" }
-base64 = { workspace = true }
 rand = { workspace = true }
 chacha20poly1305 = { workspace = true }
 serde = { workspace = true }

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -8,10 +8,10 @@
 
 use std::path::{Path, PathBuf};
 
-use base64::Engine as _;
 use chacha20poly1305::aead::generic_array::GenericArray;
 use chacha20poly1305::aead::{Aead, AeadCore, OsRng};
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit};
+use koina::base64;
 use snafu::ResultExt;
 use tracing::warn;
 
@@ -202,7 +202,7 @@ pub(crate) fn encrypt_value(plaintext: &str, primary_key: &[u8; KEY_LEN]) -> Res
     payload.extend_from_slice(&nonce);
     payload.extend_from_slice(&ciphertext_with_tag);
 
-    let encoded = base64::engine::general_purpose::STANDARD.encode(&payload);
+    let encoded = base64::encode(&payload);
     Ok(format!("{ENCRYPTED_PREFIX}{encoded}"))
 }
 
@@ -220,10 +220,9 @@ pub(crate) fn decrypt_value(encrypted: &str, primary_key: &[u8; KEY_LEN]) -> Res
         .strip_prefix(ENCRYPTED_PREFIX)
         .ok_or_else(|| build_decrypt_error("missing enc: prefix"))?;
 
-    // WHY: base64::DecodeError is not useful to propagate through taxis Error
-    let payload = base64::engine::general_purpose::STANDARD
-        .decode(encoded)
-        .map_err(|_decode_err| build_decrypt_error("invalid base64"))?;
+    // WHY: koina::base64::DecodeError is not useful to propagate through taxis Error
+    let payload =
+        base64::decode(encoded).map_err(|_decode_err| build_decrypt_error("invalid base64"))?;
 
     if payload.len() < NONCE_LEN + TAG_LEN {
         return Err(build_decrypt_error("ciphertext too short"));

--- a/crates/theatron/koilon/Cargo.toml
+++ b/crates/theatron/koilon/Cargo.toml
@@ -64,7 +64,6 @@ syntect = { version = "5", default-features = false, features = [
     "default-themes",
 ] }
 arboard = "3"
-base64 = { workspace = true }
 regex = { workspace = true }
 
 # Time — used for export timestamps

--- a/crates/theatron/koilon/src/clipboard.rs
+++ b/crates/theatron/koilon/src/clipboard.rs
@@ -102,9 +102,7 @@ fn read_system_clipboard_text() -> ClipboardContent {
 fn copy_osc52(text: &str) -> Result<(), String> {
     use std::io::Write;
 
-    use base64::{Engine, engine::general_purpose::STANDARD};
-
-    let encoded = STANDARD.encode(text.as_bytes());
+    let encoded = koina::base64::encode(text.as_bytes());
 
     // NOTE: tmux requires an OSC52 passthrough wrapper for the escape sequence to reach the terminal
     let seq = if RealSystem.var("TMUX").is_some() {
@@ -131,19 +129,17 @@ mod tests {
 
     #[test]
     fn copy_osc52_generates_valid_sequence() {
-        use base64::{Engine, engine::general_purpose::STANDARD};
         let text = "test clipboard content";
-        let encoded = STANDARD.encode(text.as_bytes());
+        let encoded = koina::base64::encode(text.as_bytes());
         assert!(!encoded.is_empty());
-        let decoded = STANDARD.decode(&encoded).unwrap();
+        let decoded = koina::base64::decode(&encoded).unwrap();
         assert_eq!(String::from_utf8(decoded).unwrap(), text);
     }
 
     #[test]
     fn copy_osc52_tmux_detection() {
         let text = "test";
-        use base64::{Engine, engine::general_purpose::STANDARD};
-        let encoded = STANDARD.encode(text.as_bytes());
+        let encoded = koina::base64::encode(text.as_bytes());
         let tmux_seq = format!("\x1bPtmux;\x1b\x1b]52;c;{}\x07\x1b\\", encoded);
         let normal_seq = format!("\x1b]52;c;{}\x07", encoded);
         assert!(tmux_seq.len() > normal_seq.len());


### PR DESCRIPTION
Closes #3526

## Summary
Replaces the external `base64` crate (~4,230 LOC with SIMD and streaming features we do not use) with a ~200 LOC hand-rolled implementation in `koina::base64` adhering to RFC 4648.

## Changes

### Phase 1 – `koina::base64`
- New module `crates/koina/src/base64.rs` exposing:
  - `encode` / `decode` – standard alphabet, padded
  - `encode_url_safe_no_pad` / `decode_url_safe_no_pad` – URL-safe alphabet, no padding
- `DecodeError` snafu variant with `InvalidChar`, `InvalidLength`, `InvalidPadding`
- RFC 4648 test vectors (§9-10), error-case tests, and `proptest` round-trip coverage

### Phase 2 – Callsite migration
| Crate | Previous | Now |
|-------|----------|-----|
| symbolon | Internal `util.rs` impl | Delegates to `koina::base64` |
| taxis | `base64::engine::general_purpose::STANDARD` | `koina::base64` |
| organon | `base64::engine::general_purpose::STANDARD` | `koina::base64` |
| diaporeia | Custom `base64::engine::GeneralPurpose` (URL_SAFE) | `koina::base64::decode_url_safe_no_pad` |
| koilon | `base64::engine::general_purpose::STANDARD` | `koina::base64` |
| krites | `base64::engine::general_purpose::STANDARD` | `koina::base64` |

### Phase 3 – Dependency removal
- Removed `base64` from `[workspace.dependencies]` and every crate manifest.

## Symbolon coverage
All security-critical paths verified:
- **PKCE**: verifier/challenge generation and round-trip pass
- **JWT**: issue → validate round-trip, signature verification, payload decoding pass
- **Encrypted config**: encrypt → decrypt round-trip passes

## Validation
- `cargo fmt --check` ✅
- `cargo clippy --workspace --features test-core --all-targets -- -D warnings` ✅
- `cargo test --workspace --features test-core` ✅

Gate-Passed: kanon 0.1.0