### PR TITLE
refactor: drop uuid crate from krites, replace with koina::Uuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3980,7 +3980,6 @@ dependencies = [
  "tracing-subscriber",
  "twox-hash",
  "unicode-normalization",
- "uuid",
 ]
 
 [[package]]
@@ -8480,7 +8479,6 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,6 @@ tracing-test = "0.2"
 # standard Prometheus scrapers — they already accept OpenMetrics text.
 prometheus-client = "0.24"
 
-# IDs
-uuid = { version = "1", default-features = false, features = ["v4", "serde"] }
-
 # Types
 compact_str = { version = "0.9", features = ["serde"] }
 indexmap = { version = "2", default-features = false, features = ["serde"] }

--- a/crates/koina/src/uuid.rs
+++ b/crates/koina/src/uuid.rs
@@ -1,20 +1,28 @@
-//! Internal UUID v4 generation (dependency-free).
+//! Clean-room UUID implementation covering v4 generation and v1 construction.
 //!
-//! WHY: The `uuid` crate is ~50-100KB of code we don't need. UUID v4 is just
-//! 16 random bytes with 6 bits fixed for version/variant. We use `rand` which
+//! WHY: The `uuid` crate is 8,574 LOC (~50-100KB) we don't need. UUID v4 is
+//! just 16 random bytes with 6 bits fixed for version/variant. UUID v1 is a
+//! timestamp + clock-seq + node packed per RFC 4122 §4.1. We use `rand` which
 //! we already depend on for other purposes.
 //!
-//! For krites (CozoDB), we keep the `uuid` crate due to complex binary format
-//! requirements (v1 timestamps, from_fields/as_fields, etc.).
+//! This module now covers all UUID operations required by krites (formerly
+//! delegated to the `uuid` crate): v4 generation, v1 construction, field
+//! decomposition (`as_fields`/`from_fields`), byte-array access, nil check,
+//! and v1 timestamp extraction. The `uuid` crate has been removed from the
+//! workspace.
 
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
-/// A UUID v4 (128-bit random identifier).
+
+/// A UUID (128-bit identifier), supporting v4 and v1 variants.
 ///
-/// WHY: Internal implementation eliminates the `uuid` crate dependency for
-/// simple v4 generation use cases. This is NOT a general-purpose UUID library;
-/// it only supports what Aletheia needs: v4 generation and hyphenated formatting.
+/// WHY: Internal implementation eliminates the `uuid` crate dependency.
+/// Supports all operations needed by the Datalog engine in krites:
+/// v4 generation, v1 construction, RFC 4122 field decomposition, binary
+/// serialization, and v1 timestamp extraction.
+///
+/// The underlying storage is always big-endian byte order per RFC 4122 §4.1.2.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Uuid([u8; 16]);
@@ -97,6 +105,128 @@ impl Uuid {
         Ok(Self(bytes))
     }
 
