### PR TITLE
feat(poiesis,organon): lint + verify crates and report-generation tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,6 +4991,11 @@ dependencies = [
  "jiff",
  "koina",
  "landlock",
+ "poiesis-core",
+ "poiesis-lint",
+ "poiesis-sheet",
+ "poiesis-text",
+ "poiesis-verify",
  "prometheus-client",
  "proptest",
  "reqwest 0.13.2",
@@ -5306,6 +5311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "poiesis-lint"
+version = "0.20.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
 name = "poiesis-sheet"
 version = "0.20.0"
 dependencies = [
@@ -5333,6 +5347,15 @@ dependencies = [
  "poiesis-core",
  "snafu",
  "zip 7.2.0",
+]
+
+[[package]]
+name = "poiesis-verify"
+version = "0.20.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "snafu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ members = [
     "crates/poiesis/text",
     "crates/poiesis/sheet",
     "crates/poiesis/slides",
+    "crates/poiesis/lint",
+    "crates/poiesis/verify",
 ]
 # WHY: proskenion requires GTK3/webkit2gtk system libraries (via Dioxus
 # desktop/webview) which are not available in CI. Excluded from workspace to

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -27,6 +27,11 @@ energeia = { path = "../energeia", optional = true, features = [
     "storage-fjall",
 ] }
 hermeneus = { path = "../hermeneus" }
+poiesis-core = { path = "../poiesis/core" }
+poiesis-text = { path = "../poiesis/text" }
+poiesis-sheet = { path = "../poiesis/sheet" }
+poiesis-lint = { path = "../poiesis/lint" }
+poiesis-verify = { path = "../poiesis/verify" }
 koina = { path = "../koina" }
 taxis = { path = "../taxis" }
 indexmap = { workspace = true }

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -30,6 +30,8 @@ pub mod memory;
 pub mod parameters;
 /// Planning project management tools (create, status, execute, verify).
 pub mod planning;
+/// Poiesis report tools: generate_document, lint_report, verify_report.
+pub mod poiesis;
 /// Web research tools (web_fetch).
 pub mod research;
 /// Issue triage tools (scan, score, stage, approve).
@@ -90,5 +92,6 @@ pub fn register_all_with_sandbox(
     energeia::register(registry, None)?;
     #[cfg(feature = "energeia")]
     bookkeeper::register(registry)?;
+    poiesis::register(registry)?;
     Ok(())
 }

--- a/crates/organon/src/builtins/poiesis.rs
+++ b/crates/organon/src/builtins/poiesis.rs
@@ -1,0 +1,444 @@
+//! Poiesis report tools: `generate_document`, `lint_report`, `verify_report`.
+//!
+//! - `generate_document` — render a JSON document descriptor to ODT/XLSX/PDF bytes
+//! - `lint_report`       — check report prose quality (banned words, citations, structure)
+//! - `verify_report`     — validate numeric claims in a verify manifest
+
+use std::future::Future;
+use std::pin::Pin;
+
+use indexmap::IndexMap;
+use poiesis_core::{Block, Document, Metadata, Renderer, RichText, Span};
+use poiesis_lint::{LintConfig, Linter};
+use poiesis_verify::Verifier;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn extract_opt_str<'a>(args: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    args.get(key).and_then(serde_json::Value::as_str)
+}
+
+fn extract_str<'a>(
+    args: &'a serde_json::Value,
+    key: &str,
+) -> std::result::Result<&'a str, ToolResult> {
+    args.get(key)
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| ToolResult::error(format!("missing required argument: {key}")))
+}
+
+// ── generate_document ─────────────────────────────────────────────────────────
+
+struct GenerateDocumentExecutor;
+
+impl ToolExecutor for GenerateDocumentExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async move {
+            let args = &input.arguments;
+
+            let title = extract_opt_str(args, "title").unwrap_or("Untitled Document");
+            let author = extract_opt_str(args, "author");
+            let format = extract_opt_str(args, "format").unwrap_or("odt");
+            let content_str = match extract_str(args, "content") {
+                Ok(s) => s,
+                Err(e) => return Ok(e),
+            };
+
+            let raw_blocks: Vec<serde_json::Value> = match serde_json::from_str(content_str) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!(
+                        "content must be a JSON array of block objects: {e}"
+                    )));
+                }
+            };
+
+            let blocks: Vec<Block> = raw_blocks.iter().filter_map(parse_block).collect();
+
+            let doc = Document {
+                metadata: Metadata {
+                    title: title.to_owned(),
+                    author: author.map(str::to_owned),
+                    created: None,
+                },
+                content: blocks,
+            };
+
+            let bytes = match format.to_lowercase().as_str() {
+                "xlsx" => {
+                    let renderer = poiesis_sheet::XlsxRenderer::new();
+                    match renderer.render(&doc) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            return Ok(ToolResult::error(format!("XLSX render failed: {e}")));
+                        }
+                    }
+                }
+                "pdf" => match poiesis_text::PdfRenderer::new() {
+                    Ok(renderer) => match renderer.render(&doc) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            return Ok(ToolResult::error(format!(
+                                "PDF render failed (falling back): {e}"
+                            )));
+                        }
+                    },
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!(
+                            "PDF renderer unavailable (no system font?): {e}"
+                        )));
+                    }
+                },
+                // Default: ODT
+                _ => {
+                    let renderer = poiesis_text::OdtRenderer::new();
+                    match renderer.render(&doc) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            return Ok(ToolResult::error(format!("ODT render failed: {e}")));
+                        }
+                    }
+                }
+            };
+
+            Ok(ToolResult::text(format!(
+                "Generated {} document: {} bytes",
+                format.to_uppercase(),
+                bytes.len()
+            )))
+        })
+    }
+}
+
+/// Parse a JSON block object into a `poiesis_core::Block`.
+fn parse_block(v: &serde_json::Value) -> Option<Block> {
+    let kind = v.get("type").and_then(serde_json::Value::as_str)?;
+    match kind {
+        "heading" => {
+            let level = v
+                .get("level")
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|n| u8::try_from(n.min(6)).ok())
+                .unwrap_or(1);
+            let text = plain(
+                v.get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(""),
+            );
+            Some(Block::Heading { level, text })
+        }
+        "paragraph" => {
+            let text = plain(
+                v.get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(""),
+            );
+            Some(Block::Paragraph(text))
+        }
+        "page_break" => Some(Block::PageBreak),
+        _ => None,
+    }
+}
+
+fn plain(s: &str) -> RichText {
+    RichText {
+        spans: vec![Span::Plain(s.to_owned())],
+    }
+}
+
+fn generate_document_def() -> ToolDef {
+    ToolDef {
+        name: koina::id::ToolName::from_static("generate_document"), // kanon:ignore RUST/expect
+        description: "Render a document descriptor to ODT, XLSX, or PDF bytes.".to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "content".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "JSON array of block objects (each with type, text, level fields)"
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "format".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Output format: odt (default), xlsx, or pdf".to_owned(),
+                        enum_values: Some(vec![
+                            "odt".to_owned(),
+                            "xlsx".to_owned(),
+                            "pdf".to_owned(),
+                        ]),
+                        default: Some(serde_json::json!("odt")),
+                    },
+                ),
+                (
+                    "title".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Document title (default: Untitled Document)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "author".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Document author (optional)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["content".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
+// ── lint_report ───────────────────────────────────────────────────────────────
+
+struct LintReportExecutor;
+
+impl ToolExecutor for LintReportExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async move {
+            let args = &input.arguments;
+            let json_output = args
+                .get("json")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+
+            // Accept either inline text or a file path.
+            let text_owned: String;
+            let text: &str = if let Some(t) = extract_opt_str(args, "text") {
+                t
+            } else if let Some(path_str) = extract_opt_str(args, "path") {
+                match std::fs::read_to_string(path_str) {
+                    Ok(s) => {
+                        text_owned = s;
+                        &text_owned
+                    }
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!(
+                            "failed to read {path_str:?}: {e}"
+                        )));
+                    }
+                }
+            } else {
+                return Ok(ToolResult::error(
+                    "lint_report requires 'text' or 'path'".to_owned(),
+                ));
+            };
+
+            let linter = Linter::new(LintConfig::default());
+            let findings = linter.check(text);
+
+            if json_output {
+                match Linter::to_json(&findings) {
+                    Ok(json) => return Ok(ToolResult::text(json)),
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!("serialize failed: {e}")));
+                    }
+                }
+            }
+
+            if findings.is_empty() {
+                return Ok(ToolResult::text("LINT: no findings".to_owned()));
+            }
+
+            let mut lines: Vec<String> = Vec::with_capacity(findings.len());
+            for f in &findings {
+                if f.line_start == f.line_end {
+                    lines.push(format!("LINT: line {}: {}", f.line_start, f.message));
+                } else {
+                    lines.push(format!(
+                        "LINT: lines {}-{}: {}",
+                        f.line_start, f.line_end, f.message
+                    ));
+                }
+            }
+            Ok(ToolResult::text(lines.join("\n")))
+        })
+    }
+}
+
+fn lint_report_def() -> ToolDef {
+    ToolDef {
+        name: koina::id::ToolName::from_static("lint_report"), // kanon:ignore RUST/expect
+        description: "Check report prose quality: banned words, citation coverage, structure."
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "text".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Report text to lint (inline)".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Path to report file to lint".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "json".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Boolean,
+                        description:
+                            "Return findings as JSON array instead of human-readable lines"
+                                .to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(false)),
+                    },
+                ),
+            ]),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
+// ── verify_report ─────────────────────────────────────────────────────────────
+
+struct VerifyReportExecutor;
+
+impl ToolExecutor for VerifyReportExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async move {
+            let args = &input.arguments;
+
+            let verifier = Verifier::new();
+
+            let results = if let Some(manifest_str) = extract_opt_str(args, "manifest") {
+                let manifest: poiesis_verify::VerifyManifest =
+                    match serde_json::from_str(manifest_str) {
+                        Ok(m) => m,
+                        Err(e) => {
+                            return Ok(ToolResult::error(format!(
+                                "failed to parse manifest JSON: {e}"
+                            )));
+                        }
+                    };
+                verifier.verify(&manifest)
+            } else if let Some(path_str) = extract_opt_str(args, "path") {
+                let path = std::path::Path::new(path_str);
+                match verifier.verify_file(path) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!(
+                            "failed to verify manifest at {path_str:?}: {e}"
+                        )));
+                    }
+                }
+            } else {
+                return Ok(ToolResult::error(
+                    "verify_report requires 'manifest' (inline JSON) or 'path'".to_owned(),
+                ));
+            };
+
+            let summary = poiesis_verify::VerifyResult::from_claims(results);
+            let any_failed = summary.any_failed();
+
+            match serde_json::to_string_pretty(&summary) {
+                Ok(json) => {
+                    if any_failed {
+                        Ok(ToolResult::error(format!(
+                            "VERIFY FAILED: {}/{} claims passed\n{json}",
+                            summary.passed, summary.total
+                        )))
+                    } else {
+                        Ok(ToolResult::text(format!(
+                            "VERIFY PASSED: {}/{} claims passed\n{json}",
+                            summary.passed, summary.total
+                        )))
+                    }
+                }
+                Err(e) => Ok(ToolResult::error(format!("serialize failed: {e}"))),
+            }
+        })
+    }
+}
+
+fn verify_report_def() -> ToolDef {
+    ToolDef {
+        name: koina::id::ToolName::from_static("verify_report"), // kanon:ignore RUST/expect
+        description:
+            "Validate numeric claims in a verify manifest against derived and reference sources."
+                .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "manifest".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Inline JSON verify manifest string".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Path to a verify manifest JSON file".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
+// ── Registration ──────────────────────────────────────────────────────────────
+
+/// Register the poiesis report tools: `generate_document`, `lint_report`, `verify_report`.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(generate_document_def(), Box::new(GenerateDocumentExecutor))?;
+    registry.register(lint_report_def(), Box::new(LintReportExecutor))?;
+    registry.register(verify_report_def(), Box::new(VerifyReportExecutor))?;
+    Ok(())
+}

--- a/crates/poiesis/lint/Cargo.toml
+++ b/crates/poiesis/lint/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "poiesis-lint"
+version.workspace = true
+description = "Report prose linting: banned words, citation checks, structure checks"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }

