### PR TITLE
feat(diaporeia): expose knowledge graph via MCP tools (Wave 6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "fjall",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "jiff",
  "koina",
@@ -1913,11 +1913,12 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "axum 0.8.8",
  "hermeneus",
  "http",
+ "jiff",
  "koina",
  "mneme",
  "nous",
@@ -2017,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "koina",
  "organon",
@@ -2096,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "jiff",
  "serde",
@@ -2127,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "eidos",
  "fjall",
@@ -2198,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2894,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -3008,7 +3009,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -3537,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "axum 0.8.8",
  "dokimion",
@@ -3804,7 +3805,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "arboard",
  "clap",
@@ -3837,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3941,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "aho-corasick",
  "bytemuck",
@@ -4417,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "futures",
  "hermeneus",
@@ -4511,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -4647,7 +4648,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "dianoia",
@@ -4845,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "axum 0.8.8",
  "episteme",
@@ -4955,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "energeia",
  "fjall",
@@ -5272,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "jiff",
  "snafu",
@@ -5280,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "poiesis-core",
  "rust_xlsxwriter",
@@ -5290,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "poiesis-core",
  "quick-xml",
@@ -5300,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "krilla",
  "poiesis-core",
@@ -5643,7 +5644,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -7111,7 +7112,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bytes",
  "compact_str",
@@ -7389,7 +7390,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -7501,7 +7502,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -7624,14 +7625,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -91,6 +91,10 @@ pub(crate) async fn run(args: Args) -> Result<()> {
             auth_mode: runtime.state.auth_mode.clone(),
             none_role: runtime.state.none_role.clone(),
             shutdown: runtime.shutdown_token.clone(),
+            // WHY: pass the same KnowledgeStore Arc that pylon uses so the
+            // MCP knowledge tools access the identical in-process instance.
+            #[cfg(feature = "knowledge-store")]
+            knowledge_store: runtime.state.knowledge_store.clone(),
         });
         let mcp_router = diaporeia::transport::streamable_http_router(diaporeia_state);
         info!("diaporeia MCP server mounted at /mcp");

--- a/crates/diaporeia/CLAUDE.md
+++ b/crates/diaporeia/CLAUDE.md
@@ -25,20 +25,27 @@ MCP server interface for external AI agents via the Model Context Protocol. 1.5K
 | `RateLimiter` | `rate_limit.rs` | Per-session rate limiting with Cheap/Expensive tiers |
 | `Error` | `error.rs` | Error enum with `Into<rmcp::ErrorData>` conversion |
 
-## MCP tools (10)
+## MCP tools (15)
 
-| Tool | Tier | Purpose |
-|------|------|---------|
-| `session_create` | Expensive | Create a new session for a nous agent |
-| `session_list` | Cheap | List sessions, optionally filtered by nous ID |
-| `session_message` | Expensive | Send a message and get the response |
-| `session_history` | Cheap | Get conversation history for a session |
-| `nous_list` | Cheap | List all registered nous agents |
-| `nous_status` | Cheap | Detailed status of a specific agent |
-| `nous_tools` | Cheap | List tools available to an agent |
-| `knowledge_search` | Expensive | Semantic search across the knowledge graph |
-| `config_get` | Cheap | Runtime config (redacted) |
-| `system_health` | Cheap | Uptime, actor health, version info |
+| Tool | Tier | RBAC | Purpose |
+|------|------|------|---------|
+| `session_create` | Expensive | Operator | Create a new session for a nous agent |
+| `session_list` | Cheap | Agent | List sessions, optionally filtered by nous ID |
+| `session_message` | Expensive | Operator | Send a message and get the response |
+| `session_history` | Cheap | Agent | Get conversation history for a session |
+| `nous_list` | Cheap | Agent | List all registered nous agents |
+| `nous_status` | Cheap | Agent | Detailed status of a specific agent |
+| `nous_tools` | Cheap | Agent | List tools available to an agent |
+| `knowledge_search` | Expensive | Operator | Semantic search across the knowledge graph (stub) |
+| `knowledge_recall` | Expensive | Agent | BM25 text recall across the knowledge graph |
+| `knowledge_get` | Cheap | Agent | Retrieve a single fact by ID |
+| `knowledge_insert` | Expensive | Operator | Insert a new fact (returns fact ID) |
+| `knowledge_forget` | Expensive | Operator | Soft-delete a fact by ID |
+| `knowledge_graph_neighbors` | Expensive | Agent | Traverse entity edges up to configured depth |
+| `config_get` | Cheap | Operator | Runtime config (redacted) |
+| `system_health` | Cheap | Agent | Uptime, actor health, version info |
+
+Knowledge graph tools require `mcp.knowledge_graph.enabled = true` in config (default `false`).
 
 ## Patterns
 

