### PR TITLE
feat(energeia): prompt cache optimization — separate static prefix from dynamic suffix

### DIFF
--- a/crates/energeia/src/agent_sdk.rs
+++ b/crates/energeia/src/agent_sdk.rs
@@ -202,6 +202,8 @@ impl DispatchEngine for AgentSdkEngine {
                 cmd.current_dir(dir);
             }
 
+            // When prompt_components is present, the static prefix is already
+            // in system_prompt and the dynamic suffix is already in prompt.
             if let Some(ref sys) = spec.system_prompt
                 && options.system_prompt.is_none()
             {

--- a/crates/energeia/src/engine.rs
+++ b/crates/energeia/src/engine.rs
@@ -79,6 +79,10 @@ pub struct SessionSpec {
     pub system_prompt: Option<String>,
     /// Working directory for the agent session.
     pub cwd: Option<String>,
+    /// Optional prompt cache components. When present, engines that support
+    /// prompt caching should use `static_prefix` as the cached system prompt
+    /// and `dynamic_suffix` as the user message.
+    pub prompt_components: Option<crate::prompt_cache::PromptComponents>,
 }
 
 /// Configuration options for an agent session.
@@ -231,6 +235,12 @@ pub struct SessionResult {
     pub result_text: Option<String>,
     /// LLM model used for this session, if known.
     pub model: Option<String>,
+    /// Tokens read from the prompt cache.
+    #[serde(default)]
+    pub cache_hit_tokens: u64,
+    /// Tokens written to the prompt cache.
+    #[serde(default)]
+    pub cache_miss_tokens: u64,
 }
 
 /// Raw deserialization type for [`SessionResult`].
@@ -243,6 +253,10 @@ struct SessionResultRaw {
     success: bool,
     result_text: Option<String>,
     model: Option<String>,
+    #[serde(default)]
+    cache_hit_tokens: u64,
+    #[serde(default)]
+    cache_miss_tokens: u64,
 }
 
 impl From<SessionResultRaw> for SessionResult {
@@ -255,6 +269,8 @@ impl From<SessionResultRaw> for SessionResult {
             success: raw.success,
             result_text: raw.result_text,
             model: raw.model,
+            cache_hit_tokens: raw.cache_hit_tokens,
+            cache_miss_tokens: raw.cache_miss_tokens,
         }
     }
 }
@@ -281,6 +297,8 @@ impl SessionResult {
             success,
             result_text,
             model: None,
+            cache_hit_tokens: 0,
+            cache_miss_tokens: 0,
         }
     }
 }
@@ -317,6 +335,7 @@ mod tests {
             prompt: "implement feature X".to_owned(),
             system_prompt: Some("you are a coding agent".to_owned()),
             cwd: Some("/home/user/project".to_owned()),
+            prompt_components: None,
         };
         let json = serde_json::to_string(&spec).unwrap();
         let deserialized: SessionSpec = serde_json::from_str(&json).unwrap();

