### PR TITLE
docs: absorb ergon_tools patterns into standards, templates, and hooks

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,0 +1,57 @@
+# Lessons Learned
+
+> Cross-dispatch pattern extraction. Each entry records what worked, what
+> failed, and where the fix was codified. This is the institutional memory
+> layer between ephemeral agent observations and durable standards.
+
+**How entries are added:** After a dispatch run completes, triage classifies
+observations from QA results and worker logs. Lessons that reflect structural
+patterns (not one-off bugs) land here. See `standards/AGENTIC_PIPELINE.md §
+Observations: ephemeral to tracked` for the full triage flow.
+
+---
+
+## Format
+
+Each entry follows this structure:
+
+```markdown
+### YYYY-MM-DD — <short title>
+
+**Context:** One sentence describing the dispatch, task type, or subsystem.
+
+**What worked:** Concrete observations about what produced good outcomes.
+
+**What failed:** Concrete observations about what produced poor outcomes.
+
+**Structural fix:** Where the lesson was codified (file path, standard section,
+issue number, or "none — one-off").
+```
+
+Entries are prepended (newest first). Do not reorder existing entries.
+
+---
+
+## Entries
+
+### 2026-04-17 — ergon_tools pattern absorption (Wave 7)
+
+**Context:** Bulk standards absorption from ergon_tools (external reference
+project). No Rust changes; standards and workflow artifacts only.
+
+**What worked:** Deriving the agentic pipeline standard from existing code
+(`crates/energeia`) rather than specifying it independently. The implementation
+already embodied the right structure; the standard made it explicit and
+navigable for agents starting cold.
+
+**What failed:** ergon_tools repo was not present at any of the expected paths
+(`~/dev/ergon`, `~/menos-ops/repos/ergon`, `~/menos-ops/repos/reference/ergon`).
+All absorption had to be driven from the issue body description alone.
+
+**Structural fix:** `standards/AGENTIC_PIPELINE.md` added as canonical pipeline
+description. `workflow/prompts/templates/` populated with 5 role templates.
+`shared/hooks/_templates/` extended with git-guard hook.
+`docs/LESSONS-LEARNED.md` (this file) created as structured capture format.
+`standards/STANDARDS.md` standards index updated to reference new files.
+Closes #3451.
+

--- a/shared/hooks/_templates/git-guard.sh
+++ b/shared/hooks/_templates/git-guard.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# git-guard.sh — inspect tool:called payloads for destructive git operations.
+#
+# Receives the tool:called event payload on stdin as JSON.
+# Exits:
+#   0 — no issue detected
+#   1 — operator-approval required (warns or blocks per ALETHEIA_GIT_GUARD_BLOCK)
+#   2 — permanently blocked operation (always an error)
+set -euo pipefail
+
+BLOCK_MODE="${ALETHEIA_GIT_GUARD_BLOCK:-0}"
+
+payload=$(cat)
+tool_name=$(printf '%s' "$payload" | grep -o '"toolName":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+# Only inspect tool calls that could run shell commands.
+case "${tool_name:-}" in
+  Bash|bash|shell|run_command|execute) : ;;
+  *) exit 0 ;;
+esac
+
+# Extract the command text from the payload.
+# The field may be "command", "cmd", or "input" depending on the tool.
+command_text=$(printf '%s' "$payload" \
+  | grep -o '"command":"[^"]*"' \
+  | head -1 \
+  | cut -d'"' -f4 || true)
+
+if [[ -z "${command_text:-}" ]]; then
+  # No parseable command field — pass through.
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Permanently blocked patterns — no override path.
+# These operations cannot be undone and should never run autonomously.
+# ---------------------------------------------------------------------------
+
+PERMANENTLY_BLOCKED=(
+  "git push --force"
+  "git push -f "
+  "git push -f$"
+  "push --force-with-lease"
+  "git push --mirror"
+  "git push --delete"
+  "git push origin :refs/"
+  "git branch -D"
+  "git branch --delete --force"
+)
+
+for pattern in "${PERMANENTLY_BLOCKED[@]}"; do
+  if printf '%s' "$command_text" | grep -qF "$pattern"; then
+    printf 'git-guard: PERMANENTLY BLOCKED — "%s" matches pattern "%s"\n' \
+      "$command_text" "$pattern" >&2
+    printf 'Reason: force push, remote branch deletion, and mirror push cannot be undone.\n' >&2
+    printf 'To proceed: operator must run this command manually outside the agent session.\n' >&2
+    exit 2
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Operator-approval required — warn by default, block when ALETHEIA_GIT_GUARD_BLOCK=1.
+# ---------------------------------------------------------------------------
+
+APPROVAL_REQUIRED=(
+  "git push origin main"
+  "git push origin master"
+  "git reset --hard"
+  "git clean -f"
+  "git clean -fd"
+  "git checkout -- "
+  "git restore --staged"
+  "git rebase -i"
+  "git filter-repo"
+  "git filter-branch"
+)
+
+for pattern in "${APPROVAL_REQUIRED[@]}"; do
+  if printf '%s' "$command_text" | grep -qF "$pattern"; then
+    if [[ "$BLOCK_MODE" == "1" ]]; then
+      printf 'git-guard: BLOCKED (operator approval required) — "%s" matches "%s"\n' \
+        "$command_text" "$pattern" >&2
+      printf 'Set ALETHEIA_GIT_GUARD_BLOCK=0 or use --override-push-guard flag to allow.\n' >&2
+      exit 1
+    else
+      printf 'git-guard: WARNING — "%s" requires operator approval (pattern: "%s")\n' \
+        "$command_text" "$pattern" >&2
+      printf 'Set ALETHEIA_GIT_GUARD_BLOCK=1 to block this operation instead of warning.\n' >&2
+      # Exit 0: warn mode does not block the operation.
+      exit 0
+    fi
+  fi
+done
+
+exit 0

