### PR TITLE
refactor(pylon): purge webchat-era naming from types, wire format, and docs

### DIFF
--- a/_llm/api.toml
+++ b/_llm/api.toml
@@ -115,7 +115,7 @@ purpose = "Conversation history"
 [[api.endpoint]]
 method = "POST"
 path = "/api/v1/sessions/stream"
-purpose = "Stream a turn (TUI webchat protocol)"
+purpose = "Stream a turn (turn stream protocol — TUI, desktop)"
 
 [[api.endpoint]]
 method = "GET"

--- a/crates/pylon/docs/handlers.md
+++ b/crates/pylon/docs/handlers.md
@@ -392,18 +392,18 @@ Retrieve conversation history.
 
 ### `POST /api/v1/sessions/stream`
 
-TUI streaming protocol. Creates or retrieves a session by `(agent_id, session_key)` and
-streams the turn using the webchat event format (distinct from the SSE format above).
+Turn stream protocol. Creates or retrieves a session by `(nous_id, session_key)` and
+streams the turn as `TurnStreamEvent` SSE events (used by TUI and desktop clients).
 
 **Request body:**
 
 ```json
-{ "agentId": "pronoea", "message": "Hello", "sessionKey": "main" }
+{ "nous_id": "pronoea", "message": "Hello", "session_key": "main" }
 ```
 
-`sessionKey` defaults to `"main"` if omitted.
+`session_key` defaults to `"main"` if omitted.
 
-**Response `200 OK`** - `text/event-stream` of `WebchatEvent`:
+**Response `200 OK`** - `text/event-stream` of `TurnStreamEvent`:
 
 | Type | Fields |
 |------|--------|

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -28,7 +28,7 @@ use crate::extract::{Claims, require_nous_access, require_role};
 use crate::idempotency::LookupResult;
 use crate::middleware::RequestId;
 use crate::state::SessionsState;
-use crate::stream::{SseEvent, TurnOutcome, UsageData, WebchatEvent};
+use crate::stream::{SseEvent, TurnOutcome, TurnStreamEvent as PylonTurnStreamEvent, UsageData};
 use crate::turn_buffer::TurnBufferHandle;
 
 use super::types::{SendMessageRequest, StreamTurnRequest};
