### PR TITLE
fix(episteme): preserve multiplicity metadata through Fact consolidation

### DIFF
--- a/crates/episteme/src/consolidation/consolidation_tests.rs
+++ b/crates/episteme/src/consolidation/consolidation_tests.rs
@@ -311,6 +311,10 @@ fn consolidated_fact_serde_roundtrip() {
             FactId::new("f-1").expect("valid test id"),
             FactId::new("f-2").expect("valid test id"),
         ],
+        source_recorded_ats: vec![
+            "2026-01-01T00:00:00Z".to_owned(),
+            "2026-01-05T00:00:00Z".to_owned(),
+        ],
     };
     let json = serde_json::to_string(&fact).expect("serialize");
     let back: ConsolidatedFact = serde_json::from_str(&json).expect("deserialize");

--- a/crates/episteme/src/consolidation/engine.rs
+++ b/crates/episteme/src/consolidation/engine.rs
@@ -9,9 +9,9 @@ use super::{
     CLUSTER_FACTS_FOR_CONSOLIDATION, COMMUNITY_OVERFLOW_CANDIDATES, CONSOLIDATION_AUDIT_DDL,
     ConsolidatedFact, ConsolidationAuditRecord, ConsolidationCandidate, ConsolidationConfig,
     ConsolidationError, ConsolidationProvider, ConsolidationResult, ConsolidationTrigger,
-    ENTITY_FACTS_FOR_CONSOLIDATION, ENTITY_OVERFLOW_CANDIDATES, RateLimitedSnafu, StoreSnafu,
-    age_cutoff, batch_facts, consolidation_system_prompt, consolidation_user_message,
-    parse_consolidation_response,
+    ENTITY_FACTS_FOR_CONSOLIDATION, ENTITY_OVERFLOW_CANDIDATES, FACT_MULTIPLICITY_DDL,
+    FactMultiplicity, RateLimitedSnafu, StoreSnafu, age_cutoff, batch_facts,
+    consolidation_system_prompt, consolidation_user_message, parse_consolidation_response,
 };
 use crate::engine::DataValue;
 use crate::id::{EntityId, FactId};
@@ -45,6 +45,19 @@ impl KnowledgeStore {
     )]
     pub(crate) fn init_consolidation_audit(&self) -> crate::error::Result<()> {
         self.run_mut_query(CONSOLIDATION_AUDIT_DDL, BTreeMap::new())?;
+        Ok(())
+    }
+
+    /// Initialize the `fact_multiplicity` side-index relation (#3634).
+    ///
+    /// Called during schema setup. Separate from the facts relation so the
+    /// fact schema stays stable and legacy records remain valid.
+    #[expect(
+        dead_code,
+        reason = "knowledge consolidation engine, feature-gated behind mneme-engine"
+    )]
+    pub(crate) fn init_fact_multiplicity(&self) -> crate::error::Result<()> {
+        self.run_mut_query(FACT_MULTIPLICITY_DDL, BTreeMap::new())?;
         Ok(())
     }
 
@@ -313,9 +326,110 @@ impl KnowledgeStore {
                 }
                 .build()
             })?;
+
+            // WHY (#3634): record multiplicity metadata in the side-index so
+            // downstream recall and conflict resolution can weight a
+            // consolidated fact by how many independent observations
+            // converged on it. Failing to record multiplicity must not
+            // prevent the fact from being persisted, but the error should
+            // surface to the caller.
+            let multiplicity = compute_multiplicity(
+                &new_id,
+                consolidated,
+                &crate::knowledge::format_timestamp(&now),
+            );
+            self.record_fact_multiplicity(&multiplicity)?;
+
             new_fact_ids.push(new_id);
         }
         Ok(new_fact_ids)