+    /// Return the raw byte representation (big-endian, per RFC 4122 §4.1.2).
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+
+    /// Construct a UUID from raw bytes (big-endian).
+    #[must_use]
+    pub fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Interpret the UUID as a big-endian u128.
+    #[must_use]
+    pub fn as_u128(&self) -> u128 {
+        u128::from_be_bytes(self.0)
+    }
+
+    /// Return `true` if this is the nil UUID (all bytes zero).
+    #[must_use]
+    pub fn is_nil(&self) -> bool {
+        self.0 == [0u8; 16]
+    }
+
+    /// Decompose into RFC 4122 fields: `(time_low, time_mid, time_hi_and_version, rest)`.
+    ///
+    /// The byte layout (RFC 4122 §4.1.2) is:
+    /// - bytes 0–3  → `time_low` (`u32`, big-endian)
+    /// - bytes 4–5  → `time_mid` (`u16`, big-endian)
+    /// - bytes 6–7  → `time_hi_and_version` (`u16`, big-endian)
+    /// - bytes 8–15 → variant + clock-seq + node (`[u8; 8]`)
+    #[must_use]
+    pub fn as_fields(&self) -> (u32, u16, u16, &[u8; 8]) {
+        let time_low = u32::from_be_bytes([self.0[0], self.0[1], self.0[2], self.0[3]]);
+        let time_mid = u16::from_be_bytes([self.0[4], self.0[5]]);
+        let time_hi = u16::from_be_bytes([self.0[6], self.0[7]]);
+        // Split the fixed-size array at a known constant boundary. This is safe
+        // because `self.0` is `[u8; 16]` and `split_array_ref` is const-aware.
+        let (_, rest_slice) = self.0.split_at(8);
+        // INVARIANT: split_at(8) on [u8; 16] yields a 8-byte suffix.
+        let rest: &[u8; 8] = rest_slice
+            .try_into()
+            .unwrap_or_else(|_| unreachable!("split_at(8) of [u8;16] always yields 8 bytes"));
+        (time_low, time_mid, time_hi, rest)
+    }
+
+    /// Construct a UUID from RFC 4122 fields.
+    ///
+    /// Inverse of [`as_fields`](Self::as_fields). Bytes are written in big-endian
+    /// order per RFC 4122 §4.1.2.
+    #[must_use]
+    pub fn from_fields(time_low: u32, time_mid: u16, time_hi: u16, rest: &[u8; 8]) -> Self {
+        let mut bytes = [0u8; 16];
+        bytes[0..4].copy_from_slice(&time_low.to_be_bytes());
+        bytes[4..6].copy_from_slice(&time_mid.to_be_bytes());
+        bytes[6..8].copy_from_slice(&time_hi.to_be_bytes());
+        bytes[8..16].copy_from_slice(rest);
+        Self(bytes)
+    }
+
+    /// Construct a UUID v1 from a 100-nanosecond timestamp, clock sequence, and node ID.
+    ///
+    /// Per RFC 4122 §4.2 the 60-bit timestamp is packed as:
+    /// - bits 0–31  → `time_low` (bytes 0–3)
+    /// - bits 32–47 → `time_mid` (bytes 4–5)
+    /// - bits 48–59 → `time_high` (low 12 bits of bytes 6–7, high nibble = version 0x1)
+    ///
+    /// `timestamp_100ns` is the count of 100-nanosecond intervals since the UUID epoch
+    /// (1582-10-15 00:00:00 UTC, i.e., `122_192_928_000_000_000` intervals before Unix epoch).
+    #[must_use]
+    #[expect(
+        clippy::as_conversions,
+        reason = "UUID field packing: masking before cast guarantees values fit in target types"
+    )]
+    pub fn new_v1(timestamp_100ns: u64, clock_seq: u16, node: &[u8; 6]) -> Self {
+        // Masking ensures each field fits in the destination type before the `as` cast.
+        // time_low: low 32 bits of 64-bit timestamp, masked to exactly 32 bits.
+        let time_low = (timestamp_100ns & 0xFFFF_FFFF) as u32;
+        // time_mid: bits 32–47, masked to 16 bits.
+        let time_mid = ((timestamp_100ns >> 32) & 0xFFFF) as u16;
+        // Set version = 1 in the high nibble of time_hi_and_version; bits 48–59.
+        let time_hi = (((timestamp_100ns >> 48) & 0x0FFF) as u16) | 0x1000;
+        // Set variant bits: RFC 4122 §4.1.1 — top two bits = 10.
+        // clock_seq is u16; masking to 6 bits then casting to u8 is safe.
+        let clock_seq_hi = (((clock_seq >> 8) & 0x3F) as u8) | 0x80;
+        let clock_seq_low = (clock_seq & 0xFF) as u8;
+
+        let mut bytes = [0u8; 16];
+        bytes[0..4].copy_from_slice(&time_low.to_be_bytes());
+        bytes[4..6].copy_from_slice(&time_mid.to_be_bytes());
+        bytes[6..8].copy_from_slice(&time_hi.to_be_bytes());
+        bytes[8] = clock_seq_hi;
+        bytes[9] = clock_seq_low;
+        bytes[10..16].copy_from_slice(node);
+        Self(bytes)
+    }
+
+    /// Extract the v1 timestamp, returning `None` for non-v1 UUIDs.
+    ///
+    /// Returns a [`V1Timestamp`] whose [`to_unix`](V1Timestamp::to_unix) method
+    /// yields `(unix_seconds: u64, subsec_100ns: u32)`.
+    ///
+    /// The 60-bit UUID v1 timestamp counts 100-nanosecond intervals from the UUID
+    /// epoch (1582-10-15T00:00:00Z). The UUID epoch precedes the Unix epoch by
+    /// exactly 122,192,928,000,000,000 intervals (≈ 122.19 billion seconds).
+    ///
+    /// RFC 4122 §4.1.4: the timestamp is stored split across three fields
+    /// (`time_low`, `time_mid`, `time_high`) and must be reassembled by shifting.
+    #[must_use]
+    pub fn get_timestamp(&self) -> Option<V1Timestamp> {
+        // Version is stored in the high nibble of byte 6
+        let version = (self.0[6] >> 4) & 0xF;
+        if version != 1 {
+            return None;
+        }
+        let time_low = u64::from(u32::from_be_bytes([self.0[0], self.0[1], self.0[2], self.0[3]]));
+        let time_mid = u64::from(u16::from_be_bytes([self.0[4], self.0[5]]));
+        let time_hi = u64::from(u16::from_be_bytes([self.0[6], self.0[7]]) & 0x0FFF);
+        let ts_100ns = time_low | (time_mid << 32) | (time_hi << 48);
+        Some(V1Timestamp(ts_100ns))
+    }
+
     /// Format as hyphenated string.
     fn hyphenated(&self) -> impl fmt::Display + '_ {
         struct Hyphenated<'a>(&'a [u8; 16]);