--- a/shared/hooks/_templates/git-guard.yaml
+++ b/shared/hooks/_templates/git-guard.yaml
@@ -1,0 +1,27 @@
+# Git guard — block destructive git operations without explicit operator approval.
+#
+# Fires on tool:called for any tool that executes a shell command. Inspects the
+# command for git operations that cannot be undone and either warns or blocks.
+#
+# Copy to shared/hooks/ and set enabled: true to activate.
+# Set ALETHEIA_GIT_GUARD_BLOCK=1 to switch from warn to block mode.
+#
+# Permanently blocked (no override): force push, --delete on remote refs, --mirror.
+# Operator-override required: push to main/master, reset --hard, clean -f.
+
+name: git-guard
+event: tool:called
+enabled: false
+description: >
+  Block or warn on destructive git operations. Permanent block on force push
+  and remote branch deletion. Operator-approval block on push to main and
+  history-rewriting commands.
+
+handler:
+  type: shell
+  command: <aletheia-root>/shared/hooks/_templates/git-guard.sh
+  timeout: 5s
+  failAction: warn   # change to "block" to hard-block the operation
+  env:
+    # Set to 1 to switch from warn to block mode for operator-approval operations.
+    ALETHEIA_GIT_GUARD_BLOCK: "0"

--- a/shared/templates/sections/domain_knowledge.md
+++ b/shared/templates/sections/domain_knowledge.md
@@ -1,0 +1,53 @@
+
+## Domain knowledge
+
+This section is populated per-agent with domain-specific facts that the
+agent needs to operate correctly. Unlike SOUL.md (identity) or CONTEXT.md
+(situational), domain knowledge is stable reference material: architecture
+decisions, terminology, data model constraints, and integration contracts.
+
+### What belongs here
+
+- **Terminology.** Names used in this domain and what they mean. Resolve
+  ambiguities between similar terms.
+- **Invariants.** Facts that are always true and that code must not violate.
+  Example: "session.turns is always sorted ascending by timestamp."
+- **Contracts.** APIs, event schemas, or data formats this agent depends on
+  or produces. What consumers expect.
+- **Architecture decisions.** Why key structures are the way they are. Enough
+  context that an agent cold-starting can make locally consistent decisions.
+- **Known limitations.** What this domain intentionally does not handle.
+  Prevents agents from implementing workarounds for intended constraints.
+
+### What does not belong here
+
+- Operational procedures (put in SOUL.md operations section)
+- Personal context about the operator (put in USER.md)
+- Task-specific notes (put in daily memory files)
+- General standards (those live in `standards/` and apply everywhere)
+
+### Template
+
+```markdown
+## [Domain name] — domain knowledge
+
+### Terminology
+| Term | Meaning |
+|------|---------|
+| [term] | [definition] |
+
+### Invariants
+- [invariant 1]
+- [invariant 2]
+
+### Contracts
+| Interface | Direction | Schema / format |
+|-----------|-----------|-----------------|
+| [name] | produces / consumes | [description or link] |
+
+### Architecture decisions
+- **[Decision]:** [rationale]
+
+### Known limitations
+- [limitation]
+```

--- a/shared/templates/sections/team_topology.md
+++ b/shared/templates/sections/team_topology.md
@@ -1,0 +1,28 @@
+
+## Team topology
+
+You are one agent in a coordinated team. Understanding the team prevents
+duplicated work and accidental conflicts.
+
+### Active agents
+
+Read `shared/nous/` to see who else is running. Each agent has a workspace
+directory there. Do not modify another agent's workspace.
+
+### Coordination rules
+
+- **No overlapping blast radius.** If your task touches a file, verify no
+  other active agent has it in their current blast radius. Check the active
+  dispatch queue if unsure.
+- **Don't read another agent's MEMORY.md.** It may contain context scoped
+  to their role or operator.
+- **Signal blocking issues.** If your task is blocked by another agent's
+  in-progress work, write the blocker to your daily memory file and surface
+  it to the operator — don't wait silently.
+
+### Hand-offs
+
+If your task produces output that a subsequent agent depends on (a PR, a
+document, a schema change), write the hand-off summary to your daily memory
+file with the tag `HANDOFF:`. The dispatcher reads tagged entries to wire
+dependencies between dispatch batches.

