### PR TITLE
refactor(theatron): audit production unwrap() usage — zero found

### DIFF
--- a/crates/theatron/src/lib.rs
+++ b/crates/theatron/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![deny(clippy::unwrap_used)]
 //! aletheia-theatron: thin facade re-exporting skene types.
 //!
 //! Theatron (Θέατρον): "theatre." Consumers write `use theatron::ApiClient`


### PR DESCRIPTION
Refs #3230

## Summary

Audit of `crates/theatron/src/**/*.rs` confirms there are **no `.unwrap()`
calls in production (non-test) code**.

| Metric | Before | After |
|--------|--------|-------|
| Production unwraps | 0 | 0 (lint-enforced) |
| Test unwraps (annotated) | 0 | 0 |

## Changes

- Add `#![deny(clippy::unwrap_used)]` to `lib.rs` to prevent future
  regressions in production code.

## Validation

```bash
cargo fmt --check                                               # ✓
cargo clippy -p theatron --all-targets -- -D warnings              # ✓
cargo test -p theatron                                          # ✓
cargo clippy -p theatron -- -D clippy::unwrap_used -D warnings     # ✓
```

Gate-Passed: kanon 0.1.0