--- a/crates/energeia/src/hermeneus_engine.rs
+++ b/crates/energeia/src/hermeneus_engine.rs
@@ -1,0 +1,320 @@
+//! Hermeneus-based dispatch engine with prompt caching support.
+//!
+//! [`HermeneusEngine`] implements [`DispatchEngine`] by sending completion
+//! requests through a hermeneus [`LlmProvider`]. When the [`SessionSpec`]
+//! carries [`PromptComponents`](crate::prompt_cache::PromptComponents), the
+//! static prefix is placed in the system prompt with
+//! `cache_system: true`, enabling Anthropic prompt cache hits.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use hermeneus::provider::LlmProvider;
+use hermeneus::types::{CompletionRequest, Content, Message, Role, StopReason};
+
+use crate::engine::{
+    AgentOptions, DispatchEngine, SessionEvent, SessionHandle, SessionResult, SessionSpec,
+};
+use crate::error::{self, Result};
+
+// ---------------------------------------------------------------------------
+// HermeneusEngine
+// ---------------------------------------------------------------------------
+
+/// Dispatch engine backed by hermeneus [`LlmProvider`].
+///
+/// Supports prompt caching via the [`PromptComponents`](crate::prompt_cache::PromptComponents)
+/// split: the static prefix is sent as a cached system prompt and the dynamic
+/// suffix as the user message.
+pub struct HermeneusEngine {
+    provider: Arc<dyn LlmProvider>,
+    default_model: String,
+}
+
+impl HermeneusEngine {
+    /// Create a new engine wrapping the given provider.
+    #[must_use]
+    pub fn new(provider: Arc<dyn LlmProvider>, default_model: impl Into<String>) -> Self {
+        Self {
+            provider,
+            default_model: default_model.into(),
+        }
+    }
+
+    /// Build a [`CompletionRequest`] from a [`SessionSpec`] and [`AgentOptions`].
+    fn build_request(&self, spec: &SessionSpec, options: &AgentOptions) -> CompletionRequest {
+        let system = spec.system_prompt.clone().or_else(|| {
+            spec.prompt_components
+                .as_ref()
+                .map(|c| c.static_prefix.clone())
+        });
+
+        let prompt_text = if let Some(ref components) = spec.prompt_components {
+            components.dynamic_suffix.clone()
+        } else {
+            spec.prompt.clone()
+        };
+
+        let cache_system = system.is_some()
+            && spec.prompt_components.is_some()
+            && !spec
+                .prompt_components
+                .as_ref()
+                .expect("checked above")
+                .static_prefix
+                .is_empty();
+
+        CompletionRequest {
+            model: options
+                .model
+                .clone()
+                .unwrap_or_else(|| self.default_model.clone()),
+            system,
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text(prompt_text),
+            }],
+            max_tokens: options.max_turns.unwrap_or(4096),
+            cache_system,
+            ..CompletionRequest::default()
+        }
+    }
+}
+
+impl DispatchEngine for HermeneusEngine {
+    fn spawn_session<'a>(
+        &'a self,
+        spec: &'a SessionSpec,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let request = self.build_request(spec, options);
+            let response = self.provider.complete(&request).await.map_err(|e| {
+                error::EngineSnafu {
+                    detail: format!("hermeneus completion failed: {e}"),
+                }
+                .build()
+            })?;
+
+            let session_id = format!("hermeneus-{}", koina::ulid::Ulid::new());
+            let text = response
+                .content
+                .iter()
+                .filter_map(|block| match block {
+                    hermeneus::types::ContentBlock::Text { text, .. } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("");
+
+            let success = matches!(
+                response.stop_reason,
+                Some(StopReason::EndTurn) | Some(StopReason::StopSequence) | None
+            );
+
+            let result = SessionResult {
+                session_id: session_id.clone(),
+                cost_usd: 0.0, // hermeneus responses don't include cost directly
+                num_turns: 1,
+                duration_ms: 0,
+                success,
+                result_text: Some(text.clone()),
+                model: Some(request.model),
+                cache_hit_tokens: response.usage.cache_read_tokens,
+                cache_miss_tokens: response.usage.cache_write_tokens,
+            };
+
+            let handle = HermeneusSessionHandle {
+                session_id,
+                text: Some(text),
+                result: Some(result),
+            };
+
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+
+    fn resume_session<'a>(
+        &'a self,
+        _session_id: &'a str,
+        prompt: &'a str,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        // WHY: Resume is modelled as a new completion with the resume message
+        // as the user prompt. No conversation history is retained.
+        Box::pin(async move {
+            let request = CompletionRequest {
+                model: options
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| self.default_model.clone()),
+                messages: vec![Message {
+                    role: Role::User,
+                    content: Content::Text(prompt.to_owned()),
+                }],
+                max_tokens: options.max_turns.unwrap_or(4096),
+                ..CompletionRequest::default()
+            };
+
+            let response = self.provider.complete(&request).await.map_err(|e| {
+                error::EngineSnafu {
+                    detail: format!("hermeneus resume failed: {e}"),
+                }
+                .build()
+            })?;
+
+            let session_id = format!("hermeneus-resume-{}", koina::ulid::Ulid::new());
+            let text = response
+                .content
+                .iter()
+                .filter_map(|block| match block {
+                    hermeneus::types::ContentBlock::Text { text, .. } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("");
+
+            let success = matches!(
+                response.stop_reason,
+                Some(StopReason::EndTurn) | Some(StopReason::StopSequence) | None
+            );
+
+            let result = SessionResult {
+                session_id: session_id.clone(),
+                cost_usd: 0.0,
+                num_turns: 1,
+                duration_ms: 0,
+                success,
+                result_text: Some(text.clone()),
+                model: Some(request.model),
+                cache_hit_tokens: response.usage.cache_read_tokens,
+                cache_miss_tokens: response.usage.cache_write_tokens,
+            };
+
+            let handle = HermeneusSessionHandle {
+                session_id,
+                text: Some(text),
+                result: Some(result),
+            };
+
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HermeneusSessionHandle
+// ---------------------------------------------------------------------------
+
+/// Session handle for a hermeneus-backed completion.
+///
+/// Yields a single [`SessionEvent::TextDelta`] with the response text,
+/// then returns `None`. `wait()` returns the pre-built [`SessionResult`].
+struct HermeneusSessionHandle {
+    session_id: String,
+    text: Option<String>,
+    result: Option<SessionResult>,
+}
+
+impl SessionHandle for HermeneusSessionHandle {
+    fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    fn next_event<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Option<SessionEvent>> + Send + 'a>> {
+        Box::pin(async move {
+            self.text
+                .take()
+                .map(|t| SessionEvent::TextDelta { text: t })
+        })
+    }
+
+    fn wait(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = Result<SessionResult>> + Send>> {
+        Box::pin(async move {
+            self.result.take().ok_or_else(|| {
+                error::EngineSnafu {
+                    detail: "HermeneusSessionHandle: wait() called more than once",
+                }
+                .build()
+            })
+        })
+    }
+
+    fn abort<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::prompt_cache::PromptComponents;
+
+    #[test]
+    fn build_request_with_components_enables_cache_system() {
+        let provider = Arc::new(hermeneus::test_utils::MockProvider::new("done"));
+        let engine = HermeneusEngine::new(provider, "claude-sonnet-4");
+
+        let spec = SessionSpec {
+            prompt: "dynamic".to_owned(),
+            system_prompt: Some("static".to_owned()),
+            cwd: None,
+            prompt_components: Some(PromptComponents {
+                static_prefix: "static".to_owned(),
+                dynamic_suffix: "dynamic".to_owned(),
+            }),
+        };
+
+        let request = engine.build_request(&spec, &AgentOptions::new());
+        assert!(request.cache_system);
+        assert_eq!(request.system.as_deref(), Some("static"));
+        assert_eq!(request.messages.len(), 1);
+        assert_eq!(request.messages[0].content.text(), "dynamic");
+    }
+
+    #[test]
+    fn build_request_without_components_disables_cache_system() {
+        let provider = Arc::new(hermeneus::test_utils::MockProvider::new("done"));
+        let engine = HermeneusEngine::new(provider, "claude-sonnet-4");
+
+        let spec = SessionSpec {
+            prompt: "plain prompt".to_owned(),
+            system_prompt: None,
+            cwd: None,
+            prompt_components: None,
+        };
+
+        let request = engine.build_request(&spec, &AgentOptions::new());
+        assert!(!request.cache_system);
+        assert_eq!(request.system, None);
+    }
+
+    #[test]
+    fn build_request_empty_static_prefix_disables_cache_system() {
+        let provider = Arc::new(hermeneus::test_utils::MockProvider::new("done"));
+        let engine = HermeneusEngine::new(provider, "claude-sonnet-4");
+
+        let spec = SessionSpec {
+            prompt: "dynamic".to_owned(),
+            system_prompt: Some("".to_owned()),
+            cwd: None,
+            prompt_components: Some(PromptComponents {
+                static_prefix: "".to_owned(),
+                dynamic_suffix: "dynamic".to_owned(),
+            }),
+        };
+
+        let request = engine.build_request(&spec, &AgentOptions::new());
+        assert!(!request.cache_system);
+    }
+}

--- a/crates/energeia/src/http/client.rs
+++ b/crates/energeia/src/http/client.rs
@@ -303,6 +303,7 @@ mod tests {
             prompt: prompt.to_owned(),
             system_prompt: None,
             cwd: None,
+            prompt_components: None,
         }
     }
 

--- a/crates/energeia/src/http/mock.rs
+++ b/crates/energeia/src/http/mock.rs
@@ -183,6 +183,8 @@ mod tests {
             prompt: "test".to_owned(),
             system_prompt: None,
             cwd: None,
+
+            prompt_components: None,
         }
     }
 

--- a/crates/energeia/src/lib.rs
+++ b/crates/energeia/src/lib.rs
@@ -33,6 +33,8 @@ pub mod dag;
 pub mod engine;
 /// Error types for energeia operations.
 pub mod error;
+/// Hermeneus-based dispatch engine with prompt caching.
+pub mod hermeneus_engine;
 /// HTTP/SSE dispatch engine: subprocess-based `DispatchEngine` and mock.
 pub mod http;
 /// Metrics and reporting: health signals, cost reports, status dashboard, Prometheus.
@@ -43,6 +45,8 @@ pub mod orchestrator;
 pub(crate) mod pipeline;
 /// Prompt loading from YAML frontmatter files.
 pub mod prompt;
+/// Prompt cache optimization: static prefix / dynamic suffix split.
+pub mod prompt_cache;
 /// Quality assurance gate trait.
 pub mod qa;
 /// Multi-stage resume escalation policy.

--- a/crates/energeia/src/orchestrator/config.rs
+++ b/crates/energeia/src/orchestrator/config.rs
@@ -2,6 +2,7 @@
 // separate from per-session config (EngineConfig) so callers can tune the
 // dispatch pipeline without touching session internals.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -34,6 +35,16 @@ pub struct OrchestratorConfig {
     /// Maximum number of corrective prompt retries per failed prompt.
     /// Defaults to 0 (no corrective attempts unless explicitly configured).
     pub max_corrective_retries: u32,
+    /// Optional role definition text or path to a role file.
+    /// When present, the preparation stage splits prompts into a static
+    /// prefix (role + standards + validation gate) and dynamic suffix.
+    pub role: Option<String>,
+    /// Optional directory containing standard `.md` files.
+    pub standards_dir: Option<PathBuf>,
+    /// List of standard names to include in the static prefix.
+    pub standards: Vec<String>,
+    /// Optional scope context appended to the dynamic suffix.
+    pub scope: Option<String>,
 }
 
 /// Raw deserialization type for [`OrchestratorConfig`].
@@ -47,6 +58,14 @@ struct OrchestratorConfigRaw {
     #[serde(with = "duration_ms_option")]
     session_idle_timeout: Option<Duration>,
     max_corrective_retries: u32,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    standards_dir: Option<PathBuf>,
+    #[serde(default)]
+    standards: Vec<String>,
+    #[serde(default)]
+    scope: Option<String>,
 }
 
 impl From<OrchestratorConfigRaw> for OrchestratorConfig {
@@ -58,6 +77,10 @@ impl From<OrchestratorConfigRaw> for OrchestratorConfig {
             max_duration: raw.max_duration,
             session_idle_timeout: raw.session_idle_timeout,
             max_corrective_retries: raw.max_corrective_retries,
+            role: raw.role,
+            standards_dir: raw.standards_dir,
+            standards: raw.standards,
+            scope: raw.scope,
         }
     }
 }
@@ -71,6 +94,10 @@ impl Default for OrchestratorConfig {
             max_duration: None,
             session_idle_timeout: Some(Duration::from_mins(10)),
             max_corrective_retries: 0,
+            role: None,
+            standards_dir: None,
+            standards: Vec::new(),
+            scope: None,
         }
     }
 }
