### PR TITLE
refactor(aletheia): zero production unwraps found — add deny ratchet

### DIFF
--- a/crates/aletheia/src/main.rs
+++ b/crates/aletheia/src/main.rs
@@ -2,6 +2,8 @@
 //!
 //! Per basanos ARCHITECTURE.md: "binary entrypoint under 100 lines."
 
+#![deny(clippy::unwrap_used)]
+
 mod cli;
 mod commands;
 mod daemon_bridge;


### PR DESCRIPTION
Refs #3230

**Before:** 0 production unwraps in 
**After:** 0 production unwraps;  ratchet added to 

All existing unwrap usage was already confined to  blocks with existing  annotations.