--- a/crates/diaporeia/Cargo.toml
+++ b/crates/diaporeia/Cargo.toml
@@ -20,7 +20,7 @@ test-full = []
 # feature unification enables nous/knowledge-store via the `aletheia` binary's
 # `recall` feature — if diaporeia doesn't also enable it, the `#[cfg]` gate
 # in test code evaluates incorrectly and NousManager::new gets the wrong arity.
-knowledge-store = ["nous/knowledge-store"]
+knowledge-store = ["nous/knowledge-store", "mneme/mneme-engine"]
 
 [dependencies]
 # MCP SDK — pin exact per TECHNOLOGY.md policy
@@ -38,6 +38,9 @@ axum = { workspace = true }
 # Async
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+
+# Time — used when knowledge-store feature is enabled for fact timestamps
+jiff = { workspace = true }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/diaporeia/src/error.rs
+++ b/crates/diaporeia/src/error.rs
@@ -74,6 +74,40 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// The knowledge graph MCP surface is disabled or not configured.
+    #[snafu(display(
+        "knowledge graph MCP surface is disabled; \
+         set mcp.knowledge_graph.enabled = true in aletheia.toml"
+    ))]
+    KnowledgeStoreUnavailable {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A knowledge store operation failed.
+    #[snafu(display("knowledge store error: {message}"))]
+    KnowledgeStore {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// The requested fact was not found.
+    #[snafu(display("fact not found: {id}"))]
+    FactNotFound {
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// The caller supplied an invalid input value.
+    #[snafu(display("invalid input: {message}"))]
+    InvalidInput {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Result alias using diaporeia's [`Error`] type.
@@ -88,17 +122,25 @@ impl From<Error> for rmcp::ErrorData {
         let message = crate::sanitize::strip_paths(&err.to_string());
         match &err {
             // NOTE: client provided an invalid agent or session ID: include what wasn't found
-            Error::NousNotFound { .. } | Error::SessionNotFound { .. } => {
-                rmcp::ErrorData::invalid_params(message, None)
-            }
+            Error::NousNotFound { .. }
+            | Error::SessionNotFound { .. }
+            | Error::FactNotFound { .. }
+            | Error::InvalidInput { .. } => rmcp::ErrorData::invalid_params(message, None),
             // WHY: authorization failures return a clear message so clients can
             // distinguish access-denied from invalid-params.
             Error::Unauthorized { .. } => {
                 rmcp::ErrorData::new(rmcp::model::ErrorCode(-32001), message, None)
             }
+            // WHY: feature-disabled surfaces a distinct code so clients can
+            // detect the configuration issue rather than treating it as a
+            // transient server error.
+            Error::KnowledgeStoreUnavailable { .. } => {
+                rmcp::ErrorData::new(rmcp::model::ErrorCode(-32002), message, None)
+            }
             // WHY: server-side failures expose only a sanitized message, never internal details
             Error::Pipeline { .. }
             | Error::SessionStore { .. }
+            | Error::KnowledgeStore { .. }
             | Error::Serialization { .. }
             | Error::Transport { .. }
             | Error::WorkspaceFile { .. } => rmcp::ErrorData::internal_error(message, None),

--- a/crates/diaporeia/src/state.rs
+++ b/crates/diaporeia/src/state.rs
@@ -9,6 +9,8 @@ use std::time::Instant;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
+#[cfg(feature = "knowledge-store")]
+use mneme::knowledge_store::KnowledgeStore;
 use mneme::store::SessionStore;
 use nous::manager::NousManager;
 use organon::registry::ToolRegistry;
@@ -43,6 +45,12 @@ pub struct DiaporeiaState {
     pub none_role: String,
     /// Root shutdown token.
     pub shutdown: CancellationToken,
+    /// Shared knowledge store for the knowledge graph MCP surface.
+    ///
+    /// `None` when the knowledge store is not configured or when
+    /// `mcp.knowledge_graph.enabled` is `false`.
+    #[cfg(feature = "knowledge-store")]
+    pub knowledge_store: Option<Arc<KnowledgeStore>>,
 }
 
 #[cfg(test)]

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -16,6 +16,7 @@ use koina::id::SessionId;
 use symbolon::types::Role;
 
 use crate::error::{
+    FactNotFoundSnafu, InvalidInputSnafu, KnowledgeStoreSnafu, KnowledgeStoreUnavailableSnafu,
     NousNotFoundSnafu, PipelineSnafu, SerializationSnafu, SessionStoreSnafu, UnauthorizedSnafu,
 };
 use crate::rate_limit::Tier;
@@ -140,6 +141,42 @@ async fn require_role(
             .into())
         }
     }
+}
+
+/// Check that the knowledge graph MCP surface is enabled.
+///
+/// Returns `Err(KnowledgeStoreUnavailable)` when the feature is disabled in
+/// config, or when the server was not compiled with the `knowledge-store`
+/// feature. On success, returns a snapshot of the current config.
+///
+/// # Why a helper
+///
+/// Every knowledge tool needs the same preamble: read config, gate on
+/// `mcp.knowledge_graph.enabled`. Centralising avoids repeating the read in
+/// every tool.
+async fn require_knowledge_graph(
+    server: &DiaporeiaServer,
+) -> Result<taxis::config::AletheiaConfig, rmcp::ErrorData> {
+    let config = server.state.config.read().await.clone();
+    if !config.mcp.knowledge_graph.enabled {
+        return Err(KnowledgeStoreUnavailableSnafu {}.build().into());
+    }
+    Ok(config)
+}
+
+/// Resolve the knowledge store from server state, returning an error if absent.
+///
+/// Fails with `KnowledgeStoreUnavailable` when compiled without the
+/// `knowledge-store` feature or when the store was not initialised.
+#[cfg(feature = "knowledge-store")]
+fn resolve_store(
+    server: &DiaporeiaServer,
+) -> Result<std::sync::Arc<mneme::knowledge_store::KnowledgeStore>, crate::error::Error> {
+    server
+        .state
+        .knowledge_store
+        .clone()
+        .ok_or_else(|| KnowledgeStoreUnavailableSnafu {}.build())
 }
 
 /// Register all tools on the server via the `#[tool_router]` macro.
@@ -492,6 +529,398 @@ impl DiaporeiaServer {
              and a knowledge store must be configured."
                 .to_string(),
         )]))