--- a/crates/poiesis/lint/src/banned_words.rs
+++ b/crates/poiesis/lint/src/banned_words.rs
@@ -1,0 +1,701 @@
+// Banned word and phrase list from kanon WRITING.md.
+// WHY: hardcoded at compile time — zero runtime overhead, no external file to lose.
+
+use super::{Finding, FindingKind, LineFix};
+
+/// An entry in the banned word/phrase table.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BannedEntry {
+    /// The word or phrase to detect (matched case-insensitively).
+    pub(crate) pattern: &'static str,
+    /// Suggested replacement shown in the finding message.
+    pub(crate) suggestion: &'static str,
+    /// When true, require word boundaries on both sides of the match.
+    /// WHY: single words like "robust" must not match inside "robustness" in a
+    /// medical context where the prefix is unrelated. Phrases are already
+    /// specific enough that substring matching is safe.
+    pub(crate) whole_word: bool,
+    /// Auto-fix replacement, or None when the fix requires human judgment.
+    pub(crate) fix: Option<&'static str>,
+}
+
+/// Full banned list: AI tropes, filler phrases, and additional AI vocabulary.
+/// Source: kanon `crates/basanos/standards/WRITING.md`.
+pub(crate) static BANNED: &[BannedEntry] = &[
+    // ── AI tropes ─────────────────────────────────────────────────────────────
+    BannedEntry {
+        pattern: "delve",
+        suggestion: "examine, explore, or look at",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "leverage",
+        suggestion: "use",
+        whole_word: true,
+        fix: Some("use"),
+    },
+    BannedEntry {
+        pattern: "utilize",
+        suggestion: "use",
+        whole_word: true,
+        fix: Some("use"),
+    },
+    BannedEntry {
+        pattern: "facilitate",
+        suggestion: "enable, support, or describe what happens",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "streamline",
+        suggestion: "simplify, reduce, or speed up",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "robust",
+        suggestion: "describe what makes it strong",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "comprehensive",
+        suggestion: "complete, thorough, or list what is covered",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "enhance",
+        suggestion: "improve, add, extend, or describe the change",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "foster",
+        suggestion: "encourage, support, or build",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "showcase",
+        suggestion: "demonstrate, show, or present",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "underscore",
+        suggestion: "emphasize or highlight (or restructure)",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "illuminate",
+        suggestion: "explain, clarify, or show",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "elucidate",
+        suggestion: "explain, clarify, or show",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "navigate",
+        suggestion: "handle, address, or work through (if metaphorical)",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "embark",
+        suggestion: "start or begin",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "harness",
+        suggestion: "use or apply",
+        whole_word: true,
+        fix: Some("use"),
+    },
+    BannedEntry {
+        pattern: "pivotal",
+        suggestion: "important, critical, or explain why",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "intricate",
+        suggestion: "complex or detailed",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "meticulous",
+        suggestion: "careful, thorough, or precise",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "multifaceted",
+        suggestion: "complex, or describe the facets",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "nuanced",
+        suggestion: "describe the actual nuance",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "paramount",
+        suggestion: "important or critical",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "profound",
+        suggestion: "significant, or describe the depth",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "groundbreaking",
+        suggestion: "new, first, or original (with evidence)",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "holistic",
+        suggestion: "complete, whole-system, or end-to-end",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "invaluable",
+        suggestion: "valuable, essential, or explain why",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "tapestry",
+        suggestion: "describe the actual domain",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "landscape",
+        suggestion: "describe the actual domain",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "realm",
+        suggestion: "describe the actual domain",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "testament",
+        suggestion: "evidence of, or demonstrates",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "journey",
+        suggestion: "process, progression, or describe it (if metaphorical)",
+        whole_word: true,
+        fix: None,
+    },
+    // ── Filler phrases ────────────────────────────────────────────────────────
+    BannedEntry {
+        pattern: "it's worth noting",
+        suggestion: "state the thing directly",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "it should be noted",
+        suggestion: "state the thing directly",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "in order to",
+        suggestion: "use \"to\"",
+        whole_word: false,
+        fix: Some("to"),
+    },
+    BannedEntry {
+        pattern: "a wide range of",
+        suggestion: "many, several, or state the count",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "at the end of the day",
+        suggestion: "delete or restate the conclusion",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "as such",
+        suggestion: "so, therefore, or restructure",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "in terms of",
+        suggestion: "about, for, or regarding",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "deep dive",
+        suggestion: "examine, analyze, or investigate",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "dive deep",
+        suggestion: "examine, analyze, or investigate",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "in today's",
+        suggestion: "delete entirely",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "in the ever-evolving",
+        suggestion: "delete entirely",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "when it comes to",
+        suggestion: "for, regarding, or restructure",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "serves as",
+        suggestion: "is",
+        whole_word: false,
+        fix: Some("is"),
+    },
+    BannedEntry {
+        pattern: "functions as",
+        suggestion: "is",
+        whole_word: false,
+        fix: Some("is"),
+    },
+    BannedEntry {
+        pattern: "stands as",
+        suggestion: "is",
+        whole_word: false,
+        fix: Some("is"),
+    },
+    BannedEntry {
+        pattern: "plays a crucial role",
+        suggestion: "matters or contributes (describe how)",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "plays a key role",
+        suggestion: "matters or contributes (describe how)",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "plays a vital role",
+        suggestion: "matters or contributes (describe how)",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "aims to bridge",
+        suggestion: "connects or links (describe the connection)",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "paving the way",
+        suggestion: "enabling, or describe what it enables",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "sheds light on",
+        suggestion: "explains, reveals, or shows",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "at its core",
+        suggestion: "fundamentally, or just state the core thing",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "key takeaway",
+        suggestion: "the point is, or just state it",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "going forward",
+        suggestion: "from now on, or delete",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "please note that",
+        suggestion: "state the thing",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "as mentioned above",
+        suggestion: "reference by name or omit",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "as mentioned below",
+        suggestion: "reference by name or omit",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "needless to say",
+        suggestion: "then don't say it",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "as a matter of fact",
+        suggestion: "delete, state the fact",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "arguably",
+        suggestion: "state the argument or don't",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "it seems",
+        suggestion: "investigate and state the finding",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "it appears",
+        suggestion: "investigate and state the finding",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "basically",
+        suggestion: "say the thing directly",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "essentially",
+        suggestion: "say the thing directly",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "in this context",
+        suggestion: "the reader knows the context; delete",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "not only",
+        suggestion: "use when genuinely contrasting; never as a default sentence opener",
+        whole_word: false,
+        fix: None,
+    },
+    // ── Additional AI vocabulary ──────────────────────────────────────────────
+    BannedEntry {
+        pattern: "notably",
+        suggestion: "state the thing",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "crucially",
+        suggestion: "state why it matters",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "specifically",
+        suggestion: "delete",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "importantly",
+        suggestion: "restructure to show importance",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "interestingly",
+        suggestion: "state the thing",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "accordingly",
+        suggestion: "so, or as a result",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "consequently",
+        suggestion: "so, or as a result",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "furthermore",
+        suggestion: "and, also, or delete",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "additionally",
+        suggestion: "and, also, or delete",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "ultimately",
+        suggestion: "delete or state the conclusion",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "seamless",
+        suggestion: "describe the actual integration",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "seamlessly",
+        suggestion: "describe the actual integration",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "straightforward",
+        suggestion: "describe the actual simplicity",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "in conclusion",
+        suggestion: "don't conclude; the last paragraph stands alone",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "in summary",
+        suggestion: "don't summarize; the content stands alone",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "as previously mentioned",
+        suggestion: "name the thing",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "it is worth mentioning",
+        suggestion: "state the thing",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "worth noting",
+        suggestion: "state the thing",
+        whole_word: false,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "currently",
+        suggestion: "state the behavior directly",
+        whole_word: true,
+        fix: None,
+    },
+    BannedEntry {
+        pattern: "presently",
+        suggestion: "state the behavior directly",
+        whole_word: true,
+        fix: None,
+    },
+];
+
+/// Scan `effective_lines` for banned words and phrases.
+///
+/// `effective_lines` must contain only non-comment lines. Each tuple is
+/// `(1-indexed line number, line content)`.
+pub(crate) fn check(effective_lines: &[(usize, &str)]) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    for &(line_num, line) in effective_lines {
+        let lower = line.to_lowercase();
+
+        for entry in BANNED {
+            let lower_pattern = entry.pattern.to_lowercase();
+            let pattern_len = lower_pattern.len();
+            debug_assert!(
+                !lower_pattern.is_empty(),
+                "banned pattern must not be empty: {entry:?}"
+            );
+
+            let mut search_start = 0usize;
+            while search_start < lower.len() {
+                let Some(tail) = lower.get(search_start..) else {
+                    break;
+                };
+                let Some(offset) = tail.find(lower_pattern.as_str()) else {
+                    break;
+                };
+                let match_start = search_start + offset;
+                let match_end = match_start + pattern_len;
+
+                let matched = if line.is_char_boundary(match_start)
+                    && line.is_char_boundary(match_end)
+                {
+                    // SAFETY: both boundaries are verified as char boundaries above
+                    #[expect(
+                        clippy::string_slice,
+                        reason = "both boundaries are verified as char boundaries immediately above"
+                    )]
+                    &line[match_start..match_end]
+                } else {
+                    // NOTE: non-ASCII boundary shift from lowercasing; skip safely.
+                    search_start = match_start + 1;
+                    continue;
+                };
+
+                let at_boundary =
+                    !entry.whole_word || is_word_boundary(&lower, match_start, match_end);
+
+                if at_boundary {
+                    let fix = entry.fix.map(|replacement| LineFix {
+                        line_number: line_num,
+                        matched: matched.to_owned(),
+                        replacement: replacement.to_owned(),
+                    });
+
+                    findings.push(Finding {
+                        line_start: line_num,
+                        line_end: line_num,
+                        message: format!("banned word {:?} -> {}", matched, entry.suggestion),
+                        kind: FindingKind::BannedWord,
+                        fix,
+                    });
+                }
+
+                search_start = match_start + pattern_len;
+            }
+        }
+    }
+
+    findings
+}
+
+/// Return true when the byte range `[start, end)` in `text` falls on word
+/// boundaries (i.e., adjacent characters are not alphanumeric or apostrophe).
+fn is_word_boundary(text: &str, start: usize, end: usize) -> bool {
+    // SAFETY: start and end are char boundaries (verified by callers before this fn)
+    #[expect(
+        clippy::string_slice,
+        reason = "start and end are verified as char boundaries by the caller before calling is_word_boundary"
+    )]
+    let before_ok = start == 0
+        || text[..start]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !c.is_alphanumeric() && c != '\'');
+
+    #[expect(
+        clippy::string_slice,
+        reason = "end is verified as a char boundary by the caller before calling is_word_boundary"
+    )]
+    let after_ok = end >= text.len()
+        || text[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !c.is_alphanumeric() && c != '\'');
+
+    before_ok && after_ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn banned_list_meets_minimum_count() {
+        assert!(
+            BANNED.len() >= 73,
+            "banned word list must have at least 73 entries, found {}",
+            BANNED.len()
+        );
+    }
+
+    #[test]
+    fn detects_single_banned_word() {
+        let lines = [(1usize, "The approach is robust and comprehensive.")];
+        let findings = check(&lines);
+        let messages: Vec<&str> = findings.iter().map(|f| f.message.as_str()).collect();
+        assert!(
+            messages.iter().any(|m| m.contains("\"robust\"")),
+            "must flag 'robust'"
+        );
+        assert!(
+            messages.iter().any(|m| m.contains("\"comprehensive\"")),
+            "must flag 'comprehensive'"
+        );
+    }
+
+    #[test]
+    fn whole_word_boundary_respected() {
+        // "robustness" contains "robust" but is a different word; must not flag.
+        let lines = [(1usize, "The robustness of the system was tested.")];
+        let findings = check(&lines);
+        assert!(
+            !findings.iter().any(|f| f.message.contains("\"robust\"")),
+            "must not flag 'robust' inside 'robustness'"
+        );
+    }
+
+    #[test]
+    fn detects_filler_phrase() {
+        // WHY: use lowercase so the matched text in the message matches the assertion.
+        let lines = [(1usize, "in order to understand, we examine the data.")];
+        let findings = check(&lines);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.message.contains("\"in order to\"")),
+            "must flag 'in order to'"
+        );
+    }
+}

