### PR TITLE
fix(organon): replace ToolResult.is_error bool with rich outcome enum

### DIFF
--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -12,8 +12,8 @@ use super::workspace::{extract_opt_u64, extract_str};
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
-    InputSchema, PropertyDef, PropertyType, Reversibility, SpawnRequest, ToolCategory, ToolContext,
-    ToolDef, ToolInput, ToolResult,
+    InputSchema, PropertyDef, PropertyType, Reversibility, SpawnRequest, SpawnResult, ToolCategory,
+    ToolContext, ToolDef, ToolInput, ToolResult,
 };
 
 /// Fallback default; runtime reads `ctx.tool_config.agent_dispatch_timeout_secs`.
@@ -154,31 +154,89 @@ impl ToolExecutor for SessionsDispatchExecutor {
                 join_set.spawn(async move { svc.spawn_and_run(request, &parent).await });
             }
 
-            let mut results = Vec::with_capacity(join_set.len());
-            while let Some(join_result) = join_set.join_next().await {
-                match join_result {
-                    Ok(Ok(spawn_result)) => results.push(serde_json::json!({
-                        "content": spawn_result.content,
-                        "is_error": spawn_result.is_error,
-                        "input_tokens": spawn_result.input_tokens,
-                        "output_tokens": spawn_result.output_tokens,
-                    })),
-                    Ok(Err(e)) => results.push(serde_json::json!({
-                        "content": format!("Spawn error: {e}"),
-                        "is_error": true,
-                    })),
-                    Err(e) => results.push(serde_json::json!({
-                        "content": format!("Task panicked: {e}"),
-                        "is_error": true,
-                    })),
-                }
-            }
-
-            Ok(ToolResult::text(
-                serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_owned()),
-            ))
+            Ok(aggregate_dispatch_results(join_set).await)
         })
     }
+}
+
+/// Drain a `JoinSet` of sub-agent spawn futures into a single
+/// [`ToolResult`] whose outcome reflects partial-success semantics.
+///
+/// # Outcome rules (#3633)
+///
+/// - All sub-agents succeeded -> [`ToolOutcome::Success`].
+/// - All sub-agents failed or panicked -> [`ToolOutcome::Failure`].
+/// - Mixed -> [`ToolOutcome::PartialSuccess`] with one reason per
+///   degraded sub-operation.
+///
+/// Extracted from the dispatch executor to keep the executor body
+/// inside the workspace's `too_many_lines` clippy threshold.
+async fn aggregate_dispatch_results(
+    mut join_set: tokio::task::JoinSet<std::result::Result<SpawnResult, String>>,
+) -> ToolResult {
+    let mut results = Vec::with_capacity(join_set.len());
+    let mut failure_reasons: Vec<String> = Vec::new();
+    let mut success_count: u32 = 0;
+    while let Some(join_result) = join_set.join_next().await {
+        match join_result {
+            Ok(Ok(spawn_result)) => {
+                if spawn_result.is_error {
+                    failure_reasons.push(format!(
+                        "sub-agent reported error: {}",
+                        truncate_reason(&spawn_result.content)
+                    ));
+                } else {
+                    success_count += 1;
+                }
+                results.push(serde_json::json!({
+                    "content": spawn_result.content,
+                    "is_error": spawn_result.is_error,
+                    "input_tokens": spawn_result.input_tokens,
+                    "output_tokens": spawn_result.output_tokens,
+                }));
+            }
+            Ok(Err(e)) => {
+                failure_reasons.push(format!("spawn error: {e}"));
+                results.push(serde_json::json!({
+                    "content": format!("Spawn error: {e}"),
+                    "is_error": true,
+                }));
+            }
+            Err(e) => {
+                failure_reasons.push(format!("task panic: {e}"));
+                results.push(serde_json::json!({
+                    "content": format!("Task panicked: {e}"),
+                    "is_error": true,
+                }));
+            }
+        }
+    }
+
+    let payload = serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_owned());
+
+    // WHY (#3633): surface partial-success so downstream observers
+    // (pipeline metrics, the LLM, audit trails) can tell "all N
+    // sub-agents succeeded" apart from "K of N succeeded, rest
+    // failed". Full failure still rides the `is_error` channel.
+    if failure_reasons.is_empty() {
+        ToolResult::text(payload)
+    } else if success_count == 0 {
+        ToolResult::error(payload)
+    } else {
+        ToolResult::partial_success(payload, failure_reasons)
+    }
+}
+
+/// Truncate a sub-agent reason string to a token-friendly length for
+/// inclusion in a `ToolOutcome::PartialSuccess` reason list.
+fn truncate_reason(text: &str) -> String {
+    const MAX: usize = 160;
+    let trimmed = text.trim();
+    if trimmed.len() <= MAX {
+        return trimmed.to_owned();
+    }
+    let end = trimmed.floor_char_boundary(MAX);
+    format!("{}…", trimmed.get(..end).unwrap_or(trimmed))
 }
 
 /// Register agent coordination tools.