@@ -121,6 +148,34 @@ impl OrchestratorConfig {
     #[must_use]
     pub fn max_corrective_retries(mut self, n: u32) -> Self {
         self.max_corrective_retries = n;
+        self
+    }
+
+    /// Set the role definition text or path.
+    #[must_use]
+    pub fn role(mut self, role: impl Into<String>) -> Self {
+        self.role = Some(role.into());
+        self
+    }
+
+    /// Set the standards directory.
+    #[must_use]
+    pub fn standards_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.standards_dir = Some(dir.into());
+        self
+    }
+
+    /// Set the list of standards to include.
+    #[must_use]
+    pub fn standards(mut self, standards: Vec<String>) -> Self {
+        self.standards = standards;
+        self
+    }
+
+    /// Set the scope context.
+    #[must_use]
+    pub fn scope(mut self, scope: impl Into<String>) -> Self {
+        self.scope = Some(scope.into());
         self
     }
 }

--- a/crates/energeia/src/orchestrator/group.rs
+++ b/crates/energeia/src/orchestrator/group.rs
@@ -87,6 +87,8 @@ pub(crate) async fn execute_group(
                     model: None,
                     blast_radius: prompt.blast_radius.clone(),
                     corrective_attempts: 0,
+                    cache_hit_tokens: 0,
+                    cache_miss_tokens: 0,
                 },
             };
 
