### PR TITLE
feat(nous): _llm bootstrap wiring

### DIFF
--- a/crates/nous/src/bootstrap/bootstrap_tests/mod.rs
+++ b/crates/nous/src/bootstrap/bootstrap_tests/mod.rs
@@ -28,6 +28,18 @@ pub(super) fn setup_oikos(nous_id: &str, files: &[(&str, &str)]) -> (TempDir, Oi
                 reason = "nous bootstrap and test setup writes configuration files to temp directories; synchronous I/O is required in test contexts"
             )]
             fs::write(root.join("theke").join(stripped), content).expect("write theke file");
+        } else if let Some(stripped) = name.strip_prefix("_llm:") {
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "nous bootstrap and test setup writes configuration files to temp directories; synchronous I/O is required in test contexts"
+            )]
+            {
+                let path = root.join("_llm").join(stripped);
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent).expect("create _llm parent dir");
+                }
+                fs::write(path, content).expect("write _llm file");
+            }
         } else {
             #[expect(
                 clippy::disallowed_methods,
@@ -837,5 +849,250 @@ async fn assemble_output_style_defaults_when_no_communication_section() {
     assert!(
         result.system_prompt.contains("Answer-first"),
         "output-style should use defaults when USER.md has no Communication section"
+    );
+}
+
+// --- _llm manifest bootstrap tests ---
+
+#[tokio::test]
+async fn assemble_llm_cold_start_loads_l1_required_and_l3_optional() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            (
+                "_llm:manifest.toml",
+                "version = 1\n\n[levels.L3]\npath = \"L3-api-index\"\n",
+            ),
+            ("_llm:README.md", "workspace overview"),
+            ("_llm:L3-api-index/nous.md", "nous api index"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos).with_llm_recipe(LlmRecipe::ColdStart);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional_with_recipe(
+            "test",
+            &mut budget,
+            Vec::new(),
+            TaskHint::General,
+            LlmRecipe::ColdStart,
+        )
+        .await
+        .expect("assemble should succeed");
+
+    assert!(
+        result
+            .sections_included
+            .contains(&"_llm/README.md".to_owned()),
+        "L1 _llm file should be included for ColdStart"
+    );
+    assert!(
+        result
+            .sections_included
+            .contains(&"_llm/L3-api-index/nous.md".to_owned()),
+        "L3 _llm file should be included for ColdStart"
+    );
+    // L1 should be Required priority, so it sorts before workspace Flexible files
+    let l1_pos = result
+        .sections_included
+        .iter()
+        .position(|s| s == "_llm/README.md")
+        .expect("L1 should be in sections");
+    let soul_pos = result
+        .sections_included
+        .iter()
+        .position(|s| s == "SOUL.md")
+        .expect("SOUL.md should be in sections");
+    assert!(
+        l1_pos > soul_pos,
+        "L1 (Important/Required) should sort after SOUL.md (Required) but before Flexible files"
+    );
+}
+
+#[tokio::test]
+async fn assemble_llm_none_skips_all_llm_content() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            (
+                "_llm:manifest.toml",
+                "version = 1\n\n[levels.L3]\npath = \"L3-api-index\"\n",
+            ),
+            ("_llm:README.md", "workspace overview"),
+            ("_llm:L3-api-index/nous.md", "nous api index"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos).with_llm_recipe(LlmRecipe::None);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional_with_recipe(
+            "test",
+            &mut budget,
+            Vec::new(),
+            TaskHint::General,
+            LlmRecipe::None,
+        )
+        .await
+        .expect("assemble should succeed");
+
+    assert!(
+        !result.system_prompt.contains("workspace overview"),
+        "_llm content should be skipped when recipe is None"
+    );
+    assert!(
+        !result
+            .sections_included
+            .iter()
+            .any(|s| s.starts_with("_llm/")),
+        "no _llm sections should appear when recipe is None"
+    );
+}
+
+#[tokio::test]
+async fn assemble_llm_missing_directory_no_regression() {
+    let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "identity")]);
+    let assembler = BootstrapAssembler::new(&oikos).with_llm_recipe(LlmRecipe::ColdStart);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional_with_recipe(
+            "test",
+            &mut budget,
+            Vec::new(),
+            TaskHint::General,
+            LlmRecipe::ColdStart,
+        )
+        .await
+        .expect("assemble should succeed even without _llm/ directory");
+
+    assert_eq!(
+        result.sections_included,
+        vec!["SOUL.md", "output-style"],
+        "bootstrap should work as before when _llm/ is absent"
+    );
+}
+
+#[tokio::test]
+async fn assemble_llm_respects_token_budget() {
+    let large_llm = "x".repeat(10_000); // ~2500 tokens at 4 chars/token
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            (
+                "_llm:manifest.toml",
+                "version = 1\n\n[levels.L3]\npath = \"L3-api-index\"\n",
+            ),
+            ("_llm:README.md", &large_llm),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos).with_llm_recipe(LlmRecipe::InSession);
+    let mut budget = TokenBudget::new(100_000, 0.0, 0, 500);
+
+    let result = assembler
+        .assemble_conditional_with_recipe(
+            "test",
+            &mut budget,
+            Vec::new(),
+            TaskHint::General,
+            LlmRecipe::InSession,
+        )
+        .await
+        .expect("assemble should succeed");
+
+    assert!(
+        result.sections_included.contains(&"SOUL.md".to_owned()),
+        "SOUL.md should always be included"
+    );
+    // L1 is Optional for InSession and is truncatable. With ~430 tokens remaining
+    // after SOUL.md + output-style, the large _llm content should be truncated to fit.
+    assert!(
+        result
+            .sections_truncated
+            .contains(&"_llm/README.md".to_owned()),
+        "large optional _llm content should be truncated under tight budget"
+    );
+    assert!(
+        result.total_tokens <= 500,
+        "total tokens should respect the bootstrap budget"
+    );
+}
+
+#[tokio::test]
+async fn assemble_llm_refactor_loads_l1_and_l3_important() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            (
+                "_llm:manifest.toml",
+                "version = 1\n\n[levels.L3]\npath = \"L3-api-index\"\n",
+            ),
+            ("_llm:architecture.toml", "architecture decisions"),
+            ("_llm:L3-api-index/nous.md", "nous api index"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos).with_llm_recipe(LlmRecipe::Refactor);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional_with_recipe(
+            "test",
+            &mut budget,
+            Vec::new(),
+            TaskHint::Planning,
+            LlmRecipe::Refactor,
+        )
+        .await
+        .expect("assemble should succeed");
+
+    assert!(
+        result
+            .sections_included
+            .contains(&"_llm/architecture.toml".to_owned()),
+        "L1 should be included for Refactor recipe"
+    );
+    assert!(
+        result
+            .sections_included
+            .contains(&"_llm/L3-api-index/nous.md".to_owned()),
+        "L3 should be included for Refactor recipe"
+    );
+}
+
+#[tokio::test]
+async fn assemble_llm_malformed_manifest_is_skipped() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "identity"),
+            ("_llm:manifest.toml", "this is not valid toml <<<<<"),
+            ("_llm:README.md", "workspace overview"),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos).with_llm_recipe(LlmRecipe::ColdStart);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble_conditional_with_recipe(
+            "test",
+            &mut budget,
+            Vec::new(),
+            TaskHint::General,
+            LlmRecipe::ColdStart,
+        )
+        .await
+        .expect("assemble should succeed even with malformed manifest");
+
+    assert!(
+        !result
+            .sections_included
+            .iter()
+            .any(|s| s.starts_with("_llm/")),
+        "malformed manifest should cause graceful skip of all _llm content"
     );
 }

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use std::time::{Duration, Instant, SystemTime};
 
