### PR TITLE
fix: gate HF-network candle tests behind online-tests feature (closes #3683)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,17 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # WHY: the `online-tests` label opts a PR into the HuggingFace-network
+    # candle suite. Re-run CI when the label toggles so the opt-in job attaches
+    # to the existing PR check bundle instead of needing a new commit.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main]
+  schedule:
+    # WHY: weekly run catches regressions in the network-gated candle tests
+    # (see #3683) without blocking every PR on HuggingFace DNS.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
 
 # PROJECT: explicit top-level default deny; job-level permissions grant only what's needed
 permissions:
@@ -91,3 +100,35 @@ jobs:
 
       - name: cargo test --workspace --features ${{ matrix.features }}
         run: cargo test --workspace --features ${{ matrix.features }} --no-fail-fast
+
+  # WHY: network-dependent candle tests download model weights from
+  # huggingface.co at runtime (see #3683). macOS GitHub runners intermittently
+  # lose DNS for HF, cascading the shared-singleton poisoning across the suite.
+  # Keep this job off the default PR gate; run on schedule, on the
+  # `online-tests` PR label, or via manual dispatch.
+  online-tests:
+    name: online tests (${{ matrix.os }})
+    if: >
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'online-tests'))
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ${{ matrix.os }}-online-tests
+
+      - name: cargo test --workspace --features test-core,online-tests
+        run: cargo test --workspace --features test-core,online-tests --no-fail-fast

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -26,6 +26,10 @@ recall = ["nous/knowledge-store", "mneme/mneme-engine", "mneme/storage-fjall", "
 storage-fjall = ["mneme/storage-fjall"]
 # Local ML embeddings via candle.
 embed-candle = ["mneme/embed-candle"]
+# WHY: network-dependent candle tests that download HuggingFace model weights
+# at test time. Opt-in only (see #3683). Enable in scheduled or label-triggered
+# CI jobs — never part of the default PR gate.
+online-tests = ["mneme/online-tests"]
 migrate-qdrant = ["dep:qdrant-client", "mneme/mneme-engine", "mneme/storage-fjall"]
 tls = ["pylon/tls"]
 keyring = ["symbolon/keyring"]
@@ -40,7 +44,7 @@ energeia = ["dep:energeia", "oikonomos/dispatch-cron"]
 matrix = ["agora/matrix"]
 # Test tiers (see docs/test-tiers.md)
 test-core = ["mneme/test-core", "nous/test-core", "pylon/test-core"]
-test-full = ["test-core", "mneme/test-full"]
+test-full = ["test-core", "mneme/test-full", "online-tests"]
 
 [dependencies]
 diaporeia = { path = "../diaporeia", optional = true }

--- a/crates/episteme/Cargo.toml
+++ b/crates/episteme/Cargo.toml
@@ -19,9 +19,15 @@ test-support = []
 mneme-engine = ["dep:krites", "dep:tokio", "graphe/mneme-engine"]
 storage-fjall = ["mneme-engine", "krites/storage-fjall"]
 embed-candle = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers", "dep:hf-hub"]
+# WHY: candle embedding tests download config.json from HuggingFace at test
+# time. macOS GitHub runners intermittently fail DNS lookup for huggingface.co
+# (see #3683). Gate those network-dependent tests behind `online-tests` so the
+# default CI matrix never depends on external reachability. Enable explicitly
+# in scheduled or label-triggered jobs.
+online-tests = []
 # Test tiers (see docs/test-tiers.md)
 test-core = ["mneme-engine"]
-test-full = ["test-core", "embed-candle"]
+test-full = ["test-core", "embed-candle", "online-tests"]
 
 [dependencies]
 eidos = { path = "../eidos" }

--- a/crates/episteme/src/embedding_tests.rs
+++ b/crates/episteme/src/embedding_tests.rs
@@ -470,7 +470,13 @@ fn lock_poisoned_error_formats() {
     );
 }
 
