### PR TITLE
feat(mcp): Serena LSP-based code navigation (closes #3355)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ clawd
 **/heartbeat-state.json
 *sync-conflict*
 
+# === External MCP server state (see docs/MCP-SERVERS.md) ===
+.serena/
+
 # === Learned skills (instance-specific, not shipped) ===
 shared/skills/
 !shared/skills/_examples/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,7 @@ Crate architecture and dependency graph: `docs/ARCHITECTURE.md`.
 
 All PRs need `Gate-Passed: kanon 0.1.0` in a commit body.
 Desktop PRs: `Gate-Passed: kanon 0.1.0 desktop-only (excluded from workspace build)`.
+
+## Optional: LSP-powered navigation
+
+External MCP servers can give an agent IDE-level navigation across the 23-crate workspace. See [docs/MCP-SERVERS.md](docs/MCP-SERVERS.md) — `scripts/serena-mcp.sh register` wires up Serena (rust-analyzer via MCP) for `find_symbol`, `find_referencing_symbols`, and `rename_symbol` across crate boundaries.

--- a/docs/MCP-SERVERS.md
+++ b/docs/MCP-SERVERS.md
@@ -1,0 +1,121 @@
+# External MCP Servers
+
+Operator-side MCP servers that extend an agent's capabilities without modifying the aletheia binary. Aletheia is a 23-crate, ~348K LOC Rust workspace. Coding agents (Claude Code, Cursor, etc.) that only have grep and file reads burn tokens re-discovering structure that a Language Server could answer in one request. The servers below close that gap.
+
+These servers run as **operator-side tooling**, not as part of the aletheia binary. They are registered in the agent's client config (e.g. `~/.claude.json`, `.mcp.json`, or Cursor's `mcp.json`). No aletheia crate depends on them, and they are not wired into the `diaporeia` tool bus. See [Why external, not vendored](#why-external-not-vendored) below.
+
+## Index
+
+| Server | Purpose | Transport | Install |
+|--------|---------|-----------|---------|
+| [Serena](#serena-lsp-powered-code-navigation) | LSP-backed symbol navigation (go-to-def, find-refs, rename) | stdio | `uv tool install` |
+
+## Serena: LSP-powered code navigation
+
+[Serena](https://github.com/oraios/serena) wraps `rust-analyzer` (and 40+ other language servers) as MCP tools. For aletheia, this means an agent can ask:
+
+- **`find_symbol`** - locate a symbol by name/path across all 23 crates.
+- **`find_referencing_symbols`** - find every caller of a trait/fn/type across the workspace.
+- **`get_symbols_overview`** - get the top-level symbols defined in a file without reading it.
+- **`rename_symbol`** - workspace-wide safe rename via LSP refactoring.
+- **`replace_symbol_body`** / **`insert_before_symbol`** / **`insert_after_symbol`** - structured edits at symbol boundaries instead of fragile line/char patches.
+
+This is the same navigation an IDE user has, exposed as MCP.
+
+### Install
+
+```bash
+uv tool install -p 3.13 'serena-agent@latest' --prerelease=allow
+```
+
+This installs the `serena` and `serena-hooks` entry points. The `--prerelease=allow` flag is required by upstream install instructions to pick up the current release line.
+
+`rust-analyzer` is auto-fetched by Serena on first activation - no separate install step is required.
+
+### Register with claude code
+
+From the aletheia workspace root:
+
+```bash
+./scripts/serena-mcp.sh register
+```
+
+This is equivalent to:
+
+```bash
+claude mcp add serena -- serena start-mcp-server \
+    --context claude-code \
+    --project "$(pwd)" \
+    --enable-web-dashboard false \
+    --open-web-dashboard false
+```
+
+For a user-level registration usable from any project (uses the current working directory at tool invocation time):
+
+```bash
+claude mcp add --scope user serena -- serena start-mcp-server \
+    --context claude-code \
+    --project-from-cwd \
+    --enable-web-dashboard false \
+    --open-web-dashboard false
+```
+
+### Start the server manually (debug / non-Claude clients)
+
+```bash
+./scripts/serena-mcp.sh start
+```
+
+This foregrounds a stdio MCP server rooted at the aletheia workspace. Useful for:
+
+- Manually speaking JSON-RPC to validate the server (see [Smoke test](#smoke-test)).
+- Registering with Cursor, Windsurf, or any other MCP-capable client that expects a raw command.
+
+### On first start
+
+Serena auto-creates `.serena/` in the workspace root with `project.yml` (language detection - 70% Rust for aletheia), a `cache/` for the LSP index, and a `memories/` folder for Serena's own project notes. The `.serena/` directory is gitignored - it is operator-local state, not repo content.
+
+### Smoke test
+
+```bash
+printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.1"}}}\n' \
+  | ./scripts/serena-mcp.sh start 2>/dev/null \
+  | head -1
+```
+
+Expect a JSON-RPC response advertising `tools/list`, `resources/list`, etc. The server logs go to `~/.serena/logs/<date>/mcp_<timestamp>.txt`.
+
+### Tools exposed in `claude-code` context
+
+The `claude-code` context (upstream renamed from the deprecated `ide-assistant`) narrows Serena's 44-tool surface to 17 navigation/edit tools - file I/O, shell, and pattern-search tools are suppressed because Claude Code already provides those. Resulting active tools:
+
+```
+check_onboarding_performed, find_referencing_symbols, find_symbol,
+get_symbols_overview, initial_instructions, insert_after_symbol,
+insert_before_symbol, list_memories, onboarding, read_memory,
+rename_memory, rename_symbol, replace_symbol_body, safe_delete_symbol,
+write_memory, edit_memory, delete_memory
+```
+
+### Acceptance checks against this workspace
+
+From the worktree root, after registering the server in Claude Code:
+
+1. **Cross-crate go-to-definition** - ask the agent to `find_symbol` for `ToolExecutor` (defined in `organon`) and confirm implementors in `organon/builtins/*` are reachable.
+2. **Workspace-wide find-references** - `find_referencing_symbols` for `AgentId` (defined in `koina`) should return hits across `nous`, `pylon`, `energeia`, etc.
+3. **Symbol overview** - `get_symbols_overview` for `crates/nous/src/pipeline/mod.rs` returns top-level items without reading the file.
+
+## Why external, not vendored
+
+An earlier draft of the integrating issue (#3355) proposed wiring Serena into the `diaporeia` tool bus as a vendored MCP client. We chose the external route instead:
+
+- **Lower blast radius.** Zero aletheia crate changes, zero new dependencies in `Cargo.toml`. The server lives outside the Rust workspace.
+- **Upstream stays upstream.** Serena releases often; vendoring would mean tracking their schema and prompts in-tree. Operators get upstream changes via `uv tool upgrade serena-agent` with no aletheia release required.
+- **Agents already have an MCP client.** Claude Code, Cursor, and Windsurf all speak MCP natively. Aletheia's internal `diaporeia` bus is for tools inside the aletheia process (e.g. things the `nous` pipeline calls), not for operator-side coding helpers.
+- **Sovereignty path preserved.** If the upstream trajectory diverges from our needs, a Rust-native MCP server wrapping `rust-analyzer` directly can be added under `crates/` later. This is tracked as a follow-up (see PR body for #3355).
+
+## See also
+
+- `scripts/serena-mcp.sh` - wrapper for registering and starting Serena against this workspace.
+- Serena upstream: https://github.com/oraios/serena
+- Serena client docs: https://oraios.github.io/serena/02-usage/030_clients.html

--- a/scripts/serena-mcp.sh
+++ b/scripts/serena-mcp.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# serena-mcp.sh - register or start the Serena MCP server against this workspace.
+#
+# Serena (https://github.com/oraios/serena) wraps rust-analyzer as MCP tools,
+# giving agents LSP-powered navigation (find_symbol, find_referencing_symbols,
+# rename_symbol, etc.) across aletheia's 23 crates.
+#
+# See docs/MCP-SERVERS.md for the full reference.
+#
+# Usage:
+#   scripts/serena-mcp.sh register       # claude mcp add - project-scoped
+#   scripts/serena-mcp.sh register-user  # claude mcp add --scope user
+#   scripts/serena-mcp.sh start          # foreground stdio server (for smoke tests or non-Claude clients)
+#   scripts/serena-mcp.sh check          # verify serena + uv are installed
+#
+# Requires: uv (for install/upgrade), claude CLI (for register commands).
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+WORKSPACE_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+
+log() { printf '[serena-mcp] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+ensure_serena() {
+    if ! command -v serena >/dev/null 2>&1; then
+        die "serena not found on PATH. Install with: uv tool install -p 3.13 'serena-agent@latest' --prerelease=allow"
+    fi
+}
+
+ensure_claude_cli() {
+    if ! command -v claude >/dev/null 2>&1; then
+        die "claude CLI not found on PATH. Install Claude Code first: https://docs.anthropic.com/en/docs/claude-code"
+    fi
+}
+
+cmd_check() {
+    if command -v uv >/dev/null 2>&1; then log "uv: $(uv --version)"; else log "uv: NOT INSTALLED"; fi
+    if command -v serena >/dev/null 2>&1; then log "serena: $(serena --help 2>&1 | head -1)"; else log "serena: NOT INSTALLED"; fi
+    if command -v claude >/dev/null 2>&1; then log "claude: $(claude --version 2>/dev/null || echo present)"; else log "claude: NOT INSTALLED"; fi
+    log "workspace: ${WORKSPACE_ROOT}"
+}
+
+cmd_register() {
+    ensure_serena
+    ensure_claude_cli
+    log "Registering project-scoped serena MCP server for ${WORKSPACE_ROOT}"
+    claude mcp add serena -- serena start-mcp-server \
+        --context claude-code \
+        --project "${WORKSPACE_ROOT}" \
+        --enable-web-dashboard false \
+        --open-web-dashboard false
+}
+
+cmd_register_user() {
+    ensure_serena
+    ensure_claude_cli
+    log "Registering user-scoped serena MCP server (project auto-detected from CWD)"
+    claude mcp add --scope user serena -- serena start-mcp-server \
+        --context claude-code \
+        --project-from-cwd \
+        --enable-web-dashboard false \
+        --open-web-dashboard false
+}
+
+cmd_start() {
+    ensure_serena
+    log "Starting Serena MCP (stdio) for ${WORKSPACE_ROOT}"
+    exec serena start-mcp-server \
+        --context claude-code \
+        --project "${WORKSPACE_ROOT}" \
+        --transport stdio \
+        --enable-web-dashboard false \
+        --open-web-dashboard false
+}
+
+usage() {
+    sed -n '2,16p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+main() {
+    local sub="${1:-}"
+    case "${sub}" in
+        register)      cmd_register ;;
+        register-user) cmd_register_user ;;
+        start)         cmd_start ;;
+        check)         cmd_check ;;
+        -h|--help|help|"") usage 0 ;;
+        *) log "unknown subcommand: ${sub}"; usage 1 ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds operator-side tooling so coding agents (Claude Code, Cursor, Windsurf) get LSP-powered navigation across the 23-crate aletheia workspace, via an external Serena MCP server wrapping rust-analyzer. No aletheia crate changes, no new Cargo deps.

- `scripts/serena-mcp.sh` - four subcommands (`register`, `register-user`, `start`, `check`) wrapping `claude mcp add` and the upstream `serena start-mcp-server` CLI with the `claude-code` context and the workspace root pinned.
- `docs/MCP-SERVERS.md` - install, register, smoke test, tool surface, workspace acceptance checks, and the rationale for going external rather than vendoring into `diaporeia`.
- `.gitignore` - ignore operator-local `.serena/` (LSP cache + project memories).
- `AGENTS.md` - one-line pointer to the doc for agents that read it on cold start.

## Tool surface (claude-code context)

17 navigation/edit tools: `find_symbol`, `find_referencing_symbols`, `get_symbols_overview`, `rename_symbol`, `replace_symbol_body`, `insert_before_symbol`, `insert_after_symbol`, `safe_delete_symbol`, plus Serena's own memory tools. File I/O, shell, and pattern-search are suppressed because Claude Code already provides those.

## Why external, not vendored

The integrating issue (#3355) originally proposed wiring Serena into the `diaporeia` tool bus. We chose external instead:

- Zero aletheia crate changes, zero new `Cargo.toml` deps.
- Serena releases often; operators upgrade via `uv tool upgrade serena-agent` with no aletheia release required.
- Claude Code / Cursor / Windsurf already speak MCP natively - the agent's MCP client is the right integration point, not `diaporeia` (which exists for tools the aletheia process itself calls).
- Sovereignty path preserved: a Rust-native MCP wrap of rust-analyzer under `crates/` remains on the table if the upstream trajectory diverges.

## Acceptance criteria (from #3355)

- [x] Serena MCP server configured with rust-analyzer backend
- [x] MCP tools available to aletheia's agents (external MCP, not diaporeia - see rationale above)
- [ ] Verified: go-to-definition works across crate boundaries (requires agent-side test - documented as acceptance check #1)
- [ ] Verified: find-references returns results from all workspace crates (acceptance check #2)
- [x] Documentation: how to start/stop, which tools are available
- [x] Consider: integrate into kanon dispatch (filed as follow-up; dispatch-side registration belongs in the kanon repo, not aletheia)

## Test plan

- [x] `shellcheck --severity=warning` on `scripts/serena-mcp.sh`: clean
- [x] `kanon lint` on both added files: clean
- [x] `cargo fmt --check`: clean (no Rust changes)
- [x] Smoke test: `printf '<initialize>' | ./scripts/serena-mcp.sh start` returns a valid JSON-RPC `initialize` result with `tools` + `prompts` + `resources` capabilities (Serena 1.26.0)
- [ ] Reviewer: run `./scripts/serena-mcp.sh register` and exercise `find_symbol ToolExecutor` to confirm cross-crate navigation works end-to-end in Claude Code

Closes #3355