### PR TITLE
security(proskenion): bump rustls-webpki to 0.103.12 for RUSTSEC-2026-0099

### DIFF
--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -2392,10 +2392,11 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "compact_str",
  "jiff",
+ "prometheus-client",
  "rand 0.9.4",
  "regex",
  "rustix",
@@ -3469,6 +3470,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proskenion"
 version = "0.13.1"
 dependencies = [
@@ -3910,9 +3934,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4209,7 +4233,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bytes",
  "compact_str",


### PR DESCRIPTION
Closes #3376