@@ -144,6 +274,38 @@ impl fmt::Display for UuidParseError {
 
 impl std::error::Error for UuidParseError {}
 
+/// A v1 UUID timestamp extracted from a [`Uuid`].
+///
+/// Wraps the 60-bit 100-nanosecond counter measured from the UUID epoch
+/// (1582-10-15T00:00:00Z, per RFC 4122 §4.1.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct V1Timestamp(u64);
+
+impl V1Timestamp {
+    /// Decompose into Unix seconds and sub-second 100-nanosecond units.
+    ///
+    /// The UUID epoch precedes the Unix epoch by exactly
+    /// 122,192,928,000,000,000 × 100 ns intervals.
+    ///
+    /// Returns `(unix_seconds, subsec_100ns)` where `subsec_100ns` is in
+    /// `[0, 10_000_000)` (there are 10,000,000 × 100 ns per second).
+    #[must_use]
+    pub fn to_unix(&self) -> (u64, u32) {
+        // UUID epoch offset: 1582-10-15 → 1970-01-01 in 100-ns intervals.
+        const UUID_UNIX_OFFSET: u64 = 122_192_928_000_000_000;
+        // 10_000_000 × 100 ns = 1 second
+        const INTERVALS_PER_SEC: u64 = 10_000_000;
+
+        let ts = self.0.saturating_sub(UUID_UNIX_OFFSET);
+        let secs = ts / INTERVALS_PER_SEC;
+        // INVARIANT: remainder is always in 0..10_000_000 which fits u32.
+        // `try_into()` encodes that fact without a silent `as` cast.
+        let subsec = u32::try_from(ts % INTERVALS_PER_SEC)
+            .unwrap_or_else(|_| unreachable!("remainder < 10_000_000 always fits u32"));
+        (secs, subsec)
+    }
+}
+
 /// Generate a random UUID v4 as a string.
 ///
 /// Convenience function for the common case of needing a UUID string
@@ -156,6 +318,8 @@ pub fn uuid_v4() -> String {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
+    use proptest::prelude::*;
+
     use super::*;
 
     #[test]
@@ -231,5 +395,99 @@ mod tests {
         let s = id.to_string();
         // Version should be 4
         assert_eq!(s.chars().nth(14), Some('4'));
+    }
+
+    #[test]
+    fn as_bytes_from_bytes_roundtrip() {
+        let id = Uuid::new_v4();
+        let bytes = *id.as_bytes();
+        let id2 = Uuid::from_bytes(bytes);
+        assert_eq!(id, id2);
+    }
+
+    #[test]
+    fn as_u128_from_u128_roundtrip() {
+        let id = Uuid::new_v4();
+        let n = id.as_u128();
+        let id2 = Uuid::from_u128(n);
+        assert_eq!(id, id2);
+    }
+
+    #[test]
+    fn nil_uuid_is_nil() {
+        let nil = Uuid::from_bytes([0u8; 16]);
+        assert!(nil.is_nil());
+        let non_nil = Uuid::new_v4();
+        assert!(!non_nil.is_nil());
+    }
+
+    #[test]
+    fn as_fields_from_fields_roundtrip() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let (time_low, time_mid, time_hi, rest) = id.as_fields();
+        let id2 = Uuid::from_fields(time_low, time_mid, time_hi, rest);
+        assert_eq!(id, id2);
+    }
+
+    #[test]
+    fn v1_uuid_timestamp_roundtrip() {
+        // Known v1 UUID: "f3b4958c-52a1-11e7-802a-010203040506"
+        // Generated 2017-06-16, Unix time ~1_497_624_119
+        let v1 = Uuid::parse_str("f3b4958c-52a1-11e7-802a-010203040506").unwrap();
+        let ts = v1.get_timestamp().expect("v1 uuid must have timestamp");
+        let (secs, subsec) = ts.to_unix();
+        // 2017-06-16 ≈ Unix time 1_497_600_000
+        assert!(secs > 1_497_000_000, "seconds should be in 2017 range");
+        assert!(subsec < 10_000_000, "subsec should be < 10M");
+    }
+
+    #[test]
+    fn v4_uuid_has_no_timestamp() {
+        let v4 = Uuid::new_v4();
+        assert!(v4.get_timestamp().is_none());
+    }
+
+    #[test]
+    fn new_v1_roundtrip_via_get_timestamp() {
+        // Construct a v1 UUID from a known timestamp, verify extraction round-trips.
+        // Timestamp: 2020-01-01T00:00:00Z in 100-ns since UUID epoch.
+        const UUID_UNIX_OFFSET: u64 = 122_192_928_000_000_000;
+        // 2020-01-01 00:00:00 UTC = 1577836800 seconds since Unix epoch
+        let unix_secs: u64 = 1_577_836_800;
+        let ts_100ns = unix_secs * 10_000_000 + UUID_UNIX_OFFSET;
+        let node: [u8; 6] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        let id = Uuid::new_v1(ts_100ns, 0x0123, &node);
+
+        // Version must be 1
+        let s = id.to_string();
+        assert_eq!(s.chars().nth(14), Some('1'), "version digit must be 1");
+
+        let extracted = id.get_timestamp().expect("must extract v1 timestamp");
+        let (secs, _subsec) = extracted.to_unix();
+        assert_eq!(secs, unix_secs);
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn prop_as_bytes_from_bytes_identity(bytes: [u8; 16]) {
+            let id = Uuid::from_bytes(bytes);
+            prop_assert_eq!(id.as_bytes(), &bytes);
+        }
+
+        #[test]
+        fn prop_parse_str_to_string_roundtrip(bytes: [u8; 16]) {
+            let id = Uuid::from_bytes(bytes);
+            let s = id.to_string();
+            let parsed = Uuid::parse_str(&s).unwrap();
+            prop_assert_eq!(id, parsed);
+        }
+
+        #[test]
+        fn prop_as_fields_from_fields_identity(bytes: [u8; 16]) {
+            let id = Uuid::from_bytes(bytes);
+            let (tl, tm, th, rest) = id.as_fields();
+            let id2 = Uuid::from_fields(tl, tm, th, rest);
+            prop_assert_eq!(id, id2);
+        }
     }
 }

