### PR TITLE
refactor: replace CompactString with String across workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Test tiers: [docs/test-tiers.md](docs/test-tiers.md)
 
 - **Errors:** `snafu` with `.context()` propagation and `Location` tracking
 - **IDs:** Newtypes for all domain IDs (`AgentId`, `SessionId`, `NousId`)
-- **Time:** `jiff` for time, `ulid` for IDs, `compact_str` for small strings
+- **Time:** `jiff` for time, `ulid` for IDs
 - **Async:** Tokio actor model (`NousActor` pattern)
 - **Config:** TOML cascade in `taxis` (owned loader, no figment)
 - **Lints:** `#[expect(lint, reason = "...")]` over `#[allow]`; every suppression justified

--- a/crates/koina/CLAUDE.md
+++ b/crates/koina/CLAUDE.md
@@ -21,10 +21,10 @@ Core types, errors, tracing, and system abstractions shared by every Aletheia cr
 
 | Type | Path | Purpose |
 |------|------|---------|
-| `NousId` | `id.rs` | Agent identifier (CompactString newtype) |
+| `NousId` | `id.rs` | Agent identifier (String newtype) |
 | `SessionId` | `id.rs` | Session identifier (UUID newtype) |
 | `TurnId` | `id.rs` | Turn counter (u64 newtype) |
-| `ToolName` | `id.rs` | Tool name identifier (CompactString newtype) |
+| `ToolName` | `id.rs` | Tool name identifier (String newtype) |
 | `SecretString` | `secret.rs` | API key/token holder with redacted output and zeroize-on-drop |
 | `FileSystem` | `system.rs` | Trait: read, write, exists, list for testable filesystem access |
 | `Clock` | `system.rs` | Trait: `now()` for testable time |
@@ -60,5 +60,5 @@ Core types, errors, tracing, and system abstractions shared by every Aletheia cr
 
 ## Dependencies
 
-Uses: compact_str, jiff, serde, snafu, tracing, ulid, uuid, zeroize, rustix, regex
+Uses: jiff, serde, snafu, tracing, ulid, uuid, zeroize, rustix, regex
 Used by: every other Aletheia crate

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -20,7 +20,6 @@ test-support = []
 [dependencies]
 fjall = { version = "3", default-features = false, optional = true }
 tempfile = { workspace = true, optional = true }
-compact_str = { workspace = true }
 jiff = { workspace = true }
 rustix = { workspace = true, features = ["fs"] }
 regex = { workspace = true }

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -3,7 +3,6 @@
 use std::borrow::Borrow;
 use std::fmt;
 
-use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
 use crate::uuid::Uuid;
