### PR TITLE
fix(koina): clippy -Dwarnings compliance post-CompactString refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3807,7 +3807,6 @@ dependencies = [
 name = "koina"
 version = "0.20.0"
 dependencies = [
- "compact_str",
  "criterion",
  "fjall",
  "jiff",
@@ -7064,7 +7063,6 @@ name = "skene"
 version = "0.20.0"
 dependencies = [
  "bytes",
- "compact_str",
  "futures-core",
  "futures-util",
  "koina",

--- a/crates/energeia/src/routing/empirical.rs
+++ b/crates/energeia/src/routing/empirical.rs
@@ -66,6 +66,10 @@ impl EmpiricalRouter {
     ///
     /// Returns the static fallback provider when empirical data is absent or
     /// insufficient.  If `candidates` is empty the static default is returned.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "binary wiring invokes pick (follow-up #3455)")
+    )]
     pub(crate) async fn pick(
         &self,
         task_category: &TaskCategory,

--- a/crates/energeia/src/routing/mod.rs
+++ b/crates/energeia/src/routing/mod.rs
@@ -44,6 +44,13 @@ impl TaskCategory {
     /// the router's hot path. Keyword matching is O(n) and zero-latency. The
     /// follow-up PR (#3455) replaces this with persona-aware routing that
     /// operates on richer metadata.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "binary wiring consumes from_prompt (follow-up #3455)"
+        )
+    )]
     pub(crate) fn from_prompt(text: &str) -> Self {
         let lower = text.to_lowercase();
         if lower.contains("refactor") || lower.contains("restructure") || lower.contains("rename") {
@@ -173,6 +180,13 @@ pub(crate) enum RoutingMode {
 /// Operator-facing routing configuration for the dispatch engine.
 ///
 /// Placed under `[dispatch.routing]` in the instance `taxis` config.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "binary wiring constructs DispatchRoutingConfig (follow-up #3455)"
+    )
+)]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
 pub(crate) struct DispatchRoutingConfig {

--- a/crates/koina/src/id.rs
+++ b/crates/koina/src/id.rs
@@ -179,7 +179,7 @@ impl TryFrom<String> for NousId {
 
 impl From<NousId> for String {
     fn from(id: NousId) -> Self {
-        id.0.into()
+        id.0
     }
 }
 
@@ -331,7 +331,7 @@ impl ToolName {
         {
             return Err(IdError::InvalidFormat {
                 kind: "ToolName",
-                value: name.to_string(),
+                value: name.clone(),
                 reason: "must contain only alphanumeric, hyphens, and underscores".to_owned(),
             });
         }
@@ -372,7 +372,7 @@ impl TryFrom<String> for ToolName {
 
 impl From<ToolName> for String {
     fn from(name: ToolName) -> Self {
-        name.0.into()
+        name.0
     }
 }
 


### PR DESCRIPTION
## Summary

- Unblocks all 8 open PRs failing identical `check + clippy + test` red on both ubuntu-latest and macos-latest.
- Root cause: PR #3669 (CompactString -> String) left three no-op conversions in `crates/koina/src/id.rs` that clippy flags under `-Dwarnings`. The new Rust nightly toolchain also surfaced six dead-code violations in `crates/energeia/src/routing/` scaffolding awaiting the #3455 follow-up.

## Fixes

`crates/koina/src/id.rs` (3 violations):
- 1x `clippy::implicit_clone`: `name.to_string()` -> `name.clone()` (line 334)
- 2x `clippy::useless_conversion`: `id.0.into()` -> `id.0` (line 182), `name.0.into()` -> `name.0` (line 375)

`crates/energeia/src/routing/{mod,empirical}.rs` (6 violations):
- `dead_code` on `from_prompt`, `StaticRouter::pick`, `EmpiricalRouter::pick`, `RoutingMode`, `DispatchRoutingConfig`, and unread fields — all suppressed with the repo's existing `#[cfg_attr(not(test), expect(dead_code, reason = "..."))]` pattern. These are scaffolding consumed by the empirical-routing binary wiring in #3455.

`Cargo.lock`: drops the stale `compact_str` entry from koina + skene deps (leftover from #3669).

## Verification

```
cargo fmt --check                              : clean
cargo clippy --workspace --all-targets -Dwarnings : clean
cargo nextest run --workspace                 : 8152 passed, 7 failed, 15 skipped
```

The 7 failures are all pre-existing on main (same failures on `a64c05a5c`), root-caused to reqwest 0.13 requiring an explicit `rustls::crypto` provider install in test context. Filed as #3693 (separate concern).

The PR #3664 PII Scan failure is unrelated: it flags the AWS docs example key `AKIAIOSFODNN7EXAMPLE` added by #3664 in a file that does not exist on main. Filed as #3694.

Closes #3689

## Test plan

- [x] `cargo clippy -p koina --lib --tests -- -D warnings` clean (was 3 errors)
- [x] `cargo clippy --workspace --all-targets -- -Dwarnings` clean (was 9 errors total)
- [x] `cargo fmt --check` clean
- [x] `cargo nextest run -p koina` 784 pass
- [x] `cargo nextest run -p energeia` 516 pass
- [x] Kanon lint on touched files: clean (pre-existing `pub-visibility` warnings on koina IDs left untouched — they are cross-crate API surface)