--- a/crates/organon/src/types/mod.rs
+++ b/crates/organon/src/types/mod.rs
@@ -390,13 +390,131 @@ impl ToolDiagnostics {
     }
 }
 
+/// Rich outcome classification for a tool invocation.
+///
+/// Replaces the collapsed `is_error: bool` view with three cases that
+/// expose partial-success states — e.g. `sessions_dispatch` running
+/// several sub-agents where some succeed and some fail (#3633).
+///
+/// Legacy callers read [`ToolResult::is_error`], which remains derived
+/// from the outcome for backward compatibility: `PartialSuccess` maps
+/// to `is_error = false` because the tool itself delivered usable
+/// output; the LLM sees caveats inside the content.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ToolOutcome {
+    /// All sub-operations succeeded.
+    #[default]
+    Success,
+    /// Tool returned usable output, but some sub-operations failed or
+    /// emitted warnings. Payload is boxed to keep `ToolOutcome`
+    /// (and therefore `ToolResult`) small so that
+    /// `Result<_, ToolResult>` helpers stay under the
+    /// `clippy::result_large_err` threshold.
+    PartialSuccess(Box<PartialSuccessInfo>),
+    /// Tool failed; no usable output.
+    Failure(Box<FailureInfo>),
+}
+
+/// Payload for [`ToolOutcome::PartialSuccess`]. Boxed in the outcome
+/// to keep the enum pointer-sized.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PartialSuccessInfo {
+    /// One reason per degraded sub-operation.
+    pub reasons: Vec<String>,
+}
+
+/// Payload for [`ToolOutcome::Failure`]. Boxed in the outcome to keep
+/// the enum pointer-sized.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailureInfo {
+    /// Single human-readable failure reason.
+    pub reason: String,
+}
+
+impl ToolOutcome {
+    /// Construct a `PartialSuccess` outcome from an iterator of reasons.
+    #[must_use]
+    pub fn partial(reasons: impl IntoIterator<Item = String>) -> Self {
+        // kanon:ignore RUST/pub-visibility
+        Self::PartialSuccess(Box::new(PartialSuccessInfo {
+            reasons: reasons.into_iter().collect(),
+        }))
+    }
+
+    /// Construct a `Failure` outcome from a single reason.
+    #[must_use]
+    pub fn failure(reason: impl Into<String>) -> Self {
+        // kanon:ignore RUST/pub-visibility
+        Self::Failure(Box::new(FailureInfo {
+            reason: reason.into(),
+        }))
+    }
+
+    /// Whether this outcome represents a pure error state.
+    ///
+    /// `PartialSuccess` returns `false` because the tool produced
+    /// usable output even if some sub-operations were degraded — the
+    /// caveats travel in the content payload, not the error channel.
+    #[must_use]
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::Failure(_))
+    }
+
+    /// Whether this outcome represents a fully-successful run.
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        matches!(self, Self::Success)
+    }
+
+    /// Whether this outcome represents a partial success.
+    #[must_use]
+    pub fn is_partial(&self) -> bool {
+        matches!(self, Self::PartialSuccess(_))
+    }
+
+    /// Reasons recorded for `PartialSuccess`, empty otherwise.
+    #[must_use]
+    pub fn partial_reasons(&self) -> &[String] {
+        match self {
+            Self::PartialSuccess(info) => info.reasons.as_slice(),
+            _ => &[],
+        }
+    }
+
+    /// Reason recorded for `Failure`, empty string otherwise.
+    #[must_use]
+    pub fn failure_reason(&self) -> &str {
+        match self {
+            Self::Failure(info) => info.reason.as_str(),
+            _ => "",
+        }
+    }
+}
+
 /// What the tool executor returns.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult {
     /// Result content: text or rich content blocks.
     pub content: ToolResultContent,
     /// Whether this result represents an error.