--- a/crates/poiesis/lint/src/citations.rs
+++ b/crates/poiesis/lint/src/citations.rs
@@ -1,0 +1,102 @@
+// Citation presence checker.
+//
+// WHY: any table-like construct without a nearby source marker suggests
+// the data was asserted without a traceable reference.
+
+use super::{Finding, FindingKind};
+
+/// Markers that indicate a table or data display in the document.
+const TABLE_MARKERS: &[&str] = &["#summus-table(", "| --- |", "| :--- |", "| ---: |", "|---|"];
+
+/// Markers that indicate a citation or source declaration.
+const CITATION_MARKERS: &[&str] = &["#source[", "Source:", "#bibliography(", "cite(", "[^"];
+
+/// Check `all_lines` for tables that lack a nearby citation.
+///
+/// `window` is the number of lines before and after a table marker to
+/// search for a citation marker. Using all lines (including comments) is
+/// intentional: citations in adjacent comment blocks count.
+pub(crate) fn check(all_lines: &[(usize, &str)], window: usize) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let n = all_lines.len();
+
+    for (idx, &(line_num, line)) in all_lines.iter().enumerate() {
+        if !is_table_marker(line) {
+            continue;
+        }
+
+        // Search within `window` lines before and after this table marker.
+        let lo = idx.saturating_sub(window);
+        let hi = (idx + window + 1).min(n);
+
+        let has_citation = all_lines
+            .get(lo..hi)
+            .is_some_and(|slice| slice.iter().any(|(_, l)| is_citation_marker(l)));
+
+        if !has_citation {
+            findings.push(Finding {
+                line_start: line_num,
+                line_end: line_num,
+                message: format!("table at line {line_num} has no citation within {window} lines"),
+                kind: FindingKind::MissingCitation,
+                fix: None,
+            });
+        }
+    }
+
+    findings
+}
+
+fn is_table_marker(line: &str) -> bool {
+    TABLE_MARKERS.iter().any(|m| line.contains(m))
+}
+
+fn is_citation_marker(line: &str) -> bool {
+    CITATION_MARKERS.iter().any(|m| line.contains(m))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_without_citation_flagged() {
+        let lines: Vec<(usize, &str)> = vec![
+            (1, "#summus-table((1fr,), (\"Col\",), (\"Val\",))"),
+            (2, "Some prose."),
+            (3, "More prose."),
+        ];
+        let findings = check(&lines, 10);
+        assert!(
+            !findings.is_empty(),
+            "table without citation must produce a finding"
+        );
+    }
+
+    #[test]
+    fn table_with_citation_passes() {
+        let lines: Vec<(usize, &str)> = vec![
+            (1, "#summus-table((1fr,), (\"Col\",), (\"Val\",))"),
+            (2, "#source[Internal database query, 2026-04-01]"),
+        ];
+        let findings = check(&lines, 10);
+        assert!(
+            findings.is_empty(),
+            "table with nearby citation must not be flagged"
+        );
+    }
+
+    #[test]
+    fn markdown_table_without_citation_flagged() {
+        let lines: Vec<(usize, &str)> = vec![
+            (1, "| Name | Value |"),
+            (2, "| --- |"),
+            (3, "| alpha | 1 |"),
+        ];
+        let findings = check(&lines, 10);
+        assert!(
+            !findings.is_empty(),
+            "markdown table separator without citation must be flagged"
+        );
+    }
+}