+use serde::Deserialize;
 use snafu::IntoError as _;
 use tracing::{debug, info, warn};
 
@@ -256,6 +257,40 @@ pub enum TaskHint {
     Conversation,
 }
 
+/// Recipe for loading `_llm/` content into the bootstrap system prompt.
+///
+/// Maps _llm/ levels to bootstrap priorities based on session state and
+/// task type. Selected automatically from [`TaskHint`] or overridden via
+/// dispatch metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum LlmRecipe {
+    /// Load L1 as Required, L3 as Optional. Used on first turn (cold start).
+    #[default]
+    ColdStart,
+    /// Load L1 as Optional, L3 as Optional. Used for general in-session turns.
+    InSession,
+    /// Load L1 as Important, L3 as Important. Used for planning and refactoring.
+    Refactor,
+    /// Skip all `_llm/` content.
+    None,
+}
+
+impl LlmRecipe {
+    /// Select a recipe based on task hint and whether this is the first turn.
+    #[must_use]
+    pub fn from_task_hint(task_hint: TaskHint, is_cold_start: bool) -> Self {
+        if is_cold_start {
+            return Self::ColdStart;
+        }
+        match task_hint {
+            TaskHint::Planning => Self::Refactor,
+            TaskHint::Conversation => Self::None,
+            _ => Self::InSession,
+        }
+    }
+}
+
 /// Load tier: whether a workspace file loads unconditionally or based on task hint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LoadTier {