@@ -131,7 +130,7 @@ macro_rules! newtype_id {
 /// A nous (agent) identifier. Lowercase alphanumeric + hyphens, 1-64 chars.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
-pub struct NousId(CompactString);
+pub struct NousId(String);
 
 impl NousId {
     /// Create a new `NousId`, validating the format.
@@ -140,7 +139,7 @@ impl NousId {
     /// Returns an error if the ID is empty, exceeds 64 characters,
     /// or contains characters other than lowercase alphanumeric and hyphens.
     #[must_use = "returns a validated identifier that should not be discarded"]
-    pub fn new(id: impl Into<CompactString>) -> Result<Self, IdError> {
+    pub fn new(id: impl Into<String>) -> Result<Self, IdError> {
         let id = id.into();
         validate_id(&id, "NousId")?;
         Ok(Self(id))
@@ -292,7 +291,7 @@ impl fmt::Display for TurnId {
 /// A tool name. Validated to be non-empty and contain only safe characters.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
-pub struct ToolName(CompactString);
+pub struct ToolName(String);
 
 impl ToolName {
     /// Construct a `ToolName` from a string literal known to be valid at compile time.
@@ -314,7 +313,7 @@ impl ToolName {
     /// Returns an error if the name is empty, exceeds 128 characters,
     /// or contains characters other than alphanumeric, hyphens, and underscores.
     #[must_use = "returns a validated tool name that should not be discarded"]
-    pub fn new(name: impl Into<CompactString>) -> Result<Self, IdError> {
+    pub fn new(name: impl Into<String>) -> Result<Self, IdError> {
         let name = name.into();
         if name.is_empty() {
             return Err(IdError::Empty { kind: "ToolName" });

--- a/crates/koina/src/id_tests.rs
+++ b/crates/koina/src/id_tests.rs
@@ -273,11 +273,6 @@ mod newtype_id_macro {
         pub struct TestStringId(String)
     );
 
-    newtype_id!(
-        /// Test ID using `CompactString` inner type.
-        pub struct TestCompactId(compact_str::CompactString)
-    );
-
     #[test]
     fn new_and_as_str() {
         let id = TestStringId::new("abc");
@@ -345,25 +340,5 @@ mod newtype_id_macro {
         assert_eq!(json, r#""serde-test""#);
         let back: TestStringId = serde_json::from_str(&json).unwrap();
         assert_eq!(id, back);
-    }
-
-    #[test]
-    fn compact_string_variant_works() {
-        let id = TestCompactId::new("compact");
-        assert_eq!(id.as_str(), "compact");
-        assert_eq!(id.to_string(), "compact");
-
-        let json = serde_json::to_string(&id).unwrap();
-        assert_eq!(json, r#""compact""#);
-        let back: TestCompactId = serde_json::from_str(&json).unwrap();
-        assert_eq!(id, back);
-    }
-
-    #[test]
-    fn distinct_types_not_interchangeable() {
-        let a = TestStringId::new("x");
-        let b = TestCompactId::new("x");
-        assert_eq!(a.as_str(), b.as_str());
-        // WHY: a == b would not compile: different types
     }
 }

--- a/crates/theatron/skene/Cargo.toml
+++ b/crates/theatron/skene/Cargo.toml
@@ -14,7 +14,6 @@ test-full = []
 [dependencies]
 koina = { path = "../../koina" }
 bytes = { workspace = true }
-compact_str = { workspace = true }
 futures-core = "0.3"
 futures-util = "0.3"
 reqwest = { workspace = true, features = ["stream", "cookies"] }

--- a/crates/theatron/skene/src/id.rs
+++ b/crates/theatron/skene/src/id.rs
@@ -3,7 +3,6 @@
 use std::borrow::Borrow;
 use std::fmt;
 
-use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
 koina::newtype_id!(
@@ -16,14 +15,10 @@ koina::newtype_id!(
     pub struct SessionId(String) // kanon:ignore RUST/pub-visibility
 );
 
-/// Turn identifier, using `CompactString` for inline storage.
-///
-/// WHY: Decimal u64 strings are at most 20 bytes (`u64::MAX`), always within
-/// `CompactString`'s 24-byte inline limit. `NousId` (<=64 bytes), `SessionId`
-/// (26-byte ULID), `ToolId` (<=128 bytes), and `PlanId` (variable) exceed it.
+/// Turn identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct TurnId(CompactString);
+pub struct TurnId(String);
 
 koina::newtype_id!(
     /// Tool call identifier.


### PR DESCRIPTION
## Summary

- Replace `compact_str::CompactString` with `std::String` in all first-party crates (koina, krites, theatron/skene, theatron/koilon, episteme, aletheia, integration-tests, taxis)
- Drop `compact_str = { version = "0.9", features = ["serde"] }` from `[workspace.dependencies]` and all per-crate `[dependencies]` sections
- Eliminate 154 unsafe blocks and a footgun-prone third-party type with no measurable benefit at aletheia's string sizes
- Resolve all downstream clippy lint cascade: `implicit_clone`, `useless_conversion`, `ptr_arg`, `manual_string_new`, `redundant_closure`

## Commits

1. `refactor(koina)`: NousId and ToolName newtypes migrated from CompactString to String
2. `refactor(skene)`: TurnId migrated from CompactString to String
3. `refactor(krites)`: DataValue::Str, Symbol.name, ColumnDef.name, and all BTreeMap option maps
4. `chore`: drop compact_str from workspace Cargo.toml and all crate Cargo.tomls
5. `fix`: downstream clippy warnings in episteme, aletheia, integration-tests, krites, taxis

## Public API changes

- `koina::NousId::new()`: accepts `impl Into<String>` (was `impl Into<CompactString>`)
- `koina::ToolName::new()`: accepts `impl Into<String>` (was `impl Into<CompactString>`)
- `krites::DataValue::Str(String)`: inner type changed from `CompactString` to `String`

## Validation

- `cargo fmt --check`: clean
- `cargo clippy --workspace --features test-core --all-targets -- -D warnings`: zero errors
- `cargo test --workspace --features test-core -- --test-threads=1`: exit 0 (parallel runs show pre-existing CozoDB engine test flakiness unrelated to this change)
- `rg 'CompactString|compact_str' crates/`: no matches in .rs or Cargo.toml files
- Cargo.lock: compact_str retained only as transitive dep of ratatui-core and tokenizers (external crates)

Closes #3524