--- a/crates/poiesis/lint/src/error.rs
+++ b/crates/poiesis/lint/src/error.rs
@@ -1,0 +1,31 @@
+// Error types for poiesis-lint.
+
+use snafu::Snafu;
+
+/// Errors that can occur during lint operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum LintError {
+    /// Failed to read the input file.
+    #[snafu(display("failed to read file {path:?}: {source}"))]
+    ReadFile {
+        /// Path that could not be read.
+        path: String,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+    /// Failed to write fixed content back to the file.
+    #[snafu(display("failed to write file {path:?}: {source}"))]
+    WriteFile {
+        /// Path that could not be written.
+        path: String,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+    /// Failed to serialize findings to JSON.
+    #[snafu(display("failed to serialize findings: {source}"))]
+    Serialize {
+        /// Underlying serde error.
+        source: serde_json::Error,
+    },
+}

--- a/crates/poiesis/lint/src/lib.rs
+++ b/crates/poiesis/lint/src/lib.rs
@@ -1,0 +1,328 @@
+#![deny(missing_docs)]
+//! poiesis-lint: report prose quality linting.
+//!
+//! Checks banned words, citation coverage, structural patterns, required
+//! sections, and header length. Ported from the `ergon_tools` sdr lint.
+
+mod banned_words;
+mod citations;
+/// Error types for the lint pipeline.
+pub mod error;
+mod structure;
+
+pub use error::LintError;
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+// ── Finding types ─────────────────────────────────────────────────────────────
+
+/// A single lint finding with location and message.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Finding {
+    /// 1-indexed first line of the finding.
+    pub line_start: usize,
+    /// 1-indexed last line of the finding (same as `line_start` for single-line findings).
+    pub line_end: usize,
+    /// Human-readable description of the issue.
+    pub message: String,
+    /// Category of this finding.
+    pub kind: FindingKind,
+    /// Auto-fix data, if this finding can be fixed automatically.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<LineFix>,
+}
+
+/// Category of a lint finding.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum FindingKind {
+    /// A banned word or phrase was found.
+    BannedWord,
+    /// A table or data display lacks a nearby citation.
+    MissingCitation,
+    /// An AI structural tell (e.g. transition density) was detected.
+    StructuralPattern,
+    /// A required section (lead or closing) is absent.
+    RequiredSectionMissing,
+    /// A heading exceeds the allowed length.
+    HeaderLength,
+}
+
+/// Data needed to apply an automatic fix for a banned word.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LineFix {
+    /// 1-indexed line number where the match occurred.
+    pub line_number: usize,
+    /// The original matched text (may differ in case from the pattern).
+    pub matched: String,
+    /// Replacement text to write back.
+    pub replacement: String,
+}
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/// Configuration for the lint pipeline.
+#[derive(Debug, Clone)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "each flag independently enables a distinct checker; this is a configuration struct not a state machine"
+)]
+pub struct LintConfig {
+    /// Enable banned word checks.
+    pub check_banned_words: bool,
+    /// Enable citation presence checks.
+    pub check_citations: bool,
+    /// Enable structural pattern checks.
+    pub check_structure: bool,
+    /// Enable required section checks.
+    pub check_sections: bool,
+    /// Enable header length checks.
+    pub check_header_length: bool,
+    /// Maximum H2 heading length in characters.
+    pub max_header_length: usize,
+    /// Number of lines before/after a table to search for citations.
+    pub citation_window: usize,
+}
+
+impl Default for LintConfig {
+    fn default() -> Self {
+        Self {
+            check_banned_words: true,
+            check_citations: true,
+            check_structure: true,
+            check_sections: true,
+            check_header_length: true,
+            max_header_length: 60,
+            citation_window: 10,
+        }
+    }
+}
+
+// ── Linter ────────────────────────────────────────────────────────────────────
+
+/// Stateless report linter. Construct once; call `check` for each document.
+pub struct Linter {
+    config: LintConfig,
+}
+
+impl Linter {
+    /// Create a new `Linter` with the given configuration.
+    pub fn new(config: LintConfig) -> Self {
+        Self { config }
+    }
+
+    /// Check `text` for all configured lint rules.
+    ///
+    /// Returns findings sorted by line number (top-to-bottom, deterministic).
+    pub fn check(&self, text: &str) -> Vec<Finding> {
+        let all_lines: Vec<(usize, &str)> =
+            text.lines().enumerate().map(|(i, l)| (i + 1, l)).collect();
+
+        // WHY: structural and banned-word checks run on non-comment lines only.
+        // Citation checks run on all lines because source markers may appear
+        // adjacent to comment lines.
+        let effective: Vec<(usize, &str)> = all_lines
+            .iter()
+            .copied()
+            .filter(|(_, l)| !l.trim_start().starts_with("//"))
+            .collect();
+
+        let mut findings: Vec<Finding> = Vec::new();
+
+        if self.config.check_banned_words {
+            findings.extend(banned_words::check(&effective));
+        }
+        if self.config.check_citations {
+            findings.extend(citations::check(&all_lines, self.config.citation_window));
+        }
+        if self.config.check_structure {
+            findings.extend(structure::check_structure(&effective));
+        }
+        if self.config.check_sections {
+            findings.extend(structure::check_sections(&effective));
+        }
+        if self.config.check_header_length {
+            findings.extend(structure::check_header_length(
+                &effective,
+                self.config.max_header_length,
+            ));
+        }
+
+        findings.sort_by_key(|f| f.line_start);
+        findings
+    }
+
+    /// Apply all auto-fixable findings to `text` and return the modified content.
+    ///
+    /// Only findings with a `fix` field are processed; unfixable findings are ignored.
+    pub fn apply_fixes(&self, text: &str, findings: &[Finding]) -> String {
+        let fixable: Vec<&LineFix> = findings.iter().filter_map(|f| f.fix.as_ref()).collect();
+
+        if fixable.is_empty() {
+            return text.to_owned();
+        }
+
+        let mut lines: Vec<String> = text.lines().map(str::to_owned).collect();
+
+        for fix in fixable {
+            // line_number is 1-indexed; saturate to avoid underflow on malformed input.
+            let idx = fix.line_number.saturating_sub(1);
+            if let Some(line) = lines.get_mut(idx) {
+                *line = replace_first_case_insensitive(line, &fix.matched, &fix.replacement);
+            }
+        }
+
+        // WHY: preserve trailing newline from the original file to avoid spurious diffs.
+        let mut new_content = lines.join("\n");
+        if text.ends_with('\n') {
+            new_content.push('\n');
+        }
+        new_content
+    }
+
+    /// Lint a file at `path`, optionally applying fixes in place.
+    ///
+    /// Returns the list of findings. If `apply_fix` is true and any fixable
+    /// findings exist, the file is rewritten with fixes applied.
+    ///
+    /// # Errors
+    ///
+    /// Returns `LintError` if the file cannot be read or written.
+    pub fn check_file(
+        &self,
+        path: &std::path::Path,
+        apply_fix: bool,
+    ) -> Result<Vec<Finding>, LintError> {
+        let content = std::fs::read_to_string(path).context(error::ReadFileSnafu {
+            path: path.display().to_string(),
+        })?;
+
+        let findings = self.check(&content);
+
+        if apply_fix && !findings.is_empty() {
+            let fixed = self.apply_fixes(&content, &findings);
+            std::fs::write(path, fixed).context(error::WriteFileSnafu {
+                path: path.display().to_string(),
+            })?;
+        }
+
+        Ok(findings)
+    }
+
+    /// Serialize `findings` to a pretty-printed JSON string.
+    ///
+    /// # Errors
+    ///
+    /// Returns `LintError::Serialize` if serialization fails.
+    pub fn to_json(findings: &[Finding]) -> Result<String, LintError> {
+        serde_json::to_string_pretty(findings).context(error::SerializeSnafu)
+    }
+}
+
+impl Default for Linter {
+    fn default() -> Self {
+        Self::new(LintConfig::default())
+    }
+}
+
+/// Replace the first occurrence of `pattern` in `line` (case-insensitively)
+/// with `replacement`, preserving surrounding characters.
+fn replace_first_case_insensitive(line: &str, pattern: &str, replacement: &str) -> String {
+    let lower = line.to_lowercase();
+    let lower_pattern = pattern.to_lowercase();
+
+    if let Some(pos) = lower.find(lower_pattern.as_str()) {
+        let end = pos + pattern.len();
+        if line.is_char_boundary(pos) && line.is_char_boundary(end) {
+            let mut result = String::with_capacity(line.len());
+            // SAFETY: pos and end are verified as char boundaries immediately above
+            #[expect(
+                clippy::string_slice,
+                reason = "pos and end are verified as char boundaries immediately above"
+            )]
+            result.push_str(&line[..pos]);
+            result.push_str(replacement);
+            #[expect(
+                clippy::string_slice,
+                reason = "pos and end are verified as char boundaries immediately above"
+            )]
+            result.push_str(&line[end..]);
+            return result;
+        }
+    }
+
+    line.to_owned()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_linter_finds_banned_words() {
+        let linter = Linter::default();
+        let findings = linter.check("The approach is robust and comprehensive.\n");
+        assert!(
+            !findings.is_empty(),
+            "default linter must flag banned words"
+        );
+    }
+
+    #[test]
+    fn clean_text_produces_no_findings() {
+        let linter = Linter {
+            config: LintConfig {
+                check_citations: false,
+                check_sections: false,
+                ..LintConfig::default()
+            },
+        };
+        let findings = linter.check("The analysis shows 47 cases across three employers.\n");
+        assert!(
+            findings.is_empty(),
+            "clean text must produce no findings, got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn apply_fixes_replaces_utilize() {
+        let linter = Linter::default();
+        let text = "We utilize the data pipeline.\n";
+        let findings = linter.check(text);
+        let fixed = linter.apply_fixes(text, &findings);
+        assert!(
+            fixed.contains("use"),
+            "fix must replace 'utilize' with 'use', got: {fixed:?}"
+        );
+    }
+
+    #[test]
+    fn to_json_round_trips() {
+        let findings = vec![Finding {
+            line_start: 5,
+            line_end: 5,
+            message: "banned word \"robust\"".to_owned(),
+            kind: FindingKind::BannedWord,
+            fix: None,
+        }];
+        let json = Linter::to_json(&findings).expect("serialize");
+        let parsed: Vec<Finding> = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.len(), 1, "round-trip must preserve finding count");
+    }
+
+    #[test]
+    fn replace_first_case_insensitive_replaces() {
+        let result = replace_first_case_insensitive("We UTILIZE the data.", "UTILIZE", "use");
+        assert_eq!(result, "We use the data.", "must replace matched text");
+    }
+
+    #[test]
+    fn replace_first_case_insensitive_no_match() {
+        let line = "Clean prose here.";
+        let result = replace_first_case_insensitive(line, "utilize", "use");
+        assert_eq!(result, line, "no match must return line unchanged");
+    }
+}

