### PR TITLE
refactor(taxis): audit production unwrap() usage — zero found

### DIFF
--- a/crates/taxis/src/lib.rs
+++ b/crates/taxis/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![deny(clippy::unwrap_used)]
 //! aletheia-taxis: configuration cascade and path resolution
 //!
 //! Taxis (τάξις): "arrangement, ordering." Resolves configuration and files


### PR DESCRIPTION
Refs #3230

## Summary

Audit of `crates/taxis/src/**/*.rs` confirms there are **no `.unwrap()`
calls in production (non-test) code**.

| Metric | Before | After |
|--------|--------|-------|
| Production unwraps | 0 | 0 (lint-enforced) |
| Test unwraps (annotated) | 86 | 86 |

All 86 occurrences are inside `#[cfg(test)]` blocks and already
annotated with `#[expect(clippy::unwrap_used, reason = "...")]`.

## Changes

- Add `#![deny(clippy::unwrap_used)]` to `lib.rs` to prevent future
  regressions in production code.

## Validation

```bash
cargo fmt --check                                               # ✓
cargo clippy -p taxis --all-targets -- -D warnings              # ✓
cargo test -p taxis --features test-core                        # ✓
cargo clippy -p taxis -- -D clippy::unwrap_used -D warnings     # ✓
```

Gate-Passed: kanon 0.1.0