### PR TITLE
feat(aletheia-memory-mcp): standalone stdio MCP server for memory (closes #3425)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aletheia-memory-mcp"
+version = "0.20.0"
+dependencies = [
+ "jiff",
+ "mneme",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "snafu",
+ "taxis",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/aletheia",
+    "crates/aletheia-memory-mcp",
     "crates/basanos",
     "crates/diaporeia",
     "crates/dianoia",

--- a/crates/aletheia-memory-mcp/Cargo.toml
+++ b/crates/aletheia-memory-mcp/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "aletheia-memory-mcp"
+version.workspace = true
+description = "Standalone stdio MCP server exposing Aletheia's memory and knowledge graph (read-only) to external agents"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "aletheia-memory-mcp"
+path = "src/main.rs"
+
+[dependencies]
+# MCP SDK — pin exact per TECHNOLOGY.md policy (matches diaporeia)
+rmcp = { version = "=1.4.0", features = [
+    "server",
+    "macros",
+    "transport-io",
+] }
+schemars = "1"
+
+# Async
+tokio = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Error handling
+snafu = { workspace = true }
+
+# Observability
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+# Internal crates: memory facade + path resolver
+mneme = { path = "../mneme", features = ["storage-fjall"] }
+taxis = { path = "../taxis" }
+
+[dev-dependencies]
+# WHY: the `client` rmcp feature enables the `ClientHandler` blanket impl we
+# need to drive the server in-process during integration tests.
+rmcp = { version = "=1.4.0", features = [
+    "server",
+    "client",
+    "macros",
+    "transport-io",
+] }
+tokio = { workspace = true, features = ["test-util"] }
+tempfile = { workspace = true }
+jiff = { workspace = true }

--- a/crates/aletheia-memory-mcp/src/error.rs
+++ b/crates/aletheia-memory-mcp/src/error.rs
@@ -1,0 +1,120 @@
+//! Error types for aletheia-memory-mcp.
+//!
+//! Each variant maps to an rmcp error code via `impl From<Error> for
+//! rmcp::ErrorData`. Server-side paths are not included in MCP messages so
+//! clients never see internal filesystem layout.
+
+use snafu::Snafu;
+
+/// Errors produced by the memory MCP server.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+#[expect(
+    missing_docs,
+    reason = "snafu error variant fields are self-documenting via display format"
+)]
+pub enum Error {
+    /// Failed to open the knowledge store.
+    #[snafu(display("failed to open knowledge store: {message}"))]
+    OpenStore {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A knowledge store operation failed.
+    #[snafu(display("knowledge store error: {message}"))]
+    KnowledgeStore {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Serialization of a response payload failed.
+    #[snafu(display("serialization error: {source}"))]
+    Serialization {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Caller supplied an invalid input value.
+    #[snafu(display("invalid input: {message}"))]
+    InvalidInput {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// MCP transport error (stdio read/write or shutdown).
+    #[snafu(display("transport error: {message}"))]
+    Transport {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Background task join failure.
+    #[snafu(display("task join error: {source}"))]
+    Join {
+        source: tokio::task::JoinError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Result alias using this crate's [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<Error> for rmcp::ErrorData {
+    fn from(err: Error) -> Self {
+        let message = err.to_string();
+        match &err {
+            Error::InvalidInput { .. } => rmcp::ErrorData::invalid_params(message, None),
+            Error::OpenStore { .. }
+            | Error::KnowledgeStore { .. }
+            | Error::Serialization { .. }
+            | Error::Transport { .. }
+            | Error::Join { .. } => rmcp::ErrorData::internal_error(message, None),
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_input_maps_to_invalid_params() {
+        let err = InvalidInputSnafu {
+            message: "limit must be positive".to_owned(),
+        }
+        .build();
+        let mcp: rmcp::ErrorData = err.into();
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(mcp.message.contains("limit"));
+    }
+
+    #[test]
+    fn knowledge_store_error_maps_to_internal_error() {
+        let err = KnowledgeStoreSnafu {
+            message: "datalog query failed".to_owned(),
+        }
+        .build();
+        let mcp: rmcp::ErrorData = err.into();
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn serialization_error_maps_to_internal_error() {
+        let raw = serde_json::from_str::<serde_json::Value>("{invalid").unwrap_err();
+        let err = Error::Serialization {
+            source: raw,
+            location: snafu::Location::new("test", 0, 0),
+        };
+        let mcp: rmcp::ErrorData = err.into();
+        assert_eq!(mcp.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+    }
+}

--- a/crates/aletheia-memory-mcp/src/lib.rs
+++ b/crates/aletheia-memory-mcp/src/lib.rs
@@ -1,0 +1,39 @@
+#![deny(missing_docs)]
+//! aletheia-memory-mcp: standalone stdio MCP server for Aletheia's memory layer.
+//!
+//! External agents (Claude Code, Cursor, `OpenHands`, etc.) spawn this binary to
+//! query the knowledge graph directly over stdio JSON-RPC. It exposes a
+//! read-only subset of the memory API — search, graph traversal, topic
+//! enumeration, and health stats — with no session, tool-execution, or write
+//! surface.
+//!
+//! # Why a separate crate from diaporeia
+//!
+//! `diaporeia` is the in-process MCP server that bundles session management,
+//! nous agent control, and memory into one authenticated HTTP/stdio surface.
+//! It is meant for operator use against a running Aletheia instance.
+//!
+//! `aletheia-memory-mcp` is a leaf binary that opens the knowledge store
+//! directly, without the rest of the runtime. It is scoped to the memory-as-
+//! service use case: any agent that speaks MCP can treat Aletheia's KG as a
+//! drop-in memory provider by spawning this binary.
+//!
+//! # Tools exposed
+//!
+//! - `memory_search` — BM25 text search over current facts.
+//! - `memory_neighbors` — one-hop graph traversal from a fact's entities.
+//! - `memory_list_topics` — enumerate fact-type buckets with counts.
+//! - `memory_stats` — fact count, topic count, schema version, open path.
+//!
+//! All tools are read-only. Writes (annotate, supersede, forget) are deferred
+//! behind an auth model review; see issue tracker for the follow-up.
+//!
+//! # Feature gating
+//!
+//! Requires the `storage-fjall` feature on `mneme` (enabled by default here)
+//! so the server can open an on-disk knowledge store at the oikos
+//! `data/knowledge.fjall` path.
+
+pub mod error;
+pub mod server;
+pub mod tools;

--- a/crates/aletheia-memory-mcp/src/main.rs
+++ b/crates/aletheia-memory-mcp/src/main.rs
@@ -1,0 +1,77 @@
+//! `aletheia-memory-mcp` — stdio MCP binary.
+//!
+//! Opens a fjall-backed knowledge store and serves read-only memory tools
+//! over stdio JSON-RPC. Configuration:
+//!
+//! - `ALETHEIA_ROOT` — instance root (default `./instance`). The store is
+//!   opened at `<root>/data/knowledge.fjall`.
+//! - `ALETHEIA_MEMORY_MCP_STORE` — override the store path directly.
+//! - `RUST_LOG` — tracing filter; defaults to `info`. Logs go to stderr so
+//!   stdout stays clean for JSON-RPC.
+//!
+//! Exit codes:
+//!
+//! - `0` — clean shutdown (peer closed the connection).
+//! - `1` — startup or transport error (details on stderr).
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use aletheia_memory_mcp::error;
+use aletheia_memory_mcp::server::MemoryServer;
+use taxis::oikos::Oikos;
+use tracing_subscriber::EnvFilter;
+
+fn main() -> ExitCode {
+    // WHY: tracing must go to stderr because stdout is the MCP JSON-RPC
+    // transport. A stray INFO log on stdout would corrupt the protocol.
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .init();
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to build tokio runtime");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match runtime.block_on(run()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            tracing::error!(error = %e, "aletheia-memory-mcp exited with error");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> error::Result<()> {
+    let store_path = resolve_store_path();
+    tracing::info!(
+        path = %store_path.display(),
+        "opening knowledge store (fjall)"
+    );
+
+    let server = MemoryServer::open_fjall(&store_path)?;
+    tracing::info!("memory MCP server ready on stdio");
+    server.serve_stdio().await?;
+    Ok(())
+}
+
+/// Resolve the knowledge store path from environment.
+///
+/// Precedence:
+/// 1. `ALETHEIA_MEMORY_MCP_STORE` — explicit override.
+/// 2. `ALETHEIA_ROOT` via `Oikos::discover` — canonical instance layout.
+fn resolve_store_path() -> PathBuf {
+    if let Ok(explicit) = std::env::var("ALETHEIA_MEMORY_MCP_STORE") {
+        return PathBuf::from(explicit);
+    }
+    Oikos::discover().knowledge_db()
+}

--- a/crates/aletheia-memory-mcp/src/server.rs
+++ b/crates/aletheia-memory-mcp/src/server.rs
@@ -1,0 +1,141 @@
+//! `MemoryServer`: stdio MCP server exposing read-only memory tools.
+//!
+//! The server holds an `Arc<KnowledgeStore>` opened either from an explicit
+//! path (fjall) or in-memory for tests. Each tool call dispatches through
+//! the `#[tool_router]` macro; long-running store queries run on a blocking
+//! task pool via `spawn_blocking` to avoid stalling the stdio reactor.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rmcp::ServiceExt;
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::model::{Implementation, InitializeResult, ServerCapabilities};
+use rmcp::tool_handler;
+
+use mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
+use snafu::ResultExt as _;
+
+use crate::error::{self, JoinSnafu, OpenStoreSnafu, TransportSnafu};
+
+/// MCP server surface for Aletheia's memory layer.
+///
+/// Clone is cheap (Arc-based). A single instance is registered on the
+/// stdio transport and handles every request for the process lifetime.
+#[derive(Clone)]
+pub struct MemoryServer {
+    pub(crate) store: Arc<KnowledgeStore>,
+    pub(crate) store_path: Option<PathBuf>,
+    #[expect(
+        dead_code,
+        reason = "read by #[tool_handler] macro-generated code in ServerHandler impl"
+    )]
+    tool_router: ToolRouter<Self>,
+}
+
+impl MemoryServer {
+    /// Build a memory server from a pre-opened knowledge store.
+    ///
+    /// `store_path` is surfaced by `memory_stats` so callers can confirm which
+    /// on-disk database is being served. Pass `None` for in-memory stores.
+    #[must_use]
+    pub fn new(store: Arc<KnowledgeStore>, store_path: Option<PathBuf>) -> Self {
+        Self {
+            store,
+            store_path,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Open a persistent knowledge store at `path` (fjall LSM-tree).
+    ///
+    /// The parent directory must exist and be writable. Returns an error if
+    /// the on-disk format is incompatible with the current schema version.
+    pub fn open_fjall(path: impl AsRef<Path>) -> error::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let store = KnowledgeStore::open_fjall(&path, KnowledgeConfig::default()).map_err(|e| {
+            OpenStoreSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
+        Ok(Self::new(store, Some(path)))
+    }
+
+    /// Open an in-memory knowledge store (for tests and ephemeral use).
+    pub fn open_in_memory() -> error::Result<Self> {
+        let store = KnowledgeStore::open_mem().map_err(|e| {
+            OpenStoreSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
+        Ok(Self::new(store, None))
+    }
+
+    /// Serve MCP over stdio until the peer closes the connection.
+    ///
+    /// Blocks the current tokio task; call from `main` after configuring
+    /// tracing. Reads JSON-RPC requests from stdin and writes responses to
+    /// stdout. stderr is free for log output.
+    #[tracing::instrument(skip_all)]
+    pub async fn serve_stdio(self) -> error::Result<()> {
+        let service = self
+            .serve(rmcp::transport::io::stdio())
+            .await
+            .map_err(|e| {
+                TransportSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
+
+        service.waiting().await.map_err(|e| {
+            TransportSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
+
+        Ok(())
+    }
+
+    /// Run a blocking knowledge-store closure on the tokio blocking pool.
+    ///
+    /// Every sync `KnowledgeStore` call must go through this helper because
+    /// Datalog queries can block on disk I/O and serializing them onto the
+    /// single-threaded stdio reactor would starve concurrent tool calls.
+    pub(crate) async fn run_blocking<F, T>(&self, f: F) -> error::Result<T>
+    where
+        F: FnOnce(Arc<KnowledgeStore>) -> error::Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let store = Arc::clone(&self.store);
+        tokio::task::spawn_blocking(move || f(store))
+            .await
+            .context(JoinSnafu)?
+    }
+}
+
+// NOTE: required type alias per rmcp: `get_info` must return this exact name.
+type ServerInfo = InitializeResult;
+
+/// rmcp `ServerHandler` binding. The macro expands to a routing table over
+/// the `#[tool]` methods on `MemoryServer` (defined in `tools.rs`).
+#[tool_handler]
+impl rmcp::handler::server::ServerHandler for MemoryServer {
+    fn get_info(&self) -> ServerInfo {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(
+                "aletheia-memory-mcp",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .with_instructions(
+                "Read-only MCP surface for Aletheia's knowledge graph. \
+                 Use memory_search for recall, memory_neighbors for graph \
+                 traversal, memory_list_topics for fact-type enumeration, \
+                 and memory_stats for health and counts. Writes are not \
+                 exposed in this surface.",
+            )
+    }
+}

--- a/crates/aletheia-memory-mcp/src/tools.rs
+++ b/crates/aletheia-memory-mcp/src/tools.rs
@@ -1,0 +1,382 @@
+//! MCP tool implementations for the memory server.
+//!
+//! All tools are read-only. Writes (annotate, supersede, forget) are deferred
+//! to a follow-up iteration pending an auth-model review: exposing mutation
+//! over an unauthenticated stdio transport would let any process that can
+//! spawn this binary modify the knowledge graph. When write tools are added,
+//! they will live behind a per-process capability token.
+
+use std::collections::BTreeMap;
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::CallToolResult;
+use rmcp::{tool, tool_router};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt as _;
+
+use mneme::engine::DataValue;
+
+use crate::error::{InvalidInputSnafu, KnowledgeStoreSnafu, SerializationSnafu};
+use crate::server::MemoryServer;
+
+/// Parameters for `memory_search`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct MemorySearchParams {
+    /// Free-text query string; matched via BM25 against current fact content.
+    pub query: String,
+    /// Maximum number of results to return. Defaults to 20 when omitted.
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+/// Parameters for `memory_neighbors`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct MemoryNeighborsParams {
+    /// ID of the seed fact whose entity neighbors should be returned.
+    pub fact_id: String,
+}
+
+/// Default search limit when the caller omits one.
+const DEFAULT_SEARCH_LIMIT: usize = 20;
+/// Cap on per-call result size to avoid unbounded payloads.
+const MAX_SEARCH_LIMIT: usize = 200;
+
+#[tool_router(vis = "pub(crate)")]
+impl MemoryServer {
+    /// BM25 full-text search across active facts in the knowledge graph.
+    ///
+    /// Returns ranked recall results — each carrying the matching fact's ID,
+    /// content, fact type, and score. Forgotten and superseded facts are
+    /// excluded.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// {
+    ///   "name": "memory_search",
+    ///   "arguments": { "query": "fleet dispatch config", "limit": 10 }
+    /// }
+    /// ```
+    #[tool(description = "BM25 text search across active facts. \
+                       Returns ranked matches with fact ID, content, and score.")]
+    async fn memory_search(
+        &self,
+        Parameters(params): Parameters<MemorySearchParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        if params.query.trim().is_empty() {
+            return Err(InvalidInputSnafu {
+                message: "query must not be empty".to_owned(),
+            }
+            .build()
+            .into());
+        }
+
+        let limit = params
+            .limit
+            .unwrap_or(DEFAULT_SEARCH_LIMIT)
+            .min(MAX_SEARCH_LIMIT);
+        // WHY: `search_text_for_recall` takes an i64 limit. `usize -> i64` via
+        // `try_from` ensures no silent truncation on 128-bit platforms.
+        let limit_i64 = i64::try_from(limit).map_err(|e| {
+            rmcp::ErrorData::from(
+                InvalidInputSnafu {
+                    message: format!("limit out of range: {e}"),
+                }
+                .build(),
+            )
+        })?;
+
+        let query = params.query.clone();
+        let results = self
+            .run_blocking(move |store| {
+                store
+                    .search_text_for_recall(&query, limit_i64)
+                    .map_err(|e| {
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })
+            })
+            .await
+            .map_err(rmcp::ErrorData::from)?;
+
+        let json = serde_json::to_string_pretty(&results)
+            .context(SerializationSnafu)
+            .map_err(rmcp::ErrorData::from)?;
+
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
+    }
+
+    /// One-hop graph traversal from a seed fact's linked entities.
+    ///
+    /// Resolves every entity attached to `fact_id` via the `fact_entities`
+    /// relation, then returns their direct neighbors along with the
+    /// relationship type and edge weight. Use this to walk outward from a
+    /// known fact into the wider knowledge graph.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// {
+    ///   "name": "memory_neighbors",
+    ///   "arguments": { "fact_id": "f-abc-123" }
+    /// }
+    /// ```
+    #[tool(
+        description = "Return one-hop graph neighbors (entities + relations) for a fact. \
+                       Useful for walking outward from a known fact."
+    )]
+    async fn memory_neighbors(
+        &self,
+        Parameters(params): Parameters<MemoryNeighborsParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        if params.fact_id.trim().is_empty() {
+            return Err(InvalidInputSnafu {
+                message: "fact_id must not be empty".to_owned(),
+            }
+            .build()
+            .into());
+        }
+
+        let fact_id = params.fact_id.clone();
+        let neighbors = self
+            .run_blocking(move |store| {
+                // WHY: two-step query — first resolve entities linked to the fact,
+                // then return their adjacent edges. Datalog script is embedded
+                // so we do not depend on any pub(crate) helper in episteme.
+                //
+                // `fact_entities{fact_id, entity_id}` links a fact to every entity it
+                // mentions. `relationships{src, dst, relation, weight}` are edges
+                // in the entity graph. We union inbound and outbound edges so the
+                // caller sees both directions.
+                let script = r"
+                    seed_entity[entity_id] :=
+                        *fact_entities{fact_id: $fact_id, entity_id}
+
+                    ?[src_id, dst_id, name, entity_type, relation, weight] :=
+                        seed_entity[src_id],
+                        *relationships{src: src_id, dst: dst_id, relation, weight},
+                        *entities{id: dst_id, name, entity_type}
+
+                    ?[src_id, dst_id, name, entity_type, relation, weight] :=
+                        seed_entity[dst_id],
+                        *relationships{src: src_id, dst: dst_id, relation, weight},
+                        *entities{id: src_id, name, entity_type}
+                ";
+
+                let mut params = BTreeMap::new();
+                params.insert("fact_id".to_owned(), DataValue::Str(fact_id.clone().into()));
+
+                let result = store.run_query(script, params).map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                let rows: Vec<serde_json::Value> = result
+                    .rows_to_json()
+                    .into_iter()
+                    .map(|row| {
+                        serde_json::json!({
+                            "src_id": row.first().cloned().unwrap_or(serde_json::Value::Null),
+                            "dst_id": row.get(1).cloned().unwrap_or(serde_json::Value::Null),
+                            "name": row.get(2).cloned().unwrap_or(serde_json::Value::Null),
+                            "entity_type": row.get(3).cloned().unwrap_or(serde_json::Value::Null),
+                            "relation": row.get(4).cloned().unwrap_or(serde_json::Value::Null),
+                            "weight": row.get(5).cloned().unwrap_or(serde_json::Value::Null),
+                        })
+                    })
+                    .collect();
+                Ok(rows)
+            })
+            .await
+            .map_err(rmcp::ErrorData::from)?;
+
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "fact_id": params.fact_id,
+            "neighbors": neighbors,
+        }))
+        .context(SerializationSnafu)
+        .map_err(rmcp::ErrorData::from)?;
+
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
+    }
+
+    /// Enumerate all `fact_type` buckets (topics) with active-fact counts.
+    ///
+    /// Forgotten and superseded facts are excluded from the counts so the
+    /// output reflects the currently-live topic distribution. Topics are
+    /// sorted alphabetically for stable output.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// {
+    ///   "name": "memory_list_topics",
+    ///   "arguments": {}
+    /// }
+    /// ```
+    #[tool(
+        description = "List all topic buckets (fact_type values) with active-fact counts. \
+                       Use as a discovery starting point for memory_search."
+    )]
+    async fn memory_list_topics(&self) -> Result<CallToolResult, rmcp::ErrorData> {
+        let topics = self
+            .run_blocking(|store| {
+                // WHY: aggregate by fact_type. Filter out forgotten and superseded
+                // facts via the lifecycle columns so counts reflect live memory.
+                let script = r"
+                    ?[fact_type, count(id)] :=
+                        *facts{id, fact_type, is_forgotten, superseded_by},
+                        is_forgotten == false,
+                        is_null(superseded_by)
+                    :order fact_type
+                ";
+
+                let result = store.run_query(script, BTreeMap::new()).map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                let topics: Vec<serde_json::Value> = result
+                    .rows_to_json()
+                    .into_iter()
+                    .map(|row| {
+                        serde_json::json!({
+                            "topic": row.first().cloned().unwrap_or(serde_json::Value::Null),
+                            "count": row.get(1).cloned().unwrap_or(serde_json::Value::Null),
+                        })
+                    })
+                    .collect();
+                Ok(topics)
+            })
+            .await
+            .map_err(rmcp::ErrorData::from)?;
+
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "topics": topics,
+        }))
+        .context(SerializationSnafu)
+        .map_err(rmcp::ErrorData::from)?;
+
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
+    }
+
+    /// Health and scale stats for the knowledge store backing this server.
+    ///
+    /// Returns total active fact count, distinct topic count, schema version,
+    /// the on-disk path (when opened from disk), and the most recent
+    /// `recorded_at` timestamp across facts — the "last updated" signal.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// {
+    ///   "name": "memory_stats",
+    ///   "arguments": {}
+    /// }
+    /// ```
+    #[tool(
+        description = "Return knowledge-graph health stats: fact count, topic count, \
+                       schema version, store path, and last updated timestamp."
+    )]
+    async fn memory_stats(&self) -> Result<CallToolResult, rmcp::ErrorData> {
+        let store_path = self.store_path.as_ref().map(|p| p.display().to_string());
+
+        let stats = self
+            .run_blocking(|store| {
+                // WHY: single query joining three projections over the facts
+                // relation to avoid three round-trips. CozoDB permits comma-
+                // separated heads with independent bodies.
+                let fact_count_script = r"
+                    ?[count(id)] :=
+                        *facts{id, is_forgotten, superseded_by},
+                        is_forgotten == false,
+                        is_null(superseded_by)
+                ";
+                let fact_count_result = store
+                    .run_query(fact_count_script, BTreeMap::new())
+                    .map_err(|e| {
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?;
+                let fact_count = fact_count_result
+                    .get_i64(0, "count(id)")
+                    .unwrap_or_default();
+
+                let topic_count_script = r"
+                    topic_set[fact_type] :=
+                        *facts{fact_type, is_forgotten, superseded_by},
+                        is_forgotten == false,
+                        is_null(superseded_by)
+
+                    ?[count(fact_type)] := topic_set[fact_type]
+                ";
+                let topic_count_result = store
+                    .run_query(topic_count_script, BTreeMap::new())
+                    .map_err(|e| {
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?;
+                let topic_count = topic_count_result
+                    .get_i64(0, "count(fact_type)")
+                    .unwrap_or_default();
+
+                let last_updated_script = r"
+                    ?[max(recorded_at)] :=
+                        *facts{recorded_at, is_forgotten},
+                        is_forgotten == false
+                ";
+                let last_updated_result = store
+                    .run_query(last_updated_script, BTreeMap::new())
+                    .map_err(|e| {
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build()
+                    })?;
+                let last_updated = last_updated_result.get_string(0, "max(recorded_at)");
+
+                let schema_version = store.schema_version().map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                Ok((fact_count, topic_count, last_updated, schema_version))
+            })
+            .await
+            .map_err(rmcp::ErrorData::from)?;
+
+        let (fact_count, topic_count, last_updated, schema_version) = stats;
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "fact_count": fact_count,
+            "topic_count": topic_count,
+            "schema_version": schema_version,
+            "store_path": store_path,
+            "last_updated": last_updated,
+        }))
+        .context(SerializationSnafu)
+        .map_err(rmcp::ErrorData::from)?;
+
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
+    }
+}

--- a/crates/aletheia-memory-mcp/tests/integration.rs
+++ b/crates/aletheia-memory-mcp/tests/integration.rs
@@ -1,0 +1,223 @@
+//! End-to-end smoke test: drive a `MemoryServer` through rmcp in-process
+//! transport and exercise each exposed tool.
+//!
+//! Uses an in-memory knowledge store seeded with a single fact so we can
+//! verify that tool call → store query → JSON response wiring is correct.
+//! The rmcp `Service` is driven via `tokio::io::duplex` so no real stdio or
+//! network is involved.
+
+use std::sync::Arc;
+
+use aletheia_memory_mcp::server::MemoryServer;
+use mneme::id::FactId;
+use mneme::knowledge::{
+    EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactSensitivity, FactTemporal,
+    default_stability_hours, far_future,
+};
+use mneme::knowledge_store::KnowledgeStore;
+use rmcp::ServiceExt;
+use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
+
+/// Seed a fresh in-memory store with one fact so list/stats/search have
+/// something to return.
+#[expect(
+    clippy::expect_used,
+    reason = "test setup: panic on unexpected store failure is acceptable"
+)]
+fn seed_store() -> Arc<KnowledgeStore> {
+    let store = KnowledgeStore::open_mem().expect("open_mem should succeed");
+    let now = jiff::Timestamp::now();
+    let fact = Fact {
+        id: FactId::new("f-test-0001").expect("valid fact id"),
+        nous_id: "alice".to_owned(),
+        fact_type: "preference".to_owned(),
+        content: "Alice prefers dark roast coffee with no cream".to_owned(),
+        scope: None,
+        sensitivity: FactSensitivity::Public,
+        temporal: FactTemporal {
+            valid_from: now,
+            valid_to: far_future(),
+            recorded_at: now,
+        },
+        provenance: FactProvenance {
+            confidence: 0.9,
+            tier: EpistemicTier::Inferred,
+            source_session_id: None,
+            stability_hours: default_stability_hours("preference"),
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
+    };
+    store
+        .insert_fact(&fact)
+        .expect("insert_fact should succeed");
+    store
+}
+
+#[tokio::test]
+#[expect(
+    clippy::expect_used,
+    reason = "test: panics on unexpected protocol failure are acceptable"
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "single end-to-end test walks all four tools in one sequence; \
+              splitting fragments the narrative without helping readability"
+)]
+async fn memory_tools_end_to_end() {
+    let store = seed_store();
+    let server = MemoryServer::new(store, None);
+
+    // WHY: use duplex pipes as the transport so the server and client both run
+    // in-process. This exercises the real rmcp serve/call path without stdio.
+    let (server_tx, client_rx) = tokio::io::duplex(4096);
+    let (client_tx, server_rx) = tokio::io::duplex(4096);
+
+    let server_handle = tokio::spawn(async move {
+        server
+            .serve((server_rx, server_tx))
+            .await
+            .expect("server serve")
+            .waiting()
+            .await
+            .expect("server waiting")
+    });
+
+    let client_info = ClientInfo::new(
+        ClientCapabilities::default(),
+        Implementation::new("test-client", "0.1.0"),
+    );
+
+    let client = client_info
+        .serve((client_rx, client_tx))
+        .await
+        .expect("client handshake");
+
+    // 1. memory_list_topics — should see "preference" with count 1.
+    let topics = client
+        .call_tool(CallToolRequestParams::new("memory_list_topics"))
+        .await
+        .expect("memory_list_topics call");
+    let topics_text = topics
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("topics text content");
+    assert!(
+        topics_text.contains("preference"),
+        "expected 'preference' topic in: {topics_text}"
+    );
+    assert!(
+        topics_text.contains('1'),
+        "expected count 1 in: {topics_text}"
+    );
+
+    // 2. memory_stats — fact_count should be 1.
+    let stats = client
+        .call_tool(CallToolRequestParams::new("memory_stats"))
+        .await
+        .expect("memory_stats call");
+    let stats_text = stats
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("stats text content");
+    let stats_json: serde_json::Value =
+        serde_json::from_str(&stats_text).expect("stats json parse");
+    assert_eq!(
+        stats_json
+            .get("fact_count")
+            .and_then(serde_json::Value::as_i64),
+        Some(1),
+        "expected fact_count=1 in: {stats_text}"
+    );
+    assert_eq!(
+        stats_json
+            .get("topic_count")
+            .and_then(serde_json::Value::as_i64),
+        Some(1),
+        "expected topic_count=1 in: {stats_text}"
+    );
+
+    // 3. memory_search — the seeded fact should be retrievable by content term.
+    let search = client
+        .call_tool(
+            CallToolRequestParams::new("memory_search").with_arguments(
+                serde_json::json!({ "query": "coffee", "limit": 5 })
+                    .as_object()
+                    .expect("object")
+                    .clone(),
+            ),
+        )
+        .await
+        .expect("memory_search call");
+    let search_text = search
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("search text content");
+    // The seeded content contains "coffee" — whether BM25 returns it depends on
+    // index build state, but the call must succeed and return a JSON array.
+    let parsed: serde_json::Value = serde_json::from_str(&search_text).expect("search json parse");
+    assert!(parsed.is_array(), "search result must be a JSON array");
+
+    // 4. memory_neighbors — seed has no entity links so neighbors should be an
+    // empty array. Call must still succeed.
+    let neighbors = client
+        .call_tool(
+            CallToolRequestParams::new("memory_neighbors").with_arguments(
+                serde_json::json!({ "fact_id": "f-test-0001" })
+                    .as_object()
+                    .expect("object")
+                    .clone(),
+            ),
+        )
+        .await
+        .expect("memory_neighbors call");
+    let neighbors_text = neighbors
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("neighbors text content");
+    let neighbors_json: serde_json::Value =
+        serde_json::from_str(&neighbors_text).expect("neighbors json parse");
+    assert_eq!(
+        neighbors_json.get("fact_id").and_then(|v| v.as_str()),
+        Some("f-test-0001"),
+    );
+    assert!(
+        neighbors_json
+            .get("neighbors")
+            .is_some_and(serde_json::Value::is_array),
+        "neighbors must be a JSON array: {neighbors_text}"
+    );
+
+    // Invalid input: empty query should yield a protocol-level error.
+    let bad = client
+        .call_tool(
+            CallToolRequestParams::new("memory_search").with_arguments(
+                serde_json::json!({ "query": "" })
+                    .as_object()
+                    .expect("object")
+                    .clone(),
+            ),
+        )
+        .await;
+    assert!(bad.is_err(), "empty query must produce an error response");
+
+    drop(client);
+    // Give the server a moment to observe the client dropping, then clean up.
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), server_handle).await;
+}