--- a/crates/koina/src/uuid.rs
+++ b/crates/koina/src/uuid.rs
@@ -220,7 +220,9 @@ impl Uuid {
         if version != 1 {
             return None;
         }
-        let time_low = u64::from(u32::from_be_bytes([self.0[0], self.0[1], self.0[2], self.0[3]]));
+        let time_low = u64::from(u32::from_be_bytes([
+            self.0[0], self.0[1], self.0[2], self.0[3],
+        ]));
         let time_mid = u64::from(u16::from_be_bytes([self.0[4], self.0[5]]));
         let time_hi = u64::from(u16::from_be_bytes([self.0[6], self.0[7]]) & 0x0FFF);
         let ts_100ns = time_low | (time_mid << 32) | (time_hi << 48);
@@ -317,6 +319,7 @@ pub fn uuid_v4() -> String {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use proptest::prelude::*;
 

--- a/crates/krites/Cargo.toml
+++ b/crates/krites/Cargo.toml
@@ -49,7 +49,6 @@ regex = { workspace = true }
 sha2 = { workspace = true, default-features = false }
 either = { version = "1", default-features = false }
 rand = { workspace = true }
-uuid = { workspace = true, features = ["v1", "serde"] }
 pest = "2.8"
 pest_derive = "2.8"
 unicode-normalization = { version = "0.1", default-features = false }

--- a/crates/krites/src/data/functions/temporal.rs
+++ b/crates/krites/src/data/functions/temporal.rs
@@ -8,10 +8,6 @@
     reason = "temporal functions return Result for API consistency with other builtins"
 )]
 #![expect(