--- a/standards/AGENTIC_PIPELINE.md
+++ b/standards/AGENTIC_PIPELINE.md
@@ -1,0 +1,187 @@
+# Agentic Pipeline Standard
+
+> Canonical description of the aletheia dispatch pipeline: the closed loop from
+> planner through dispatcher, workers, QA, CI, and triage. Read this before
+> working on energeia, the orchestrator, or the steward.
+
+---
+
+## The loop
+
+```
+planner
+  │  execution plan (DAG, ordered batches)
+  ▼
+dispatcher (energeia)
+  │  prompts → sessions
+  ▼
+workers (CC agents)
+  │  PRs
+  ▼
+QA gate (energeia qa)
+  │  verdict
+  ▼
+CI (GitHub Actions)
+  │  status
+  ▼
+steward (energeia steward)
+  │  merge / fix / escalate
+  ▼
+triage
+  │  issues, lessons, next plan
+  └──────────────────────────► planner
+```
+
+Each arrow is a hand-off. Each box is a module boundary with typed inputs and
+outputs. The loop closes at triage: unresolved failures become issues that feed
+the next planning cycle.
+
+---
+
+## Prompt as atomic unit
+
+A prompt is a self-contained work order. The worker that picks it up has zero
+prior context beyond what the prompt supplies. Every prompt must include:
+
+- **Task** — what to build or fix (last, after all context).
+- **Blast radius** — which files and crates are in scope. This is the
+  authorization boundary, not an advisory: the worker stays inside it.
+- **Acceptance criteria** — machine-verifiable conditions. Each criterion
+  maps to a QA check. Vague criteria produce vague verdicts.
+- **Standards reference** — which standards govern this work. At minimum
+  `standards/STANDARDS.md`, `standards/RUST.md`, and `AGENTS.md`.
+- **Dependencies** — prompt numbers this prompt depends on. Unmet
+  dependencies block dispatch.
+
+Prompts live in YAML frontmatter files. See `workflow/prompts/` for the
+canonical location and `crates/energeia/src/prompt.rs` for the loader.
+
+---
+
+## Execution plan as dependency DAG
+
+Plans are not flat lists. Prompts form a DAG: some work must finish before
+other work can start. The dispatcher computes the topological frontier (the
+set of prompts whose dependencies are all satisfied) and dispatches them in
+parallel, then advances to the next frontier batch.
+
+Rules for plan authors:
+
+- **Partition by blast radius.** No two prompts in the same batch touch the
+  same files, because parallel workers will conflict.
+- **Keep batches small.** 4–6 prompts per batch is the working limit for a
+  single dispatch run. Larger batches increase conflict surface and QA cost.
+- **Order by dependency, not by preference.** If prompt B reads output from
+  prompt A, declare the dependency. The DAG enforces order; the author
+  should not.
+
+---
+
+## Blast radius as authorization boundary
+
+The blast radius in a prompt is not a suggestion. It defines what the worker
+is authorized to touch. Files outside the blast radius are off-limits.
+
+Why this matters:
+
+- Parallel agents working on overlapping files will create merge conflicts
+  that block the entire queue.
+- QA mechanical checks flag blast-radius violations as hard failures
+  (`MechanicalIssueKind::BlastRadiusViolation`).
+- Steward will not merge a PR with an unresolved blast-radius violation.
+
+When a task genuinely requires changes beyond the declared blast radius,
+the prompt is wrong. Fix the plan, not the boundary.
+
+---
+
+## Verdict types as control signals
+
+QA produces one of three verdicts. The dispatcher uses verdicts as control
+signals, not just labels.
+
+| Verdict | Meaning | Dispatcher action |
+|---------|---------|-------------------|
+| `Pass` | All criteria met, no mechanical issues | Steward merges |
+| `Partial` | Some criteria met, some failed | Escalate to operator for review |
+| `Fail` | Hard failure: mechanical issues or all criteria failed | Re-queue with corrective context, or file issue |
+
+`Partial` is not a slow path to `Pass`. If a prompt consistently produces
+`Partial`, the acceptance criteria or the prompt itself is ambiguous.
+Fix the prompt.
+
+---
+
+## Observations: ephemeral to tracked
+
+During a dispatch run, workers and QA produce observations: findings,
+anomalies, patterns, friction. These are ephemeral until triage.
+
+At triage, observations are classified:
+
+- **Structural fix needed** → GitHub issue + follow-up prompt.
+- **Lesson learned** → entry in `docs/LESSONS-LEARNED.md`.
+- **False positive** → note in QA calibration log.
+
+Observations that are never triaged become noise. Triage is not optional;
+it is the step that closes the loop and prevents the same failure from
+recurring.
+
+See `docs/LESSONS-LEARNED.md` for the lessons capture format.
+
+---
+
+## Stage-by-stage reference
+
+The energeia pipeline (`crates/energeia/src/pipeline/`) runs five stages:
+
+| Stage | Module | What it does |
+|-------|--------|-------------|
+| Validation | `validation.rs` | Preflight: non-empty prompt list, unique numbers, valid DAG |
+| Preparation | `preparation.rs` | Build DAG, compute first frontier, initialize shared state |
+| Health check | `health_check.rs` | Probe backend reachability before spawning sessions |
+| Execution | `execution.rs` | Drive frontier group loop, collect session outcomes |
+| Post-processing | `post_processing.rs` | Record metrics, assemble result, persist store record |
+
+QA runs after execution as a separate gate, not as a pipeline stage, because
+QA cost is per-prompt and may be skipped for sessions that did not produce a PR.
+
+---
+
+## Model tier selection
+
+Match the model tier to the task complexity. Using Opus for mechanical work
+wastes budget; using Haiku for architecture produces low-quality output.
+
+| Tier | Model | When |
+|------|-------|------|
+| Architecture | Opus 4 | System design, cross-crate refactors, plan authoring |
+| Execution | Sonnet 4.6 | Standard feature work, bug fixes, documentation |
+| Mechanical | Haiku 4.5 | Lint fixes, formatting, dependency bumps |
+
+The dispatcher reads the model tier from the prompt's YAML frontmatter
+(`model_tier` field). Absent the field, it defaults to Sonnet.
+
+---
+
+## QA sub-agent requirement
+
+Every dispatch prompt should specify at least one QA criterion. Prompts with
+zero acceptance criteria produce `Pass` verdicts vacuously — the QA gate
+has nothing to evaluate.
+
+For complex PRs (cross-crate, new subsystems, security-sensitive), a
+semantic QA sub-agent review is required before merge. The `semantic_evaluated`
+flag in `QaResult` records whether this ran.
+
+---
+
+## See also
+
+- `crates/energeia/src/types.rs` — DispatchSpec, QaResult, QaVerdict, Budget
+- `crates/energeia/src/pipeline/` — concrete stage implementations
+- `crates/energeia/src/qa/` — QaGate trait and mechanical checks
+- `crates/energeia/src/steward/` — CI management and merge pipeline
+- `docs/LESSONS-LEARNED.md` — lessons capture format
+- `standards/PROMPTING.md` — API-level prompt construction (system prompts, XML tags, caching)
+- `workflow/prompts/templates/` — concrete agent-role prompt templates