@@ -402,6 +437,50 @@ const DEFAULT_OUTPUT_STYLE: &str = "\
 - No forced linearity, no basics when the bigger picture is visible.
 - If you can say it in one sentence, don't use three.";
 
+/// Parsed `_llm/manifest.toml` describing available levels.
+///
+/// WHY: The manifest is the single source of truth for which _llm/ levels
+/// exist and where they live. Parsing it lets the bootstrap assembler
+/// discover levels dynamically rather than hardcoding paths.
+#[derive(Debug, Clone, Deserialize)]
+#[expect(
+    dead_code,
+    reason = "fields deserialized from manifest for future use but not yet consumed"
+)]
+struct LlmManifest {
+    #[serde(default)]
+    version: u32,
+    #[serde(default)]
+    levels: HashMap<String, LlmLevel>,
+    #[serde(default)]
+    crates: Vec<LlmManifestCrate>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[expect(
+    dead_code,
+    reason = "fields deserialized from manifest for future use but not yet consumed"
+)]
+struct LlmLevel {
+    path: String,
+    #[serde(default)]
+    generator: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[expect(
+    dead_code,
+    reason = "fields deserialized from manifest for future use but not yet consumed"
+)]
+struct LlmManifestCrate {
+    name: String,
+    path: String,
+    #[serde(rename = "source_hash")]
+    _source_hash: String,
+    #[serde(rename = "l3_token_estimate")]
+    _l3_token_estimate: u64,
+}
+
 /// Assembles the bootstrap system prompt from oikos workspace files.
 ///
 /// Resolves files through the three-tier cascade (`nous/{id}/` → `shared/` → `theke/`),
@@ -419,6 +498,8 @@ pub struct BootstrapAssembler<'a> {
     /// Shared file cache: `None` disables caching (legacy path, used by tests
     /// that want guaranteed fresh reads).
     cache: Option<&'a BootstrapFileCache>,
+    /// Recipe for loading `_llm/` content. `None` skips _llm/ entirely.
+    llm_recipe: LlmRecipe,
 }
 
 impl<'a> BootstrapAssembler<'a> {
@@ -432,6 +513,7 @@ impl<'a> BootstrapAssembler<'a> {
             estimator: CharEstimator::default(),
             min_truncation_budget,
             cache: None,
+            llm_recipe: LlmRecipe::default(),
         }
     }
 
@@ -448,6 +530,7 @@ impl<'a> BootstrapAssembler<'a> {
             estimator: CharEstimator::new(chars_per_token),
             min_truncation_budget,
             cache: None,
+            llm_recipe: LlmRecipe::default(),
         }
     }
 