+    }
+
+    /// Persist a `FactMultiplicity` record for a consolidated fact (#3634).
+    fn record_fact_multiplicity(
+        &self,
+        record: &FactMultiplicity,
+    ) -> Result<(), ConsolidationError> {
+        let script = r"
+?[fact_id, source_count, first_observed, last_observed, time_spread_seconds, recorded_at] <-
+    [[$fact_id, $source_count, $first_observed, $last_observed, $time_spread_seconds, $recorded_at]]
+
+:put fact_multiplicity {fact_id => source_count, first_observed, last_observed,
+                        time_spread_seconds, recorded_at}
+";
+        let mut params = BTreeMap::new();
+        let str_val = |s: &str| DataValue::Str(s.into());
+        params.insert("fact_id".to_owned(), str_val(record.fact_id.as_str()));
+        params.insert(
+            "source_count".to_owned(),
+            DataValue::from(i64::from(record.source_count)),
+        );
+        params.insert("first_observed".to_owned(), str_val(&record.first_observed));
+        params.insert("last_observed".to_owned(), str_val(&record.last_observed));
+        params.insert(
+            "time_spread_seconds".to_owned(),
+            DataValue::from(record.time_spread_seconds),
+        );
+        params.insert("recorded_at".to_owned(), str_val(&record.recorded_at));
+        self.run_mut_query(script, params).map_err(|e| {
+            StoreSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
+        Ok(())
+    }
+
+    /// Look up multiplicity metadata for a consolidated fact (#3634).
+    ///
+    /// Returns `None` if no multiplicity record exists (e.g. the fact was
+    /// not produced by consolidation, or was persisted before this
+    /// side-index was introduced).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the knowledge store query fails.
+    #[instrument(skip(self))]
+    pub fn get_fact_multiplicity(
+        &self,
+        fact_id: &FactId,
+    ) -> Result<Option<FactMultiplicity>, ConsolidationError> {
+        let script = r"
+?[source_count, first_observed, last_observed, time_spread_seconds, recorded_at] :=
+    *fact_multiplicity{fact_id: $fact_id, source_count, first_observed,
+                       last_observed, time_spread_seconds, recorded_at}
+";
+        let mut params = BTreeMap::new();
+        params.insert(
+            "fact_id".to_owned(),
+            DataValue::Str(fact_id.as_str().into()),
+        );
+        let result = self.run_query(script, params).map_err(|e| {
+            StoreSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
+
+        if result.is_empty() {
+            return Ok(None);
+        }
+
+        let source_count_i64 = result.get_i64(0, "source_count").unwrap_or(0);
+        let source_count = u32::try_from(source_count_i64).unwrap_or(0);
+        let first_observed = result.get_string(0, "first_observed").unwrap_or_default();
+        let last_observed = result.get_string(0, "last_observed").unwrap_or_default();
+        let time_spread_seconds = result.get_i64(0, "time_spread_seconds").unwrap_or(0);
+        let recorded_at = result.get_string(0, "recorded_at").unwrap_or_default();
+
+        Ok(Some(FactMultiplicity {
+            fact_id: fact_id.clone(),
+            source_count,
+            first_observed,
+            last_observed,
+            time_spread_seconds,
+            recorded_at,
+        }))
     }
 
     /// Mark original facts as superseded.
@@ -572,6 +686,11 @@ fn run_llm_consolidation(
         let entries = parse_consolidation_response(&response)?;
 
         let batch_fact_ids: Vec<FactId> = batch.iter().map(|(id, _, _, _)| id.clone()).collect();
+        // WHY (#3634): preserve source recorded_at timestamps so multiplicity
+        // metadata (time-spread, first/last observation) can be computed
+        // downstream. Aligned by index to `batch_fact_ids`.
+        let batch_recorded_ats: Vec<String> =
+            batch.iter().map(|(_, _, _, ts)| ts.clone()).collect();
 
         for entry in entries {
             all_consolidated.push(ConsolidatedFact {
@@ -582,6 +701,7 @@ fn run_llm_consolidation(
                 // need the same IDs for all_superseded after the loop; Arc<[FactId]>
                 // would eliminate this but ConsolidatedFact is part of the public API.
                 source_fact_ids: batch_fact_ids.clone(),
+                source_recorded_ats: batch_recorded_ats.clone(),
             });
         }
         all_superseded.extend(batch_fact_ids);
@@ -593,6 +713,50 @@ fn run_llm_consolidation(
         consolidated_facts: all_consolidated,
         superseded_fact_ids: all_superseded,
     })
+}
+
+/// Compute multiplicity metadata for a consolidated fact (#3634).
+///
+/// `source_count` is the number of independent source fact IDs. The time
+/// window spans the earliest to latest `recorded_at` across those sources;
+/// when timestamps are unavailable or unparseable we fall back to `now`
+/// for both ends (zero spread) so the record remains well-formed.
+fn compute_multiplicity(
+    new_id: &FactId,
+    consolidated: &ConsolidatedFact,
+    now: &str,
+) -> FactMultiplicity {
+    let source_count = u32::try_from(consolidated.source_fact_ids.len()).unwrap_or(u32::MAX);
+    let parsed: Vec<jiff::Timestamp> = consolidated
+        .source_recorded_ats
+        .iter()
+        .filter_map(|s| crate::knowledge::parse_timestamp(s))
+        .collect();
+    let (first_observed, last_observed, time_spread_seconds) =
+        match (parsed.iter().min().copied(), parsed.iter().max().copied()) {
+            (Some(min_ts), Some(max_ts)) => {
+                let spread = max_ts.since(min_ts).map_or(0_i64, |span| {
+                    i64::from(span.get_hours())
+                        .saturating_mul(3600)
+                        .saturating_add(span.get_minutes().saturating_mul(60))
+                        .saturating_add(span.get_seconds())
+                });
+                (
+                    crate::knowledge::format_timestamp(&min_ts),
+                    crate::knowledge::format_timestamp(&max_ts),
+                    spread,
+                )
+            }
+            _ => (now.to_owned(), now.to_owned(), 0_i64),
+        };
+    FactMultiplicity {
+        fact_id: new_id.clone(),
+        source_count,
+        first_observed,
+        last_observed,
+        time_spread_seconds,
+        recorded_at: now.to_owned(),
+    }
 }
 
 /// Parse fact rows from query results.
@@ -618,3 +782,7 @@ fn parse_fact_rows(rows: &[Vec<DataValue>]) -> Vec<(FactId, String, f64, String)
         })
         .collect()
 }
+
+#[cfg(all(test, feature = "mneme-engine"))]
+#[path = "engine_tests.rs"]
+mod engine_tests;

--- a/crates/episteme/src/consolidation/engine_tests.rs
+++ b/crates/episteme/src/consolidation/engine_tests.rs
@@ -1,0 +1,117 @@
+//! Integration tests for the consolidation engine against a real
+//! in-memory `KnowledgeStore`.
+//!
+//! These tests exercise the multiplicity side-index introduced for #3634:
+//! when facts are consolidated, the source-observation count, time spread,
+//! and first/last observation timestamps must be preserved so downstream
+//! recall and conflict resolution can weight consolidated facts by
+//! convergence strength.
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+use super::*;
+use crate::consolidation::ConsolidationResult;
+use crate::test_fixtures::make_store;
+
+/// Requirement #3634: consolidating N source facts into one Fact must
+/// preserve the source count so downstream recall and conflict resolution
+/// can weight by convergence strength.
+///
+/// Builds a `ConsolidationResult` describing 5 source facts merged into a
+/// single consolidated fact, persists it via `persist_consolidated_facts`,
+/// then reads back the multiplicity record and asserts:
+/// - `source_count` equals the input count (5)
+/// - `first_observed` / `last_observed` bound the source timestamps
+/// - `time_spread_seconds` is non-negative and matches the span
+#[test]
+fn consolidation_preserves_multiplicity_metadata() {
+    let store = make_store();
+
+    let source_ids: Vec<FactId> = (0..5)
+        .map(|i| FactId::new(format!("src-fact-{i}")).expect("valid test id"))
+        .collect();
+    let source_recorded_ats: Vec<String> = vec![
+        "2026-01-01T00:00:00Z".to_owned(),
+        "2026-01-02T00:00:00Z".to_owned(),
+        "2026-01-03T00:00:00Z".to_owned(),
+        "2026-01-04T00:00:00Z".to_owned(),
+        "2026-01-05T00:00:00Z".to_owned(),
+    ];
+
+    let consolidated = ConsolidatedFact {
+        content: "Alice is a senior engineer at Acme Corp".to_owned(),
+        confidence: 0.95,
+        tier: "inferred".to_owned(),
+        source_fact_ids: source_ids.clone(),
+        source_recorded_ats: source_recorded_ats.clone(),
+    };
+    let result = ConsolidationResult {
+        original_count: source_ids.len(),
+        consolidated_count: 1,
+        consolidated_facts: vec![consolidated],
+        superseded_fact_ids: source_ids.clone(),
+    };
+
+    let new_ids = store
+        .persist_consolidated_facts(&result, "nous-test")
+        .expect("persist succeeds");
+    assert_eq!(
+        new_ids.len(),
+        1,
+        "exactly one consolidated fact must be persisted"
+    );
+
+    let new_id = new_ids.first().expect("one new fact id").clone();
+    let multiplicity = store
+        .get_fact_multiplicity(&new_id)
+        .expect("query succeeds")
+        .expect("multiplicity record must exist for a consolidated fact");
+
+    // Acceptance: source_count ≥ input count (equal here, ≥ honors the
+    // brief's contract for cases where batches merge multiple times).
+    let input_count = u32::try_from(source_ids.len()).expect("fits u32");
+    assert!(
+        multiplicity.source_count >= input_count,
+        "source_count ({}) must be ≥ input count ({})",
+        multiplicity.source_count,
+        input_count
+    );
+    assert_eq!(
+        multiplicity.source_count, input_count,
+        "exact source_count must equal the number of source fact IDs"
+    );
+
+    // Time-spread: first/last observed must bound the inputs and the
+    // spread must equal the full 4-day window in seconds (4 * 86_400).
+    assert_eq!(
+        multiplicity.first_observed, "2026-01-01T00:00:00Z",
+        "first_observed must be the earliest source recorded_at"
+    );
+    assert_eq!(
+        multiplicity.last_observed, "2026-01-05T00:00:00Z",
+        "last_observed must be the latest source recorded_at"
+    );
+    assert_eq!(
+        multiplicity.time_spread_seconds,
+        4 * 86_400,
+        "time_spread_seconds must match the full 4-day window"
+    );
+    assert_eq!(
+        multiplicity.fact_id, new_id,
+        "multiplicity record must be keyed on the new consolidated fact id"
+    );
+}
+
+/// Negative control: facts not produced by consolidation have no
+/// multiplicity record. `get_fact_multiplicity` returns `Ok(None)`.
+#[test]
+fn non_consolidated_fact_has_no_multiplicity() {
+    let store = make_store();
+    let missing_id = FactId::new("does-not-exist").expect("valid test id");
+    let result = store
+        .get_fact_multiplicity(&missing_id)
+        .expect("query succeeds");
+    assert!(
+        result.is_none(),
+        "facts with no consolidation history must return None"
+    );
+}

--- a/crates/episteme/src/consolidation/mod.rs
+++ b/crates/episteme/src/consolidation/mod.rs
@@ -156,6 +156,14 @@ pub struct ConsolidatedFact {
     pub tier: String,
     /// IDs of the original facts that were consolidated into this one.
     pub source_fact_ids: Vec<FactId>,
+    /// `recorded_at` timestamps (ISO 8601) of the original facts, aligned to
+    /// [`source_fact_ids`](Self::source_fact_ids) by index.
+    ///
+    /// Used to compute multiplicity time-spread metadata (#3634). Defaulted
+    /// via `#[serde(default)]` so legacy serialized `ConsolidatedFact`
+    /// records (which predate this field) still deserialize.
+    #[serde(default)]
+    pub source_recorded_ats: Vec<String>,
 }
 
 /// Result of a consolidation operation.
@@ -169,6 +177,37 @@ pub struct ConsolidationResult {
     pub original_count: usize,
     /// Number of output facts.
     pub consolidated_count: usize,
+}
+
+/// Multiplicity metadata for a consolidated fact.
+///
+/// Stored in the `fact_multiplicity` relation keyed by the consolidated
+/// fact's ID. Captures the epistemic strength of a merged fact: how many
+/// independent observations converged on it, and over what time window.
+///
+/// A fact that emerged from 5 converging observations over 30 days is
+/// epistemically stronger than one built from 2 observations on the same
+/// day. Recall and conflict resolution can consult this via
+/// [`KnowledgeStore::get_fact_multiplicity`](crate::knowledge_store::KnowledgeStore)
+/// to weight consolidated facts appropriately (#3634).
+///
+/// The `#[serde(default)]` on `source_count` allows deserializing legacy
+/// records emitted before this struct gained richer fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FactMultiplicity {
+    /// The consolidated fact this multiplicity record describes.
+    pub fact_id: FactId,
+    /// Number of independent source observations that converged on this fact.
+    #[serde(default)]
+    pub source_count: u32,
+    /// Earliest `recorded_at` timestamp among source facts (ISO 8601).
+    pub first_observed: String,
+    /// Latest `recorded_at` timestamp among source facts (ISO 8601).
+    pub last_observed: String,
+    /// Span between `first_observed` and `last_observed` in seconds.
+    pub time_spread_seconds: i64,
+    /// When this multiplicity record was written (ISO 8601).
+    pub recorded_at: String,
 }
 
 /// Record of a completed consolidation for the audit trail.