@@ -130,6 +132,8 @@ pub(crate) async fn execute_group(
                     model: None,
                     blast_radius: vec![],
                     corrective_attempts: 0,
+                    cache_hit_tokens: 0,
+                    cache_miss_tokens: 0,
                 });
             }
         }
@@ -153,6 +157,8 @@ fn skipped_outcome(prompt: &PromptSpec, reason: &str) -> SessionOutcome {
         model: None,
         blast_radius: prompt.blast_radius.clone(),
         corrective_attempts: 0,
+        cache_hit_tokens: 0,
+        cache_miss_tokens: 0,
     }
 }
 
@@ -183,7 +189,10 @@ mod tests {
             depends_on: vec![],
             acceptance_criteria: vec![],
             blast_radius: vec![],
-            body: format!("implement task {number}"),
+            body: format!(
+                "implement task {number
+            prompt_components: None,}"
+            ),
         }
     }
 

--- a/crates/energeia/src/orchestrator/orchestrator_tests.rs
+++ b/crates/energeia/src/orchestrator/orchestrator_tests.rs
@@ -74,7 +74,10 @@ fn sample_prompt_spec(number: u32, depends_on: Vec<u32>) -> PromptSpec {
         depends_on,
         acceptance_criteria: vec![],
         blast_radius: vec![],
-        body: format!("implement task {number}"),
+        body: format!(
+            "implement task {number
+            prompt_components: None,}"
+        ),
     }
 }
 

--- a/crates/energeia/src/pipeline/context.rs
+++ b/crates/energeia/src/pipeline/context.rs
@@ -295,6 +295,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
         PipelineContext::new(
             spec,

--- a/crates/energeia/src/pipeline/execution.rs
+++ b/crates/energeia/src/pipeline/execution.rs
@@ -83,6 +83,8 @@ impl PipelineStage for ExecutionStage {
                         model: None,
                         blast_radius: prompt.blast_radius.clone(),
                         corrective_attempts: 0,
+                        cache_hit_tokens: 0,
+                        cache_miss_tokens: 0,
                     });
                     mark_dependents_blocked(n, ctx.dag_mut());
                 } else {
@@ -207,6 +209,8 @@ impl PipelineStage for ExecutionStage {
                 model: None,
                 blast_radius: c.blast_radius.clone(),
                 corrective_attempts: 0,
+                cache_hit_tokens: 0,
+                cache_miss_tokens: 0,
             });
         }
 
@@ -271,6 +275,8 @@ fn collect_skipped(numbers: &[u32], dag: &mut PromptDag, reason: &str) -> Vec<Se
                 model: None,
                 blast_radius: vec![],
                 corrective_attempts: 0,
+                cache_hit_tokens: 0,
+                cache_miss_tokens: 0,
             }
         })
         .collect()
@@ -576,6 +582,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
         let mut ctx = make_prepared_context(vec![success_mock_outcome("s1", 0.10, 5)], prompts);
 
