### PR TITLE
refactor(oikonomos): audit production unwrap() usage — zero found

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![deny(clippy::unwrap_used)]
 //! aletheia-oikonomos: per-nous background task runner
 //!
 //! Oikonomos (οἰκονόμος): "the steward." The quiet persistent presence that


### PR DESCRIPTION
Refs #3230

## Summary

Audit of `crates/daemon/src/**/*.rs` confirms there are **no `.unwrap()` calls in production (non-test) code**.

| Metric | Before | After |
|--------|--------|-------|
| Production unwraps | 0 | 0 (lint-enforced) |
| Test unwraps (annotated) | 139 | 139 |

All 139 occurrences are inside `#[cfg(test)]` blocks and already annotated with `#[expect(clippy::unwrap_used)]`.

## Changes

- Add `#![deny(clippy::unwrap_used)]` to `lib.rs` to prevent future regressions in production code.

## Validation

```bash
cargo fmt --check                                               # ✓
cargo clippy -p oikonomos --all-targets -- -D warnings          # ✓
cargo test -p oikonomos --features test-core                    # ✓
cargo clippy -p oikonomos -- -D clippy::unwrap_used -D warnings # ✓
```

Gate-Passed: kanon 0.1.0