@@ -396,6 +435,21 @@ pub const CONSOLIDATION_AUDIT_DDL: &str = r":create consolidation_audit {
     original_fact_ids: String,
     consolidated_fact_ids: String,
     consolidated_at: String
+}";
+
+/// Datalog DDL for the `fact_multiplicity` side-index (#3634).
+///
+/// Side-indexed rather than folded into the `facts` relation so that the
+/// fact schema stays stable and legacy records without multiplicity
+/// metadata remain valid. Consumers (recall, conflict resolution) look
+/// up multiplicity by fact ID on demand.
+pub const FACT_MULTIPLICITY_DDL: &str = r":create fact_multiplicity {
+    fact_id: String =>
+    source_count: Int,
+    first_observed: String,
+    last_observed: String,
+    time_spread_seconds: Int,
+    recorded_at: String
 }";
 
 /// Compute the age cutoff timestamp (now - `min_age_days`).

--- a/crates/episteme/src/knowledge_store/migration.rs
+++ b/crates/episteme/src/knowledge_store/migration.rs
@@ -479,6 +479,55 @@ impl KnowledgeStore {
         Ok(())
     }
 
+    /// Migrate v8 → v9: add `fact_multiplicity` side-index (#3634).
+    ///
+    /// Preserves multiplicity metadata for consolidated facts — source
+    /// observation count, time spread, first/last observed timestamps —
+    /// so recall and conflict resolution can weight consolidated facts by
+    /// convergence strength without joining against the audit relation.
+    ///
+    /// Additive migration: no existing data is rewritten. Facts consolidated
+    /// before v9 will have no multiplicity record; `get_fact_multiplicity`
+    /// returns `None` for those.
+    pub(super) fn migrate_v8_to_v9(&self) -> crate::error::Result<()> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::{DataValue, ScriptMutability};
+        tracing::info!("migrating knowledge schema v8 -> v9");
+
+        self.db
+            .run(
+                crate::consolidation::FACT_MULTIPLICITY_DDL,
+                BTreeMap::new(),
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v8->v9 create fact_multiplicity: {e}"),
+                }
+                .build()
+            })?;
+
+        let mut params = BTreeMap::new();
+        params.insert("key".to_owned(), DataValue::Str("schema".into()));
+        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
+        self.db
+            .run(
+                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
+                params,
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v8->v9 update version: {e}"),
+                }
+                .build()
+            })?;
+
+        tracing::info!("knowledge schema migration v8 -> v9 complete");
+        Ok(())
+    }
+
     /// Migrate v7 → v8: add `type_hierarchy`, `derived_facts`, and `defaults` relations.
     ///
     /// These relations support the derived-rule engine introduced in the Wave 5

