### PR TITLE
test: fix 8 pre-existing failures surfaced by workspace CI restoration

### DIFF
--- a/crates/eval/src/scenarios/conversation.rs
+++ b/crates/eval/src/scenarios/conversation.rs
@@ -180,7 +180,7 @@ impl Scenario for ConversationEmptyRejected {
     fn meta(&self) -> ScenarioMeta {
         ScenarioMeta {
             id: "conversation-empty-rejected",
-            description: "Sending empty content returns 400",
+            description: "Sending empty content returns 422",
             category: "conversation",
             requires_auth: true,
             requires_nous: true,
@@ -191,6 +191,9 @@ impl Scenario for ConversationEmptyRejected {
     fn run<'a>(&'a self, client: &'a EvalClient) -> ScenarioFuture<'a> {
         Box::pin(
             async move {
+                // WHY: pylon returns 422 Unprocessable Entity for validation
+                // failures (empty content). See pylon::error::ApiError::Validation
+                // and the `send_message_empty_content_returns_422` test.
                 let nous_list = client.list_nous().await?;
                 let nous = nous_list
                     .first()
@@ -200,11 +203,11 @@ impl Scenario for ConversationEmptyRejected {
                 let session = client.create_session(nous_id, &key).await?;
                 match client.send_message(&session.id, "").await {
                     Err(crate::error::Error::UnexpectedStatus { status, .. }) => {
-                        assert_eval(status == 400, format!("expected 400, got {status}"))
+                        assert_eval(status == 422, format!("expected 422, got {status}"))
                     }
                     Err(e) => Err(e),
                     Ok(_) => crate::error::AssertionSnafu {
-                        message: "expected 400 for empty content but got success",
+                        message: "expected 422 for empty content but got success",
                     }
                     .fail(),
                 }

--- a/crates/hermeneus/src/cc/process_tests.rs
+++ b/crates/hermeneus/src/cc/process_tests.rs
@@ -268,7 +268,6 @@ async fn run_completion_spawn_failure_reports_binary_path() {
 }
 
 #[tokio::test]
-#[ignore = "ETXTBSY race between chmod+x and exec — flaky on CI; tracked in #3568"]
 async fn run_completion_success_collects_output() {
     // WHY: End-to-end subprocess path with a real script. Verifies that
     // run_completion feeds stdin, reads stdout stream-json, and returns
@@ -304,7 +303,6 @@ printf '{"type":"result","subtype":"success","result":"hello world","is_error":f
 }
 
 #[tokio::test]
-#[ignore = "ETXTBSY race between chmod+x and exec — flaky on CI; tracked in #3568"]
 async fn run_completion_with_system_prompt_succeeds() {
     // WHY: Verifies the --system-prompt branch executes without error.
     // The actual arg passing is structural (cmd.arg) and not visible from
@@ -331,7 +329,6 @@ printf '{"type":"result","subtype":"success","result":"sys ok","is_error":false}
 }
 
 #[tokio::test]
-#[ignore = "ETXTBSY race between chmod+x and exec — flaky on CI; tracked in #3568"]
 async fn run_completion_timeout_returns_error() {
     // WHY: Subprocess that sleeps past the deadline must be killed and
     // must surface a timeout error message that includes the duration.
@@ -357,7 +354,6 @@ async fn run_completion_timeout_returns_error() {
 }
 
 #[tokio::test]
-#[ignore = "ETXTBSY race between chmod+x and exec — flaky on CI; tracked in #3568"]
 async fn run_completion_nonzero_exit_with_stderr_captured() {
     // WHY: When CC emits a result event with empty result text and then exits
     // nonzero, run_completion falls through to the stderr-capture branch
@@ -427,7 +423,6 @@ async fn run_streaming_spawn_failure_reports_binary_path() {
 }
 
 #[tokio::test]
-#[ignore = "ETXTBSY race between chmod+x and exec — flaky on CI; tracked in #3568"]
 async fn run_streaming_invokes_callback_for_each_delta() {
     // WHY: run_streaming must call on_delta once per assistant text event,
     // in order, with the exact text. This is the primary contract of the
@@ -468,7 +463,6 @@ printf '{"type":"result","subtype":"success","result":"chunk1chunk2chunk3","is_e
 }
 
 #[tokio::test]
-#[ignore = "ETXTBSY race between chmod+x and exec — flaky on CI; tracked in #3568"]
 async fn run_streaming_timeout_returns_error() {
     // WHY: Same timeout contract as run_completion — streaming subprocess
     // that stalls must be killed and must return a timeout error.

--- a/crates/integration-tests/tests/cross_crate_pipeline/auth_errors.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline/auth_errors.rs
@@ -128,8 +128,10 @@ async fn error_invalid_session_returns_404() {
 }
 
 #[tokio::test]
-#[ignore = "pre-existing: returns 422 not 400 — tracked in #3568"]
-async fn error_empty_message_returns_400() {
+async fn error_empty_message_returns_422() {
+    // WHY: pylon returns 422 Unprocessable Entity for validation failures
+    // (empty content), matching the canonical pattern in error.rs and other
+    // `*_returns_422` tests in pylon::tests::error_envelope and streaming.
     let harness = TestHarness::build().await;
     let router = harness.router();
 
@@ -142,12 +144,14 @@ async fn error_empty_message_returns_400() {
         Some(serde_json::json!({ "content": "" })),
     );
     let resp = router.clone().oneshot(req).await.expect("empty message");
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
 
 #[tokio::test]
-#[ignore = "pre-existing: returns 422 not 400 — tracked in #3568"]
-async fn error_empty_rename_returns_400() {
+async fn error_empty_rename_returns_422() {
+    // WHY: pylon returns 422 Unprocessable Entity for validation failures
+    // (empty name), matching the canonical pattern in error.rs and the
+    // `rename_session_empty_name_returns_422_with_envelope` test in pylon.
     let harness = TestHarness::build().await;
     let router = harness.router();
 
@@ -160,7 +164,7 @@ async fn error_empty_rename_returns_400() {
         Some(serde_json::json!({ "name": "" })),
     );
     let resp = router.clone().oneshot(req).await.expect("empty rename");
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
 
 #[tokio::test]

--- a/crates/integration-tests/tests/cross_crate_pipeline/lifecycle.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline/lifecycle.rs
@@ -242,7 +242,6 @@ async fn system_prompt_includes_oikos_bootstrap_files() {
 // ===========================================================================
 
 #[tokio::test]
-#[ignore = "pre-existing: unarchive+rename sequence panics — tracked in #3568"]
 async fn session_lifecycle_create_list_archive_unarchive_rename() {
     let harness = TestHarness::build().await;
     let router = harness.router();
@@ -270,7 +269,10 @@ async fn session_lifecycle_create_list_archive_unarchive_rename() {
         .expect("list sessions");
     assert_eq!(resp.status(), StatusCode::OK);
     let list = body_json(resp).await;
-    let sessions = list["sessions"].as_array().expect("sessions array");
+    // WHY: pylon's cursor-pagination refactor (#3467) renamed the response
+    // envelope field from `sessions` to `items` — the shared PaginatedResponse
+    // uses `items` across every paginated endpoint.
+    let sessions = list["items"].as_array().expect("items array");
     assert!(
         sessions.iter().any(|s| s["id"] == id),
         "session should appear in list"
@@ -323,7 +325,7 @@ async fn session_lifecycle_create_list_archive_unarchive_rename() {
         .await
         .expect("list after rename");
     let list = body_json(resp).await;
-    let sessions = list["sessions"].as_array().expect("sessions array");
+    let sessions = list["items"].as_array().expect("items array");
     let our_session = sessions
         .iter()
         .find(|s| s["id"] == id)

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -256,7 +256,6 @@ async fn eval_session_scenarios_pass() {
 }
 
 #[tokio::test]
-#[ignore = "pre-existing: conversation scenarios drifted — tracked in #3568"]
 async fn eval_conversation_scenarios_pass() {
     let (base_url, token, _dir) = start_test_server().await;
 
@@ -281,7 +280,6 @@ async fn eval_conversation_scenarios_pass() {
 }
 
 #[tokio::test]
-#[ignore = "pre-existing: non-canary scenario fails — tracked in #3568"]
 async fn eval_full_run_excludes_canary() {
     // WHY: full run excludes the `canary-*` categories which exercise a real
     // LLM and would fail against the mock provider. Run all OTHER categories

--- a/crates/organon/src/sandbox/policy_tests.rs
+++ b/crates/organon/src/sandbox/policy_tests.rs
@@ -1101,7 +1101,6 @@ fn temp_directory_access() {
 /// Test read-only paths are actually read-only.
 #[cfg(target_os = "linux")]
 #[test]
-#[ignore = "pre-existing: landlock test flaky on some kernels — tracked in #3568"]
 fn read_only_paths_cannot_be_written() {
     let read_only_dir = tempfile::tempdir().expect("create read-only dir");
     let test_file = read_only_dir.path().join("readonly.txt");


### PR DESCRIPTION
## Summary

Resolves #3568 by fixing all 8 tests ignored in #3566 as the CI-unblock stopgap. All previously failing tests now pass; the corresponding `#[ignore]` attributes are removed.

## Triage and fixes

Three root causes, grouped per commit:

### 1. Validation status standardization (400 → 422)
pylon returns 422 Unprocessable Entity for request validation failures. The canonical pattern is documented in `pylon::error::ApiError::Validation` and exercised by `send_message_empty_content_returns_422`, `rename_session_empty_name_returns_422_with_envelope`, etc. Three tests drifted when the status code was standardized:
- `integration-tests::cross_crate_pipeline::auth_errors::error_empty_message_returns_400` → renamed to `_returns_422`
- `integration-tests::cross_crate_pipeline::auth_errors::error_empty_rename_returns_400` → renamed to `_returns_422`
- `dokimion::scenarios::conversation::ConversationEmptyRejected` scenario — updated to expect 422 (fixes `eval_conversation_scenarios_pass` and the cascading `eval_full_run_excludes_canary`)

### 2. Paginated envelope field rename (`sessions` → `items`)
`session_lifecycle_create_list_archive_unarchive_rename` panicked at `list["sessions"].as_array().expect("sessions array")`. PR #3467 refactored list endpoints to share a `PaginatedResponse<T>` with a canonical `items` field; the test hadn't been updated. Fixed both assertion sites.

### 3. Previously flaky tests now stable
- `organon::sandbox::policy::policy_tests::read_only_paths_cannot_be_written` — passes under current Landlock ABI, `#[ignore]` removed with no code change.
- `hermeneus::cc::process::process_tests::{run_completion_*, run_streaming_*}` (6 tests) — the ETXTBSY race between chmod+x and exec is already mitigated by the existing `write_script` helper (per-thread atomic nonce + post-chmod metadata poll). All 27 `cc::process::process_tests` pass under `--features cc-provider`. `#[ignore]` removed.

## Verification

```
cargo nextest run -p integration-tests --test cross_crate_pipeline --test eval_harness
  → 24/24 pass (including the 5 previously-ignored)

cargo nextest run -p hermeneus --features cc-provider 'cc::process'
  → 27/27 pass (including 6 previously-ignored)

cargo nextest run -p organon 'read_only_paths_cannot_be_written'
  → 1/1 pass
```

## Out of scope (pre-existing)

- `organon::builtins::web_search::tests::missing_api_key_returns_configuration_error` panics `No provider set` from reqwest — unrelated TLS crypto provider install missing in test harness; fails on plain `main` too.
- `koina::id.rs` has 3 `-Dwarnings` clippy violations on main (fixed in unmerged `c81c559ff`, not pulled here).

## Closes

Closes #3568