-#[cfg(feature = "embed-candle")]
+// WHY: these tests call `CandelProvider::new`, which downloads `config.json`
+// and model weights from huggingface.co at test time. macOS GitHub-hosted
+// runners intermittently fail DNS lookup for huggingface.co (see #3683).
+// Gate behind `online-tests` so the default CI run never depends on external
+// reachability; scheduled/label-triggered jobs opt in with
+// `--features test-core,online-tests` (or `test-full`).
+#[cfg(all(feature = "embed-candle", feature = "online-tests"))]
 mod candle_tests {
     use std::sync::LazyLock;
 

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -18,11 +18,13 @@ graph-algo = ["episteme/graph-algo"]
 # Gates MockEmbeddingProvider and other test helpers. No test code in release binaries.
 test-support = ["episteme/test-support"]
 embed-candle = ["episteme/embed-candle"]
+# Passthrough for the network-dependent candle tests (see episteme #3683).
+online-tests = ["episteme/online-tests"]
 mneme-engine = ["dep:krites", "graphe/mneme-engine", "episteme/mneme-engine"]
 storage-fjall = ["mneme-engine", "episteme/storage-fjall"]
 # Test tiers (see docs/test-tiers.md)
 test-core = ["mneme-engine", "storage-fjall"]
-test-full = ["test-core", "embed-candle"]
+test-full = ["test-core", "embed-candle", "online-tests"]
 
 [dependencies]
 eidos = { path = "../eidos" }

--- a/docs/test-tiers.md
+++ b/docs/test-tiers.md
@@ -9,11 +9,24 @@ coverage against build time and resource requirements.
 |------|-------------|-----------------|---------------|
 | **default** | *(none)* | Pure-logic unit tests, config validation, type invariants | ~5,400 |
 | **test-core** | `--features test-core` | Storage engine tests (Datalog, HNSW, fjall, knowledge store CRUD) | ~5,435 |
-| **test-full** | `--features test-full` | ML embedding tests (candle model loading, vector generation) | ~5,435 |
+| **test-full** | `--features test-full` | ML embedding tests (candle model loading, vector generation) - includes `online-tests` | ~5,435 |
 | **all** | `--all-features` | + local-llm, computer-use, other optional features | ~5,475 |
 
 Each tier is a strict superset of the previous: `test-full` implies `test-core`,
 which adds to the default set.
+
+### Online-only tests
+
+A small set of tests call `CandelProvider::new`, which downloads model weights
+from `huggingface.co` at test time. macOS GitHub runners intermittently fail
+DNS lookup for HuggingFace, so these tests are gated behind a dedicated
+`online-tests` feature (see #3683) and **excluded** from the default CI matrix.
+
+- `--features test-core`: fast deterministic gate, no external network.
+- `--features test-core,online-tests`: adds the HuggingFace-network candle
+  tests. Enable via the `online-tests` PR label, the weekly schedule, or
+  `workflow_dispatch` in `.github/workflows/ci.yml`.
+- `--features test-full`: everything, including `online-tests`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Introduce an `online-tests` feature in `episteme` (with passthroughs in `mneme` and `aletheia`) that gates the candle tests which download model weights from `huggingface.co` at test time.
- Default CI matrix keeps running `--features test-core` and no longer invokes `CandelProvider::new`, so macOS DNS flakes on HuggingFace (#3683) stop masquerading as real regressions.
- Add an opt-in `online-tests` CI job that runs on schedule (weekly Mon 07:00 UTC), on manual `workflow_dispatch`, or on PRs carrying the `online-tests` label.

## Why

`cargo test --workspace --features test-core` pulled in `embed-candle` via aletheia's default features, which propagated through mneme into episteme. The `candle_tests` module instantiated a shared `CandelProvider` via `LazyLock`, which fetched `config.json` from HuggingFace at first use. On macOS GitHub runners this failed roughly 1 in 3 runs with `InitFailed { message: "failed to download config.json: ... failed to lookup address information" }`, poisoning the singleton and cascading across the suite. Every flake looked like a real regression.

This PR implements option 2 from the issue (gate behind a dedicated feature). A follow-up is still warranted for option 3 (offline-capable provider constructor / vendored tiny model) to make the online suite deterministic when it does run.

## Changes

- `crates/episteme/Cargo.toml`: new `online-tests` feature; `test-full = ["test-core", "embed-candle", "online-tests"]`.
- `crates/mneme/Cargo.toml`: `online-tests = ["episteme/online-tests"]`; `test-full` extends it.
- `crates/aletheia/Cargo.toml`: `online-tests = ["mneme/online-tests"]`; `test-full` extends it.
- `crates/episteme/src/embedding_tests.rs`: `mod candle_tests` now gated on `all(feature = "embed-candle", feature = "online-tests")`.
- `.github/workflows/ci.yml`: default matrix unchanged; new `online-tests` job runs on `schedule`, `workflow_dispatch`, or `online-tests` PR label.
- `docs/test-tiers.md`: document the new gate.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo check --workspace --features test-core --all-targets` clean.
- [x] `cargo test -p episteme --features test-core --lib embedding` — 48 passed, 0 failed, zero candle provider invocations, no HuggingFace traffic.
- [x] `cargo test --workspace --features test-core --lib -- --list | grep candle_tests` — empty (confirms candle tests excluded from default gate).
- [x] `cargo test -p episteme --features embed-candle,online-tests --lib -- --list | grep candle_tests` — all 8 `candle_tests::*` entries present (confirms opt-in still surfaces them).
- [ ] CI default matrix (ubuntu + macos with `--features test-core`) green on this PR — no HF network hit.
- [ ] Apply the `online-tests` label to trigger the new job and verify it runs the candle suite end-to-end (can be done post-merge on a follow-up PR).

Closes #3683