--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -480,7 +480,7 @@ pub struct KnowledgeStore {
 
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
-    const SCHEMA_VERSION: i64 = 8;
+    const SCHEMA_VERSION: i64 = 9;
 
     /// Open an in-memory knowledge store with default configuration.
     ///
@@ -594,6 +594,9 @@ impl KnowledgeStore {
             if current_version < 8 {
                 self.migrate_v7_to_v8()?;
             }
+            if current_version < 9 {
+                self.migrate_v8_to_v9()?;
+            }
             return Ok(());
         }
 
@@ -654,6 +657,21 @@ impl KnowledgeStore {
         self.db
             .run(
                 crate::consolidation::CONSOLIDATION_AUDIT_DDL,
+                BTreeMap::new(),
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
+
+        // WHY (#3634): fact_multiplicity is a side-index for consolidated-fact
+        // strength. Lives next to consolidation_audit so both arrive at v9.
+        self.db
+            .run(
+                crate::consolidation::FACT_MULTIPLICITY_DDL,
                 BTreeMap::new(),
                 ScriptMutability::Mutable,
             )

--- a/crates/episteme/src/knowledge_store/tests/causal.rs
+++ b/crates/episteme/src/knowledge_store/tests/causal.rs
@@ -335,10 +335,14 @@ fn rejects_invalid_confidence() {
 }
 
 #[test]
-fn schema_version_is_eight_after_fresh_init() {
+fn schema_version_is_current_after_fresh_init() {
     let store = KnowledgeStore::open_mem().expect("open_mem should succeed");
     let version = store
         .schema_version()
         .expect("schema_version should succeed");
-    assert_eq!(version, 8, "fresh init should be at schema version 8");
+    assert_eq!(
+        version,
+        KnowledgeStore::SCHEMA_VERSION,
+        "fresh init should be at current schema version"
+    );
 }

--- a/crates/episteme/src/knowledge_store/tests/derived_rules.rs
+++ b/crates/episteme/src/knowledge_store/tests/derived_rules.rs
@@ -504,12 +504,16 @@ fn defeasible_default_entity_scoped_override_does_not_suppress_other_entity() {
 // ── Schema version test ────────────────────────────────────────────────────────
 
 #[test]
-fn schema_version_is_eight_after_fresh_init() {
+fn schema_version_is_current_after_fresh_init() {
     let store = KnowledgeStore::open_mem().expect("open_mem");
     let version = store
         .schema_version()
         .expect("schema_version should succeed");
-    assert_eq!(version, 8, "fresh init should be at schema version 8");
+    assert_eq!(
+        version,
+        KnowledgeStore::SCHEMA_VERSION,
+        "fresh init should be at current schema version"
+    );
 }
 
 // ── Rule-ID query filter ───────────────────────────────────────────────────────

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -202,7 +202,10 @@ fn schema_version_queryable() {
     })
     .expect("open_mem");
     let version = store.schema_version().expect("version");
-    assert_eq!(version, 8);
+    // v8 -> v9: additive migration added the `fact_multiplicity` side-index
+    // that records source-observation count / first+last timestamps / spread
+    // for consolidated facts (see KnowledgeStore::SCHEMA_VERSION).
+    assert_eq!(version, 9);
 }
 
 // Verify ordering of multiple facts by confidence (descending).


### PR DESCRIPTION
## Summary

Closes #3634.

When facts are consolidated (`crates/episteme/src/consolidation/engine.rs`), the resulting `Fact` previously lost the multiplicity signal: a fact that emerged from 5 converging observations was indistinguishable from one built from 2, because recall and conflict resolution never joined against `consolidation_audit`.

This PR introduces a dedicated side-index `fact_multiplicity` keyed by the consolidated fact's ID. Whenever `persist_consolidated_facts` inserts a new consolidated fact it also records:

- `source_count` — number of independent source observations
- `first_observed` / `last_observed` — ISO 8601 bounds of source `recorded_at` timestamps
- `time_spread_seconds` — span between first and last observation

A new `pub fn KnowledgeStore::get_fact_multiplicity(fact_id) -> Result<Option<FactMultiplicity>>` exposes the record to downstream recall / conflict pipelines without requiring a join.

### Design choice: side-index vs extending `FactProvenance`

The issue presented three options. The side-index (option 3 in spirit) was chosen because:

1. Keeps the `facts` relation and the `Fact` struct schema stable — no churn across the 50+ `FactProvenance { ... }` construction sites workspace-wide.
2. `#[serde(default)]` on the new `ConsolidatedFact.source_recorded_ats` field means legacy serialized payloads still deserialize.
3. Follows the established pattern of `consolidation_audit`, `fact_entities`, `merge_audit`, etc. — metadata lives in its own relation.
4. Legacy consolidated facts (persisted before v9) gracefully return `None`; no backfill migration required.

### Schema

Schema version bumped v8 → v9. Migration is additive (creates the new relation only); no existing data is rewritten. Fresh stores get the relation via `init_schema`.

### Test

Added `crates/episteme/src/consolidation/engine_tests.rs` with two tests:

- `consolidation_preserves_multiplicity_metadata` — consolidates 5 source facts spanning 4 days into one fact, asserts `source_count == 5` (≥ input count), `first_observed` / `last_observed` match the extremes, and `time_spread_seconds == 4 * 86_400`.
- `non_consolidated_fact_has_no_multiplicity` — negative control: unknown fact ID returns `Ok(None)`.

## Test plan

- [x] `cargo test -p episteme --features mneme-engine --lib` — 1148/1148 pass (including the two new tests).
- [x] `cargo fmt --check -p episteme` — clean.
- [x] `cargo clippy -p episteme --features mneme-engine --lib --tests` — no new warnings (3 pre-existing `koina` warnings, unrelated).
- [x] `cargo check --workspace --all-targets` — clean, exit code 0.
- [x] `kanon lint crates/episteme/src/consolidation` — no `file-too-long` regression; all remaining violations pre-existing on `main`.
- [ ] Manual verification against a pre-v9 store (migration path).

## Files changed

- `crates/episteme/src/consolidation/mod.rs` — new `FactMultiplicity` struct, `FACT_MULTIPLICITY_DDL`, `source_recorded_ats` on `ConsolidatedFact` (with `#[serde(default)]`).
- `crates/episteme/src/consolidation/engine.rs` — `record_fact_multiplicity`, `get_fact_multiplicity`, `compute_multiplicity`, wired into `persist_consolidated_facts` and `run_llm_consolidation`.
- `crates/episteme/src/consolidation/engine_tests.rs` — new integration test file.
- `crates/episteme/src/consolidation/consolidation_tests.rs` — updated `ConsolidatedFact` literal with new field.
- `crates/episteme/src/knowledge_store/mod.rs` — bumped `SCHEMA_VERSION` to 9, added DDL init and migration chaining.
- `crates/episteme/src/knowledge_store/migration.rs` — new `migrate_v8_to_v9`.
- `crates/episteme/src/knowledge_store/tests/{causal,derived_rules}.rs` — renamed version-pinned tests to reference the current constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)