### PR DESCRIPTION
## Summary

- New leaf crate `aletheia-memory-mcp` — standalone stdio MCP binary exposing Aletheia's knowledge graph to external agents (Claude Code, Cursor, OpenHands, Hermes, etc.) without requiring the full runtime
- Four **read-only** tools: `memory_search` (BM25), `memory_neighbors` (one-hop graph traversal), `memory_list_topics` (fact_type aggregation), `memory_stats` (health counters)
- Distinct from `diaporeia`: diaporeia is the in-process HTTP/stdio server bundling sessions + nous + memory; this crate is a dedicated memory-as-service surface that opens the knowledge store directly

## Design

- `KnowledgeStore` opened via `mneme/storage-fjall` at `<oikos root>/data/knowledge.fjall` (or overridden via `ALETHEIA_MEMORY_MCP_STORE`)
- Blocking Datalog queries run on `spawn_blocking` so the stdio reactor never stalls
- Tracing goes to stderr so stdout stays clean for JSON-RPC
- Commits landed in three concerns: scaffold → transport/server → tool impls + integration test
- Writes (annotate/supersede/forget) deliberately **not** exposed — needs auth-model review before any MCP-accessible mutation, since stdio spawn has no authentication and the existing diaporeia write tools require Operator role on an authenticated HTTP surface

## Test plan

- [x] `cargo test -p aletheia-memory-mcp` — 4 pass (3 unit, 1 integration)
- [x] `cargo nextest run -p aletheia-memory-mcp` — 4/4 pass
- [x] `cargo clippy -p aletheia-memory-mcp --all-targets --no-deps -- -D warnings` — clean
- [x] `cargo fmt -p aletheia-memory-mcp --check` — clean
- [x] `cargo check --workspace` — clean
- [x] `kanon lint crates/aletheia-memory-mcp` — only Datalog-in-raw-string false positives (indexing-slicing) and two lib API constructors (pub-visibility), pattern matches diaporeia baseline
- [x] Integration test drives `memory_search`, `memory_neighbors`, `memory_list_topics`, `memory_stats`, and a negative-case empty-query validation through rmcp over `tokio::io::duplex` pipes end-to-end

## Follow-up

- Write tools (`memory_annotate`, `memory_supersede`, `memory_forget`) behind a per-process capability token — filed separately; not in this PR

Closes #3425