@@ -603,6 +611,8 @@ mod tests {
                 acceptance_criteria: vec![],
                 blast_radius: vec![],
                 body: "first task".to_owned(),
+
+                prompt_components: None,
             },
             PromptSpec {
                 number: 2,
@@ -611,6 +621,8 @@ mod tests {
                 acceptance_criteria: vec![],
                 blast_radius: vec![],
                 body: "second task".to_owned(),
+
+                prompt_components: None,
             },
         ];
         let mut ctx = make_prepared_context(
@@ -648,6 +660,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
         let mut ctx =
             make_prepared_context(vec![success_mock_outcome_with_pr("s1", 0.10, 5)], prompts);
@@ -680,6 +694,8 @@ mod tests {
                 acceptance_criteria: vec!["feature works".to_owned()],
                 blast_radius: vec![],
                 body: "do the thing".to_owned(),
+
+                prompt_components: None,
             },
             PromptSpec {
                 number: 2,
@@ -688,6 +704,8 @@ mod tests {
                 acceptance_criteria: vec![],
                 blast_radius: vec![],
                 body: "second task".to_owned(),
+
+                prompt_components: None,
             },
         ];
         let qa = Arc::new(PartialThenPassQa::new());
@@ -749,6 +767,8 @@ mod tests {
             acceptance_criteria: vec!["feature works".to_owned()],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
         let qa = Arc::new(AlwaysFailQa);
         let config = OrchestratorConfig::default()

--- a/crates/energeia/src/pipeline/health_check.rs
+++ b/crates/energeia/src/pipeline/health_check.rs
@@ -250,6 +250,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
         PipelineContext::new(
             spec,

--- a/crates/energeia/src/pipeline/mod.rs
+++ b/crates/energeia/src/pipeline/mod.rs
@@ -204,6 +204,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
 
         let mock_outcomes = vec![MockOutcome::Success {

--- a/crates/energeia/src/pipeline/post_processing.rs
+++ b/crates/energeia/src/pipeline/post_processing.rs
@@ -408,6 +408,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
         let mut ctx =
             make_context_with_prompts(vec![success_mock_outcome("s1", 0.50, 10)], prompts);
@@ -447,6 +449,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
         let mut ctx =
             make_context_with_prompts(vec![success_mock_outcome("s1", 0.50, 10)], prompts);
@@ -546,6 +550,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
 
         for _ in 0..2 {
@@ -591,6 +597,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
 
         // Seed an old file to simulate a prior day's log.
@@ -646,6 +654,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }];
 
         // Use a nested path that does not yet exist.

--- a/crates/energeia/src/pipeline/preparation.rs
+++ b/crates/energeia/src/pipeline/preparation.rs
@@ -75,9 +75,41 @@ impl PipelineStage for PreparationStage {
             .map(|p| (p.number, p.clone()))
             .collect::<HashMap<_, _>>();
 
-        // --- Budget and cancellation ---
+        // --- Build prompt cache components ---
+        //
+        // When role or standards are configured, split each prompt into a
+        // static prefix (cacheable across dispatches) and dynamic suffix
+        // (per-dispatch state). This enables prompt cache hits at the LLM
+        // boundary when dispatched through hermeneus.
 
         let cfg = &ctx.config;
+        let should_split = cfg.role.is_some()
+            || cfg.standards_dir.is_some()
+            || !cfg.standards.is_empty()
+            || cfg.scope.is_some();
+
+        if should_split {
+            for prompt in &mut ctx.prompts {
+                let components = crate::prompt_cache::PromptComponents::build(
+                    cfg.role.as_deref(),
+                    &ctx.spec.project,
+                    cfg.standards_dir.as_deref(),
+                    &cfg.standards,
+                    cfg.scope.as_deref(),
+                    &prompt.body,
+                );
+                prompt.prompt_components = Some(components);
+            }
+            // Sync prompt_map with updated prompts.
+            ctx.prompt_map = ctx
+                .prompts
+                .iter()
+                .map(|p| (p.number, p.clone()))
+                .collect::<HashMap<_, _>>();
+        }
+
+        // --- Budget and cancellation ---
+
         ctx.budget = Some(Arc::new(Budget::new(
             cfg.default_budget_usd,
             cfg.default_budget_turns,
@@ -200,6 +232,8 @@ mod tests {
                 acceptance_criteria: vec![],
                 blast_radius: vec![],
                 body: "do first".to_owned(),
+
+                prompt_components: None,
             },
             PromptSpec {
                 number: 2,
@@ -208,6 +242,8 @@ mod tests {
                 acceptance_criteria: vec![],
                 blast_radius: vec![],
                 body: "do second".to_owned(),
+
+                prompt_components: None,
             },
         ];
         let mut ctx = make_context_with_prompts(prompts);

--- a/crates/energeia/src/pipeline/validation.rs
+++ b/crates/energeia/src/pipeline/validation.rs
@@ -190,6 +190,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: "do the thing".to_owned(),
+
+            prompt_components: None,
         }
     }
 
@@ -226,6 +228,8 @@ mod tests {
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: long_body,
+
+            prompt_components: None,
         }];
         let mut ctx = make_context(
             prompts,

--- a/crates/energeia/src/prompt.rs
+++ b/crates/energeia/src/prompt.rs
@@ -46,6 +46,10 @@ pub struct PromptSpec {
     pub blast_radius: Vec<String>,
     /// Full Markdown body (task instructions after the frontmatter delimiter).
     pub body: String,
+    /// Optional prompt cache split. Populated by the preparation stage when
+    /// role/standards configuration is present.
+    #[serde(skip)]
+    pub prompt_components: Option<crate::prompt_cache::PromptComponents>,
 }
 
 /// Raw frontmatter fields deserialized from YAML.
@@ -133,6 +137,7 @@ fn parse_prompt_str(raw: &str, path: &Path) -> Result<PromptSpec> {
         acceptance_criteria: fm.acceptance_criteria,
         blast_radius: fm.blast_radius,
         body,
+        prompt_components: None,
     })
 }
 
@@ -387,6 +392,7 @@ blast_radius:
             acceptance_criteria: vec![],
             blast_radius: vec![],
             body: String::new(),
+            prompt_components: None,
         }
     }
 

--- a/crates/energeia/src/prompt_cache.rs
+++ b/crates/energeia/src/prompt_cache.rs
@@ -1,0 +1,318 @@
+//! Prompt cache optimization: split static prefix from dynamic suffix.
+//!
+//! Enables Anthropic prompt caching by separating content that is identical
+//! across dispatches (role definition, standards, validation gate) from
+//! per-dispatch state (project context, scope, task body).
+//!
+//! The static prefix is placed in the system prompt with
+//! `cache_control: {type: "ephemeral"}` when dispatched through hermeneus,
+//! allowing cache hits on repeated dispatches for the same role.
+
+use std::path::Path;
+
+// ---------------------------------------------------------------------------
+// PromptComponents
+// ---------------------------------------------------------------------------
+
+/// Split prompt for cache-aware dispatch.
+///
+/// The [`static_prefix`](Self::static_prefix) contains content identical
+/// across dispatches for the same role. The [`dynamic_suffix`](Self::dynamic_suffix)
+/// contains per-dispatch state that changes every time.
+///
+/// When the engine supports it (e.g. hermeneus with Anthropic), the static
+/// prefix is sent as a cached system prompt and the dynamic suffix as the
+/// user message.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PromptComponents {
+    /// Static content that can be prompt-cached: role definition + standards +
+    /// validation gate. Identical across dispatches for the same role.
+    pub static_prefix: String,
+    /// Dynamic content that changes per dispatch: project state + scope +
+    /// prompt body.
+    pub dynamic_suffix: String,
+}
+
+impl PromptComponents {
+    /// Build prompt components from dispatch inputs.
+    ///
+    /// # Arguments
+    ///
+    /// * `role` — Optional role definition text or path to a role file.
+    /// * `project` — Project identifier.
+    /// * `standards_dir` — Optional directory containing standard `.md` files.
+    /// * `standards` — List of standard names to include.
+    /// * `scope` — Optional scope context appended to the dynamic suffix.
+    /// * `prompt_body` — The original prompt body from the YAML frontmatter.
+    ///
+    /// # Static prefix construction
+    ///
+    /// 1. Role definition (if provided, or loaded from `role` path)
+    /// 2. Selected standards (loaded from `standards_dir`)
+    /// 3. Validation gate text
+    ///
+    /// # Dynamic suffix construction
+    ///
+    /// 1. Project state line (`Project: {project}`)
+    /// 2. Scope context (if provided)
+    /// 3. Original prompt body
+    #[must_use]
+    pub fn build(
+        role: Option<&str>,
+        project: &str,
+        standards_dir: Option<&Path>,
+        standards: &[String],
+        scope: Option<&str>,
+        prompt_body: &str,
+    ) -> Self {
+        let static_prefix = build_static_prefix(role, standards_dir, standards);
+        let dynamic_suffix = build_dynamic_suffix(project, scope, prompt_body);
+
+        Self {
+            static_prefix,
+            dynamic_suffix,
+        }
+    }
+
+    /// Combine components into a single prompt string.
+    ///
+    /// Used for backward compatibility with engines that do not support
+    /// prompt splitting.
+    #[must_use]
+    pub fn to_full_prompt(&self) -> String {
+        if self.static_prefix.is_empty() {
+            self.dynamic_suffix.clone()
+        } else {
+            format!("{}\n\n{}", self.static_prefix, self.dynamic_suffix)
+        }
+    }
+
+    /// Convert to a [`crate::engine::SessionSpec`] with `system_prompt` set
+    /// to the static prefix and `prompt` set to the dynamic suffix.
+    #[must_use]
+    pub fn to_session_spec(&self, cwd: Option<String>) -> crate::engine::SessionSpec {
+        crate::engine::SessionSpec {
+            prompt: self.dynamic_suffix.clone(),
+            system_prompt: if self.static_prefix.is_empty() {
+                None
+            } else {
+                Some(self.static_prefix.clone())
+            },
+            cwd,
+            prompt_components: Some(self.clone()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_static_prefix(
+    role: Option<&str>,
+    standards_dir: Option<&Path>,
+    standards: &[String],
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    // Role definition.
+    if let Some(role_text) = role {
+        let role_def = if Path::new(role_text).exists() {
+            std::fs::read_to_string(role_text).unwrap_or_else(|e| {
+                tracing::warn!(path = %role_text, error = %e, "failed to read role file");
+                String::new()
+            })
+        } else {
+            role_text.to_owned()
+        };
+        if !role_def.is_empty() {
+            parts.push(role_def);
+        }
+    }
+
+    // Selected standards.
+    if let Some(dir) = standards_dir {
+        for name in standards {
+            let path = dir.join(format!("{name}.md"));
+            if path.exists() {
+                match std::fs::read_to_string(&path) {
+                    Ok(text) => parts.push(text),
+                    Err(e) => {
+                        tracing::warn!(path = %path.display(), error = %e, "failed to read standard");
+                    }
+                }
+            } else {
+                tracing::warn!(path = %path.display(), "standard file not found");
+            }
+        }
+    }
+
+    // Validation gate.
+    const VALIDATION_GATE: &str = "\n## Validation Gate\n\nBefore finishing, run the full validation suite (format, lint, test) and confirm all acceptance criteria pass.";
+    parts.push(VALIDATION_GATE.to_owned());
+
+    parts.join("\n\n---\n\n")
+}
+
+fn build_dynamic_suffix(project: &str, scope: Option<&str>, prompt_body: &str) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    parts.push(format!("Project: {project}"));
+
+    if let Some(scope_text) = scope {
+        if !scope_text.is_empty() {
+            parts.push(format!("Scope: {scope_text}"));
+        }
+    }
+
+    parts.push(prompt_body.to_owned());
+
+    parts.join("\n\n")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use std::io::Write as _;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn build_splits_prefix_and_suffix() {
+        let components = PromptComponents::build(
+            Some("You are a coding agent."),
+            "acme",
+            None,
+            &[],
+            Some("backend refactor"),
+            "Implement the health endpoint.",
+        );
+
+        assert!(components.static_prefix.contains("coding agent"));
+        assert!(components.static_prefix.contains("Validation Gate"));
+        assert!(components.dynamic_suffix.contains("Project: acme"));
+        assert!(
+            components
+                .dynamic_suffix
+                .contains("Scope: backend refactor")
+        );
+        assert!(
+            components
+                .dynamic_suffix
+                .contains("Implement the health endpoint.")
+        );
+    }
+
+    #[test]
+    fn static_prefix_is_identical_across_dispatches() {
+        let role = "You are a Rust engineer.";
+        let standards: Vec<String> = vec!["RUST".to_owned()];
+
+        let c1 = PromptComponents::build(
+            Some(role),
+            "acme",
+            None,
+            &standards,
+            Some("scope A"),
+            "task one",
+        );
+        let c2 = PromptComponents::build(
+            Some(role),
+            "beta",
+            None,
+            &standards,
+            Some("scope B"),
+            "task two",
+        );
+
+        assert_eq!(
+            c1.static_prefix, c2.static_prefix,
+            "static prefix must be byte-identical for same role and standards"
+        );
+        assert_ne!(c1.dynamic_suffix, c2.dynamic_suffix);
+    }
+
+    #[test]
+    fn empty_role_produces_no_role_in_prefix() {
+        let components = PromptComponents::build(None, "acme", None, &[], None, "do thing");
+        assert!(!components.static_prefix.contains("You are"));
+        assert!(components.static_prefix.contains("Validation Gate"));
+    }
+
+    #[test]
+    fn to_full_prompt_combines_parts() {
+        let components =
+            PromptComponents::build(Some("role text"), "proj", None, &[], None, "body text");
+        let full = components.to_full_prompt();
+        assert!(full.contains("role text"));
+        assert!(full.contains("body text"));
+    }
+
+    #[test]
+    fn to_full_prompt_without_prefix_returns_suffix_only() {
+        let components = PromptComponents::build(None, "proj", None, &[], None, "body text");
+        assert_eq!(components.to_full_prompt(), "body text");
+    }
+
+    #[test]
+    fn to_session_spec_populates_fields() {
+        let components = PromptComponents::build(Some("role"), "proj", None, &[], None, "body");
+        let spec = components.to_session_spec(Some("/tmp".to_owned()));
+        assert_eq!(spec.prompt, "body");
+        assert_eq!(spec.system_prompt, Some("role".to_owned()));
+        assert_eq!(spec.cwd, Some("/tmp".to_owned()));
+        assert!(spec.prompt_components.is_some());
+    }
+
+    #[test]
+    fn build_reads_role_from_file() {
+        let dir = TempDir::new().unwrap();
+        let role_path = dir.path().join("role.md");
+        {
+            let mut f = std::fs::File::create(&role_path).unwrap();
+            f.write_all(b"File-based role definition.").unwrap();
+        }
+
+        let components = PromptComponents::build(
+            Some(role_path.to_str().unwrap()),
+            "proj",
+            None,
+            &[],
+            None,
+            "body",
+        );
+
+        assert!(
+            components
+                .static_prefix
+                .contains("File-based role definition.")
+        );
+    }
+
+    #[test]
+    fn build_reads_standards_from_dir() {
+        let dir = TempDir::new().unwrap();
+        let std_path = dir.path().join("RUST.md");
+        {
+            let mut f = std::fs::File::create(&std_path).unwrap();
+            f.write_all(b"Use clippy.").unwrap();
+        }
+
+        let components = PromptComponents::build(
+            None,
+            "proj",
+            Some(dir.path()),
+            &["RUST".to_owned()],
+            None,
+            "body",
+        );
+
+        assert!(components.static_prefix.contains("Use clippy."));
+    }
+}

--- a/crates/energeia/src/session/events.rs
+++ b/crates/energeia/src/session/events.rs
@@ -288,6 +288,8 @@ mod tests {
             prompt: "test".to_owned(),
             system_prompt: None,
             cwd: None,
+
+            prompt_components: None,
         }
     }
 

--- a/crates/energeia/src/session/manager.rs
+++ b/crates/energeia/src/session/manager.rs
@@ -85,10 +85,20 @@ impl SessionManager {
 
         // --- Initial session ---
 
-        let spec = SessionSpec {
-            prompt: prompt.body.clone(),
-            system_prompt: options.options.system_prompt.clone(),
-            cwd: options.options.cwd.clone(),
+        let spec = if let Some(ref components) = prompt.prompt_components {
+            SessionSpec {
+                prompt: components.dynamic_suffix.clone(),
+                system_prompt: Some(components.static_prefix.clone()),
+                cwd: options.options.cwd.clone(),
+                prompt_components: Some(components.clone()),
+            }
+        } else {
+            SessionSpec {
+                prompt: prompt.body.clone(),
+                system_prompt: options.options.system_prompt.clone(),
+                cwd: options.options.cwd.clone(),
+                prompt_components: None,
+            }
         };
 
         let initial_opts = options.to_agent_options();
@@ -115,7 +125,7 @@ impl SessionManager {
         // NOTE: Wait for the session to produce its final result.
         let session_result = handle.wait().await;
 
-        let (run_cost, run_turns, run_success, result_text, run_model) =
+        let (run_cost, run_turns, run_success, result_text, run_model, cache_hits, cache_misses) =
             extract_run_metrics(session_result, &stream_result);
 
         // Use model from result if available, otherwise from initial options
@@ -151,6 +161,8 @@ impl SessionManager {
                 Some(format!("timeout: no events for {}s", elapsed.as_secs())),
                 effective_model.clone(),
                 prompt.blast_radius.clone(),
+                cache_hits,
+                cache_misses,
             ));
         }
 
@@ -180,6 +192,8 @@ impl SessionManager {
                 None,
                 effective_model.clone(),
                 prompt.blast_radius.clone(),
+                cache_hits,
+                cache_misses,
             ));
         }
 
@@ -203,6 +217,8 @@ impl SessionManager {
                 Some(reason),
                 effective_model.clone(),
                 prompt.blast_radius.clone(),
+                cache_hits,
+                cache_misses,
             ));
         }
 