--- a/standards/PROMPTING.md
+++ b/standards/PROMPTING.md
@@ -267,6 +267,58 @@ Use Tier 1 by default. Use Tier 2 when the task requires domain-specific judgmen
 
 ---
 
+## Dispatch prompts
+
+Dispatch prompts (work orders sent to coding agents via energeia) have
+additional requirements beyond standard API prompts. A dispatch prompt is
+picked up by a worker with zero prior context. It must be fully self-contained.
+
+### Ten ground rules
+
+1. **Self-contained work order.** The worker reads nothing except what the
+   prompt provides (plus the repo). No implicit prior context, no "as
+   discussed", no session state.
+
+2. **Blast radius is an authorization boundary.** List every file and
+   directory the worker may touch. Files outside that list are off-limits.
+   The QA gate enforces this mechanically.
+
+3. **One PR per prompt.** Each prompt produces exactly one pull request.
+   Prompts that produce multiple PRs are scoped incorrectly.
+
+4. **Acceptance criteria are verifiable.** Every criterion must have a
+   deterministic pass/fail answer (a command that exits 0 or non-zero, a
+   structural property that can be checked). "Code is clean" is not a
+   criterion. "`cargo clippy -- -D warnings` exits 0" is.
+
+5. **Task goes last.** Context, constraints, and criteria come first. The
+   task directive is the final section. Placing the task first degrades
+   quality by up to 30% (see § User prompt ordering).
+
+6. **Model tier matches task complexity.** Opus for architecture, Sonnet for
+   execution, Haiku for mechanical. See `standards/AGENTIC_PIPELINE.md §
+   Model tier selection`.
+
+7. **QA sub-agent before completion.** Complex PRs (cross-crate, security,
+   new subsystems) require a semantic QA sub-agent evaluation before merge.
+   Declare this in the acceptance criteria.
+
+8. **Standards reference is explicit.** Name the standards files that govern
+   the work. Don't assume the worker will discover them.
+
+9. **Progress commits required.** Multi-step tasks must commit at each logical
+   checkpoint. Commits enable bisect and recovery if the worker gets stuck.
+
+10. **Gate trailer in final commit.** Include `Gate-Passed: kanon 0.1.0` in
+    the final commit body. The steward checks for this before merging.
+
+### Templates
+
+Role-specific prompt templates with YAML frontmatter:
+`workflow/prompts/templates/` — coder, reviewer, researcher, refactor, infra.
+
+---
+
 ## Anti-patterns
 
 - Prose-dump system prompts without structural markers (use XML tags)
