### PR TITLE
refactor(thesauros): eliminate production unwrap()

### DIFF
--- a/crates/thesauros/src/lib.rs
+++ b/crates/thesauros/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::unwrap_used)]
 #![deny(missing_docs)]
 //! aletheia-thesauros: domain pack loader
 //!


### PR DESCRIPTION
Refs #3230

## Audit Result

- **Before:** 35 `.unwrap()` calls total — **0 in production code**, all 35 already confined to `#[cfg(test)]` modules with `#[expect(clippy::unwrap_used)]`.
- **After:** 0 production unwraps, enforced by `#![deny(clippy::unwrap_used)]` at crate root.

## Change

Add `#![deny(clippy::unwrap_used)]` to `crates/thesauros/src/lib.rs` to prevent future regressions. No production unwraps required replacement; test code was already properly annotated per existing standards.

## Validation

- `cargo fmt --check`
- `cargo clippy -p thesauros --all-targets -- -D warnings`
- `cargo test -p thesauros --features test-core`
- `cargo clippy -p thesauros -- -D clippy::unwrap_used -D warnings`