-    clippy::cast_lossless,
-    reason = "uuid timestamp subsec is u32 — cast_lossless wants From but as is clearer in context"
-)]
-#![expect(
     clippy::single_match_else,
     reason = "timezone branch reads better as if-let for the happy path"
 )]
@@ -28,7 +24,6 @@ use itertools::Itertools;
 #[cfg(target_arch = "wasm32")]
 use js_sys::Date;
 use rand::prelude::*;
-use uuid::v1::Timestamp;
 
 use super::arg;
 use crate::data::error::*;
@@ -172,33 +167,38 @@ pub(crate) fn op_parse_timestamp(args: &[DataValue]) -> Result<DataValue> {
 }
 
 pub(crate) fn op_rand_uuid_v1(_args: &[DataValue]) -> Result<DataValue> {
+    // UUID epoch offset: 1582-10-15 → 1970-01-01 in 100-nanosecond intervals.
+    const UUID_UNIX_OFFSET: u64 = 122_192_928_000_000_000;
+    const INTERVALS_PER_SEC: u64 = 10_000_000;
+
     let mut rng = rand::rng();
-    #[expect(
-        deprecated,
-        reason = "vendored CozoDB: uuid Context → ContextV1 rename pending uuid 2.x"
-    )]
-    let uuid_ctx = uuid::v1::Context::new(rng.random());
+    let clock_seq: u16 = rng.random();
+
     #[cfg(target_arch = "wasm32")]
-    let ts = {
-        let since_epoch: f64 = Date::now();
-        let seconds = since_epoch.floor();
-        let fractional = (since_epoch - seconds) * 1.0e9;
-        Timestamp::from_unix(uuid_ctx, seconds as u64, fractional as u32)
+    let ts_100ns = {
+        let since_epoch_ms: f64 = Date::now();
+        let since_epoch_secs = since_epoch_ms.floor() / 1000.;
+        let secs = since_epoch_secs as u64;
+        let nanos = ((since_epoch_ms / 1000. - since_epoch_secs) * 1.0e9) as u64;
+        secs * INTERVALS_PER_SEC + nanos / 100 + UUID_UNIX_OFFSET
     };
     #[cfg(not(target_arch = "wasm32"))]
-    let ts = {
+    let ts_100ns = {
         let now = SystemTime::now();
         let since_epoch = now.duration_since(UNIX_EPOCH).unwrap_or_default();
-        Timestamp::from_unix(uuid_ctx, since_epoch.as_secs(), since_epoch.subsec_nanos())
+        let secs = since_epoch.as_secs();
+        let nanos = u64::from(since_epoch.subsec_nanos());
+        secs * INTERVALS_PER_SEC + nanos / 100 + UUID_UNIX_OFFSET
     };
+
     let mut rand_vals = [0u8; 6];
     rng.fill(&mut rand_vals);
-    let id = uuid::Uuid::new_v1(ts, &rand_vals);
+    let id = koina::uuid::Uuid::new_v1(ts_100ns, clock_seq, &rand_vals);
     Ok(DataValue::uuid(id))
 }
 
 pub(crate) fn op_rand_uuid_v4(_args: &[DataValue]) -> Result<DataValue> {
-    let id = uuid::Uuid::new_v4();
+    let id = koina::uuid::Uuid::new_v4();
     Ok(DataValue::uuid(id))
 }
 
@@ -210,9 +210,9 @@ pub(crate) fn op_uuid_timestamp(args: &[DataValue]) -> Result<DataValue> {
                 let (s, subs) = t.to_unix();
                 #[expect(
                     clippy::cast_precision_loss,
-                    reason = "i64 to f64: precision loss acceptable"
+                    reason = "u64 to f64: precision loss acceptable for Unix seconds"
                 )]
