### PR TITLE
refactor(pylon): eliminate production unwrap()

### DIFF
--- a/crates/pylon/src/lib.rs
+++ b/crates/pylon/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::unwrap_used)]
 #![deny(missing_docs)]
 //! Pylon (πυλών): "gateway." Routes HTTP and SSE requests to the agent pipeline.
 


### PR DESCRIPTION
Refs #3230

## Audit Result

- **Before:** 0 ".unwrap()" calls in production code; all occurrences are already confined to "#[cfg(test)]" modules with "#[expect(clippy::unwrap_used)]".
- **After:** 0 production unwraps, enforced by "#![deny(clippy::unwrap_used)]" at crate root.

## Change

Add "#![deny(clippy::unwrap_used)]" to "crates/pylon/src/lib.rs" to prevent future regressions. No production unwraps required replacement; test code was already properly annotated per existing standards.

## Validation

- "cargo fmt --check"
- "cargo clippy -p pylon --all-targets -- -D warnings"
- "cargo test -p pylon --features test-core"
- "cargo clippy -p pylon -- -D clippy::unwrap_used -D warnings"

Gate-Passed: kanon 0.1.0