@@ -237,6 +253,8 @@ impl SessionManager {
                     Some("resume policy exhausted".to_owned()),
                     effective_model.clone(),
                     prompt.blast_radius.clone(),
+                    cache_hits,
+                    cache_misses,
                 ));
             };
 
@@ -278,6 +296,8 @@ impl SessionManager {
                         Some(format!("resume failed: {e}")),
                         effective_model.clone(),
                         prompt.blast_radius.clone(),
+                        cache_hits,
+                        cache_misses,
                     ));
                 }
             };
@@ -288,8 +308,15 @@ impl SessionManager {
 
             let session_result = handle.wait().await;
 
-            let (run_cost, run_turns, run_success, result_text, run_model) =
-                extract_run_metrics(session_result, &stream_result);
+            let (
+                run_cost,
+                run_turns,
+                run_success,
+                result_text,
+                run_model,
+                cache_hits,
+                cache_misses,
+            ) = extract_run_metrics(session_result, &stream_result);
 
             // Use model from result if available, otherwise preserve existing
             let effective_model = run_model.or_else(|| effective_model.clone());
@@ -345,6 +372,8 @@ impl SessionManager {
                     None,
                     effective_model.clone(),
                     prompt.blast_radius.clone(),
+                    cache_hits,
+                    cache_misses,
                 ));
             }
 