--- a/crates/poiesis/lint/src/structure.rs
+++ b/crates/poiesis/lint/src/structure.rs
@@ -1,0 +1,268 @@
+// Structural pattern checks: AI structural tells.
+//
+// Checks:
+//   check_structure  — transition word density (≥3 consecutive paragraphs)
+//   check_sections   — required lead and closing sections present
+//   check_header_length — H2 headings over the configured limit
+
+use super::{Finding, FindingKind};
+
+/// Transition words that indicate AI-generated filler structure.
+const TRANSITION_WORDS: &[&str] = &[
+    "furthermore",
+    "additionally",
+    "moreover",
+    "consequently",
+    "accordingly",
+    "therefore",
+    "nevertheless",
+    "nonetheless",
+    "subsequently",
+    "ultimately",
+];
+
+/// Minimum consecutive paragraphs that all begin with a transition word before flagging.
+const TRANSITION_DENSITY_THRESHOLD: usize = 3;
+
+/// Check for AI structural tells in `effective_lines`.
+///
+/// Returns findings for transition-word-dense runs of paragraphs.
+pub(crate) fn check_structure(effective_lines: &[(usize, &str)]) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let mut consecutive = 0usize;
+    let mut run_start = 0usize;
+
+    for &(line_num, line) in effective_lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            // Empty line ends the current paragraph run.
+            if consecutive >= TRANSITION_DENSITY_THRESHOLD {
+                findings.push(Finding {
+                    line_start: run_start,
+                    line_end: line_num.saturating_sub(1),
+                    message: format!(
+                        "{consecutive} consecutive paragraphs begin with transition words — structural tell"
+                    ),
+                    kind: FindingKind::StructuralPattern,
+                    fix: None,
+                });
+            }
+            consecutive = 0;
+            run_start = 0;
+            continue;
+        }
+
+        // Check if this line starts with a transition word.
+        let lower = trimmed.to_lowercase();
+        let starts_with_transition = TRANSITION_WORDS
+            .iter()
+            .any(|tw| lower.starts_with(tw) || lower.starts_with(&format!("{tw},")));
+
+        if starts_with_transition {
+            if consecutive == 0 {
+                run_start = line_num;
+            }
+            consecutive += 1;
+        } else if !trimmed.starts_with('#') && !trimmed.starts_with('|') {
+            // Non-heading, non-table prose that doesn't start with a transition word resets the run.
+            if consecutive >= TRANSITION_DENSITY_THRESHOLD {
+                findings.push(Finding {
+                    line_start: run_start,
+                    line_end: line_num.saturating_sub(1),
+                    message: format!(
+                        "{consecutive} consecutive paragraphs begin with transition words — structural tell"
+                    ),
+                    kind: FindingKind::StructuralPattern,
+                    fix: None,
+                });
+            }
+            consecutive = 0;
+            run_start = 0;
+        }
+    }
+
+    // Flush any open run at end of file.
+    if consecutive >= TRANSITION_DENSITY_THRESHOLD {
+        let last_line = effective_lines.last().map_or(run_start, |(n, _)| *n);
+        findings.push(Finding {
+            line_start: run_start,
+            line_end: last_line,
+            message: format!(
+                "{consecutive} consecutive paragraphs begin with transition words — structural tell"
+            ),
+            kind: FindingKind::StructuralPattern,
+            fix: None,
+        });
+    }
+
+    findings
+}
+
+/// Check that `effective_lines` contains both a lead section and a closing section.
+///
+/// The lead section is identified by one of: a line starting with `## Summary`,
+/// `## Executive Summary`, `## Overview`, or `## Key Findings`.
+/// The closing section is identified by a line starting with `## Appendix`,
+/// `## References`, or `## Sources`.
+pub(crate) fn check_sections(effective_lines: &[(usize, &str)]) -> Vec<Finding> {
+    let lead_markers = [
+        "## summary",
+        "## executive summary",
+        "## overview",
+        "## key findings",
+    ];
+    let closing_markers = ["## appendix", "## references", "## sources"];
+
+    let has_lead = effective_lines.iter().any(|(_, l)| {
+        let lower = l.trim().to_lowercase();
+        lead_markers.iter().any(|m| lower == *m)
+    });
+
+    let has_closing = effective_lines.iter().any(|(_, l)| {
+        let lower = l.trim().to_lowercase();
+        closing_markers.iter().any(|m| lower == *m)
+    });
+
+    let mut findings = Vec::new();
+
+    if !has_lead {
+        findings.push(Finding {
+            line_start: 1,
+            line_end: 1,
+            message:
+                "document is missing a lead section (Summary, Executive Summary, Overview, or Key Findings)"
+                    .to_owned(),
+            kind: FindingKind::RequiredSectionMissing,
+            fix: None,
+        });
+    }
+
+    if !has_closing {
+        findings.push(Finding {
+            line_start: 1,
+            line_end: 1,
+            message: "document is missing a closing section (Appendix, References, or Sources)"
+                .to_owned(),
+            kind: FindingKind::RequiredSectionMissing,
+            fix: None,
+        });
+    }
+
+    findings
+}
+
+/// Check that H2 headings do not exceed `max_len` characters (excluding `## ` prefix).
+pub(crate) fn check_header_length(
+    effective_lines: &[(usize, &str)],
+    max_len: usize,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    for &(line_num, line) in effective_lines {
+        let trimmed = line.trim();
+        let Some(heading_text) = trimmed.strip_prefix("## ") else {
+            continue;
+        };
+
+        if heading_text.chars().count() > max_len {
+            findings.push(Finding {
+                line_start: line_num,
+                line_end: line_num,
+                message: format!(
+                    "H2 heading at line {line_num} is {} characters (max {max_len}): {:?}",
+                    heading_text.chars().count(),
+                    heading_text
+                ),
+                kind: FindingKind::HeaderLength,
+                fix: None,
+            });
+        }
+    }
+
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transition_density_below_threshold_no_finding() {
+        let lines: Vec<(usize, &str)> = vec![
+            (1, "Furthermore, the analysis shows three cases."),
+            (2, "Additionally, we see two more."),
+        ];
+        let findings = check_structure(&lines);
+        assert!(
+            findings.is_empty(),
+            "two consecutive transition paragraphs must not flag (threshold is 3)"
+        );
+    }
+
+    #[test]
+    fn transition_density_at_threshold_flagged() {
+        let lines: Vec<(usize, &str)> = vec![
+            (1, "Furthermore, the analysis shows three cases."),
+            (2, "Additionally, we see two more."),
+            (3, "Moreover, results confirm the pattern."),
+        ];
+        let findings = check_structure(&lines);
+        assert!(
+            !findings.is_empty(),
+            "three consecutive transition paragraphs must be flagged"
+        );
+    }
+
+    #[test]
+    fn sections_both_present_passes() {
+        let lines: Vec<(usize, &str)> = vec![
+            (1, "## Summary"),
+            (2, "The analysis shows 47 cases."),
+            (3, "## Appendix"),
+        ];
+        let findings = check_sections(&lines);
+        assert!(
+            findings.is_empty(),
+            "document with both lead and closing sections must pass"
+        );
+    }
+
+    #[test]
+    fn sections_missing_lead_flagged() {
+        let lines: Vec<(usize, &str)> = vec![(1, "## Appendix")];
+        let findings = check_sections(&lines);
+        assert!(
+            findings.iter().any(|f| f.message.contains("lead section")),
+            "missing lead section must be flagged"
+        );
+    }
+
+    #[test]
+    fn sections_missing_closing_flagged() {
+        let lines: Vec<(usize, &str)> = vec![(1, "## Summary"), (2, "Analysis complete.")];
+        let findings = check_sections(&lines);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.message.contains("closing section")),
+            "missing closing section must be flagged"
+        );
+    }
+
+    #[test]
+    fn header_length_within_limit_passes() {
+        let lines: Vec<(usize, &str)> = vec![(1, "## Short Heading")];
+        let findings = check_header_length(&lines, 60);
+        assert!(findings.is_empty(), "short heading must pass");
+    }
+
+    #[test]
+    fn header_length_over_limit_flagged() {
+        let mut heading = "## ".to_owned();
+        heading.push_str(&"x".repeat(70));
+        let owned: Vec<(usize, String)> = vec![(1, heading)];
+        let lines: Vec<(usize, &str)> = owned.iter().map(|(n, s)| (*n, s.as_str())).collect();
+        let findings = check_header_length(&lines, 60);
+        assert!(!findings.is_empty(), "heading over limit must be flagged");
+    }
+}

--- a/crates/poiesis/verify/Cargo.toml
+++ b/crates/poiesis/verify/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "poiesis-verify"
+version.workspace = true
+description = "Report claim verification: arithmetic evaluation and source resolution"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }

--- a/crates/poiesis/verify/src/arithmetic.rs
+++ b/crates/poiesis/verify/src/arithmetic.rs
@@ -1,0 +1,382 @@
+// Simple recursive-descent expression evaluator.
+//
+// Supports: f64 literals, +, -, *, /, parentheses. No variables.
+// WHY: a dependency like `meval` would pull in transitive deps for a ~50-line
+// problem. Rolling our own keeps the dep count flat and the logic auditable.
+
+use crate::error::VerifyError;
+
+/// Evaluate an arithmetic formula string and return the f64 result.
+///
+/// # Errors
+///
+/// Returns `VerifyError::Eval` if the formula contains unknown characters,
+/// unmatched parentheses, or a division-by-zero.
+pub fn eval(formula: &str) -> Result<f64, VerifyError> {
+    let tokens = tokenize(formula)?;
+    let mut pos = 0usize;
+    if tokens.is_empty() {
+        return Err(VerifyError::Eval {
+            formula: formula.to_owned(),
+            detail: "empty formula".to_owned(),
+        });
+    }
+    let result = parse_expr(&tokens, &mut pos, formula)?;
+    if pos != tokens.len() {
+        return Err(VerifyError::Eval {
+            formula: formula.to_owned(),
+            detail: format!("unexpected token at position {pos}"),
+        });
+    }
+    Ok(result)
+}
+
+// ── Token type ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Num(f64),
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    LParen,
+    RParen,
+}
+
+// ── Tokenizer ────────────────────────────────────────────────────────────────
+
+fn tokenize(input: &str) -> Result<Vec<Token>, VerifyError> {
+    let mut tokens = Vec::new();
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((idx, ch)) = chars.next() {
+        match ch {
+            ' ' | '\t' | '\n' | '\r' => {}
+            '+' => tokens.push(Token::Plus),
+            '-' => {
+                // WHY: a '-' that appears at the start or after an operator is
+                // a unary negation, not a binary minus. We handle it by
+                // consuming the following number literal directly here.
+                let is_unary = matches!(
+                    tokens.last(),
+                    None | Some(
+                        Token::Plus | Token::Minus | Token::Star | Token::Slash | Token::LParen
+                    )
+                );
+                if is_unary {
+                    let (num, _) = consume_number(input, idx + ch.len_utf8(), &mut chars)?;
+                    tokens.push(Token::Num(-num));
+                } else {
+                    tokens.push(Token::Minus);
+                }
+            }
+            '*' => tokens.push(Token::Star),
+            '/' => tokens.push(Token::Slash),
+            '(' => tokens.push(Token::LParen),
+            ')' => tokens.push(Token::RParen),
+            '0'..='9' | '.' => {
+                let (num, _) = consume_number(input, idx, &mut chars)?;
+                tokens.push(Token::Num(num));
+            }
+            _ => {
+                return Err(VerifyError::Eval {
+                    formula: input.to_owned(),
+                    detail: format!("unexpected character '{ch}' at byte {idx}"),
+                });
+            }
+        }
+    }
+
+    Ok(tokens)
+}
+
+/// Consume a decimal number starting at `start` in `input`.
+///
+/// `chars` must be positioned just AFTER `start` (i.e. the first character of
+/// the number has already been consumed by the caller). Returns `(value,
+/// bytes_consumed)`.
+fn consume_number(
+    input: &str,
+    start: usize,
+    chars: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
+) -> Result<(f64, usize), VerifyError> {
+    // Find the end of the number by peeking ahead.
+    let end = loop {
+        match chars.peek() {
+            Some((_, c)) if c.is_ascii_digit() || *c == '.' || *c == 'e' || *c == 'E' => {
+                chars.next();
+            }
+            Some((idx, _)) => break *idx,
+            None => break input.len(),
+        }
+    };
+
+    let slice = input.get(start..end).ok_or_else(|| VerifyError::Eval {
+        formula: input.to_owned(),
+        detail: format!("byte slice {start}..{end} out of bounds"),
+    })?;
+
+    slice
+        .parse::<f64>()
+        .map(|v| (v, end - start))
+        .map_err(|e| VerifyError::Eval {
+            formula: input.to_owned(),
+            detail: format!("cannot parse '{slice}' as a number: {e}"),
+        })
+}
+
+// ── Recursive-descent parser (precedence climbing) ───────────────────────────
+//
+// Grammar:
+//   expr   = term (('+' | '-') term)*
+//   term   = factor (('*' | '/') factor)*
+//   factor = NUMBER | '(' expr ')'
+
+fn parse_expr(tokens: &[Token], pos: &mut usize, formula: &str) -> Result<f64, VerifyError> {
+    let mut lhs = parse_term(tokens, pos, formula)?;
+
+    while let Some(tok) = tokens.get(*pos) {
+        match tok {
+            Token::Plus => {
+                *pos += 1;
+                lhs += parse_term(tokens, pos, formula)?;
+            }
+            Token::Minus => {
+                *pos += 1;
+                lhs -= parse_term(tokens, pos, formula)?;
+            }
+            _ => break,
+        }
+    }
+
+    Ok(lhs)
+}
+
+fn parse_term(tokens: &[Token], pos: &mut usize, formula: &str) -> Result<f64, VerifyError> {
+    let mut lhs = parse_factor(tokens, pos, formula)?;
+
+    while let Some(tok) = tokens.get(*pos) {
+        match tok {
+            Token::Star => {
+                *pos += 1;
+                lhs *= parse_factor(tokens, pos, formula)?;
+            }
+            Token::Slash => {
+                *pos += 1;
+                let rhs = parse_factor(tokens, pos, formula)?;
+                if rhs.abs() < f64::EPSILON {
+                    return Err(VerifyError::Eval {
+                        formula: formula.to_owned(),
+                        detail: "division by zero".to_owned(),
+                    });
+                }
+                lhs /= rhs;
+            }
+            _ => break,
+        }
+    }
+
+    Ok(lhs)
+}
+
+fn parse_factor(tokens: &[Token], pos: &mut usize, formula: &str) -> Result<f64, VerifyError> {
+    match tokens.get(*pos) {
+        Some(Token::Num(v)) => {
+            let v = *v;
+            *pos += 1;
+            Ok(v)
+        }
+        Some(Token::LParen) => {
+            *pos += 1;
+            let inner = parse_expr(tokens, pos, formula)?;
+            match tokens.get(*pos) {
+                Some(Token::RParen) => {
+                    *pos += 1;
+                    Ok(inner)
+                }
+                _ => Err(VerifyError::Eval {
+                    formula: formula.to_owned(),
+                    detail: "expected closing ')'".to_owned(),
+                }),
+            }
+        }
+        Some(other) => Err(VerifyError::Eval {
+            formula: formula.to_owned(),
+            detail: format!("unexpected token {other:?}"),
+        }),
+        None => Err(VerifyError::Eval {
+            formula: formula.to_owned(),
+            detail: "unexpected end of expression".to_owned(),
+        }),
+    }
+}
+
+// ── Arithmetic formula check ─────────────────────────────────────────────────
+
+/// Evaluate `formula` and compare to `expected` within `tolerance`.
+///
+/// # Errors
+///
+/// Returns `VerifyError::Eval` if the formula cannot be parsed or evaluated.
+pub(crate) fn check(
+    formula: &str,
+    expected: f64,
+    tolerance: f64,
+) -> Result<ArithmeticResult, VerifyError> {
+    let actual = eval(formula)?;
+    let diff = (actual - expected).abs();
+    Ok(ArithmeticResult {
+        actual,
+        diff,
+        pass: diff <= tolerance,
+    })
+}
+
+/// Result of an arithmetic check.
+#[derive(Debug, Clone)]
+pub(crate) struct ArithmeticResult {
+    pub(crate) actual: f64,
+    pub(crate) diff: f64,
+    pub(crate) pass: bool,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(
+    clippy::unreadable_literal,
+    reason = "test fixture values match upstream report data verbatim"
+)]
+mod tests {
+    use super::*;
+
+    fn approx(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn eval_integer_literal() {
+        let v = eval("42").expect("must eval");
+        assert!(approx(v, 42.0), "literal 42 must evaluate to 42.0");
+    }
+
+    #[test]
+    fn eval_float_literal() {
+        // WHY: 2.5 avoids the clippy::approx_constant lint triggered by values near π.
+        let v = eval("2.5").expect("must eval");
+        assert!(approx(v, 2.5), "literal 2.5 must evaluate to 2.5");
+    }
+
+    #[test]
+    fn eval_addition() {
+        let v = eval("1 + 2").expect("must eval");
+        assert!(approx(v, 3.0), "1 + 2 must be 3");
+    }
+
+    #[test]
+    fn eval_subtraction() {
+        let v = eval("10 - 4").expect("must eval");
+        assert!(approx(v, 6.0), "10 - 4 must be 6");
+    }
+
+    #[test]
+    fn eval_multiplication() {
+        let v = eval("3 * 7").expect("must eval");
+        assert!(approx(v, 21.0), "3 * 7 must be 21");
+    }
+
+    #[test]
+    fn eval_division() {
+        let v = eval("10 / 4").expect("must eval");
+        assert!(approx(v, 2.5), "10 / 4 must be 2.5");
+    }
+
+    #[test]
+    fn eval_operator_precedence() {
+        let v = eval("2 + 3 * 4").expect("must eval");
+        assert!(approx(v, 14.0), "2 + 3 * 4 must respect precedence -> 14");
+    }
+
+    #[test]
+    fn eval_parentheses_override_precedence() {
+        let v = eval("(2 + 3) * 4").expect("must eval");
+        assert!(
+            approx(v, 20.0),
+            "(2 + 3) * 4 must evaluate inner first -> 20"
+        );
+    }
+
+    #[test]
+    fn eval_negative_unary() {
+        let v = eval("-5 + 3").expect("must eval");
+        assert!(approx(v, -2.0), "-5 + 3 must be -2");
+    }
+
+    #[test]
+    fn eval_savings_sum() {
+        let v = eval("78187 + 26558 + 1620 + 1165 + 127 + 127 + 0").expect("must eval");
+        assert!(approx(v, 107784.0), "savings components must sum to 107784");
+    }
+
+    #[test]
+    fn eval_percentage_formula() {
+        let v = eval("106365 / 107784 * 100").expect("must eval");
+        assert!(
+            (v - 98.683_f64).abs() < 0.01,
+            "percentage formula must evaluate near 98.68"
+        );
+    }
+
+    #[test]
+    fn eval_nested_parentheses() {
+        let v = eval("((2 + 3) * (4 - 1)) / 5").expect("must eval");
+        assert!(approx(v, 3.0), "nested parens must evaluate correctly");
+    }
+
+    #[test]
+    fn eval_division_by_zero_fails() {
+        let result = eval("10 / 0");
+        assert!(result.is_err(), "division by zero must return an error");
+    }
+
+    #[test]
+    fn eval_unknown_character_fails() {
+        let result = eval("1 + x");
+        assert!(result.is_err(), "unknown character must return an error");
+    }
+
+    #[test]
+    fn eval_unmatched_paren_fails() {
+        let result = eval("(1 + 2");
+        assert!(result.is_err(), "unmatched paren must return an error");
+    }
+
+    #[test]
+    fn eval_empty_string_fails() {
+        let result = eval("");
+        assert!(result.is_err(), "empty formula must return an error");
+    }
+
+    #[test]
+    fn check_pass_within_tolerance() {
+        let r = check("78187 + 26558 + 1620 + 1165 + 127 + 127 + 0", 107784.0, 1.0)
+            .expect("check must succeed");
+        assert!(r.pass, "must PASS within tolerance");
+        assert!(r.diff.abs() < 1e-9, "diff must be zero for exact match");
+    }
+
+    #[test]
+    fn check_fail_outside_tolerance() {
+        let r = check("100", 102.0, 1.0).expect("check must succeed");
+        assert!(!r.pass, "must FAIL when diff exceeds tolerance");
+        assert!(approx(r.diff, 2.0), "diff must be 2.0");
+    }
+
+    #[test]
+    fn check_exact_tolerance_boundary_passes() {
+        let r = check("100", 101.0, 1.0).expect("check must succeed");
+        assert!(r.pass, "diff == tolerance must still PASS");
+    }
+}

--- a/crates/poiesis/verify/src/error.rs
+++ b/crates/poiesis/verify/src/error.rs
@@ -1,0 +1,33 @@
+// Error types for poiesis-verify.
+
+use snafu::Snafu;
+
+/// Errors that can occur during verify operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum VerifyError {
+    /// Failed to evaluate an arithmetic formula.
+    #[snafu(display("arithmetic evaluation failed for formula {formula:?}: {detail}"))]
+    Eval {
+        /// The formula that could not be evaluated.
+        formula: String,
+        /// Human-readable description of the parse/eval error.
+        detail: String,
+    },
+    /// Failed to read the manifest file.
+    #[snafu(display("failed to read manifest {path:?}: {source}"))]
+    ReadManifest {
+        /// Path that could not be read.
+        path: String,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+    /// Failed to parse the manifest JSON.
+    #[snafu(display("failed to parse manifest {path:?}: {detail}"))]
+    ParseManifest {
+        /// Path whose contents could not be parsed.
+        path: String,
+        /// JSON parse error description.
+        detail: String,
+    },
+}

--- a/crates/poiesis/verify/src/lib.rs
+++ b/crates/poiesis/verify/src/lib.rs
@@ -1,0 +1,438 @@
+#![deny(missing_docs)]
+//! poiesis-verify: report claim verification.
+//!
+//! Validates numeric claims in a [`VerifyManifest`] against `Derived`
+//! (arithmetic formula) and `Ref` (cross-claim reference) sources.
+//! SQL sources are stored in the manifest schema for auditability but are not
+//! executed by this crate — execution requires an external tool.
+//!
+//! Ported from the `ergon_tools` sdr verify.
+
+/// Recursive-descent arithmetic formula evaluator.
+pub mod arithmetic;
+/// Error types for the verify pipeline.
+pub mod error;
+/// Verify manifest schema: `VerifyManifest`, `Claim`, `Source`, `Arithmetic`.
+pub mod manifest;
+
+pub use error::VerifyError;
+pub use manifest::{Arithmetic, Claim, Source, VerifyManifest};
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+use snafu::ResultExt;
+
+// ── Public entry point ───────────────────────────────────────────────────────
+
+/// Stateless claim verifier.
+pub struct Verifier;
+
+impl Default for Verifier {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl Verifier {
+    /// Create a new `Verifier`.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Verify all claims in `manifest`.
+    ///
+    /// Claims are processed in declaration order so that `Ref` sources that
+    /// point to earlier claims can be resolved without a topological sort.
+    ///
+    /// SQL sources are skipped (they require an external query tool). A claim
+    /// backed only by SQL sources is marked inconclusive (pass=true, no actual).
+    pub fn verify(&self, manifest: &VerifyManifest) -> Vec<ClaimResult> {
+        let mut resolved_values: HashMap<String, f64> = HashMap::new();
+        let mut results = Vec::with_capacity(manifest.claims.len());
+
+        for claim in &manifest.claims {
+            let result = verify_claim(claim, &resolved_values);
+            let representative = result.actual.unwrap_or(claim.value);
+            resolved_values.insert(claim.id.clone(), representative);
+            results.push(result);
+        }
+
+        results
+    }
+
+    /// Load a manifest from a JSON file and verify it.
+    ///
+    /// # Errors
+    ///
+    /// Returns `VerifyError` if the file cannot be read or if the JSON is invalid.
+    pub fn verify_file(&self, path: &std::path::Path) -> Result<Vec<ClaimResult>, VerifyError> {
+        let raw = std::fs::read_to_string(path).context(error::ReadManifestSnafu {
+            path: path.display().to_string(),
+        })?;
+
+        let manifest: VerifyManifest =
+            serde_json::from_str(&raw).map_err(|e| VerifyError::ParseManifest {
+                path: path.display().to_string(),
+                detail: e.to_string(),
+            })?;
+
+        Ok(self.verify(&manifest))
+    }
+}
+
+// ── Result types ─────────────────────────────────────────────────────────────
+
+/// Result of validating a single claim.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaimResult {
+    /// Claim identifier.
+    pub id: String,
+    /// Verbatim claim text.
+    pub text: String,
+    /// The numeric value asserted.
+    pub claimed: f64,
+    /// The value resolved from sources, if any source was resolvable.
+    pub actual: Option<f64>,
+    /// Absolute difference between `actual` and `claimed`, if `actual` is set.
+    pub diff: Option<f64>,
+    /// Tolerance used for this claim.
+    pub tolerance: f64,
+    /// Human-readable unit.
+    pub unit: String,
+    /// True iff the claim passes all checks.
+    pub pass: bool,
+    /// Result of the arithmetic sub-check, if an `arithmetic` formula was provided.
+    pub arith_check: Option<ArithCheck>,
+}
+
+/// Result of the arithmetic formula sub-check.
+#[derive(Debug, Clone, Serialize)]
+pub struct ArithCheck {
+    /// The formula evaluated.
+    pub formula: String,
+    /// Expected result from the manifest.
+    pub expected: f64,
+    /// Actual evaluated result.
+    pub actual: f64,
+    /// Absolute difference.
+    pub diff: f64,
+    /// True iff diff <= tolerance.
+    pub pass: bool,
+}
+
+/// Summary of a full manifest verification run.
+#[derive(Debug, Clone, Serialize)]
+pub struct VerifyResult {
+    /// Per-claim results.
+    pub claims: Vec<ClaimResult>,
+    /// Total number of claims.
+    pub total: usize,
+    /// Number of passing claims.
+    pub passed: usize,
+    /// Number of failing claims.
+    pub failed: usize,
+}
+
+impl VerifyResult {
+    /// Build a `VerifyResult` from a list of `ClaimResult`s.
+    pub fn from_claims(claims: Vec<ClaimResult>) -> Self {
+        let total = claims.len();
+        let passed = claims.iter().filter(|r| r.pass).count();
+        let failed = total - passed;
+        Self {
+            claims,
+            total,
+            passed,
+            failed,
+        }
+    }
+
+    /// Return true if any claim failed.
+    pub fn any_failed(&self) -> bool {
+        self.failed > 0
+    }
+}
+
+// ── Internal claim validation ─────────────────────────────────────────────────
+
+fn verify_claim(claim: &Claim, resolved_claims: &HashMap<String, f64>) -> ClaimResult {
+    let mut source_value: Option<f64> = None;
+
+    for src in &claim.sources {
+        if let Some(v) = resolve_source(src, resolved_claims) {
+            source_value = Some(v);
+            break;
+        }
+        // None: source not resolvable (SQL or unresolved Ref) — try next.
+    }
+
+    let arith_result = claim.arithmetic.as_ref().and_then(|arith| {
+        match arithmetic::check(&arith.formula, arith.result, claim.tolerance) {
+            Ok(r) => Some(ArithCheck {
+                formula: arith.formula.clone(),
+                expected: arith.result,
+                actual: r.actual,
+                diff: r.diff,
+                pass: r.pass,
+            }),
+            Err(_) => None,
+        }
+    });
+
+    let (pass, diff, actual) = determine_outcome(
+        claim.value,
+        claim.tolerance,
+        source_value,
+        arith_result.as_ref(),
+    );
+
+    ClaimResult {
+        id: claim.id.clone(),
+        text: claim.text.clone(),
+        claimed: claim.value,
+        actual,
+        diff,
+        tolerance: claim.tolerance,
+        unit: claim.unit.clone(),
+        pass,
+        arith_check: arith_result,
+    }
+}
+
+/// Resolve a single source to a scalar f64, or None if unresolvable.
+///
+/// SQL sources always return None (execution not in scope for this crate).
+fn resolve_source(source: &Source, resolved_claims: &HashMap<String, f64>) -> Option<f64> {
+    match source {
+        Source::Sql { .. } => None,
+        Source::Derived { formula, .. } => arithmetic::eval(formula).ok(),
+        Source::Ref { ref_id } => resolved_claims.get(ref_id.as_str()).copied(),
+    }
+}
+
+fn determine_outcome(
+    claimed: f64,
+    tolerance: f64,
+    source_value: Option<f64>,
+    arith_result: Option<&ArithCheck>,
+) -> (bool, Option<f64>, Option<f64>) {
+    match source_value {
+        Some(actual) => {
+            let diff = (actual - claimed).abs();
+            let source_pass = diff <= tolerance;
+            let arith_pass = arith_result.is_none_or(|a| a.pass);
+            (source_pass && arith_pass, Some(diff), Some(actual))
+        }
+        None => {
+            // No resolvable source; fall back to arithmetic-only check.
+            match arith_result {
+                Some(a) => (a.pass, Some(a.diff), Some(a.actual)),
+                None => {
+                    // Nothing resolvable — inconclusive (treat as pass).
+                    (true, None, None)
+                }
+            }
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions against known-length collections"
+)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn derived_manifest(formula: &str, claimed: f64, tolerance: f64) -> VerifyManifest {
+        VerifyManifest {
+            report: "test.typ".to_owned(),
+            claims: vec![Claim {
+                id: "c1".to_owned(),
+                text: "test claim".to_owned(),
+                value: claimed,
+                unit: "dollars".to_owned(),
+                location: "line 1".to_owned(),
+                sources: vec![Source::Derived {
+                    formula: formula.to_owned(),
+                    result: None,
+                }],
+                arithmetic: None,
+                tolerance,
+                status: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn derived_source_pass() {
+        let manifest = derived_manifest("50 + 50", 100.0, 0.0);
+        let v = Verifier::new();
+        let results = v.verify(&manifest);
+        assert_eq!(results.len(), 1, "must have one result");
+        assert!(results[0].pass, "50 + 50 vs claimed 100 must PASS");
+    }
+
+    #[test]
+    fn derived_source_fail() {
+        let manifest = derived_manifest("50 + 49", 100.0, 0.0);
+        let v = Verifier::new();
+        let results = v.verify(&manifest);
+        assert!(!results[0].pass, "50 + 49 vs claimed 100 must FAIL");
+    }
+
+    #[test]
+    fn tolerance_allows_small_diff() {
+        let manifest = derived_manifest("100.5", 100.0, 1.0);
+        let v = Verifier::new();
+        let results = v.verify(&manifest);
+        assert!(results[0].pass, "diff 0.5 within tolerance 1.0 must PASS");
+    }
+
+    #[test]
+    fn reference_claim_resolves() {
+        let manifest = VerifyManifest {
+            report: "r.typ".to_owned(),
+            claims: vec![
+                Claim {
+                    id: "base".to_owned(),
+                    text: "100".to_owned(),
+                    value: 100.0,
+                    unit: "dollars".to_owned(),
+                    location: "line 1".to_owned(),
+                    sources: vec![Source::Derived {
+                        formula: "100".to_owned(),
+                        result: None,
+                    }],
+                    arithmetic: None,
+                    tolerance: 0.0,
+                    status: None,
+                },
+                Claim {
+                    id: "ref_check".to_owned(),
+                    text: "also 100".to_owned(),
+                    value: 100.0,
+                    unit: "dollars".to_owned(),
+                    location: "line 2".to_owned(),
+                    sources: vec![Source::Ref {
+                        ref_id: "base".to_owned(),
+                    }],
+                    arithmetic: None,
+                    tolerance: 0.0,
+                    status: None,
+                },
+            ],
+        };
+        let v = Verifier::new();
+        let results = v.verify(&manifest);
+        assert_eq!(results.len(), 2, "must have two results");
+        assert!(results[0].pass, "base claim must PASS");
+        assert!(results[1].pass, "reference claim must PASS");
+    }
+
+    #[test]
+    fn arithmetic_check_independent() {
+        let manifest = VerifyManifest {
+            report: "r.typ".to_owned(),
+            claims: vec![Claim {
+                id: "c".to_owned(),
+                text: "107784".to_owned(),
+                value: 107_784.0,
+                unit: "dollars".to_owned(),
+                location: "line 1".to_owned(),
+                sources: vec![Source::Derived {
+                    formula: "107784".to_owned(),
+                    result: None,
+                }],
+                arithmetic: Some(Arithmetic {
+                    formula: "78187 + 26558 + 1620 + 1165 + 127 + 127 + 0".to_owned(),
+                    result: 107_784.0,
+                }),
+                tolerance: 1.0,
+                status: None,
+            }],
+        };
+        let v = Verifier::new();
+        let results = v.verify(&manifest);
+        assert!(results[0].pass, "arithmetic check with source must PASS");
+        let arith = results[0]
+            .arith_check
+            .as_ref()
+            .expect("must have arith_check");
+        assert!(arith.pass, "arithmetic formula check must PASS");
+    }
+
+    #[test]
+    fn sql_source_skipped_inconclusive() {
+        let manifest = VerifyManifest {
+            report: "r.typ".to_owned(),
+            claims: vec![Claim {
+                id: "c".to_owned(),
+                text: "100".to_owned(),
+                value: 100.0,
+                unit: "dollars".to_owned(),
+                location: "line 1".to_owned(),
+                sources: vec![Source::Sql {
+                    table: "t".to_owned(),
+                    query: "SELECT 100".to_owned(),
+                    result: None,
+                    queried: "2026-04-01".to_owned(),
+                }],
+                arithmetic: None,
+                tolerance: 0.0,
+                status: None,
+            }],
+        };
+        // SQL-only claim is inconclusive (pass=true, actual=None).
+        let v = Verifier::new();
+        let results = v.verify(&manifest);
+        assert!(
+            results[0].pass,
+            "SQL-only claim with no arithmetic must be inconclusive (pass)"
+        );
+        assert!(
+            results[0].actual.is_none(),
+            "SQL-only claim must have no actual value"
+        );
+    }
+
+    #[test]
+    fn verify_result_any_failed() {
+        let claims = vec![
+            ClaimResult {
+                id: "a".to_owned(),
+                text: "pass".to_owned(),
+                claimed: 1.0,
+                actual: Some(1.0),
+                diff: Some(0.0),
+                tolerance: 0.0,
+                unit: "n".to_owned(),
+                pass: true,
+                arith_check: None,
+            },
+            ClaimResult {
+                id: "b".to_owned(),
+                text: "fail".to_owned(),
+                claimed: 2.0,
+                actual: Some(3.0),
+                diff: Some(1.0),
+                tolerance: 0.0,
+                unit: "n".to_owned(),
+                pass: false,
+                arith_check: None,
+            },
+        ];
+        let r = VerifyResult::from_claims(claims);
+        assert!(
+            r.any_failed(),
+            "result with one failed claim must return true"
+        );
+        assert_eq!(r.total, 2, "total must be 2");
+        assert_eq!(r.passed, 1, "passed must be 1");
+        assert_eq!(r.failed, 1, "failed must be 1");
+    }
+}

--- a/crates/poiesis/verify/src/manifest.rs
+++ b/crates/poiesis/verify/src/manifest.rs
@@ -1,0 +1,216 @@
+// Manifest schema for poiesis-verify.
+//
+// WHY: the manifest is the source-of-truth for what was claimed and what was
+// queried. Keeping deserialization in one place makes the schema easy to evolve.
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level verify manifest: maps report claims to their sources.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifyManifest {
+    /// Path or name of the report this manifest covers.
+    pub report: String,
+    /// Every numeric (or categorical) claim made in the report.
+    pub claims: Vec<Claim>,
+}
+
+/// A single verifiable claim from the report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Claim {
+    /// Unique, stable identifier used by reference sources.
+    pub id: String,
+    /// Verbatim text of the claim as it appears in the report.
+    pub text: String,
+    /// The numeric value asserted by the claim.
+    pub value: f64,
+    /// Human-readable unit (e.g. "dollars", "percent", "count").
+    pub unit: String,
+    /// Location in the report source (e.g. "line 104, h2 heading").
+    pub location: String,
+    /// One or more sources that back the claim.
+    pub sources: Vec<Source>,
+    /// Optional arithmetic formula that produces `value` from its components.
+    pub arithmetic: Option<Arithmetic>,
+    /// Maximum acceptable absolute difference between `value` and the resolved
+    /// source value for the claim to PASS.
+    #[serde(default = "default_tolerance")]
+    pub tolerance: f64,
+    /// Last known status from a previous verification run.
+    pub status: Option<String>,
+}
+
+/// A single source backing a claim.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum Source {
+    /// A SQL query (stored for record-keeping; execution not performed by this crate).
+    Sql {
+        /// Primary table queried (for display purposes).
+        table: String,
+        /// Full SQL query text.
+        query: String,
+        /// Last observed result (populated on verify, null in authored manifest).
+        result: Option<f64>,
+        /// ISO-8601 date the query was last run.
+        queried: String,
+    },
+    /// An arithmetic expression derived from other values.
+    Derived {
+        /// Formula string (e.g. "106365 / 107784 * 100").
+        formula: String,
+        /// Last observed result.
+        result: Option<f64>,
+    },
+    /// Pointer to another claim's validated value.
+    #[serde(rename = "reference")]
+    Ref {
+        /// The `id` of the referenced claim.
+        #[serde(rename = "ref")]
+        ref_id: String,
+    },
+}
+
+/// Arithmetic formula check for a claim.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Arithmetic {
+    /// Formula string (e.g. "78187 + 26558 + 1620").
+    pub formula: String,
+    /// Expected result of evaluating the formula.
+    pub result: f64,
+}
+
+fn default_tolerance() -> f64 {
+    // WHY: default to strict zero tolerance; callers must opt in to slack.
+    0.0
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test assertions against known-length collections"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_sql_source() {
+        let json = r#"
+        {
+            "report": "test.typ",
+            "claims": [{
+                "id": "total",
+                "text": "$100",
+                "value": 100.0,
+                "unit": "dollars",
+                "location": "line 1",
+                "sources": [{
+                    "type": "sql",
+                    "table": "public.roi",
+                    "query": "SELECT SUM(x) FROM public.roi",
+                    "result": 100.45,
+                    "queried": "2026-04-01"
+                }],
+                "arithmetic": null,
+                "tolerance": 1.0,
+                "status": "pass"
+            }]
+        }"#;
+
+        let manifest: VerifyManifest = serde_json::from_str(json).expect("must parse");
+        assert_eq!(manifest.report, "test.typ", "report name must match");
+        assert_eq!(manifest.claims.len(), 1, "must have one claim");
+
+        let claim = &manifest.claims[0];
+        assert_eq!(claim.id, "total", "id must match");
+        assert!((claim.value - 100.0_f64).abs() < 1e-9, "value must match");
+        assert!(
+            (claim.tolerance - 1.0_f64).abs() < 1e-9,
+            "tolerance must match"
+        );
+    }
+
+    #[test]
+    fn roundtrip_derived_source() {
+        let json = r#"
+        {
+            "report": "r.typ",
+            "claims": [{
+                "id": "pct",
+                "text": "98.7%",
+                "value": 98.7,
+                "unit": "percent",
+                "location": "line 5",
+                "sources": [{
+                    "type": "derived",
+                    "formula": "106365 / 107784 * 100",
+                    "result": 98.68
+                }],
+                "arithmetic": null,
+                "tolerance": 0.1,
+                "status": null
+            }]
+        }"#;
+
+        let manifest: VerifyManifest = serde_json::from_str(json).expect("must parse");
+        assert!(
+            matches!(
+                &manifest.claims[0].sources[0],
+                Source::Derived { formula, .. } if formula == "106365 / 107784 * 100"
+            ),
+            "source must be Derived with correct formula"
+        );
+    }
+
+    #[test]
+    fn roundtrip_reference_source() {
+        let json = r#"
+        {
+            "report": "r.typ",
+            "claims": [{
+                "id": "pct",
+                "text": "98.7%",
+                "value": 98.7,
+                "unit": "percent",
+                "location": "line 5",
+                "sources": [{"type": "reference", "ref": "total_savings"}],
+                "arithmetic": null,
+                "tolerance": 0.0,
+                "status": null
+            }]
+        }"#;
+
+        let manifest: VerifyManifest = serde_json::from_str(json).expect("must parse");
+        assert!(
+            matches!(
+                &manifest.claims[0].sources[0],
+                Source::Ref { ref_id } if ref_id == "total_savings"
+            ),
+            "source must be Ref with correct ref_id"
+        );
+    }
+
+    #[test]
+    fn default_tolerance_is_zero() {
+        let json = r#"
+        {
+            "report": "r.typ",
+            "claims": [{
+                "id": "x",
+                "text": "1",
+                "value": 1.0,
+                "unit": "count",
+                "location": "line 1",
+                "sources": [{"type": "derived", "formula": "1", "result": 1.0}],
+                "arithmetic": null,
+                "status": null
+            }]
+        }"#;
+
+        let manifest: VerifyManifest = serde_json::from_str(json).expect("must parse");
+        assert!(
+            manifest.claims[0].tolerance.abs() < 1e-12,
+            "omitting tolerance must default to 0.0"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Salvaged from the in-flight `feat/poiesis-sdr-expansion` branch (task #3450). Adds two new crates to the poiesis family and three organon tools that consume them, closing the loop between document generation, prose quality linting, and numeric claim verification.

### New crates

**`crates/poiesis/lint`** — stateless report-prose linter:
- Banned-word/phrase checks (AI tropes + filler phrases sourced from `WRITING.md`) with word-boundary awareness and optional auto-fix.
- Citation presence check: any table marker must have a source marker within a configurable window.
- Structural pattern check: flags \u{2265}3 consecutive paragraphs opening with a transition word.
- Required-section check: looks for a lead (`## Summary` / `## Overview` / \u{2026}) and a closing (`## References` / `## Appendix` / \u{2026}).
- H2 heading length check.

**`crates/poiesis/verify`** — numeric claim verifier:
- Recursive-descent arithmetic evaluator (+, \u{2212}, *, /, parens, unary minus, no external deps).
- Manifest schema with `Sql` / `Derived` / `Ref` source kinds. SQL is stored for audit but not executed by this crate.
- Per-claim tolerance, cross-claim `Ref` resolution in manifest order (no topo sort needed).

### Organon tools (`crates/organon/src/builtins/poiesis.rs`, 422 LOC)

- `generate_document` \u{2014} render a JSON block descriptor to ODT / XLSX / PDF using the existing poiesis renderers.
- `lint_report` \u{2014} run the lint pipeline, return findings JSON; optional in-place fix application.
- `verify_report` \u{2014} load a manifest and return per-claim pass/fail + diffs.

All registered through `builtins/mod.rs::register_all_with_sandbox`.

### Dependency graph

- `poiesis-lint`: `serde`, `serde_json`, `snafu` (zero runtime deps beyond what's already in the workspace).
- `poiesis-verify`: same \u{2014} no math crate, no parser-combinator crate.
- `organon`: adds path deps on `poiesis-core`, `poiesis-text`, `poiesis-sheet`, `poiesis-lint`, `poiesis-verify`.

## One behavior touch-up during salvage

`parse_block` in `organon/src/builtins/poiesis.rs` cast `u64 -> u8` for heading levels with an `as` cast. Changed to `u8::try_from(n.min(6)).ok().unwrap_or(1)` so a malformed oversize level falls back safely.

## Depends on

- Based on [#3677](https://github.com/forkwright/aletheia/pull/3677) for the energeia salvage fixes. Rebase to `main` after that lands.

## Test plan

- [x] `cargo test -p poiesis-lint -p poiesis-verify -p organon` \u{2014} all pass
- [x] `cargo clippy --workspace --features test-core --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] CI: ubuntu + macos clippy/test, cargo deny, cargo audit, PII scan