@@ -381,7 +381,7 @@ pub async fn send_message(
 /// POST /api/v1/sessions/stream: stream a conversation turn (TUI protocol).
 ///
 /// Accepts the webchat-style `StreamRequest` (agentId, message, sessionKey) and
-/// returns SSE events in the `WebchatEvent` format that the TUI expects:
+/// returns SSE events in the `PylonTurnStreamEvent` format that the TUI expects:
 /// `turn_start`, `text_delta`, `thinking_delta`, `tool_start`, `tool_result`,
 /// `turn_complete`, `error`.
 #[utoipa::path(
@@ -393,7 +393,7 @@ pub async fn send_message(
         content_type = "application/json"
     ),
     responses(
-        (status = 200, description = "SSE event stream (WebchatEvent format)", content_type = "text/event-stream"),
+        (status = 200, description = "SSE event stream (PylonTurnStreamEvent format)", content_type = "text/event-stream"),
         (status = 400, description = "Bad request", body = crate::error::ErrorResponse),
         (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
         (status = 404, description = "Nous not found", body = crate::error::ErrorResponse),
@@ -486,7 +486,7 @@ pub async fn stream_turn(
     let webchat_request_id = request_id.0.clone();
     let turn_id = koina::ulid::Ulid::new().to_string();
     // WHY(#3276): channel carries (seq, event) pairs for Last-Event-ID support.
-    let (webchat_tx, webchat_rx) = mpsc::channel::<(u64, WebchatEvent)>(32);
+    let (webchat_tx, webchat_rx) = mpsc::channel::<(u64, PylonTurnStreamEvent)>(32);
     let (nous_tx, mut nous_rx) = mpsc::channel::<TurnStreamEvent>(64);
 
     // WHY(#3276): Create a turn buffer so events survive client disconnection.
@@ -496,7 +496,7 @@ pub async fn stream_turn(
         .await;
     let buf_handle = TurnBufferHandle::new(turn_buf);
 
-    let start_event = WebchatEvent::MessageStart {
+    let start_event = PylonTurnStreamEvent::MessageStart {
         session_id: session_id.clone(),
         nous_id: agent_id.clone(),
         turn_id: turn_id.clone(),
@@ -527,16 +527,16 @@ pub async fn stream_turn(
             while let Some(event) = nous_rx.recv().await {
                 let webchat_event = match event {
                     TurnStreamEvent::LlmDelta(LlmStreamEvent::TextDelta { text }) => {
-                        WebchatEvent::TextDelta { text }
+                        PylonTurnStreamEvent::TextDelta { text }
                     }
                     TurnStreamEvent::LlmDelta(LlmStreamEvent::ThinkingDelta { thinking }) => {
-                        WebchatEvent::ThinkingDelta { text: thinking }
+                        PylonTurnStreamEvent::ThinkingDelta { text: thinking }
                     }
                     TurnStreamEvent::ToolStart {
                         tool_id,
                         tool_name,
                         input,
-                    } => WebchatEvent::ToolUse {
+                    } => PylonTurnStreamEvent::ToolUse {
                         tool_name,
                         tool_id,
                         input,
@@ -547,7 +547,7 @@ pub async fn stream_turn(
                         result,
                         is_error,
                         duration_ms,
-                    } => WebchatEvent::ToolResult {
+                    } => PylonTurnStreamEvent::ToolResult {
                         tool_name,
                         tool_id,
                         result,
@@ -593,7 +593,7 @@ pub async fn stream_turn(
                     // seeing turn_complete before the final text_delta events.
                     let _ = bridge_handle.await;
 
-                    let event = WebchatEvent::MessageComplete {
+                    let event = PylonTurnStreamEvent::MessageComplete {
                         outcome: TurnOutcome {
                             text: result.content.clone(),
                             nous_id: aid,
@@ -615,7 +615,7 @@ pub async fn stream_turn(
                     tracing::error!(error = %err, "streaming turn failed");
                     let _ = bridge_handle.await;
                     let (_, err_message) = turn_error_info(&err);
-                    let event = WebchatEvent::Error {
+                    let event = PylonTurnStreamEvent::Error {
                         message: err_message,
                         request_id: Some(webchat_request_id.clone()),
                     };
@@ -623,7 +623,7 @@ pub async fn stream_turn(
                     let _ = webchat_tx.send((seq, event)).await;
                     // WHY: Always send a completion marker so the TUI knows the stream
                     // is finished, even on error paths.
-                    let event = WebchatEvent::MessageComplete {
+                    let event = PylonTurnStreamEvent::MessageComplete {
                         outcome: TurnOutcome {
                             text: String::new(),
                             nous_id: aid,
@@ -655,7 +655,7 @@ pub async fn stream_turn(
                     .id(seq.to_string())),
                 Err(e) => {
                     warn!(error = %e, "failed to serialize SSE event");
-                    // WHY: Use the WebchatEvent::Error shape so the fallback event has the
+                    // WHY: Use the PylonTurnStreamEvent::Error shape so the fallback event has the
                     // same structure as all other error events in the stream (#3160).
                     Ok(Event::default()
                         .event("error")
@@ -980,8 +980,8 @@ async fn record_sse_event(buf: &TurnBufferHandle, event: &SseEvent) -> u64 {
     buf.record(&event_type, &data).await
 }
 
-/// Record a [`WebchatEvent`] to the turn buffer. Returns the assigned sequence number.
-async fn record_webchat_event(buf: &TurnBufferHandle, event: &WebchatEvent) -> u64 {
+/// Record a [`PylonTurnStreamEvent`] to the turn buffer. Returns the assigned sequence number.
+async fn record_webchat_event(buf: &TurnBufferHandle, event: &PylonTurnStreamEvent) -> u64 {
     let event_type = event.event_type().to_owned();
     let data = serde_json::to_string(event).unwrap_or_default();
     buf.record(&event_type, &data).await

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -412,7 +412,7 @@ pub async fn send_message(
     clippy::too_many_lines,
     reason = "streaming bridge setup is inherently sequential"
 )]
-#[instrument(skip(state, claims, body), fields(agent_id = %body.agent_id))]
+#[instrument(skip(state, claims, body), fields(nous_id = %body.nous_id))]
 pub async fn stream_turn(
     State(state): State<SessionsState>,
     claims: Claims,
@@ -420,8 +420,8 @@ pub async fn stream_turn(
     Json(body): Json<StreamTurnRequest>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, ApiError> {
     require_role(&claims, Role::Operator)?;
-    require_nous_access(&claims, &body.agent_id)?;
-    let agent_id = body.agent_id;
+    require_nous_access(&claims, &body.nous_id)?;
+    let agent_id = body.nous_id;
     let message = body.message;
     let session_key = body.session_key;
 
@@ -446,7 +446,7 @@ pub async fn stream_turn(
     }
     if agent_id.len() > max_id_bytes {
         field_errors.push(FieldError {
-            field: "agent_id".to_owned(),
+            field: "nous_id".to_owned(),
             code: "too_long".to_owned(),
             message: format!("exceeds maximum length of {max_id_bytes} bytes"),
         });

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -483,10 +483,10 @@ pub async fn stream_turn(
 
     let session_id = resolve_session(&state, &agent_id, &session_key, model.as_deref()).await?;
 
-    let webchat_request_id = request_id.0.clone();
+    let stream_request_id = request_id.0.clone();
     let turn_id = koina::ulid::Ulid::new().to_string();
     // WHY(#3276): channel carries (seq, event) pairs for Last-Event-ID support.
-    let (webchat_tx, webchat_rx) = mpsc::channel::<(u64, PylonTurnStreamEvent)>(32);
+    let (turn_tx, turn_rx) = mpsc::channel::<(u64, PylonTurnStreamEvent)>(32);
     let (nous_tx, mut nous_rx) = mpsc::channel::<TurnStreamEvent>(64);
 
     // WHY(#3276): Create a turn buffer so events survive client disconnection.
@@ -502,8 +502,8 @@ pub async fn stream_turn(
         turn_id: turn_id.clone(),
         request_id: Some(request_id.0.clone()),
     };
-    let seq = record_webchat_event(&buf_handle, &start_event).await;
-    let _ = webchat_tx.send((seq, start_event)).await;
+    let seq = record_turn_event(&buf_handle, &start_event).await;
+    let _ = turn_tx.send((seq, start_event)).await;
 
     let sid = session_id;
     let aid = agent_id;
@@ -520,12 +520,12 @@ pub async fn stream_turn(
     // WHY: Returns a JoinHandle so the turn task can wait for all deltas to drain
     // before emitting turn_complete (prevents the race where turn_complete
     // arrives at the TUI before the final text_delta events).
-    let bridge_tx = webchat_tx.clone();
+    let bridge_tx = turn_tx.clone();
     let bridge_buf = buf_handle.clone();
     let bridge_handle = tokio::spawn(
         async move {
             while let Some(event) = nous_rx.recv().await {
-                let webchat_event = match event {
+                let turn_event = match event {
                     TurnStreamEvent::LlmDelta(LlmStreamEvent::TextDelta { text }) => {
                         PylonTurnStreamEvent::TextDelta { text }
                     }
@@ -556,8 +556,8 @@ pub async fn stream_turn(
                     },
                     _ => continue,
                 };
-                let seq = record_webchat_event(&bridge_buf, &webchat_event).await;
-                if bridge_tx.send((seq, webchat_event)).await.is_err() {
+                let seq = record_turn_event(&bridge_buf, &turn_event).await;
+                if bridge_tx.send((seq, turn_event)).await.is_err() {
                     break;
                 }
             }
@@ -606,8 +606,8 @@ pub async fn stream_turn(
                             cache_write_tokens: result.usage.cache_write_tokens,
                         },
                     };
-                    let seq = record_webchat_event(&buf_handle_task, &event).await;
-                    let _ = webchat_tx.send((seq, event)).await;
+                    let seq = record_turn_event(&buf_handle_task, &event).await;
+                    let _ = turn_tx.send((seq, event)).await;
                     buf_handle_task.mark_completed().await;
                 }
                 Err(err) => {
@@ -617,10 +617,10 @@ pub async fn stream_turn(
                     let (_, err_message) = turn_error_info(&err);
                     let event = PylonTurnStreamEvent::Error {
                         message: err_message,
-                        request_id: Some(webchat_request_id.clone()),
+                        request_id: Some(stream_request_id.clone()),
                     };
-                    let seq = record_webchat_event(&buf_handle_task, &event).await;
-                    let _ = webchat_tx.send((seq, event)).await;
+                    let seq = record_turn_event(&buf_handle_task, &event).await;
+                    let _ = turn_tx.send((seq, event)).await;
                     // WHY: Always send a completion marker so the TUI knows the stream
                     // is finished, even on error paths.
                     let event = PylonTurnStreamEvent::MessageComplete {
@@ -636,8 +636,8 @@ pub async fn stream_turn(
                             cache_write_tokens: 0,
                         },
                     };
-                    let seq = record_webchat_event(&buf_handle_task, &event).await;
-                    let _ = webchat_tx.send((seq, event)).await;
+                    let seq = record_turn_event(&buf_handle_task, &event).await;
+                    let _ = turn_tx.send((seq, event)).await;
                     buf_handle_task.mark_failed().await;
                 }
             }
@@ -647,7 +647,7 @@ pub async fn stream_turn(
 
     // WHY: Abort streaming turn task when the client disconnects.
     let stream = GuardedStream {
-        inner: ReceiverStream::new(webchat_rx).map(|(seq, event)| {
+        inner: ReceiverStream::new(turn_rx).map(|(seq, event)| {
             match serde_json::to_string(&event) {
                 Ok(data) => Ok(Event::default()
                     .event(event.event_type())
@@ -981,7 +981,7 @@ async fn record_sse_event(buf: &TurnBufferHandle, event: &SseEvent) -> u64 {
 }
 
 /// Record a [`TurnStreamEvent`] to the turn buffer. Returns the assigned sequence number.
-async fn record_webchat_event(buf: &TurnBufferHandle, event: &PylonTurnStreamEvent) -> u64 {
+async fn record_turn_event(buf: &TurnBufferHandle, event: &PylonTurnStreamEvent) -> u64 {
     let event_type = event.event_type().to_owned();
     let data = serde_json::to_string(event).unwrap_or_default();
     buf.record(&event_type, &data).await

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -378,22 +378,22 @@ pub async fn send_message(
     ))
 }
 
-/// POST /api/v1/sessions/stream: stream a conversation turn (TUI protocol).
+/// POST /api/v1/sessions/stream: stream a conversation turn (turn stream protocol).
 ///
-/// Accepts the webchat-style `StreamRequest` (agentId, message, sessionKey) and
-/// returns SSE events in the `PylonTurnStreamEvent` format that the TUI expects:
-/// `turn_start`, `text_delta`, `thinking_delta`, `tool_start`, `tool_result`,
-/// `turn_complete`, `error`.
+/// Accepts a `StreamTurnRequest` (`nous_id`, `message`, `session_key`) and
+/// returns SSE events in `TurnStreamEvent` format (used by TUI and desktop clients):
+/// `message_start`, `text_delta`, `thinking_delta`, `tool_use`, `tool_result`,
+/// `message_complete`, `error`.
 #[utoipa::path(
     post,
     path = "/api/v1/sessions/stream",
     request_body(
         content = serde_json::Value,
-        description = "Stream turn request: `{agentId, message, sessionKey?}`",
+        description = "Stream turn request: `{nous_id, message, session_key?}`",
         content_type = "application/json"
     ),
     responses(
-        (status = 200, description = "SSE event stream (PylonTurnStreamEvent format)", content_type = "text/event-stream"),
+        (status = 200, description = "SSE event stream (TurnStreamEvent format)", content_type = "text/event-stream"),
         (status = 400, description = "Bad request", body = crate::error::ErrorResponse),
         (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
         (status = 404, description = "Nous not found", body = crate::error::ErrorResponse),
@@ -655,7 +655,7 @@ pub async fn stream_turn(
                     .id(seq.to_string())),
                 Err(e) => {
                     warn!(error = %e, "failed to serialize SSE event");
-                    // WHY: Use the PylonTurnStreamEvent::Error shape so the fallback event has the
+                    // WHY: Use the TurnStreamEvent::Error shape so the fallback event has the
                     // same structure as all other error events in the stream (#3160).
                     Ok(Event::default()
                         .event("error")
@@ -980,7 +980,7 @@ async fn record_sse_event(buf: &TurnBufferHandle, event: &SseEvent) -> u64 {
     buf.record(&event_type, &data).await
 }
 
-/// Record a [`PylonTurnStreamEvent`] to the turn buffer. Returns the assigned sequence number.
+/// Record a [`TurnStreamEvent`] to the turn buffer. Returns the assigned sequence number.
 async fn record_webchat_event(buf: &TurnBufferHandle, event: &PylonTurnStreamEvent) -> u64 {
     let event_type = event.event_type().to_owned();
     let data = serde_json::to_string(event).unwrap_or_default();

--- a/crates/pylon/src/handlers/sessions/types.rs
+++ b/crates/pylon/src/handlers/sessions/types.rs
@@ -26,17 +26,15 @@ pub struct SendMessageRequest {
     pub content: String,
 }
 
-/// Body for `POST /api/v1/sessions/stream` (TUI streaming protocol).
+/// Body for `POST /api/v1/sessions/stream` (turn streaming protocol).
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct StreamTurnRequest {
-    /// Target agent ID.
-    #[serde(alias = "agentId")]
-    pub agent_id: String,
+    /// Target nous agent ID.
+    pub nous_id: String,
     /// User message text.
     pub message: String,
     /// Session key for deduplication (defaults to "main").
-    #[serde(alias = "sessionKey", default = "default_session_key")]
+    #[serde(default = "default_session_key")]
     pub session_key: String,
 }
 

--- a/crates/pylon/src/stream.rs
+++ b/crates/pylon/src/stream.rs
@@ -94,7 +94,7 @@ impl SseEvent {
     }
 }
 
-/// SSE events for the TUI streaming protocol (`POST /api/v1/sessions/stream`).
+/// SSE events for the turn streaming protocol (`POST /api/v1/sessions/stream`).
 ///
 /// Used by `koilon` and the Signal integration. Unified with `SseEvent` naming:
 /// event types use the same `message_start`/`message_complete` vocabulary,
@@ -102,7 +102,7 @@ impl SseEvent {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type")]
 #[non_exhaustive]
-pub(crate) enum WebchatEvent {
+pub(crate) enum TurnStreamEvent {
     /// Turn accepted — mirrors `SseEvent::MessageStart`.
     #[serde(rename = "message_start")]
     MessageStart {
@@ -148,7 +148,7 @@ pub(crate) enum WebchatEvent {
     },
 }
 
-impl WebchatEvent {
+impl TurnStreamEvent {
     /// SSE event name for the `event:` field.
     #[must_use]
     pub(crate) fn event_type(&self) -> &'static str {

--- a/crates/pylon/src/tests/error_envelope.rs
+++ b/crates/pylon/src/tests/error_envelope.rs
@@ -542,7 +542,7 @@ async fn stream_turn_missing_agent_id_returns_422_with_envelope() {
     assert_eq!(
         resp.status(),
         StatusCode::UNPROCESSABLE_ENTITY,
-        "missing agentId field should return 422"
+        "missing nous_id field should return 422"
     );
     let body = body_json(resp).await;
     assert_error_envelope(&body, "validation_failed");
@@ -555,7 +555,7 @@ async fn stream_turn_unknown_agent_returns_404_with_envelope() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": "nonexistent-agent",
+            "nous_id": "nonexistent-agent",
             "message": "hello"
         })),
     );

--- a/crates/pylon/src/tests/message.rs
+++ b/crates/pylon/src/tests/message.rs
@@ -200,9 +200,9 @@ async fn stream_turn_returns_sse() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": "syn",
+            "nous_id": "syn",
             "message": "Hello from TUI",
-            "sessionKey": "stream-test"
+            "session_key": "stream-test"
         })),
     );
 
@@ -226,9 +226,9 @@ async fn stream_turn_contains_turn_start_event() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": "syn",
+            "nous_id": "syn",
             "message": "Hello!",
-            "sessionKey": "stream-events"
+            "session_key": "stream-events"
         })),
     );
 
@@ -247,9 +247,9 @@ async fn stream_turn_empty_message_returns_400() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": "syn",
+            "nous_id": "syn",
             "message": "",
-            "sessionKey": "empty-msg"
+            "session_key": "empty-msg"
         })),
     );
 
@@ -264,9 +264,9 @@ async fn stream_turn_unknown_agent_returns_404() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": "nonexistent",
+            "nous_id": "nonexistent",
             "message": "Hello!",
-            "sessionKey": "test"
+            "session_key": "test"
         })),
     );
 

--- a/crates/pylon/src/tests/sse_events.rs
+++ b/crates/pylon/src/tests/sse_events.rs
@@ -120,7 +120,7 @@ fn sse_event_error_omits_request_id_when_none() {
 
 #[test]
 fn tui_event_message_start_type() {
-    let event = crate::stream::WebchatEvent::MessageStart {
+    let event = crate::stream::TurnStreamEvent::MessageStart {
         session_id: "s1".to_owned(),
         nous_id: "syn".to_owned(),
         turn_id: "t1".to_owned(),
@@ -131,7 +131,7 @@ fn tui_event_message_start_type() {
 
 #[test]
 fn tui_event_text_delta_type() {
-    let event = crate::stream::WebchatEvent::TextDelta {
+    let event = crate::stream::TurnStreamEvent::TextDelta {
         text: "hello".to_owned(),
     };
     assert_eq!(event.event_type(), "text_delta");
@@ -139,7 +139,7 @@ fn tui_event_text_delta_type() {
 
 #[test]
 fn tui_event_thinking_delta_type() {
-    let event = crate::stream::WebchatEvent::ThinkingDelta {
+    let event = crate::stream::TurnStreamEvent::ThinkingDelta {
         text: "hmm".to_owned(),
     };
     assert_eq!(event.event_type(), "thinking_delta");
@@ -147,7 +147,7 @@ fn tui_event_thinking_delta_type() {
 
 #[test]
 fn tui_event_tool_use_type() {
-    let event = crate::stream::WebchatEvent::ToolUse {
+    let event = crate::stream::TurnStreamEvent::ToolUse {
         tool_name: "search".to_owned(),
         tool_id: "t1".to_owned(),
         input: serde_json::json!({}),
@@ -157,7 +157,7 @@ fn tui_event_tool_use_type() {
 
 #[test]
 fn tui_event_tool_result_type() {
-    let event = crate::stream::WebchatEvent::ToolResult {
+    let event = crate::stream::TurnStreamEvent::ToolResult {
         tool_name: "search".to_owned(),
         tool_id: "t1".to_owned(),
         result: "found".to_owned(),
@@ -169,7 +169,7 @@ fn tui_event_tool_result_type() {
 
 #[test]
 fn tui_event_message_complete_type() {
-    let event = crate::stream::WebchatEvent::MessageComplete {
+    let event = crate::stream::TurnStreamEvent::MessageComplete {
         outcome: crate::stream::TurnOutcome {
             text: "done".to_owned(),
             nous_id: "syn".to_owned(),
@@ -187,7 +187,7 @@ fn tui_event_message_complete_type() {
 
 #[test]
 fn tui_event_error_type() {
-    let event = crate::stream::WebchatEvent::Error {
+    let event = crate::stream::TurnStreamEvent::Error {
         message: "fail".to_owned(),
         request_id: None,
     };
@@ -196,7 +196,7 @@ fn tui_event_error_type() {
 
 #[test]
 fn tui_event_message_start_serialization() {
-    let event = crate::stream::WebchatEvent::MessageStart {
+    let event = crate::stream::TurnStreamEvent::MessageStart {
         session_id: "s1".to_owned(),
         nous_id: "syn".to_owned(),
         turn_id: "t1".to_owned(),
@@ -212,7 +212,7 @@ fn tui_event_message_start_serialization() {
 
 #[test]
 fn tui_event_message_complete_serialization() {
-    let event = crate::stream::WebchatEvent::MessageComplete {
+    let event = crate::stream::TurnStreamEvent::MessageComplete {
         outcome: crate::stream::TurnOutcome {
             text: "response".to_owned(),
             nous_id: "syn".to_owned(),

--- a/crates/pylon/src/tests/streaming.rs
+++ b/crates/pylon/src/tests/streaming.rs
@@ -432,9 +432,9 @@ async fn stream_turn_empty_message_returns_422() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": "syn",
+            "nous_id": "syn",
             "message": "",
-            "sessionKey": "test"
+            "session_key": "test"
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
@@ -459,9 +459,9 @@ async fn stream_turn_oversized_message_returns_422() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": "syn",
+            "nous_id": "syn",
             "message": oversized_message,
-            "sessionKey": "test"
+            "session_key": "test"
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
@@ -477,7 +477,7 @@ async fn stream_turn_oversized_message_returns_422() {
     );
 }
 
-/// Error path: `stream_turn` with unknown `agent_id` returns 404 Not Found.
+/// Error path: `stream_turn` with unknown `nous_id` returns 404 Not Found.
 #[tokio::test]
 async fn stream_turn_unknown_agent_returns_404() {
     let (app, _dir) = app().await;
@@ -485,9 +485,9 @@ async fn stream_turn_unknown_agent_returns_404() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": "nonexistent-agent",
+            "nous_id": "nonexistent-agent",
             "message": "test",
-            "sessionKey": "test"
+            "session_key": "test"
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
@@ -497,7 +497,7 @@ async fn stream_turn_unknown_agent_returns_404() {
     assert_eq!(body["error"]["code"], "nous_not_found");
 }
 
-/// Error path: `stream_turn` with oversized `agent_id` returns 422.
+/// Error path: `stream_turn` with oversized `nous_id` returns 422.
 #[tokio::test]
 async fn stream_turn_oversized_agent_id_returns_422() {
     let (app, _dir) = app().await;
@@ -506,9 +506,9 @@ async fn stream_turn_oversized_agent_id_returns_422() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": oversized_agent_id,
+            "nous_id": oversized_agent_id,
             "message": "test",
-            "sessionKey": "test"
+            "session_key": "test"
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
@@ -520,7 +520,7 @@ async fn stream_turn_oversized_agent_id_returns_422() {
     assert!(
         errors
             .iter()
-            .any(|e| e["field"] == "agent_id" && e["code"] == "too_long")
+            .any(|e| e["field"] == "nous_id" && e["code"] == "too_long")
     );
 }
 
@@ -533,9 +533,9 @@ async fn stream_turn_oversized_session_key_returns_422() {
         "POST",
         "/api/v1/sessions/stream",
         Some(serde_json::json!({
-            "agentId": "syn",
+            "nous_id": "syn",
             "message": "test",
-            "sessionKey": oversized_session_key
+            "session_key": oversized_session_key
         })),
     );
     let resp = app.oneshot(req).await.unwrap();

--- a/crates/theatron/proskenion/src/api/streaming.rs
+++ b/crates/theatron/proskenion/src/api/streaming.rs
@@ -64,8 +64,8 @@ pub(crate) fn stream_turn(
 
     let body = serde_json::json!({
         "message": message,
-        "agentId": nous_id,
-        "sessionKey": session_key,
+        "nous_id": nous_id,
+        "session_key": session_key,
     });
 
     let builder = client

--- a/crates/theatron/skene/src/api/streaming.rs
+++ b/crates/theatron/skene/src/api/streaming.rs
@@ -44,8 +44,8 @@ pub fn stream_message(
 
     let body = serde_json::json!({
         "message": text,
-        "agentId": nous_id,
-        "sessionKey": session_key,
+        "nous_id": nous_id,
+        "session_key": session_key,
     });
 
     let builder = client

--- a/docs/TRANSLATION-TAX.md
+++ b/docs/TRANSLATION-TAX.md
@@ -222,7 +222,7 @@ with a monotonic sequence ID (`crates/pylon/src/stream.rs:10`). The
   not the original `TurnStreamEvent` structs, so typed consumers must re-parse.
 - **Thinking deltas are schema-ready but not emitted.** `SseEvent::ThinkingDelta`
   exists in the OpenAPI schema (`crates/pylon/src/stream.rs:33`) but the
-  streaming bridge does not forward thinking blocks to the webchat protocol.
+  streaming bridge does not forward thinking blocks to the turn stream protocol.
 
 ### Verdict
 


### PR DESCRIPTION
## Summary

- Renames `WebchatEvent` → `TurnStreamEvent` in `pylon/src/stream.rs` and all 24+ use sites in `streaming.rs` and 9 construction sites in `tests/sse_events.rs`
- Removes `#[serde(rename_all = "camelCase")]`, `alias = "agentId"`, and `alias = "sessionKey"` from `StreamTurnRequest`; wire fields are now `nous_id` / `message` / `session_key` (snake_case, matching the rest of the session API)
- Updates all streaming test fixtures in `tests/streaming.rs`, `tests/message.rs`, `tests/error_envelope.rs` to use `nous_id` / `session_key`
- Updates `skene` (shared API client) and `proskenion` (desktop) to send the new field names
- Rewrites 5 webchat-referencing docstrings in `streaming.rs`, plus `handlers.md`, `_llm/api.toml`, and `docs/TRANSLATION-TAX.md`
- Renames internal variables: `webchat_request_id` → `stream_request_id`, `webchat_tx/rx` → `turn_tx/rx`, `webchat_event` → `turn_event`, `record_webchat_event` → `record_turn_event`
- Historical mentions in `standards/RELEASES.md:122` and `docs/CHANGELOG.md:76` are preserved unchanged

## Test plan

- [x] `cargo fmt --all -- --check` — no new failures in changed files (3 pre-existing failures in eval/nous unrelated to this PR)
- [x] `cargo test -p pylon --features test-core` — 34/34 pass
- [x] `cargo test -p koilon` — 1022/1022 pass
- [x] `cargo build -p proskenion` — builds clean

Closes #3555

🤖 Generated with [Claude Code](https://claude.com/claude-code)