+    }
+
+    /// BM25 text recall across the knowledge graph.
+    ///
+    /// Returns ranked fact results using BM25 full-text scoring. For read
+    /// access, requires `Agent` role or above. When the knowledge graph MCP
+    /// surface is disabled (`mcp.knowledge_graph.enabled = false`), returns
+    /// error code -32002.
+    #[tool(description = "BM25 text recall across the knowledge graph. \
+        Returns ranked facts. Requires Agent role.")]
+    async fn knowledge_recall(
+        &self,
+        Parameters(params): Parameters<params::KnowledgeRecallParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Expensive)?;
+        require_role(self, &context, Role::Agent, "knowledge_recall").await?;
+        let config = require_knowledge_graph(self).await?;
+
+        #[cfg(feature = "knowledge-store")]
+        {
+            let store = resolve_store(self).map_err(rmcp::ErrorData::from)?;
+            let limit = params
+                .limit
+                .unwrap_or(20)
+                .min(config.mcp.knowledge_graph.max_search_results);
+            let limit_i64 = i64::from(limit);
+
+            let results = store
+                .search_text_for_recall(&params.query, limit_i64)
+                .map_err(|e| {
+                    rmcp::ErrorData::from(
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+
+            // Optionally filter to a single nous_id.
+            let results: Vec<_> = if let Some(ref nous_id) = params.nous_id {
+                results
+                    .into_iter()
+                    .filter(|r| r.source_id.contains(nous_id.as_str()))
+                    .collect()
+            } else {
+                results
+            };
+
+            let json = serde_json::to_string_pretty(&results)
+                .context(SerializationSnafu {})
+                .map_err(rmcp::ErrorData::from)?;
+            return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                json,
+            )]));
+        }
+
+        #[cfg(not(feature = "knowledge-store"))]
+        {
+            let _ = (params, config);
+            Err(KnowledgeStoreUnavailableSnafu {}.build().into())
+        }
+    }
+
+    /// Retrieve a single fact by ID.
+    ///
+    /// Returns the full `Fact` record including provenance, lifecycle, and
+    /// access metadata. Requires `Agent` role or above.
+    #[tool(description = "Retrieve a single knowledge fact by ID. Requires Agent role.")]
+    async fn knowledge_get(
+        &self,
+        Parameters(params): Parameters<params::KnowledgeGetParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Cheap)?;
+        require_role(self, &context, Role::Agent, "knowledge_get").await?;
+        require_knowledge_graph(self).await?;
+
+        #[cfg(feature = "knowledge-store")]
+        {
+            let store = resolve_store(self).map_err(rmcp::ErrorData::from)?;
+            let mut facts = store.read_facts_by_id(&params.fact_id).map_err(|e| {
+                rmcp::ErrorData::from(
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+            let fact = facts.pop().ok_or_else(|| {
+                rmcp::ErrorData::from(
+                    FactNotFoundSnafu {
+                        id: params.fact_id.clone(),
+                    }
+                    .build(),
+                )
+            })?;
+            let json = serde_json::to_string_pretty(&fact)
+                .context(SerializationSnafu {})
+                .map_err(rmcp::ErrorData::from)?;
+            return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                json,
+            )]));
+        }
+
+        #[cfg(not(feature = "knowledge-store"))]
+        {
+            let _ = params;
+            Err(KnowledgeStoreUnavailableSnafu {}.build().into())
+        }
+    }
+
+    /// Insert a new fact into the knowledge graph.
+    ///
+    /// Creates a fact with the given content under the specified nous agent.
+    /// The fact is admitted through the configured admission policy.
+    ///
+    /// Requires `Operator` role or above. Mutations are restricted to
+    /// Operator+ to prevent agents from unilaterally persisting beliefs.
+    #[tool(description = "Insert a new fact into the knowledge graph. \
+        Requires Operator role. Returns the new fact ID.")]
+    async fn knowledge_insert(
+        &self,
+        Parameters(params): Parameters<params::KnowledgeInsertParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Expensive)?;
+        require_role(self, &context, Role::Operator, "knowledge_insert").await?;
+        require_knowledge_graph(self).await?;
+
+        #[cfg(feature = "knowledge-store")]
+        {
+            use mneme::id::FactId;
+            use mneme::knowledge::{
+                EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactSensitivity,
+                FactTemporal, default_stability_hours, far_future,
+            };
+
+            let store = resolve_store(self).map_err(rmcp::ErrorData::from)?;
+
+            // Parse sensitivity, defaulting to Public.
+            let sensitivity = params
+                .sensitivity
+                .as_deref()
+                .unwrap_or("public")
+                .parse::<FactSensitivity>()
+                .map_err(|e| rmcp::ErrorData::from(InvalidInputSnafu { message: e }.build()))?;
+
+            let now = jiff::Timestamp::now();
+            // WHY: koina::uuid::uuid_v4() provides UUID v4 without adding a
+            // direct `uuid` crate dep. Prefix with "f-mcp-" to make the origin
+            // of MCP-inserted facts identifiable during audits.
+            let fact_id_str = format!("f-mcp-{}", koina::uuid::uuid_v4());
+            let fact_id = FactId::new(&fact_id_str).map_err(|e| {
+                rmcp::ErrorData::from(
+                    InvalidInputSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let fact = Fact {
+                id: fact_id.clone(),
+                nous_id: params.nous_id.clone(),
+                fact_type: "knowledge".to_string(),
+                content: params.content.clone(),
+                scope: None,
+                sensitivity,
+                temporal: FactTemporal {
+                    valid_from: now,
+                    valid_to: far_future(),
+                    recorded_at: now,
+                },
+                provenance: FactProvenance {
+                    confidence: 0.8,
+                    tier: EpistemicTier::Inferred,
+                    source_session_id: None,
+                    stability_hours: default_stability_hours("knowledge"),
+                },
+                lifecycle: FactLifecycle {
+                    superseded_by: None,
+                    is_forgotten: false,
+                    forgotten_at: None,
+                    forget_reason: None,
+                },
+                access: FactAccess {
+                    access_count: 0,
+                    last_accessed_at: None,
+                },
+            };
+
+            store.insert_fact_async(fact).await.map_err(|e| {
+                rmcp::ErrorData::from(
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let json = serde_json::to_string_pretty(&serde_json::json!({
+                "fact_id": fact_id.as_str(),
+                "nous_id": params.nous_id,
+                "sensitivity": sensitivity.as_str(),
+            }))
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
+            return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                json,
+            )]));
+        }
+
+        #[cfg(not(feature = "knowledge-store"))]
+        {
+            let _ = params;
+            Err(KnowledgeStoreUnavailableSnafu {}.build().into())
+        }
+    }
+
+    /// Soft-delete a fact from the knowledge graph.
+    ///
+    /// The fact is marked as forgotten (not physically deleted). Forgotten
+    /// facts are excluded from recall but remain for audit purposes.
+    ///
+    /// Requires `Operator` role or above.
+    #[tool(description = "Soft-delete a fact from the knowledge graph. \
+        Requires Operator role.")]
+    async fn knowledge_forget(
+        &self,
+        Parameters(params): Parameters<params::KnowledgeForgetParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Expensive)?;
+        require_role(self, &context, Role::Operator, "knowledge_forget").await?;
+        require_knowledge_graph(self).await?;
+
+        #[cfg(feature = "knowledge-store")]
+        {
+            use mneme::id::FactId;
+            use mneme::knowledge::ForgetReason;
+
+            let store = resolve_store(self).map_err(rmcp::ErrorData::from)?;
+
+            let fact_id = FactId::new(&params.fact_id).map_err(|e| {
+                rmcp::ErrorData::from(
+                    InvalidInputSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let reason = params
+                .reason
+                .as_deref()
+                .unwrap_or("user_requested")
+                .parse::<ForgetReason>()
+                .map_err(|e| rmcp::ErrorData::from(InvalidInputSnafu { message: e }.build()))?;
+
+            let fact_id_clone = fact_id.clone();
+            let reason_clone = reason;
+            tokio::task::spawn_blocking(move || store.forget_fact(&fact_id_clone, reason_clone))
+                .await
+                .map_err(|e| {
+                    rmcp::ErrorData::from(
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?
+                .map_err(|e| {
+                    rmcp::ErrorData::from(
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+
+            let json = serde_json::to_string_pretty(&serde_json::json!({
+                "fact_id": fact_id.as_str(),
+                "forgotten": true,
+                "reason": reason.as_str(),
+            }))
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
+            return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                json,
+            )]));
+        }
+
+        #[cfg(not(feature = "knowledge-store"))]
+        {
+            let _ = params;
+            Err(KnowledgeStoreUnavailableSnafu {}.build().into())
+        }
+    }
+
+    /// Traverse entity edges in the knowledge graph.
+    ///
+    /// Returns entities within `depth` hops of the given entity, along with
+    /// the relationships connecting them. Depth is capped at 4 to prevent
+    /// unbounded traversal.
+    ///
+    /// Requires `Agent` role or above.
+    #[tool(
+        description = "Traverse entity edges in the knowledge graph up to the given depth. \
+        Returns neighbors and connecting relationships. Requires Agent role."
+    )]
+    async fn knowledge_graph_neighbors(
+        &self,
+        Parameters(params): Parameters<params::KnowledgeGraphNeighborsParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Expensive)?;
+        require_role(self, &context, Role::Agent, "knowledge_graph_neighbors").await?;
+        let config = require_knowledge_graph(self).await?;
+
+        #[cfg(feature = "knowledge-store")]
+        {
+            use std::collections::BTreeMap;
+
+            use mneme::engine::DataValue;
+
+            let store = resolve_store(self).map_err(rmcp::ErrorData::from)?;
+
+            let max_depth = config.mcp.knowledge_graph.max_graph_depth.min(4);
+            let depth = params.depth.unwrap_or(2).min(max_depth);
+
+            // WHY: run_query accepts arbitrary Datalog so we can traverse
+            // the neighborhood without exposing `entity_neighborhood`
+            // (which is pub(crate) in episteme) through the public facade.
+            // The query fetches direct edges (1-hop) from the seed entity.
+            // Multi-hop traversal beyond depth=1 is left for future work
+            // once the Datalog recursive-rule API is stable.
+            let script = r"
+                ?[entity_id, name, entity_type, relation, weight] :=
+                    *relationships{src: $entity_id, dst: entity_id, relation, weight},
+                    *entities{id: entity_id, name, entity_type}
+
+                ?[entity_id, name, entity_type, relation, weight] :=
+                    *relationships{src: entity_id, dst: $entity_id, relation, weight},
+                    *entities{id: entity_id, name, entity_type}
+            ";
+            let mut query_params: BTreeMap<String, DataValue> = BTreeMap::new();
+            query_params.insert(
+                "entity_id".to_owned(),
+                DataValue::Str(params.entity_id.clone().into()),
+            );
+
+            let result = store.run_query(script, query_params).map_err(|e| {
+                rmcp::ErrorData::from(
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let neighbors: Vec<serde_json::Value> = result
+                .rows_to_json()
+                .into_iter()
+                .map(|row| {
+                    serde_json::json!({
+                        "entity_id": row.first().cloned().unwrap_or(serde_json::Value::Null),
+                        "name": row.get(1).cloned().unwrap_or(serde_json::Value::Null),
+                        "entity_type": row.get(2).cloned().unwrap_or(serde_json::Value::Null),
+                        "relation": row.get(3).cloned().unwrap_or(serde_json::Value::Null),
+                        "weight": row.get(4).cloned().unwrap_or(serde_json::Value::Null),
+                    })
+                })
+                .collect();
+
+            let json = serde_json::to_string_pretty(&serde_json::json!({
+                "entity_id": params.entity_id,
+                "depth": depth,
+                "neighbors": neighbors,
+            }))
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
+            return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                json,
+            )]));
+        }
+
+        #[cfg(not(feature = "knowledge-store"))]
+        {
+            let _ = (params, config);
+            Err(KnowledgeStoreUnavailableSnafu {}.build().into())
+        }
     }
 
     /// Get the runtime configuration with sensitive fields redacted.

--- a/crates/diaporeia/src/tools/params.rs
+++ b/crates/diaporeia/src/tools/params.rs
@@ -66,6 +66,62 @@ pub(crate) struct KnowledgeSearchParams {
     pub limit: Option<u32>,
 }
 
+/// Parameters for `knowledge.recall` — semantic + BM25 recall.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct KnowledgeRecallParams {
+    /// The recall query text (used for both BM25 and vector search).
+    pub query: String,
+    /// Scope the recall to a specific nous agent ID.
+    ///
+    /// When omitted, results span all agents visible to the caller.
+    pub nous_id: Option<String>,
+    /// Maximum number of facts to return (default: 20).
+    pub limit: Option<u32>,
+}
+
+/// Sensitivity classification for a new fact.
+///
+/// Accepted values: `"public"` (default), `"internal"`, `"confidential"`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct KnowledgeInsertParams {
+    /// The fact content to store.
+    pub content: String,
+    /// The nous agent ID that owns this fact.
+    pub nous_id: String,
+    /// Data-sovereignty sensitivity: `"public"`, `"internal"`, or `"confidential"`.
+    ///
+    /// Defaults to `"public"` when omitted.
+    pub sensitivity: Option<String>,
+}
+
+/// Parameters for `knowledge.forget` — soft-delete a fact.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct KnowledgeForgetParams {
+    /// The fact ID to soft-delete.
+    pub fact_id: String,
+    /// Human-readable reason for forgetting.
+    ///
+    /// Accepted values: `"user_requested"` (default), `"superseded"`,
+    /// `"incorrect"`, `"privacy"`.
+    pub reason: Option<String>,
+}
+
+/// Parameters for `knowledge.get` — fetch a single fact by ID.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct KnowledgeGetParams {
+    /// The fact ID to retrieve.
+    pub fact_id: String,
+}
+
+/// Parameters for `knowledge.graph_neighbors` — traverse entity edges.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct KnowledgeGraphNeighborsParams {
+    /// The entity ID to start from.
+    pub entity_id: String,
+    /// Maximum number of hops from the start entity (default: 2, max: 4).
+    pub depth: Option<u32>,
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
@@ -139,5 +195,68 @@ mod tests {
         let json = r"{}";
         let params: SessionListParams = serde_json::from_str(json).unwrap();
         assert!(params.nous_id.is_none());
+    }
+
+    #[test]
+    fn knowledge_recall_params_deserializes_minimal() {
+        let json = r#"{"query": "Rust ownership"}"#;
+        let params: KnowledgeRecallParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.query, "Rust ownership");
+        assert!(params.nous_id.is_none());
+        assert!(params.limit.is_none());
+    }
+
+    #[test]
+    fn knowledge_recall_params_deserializes_full() {
+        let json = r#"{"query": "error handling", "nous_id": "syn", "limit": 10}"#;
+        let params: KnowledgeRecallParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.query, "error handling");
+        assert_eq!(params.nous_id.as_deref(), Some("syn"));
+        assert_eq!(params.limit, Some(10));
+    }
+
+    #[test]
+    fn knowledge_insert_params_requires_content_and_nous_id() {
+        let json = r#"{"content": "Rust uses ownership for memory safety.", "nous_id": "syn"}"#;
+        let params: KnowledgeInsertParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.nous_id, "syn");
+        assert!(params.sensitivity.is_none());
+    }
+
+    #[test]
+    fn knowledge_insert_params_rejects_missing_nous_id() {
+        let json = r#"{"content": "some fact"}"#;
+        let result = serde_json::from_str::<KnowledgeInsertParams>(json);
+        assert!(result.is_err(), "missing nous_id must fail");
+    }
+
+    #[test]
+    fn knowledge_forget_params_deserializes_with_defaults() {
+        let json = r#"{"fact_id": "f-abc123"}"#;
+        let params: KnowledgeForgetParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.fact_id, "f-abc123");
+        assert!(params.reason.is_none());
+    }
+
+    #[test]
+    fn knowledge_get_params_deserializes() {
+        let json = r#"{"fact_id": "f-xyz"}"#;
+        let params: KnowledgeGetParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.fact_id, "f-xyz");
+    }
+
+    #[test]
+    fn knowledge_graph_neighbors_params_deserializes() {
+        let json = r#"{"entity_id": "e-42", "depth": 3}"#;
+        let params: KnowledgeGraphNeighborsParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.entity_id, "e-42");
+        assert_eq!(params.depth, Some(3));
+    }
+
+    #[test]
+    fn knowledge_graph_neighbors_params_allows_default_depth() {
+        let json = r#"{"entity_id": "e-1"}"#;
+        let params: KnowledgeGraphNeighborsParams = serde_json::from_str(json).unwrap();
+        assert!(params.depth.is_none());
     }
 }