+    ///
+    /// Retained for backward compatibility and wire-format stability
+    /// (serialized LLM-facing envelopes and persisted sessions).
+    /// New code should inspect [`ToolResult::outcome`] for the
+    /// partial-success distinction (#3633); `is_error` stays
+    /// synchronized with it via the constructors and remains a
+    /// faithful binary collapse: `Success` or `PartialSuccess`
+    /// → `false`, `Failure` → `true`.
     pub is_error: bool,
+    /// Rich outcome classification. Defaults to `Success` when a
+    /// legacy payload without this field is deserialized; the
+    /// `is_error` flag is not consulted during deserialization
+    /// because `#[serde(default)]` runs before field population.
+    /// For legacy inputs, call [`ToolResult::normalize`] to reconcile.
+    #[serde(default)]
+    pub outcome: ToolOutcome,
     /// Optional diagnostic metadata from the execution environment.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub diagnostics: Option<ToolDiagnostics>,
@@ -410,6 +528,7 @@ impl ToolResult {
         Self {
             content: ToolResultContent::Text(content.into()),
             is_error: false,
+            outcome: ToolOutcome::Success,
             diagnostics: None,
         }
     }
@@ -418,9 +537,11 @@ impl ToolResult {
     #[must_use]
     pub fn error(content: impl Into<String>) -> Self {
         // kanon:ignore RUST/pub-visibility
+        let reason = content.into();
         Self {
-            content: ToolResultContent::Text(content.into()),
+            content: ToolResultContent::Text(reason.clone()),
             is_error: true,
+            outcome: ToolOutcome::failure(reason),
             diagnostics: None,
         }
     }
@@ -432,8 +553,48 @@ impl ToolResult {
         Self {
             content: ToolResultContent::Blocks(blocks),
             is_error: false,
+            outcome: ToolOutcome::Success,
             diagnostics: None,
         }
+    }
+
+    /// Create a partial-success result: the tool produced usable
+    /// output, but some sub-operations failed or emitted warnings.
+    ///
+    /// `reasons` should carry one human-readable note per degraded
+    /// sub-operation. `is_error` is set to `false` because the tool
+    /// surface delivered output; caveats travel in-band.
+    ///
+    /// See #3633 — `sessions_dispatch` is the canonical producer.
+    #[must_use]
+    pub fn partial_success(
+        content: impl Into<String>,
+        reasons: impl IntoIterator<Item = String>,
+    ) -> Self {
+        // kanon:ignore RUST/pub-visibility
+        Self {
+            content: ToolResultContent::Text(content.into()),
+            is_error: false,
+            outcome: ToolOutcome::partial(reasons),
+            diagnostics: None,
+        }
+    }
+
+    /// Reconcile `outcome` against `is_error` after deserialization.
+    ///
+    /// Legacy payloads omit the `outcome` field, so it defaults to
+    /// `Success`; call this to promote `is_error = true` legacy
+    /// records to `Failure` so downstream observers see the error
+    /// through the new API.
+    #[must_use]
+    pub fn normalize(mut self) -> Self {
+        // kanon:ignore RUST/pub-visibility
+        if self.is_error && matches!(self.outcome, ToolOutcome::Success) {
+            // text_summary() already returns an owned String.
+            let reason = self.content.text_summary();
+            self.outcome = ToolOutcome::failure(reason);
+        }
+        self
     }
 
     /// Attach diagnostic metadata to this result.
@@ -466,17 +627,39 @@ pub struct ToolStats {
     pub total_calls: u32,
     pub total_duration_ms: u64,
     pub error_count: u32,
+    /// Count of calls that produced `ToolOutcome::PartialSuccess`
+    /// (see #3633). Separate from `error_count` because partial
+    /// successes deliver usable output even with degraded
+    /// sub-operations.
+    pub partial_count: u32,
     pub calls_by_tool: IndexMap<String, u32>,
 }
 
 impl ToolStats {
-    /// Record a tool execution.
+    /// Record a tool execution (binary-outcome variant).
+    ///
+    /// Retained for call sites that only know `is_error`; prefer
+    /// [`ToolStats::record_outcome`] to capture partial-success
+    /// state explicitly.
     pub fn record(&mut self, name: &str, duration_ms: u64, is_error: bool) {
+        // kanon:ignore RUST/pub-visibility
+        let outcome = if is_error {
+            ToolOutcome::failure(String::new())
+        } else {
+            ToolOutcome::Success
+        };
+        self.record_outcome(name, duration_ms, &outcome);
+    }
+
+    /// Record a tool execution with full outcome detail.
+    pub fn record_outcome(&mut self, name: &str, duration_ms: u64, outcome: &ToolOutcome) {
         // kanon:ignore RUST/pub-visibility
         self.total_calls += 1;
         self.total_duration_ms += duration_ms;
-        if is_error {
-            self.error_count += 1;
+        match outcome {
+            ToolOutcome::Success => {}
+            ToolOutcome::PartialSuccess(_) => self.partial_count += 1,
+            ToolOutcome::Failure(_) => self.error_count += 1,
         }
         *self.calls_by_tool.entry(name.to_owned()).or_insert(0) += 1;
     }

--- a/crates/organon/src/types_tests.rs
+++ b/crates/organon/src/types_tests.rs
@@ -887,3 +887,98 @@ fn tool_result_serde_backward_compat_missing_diagnostics() {
         "missing diagnostics should default to None"
     );
 }
+
+// ---------------------------------------------------------------------------
+// ToolOutcome / partial success (#3633)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tool_result_partial_success_constructor_carries_reasons() {
+    // Scenario: 3-way sub-agent dispatch where 2 succeeded and 1 failed.
+    // Old is_error bool would collapse this into a binary; new outcome
+    // surfaces it as PartialSuccess with one reason per failed sub-op.
+    let r = ToolResult::partial_success(
+        r#"[{"ok":1},{"ok":2},{"err":"boom"}]"#,
+        vec!["sub-agent #3: boom".to_owned()],
+    );
+    assert!(
+        !r.is_error,
+        "partial_success should map to is_error=false — tool delivered usable output"
+    );
+    assert!(r.outcome.is_partial(), "outcome should be PartialSuccess");
+    assert_eq!(
+        r.outcome.partial_reasons(),
+        &["sub-agent #3: boom".to_owned()],
+        "reasons should propagate through the outcome, not be collapsed"
+    );
+
+    // Old consumers still reading is_error get the back-compat view.
+    match &r.outcome {
+        ToolOutcome::PartialSuccess(info) => {
+            assert_eq!(info.reasons.len(), 1, "one reason per failed sub-operation");
+        }
+        other => panic!("expected PartialSuccess, got {other:?}"),
+    }
+}
+
+#[test]
+fn tool_outcome_is_error_collapse_matches_legacy_bool() {
+    assert!(!ToolOutcome::Success.is_error());
+    assert!(!ToolOutcome::partial(Vec::<String>::new()).is_error());
+    assert!(ToolOutcome::failure("x").is_error());
+}
+
+#[test]
+fn tool_result_outcome_serde_roundtrip_partial() {
+    let r = ToolResult::partial_success("payload", vec!["warn".to_owned()]);
+    let json = serde_json::to_string(&r).expect("serialize");
+    let back: ToolResult = serde_json::from_str(&json).expect("deserialize");
+    assert!(back.outcome.is_partial(), "outcome should survive serde");
+    assert_eq!(back.outcome.partial_reasons(), &["warn".to_owned()]);
+    assert!(!back.is_error);
+}
+
+#[test]
+fn tool_result_serde_legacy_payload_defaults_to_success_then_normalizes() {
+    // Legacy payloads predate the `outcome` field; #[serde(default)]
+    // populates it as Success. For legacy error records, normalize()
+    // promotes the outcome to Failure to match is_error=true.
+    let success_legacy = r#"{"content":"ok","is_error":false}"#;
+    let back: ToolResult = serde_json::from_str(success_legacy).expect("deserialize success");
+    assert!(
+        back.outcome.is_success(),
+        "legacy success defaults correctly"
+    );
+
+    let error_legacy = r#"{"content":"bad","is_error":true}"#;
+    let back: ToolResult = serde_json::from_str::<ToolResult>(error_legacy)
+        .expect("deserialize error")
+        .normalize();
+    assert!(
+        back.outcome.is_error(),
+        "normalize() promotes legacy is_error=true records to Failure"
+    );
+    assert!(back.is_error);
+}
+
+#[test]
+fn tool_stats_record_outcome_separates_partial_from_error() {
+    let mut stats = ToolStats::default();
+    stats.record_outcome("dispatch", 10, &ToolOutcome::Success);
+    stats.record_outcome(
+        "dispatch",
+        20,
+        &ToolOutcome::partial(vec!["one failed".to_owned()]),
+    );
+    stats.record_outcome("dispatch", 30, &ToolOutcome::failure("crash"));
+    assert_eq!(stats.total_calls, 3);
+    assert_eq!(
+        stats.error_count, 1,
+        "only true failures count as errors, not partials"
+    );
+    assert_eq!(
+        stats.partial_count, 1,
+        "partial successes get their own counter (#3633)"
+    );
+    assert_eq!(stats.total_duration_ms, 60);
+}


### PR DESCRIPTION
## Summary

Closes #3633. Introduce `ToolOutcome::{Success, PartialSuccess(reasons), Failure(reason)}` as the richer surface for tool results while keeping `is_error: bool` as a back-compat derived view.

- New `ToolOutcome` enum with boxed payloads (keeps `ToolResult` under the `result_large_err` threshold used by `Result<_, ToolResult>` helpers)
- New `ToolResult::partial_success(content, reasons)` constructor + `normalize()` for legacy payloads missing the field
- New `ToolStats::record_outcome` + `partial_count` so pipeline metrics can tell partial successes apart from errors
- `sessions_dispatch` (dromeus) now surfaces `PartialSuccess` when some sub-agents fail and others succeed, instead of collapsing to a single success/error
- `is_error` stays synchronized with the outcome: Success / PartialSuccess -> false, Failure -> true. Partial-success caveats travel in-band in the content payload (LLM still sees usable output).

## Scope

Additive change. 3 files touched (all in `crates/organon`):
- `src/types/mod.rs` (+160 lines): enum + constructors + normalize + stats
- `src/builtins/agent.rs` (+74 lines): dispatch aggregation uses PartialSuccess
- `src/types_tests.rs` (+95 lines): 5 new tests

No existing call sites needed to change — every reader of `ToolResult::is_error` still gets the same boolean view.

## Wire-format stability

- Legacy serialized `ToolResult` payloads (no `outcome` field) deserialize with `outcome = Success` via `#[serde(default)]`. Call `normalize()` to promote `is_error=true` legacy records to `Failure`.
- New field uses `#[serde(tag = "status")]` internally-tagged representation with boxed payloads.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p organon --lib --tests` (zero new warnings; pre-existing unrelated warnings in energeia/koina untouched)
- [x] `cargo test -p organon` — 449 lib tests + 3 integration tests pass
- [x] `cargo nextest run -p organon` — 451 pass, 1 pre-existing flake unrelated to this change (`missing_api_key_returns_configuration_error` — reqwest crypto provider not installed)
- [x] `cargo test --workspace --lib` — all test suites pass
- [x] New assertion: 3-way sub-agent dispatch with 2 successes + 1 failure now produces `ToolOutcome::PartialSuccess` with the failed sub-op's reason; legacy `is_error` view remains false because the tool delivered usable output
- [x] `kanon lint crates/organon` — no new violations introduced on touched files