@@ -280,3 +332,6 @@ Use Tier 1 by default. Use Tier 2 when the task requires domain-specific judgmen
 - Examples that don't match actual use cases
 - Rules without WHY (followed rigidly, not understood)
 - Identity claims in role definitions (see [Role framing](#role-framing) -- use directive-only instead)
+- Dispatch prompts that assume prior context (worker starts cold every time)
+- Acceptance criteria that cannot be mechanically verified
+- Missing blast radius (QA cannot check what it cannot enumerate)

--- a/standards/STANDARDS.md
+++ b/standards/STANDARDS.md
@@ -7,6 +7,8 @@
 | File | Scope |
 |------|-------|
 | **This file** | Universal principles: philosophy, comments, naming, errors, concurrency, config, git, security, logging, observability contracts, writing, code review (testing → TESTING.md) |
+| AGENTIC_PIPELINE.md | **Canonical** pipeline description: planner→dispatcher→worker→QA→CI→triage loop, prompt-as-work-order, blast radius as authorization boundary, verdict control signals, model tier selection |
+| PROMPTING.md | API-level prompt construction: system prompt ordering, XML tags, voice, caching, few-shot examples, structured output, role framing |
 | REPO-SETUP.md | New project checklist: required files, directories, CI, Cargo.toml template, deny.toml baseline, verification script |
 | ENVIRONMENT.md | Environment variables, configuration files, secrets handling, feature flags, path resolution |
 | PLANNING.md | Project planning: phase structure, ROADMAP/STATE/PLAN/SUMMARY formats, lifecycle, migration |

--- a/workflow/prompts/templates/README.md
+++ b/workflow/prompts/templates/README.md
@@ -1,0 +1,49 @@
+# Prompt Templates
+
+Role-scoped prompt skeletons for dispatch tasks. Each template is a starting
+point, not a fill-in-the-blank form. Adapt to the specific task.
+
+## Templates
+
+| File | Role | When to use |
+|------|------|-------------|
+| `coder.md` | Feature implementation, bug fixes | Standard development work |
+| `reviewer.md` | QA sub-agent, code review | After a coder agent produces a PR |
+| `researcher.md` | Investigation, architecture analysis | Before implementation, for complex unknowns |
+| `refactor.md` | Structural improvements, cross-crate moves | Planned refactors with known scope |
+| `infra.md` | CI, tooling, deployment, standards | Non-product work that touches build or ops |
+
+## How to use
+
+1. Copy the relevant template.
+2. Fill in the `[BRACKETED]` fields — these are required.
+3. Fill in the optional fields (marked with `# optional`) if you have the
+   information. Leave them out otherwise; the worker will discover them.
+4. Place the filled prompt in `workflow/prompts/<project>/` with a numeric
+   prefix (`01-`, `02-`, ...) that reflects the DAG execution order.
+
+## YAML frontmatter
+
+Each dispatch prompt requires YAML frontmatter:
+
+```yaml
+---
+number: 1
+description: "Short title for dashboards and QA reports"
+depends_on: []          # prompt numbers this prompt depends on
+model_tier: sonnet      # sonnet | opus | haiku
+blast_radius:           # list of files/directories in scope
+  - crates/my-crate/src/
+acceptance_criteria:    # must be machine-verifiable
+  - "cargo test -p my-crate passes"
+  - "cargo clippy --workspace -- -D warnings clean"
+---
+```
+
+Frontmatter is parsed by `crates/energeia/src/prompt.rs`.
+
+## Relationship to PROMPTING.md
+
+`standards/PROMPTING.md` covers API-level prompt construction: XML tags,
+voice, caching, structured output. These templates apply those principles
+to specific roles. The two documents are additive.

--- a/workflow/prompts/templates/coder.md
+++ b/workflow/prompts/templates/coder.md
@@ -1,0 +1,51 @@
+---
+number: [N]
+description: "[Short title for this task]"
+depends_on: []
+model_tier: sonnet
+blast_radius:
+  - [crates/affected-crate/src/]
+acceptance_criteria:
+  - "cargo test -p [crate] passes"
+  - "cargo clippy --workspace --features test-core --all-targets -- -D warnings clean"
+  - "cargo fmt --all -- --check passes"
+  - "[Feature-specific criterion]"
+---
+
+# Standards
+
+- `standards/STANDARDS.md` — universal principles
+- `standards/RUST.md` — Rust-specific rules
+- `AGENTS.md` — build commands, key patterns, where to add things
+
+# Context
+
+[Prior work, related PRs, or handoff from a prior prompt in this wave.
+Omit if this is the first prompt in a plan.]
+
+# Blast radius
+
+Changes are scoped to:
+
+[List the same files/directories as the frontmatter blast_radius. Be explicit
+about what is OUT of scope if there is a risk of confusion.]
+
+Files outside this scope require a separate prompt and separate PR.
+
+# Acceptance criteria
+
+1. [Restate each criterion from the frontmatter. One sentence each. Make them
+   testable: "X passes" or "Y is present in Z".]
+2. `cargo test -p [crate]` passes.
+3. `cargo clippy --workspace --features test-core --all-targets -- -D warnings` clean.
+4. `cargo fmt --all -- --check` passes.
+
+# Task
+
+[The specific work to do. Describe the outcome, not the approach. The worker
+chooses the approach.]
+
+[If there are multiple sub-tasks, list them in priority order. The worker
+completes them in order and stops if one fails.]
+
+Commit with `Gate-Passed: kanon 0.1.0` in the commit body.

--- a/workflow/prompts/templates/infra.md
+++ b/workflow/prompts/templates/infra.md
@@ -1,0 +1,60 @@
+---
+number: [N]
+description: "Infra: [CI change, tooling update, or standards edit]"
+depends_on: []
+model_tier: haiku     # mechanical/config work; use sonnet for complex CI logic
+blast_radius:
+  - [.github/workflows/ | scripts/ | standards/ | Cargo.toml | etc.]
+acceptance_criteria:
+  - "[CI check passes | script produces correct output | standard is consistent]"
+  - "cargo clippy --workspace --features test-core --all-targets -- -D warnings clean (if Rust touched)"
+---
+
+# Role
+
+Infrastructure, tooling, CI, or standards work. No product feature changes.
+
+# Standards
+
+- `standards/STANDARDS.md` — repository hygiene, dead weight rules
+- `standards/CI.md` — CI tooling and workflow conventions
+- `standards/SHELL.md` — shell script requirements (set -euo pipefail, quoting)
+- `standards/WRITING.md` — prose standards for documentation edits
+
+# Context
+
+[Why this infrastructure change is needed. What is broken or missing. What
+the correct state looks like.]
+
+# Blast radius
+
+Changes are scoped to:
+
+[List affected files. Infrastructure changes often touch configuration files,
+scripts, and CI definitions. Be specific.]
+
+**No product code changes.** If product code must change to support this
+infrastructure work, that is a separate prompt.
+
+# Acceptance criteria
+
+1. [Primary criterion — e.g., "CI workflow lint job runs and passes"]
+2. [Secondary criterion — e.g., "Script exits 0 on valid input, non-zero on invalid"]
+3. [Standards criterion — e.g., "No information is duplicated between the two docs"]
+
+# Checklist (infra-specific)
+
+- [ ] Shell scripts: `set -euo pipefail` on line 2, all variables quoted
+- [ ] CI workflows: pinned action versions (`uses: actions/checkout@v4.2.2`)
+- [ ] Documentation edits: no words from the WRITING.md banned list
+- [ ] No dead weight added (scripts, empty dirs, placeholder docs)
+
+# Task
+
+[Describe the infrastructure change. Reference the specific files to create,
+modify, or delete.]
+
+[For standards edits: state exactly what changes and why, and confirm that
+the information is not duplicated elsewhere in the standards tree.]
+
+Commit with conventional format: `chore(scope): description` or `ci(scope): description`.

--- a/workflow/prompts/templates/refactor.md
+++ b/workflow/prompts/templates/refactor.md
@@ -1,0 +1,67 @@
+---
+number: [N]
+description: "Refactor: [what is being restructured]"
+depends_on: []
+model_tier: sonnet
+blast_radius:
+  - [every file that will be touched — refactors touch many files]
+acceptance_criteria:
+  - "cargo test --workspace --features test-core passes (no regressions)"
+  - "cargo clippy --workspace --features test-core --all-targets -- -D warnings clean"
+  - "cargo fmt --all -- --check passes"
+  - "Public API surface of [crate] unchanged (or migration documented in CHANGELOG)"
+  - "[Structural property the refactor is meant to achieve]"
+---
+
+# Standards
+
+- `standards/STANDARDS.md` — information hierarchy and define-once principles
+- `standards/RUST.md` — Rust-specific layout and visibility rules
+- `standards/ARCHITECTURE.md` — dependency direction, crate boundaries
+- `AGENTS.md` — where to add things, common mistakes
+
+# Context
+
+[Why this refactor is happening. What problem it solves. What the code looks
+like before and what it should look like after.]
+
+[If there was a prior research prompt: reference its findings here.]
+
+# Blast radius
+
+This refactor touches:
+
+[List every file or directory. Refactors often have wide blast radius — be
+complete. Files not listed are off-limits.]
+
+**Public API impact:** [None | Changes documented in CHANGELOG | Migration
+required — details below]
+
+# Constraints
+
+- Tests pass before and after. If a test must change, explain why in the commit body.
+- No behavior changes, only structural changes. If behavior must change, that
+  is a separate prompt.
+- No new dependencies unless the refactor requires them. Justify any additions.
+- Preserve all existing `WHY:`, `WARNING:`, and `SAFETY:` comments unless the
+  code they annotate is removed.
+
+# Acceptance criteria
+
+1. `cargo test --workspace --features test-core` passes.
+2. `cargo clippy --workspace --features test-core --all-targets -- -D warnings` clean.
+3. `cargo fmt --all -- --check` passes.
+4. [Structural criterion — e.g., "No import cycles in crates/mneme/"]
+5. [API criterion — e.g., "SessionStore trait signature unchanged"]
+
+# Task
+
+[Describe the structural transformation. Be specific: which types move where,
+which traits are extracted, which modules are split or merged.]
+
+[If the refactor has multiple steps, order them so each step leaves the
+codebase compilable. A refactor that breaks compilation partway through
+cannot be reviewed or bisected.]
+
+Commit each logical step separately. Each commit must pass `cargo check`.
+Use `Gate-Passed: kanon 0.1.0` in the final commit body.

--- a/workflow/prompts/templates/researcher.md
+++ b/workflow/prompts/templates/researcher.md
@@ -1,0 +1,80 @@
+---
+number: [N]
+description: "Research: [question or unknowns to resolve]"
+depends_on: []
+model_tier: opus      # research requires Opus for depth and accuracy
+blast_radius:
+  - [list files to READ — researcher does not write code]
+acceptance_criteria:
+  - "Each open question answered with evidence from the codebase or cited external sources"
+  - "Architectural recommendation provided if asked"
+  - "No code changes committed"
+---
+
+# Role
+
+Investigate and report. Do not write or commit code. Produce findings that
+enable a subsequent coder or refactor prompt to proceed with confidence.
+
+# Standards
+
+- `standards/STANDARDS.md` — philosophy and naming conventions inform analysis
+- `docs/ARCHITECTURE.md` — crate structure and dependency graph
+- `docs/ARCHITECTURE-QUICK.md` — one-page crate reference for orientation
+
+# Context
+
+[Why this research is needed. What decision it unblocks. What a coder will do
+with the findings.]
+
+# Blast radius (read-only)
+
+Read access to:
+
+[List files and crates to examine. This is a read scope, not a write scope.
+The researcher reads but does not modify.]
+
+# Open questions
+
+[Number each question. The output must address every question.]
+
+1. [Question 1]
+2. [Question 2]
+3. [Question 3]
+
+# Output format
+
+```
+## Findings
+
+### Q1: [Question text]
+
+[Answer. Cite specific files, function names, line numbers where relevant.
+If the answer is uncertain, say so and explain what would resolve it.]
+
+### Q2: [Question text]
+
+[Answer.]
+
+[Repeat for each question]
+
+---
+
+## Recommendation
+
+[If the research was architectural: state the recommended approach with
+rationale. If purely investigative: state what the next prompt should do.]
+
+---
+
+## Open issues
+
+[Anything discovered that was not part of the original scope but warrants
+a follow-up issue. One bullet per issue, include enough context to file it.]
+```
+
+# Task
+
+Investigate the open questions above. Use the codebase as the primary source.
+Cite external sources only when the codebase is silent on a topic. Produce
+findings in the output format. Do not commit anything.

--- a/workflow/prompts/templates/reviewer.md
+++ b/workflow/prompts/templates/reviewer.md
@@ -1,0 +1,91 @@
+---
+number: [N]
+description: "QA review: [title of the PR being reviewed]"
+depends_on: [[N-1]]   # the coder prompt this reviews
+model_tier: opus      # semantic review requires Opus
+blast_radius:
+  - [same blast radius as the coder prompt]
+acceptance_criteria:
+  - "QA verdict emitted as Pass, Partial, or Fail with evidence"
+  - "Each acceptance criterion from PR evaluated independently"
+---
+
+# Role
+
+Evaluate a pull request against its stated acceptance criteria. Ground every
+judgment in specific code from the diff. Evaluate each criterion independently.
+
+# Standards
+
+Review against: `standards/STANDARDS.md`, `standards/RUST.md`, `AGENTS.md`,
+and the PR's own acceptance criteria (listed below).
+
+# Context
+
+PR #[number]: [PR title]
+Branch: [branch name]
+Author prompt: #[N-1]
+
+[Brief description of what the PR is supposed to do.]
+
+# Acceptance criteria to evaluate
+
+[Copy the acceptance criteria from the coder prompt. These are the criteria
+the worker was supposed to satisfy. Evaluate each one.]
+
+1. [Criterion 1]
+2. [Criterion 2]
+3. `cargo test -p [crate]` passes.
+4. `cargo clippy --workspace --features test-core --all-targets -- -D warnings` clean.
+5. `cargo fmt --all -- --check` passes.
+
+# Mechanical checks
+
+Before semantic review, verify:
+
+- [ ] No files outside blast radius modified
+- [ ] No `unwrap()` in library code
+- [ ] No bare `TODO` or `FIXME` without issue numbers
+- [ ] No commented-out code blocks
+- [ ] No `#[allow]` without `#[expect(lint, reason = "...")]` replacement
+
+Any mechanical failure → verdict is `Fail`, skip semantic review.
+
+# Output format
+
+```
+## Mechanical
+
+[ ] blast-radius clean
+[ ] no unwrap in library code
+[ ] no bare TODO/FIXME
+[ ] no commented-out blocks
+[ ] no #[allow] without expect
+
+Mechanical verdict: PASS | FAIL
+
+---
+
+## Criteria
+
+### 1. [Criterion text]
+Verdict: PASS | FAIL
+Evidence: [specific file, line, or observation]
+
+[Repeat for each criterion]
+
+---
+
+## Overall verdict
+
+PASS | PARTIAL | FAIL
+
+Reasons:
+- [concise bullet per failure or concern]
+```
+
+# Task
+
+Review PR #[number] against the criteria above. Emit the output in the format
+specified. Do not suggest improvements outside the stated criteria — scope that
+to a follow-up issue.


### PR DESCRIPTION
## Summary

Closes #3451. Wave 7 / dispatch-infra improvement. Scope constrained to ~5 patterns as specified.

ergon_tools repo was not present at any of the checked paths (`~/dev/ergon`, `~/menos-ops/repos/ergon`, `~/menos-ops/repos/reference/ergon`). All absorption driven from the issue body description.

### Patterns absorbed

**1. AGENTIC_PIPELINE.md** (`standards/AGENTIC_PIPELINE.md`)
- New canonical written description of the planner→dispatcher→worker→QA→CI→triage loop
- Covers: prompt-as-work-order, blast radius as authorization boundary, verdict types (PASS/PARTIAL/FAIL) as control signals, model tier selection table, QA sub-agent requirement, stage-by-stage reference to energeia pipeline modules
- Added to STANDARDS.md index alongside PROMPTING.md

**2. Dispatch prompt standards** (`standards/PROMPTING.md`)
- Added "Dispatch prompts" section with 10 ground rules for self-contained work orders
- Covers: cold-start assumption, blast radius enforcement, one-PR-per-prompt rule, verifiable acceptance criteria, task-last ordering, model tier matching, QA sub-agent, explicit standards reference, progress commits, gate trailer
- New anti-patterns for dispatch context (missing blast radius, unverifiable criteria, prior-context assumptions)

**3. Prompt templates** (`workflow/prompts/templates/`)
- 5 role-specific skeletons: coder, reviewer, researcher, refactor, infra
- Each includes YAML frontmatter schema (number, depends_on, model_tier, blast_radius, acceptance_criteria)
- README explains how to use, when to use each role, and relationship to PROMPTING.md

**4. Lessons-learned format** (`docs/LESSONS-LEARNED.md`)
- Structured capture format: context, what worked, what failed, structural fix
- Bridges ephemeral agent observations → durable institutional knowledge
- First entry documents this absorption run itself

**5. Git guard hook** (`shared/hooks/_templates/git-guard.sh` + `.yaml`)
- `tool:called` hook that inspects shell commands for destructive git operations
- Permanently blocked: force push, remote branch deletion, mirror push (no override)
- Operator-approval required (warn or block mode): push to main, reset --hard, clean -f, history rewriting
- Wire by copying to `shared/hooks/` and setting `enabled: true`

**6. Agent template sections** (`shared/templates/sections/`)
- `team_topology.md` — coordination rules for multi-agent blast radius, hand-offs, blocking signals
- `domain_knowledge.md` — template for stable domain reference material (terminology, invariants, contracts, architecture decisions)

## Validation

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --features test-core --all-targets -- -D warnings`: pre-existing failures in `crates/energeia/src/session/manager.rs` (missing `cache_hit_tokens`/`cache_miss_tokens` fields). These failures exist on `origin/main` and are not introduced by this PR (no Rust code changed). Filed as a separate fix.

## Notes

- No Rust code changes. Standards, templates, hooks, and docs only.
- `workflow/prompts/` is a new directory. The `energeia` prompt loader already reads from configurable paths; this establishes the canonical location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)