--- a/crates/diaporeia/tests/public_api.rs
+++ b/crates/diaporeia/tests/public_api.rs
@@ -135,6 +135,8 @@ impl StateBuilder {
             auth_mode: self.auth_mode,
             none_role: self.none_role,
             shutdown: CancellationToken::new(),
+            #[cfg(feature = "knowledge-store")]
+            knowledge_store: None,
         });
 
         (state, jwt_manager, self.instance_root)
@@ -507,6 +509,8 @@ async fn router_rejects_expired_bearer_token() {
         auth_mode: "token".to_owned(),
         none_role: "readonly".to_owned(),
         shutdown: CancellationToken::new(),
+        #[cfg(feature = "knowledge-store")]
+        knowledge_store: None,
     });
 
     let token = issue_token(&jwt_manager, "alice", Role::Admin);

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -563,6 +563,41 @@ impl Default for PromptAuditSettings {
 pub struct McpConfig {
     /// Per-session rate limiting for MCP tool calls.
     pub rate_limit: McpRateLimitConfig,
+    /// Knowledge graph MCP surface configuration.
+    pub knowledge_graph: KnowledgeGraphMcpConfig,
+}
+
+/// Configuration for the knowledge graph MCP surface.
+///
+/// When enabled, the MCP server exposes `knowledge.*` tools for querying
+/// and mutating the knowledge graph. Read operations require `Agent` role;
+/// mutations (`insert`, `forget`) require `Operator` role.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct KnowledgeGraphMcpConfig {
+    /// Whether the knowledge graph MCP tools are enabled.
+    ///
+    /// Defaults to `false` — operators must explicitly opt in.
+    pub enabled: bool,
+    /// Maximum number of results returned by `knowledge.search`.
+    ///
+    /// Defaults to 50.
+    pub max_search_results: u32,
+    /// Maximum graph traversal depth for `knowledge.graph_neighbors`.
+    ///
+    /// Capped at 4 to prevent unbounded Datalog recursion.
+    pub max_graph_depth: u32,
+}
+
+impl Default for KnowledgeGraphMcpConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_search_results: 50,
+            max_graph_depth: 2,
+        }
+    }
 }
 
 /// Per-session rate limiting configuration for MCP requests.

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -22,10 +22,10 @@ pub use gateway::{
 };
 pub use maintenance::{
     CircuitBreakerSettings, CredentialConfig, CronTaskEntry, CronTaskSettings,
-    DbMonitoringSettings, DiskSpaceSettings, DriftDetectionSettings, LoggingSettings,
-    MaintenanceSettings, McpConfig, McpRateLimitConfig, PromptAuditSettings, RedactionSettings,
-    RetentionSettings, SandboxSettings, SqliteRecoverySettings, TraceRotationSettings,
-    WatchdogSettings,
+    DbMonitoringSettings, DiskSpaceSettings, DriftDetectionSettings, KnowledgeGraphMcpConfig,
+    LoggingSettings, MaintenanceSettings, McpConfig, McpRateLimitConfig, PromptAuditSettings,
+    RedactionSettings, RetentionSettings, SandboxSettings, SqliteRecoverySettings,
+    TraceRotationSettings, WatchdogSettings,
 };
 pub use resolved::{
     AgentCapabilities, ResolvedModelConfig, ResolvedNousConfig, TokenLimits, resolve_nous,


### PR DESCRIPTION
## Summary

Wave 6 — closes #3368. Exposes aletheia's knowledge graph through 5 new MCP tools on the existing diaporeia server.

**New tools:**
- knowledge_recall(query, nous_id, limit) — BM25 text recall, Agent role
- knowledge_get(fact_id) — fetch single fact by ID, Agent role
- knowledge_insert(content, nous_id, sensitivity) — insert new fact, Operator role
- knowledge_forget(fact_id, reason) — soft-delete fact, Operator role
- knowledge_graph_neighbors(entity_id, depth) — traverse entity edges via Datalog, Agent role

**Config addition** ([mcp.knowledge_graph]):
enabled = false (default, opt-in), max_search_results = 50, max_graph_depth = 2 (capped at 4).

**RBAC**: read operations (recall, get, neighbors) require Agent; mutations (insert, forget) require Operator. All tools reject early when mcp.knowledge_graph.enabled = false.

**Feature gate**: zero-cost when compiled without knowledge-store feature. diaporeia defaults knowledge-store = true due to workspace feature unification.

## Example (socat stdio transport)

Connect via stdio transport: socat - EXEC:"aletheia mcp stdio"
Then send: {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"knowledge_recall","arguments":{"query":"session memory","limit":5}}}

## Validation

- cargo fmt --all -- --check: clean
- cargo clippy --workspace --features test-core --all-targets -- -D warnings: clean
- cargo test -p diaporeia -p taxis --features test-core: 27+28 passing (all ok)

Full workspace test blocked by pre-existing cross-agent build cache collision; diaporeia and taxis pass cleanly in isolation.

Closes #3368