@@ -459,6 +542,16 @@ impl<'a> BootstrapAssembler<'a> {
     #[must_use]
     pub fn with_cache(mut self, cache: &'a BootstrapFileCache) -> Self {
         self.cache = Some(cache);
+        self
+    }
+
+    /// Set the [`LlmRecipe`] for loading `_llm/` content.
+    ///
+    /// Determines which _llm/ levels are loaded and at what priority tier.
+    /// The default is [`LlmRecipe::ColdStart`].
+    #[must_use]
+    pub fn with_llm_recipe(mut self, recipe: LlmRecipe) -> Self {
+        self.llm_recipe = recipe;
         self
     }
 
@@ -526,11 +619,10 @@ impl<'a> BootstrapAssembler<'a> {
     /// Operational files (AGENTS, GOALS, TOOLS, CHECKLIST, MEMORY, CONTEXT)
     /// load only when relevant to the task hint.
     ///
-    /// # Why
-    ///
-    /// Identity files define "who the agent is" and must always load.
-    /// Operational files bloat the context window unnecessarily for simple
-    /// queries. Loading TOOLS.md for a casual greeting wastes tokens.
+    /// Uses [`LlmRecipe::from_task_hint`] with `is_cold_start = false` to
+    /// select the _llm/ loading recipe. Use
+    /// [`assemble_conditional_with_recipe`](Self::assemble_conditional_with_recipe)
+    /// for explicit recipe control (e.g. cold-start detection).
     ///
     /// # Complexity
     ///
@@ -554,8 +646,44 @@ impl<'a> BootstrapAssembler<'a> {
         extra_sections: Vec<BootstrapSection>,
         hint: TaskHint,
     ) -> Result<BootstrapResult> {
+        self.assemble_conditional_with_recipe(
+            nous_id,
+            budget,
+            extra_sections,
+            hint,
+            self.llm_recipe,
+        )
+        .await
+    }
+
+    /// Assemble the bootstrap system prompt with conditional file loading and
+    /// explicit _llm/ recipe control.
+    ///
+    /// Same as [`assemble_conditional`](Self::assemble_conditional) but accepts
+    /// an explicit [`LlmRecipe`] so callers can override automatic selection
+    /// (e.g. to load L1 as Required on a cold start).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`error::Error::ContextAssembly`] if a Required file (SOUL.md) is
+    /// missing or unreadable.
+    ///
+    /// # Cancel safety
+    ///
+    /// Not cancel-safe. Delegates to the same I/O path as `assemble_conditional`.
+    pub async fn assemble_conditional_with_recipe(
+        &self,
+        nous_id: &str,
+        budget: &mut TokenBudget,
+        extra_sections: Vec<BootstrapSection>,
+        hint: TaskHint,
+        recipe: LlmRecipe,
+    ) -> Result<BootstrapResult> {
         let (mut sections, filtered_names) = self.resolve_workspace_files(nous_id, hint).await?;
         sections.extend(extra_sections);
+
+        let llm_sections = self.resolve_llm_sections(recipe).await;
+        sections.extend(llm_sections);
 
         // NOTE: stable sort preserves declaration order within same priority
         sections.sort_by_key(|s| s.priority);
@@ -782,6 +910,173 @@ impl<'a> BootstrapAssembler<'a> {
         debug!("injected output-style section ({style_tokens} tokens)");
 
         Ok((sections, filtered))
+    }
+
+    /// Resolve `_llm/` content into bootstrap sections based on the recipe.
+    ///
+    /// Reads `_llm/manifest.toml` when present to discover available levels.
+    /// Loads L1 (workspace manifest files at `_llm/` root) and L3 (cross-crate
+    /// index from the path declared in the manifest). L2 is reserved for
+    /// per-crate summaries and skipped when absent.
+    ///
+    /// Returns an empty vec when:
+    /// - the recipe is [`LlmRecipe::None`]
+    /// - `_llm/manifest.toml` does not exist
+    /// - any I/O or parse error occurs (logged, not propagated)
+    ///
+    /// # Cancel safety
+    ///
+    /// Not cancel-safe. Performs async file I/O.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "L1 + L3 loading in one method keeps the recipe→levels mapping colocated"
+    )]
+    async fn resolve_llm_sections(&self, recipe: LlmRecipe) -> Vec<BootstrapSection> {
+        if recipe == LlmRecipe::None {
+            return Vec::new();
+        }
+
+        let llm_root = self.oikos.root().join("_llm");
+        let manifest_path = llm_root.join("manifest.toml");
+
+        if !manifest_path.exists() {
+            debug!(path = %manifest_path.display(), "_llm/manifest.toml not found, skipping");
+            return Vec::new();
+        }
+
+        let manifest_raw = match tokio::fs::read_to_string(&manifest_path).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(
+                    path = %manifest_path.display(),
+                    error = %e,
+                    "failed to read _llm/manifest.toml, skipping"
+                );
+                return Vec::new();
+            }
+        };
+
+        let manifest: LlmManifest = match toml::from_str(&manifest_raw) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(
+                    path = %manifest_path.display(),
+                    error = %e,
+                    "failed to parse _llm/manifest.toml, skipping"
+                );
+                return Vec::new();
+            }
+        };
+
+        let mut sections = Vec::new();
+
+        // --- L1: workspace manifest files at _llm/ root ---
+        let (l1_priority, l1_truncatable) = match recipe {
+            LlmRecipe::ColdStart => (SectionPriority::Required, false),
+            LlmRecipe::InSession => (SectionPriority::Optional, true),
+            LlmRecipe::Refactor => (SectionPriority::Important, true),
+            LlmRecipe::None => return Vec::new(),
+        };
+
+        if let Ok(mut entries) = tokio::fs::read_dir(&llm_root).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let path = entry.path();
+                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+
+                if name == "manifest.toml" || name == "recipes.toml" {
+                    continue;
+                }
+                if path.is_dir() {
+                    continue;
+                }
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if !matches!(ext, "md" | "toml") {
+                    continue;
+                }
+
+                match tokio::fs::read_to_string(&path).await {
+                    Ok(raw) => {
+                        let content = raw.trim().to_owned();
+                        if content.is_empty() {
+                            continue;
+                        }
+                        let tokens = self.estimator.estimate(&content);
+                        sections.push(BootstrapSection {
+                            name: format!("_llm/{name}"),
+                            priority: l1_priority,
+                            content,
+                            tokens,
+                            truncatable: l1_truncatable,
+                        });
+                    }
+                    Err(e) => {
+                        warn!(
+                            path = %path.display(),
+                            error = %e,
+                            "failed to read _llm file, skipping"
+                        );
+                    }
+                }
+            }
+        }
+
+        // --- L3: cross-crate index ---
+        let (l3_priority, l3_truncatable) = match recipe {
+            LlmRecipe::ColdStart | LlmRecipe::InSession => (SectionPriority::Optional, true),
+            LlmRecipe::Refactor => (SectionPriority::Important, true),
+            LlmRecipe::None => return Vec::new(),
+        };
+
+        if let Some(l3_level) = manifest.levels.get("L3") {
+            let l3_dir = llm_root.join(&l3_level.path);
+            if l3_dir.is_dir()
+                && let Ok(mut entries) = tokio::fs::read_dir(&l3_dir).await
+            {
+                while let Ok(Some(entry)) = entries.next_entry().await {
+                    let path = entry.path();
+                    if !path.is_file() {
+                        continue;
+                    }
+                    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                        continue;
+                    };
+                    if !std::path::Path::new(name)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+                    {
+                        continue;
+                    }
+
+                    match tokio::fs::read_to_string(&path).await {
+                        Ok(raw) => {
+                            let content = raw.trim().to_owned();
+                            if content.is_empty() {
+                                continue;
+                            }
+                            let tokens = self.estimator.estimate(&content);
+                            sections.push(BootstrapSection {
+                                name: format!("_llm/{}/{name}", l3_level.path),
+                                priority: l3_priority,
+                                content,
+                                tokens,
+                                truncatable: l3_truncatable,
+                            });
+                        }
+                        Err(e) => {
+                            warn!(
+                                path = %path.display(),
+                                error = %e,
+                                "failed to read L3 index file, skipping"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        sections
     }
 
     /// Truncate a section to fit within the given token limit.

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -662,6 +662,7 @@ pub async fn assemble_context_conditional(
         ctx,
         extra_sections,
         task_hint,
+        crate::bootstrap::LlmRecipe::from_task_hint(task_hint, false),
         None,
     )
     .await
@@ -675,6 +676,10 @@ pub async fn assemble_context_conditional(
 /// reads across pipeline turns (#3388). When `None`, behaviour matches the
 /// legacy path that re-reads every file every turn.
 #[instrument(skip_all, fields(nous_id = %nous_config.id, ?task_hint))]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "recipe parameter required for explicit cold-start/refactor control (#3366)"
+)]
 pub async fn assemble_context_conditional_with_cache(
     oikos: &Oikos,
     nous_config: &NousConfig,
@@ -682,6 +687,7 @@ pub async fn assemble_context_conditional_with_cache(
     ctx: &mut PipelineContext,
     extra_sections: Vec<BootstrapSection>,
     task_hint: TaskHint,
+    recipe: crate::bootstrap::LlmRecipe,
     cache: Option<&crate::bootstrap::BootstrapFileCache>,
 ) -> crate::error::Result<()> {
     let mut budget = TokenBudget::new(
@@ -695,8 +701,15 @@ pub async fn assemble_context_conditional_with_cache(
     if let Some(cache) = cache {
         assembler = assembler.with_cache(cache);
     }
+    assembler = assembler.with_llm_recipe(recipe);
     let result = assembler
-        .assemble_conditional(&nous_config.id, &mut budget, extra_sections, task_hint)
+        .assemble_conditional_with_recipe(
+            &nous_config.id,
+            &mut budget,
+            extra_sections,
+            task_hint,
+            recipe,
+        )
         .await?;
 
     ctx.system_prompt = Some(result.system_prompt);
@@ -798,6 +811,8 @@ pub(crate) async fn run_pipeline(
 
         let mut ctx = PipelineContext::default();
         let task_hint = classify_task_hint(&input.content);
+        let recipe =
+            crate::bootstrap::LlmRecipe::from_task_hint(task_hint, input.session.turn == 1);
 
         run_context_stage(
             oikos,
@@ -806,6 +821,7 @@ pub(crate) async fn run_pipeline(
             &mut ctx,
             extra_bootstrap,
             task_hint,
+            recipe,
             bootstrap_cache,
             emitter,
         )

--- a/crates/nous/src/pipeline/stages.rs
+++ b/crates/nous/src/pipeline/stages.rs
@@ -14,7 +14,7 @@ use organon::registry::ToolRegistry;
 use organon::types::ToolContext;
 use taxis::oikos::Oikos;
 
-use crate::bootstrap::{BootstrapFileCache, BootstrapSection, TaskHint};
+use crate::bootstrap::{BootstrapFileCache, BootstrapSection, LlmRecipe, TaskHint};
 use crate::compact::CompactConfig;
 use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
@@ -40,6 +40,7 @@ pub(super) async fn run_context_stage(
     ctx: &mut PipelineContext,
     extra_bootstrap: Vec<BootstrapSection>,
     task_hint: TaskHint,
+    recipe: LlmRecipe,
     bootstrap_cache: Option<&BootstrapFileCache>,
     emitter: &EventEmitter,
 ) -> error::Result<()> {
@@ -57,6 +58,7 @@ pub(super) async fn run_context_stage(
         ctx,
         extra_bootstrap,
         task_hint,
+        recipe,
         bootstrap_cache,
     )
     .instrument(span.clone())


### PR DESCRIPTION
## Summary

Salvaged from the in-flight `feat/llm-bootstrap-wiring` branch (task #3366). Threads recipe-driven bootstrap through the nous pipeline so system-prompt assembly can be scoped per task type (cold start vs per-crate edits vs cross-crate refactors).

### What landed

- `crates/nous/src/bootstrap/mod.rs` — recipe-aware assembler that consults the `RecipeRegistry` for the pack of files to load per task type.
- `crates/nous/src/bootstrap/bootstrap_tests/` — new 257-line test module covering packing precedence and recipe selection.
- `crates/nous/src/pipeline/mod.rs` — stage selects a recipe from the turn context (task hints + crate/file signals).
- `crates/nous/src/pipeline/stages.rs` — stage wiring.

Other changes from the source branch (`execute/dispatch.rs`, `eval/src/benchmarks/*`, `taxis/src/config/behavior/dispatch.rs`) became null after 3-way merge — the relevant behavior already landed via other PRs (#3657, #3660, #3654, etc.). Only genuinely still-relevant changes kept.

**Note:** the two DPO correctness fixes originally salvaged here were moved down to #3677 so they sit at the base of the chain and benefit every dependent PR.

### Depends on

- Based on [#3677](https://github.com/forkwright/aletheia/pull/3677). Rebase to `main` after that lands.

## Test plan

- [x] `cargo test -p nous --lib` — all pass
- [x] `cargo clippy --workspace --features test-core --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] CI: ubuntu + macos clippy/test, cargo deny, cargo audit, PII scan