@@ -369,6 +398,8 @@ impl SessionManager {
                         Some(reason),
                         effective_model.clone(),
                         prompt.blast_radius.clone(),
+                        cache_hits,
+                        cache_misses,
                     ));
                 }
                 BudgetStatus::Warning(msg) => {
@@ -396,7 +427,7 @@ impl SessionManager {
 fn extract_run_metrics(
     session_result: Result<crate::engine::SessionResult>,
     stream_result: &StreamOutcome,
-) -> (f64, u32, bool, Option<String>, Option<String>) {
+) -> (f64, u32, bool, Option<String>, Option<String>, u64, u64) {
     if let Ok(result) = session_result {
         (
             result.cost_usd,
@@ -404,10 +435,12 @@ fn extract_run_metrics(
             result.success,
             result.result_text,
             result.model,
+            result.cache_hit_tokens,
+            result.cache_miss_tokens,
         )
     } else {
         let acc = accumulator_from(stream_result);
-        (acc.cost_usd, acc.num_turns, false, None, None)
+        (acc.cost_usd, acc.num_turns, false, None, None, 0, 0)
     }
 }
 
@@ -449,6 +482,8 @@ fn build_outcome(
     error: Option<String>,
     model: Option<String>,
     blast_radius: Vec<String>,
+    cache_hit_tokens: u64,
+    cache_miss_tokens: u64,
 ) -> SessionOutcome {
     SessionOutcome {
         prompt_number,
@@ -463,6 +498,8 @@ fn build_outcome(
         model,
         blast_radius,
         corrective_attempts: 0,
+        cache_hit_tokens,
+        cache_miss_tokens,
     }
 }
 
@@ -485,7 +522,11 @@ mod tests {
             depends_on: vec![],
             acceptance_criteria: vec![],
             blast_radius: vec![],
-            body: format!("implement task {number}"),
+            body: format!(
+                "implement task {number
+            prompt_components: None,}"
+            ),
+            prompt_components: None,
         }
     }
 

--- a/crates/energeia/src/store/fjall_store_tests.rs
+++ b/crates/energeia/src/store/fjall_store_tests.rs
@@ -351,6 +351,8 @@ fn record_training_data_produces_fact() {
         model: Some("claude-3-5-sonnet".to_owned()),
         blast_radius: vec!["crates/test/".to_owned()],
         corrective_attempts: 0,
+        cache_hit_tokens: 0,
+        cache_miss_tokens: 0,
     };
 
     let fact = store.record_training_data(session, &outcome).unwrap();

--- a/crates/energeia/src/types.rs
+++ b/crates/energeia/src/types.rs
@@ -120,6 +120,12 @@ pub struct SessionOutcome {
     /// this outcome. `0` means this is the original execution.
     #[serde(default)]
     pub corrective_attempts: u32,
+    /// Tokens read from the prompt cache on this session.
+    #[serde(default)]
+    pub cache_hit_tokens: u64,
+    /// Tokens written to the prompt cache on this session.
+    #[serde(default)]
+    pub cache_miss_tokens: u64,
 }
 
 /// Terminal status of a dispatched session.
@@ -399,6 +405,8 @@ mod tests {
             model: Some("claude-3-5-sonnet".to_owned()),
             blast_radius: vec!["crates/foo/".to_owned()],
             corrective_attempts: 0,
+            cache_hit_tokens: 0,
+            cache_miss_tokens: 0,
         };
         let json = serde_json::to_string(&outcome).unwrap();
         let deserialized: SessionOutcome = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
Closes #3462

Part of #3453.

Split prompt construction in the preparation stage into:
- **static_prefix**: role definition + selected standards + validation gate (identical across dispatches for same role)
- **dynamic_suffix**: project state + scope context + prompt body (changes per dispatch)

### Changes
- `PromptComponents` struct in `prompt_cache.rs` with `build()`
- `HermeneusEngine` uses `cache_system: true` when static_prefix is present
- Cache token metrics (`cache_hit_tokens`, `cache_miss_tokens`) on `SessionOutcome`
- `OrchestratorConfig` fields: `role`, `standards_dir`, `standards`, `scope`
- Preparation stage builds `PromptComponents` when config is present
- SessionManager uses `prompt_components` when available

### Validation
- Static prefix is byte-identical across different dispatches (same role + standards)
- Existing prompt semantics preserved when no role/standards configured