-                let s = (s as f64) + (subs as f64 / 10_000_000.);
+                let s = (s as f64) + (f64::from(subs) / 10_000_000.);
                 s.into()
             }
         },

--- a/crates/krites/src/data/functions/utility.rs
+++ b/crates/krites/src/data/functions/utility.rs
@@ -381,7 +381,7 @@ pub(crate) fn op_to_uuid(args: &[DataValue]) -> Result<DataValue> {
     match arg(args, 0)? {
         d @ DataValue::Uuid(_u) => Ok(d.clone()),
         DataValue::Str(s) => {
-            let id = uuid::Uuid::try_parse(s).map_err(|e| {
+            let id = koina::uuid::Uuid::parse_str(s).map_err(|e| {
                 ParseFailedSnafu {
                     target: format!("UUID: {e}"),
                 }

--- a/crates/krites/src/data/memcmp.rs
+++ b/crates/krites/src/data/memcmp.rs
@@ -337,7 +337,7 @@ impl DataValue {
                 let s_l = u32::from_be_bytes(as_array(&uuid_data[4..8]));
                 let mut s_rest = [0u8; 8];
                 s_rest.copy_from_slice(&uuid_data[8..]);
-                let uuid = uuid::Uuid::from_fields(s_l, s_m, s_h, &s_rest);
+                let uuid = koina::uuid::Uuid::from_fields(s_l, s_m, s_h, &s_rest);
                 (DataValue::Uuid(UuidWrapper(uuid)), remaining)
             }
             REGEX_TAG => {

--- a/crates/krites/src/data/tests/memcmp.rs
+++ b/crates/krites/src/data/tests/memcmp.rs
@@ -8,7 +8,7 @@
     clippy::unreadable_literal,
     reason = "test: numeric literals mirror tested bit patterns verbatim"
 )]
-use uuid::Uuid;
+use koina::uuid::Uuid;
 
 use crate::data::memcmp::{MemCmpEncoder, decode_bytes};
 use crate::data::value::{DataValue, Num, UuidWrapper};

--- a/crates/krites/src/data/tests/proptest_memcmp.rs
+++ b/crates/krites/src/data/tests/proptest_memcmp.rs
@@ -8,9 +8,9 @@
 use std::collections::BTreeSet;
 
 use compact_str::CompactString;
+use koina::uuid::Uuid;
 use ndarray::Array1;
 use proptest::prelude::*;
-use uuid::Uuid;
 
 use crate::data::memcmp::MemCmpEncoder;
 use crate::data::value::{DataValue, JsonData, Num, UuidWrapper, Validity, Vector};

--- a/crates/krites/src/data/value.rs
+++ b/crates/krites/src/data/value.rs
@@ -36,6 +36,7 @@ use std::ops::Deref;
 
 use compact_str::CompactString;
 use koina::base64;
+use koina::uuid::Uuid;
 use ndarray::Array1;
 use ordered_float::OrderedFloat;
 use regex::Regex;
@@ -44,7 +45,6 @@ use serde::ser::SerializeTuple;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::digest::FixedOutput;
 use sha2::{Digest, Sha256};
-use uuid::Uuid;
 
 use crate::data::json::JsonValue;
 use crate::data::relation::VecElementType;
@@ -815,7 +815,7 @@ impl DataValue {
     pub(crate) fn get_uuid(&self) -> Option<Uuid> {
         match self {
             DataValue::Uuid(UuidWrapper(uuid)) => Some(*uuid),
-            DataValue::Str(s) => uuid::Uuid::try_parse(s).ok(), // WHY: parse failure means not a valid UUID; None is correct
+            DataValue::Str(s) => Uuid::parse_str(s).ok(), // WHY: parse failure means not a valid UUID; None is correct
             _ => None,
         }
     }

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -298,10 +298,7 @@ pub fn parse_toml_file(path: &std::path::Path) -> Result<toml::Value> {
     clippy::double_must_use,
     reason = "kanon lint requires explicit #[must_use] on pub fns returning Result"
 )]
-pub fn parse_toml_file_with(
-    path: &std::path::Path,
-    fs: &impl FileSystem,
-) -> Result<toml::Value> {
+pub fn parse_toml_file_with(path: &std::path::Path, fs: &impl FileSystem) -> Result<toml::Value> {
     let bytes = fs.read_file(path).context(crate::error::ReadConfigSnafu {
         path: path.to_path_buf(),
     })?;


### PR DESCRIPTION
## Summary

- Extends `koina::uuid::Uuid` with the full API surface required by krites: `as_bytes`, `from_bytes`, `as_u128`, `is_nil`, `as_fields`, `from_fields`, `new_v1`, `get_timestamp`, and `V1Timestamp`
- Migrates all `uuid::Uuid` usage in krites (7 files) to `koina::uuid::Uuid` counterparts
- Removes `uuid` from `krites/Cargo.toml` and the workspace `[dependencies]` table; 8,574 LOC eliminated from the compiled dependency graph

## Commits

1. **feat(koina): extend Uuid with as_bytes/from_bytes/v1/timestamp helpers** — adds `as_bytes`, `from_bytes`, `as_u128`, `is_nil`, `as_fields`, `from_fields`, `new_v1(timestamp_100ns, clock_seq, node)`, `get_timestamp() -> Option<V1Timestamp>`, and `V1Timestamp::to_unix() -> (u64, u32)`. Property tests: bytes roundtrip, parse/to_string roundtrip, fields roundtrip.
2. **refactor(krites): migrate DataValue::Uuid from uuid crate to koina::Uuid** — `value.rs`, `memcmp.rs`, `functions/temporal.rs`, `functions/utility.rs`, both test files.
3. **refactor: drop uuid dep from workspace** — removes `uuid = { version = "1", features = ["v1", "serde"] }` from `krites/Cargo.toml` and the workspace root.

## uuid LOC removed

The `uuid 1.x` crate contributed **8,574 lines** (per the task scope) to the compiled workspace. After this PR, `grep "^uuid " Cargo.lock` returns 0 direct entries (uuid remains as a transitive dep of `rkyv` and `rmcp`, which are unrelated to krites).

## Noteworthy

- The v1 UUID timestamp layout follows **RFC 4122 §4.1.4**: the 60-bit counter is split across `time_low` (bytes 0–3), `time_mid` (bytes 4–5), and `time_high` (bytes 6–7, low 12 bits), counting 100-nanosecond intervals from 1582-10-15T00:00:00Z. The `koina::V1Timestamp::to_unix` doc cites this section explicitly.
- `op_rand_uuid_v1` in `temporal.rs` now computes the 100 ns interval count manually (Unix epoch offset = 122,192,928,000,000,000 intervals) instead of delegating to `uuid::v1::Context` + `Timestamp::from_unix`. This removes the last `uuid::v1` dependency.
- The `UuidWrapper::Ord` and memcmp encode/decode in krites uses `as_fields()` for the (time_hi, time_mid, time_low) sort order; `koina::Uuid::as_fields()` provides identical field decomposition.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --features test-core --all-targets -- -D warnings` passes
- [x] `cargo test -p koina` — 249 tests pass including new property tests
- [x] `cargo test -p krites --features test-core` — 398 tests pass
- [x] `grep "^uuid " Cargo.lock | wc -l` = 0

Closes #3527