### PR TITLE
feat(poiesis): poiesis-typst crate + render_typst_report tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "aquamarine"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +295,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
 ]
 
 [[package]]
@@ -636,6 +654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "basanos"
 version = "0.20.0"
 dependencies = [
@@ -661,6 +685,20 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "biblatex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d0c374feba1b9a59042a7c1cf00ce7c34b977b9134fe7c42b08e5183729f66"
+dependencies = [
+ "paste",
+ "roman-numerals-rs",
+ "strum",
+ "unic-langid",
+ "unicode-normalization",
+ "unscanny",
+]
 
 [[package]]
 name = "bincode"
@@ -835,6 +873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytecheck"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,7 +979,7 @@ dependencies = [
  "safetensors",
  "thiserror 2.0.18",
  "tokenizers",
- "yoke",
+ "yoke 0.8.2",
  "zip 7.2.0",
 ]
 
@@ -1064,6 +1108,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chinese-number"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e964125508474a83c95eb935697abbeb446ff4e9d62c71ce880e3986d1c606b"
+dependencies = [
+ "chinese-variant",
+ "enum-ordinalize",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "chinese-variant"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b52a9840ffff5d4d0058ae529fa066a75e794e3125546acfc61c23ad755e49"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1175,16 @@ dependencies = [
  "crypto-common 0.1.7",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "citationberg"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6597e8bdbca37f1f56e5a80d15857b0932aead21a78d20de49e99e74933046"
+dependencies = [
+ "quick-xml",
+ "serde",
 ]
 
 [[package]]
@@ -1203,6 +1275,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "codex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9589e1effc5cacbea347899645c654158b03b2053d24bb426fd3128ced6e423c"
+
+[[package]]
 name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1328,30 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "comemo"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c963350b2b08aa4b725d7802593245380ab53dacfedcaa971385fc33306c0d4"
+dependencies = [
+ "comemo-macros",
+ "parking_lot",
+ "rustc-hash",
+ "siphasher",
+ "slab",
+]
+
+[[package]]
+name = "comemo-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c400139ba1389ef9e20ad2d87cda68b437a66483aa0da616bdf2cea7413853"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1597,7 +1708,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1737,6 +1869,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "date_header"
@@ -2050,6 +2188,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2237,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -2144,6 +2303,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2319,6 +2498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,6 +2603,12 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
@@ -2471,6 +2662,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -2866,6 +3080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glidesort"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,6 +3204,109 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hayagriva"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cb69425736f184173b3ca6e27fcba440a61492a790c786b1c6af7e06a03e575"
+dependencies = [
+ "biblatex",
+ "ciborium",
+ "citationberg",
+ "indexmap 2.14.0",
+ "paste",
+ "roman-numerals-rs",
+ "serde",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "unic-langid",
+ "unicode-segmentation",
+ "unscanny",
+ "url",
+]
+
+[[package]]
+name = "hayro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048488ba88552bb0fb2a7e4001c64d5bed65d1a92167186a1bb9151571f32e60"
+dependencies = [
+ "bytemuck",
+ "hayro-interpret",
+ "image",
+ "kurbo 0.12.0",
+]
+
+[[package]]
+name = "hayro-font"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10e7e97ce840a6a70e7901e240ec65ba61106b66b37a4a1b899a2ce484248463"
+dependencies = [
+ "log",
+ "phf 0.13.1",
+]
+
+[[package]]
+name = "hayro-interpret"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56204c972d08e844f3db13b1e14be769f846e576699b46d4f4637cc4f8f70102"
+dependencies = [
+ "bitflags 2.11.0",
+ "hayro-font",
+ "hayro-syntax",
+ "kurbo 0.12.0",
+ "log",
+ "moxcms 0.7.11",
+ "phf 0.13.1",
+ "rustc-hash",
+ "siphasher",
+ "skrifa",
+ "smallvec",
+ "yoke 0.8.2",
+]
+
+[[package]]
+name = "hayro-svg"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c673304cec6e0dfd3b4f71fccecd45646899aa70279b62d3f933842abc4ac5"
+dependencies = [
+ "base64 0.22.1",
+ "hayro-interpret",
+ "image",
+ "kurbo 0.12.0",
+ "siphasher",
+ "xmlwriter",
+]
+
+[[package]]
+name = "hayro-syntax"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9e5c7dbc0f11dc42775d1a6cc00f5f5137b90b6288dd7fe5f71d17b14d10be"
+dependencies = [
+ "flate2",
+ "kurbo 0.12.0",
+ "log",
+ "rustc-hash",
+ "smallvec",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "hayro-write"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc05d8b4bc878b9aee48d980ecb25ed08f1dd9fad6da5ab4d9b7c56ec03a0cf6"
+dependencies = [
+ "flate2",
+ "hayro-syntax",
+ "log",
+ "pdf-writer",
+]
 
 [[package]]
 name = "heck"
@@ -3219,6 +3542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hypher"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef68590049bab63a464eee1a1158ac04c6f6613a546d8d90f78636b8b94f171"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,6 +3573,19 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "serde",
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
@@ -3251,9 +3593,9 @@ dependencies = [
  "displaydoc",
  "potential_utf",
  "utf8_iter",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
- "zerovec",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -3263,11 +3605,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
+ "litemap 0.8.2",
+ "tinystr 0.8.3",
+ "writeable 0.6.3",
+ "zerovec 0.11.6",
 ]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap 0.7.5",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -3275,12 +3650,12 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "icu_collections",
+ "icu_collections 2.2.0",
  "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
+ "icu_properties 2.2.0",
+ "icu_provider 2.2.0",
  "smallvec",
- "zerovec",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -3291,17 +3666,39 @@ checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections 1.5.0",
+ "icu_locid_transform",
+ "icu_properties_data 1.5.1",
+ "icu_provider 1.5.0",
+ "serde",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_properties"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "icu_collections",
+ "icu_collections 2.2.0",
  "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
+ "icu_properties_data 2.2.0",
+ "icu_provider 2.2.0",
+ "zerotrie 0.2.4",
+ "zerovec 0.11.6",
 ]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_properties_data"
@@ -3311,18 +3708,98 @@ checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "postcard",
+ "serde",
+ "stable_deref_trait",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "writeable",
- "yoke",
+ "writeable 0.6.3",
+ "yoke 0.8.2",
  "zerofrom",
- "zerotrie",
- "zerovec",
+ "zerotrie 0.2.4",
+ "zerovec 0.11.6",
 ]
+
+[[package]]
+name = "icu_provider_adapters"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6324dfd08348a8e0374a447ebd334044d766b1839bb8d5ccf2482a99a77c0bc"
+dependencies = [
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider_blob"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24b98d1365f55d78186c205817631a4acf08d7a45bdf5dc9dcf9c5d54dccf51"
+dependencies = [
+ "icu_provider 1.5.0",
+ "postcard",
+ "serde",
+ "writeable 0.5.5",
+ "zerotrie 0.1.3",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "icu_segmenter"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a717725612346ffc2d7b42c94b820db6908048f39434504cb130e8b46256b0de"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+ "icu_collections 1.5.0",
+ "icu_locid",
+ "icu_provider 1.5.0",
+ "icu_segmenter_data",
+ "serde",
+ "utf8_iter",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e52775179941363cc594e49ce99284d13d6948928d8e72c755f55e98caa1eb"
 
 [[package]]
 name = "id-arena"
@@ -3354,7 +3831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
- "icu_properties",
+ "icu_properties 2.2.0",
 ]
 
 [[package]]
@@ -3368,12 +3845,12 @@ dependencies = [
  "color_quant",
  "gif 0.14.1",
  "image-webp",
- "moxcms",
+ "moxcms 0.8.1",
  "num-traits",
  "png 0.18.1",
  "tiff",
- "zune-core",
- "zune-jpeg",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -3385,6 +3862,12 @@ dependencies = [
  "byteorder-lite",
  "quick-error 2.0.1",
 ]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imagesize"
@@ -3477,6 +3960,12 @@ checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 
 [[package]]
 name = "inotify"
@@ -3768,6 +4257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,6 +4395,38 @@ dependencies = [
 
 [[package]]
 name = "krilla"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ddfec86fec13d068075e14f22a7e217c281f3ed69ddcb427bf3f5d504fd674"
+dependencies = [
+ "base64 0.22.1",
+ "bumpalo",
+ "comemo",
+ "flate2",
+ "float-cmp 0.10.0",
+ "gif 0.13.3",
+ "hayro-write",
+ "image-webp",
+ "imagesize 0.14.0",
+ "indexmap 2.14.0",
+ "once_cell",
+ "pdf-writer",
+ "png 0.17.16",
+ "rayon",
+ "rustc-hash",
+ "rustybuzz",
+ "siphasher",
+ "skrifa",
+ "smallvec",
+ "subsetter",
+ "tiny-skia-path",
+ "xmp-writer",
+ "yoke 0.8.2",
+ "zune-jpeg 0.5.15",
+]
+
+[[package]]
+name = "krilla"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ddd739cf930f99a70ee89ec51b21fab894b5f142dc9672e0e9a27947b2bc093"
@@ -3904,10 +4434,10 @@ dependencies = [
  "base64 0.22.1",
  "bumpalo",
  "flate2",
- "float-cmp",
+ "float-cmp 0.10.0",
  "gif 0.13.3",
  "image-webp",
- "imagesize",
+ "imagesize 0.14.0",
  "indexmap 2.14.0",
  "once_cell",
  "pdf-writer",
@@ -3920,8 +4450,23 @@ dependencies = [
  "subsetter",
  "tiny-skia-path",
  "xmp-writer",
- "yoke",
- "zune-jpeg",
+ "yoke 0.8.2",
+ "zune-jpeg 0.5.15",
+]
+
+[[package]]
+name = "krilla-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f485e1a850201a01dcd8d73e7cf09f2cd4c4cc85c2cd296359094d49336d8ef7"
+dependencies = [
+ "flate2",
+ "fontdb",
+ "krilla 0.6.0",
+ "png 0.17.16",
+ "resvg",
+ "tiny-skia",
+ "usvg",
 ]
 
 [[package]]
@@ -3965,6 +4510,17 @@ dependencies = [
  "tracing-subscriber",
  "twox-hash",
  "unicode-normalization",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -4054,6 +4610,25 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lipsum"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
+dependencies = [
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+]
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "litemap"
@@ -4532,6 +5107,16 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
@@ -4539,6 +5124,12 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "ndarray"
@@ -4668,6 +5259,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4809,6 +5410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oikonomos"
 version = "0.20.0"
 dependencies = [
@@ -4934,6 +5544,7 @@ dependencies = [
  "poiesis-lint",
  "poiesis-sheet",
  "poiesis-text",
+ "poiesis-typst",
  "poiesis-verify",
  "prometheus-client",
  "proptest",
@@ -4964,6 +5575,30 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5105,8 +5740,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -5115,7 +5761,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -5130,13 +5776,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5159,6 +5828,12 @@ checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -5282,10 +5957,26 @@ dependencies = [
 name = "poiesis-text"
 version = "0.20.0"
 dependencies = [
- "krilla",
+ "krilla 0.7.0",
  "poiesis-core",
  "snafu",
  "zip 7.2.0",
+]
+
+[[package]]
+name = "poiesis-typst"
+version = "0.20.0"
+dependencies = [
+ "comemo",
+ "jiff",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tempfile",
+ "tracing",
+ "typst",
+ "typst-pdf",
 ]
 
 [[package]]
@@ -5336,12 +6027,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
- "zerovec",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -5379,7 +6082,7 @@ checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
- "float-cmp",
+ "float-cmp 0.10.0",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -5451,6 +6154,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro-utils"
@@ -5551,6 +6260,16 @@ name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "psm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
 
 [[package]]
 name = "ptr_meta"
@@ -5665,6 +6384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qcms"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edecfcd5d755a5e5d98e24cf43113e7cdaec5a070edd0f6b250c03a573da30fa"
+
+[[package]]
 name = "qdrant-client"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5706,6 +6431,7 @@ checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "encoding_rs",
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -6252,6 +6978,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif 0.13.3",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6356,6 +7108,18 @@ dependencies = [
  "rmp",
  "serde",
 ]
+
+[[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "ruma"
@@ -6918,6 +7682,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -7071,6 +7844,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7109,6 +7891,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -7250,6 +8041,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7260,6 +8065,9 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp 0.9.0",
+]
 
 [[package]]
 name = "string_cache"
@@ -7293,7 +8101,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
@@ -7332,7 +8140,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb6895a12ac5599bb6057362f00e8a3cf1daab4df33f553a55690a44e4fed8d0"
 dependencies = [
- "kurbo",
+ "kurbo 0.12.0",
  "rustc-hash",
  "skrifa",
  "write-fonts",
@@ -7351,6 +8159,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
  "is_ci",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo 0.11.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -7516,7 +8334,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -7559,7 +8377,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2 0.10.9",
  "signal-hook",
  "siphasher",
@@ -7612,6 +8430,12 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
@@ -7673,7 +8497,7 @@ dependencies = [
  "half",
  "quick-error 2.0.1",
  "weezl",
- "zune-jpeg",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -7711,6 +8535,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
 name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7723,12 +8562,24 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "serde",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
- "zerovec",
+ "serde_core",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -7856,12 +8707,24 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow 0.7.15",
@@ -7875,7 +8738,7 @@ checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -7887,6 +8750,9 @@ name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -7913,6 +8779,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -8187,6 +9055,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "two-face"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e51b6e60e545cfdae5a4639ff423818f52372211a8d9a3e892b4b0761f76b2"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8194,6 +9073,12 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
  "rand 0.9.4",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-path"
@@ -8223,6 +9108,300 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
 
 [[package]]
+name = "typst"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6511ee598476f4f322b4d13891083d96dbacb8f9c2b908604c7094ba390653"
+dependencies = [
+ "comemo",
+ "ecow",
+ "rustc-hash",
+ "typst-eval",
+ "typst-html",
+ "typst-layout",
+ "typst-library",
+ "typst-macros",
+ "typst-realize",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+]
+
+[[package]]
+name = "typst-assets"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5613cb719a6222fe9b74027c3625d107767ec187bff26b8fc931cf58942c834f"
+
+[[package]]
+name = "typst-eval"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687757487dfc0c1e941344d5024cf7a28364e70c3e304faad89ac65597f62526"
+dependencies = [
+ "comemo",
+ "ecow",
+ "indexmap 2.14.0",
+ "rustc-hash",
+ "stacker",
+ "toml 0.8.23",
+ "typst-library",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "typst-html"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e29f8da4f964d4c90739c3c1e0288b0ba1bccc3cc50623a6d558300b86ca8aad"
+dependencies = [
+ "bumpalo",
+ "comemo",
+ "ecow",
+ "palette",
+ "rustc-hash",
+ "time",
+ "typst-assets",
+ "typst-library",
+ "typst-macros",
+ "typst-svg",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+]
+
+[[package]]
+name = "typst-layout"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cab0200105831a9158e63718a0f6141c78cb2c1722ed17d19ad28941e3b8491"
+dependencies = [
+ "az",
+ "bumpalo",
+ "codex",
+ "comemo",
+ "ecow",
+ "either",
+ "hypher",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
+ "icu_provider_adapters",
+ "icu_provider_blob",
+ "icu_segmenter",
+ "kurbo 0.12.0",
+ "memchr",
+ "rustc-hash",
+ "rustybuzz",
+ "smallvec",
+ "ttf-parser",
+ "typst-assets",
+ "typst-library",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+ "unicode-bidi",
+ "unicode-math-class",
+ "unicode-script",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "typst-library"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e276a5de53020c43efe2111ec236252e54ea4480b5ac18063e663dfbe03d9d1b"
+dependencies = [
+ "az",
+ "bitflags 2.11.0",
+ "bumpalo",
+ "chinese-number",
+ "ciborium",
+ "codex",
+ "comemo",
+ "csv",
+ "ecow",
+ "flate2",
+ "fontdb",
+ "glidesort",
+ "hayagriva",
+ "hayro-syntax",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
+ "icu_provider_blob",
+ "image",
+ "indexmap 2.14.0",
+ "kamadak-exif",
+ "kurbo 0.12.0",
+ "lipsum",
+ "memchr",
+ "palette",
+ "phf 0.13.1",
+ "png 0.17.16",
+ "qcms",
+ "rayon",
+ "regex",
+ "regex-syntax",
+ "roxmltree",
+ "rust_decimal",
+ "rustc-hash",
+ "rustybuzz",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "siphasher",
+ "smallvec",
+ "syntect",
+ "time",
+ "toml 0.8.23",
+ "ttf-parser",
+ "two-face",
+ "typed-arena",
+ "typst-assets",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+ "unicode-math-class",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "unscanny",
+ "usvg",
+ "utf8_iter",
+ "wasmi",
+ "xmlwriter",
+]
+
+[[package]]
+name = "typst-macros"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "141cbd1027129fbf6bda1013f52a264df7befc7388cc8f47767d65e803fd3a59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "typst-pdf"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c8a4630754767cd10d48e8b8186e7dc784631a30a3a93521edf7d77aebd0c0"
+dependencies = [
+ "az",
+ "bytemuck",
+ "comemo",
+ "ecow",
+ "image",
+ "indexmap 2.14.0",
+ "infer",
+ "krilla 0.6.0",
+ "krilla-svg",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "typst-assets",
+ "typst-library",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+]
+
+[[package]]
+name = "typst-realize"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ffe964757fb93d2e98978aa2a74ee85b0f94c8643e8f3550737258b58f39d8"
+dependencies = [
+ "arrayvec",
+ "bumpalo",
+ "comemo",
+ "ecow",
+ "regex",
+ "typst-library",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+]
+
+[[package]]
+name = "typst-svg"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46b811837ade1f0243ef0d8bf3fb06d166443090eac22c28643f374c2ccdc9d"
+dependencies = [
+ "base64 0.22.1",
+ "comemo",
+ "ecow",
+ "flate2",
+ "hayro",
+ "hayro-svg",
+ "image",
+ "rustc-hash",
+ "ttf-parser",
+ "typst-assets",
+ "typst-library",
+ "typst-macros",
+ "typst-timing",
+ "typst-utils",
+ "xmlparser",
+ "xmlwriter",
+]
+
+[[package]]
+name = "typst-syntax"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a95d9192060e23b1e491b0b94dff676acddc92a4d672aeb8ca3890a5a734e879"
+dependencies = [
+ "ecow",
+ "rustc-hash",
+ "serde",
+ "toml 0.8.23",
+ "typst-timing",
+ "typst-utils",
+ "unicode-ident",
+ "unicode-math-class",
+ "unicode-script",
+ "unicode-segmentation",
+ "unscanny",
+]
+
+[[package]]
+name = "typst-timing"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be94f8faf19841b49574ef5c7fd7a12e2deb7c3d8deba5a596f35d2222024cd"
+dependencies = [
+ "parking_lot",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "typst-utils"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3966c92e8fa48c7ce898130d07000d985f18206d92b250f0f939287fbccdee3"
+dependencies = [
+ "once_cell",
+ "portable-atomic",
+ "rayon",
+ "rustc-hash",
+ "siphasher",
+ "thin-vec",
+ "unicode-math-class",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8245,10 +9424,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+ "unic-langid-macros",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr 0.8.3",
+]
+
+[[package]]
+name = "unic-langid-macros"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5957eb82e346d7add14182a3315a7e298f04e1ba4baac36f7f0dbfedba5fc25"
+dependencies = [
+ "proc-macro-hack",
+ "tinystr 0.8.3",
+ "unic-langid-impl",
+ "unic-langid-macros-impl",
+]
+
+[[package]]
+name = "unic-langid-macros-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn 2.0.117",
+ "unic-langid-impl",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-bidi-mirroring"
@@ -8273,6 +9502,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-math-class"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d246cf599d5fae3c8d56e04b20eb519adb89a8af8d0b0fbcded369aa3647d65"
 
 [[package]]
 name = "unicode-normalization"
@@ -8322,6 +9557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8360,6 +9601,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"
@@ -8411,6 +9658,33 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize 0.13.0",
+ "kurbo 0.11.3",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -8645,7 +9919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -8657,7 +9931,7 @@ dependencies = [
  "anyhow",
  "indexmap 2.14.0",
  "wasm-encoder",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -8684,6 +9958,52 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmi"
+version = "0.51.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb321403ce594274827657a908e13d1d9918aa02257b8bf8391949d9764023ff"
+dependencies = [
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser 0.228.0",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "0.51.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b8e98e45a2a534489f8225e765cbf1cb9a3078072605e58158910cf4749172"
+
+[[package]]
+name = "wasmi_core"
+version = "0.51.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25f375c0cdf14810eab07f532f61f14d4966f09c747a55067fdf3196e8512e6"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "0.51.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624e2a68a4293ecb8f564260b68394b29cf3b3edba6bce35532889a2cb33c3d9"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.228.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -8724,7 +10044,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "string_cache 0.8.9",
  "string_cache_codegen",
@@ -8936,6 +10256,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -9260,7 +10589,7 @@ dependencies = [
  "serde_json",
  "wasm-encoder",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.244.0",
  "wit-parser",
 ]
 
@@ -9279,7 +10608,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -9290,10 +10619,16 @@ checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
 dependencies = [
  "font-types",
  "indexmap 2.14.0",
- "kurbo",
+ "kurbo 0.12.0",
  "log",
  "read-fonts",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "writeable"
@@ -9340,6 +10675,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
 name = "xmp-writer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9362,13 +10709,37 @@ dependencies = [
 
 [[package]]
 name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.8.2",
  "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -9446,13 +10817,37 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb594dd55d87335c5f60177cee24f19457a5ec10a065e0a3014722ad252d0a1f"
+dependencies = [
+ "displaydoc",
+ "litemap 0.7.5",
+ "serde",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "serde",
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec-derive 0.10.3",
 ]
 
 [[package]]
@@ -9461,9 +10856,21 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
- "yoke",
+ "serde",
+ "yoke 0.8.2",
  "zerofrom",
- "zerovec-derive",
+ "zerovec-derive 0.11.3",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9574,9 +10981,24 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
 
 [[package]]
 name = "zune-jpeg"
@@ -9584,5 +11006,5 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
- "zune-core",
+ "zune-core 0.5.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/poiesis/sheet",
     "crates/poiesis/slides",
     "crates/poiesis/lint",
+    "crates/poiesis/typst",
     "crates/poiesis/verify",
 ]
 # WHY: proskenion requires GTK3/webkit2gtk system libraries (via Dioxus

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -31,6 +31,7 @@ poiesis-core = { path = "../poiesis/core" }
 poiesis-text = { path = "../poiesis/text" }
 poiesis-sheet = { path = "../poiesis/sheet" }
 poiesis-lint = { path = "../poiesis/lint" }
+poiesis-typst = { path = "../poiesis/typst" }
 poiesis-verify = { path = "../poiesis/verify" }
 koina = { path = "../koina" }
 taxis = { path = "../taxis" }

--- a/crates/organon/src/builtins/poiesis.rs
+++ b/crates/organon/src/builtins/poiesis.rs
@@ -454,9 +454,7 @@ impl ToolExecutor for RenderTypstReportExecutor {
                 match serde_json::from_str(raw) {
                     Ok(v) => v,
                     Err(e) => {
-                        return Ok(ToolResult::error(format!(
-                            "data must be valid JSON: {e}"
-                        )));
+                        return Ok(ToolResult::error(format!("data must be valid JSON: {e}")));
                     }
                 }
             } else {
@@ -483,12 +481,12 @@ impl ToolExecutor for RenderTypstReportExecutor {
             };
 
             // Optional: write to a caller-provided path in addition to returning bytes.
-            if let Some(out_path) = extract_opt_str(args, "out_path") {
-                if let Err(e) = std::fs::write(out_path, &pdf_bytes) {
-                    return Ok(ToolResult::error(format!(
-                        "wrote 0 bytes to {out_path:?}: {e}"
-                    )));
-                }
+            if let Some(out_path) = extract_opt_str(args, "out_path")
+                && let Err(e) = tokio::fs::write(out_path, &pdf_bytes).await
+            {
+                return Ok(ToolResult::error(format!(
+                    "wrote 0 bytes to {out_path:?}: {e}"
+                )));
             }
 
             let encoded = koina::base64::encode(&pdf_bytes);
@@ -538,8 +536,7 @@ fn render_typst_report_def() -> ToolDef {
                     "template".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::String,
-                        description: "Built-in template slug (e.g. `default`)."
-                            .to_owned(),
+                        description: "Built-in template slug (e.g. `default`).".to_owned(),
                         enum_values: Some(vec!["default".to_owned()]),
                         default: None,
                     },

--- a/crates/organon/src/builtins/poiesis.rs
+++ b/crates/organon/src/builtins/poiesis.rs
@@ -1,12 +1,15 @@
-//! Poiesis report tools: `generate_document`, `lint_report`, `verify_report`.
+//! Poiesis report tools: `generate_document`, `lint_report`, `verify_report`,
+//! `render_typst_report`.
 //!
-//! - `generate_document` — render a JSON document descriptor to ODT/XLSX/PDF bytes
-//! - `lint_report`       — check report prose quality (banned words, citations, structure)
-//! - `verify_report`     — validate numeric claims in a verify manifest
+//! - `generate_document`    — render a JSON document descriptor to ODT/XLSX/PDF bytes
+//! - `lint_report`          — check report prose quality (banned words, citations, structure)
+//! - `verify_report`        — validate numeric claims in a verify manifest
+//! - `render_typst_report`  — render a Typst source (or built-in template slug) to PDF
 
 use std::future::Future;
 use std::pin::Pin;
 
+use hermeneus::types::{DocumentSource, ToolResultBlock};
 use indexmap::IndexMap;
 use poiesis_core::{Block, Document, Metadata, Renderer, RichText, Span};
 use poiesis_lint::{LintConfig, Linter};
@@ -433,12 +436,161 @@ fn verify_report_def() -> ToolDef {
     }
 }
 
+// ── render_typst_report ───────────────────────────────────────────────────────
+
+struct RenderTypstReportExecutor;
+
+impl ToolExecutor for RenderTypstReportExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async move {
+            let args = &input.arguments;
+
+            // Optional inline JSON data; defaults to empty object.
+            let data: serde_json::Value = if let Some(raw) = extract_opt_str(args, "data") {
+                match serde_json::from_str(raw) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!(
+                            "data must be valid JSON: {e}"
+                        )));
+                    }
+                }
+            } else {
+                serde_json::json!({})
+            };
+
+            // Choose source: inline `source` wins over `template` slug.
+            let pdf_result = if let Some(source) = extract_opt_str(args, "source") {
+                poiesis_typst::render_typst(source, &data)
+            } else if let Some(slug) = extract_opt_str(args, "template") {
+                poiesis_typst::render_template(slug, &data)
+            } else {
+                return Ok(ToolResult::error(
+                    "render_typst_report requires 'source' (inline Typst) or 'template' (slug)"
+                        .to_owned(),
+                ));
+            };
+
+            let pdf_bytes = match pdf_result {
+                Ok(b) => b,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("typst render failed: {e}")));
+                }
+            };
+
+            // Optional: write to a caller-provided path in addition to returning bytes.
+            if let Some(out_path) = extract_opt_str(args, "out_path") {
+                if let Err(e) = std::fs::write(out_path, &pdf_bytes) {
+                    return Ok(ToolResult::error(format!(
+                        "wrote 0 bytes to {out_path:?}: {e}"
+                    )));
+                }
+            }
+
+            let encoded = koina::base64::encode(&pdf_bytes);
+            let summary = format!("Rendered Typst report: {} bytes PDF", pdf_bytes.len());
+
+            Ok(ToolResult::blocks(vec![
+                ToolResultBlock::Text { text: summary },
+                ToolResultBlock::Document {
+                    source: DocumentSource {
+                        source_type: "base64".to_owned(),
+                        media_type: "application/pdf".to_owned(),
+                        data: encoded,
+                    },
+                },
+            ]))
+        })
+    }
+}
+
+fn render_typst_report_def() -> ToolDef {
+    ToolDef {
+        name: koina::id::ToolName::from_static("render_typst_report"), // kanon:ignore RUST/expect
+        description: "Render a Typst source string (or built-in template slug) to a PDF, \
+                      with optional JSON data injected at the virtual path `data.json`."
+            .to_owned(),
+        extended_description: Some(
+            "Pass either `source` (inline Typst markup) or `template` (one of the built-in \
+             slugs, currently: `default`). The JSON blob passed as `data` is exposed to the \
+             Typst document as a virtual file read via `json(\"data.json\")`. The result \
+             contains a text summary plus a base64-encoded PDF document block; optionally \
+             also writes the PDF to `out_path` on the filesystem."
+                .to_owned(),
+        ),
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "source".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Inline Typst source. Mutually exclusive with `template`."
+                            .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "template".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Built-in template slug (e.g. `default`)."
+                            .to_owned(),
+                        enum_values: Some(vec!["default".to_owned()]),
+                        default: None,
+                    },
+                ),
+                (
+                    "data".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Inline JSON data blob exposed to the template as `data.json`."
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "out_path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Optional filesystem path to write the rendered PDF to, in addition \
+                             to returning base64 bytes."
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
 // ── Registration ──────────────────────────────────────────────────────────────
 
-/// Register the poiesis report tools: `generate_document`, `lint_report`, `verify_report`.
+/// Register the poiesis report tools: `generate_document`, `lint_report`, `verify_report`,
+/// `render_typst_report`.
 pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(generate_document_def(), Box::new(GenerateDocumentExecutor))?;
     registry.register(lint_report_def(), Box::new(LintReportExecutor))?;
     registry.register(verify_report_def(), Box::new(VerifyReportExecutor))?;
+    registry.register(
+        render_typst_report_def(),
+        Box::new(RenderTypstReportExecutor),
+    )?;
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "poiesis_tests.rs"]
+mod tests;

--- a/crates/organon/src/builtins/poiesis_tests.rs
+++ b/crates/organon/src/builtins/poiesis_tests.rs
@@ -1,0 +1,161 @@
+#![expect(clippy::expect_used, reason = "test assertions")]
+//! Tests for poiesis tool executors.
+//!
+//! Current coverage: `render_typst_report`. The other poiesis executors (lint,
+//! verify, generate_document) are exercised by the underlying crates' tests.
+
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+
+use koina::id::{NousId, SessionId, ToolName};
+
+use super::*;
+
+fn test_ctx(dir: &std::path::Path) -> ToolContext {
+    ToolContext {
+        nous_id: NousId::new("test-agent").expect("valid"),
+        session_id: SessionId::new(),
+        workspace: dir.to_path_buf(),
+        allowed_roots: vec![dir.to_path_buf()],
+        services: None,
+        active_tools: Arc::new(RwLock::new(HashSet::new())),
+        tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
+    }
+}
+
+fn tool_input(name: &str, args: serde_json::Value) -> ToolInput {
+    ToolInput {
+        name: ToolName::new(name).expect("valid"),
+        tool_use_id: "toolu_test".to_owned(),
+        arguments: args,
+    }
+}
+
+#[tokio::test]
+async fn render_typst_report_inline_source_returns_document_block() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    let input = tool_input(
+        "render_typst_report",
+        serde_json::json!({
+            "source": "= Hello world\n\nA test report."
+        }),
+    );
+    let result = RenderTypstReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+
+    assert!(!result.is_error, "render must succeed: {result:?}");
+    // Expect two content blocks: text summary + base64 PDF document.
+    match &result.content {
+        crate::types::ToolResultContent::Blocks(blocks) => {
+            assert_eq!(blocks.len(), 2, "expected 2 blocks, got {}", blocks.len());
+            let has_doc = blocks.iter().any(|b| {
+                matches!(b, ToolResultBlock::Document { source } if source.media_type == "application/pdf")
+            });
+            assert!(has_doc, "result must include a PDF document block");
+        }
+        other => panic!("expected Blocks content, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn render_typst_report_default_template_with_data() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    let input = tool_input(
+        "render_typst_report",
+        serde_json::json!({
+            "template": "default",
+            "data": serde_json::json!({
+                "title": "Research Summary",
+                "author": "alice",
+                "body": ["One paragraph.", "Two paragraphs."]
+            }).to_string()
+        }),
+    );
+    let result = RenderTypstReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+
+    assert!(!result.is_error, "template render must succeed: {result:?}");
+}
+
+#[tokio::test]
+async fn render_typst_report_writes_out_path() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+    let out_path = dir.path().join("report.pdf");
+
+    let input = tool_input(
+        "render_typst_report",
+        serde_json::json!({
+            "source": "Hello from Typst.",
+            "out_path": out_path.display().to_string(),
+        }),
+    );
+    let result = RenderTypstReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+    assert!(!result.is_error, "render must succeed: {result:?}");
+
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test inspects the sandbox path the executor wrote to"
+    )]
+    let bytes = std::fs::read(&out_path).expect("PDF must exist at out_path");
+    assert!(bytes.starts_with(b"%PDF-"), "file must be a PDF");
+}
+
+#[tokio::test]
+async fn render_typst_report_requires_source_or_template() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    let input = tool_input("render_typst_report", serde_json::json!({}));
+    let result = RenderTypstReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+    assert!(
+        result.is_error,
+        "must error when neither source nor template is provided"
+    );
+}
+
+#[tokio::test]
+async fn render_typst_report_unknown_template_is_error() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    let input = tool_input(
+        "render_typst_report",
+        serde_json::json!({ "template": "no-such-template" }),
+    );
+    let result = RenderTypstReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+    assert!(result.is_error, "unknown template must error");
+}
+
+#[tokio::test]
+async fn render_typst_report_malformed_typst_is_error() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    let input = tool_input(
+        "render_typst_report",
+        serde_json::json!({ "source": "#this-function-does-not-exist()" }),
+    );
+    let result = RenderTypstReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+    assert!(result.is_error, "malformed typst must error");
+}

--- a/crates/organon/src/builtins/poiesis_tests.rs
+++ b/crates/organon/src/builtins/poiesis_tests.rs
@@ -2,7 +2,7 @@
 //! Tests for poiesis tool executors.
 //!
 //! Current coverage: `render_typst_report`. The other poiesis executors (lint,
-//! verify, generate_document) are exercised by the underlying crates' tests.
+//! verify, `generate_document`) are exercised by the underlying crates' tests.
 
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};

--- a/crates/poiesis/CLAUDE.md
+++ b/crates/poiesis/CLAUDE.md
@@ -2,35 +2,52 @@
 
 ## At a glance
 
-Document rendering family: format-agnostic model plus PDF, ODT, XLSX, ODS, and PPTX backends. Zero internal dependencies. Entry point: `core/src/lib.rs` (Document, Renderer).
+Report tooling family: format-agnostic document model plus rendering backends (Typst→PDF, ODT, XLSX, ODS, PPTX) and report-quality checks (prose lint, numeric claim verify). Zero internal dependencies. Entry points: `core/src/lib.rs` (Document, Renderer) and `typst/src/lib.rs` (`render_typst`, `render_template`).
+
+**Typst is the primary renderer.** Prefer `poiesis-typst` for prose-oriented PDF output — it supports templates, math, citations, breakable blocks, cross-references, and JSON data injection, with structured compile diagnostics carrying source locations. The `text/pdf` backend (via `krilla`) remains for the simple document-model path where no template system or data injection is needed.
 
 ## Depth
 
-Document rendering family: format-agnostic document model plus backends for PDF, ODT, XLSX, ODS, and PPTX. ~1.7K lines.
+Report tooling family: format-agnostic document model, Typst-based PDF primary renderer, format-specific backends (ODT/XLSX/ODS/PPTX), and report-quality checks (lint + verify). ~2K lines.
 
 ## Read first
 
-1. `core/src/lib.rs`: Module structure and public re-exports
-2. `core/src/renderer.rs`: The `Renderer` trait
-3. `core/src/document.rs`: Top-level `Document` type
-4. `core/src/block.rs`: `Block` enum — headings, paragraphs, tables, lists, images, page breaks
-5. `text/src/pdf.rs`: Most complex backend (A4 layout, line wrapping, system font loading)
+1. `typst/src/lib.rs`: Primary renderer — `render_typst(source, data)`, `render_template(slug, data)`
+2. `typst/README.md`: Typst backend rationale, template slug convention, attribution
+3. `core/src/lib.rs`: Module structure and public re-exports for the Document model
+4. `core/src/renderer.rs`: The `Renderer` trait (used by non-Typst backends)
+5. `core/src/block.rs`: `Block` enum — headings, paragraphs, tables, lists, images, page breaks
+6. `text/src/pdf.rs`: Document-model PDF backend (A4 layout, line wrapping, via `krilla`)
 
 ## Key types
 
 | Type | Path | Purpose |
 |------|------|---------|
+| `render_typst` | `typst/src/lib.rs` | Primary PDF path: Typst source + JSON data → PDF bytes |
+| `render_template` | `typst/src/lib.rs` | Resolve a built-in template slug and render |
+| `PoiesisError` | `typst/src/error.rs` | Typst render errors (serialize, compile, PDF export, unknown slug) |
 | `Document` | `core/src/document.rs` | Format-agnostic document: metadata + ordered content blocks |
 | `Renderer` | `core/src/renderer.rs` | Trait: `render(&self, &Document) -> Result<Vec<u8>, Error>` |
 | `Metadata` | `core/src/metadata.rs` | Title, author, optional creation timestamp |
 | `Block` | `core/src/block.rs` | Block-level element: Heading, Paragraph, Table, List, Image, PageBreak |
 | `RichText` | `core/src/rich_text.rs` | Sequence of styled inline `Span`s |
 | `Span` | `core/src/rich_text.rs` | Inline style: Plain, Bold, Italic, Code, Link |
-| `PdfRenderer` | `text/src/pdf.rs` | PDF backend via `krilla` (A4, requires system font) |
+| `PdfRenderer` | `text/src/pdf.rs` | Document-model PDF backend via `krilla` (A4, requires system font) |
 | `OdtRenderer` | `text/src/odt.rs` | ODT backend via clean-room ZIP/XML |
 | `XlsxRenderer` | `sheet/src/xlsx.rs` | Excel backend via `rust_xlsxwriter` |
 | `OdsRenderer` | `sheet/src/ods.rs` | ODS backend via `spreadsheet-ods` |
 | `PptxRenderer` | `slides/src/pptx.rs` | PowerPoint backend via hand-rolled ZIP/XML emitter |
+| `Linter` | `lint/src/lib.rs` | Report prose linter (banned words, citations, structure) |
+| `Verifier` | `verify/src/lib.rs` | Numeric-claim verifier (arithmetic eval, cross-claim refs) |
+
+## Template slug convention (poiesis-typst)
+
+Built-in Typst templates live at `typst/templates/<slug>.typ` and are embedded
+at compile time. Slug → source mapping is registered in `typst/src/templates.rs`.
+Templates load their data payload via `json("data.json")`, which
+`render_typst` synthesizes from the caller's JSON `Value`.
+
+Current slugs: `default`.
 
 ## Feature flags
 
@@ -44,24 +61,27 @@ Document rendering family: format-agnostic document model plus backends for PDF,
 
 ## Patterns
 
-- **Format-agnostic core**: `Document`, `Block`, and `RichText` are plain data types with zero format-specific code.
-- **Trait-based backends**: Each subcrate implements `Renderer`; callers pass the same `Document` to any backend.
+- **Typst-first**: when rendering a prose-oriented report to PDF, use `poiesis-typst`. Templates and math belong there.
+- **Format-agnostic core**: `Document`, `Block`, and `RichText` are plain data types with zero format-specific code (used by non-Typst backends).
+- **Trait-based backends**: Each non-Typst subcrate implements `Renderer`; callers pass the same `Document` to any backend.
 - **Feature-gated dependencies**: Every backend is behind a Cargo feature so consumers only compile what they need.
-- **Plain-text fallback**: Backends that cannot natively express a feature (images in PDF/spreadsheets, rich text in XLSX) degrade to plain text or alt text rather than failing.
+- **Plain-text fallback**: Non-Typst backends that cannot natively express a feature (images in PDF/spreadsheets, rich text in XLSX) degrade to plain text or alt text rather than failing.
 - **ZIP-based packaging**: ODT, XLSX, ODS, and PPTX are all ZIP archives; tests verify the `PK` magic bytes.
+- **In-memory Typst world**: `poiesis-typst` embeds the compiler as a library; source and injected data live in memory (no temp files, no CLI subprocess).
 
 ## Common tasks
 
 | Task | Where |
 |------|-------|
-| Add block type | `core/src/block.rs` (enum) + every backend renderer (match arm) |
+| Add Typst template | Drop `typst/templates/<slug>.typ`, register in `typst/src/templates.rs` (`SLUGS` + `lookup`) |
+| Modify Typst compiler wiring | `typst/src/world.rs` (`TypstWorld`, font discovery) |
+| Add block type | `core/src/block.rs` (enum) + every non-Typst backend renderer (match arm) |
 | Add inline span style | `core/src/rich_text.rs` (enum) + `text/src/odt.rs` (XML mapping) |
 | Add new backend | New subcrate implementing `Renderer` for the format |
-| Modify PDF layout | `text/src/pdf.rs` (page constants, cursor, `draw_wrapped`) |
-| Modify table rendering | Backend-specific table match arm (e.g. `sheet/src/xlsx.rs`) |
-| Change sheet naming | `sheet/src/xlsx.rs` (`sanitize_sheet_name`) or `sheet/src/ods.rs` (`truncate_sheet_name`) |
+| Modify PDF layout (document model path) | `text/src/pdf.rs` (page constants, cursor, `draw_wrapped`) |
+| Modify table rendering (non-Typst) | Backend-specific table match arm (e.g. `sheet/src/xlsx.rs`) |
 
 ## Dependencies
 
-Uses: jiff, snafu, krilla (optional), zip (optional), quick-xml (optional), rust_xlsxwriter (optional), spreadsheet-ods (optional)
-Used by: (none yet)
+Uses: jiff, snafu, typst + typst-pdf + comemo + parking_lot (typst backend), krilla (optional), zip (optional), quick-xml (optional), rust_xlsxwriter (optional), spreadsheet-ods (optional)
+Used by: organon (as report tools)

--- a/crates/poiesis/typst/Cargo.toml
+++ b/crates/poiesis/typst/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "poiesis-typst"
+version.workspace = true
+description = "Typst-based PDF rendering backend for poiesis: embeddable compiler, JSON data injection, template assets"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+# Typst compiler (library API — reproducible, offline, rich diagnostics)
+# WHY: the library route avoids subprocess coupling and gives typed
+# access to source locations on errors. Apache-2.0.
+typst = "0.14"
+typst-pdf = "0.14"
+# typst's memoization layer; required by the World trait bounds.
+comemo = "0.5"
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tracing = { workspace = true }
+jiff = { workspace = true }
+# WHY: workspace disallows std::sync::Mutex. parking_lot is the synchronous
+# fast path (typst's World trait is sync and the lock is never held across an
+# await point).
+parking_lot = "0.12"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/poiesis/typst/README.md
+++ b/crates/poiesis/typst/README.md
@@ -1,0 +1,103 @@
+# poiesis-typst
+
+Typst-based PDF rendering for the poiesis report tooling arc.
+
+**Typst is the primary rendering backend** for poiesis. It is more expressive
+than direct PDF generation: templates, math, citations, breakable blocks,
+cross-references, and page-aware layout all come for free, and compiler
+diagnostics carry source locations. Other backends (ODT, XLSX, ODS, PPTX) exist
+for format-specific output; when rendering a prose-oriented report to PDF,
+prefer this crate.
+
+## Public API
+
+```rust
+use poiesis_typst::{render_typst, render_template, templates, PoiesisError};
+use serde_json::json;
+
+// 1. Inline source with injected data
+let pdf: Vec<u8> = render_typst(
+    r#"
+    #let d = json("data.json")
+    = #d.title
+
+    Hello, #d.author.
+    "#,
+    &json!({ "title": "Report", "author": "alice" }),
+)?;
+
+// 2. Built-in template by slug
+let pdf = render_template(templates::DEFAULT, &json!({
+    "title": "Quarterly Review",
+    "body": ["First paragraph.", "Second paragraph."]
+}))?;
+```
+
+On failure, [`PoiesisError`] carries a formatted diagnostic string including
+source file, line, and column.
+
+## Data injection
+
+The JSON value passed to [`render_typst`] is exposed to the Typst document as a
+virtual file at path `data.json`. Templates load it with Typst's built-in
+`json()` function:
+
+```typst
+#let data = json("data.json")
+```
+
+No bespoke substitution layer — the injection piggybacks on Typst's own file
+resolution, so templates written against it also work when edited interactively
+against a real `data.json` on disk.
+
+## Template slug convention
+
+Built-in templates are identified by a short kebab-case slug. Each slug maps to
+a `.typ` source embedded at compile time from `templates/<slug>.typ`.
+
+| Slug      | File                        | Purpose                                        |
+|-----------|-----------------------------|------------------------------------------------|
+| `default` | `templates/default.typ`     | Minimal one-page report: title, body, optional table |
+
+To add a template:
+
+1. Drop `templates/<slug>.typ` alongside `default.typ`.
+2. Register in `src/templates.rs` (`SLUGS` array + `lookup` match arm).
+3. Document the expected data shape in this README.
+
+Keep built-in templates generic. Client-specific branding belongs in the
+consumer's own `.typ` source passed to [`render_typst`] directly.
+
+## Why the library API (not the CLI)
+
+This crate embeds the Typst compiler as a library via the `typst` + `typst-pdf`
+crates, not by shelling out to the `typst` binary. Rationale:
+
+- **Offline and reproducible.** No dependency on `typst` being on `PATH` or a
+  specific version installed; the Cargo lockfile pins the exact compiler.
+- **Structured diagnostics.** The library returns typed `SourceDiagnostic`
+  values with spans; formatting happens in [`world::format_diagnostics`] to
+  produce `file:line:col` error strings. A CLI shim would force us to parse
+  stderr.
+- **No temp files.** Source lives in memory; the virtual filesystem for data
+  injection is constructed per render. Parallel renders do not race on shared
+  scratch paths.
+
+## Attribution
+
+The compiler `World` implementation is adapted from `ergon_tools/sdr` (Cody's
+private code, freely adaptable per issue #3450). Changes from the sdr original:
+
+- in-memory source instead of disk-backed root;
+- synthesized `data.json` virtual file for JSON injection;
+- `parking_lot::Mutex` instead of `std::sync::Mutex` (workspace lint policy);
+- font discovery unchanged.
+
+## Running tests
+
+```bash
+cargo test -p poiesis-typst
+```
+
+14 unit tests cover: minimal rendering, template round-trip, data injection,
+malformed-source diagnostics, unknown-slug error, template fallback paths.

--- a/crates/poiesis/typst/src/error.rs
+++ b/crates/poiesis/typst/src/error.rs
@@ -1,0 +1,38 @@
+//! Error types for poiesis-typst.
+
+use snafu::Snafu;
+
+/// Errors returned by the Typst rendering pipeline.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum PoiesisError {
+    /// Data injection produced invalid JSON.
+    #[snafu(display("failed to serialize injected data: {detail}"))]
+    SerializeData {
+        /// Human-readable description of the serialization failure.
+        detail: String,
+    },
+
+    /// Typst compilation produced errors.
+    #[snafu(display("typst compilation failed:\n{diagnostics}"))]
+    Compile {
+        /// Formatted diagnostics including source locations.
+        diagnostics: String,
+    },
+
+    /// PDF export failed after successful compilation.
+    #[snafu(display("typst PDF export failed:\n{diagnostics}"))]
+    PdfExport {
+        /// Formatted diagnostics from the PDF exporter.
+        diagnostics: String,
+    },
+
+    /// A built-in template slug was not recognized.
+    #[snafu(display("unknown template slug: {slug:?} (known: {known})"))]
+    UnknownTemplate {
+        /// The slug that was requested.
+        slug: String,
+        /// Comma-separated list of known template slugs.
+        known: String,
+    },
+}

--- a/crates/poiesis/typst/src/lib.rs
+++ b/crates/poiesis/typst/src/lib.rs
@@ -1,0 +1,215 @@
+#![deny(missing_docs)]
+//! poiesis-typst: Typst-based PDF rendering for poiesis.
+//!
+//! Typst is the primary rendering backend for the poiesis report tooling arc.
+//! It is more expressive than direct PDF generation: templates, math,
+//! citations, breakable blocks, cross-references, and page-aware layout all
+//! come for free, and diagnostics carry source locations.
+//!
+//! This crate embeds the Typst compiler as a library (not a subprocess), so
+//! rendering is reproducible, offline, and returns structured errors.
+//!
+//! ## Public API
+//!
+//! - [`render_typst`] — compile an arbitrary Typst source string with an
+//!   injected JSON data blob and return PDF bytes.
+//! - [`render_template`] — compile a built-in template (looked up by slug)
+//!   against JSON data and return PDF bytes.
+//! - [`templates`] — listing of built-in template slugs.
+//!
+//! ## Data injection
+//!
+//! The JSON value supplied to [`render_typst`] is exposed to the Typst source
+//! as a virtual file named `data.json`. Templates load it with:
+//!
+//! ```typst
+//! #let data = json("data.json")
+//! ```
+//!
+//! This mirrors Typst's own `json()` function and avoids a bespoke macro
+//! layer. See [`templates::DEFAULT`] for an example.
+//!
+//! ## Attribution
+//!
+//! The compiler `World` implementation is adapted from `ergon_tools/sdr`
+//! (Cody's private code, freely adaptable per issue #3450).
+
+mod error;
+mod world;
+
+/// Built-in Typst templates.
+pub mod templates;
+
+pub use error::PoiesisError;
+
+use tracing::instrument;
+use typst::layout::PagedDocument;
+
+use crate::world::{TypstWorld, format_diagnostics};
+
+/// Result alias for poiesis-typst operations.
+pub type Result<T, E = PoiesisError> = std::result::Result<T, E>;
+
+/// Render a Typst source string to PDF bytes, with optional JSON data injected
+/// at the virtual path `data.json`.
+///
+/// Templates can read the injected data via `json("data.json")`. Pass
+/// `serde_json::Value::Null` (or any empty object) if the template does not
+/// consume data.
+///
+/// # Errors
+///
+/// Returns [`PoiesisError::SerializeData`] if `data` cannot be serialized,
+/// [`PoiesisError::Compile`] if Typst rejects the source, or
+/// [`PoiesisError::PdfExport`] if PDF export fails.
+#[instrument(skip_all, fields(source_bytes = source.len()))]
+pub fn render_typst(source: &str, data: &serde_json::Value) -> Result<Vec<u8>> {
+    let data_bytes =
+        serde_json::to_vec(data).map_err(|e| PoiesisError::SerializeData {
+            detail: e.to_string(),
+        })?;
+
+    let world = TypstWorld::new(source, Some(data_bytes));
+
+    let result = typst::compile::<PagedDocument>(&world);
+
+    for warning in &result.warnings {
+        tracing::warn!(message = %warning.message, "typst warning");
+    }
+
+    let document = result
+        .output
+        .map_err(|diagnostics| PoiesisError::Compile {
+            diagnostics: format_diagnostics(&world, &diagnostics),
+        })?;
+
+    let pdf_bytes = typst_pdf::pdf(&document, &typst_pdf::PdfOptions::default()).map_err(
+        |diagnostics| PoiesisError::PdfExport {
+            diagnostics: format_diagnostics(&world, &diagnostics),
+        },
+    )?;
+
+    Ok(pdf_bytes)
+}
+
+/// Render a built-in template slug against JSON data.
+///
+/// See [`templates`] for the list of slugs.
+///
+/// # Errors
+///
+/// Returns [`PoiesisError::UnknownTemplate`] if the slug is not recognized,
+/// plus any error from [`render_typst`].
+#[instrument(skip_all, fields(slug))]
+pub fn render_template(slug: &str, data: &serde_json::Value) -> Result<Vec<u8>> {
+    let source = templates::lookup(slug).ok_or_else(|| PoiesisError::UnknownTemplate {
+        slug: slug.to_owned(),
+        known: templates::SLUGS.join(", "),
+    })?;
+    render_typst(source, data)
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_minimal_document_produces_pdf() {
+        let source = "= Hello\n\nThis is a test.";
+        let pdf = render_typst(source, &serde_json::Value::Null).expect("minimal must render");
+        assert!(pdf.starts_with(b"%PDF-"), "output must be PDF-magic");
+        assert!(pdf.len() > 200, "PDF should be more than a few bytes");
+        assert!(pdf.len() < 5_000_000, "one-pager PDF should be <5MB");
+    }
+
+    #[test]
+    fn render_default_template_round_trip() {
+        let data = serde_json::json!({
+            "title": "Quarterly Review",
+            "author": "alice",
+            "subtitle": "Draft — internal circulation only",
+            "body": [
+                "First body paragraph describing the headline finding.",
+                "Second body paragraph with supporting detail."
+            ],
+            "table": {
+                "columns": 3,
+                "header": ["Metric", "Q1", "Q2"],
+                "rows": [
+                    ["Revenue", "100", "120"],
+                    ["Costs",   "60",  "70"]
+                ]
+            },
+            "footer": "Prepared for internal review."
+        });
+        let pdf = render_template(templates::DEFAULT, &data).expect("default must render");
+        assert!(pdf.starts_with(b"%PDF-"), "output must be PDF-magic");
+        // WHY: exact byte equality is not meaningful — PDFs embed fonts and
+        // creation dates. Assert on magic prefix and reasonable size bounds.
+        assert!(pdf.len() > 500, "template PDF should be more than 500 bytes");
+        assert!(pdf.len() < 5_000_000, "template PDF should be <5MB");
+    }
+
+    #[test]
+    fn render_default_template_with_only_title() {
+        let data = serde_json::json!({ "title": "Minimal" });
+        let pdf = render_template(templates::DEFAULT, &data)
+            .expect("minimal template data must render");
+        assert!(pdf.starts_with(b"%PDF-"));
+    }
+
+    #[test]
+    fn render_default_template_no_data_uses_default_title() {
+        let data = serde_json::json!({});
+        let pdf =
+            render_template(templates::DEFAULT, &data).expect("empty data must still render");
+        assert!(pdf.starts_with(b"%PDF-"));
+    }
+
+    #[test]
+    fn unknown_template_returns_error() {
+        let data = serde_json::Value::Null;
+        let err = render_template("no-such-template", &data).expect_err("must error");
+        assert!(
+            matches!(err, PoiesisError::UnknownTemplate { .. }),
+            "expected UnknownTemplate, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_typst_returns_compile_error() {
+        let source = "#this-function-does-not-exist()";
+        let err = render_typst(source, &serde_json::Value::Null).expect_err("must error");
+        assert!(
+            matches!(err, PoiesisError::Compile { .. }),
+            "expected Compile, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn compile_diagnostics_include_location() {
+        let source = "#unknown-function()";
+        let err = render_typst(source, &serde_json::Value::Null).expect_err("must error");
+        let PoiesisError::Compile { diagnostics } = err else {
+            panic!("expected Compile error");
+        };
+        assert!(
+            diagnostics.contains("main.typ"),
+            "diagnostics must reference main.typ: {diagnostics}"
+        );
+    }
+
+    #[test]
+    fn data_injection_is_visible_to_template() {
+        // Template that prints a field from data; failure to load means
+        // json() returns an error and compile fails.
+        let source = r#"
+#let d = json("data.json")
+The marker is #d.marker.
+"#;
+        let data = serde_json::json!({ "marker": "sentinel-value-xyz" });
+        let pdf = render_typst(source, &data).expect("must render");
+        assert!(pdf.starts_with(b"%PDF-"));
+    }
+}

--- a/crates/poiesis/typst/src/lib.rs
+++ b/crates/poiesis/typst/src/lib.rs
@@ -64,10 +64,9 @@ pub type Result<T, E = PoiesisError> = std::result::Result<T, E>;
 /// [`PoiesisError::PdfExport`] if PDF export fails.
 #[instrument(skip_all, fields(source_bytes = source.len()))]
 pub fn render_typst(source: &str, data: &serde_json::Value) -> Result<Vec<u8>> {
-    let data_bytes =
-        serde_json::to_vec(data).map_err(|e| PoiesisError::SerializeData {
-            detail: e.to_string(),
-        })?;
+    let data_bytes = serde_json::to_vec(data).map_err(|e| PoiesisError::SerializeData {
+        detail: e.to_string(),
+    })?;
 
     let world = TypstWorld::new(source, Some(data_bytes));
 
@@ -77,17 +76,16 @@ pub fn render_typst(source: &str, data: &serde_json::Value) -> Result<Vec<u8>> {
         tracing::warn!(message = %warning.message, "typst warning");
     }
 
-    let document = result
-        .output
-        .map_err(|diagnostics| PoiesisError::Compile {
-            diagnostics: format_diagnostics(&world, &diagnostics),
-        })?;
+    let document = result.output.map_err(|diagnostics| PoiesisError::Compile {
+        diagnostics: format_diagnostics(&world, &diagnostics),
+    })?;
 
-    let pdf_bytes = typst_pdf::pdf(&document, &typst_pdf::PdfOptions::default()).map_err(
-        |diagnostics| PoiesisError::PdfExport {
-            diagnostics: format_diagnostics(&world, &diagnostics),
-        },
-    )?;
+    let pdf_bytes =
+        typst_pdf::pdf(&document, &typst_pdf::PdfOptions::default()).map_err(|diagnostics| {
+            PoiesisError::PdfExport {
+                diagnostics: format_diagnostics(&world, &diagnostics),
+            }
+        })?;
 
     Ok(pdf_bytes)
 }
@@ -147,23 +145,25 @@ mod tests {
         assert!(pdf.starts_with(b"%PDF-"), "output must be PDF-magic");
         // WHY: exact byte equality is not meaningful — PDFs embed fonts and
         // creation dates. Assert on magic prefix and reasonable size bounds.
-        assert!(pdf.len() > 500, "template PDF should be more than 500 bytes");
+        assert!(
+            pdf.len() > 500,
+            "template PDF should be more than 500 bytes"
+        );
         assert!(pdf.len() < 5_000_000, "template PDF should be <5MB");
     }
 
     #[test]
     fn render_default_template_with_only_title() {
         let data = serde_json::json!({ "title": "Minimal" });
-        let pdf = render_template(templates::DEFAULT, &data)
-            .expect("minimal template data must render");
+        let pdf =
+            render_template(templates::DEFAULT, &data).expect("minimal template data must render");
         assert!(pdf.starts_with(b"%PDF-"));
     }
 
     #[test]
     fn render_default_template_no_data_uses_default_title() {
         let data = serde_json::json!({});
-        let pdf =
-            render_template(templates::DEFAULT, &data).expect("empty data must still render");
+        let pdf = render_template(templates::DEFAULT, &data).expect("empty data must still render");
         assert!(pdf.starts_with(b"%PDF-"));
     }
 

--- a/crates/poiesis/typst/src/templates.rs
+++ b/crates/poiesis/typst/src/templates.rs
@@ -1,0 +1,48 @@
+//! Built-in Typst templates, embedded at compile time.
+//!
+//! Each template is identified by a short slug string. Call
+//! [`crate::render_template`] with the slug to render. Templates expect
+//! their data payload to be available at the virtual path `data.json`
+//! (which [`crate::render_typst`] populates automatically).
+
+/// Slug for the default one-page report template.
+pub const DEFAULT: &str = "default";
+
+/// Source for the [`DEFAULT`] template.
+///
+/// Embedded at compile time from `templates/default.typ`.
+pub const DEFAULT_SOURCE: &str = include_str!("../templates/default.typ");
+
+/// List of all known template slugs.
+pub const SLUGS: &[&str] = &[DEFAULT];
+
+/// Resolve a slug to its Typst source, or `None` if unknown.
+#[must_use]
+pub fn lookup(slug: &str) -> Option<&'static str> {
+    match slug {
+        DEFAULT => Some(DEFAULT_SOURCE),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_slug_is_registered() {
+        assert!(SLUGS.contains(&DEFAULT), "DEFAULT must be in SLUGS");
+    }
+
+    #[test]
+    fn lookup_default_returns_source() {
+        let src = lookup(DEFAULT).expect("default must resolve");
+        assert!(src.contains("json(\"data.json\")"), "default must load data");
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        assert!(lookup("no-such").is_none());
+    }
+}

--- a/crates/poiesis/typst/src/templates.rs
+++ b/crates/poiesis/typst/src/templates.rs
@@ -38,7 +38,10 @@ mod tests {
     #[test]
     fn lookup_default_returns_source() {
         let src = lookup(DEFAULT).expect("default must resolve");
-        assert!(src.contains("json(\"data.json\")"), "default must load data");
+        assert!(
+            src.contains("json(\"data.json\")"),
+            "default must load data"
+        );
     }
 
     #[test]

--- a/crates/poiesis/typst/src/world.rs
+++ b/crates/poiesis/typst/src/world.rs
@@ -1,0 +1,308 @@
+//! Minimal in-memory implementation of the Typst `World` trait.
+//!
+//! Adapted from `ergon_tools/sdr` (Cody's private code, freely adaptable per
+//! issue #3450). Changes from the sdr original:
+//! - source lives in memory (not on disk) so `render_typst` can be called
+//!   without touching the filesystem;
+//! - an optional `data.json` virtual file is synthesized so templates can load
+//!   injected data via `json("data.json")`;
+//! - fonts are discovered from standard system paths, same as sdr.
+//!
+//! WHY library not CLI: reproducibility and error fidelity. The library route
+//! gives typed diagnostics with source spans; the CLI route requires writing
+//! temp files, parsing stderr, and depends on `typst` being on `PATH`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use parking_lot::Mutex;
+use typst::WorldExt;
+use typst::diag::{FileError, FileResult, Severity, SourceDiagnostic};
+use typst::foundations::{Bytes, Datetime};
+use typst::syntax::{FileId, Source, VirtualPath};
+use typst::text::{Font, FontBook};
+use typst::utils::LazyHash;
+use typst::{Library, LibraryExt, World};
+
+/// The virtual path for the injected JSON data file.
+///
+/// Templates may call `json("data.json")` to load the data passed to
+/// [`crate::render_typst`].
+pub(crate) const DATA_VPATH: &str = "data.json";
+
+/// A loaded font face.
+struct FontEntry {
+    font: Font,
+}
+
+/// A typst `World` backed by an in-memory main source and an optional
+/// in-memory data blob, with fonts discovered from the system.
+pub(crate) struct TypstWorld {
+    /// `FileId` of the main `.typ` source (in-memory).
+    main: FileId,
+    /// In-memory main source text.
+    main_source: Source,
+
+    /// `FileId` of the virtual `data.json` file, if data was provided.
+    data_id: Option<FileId>,
+    /// Raw bytes of the injected data file.
+    data_bytes: Option<Bytes>,
+
+    /// Typst standard library.
+    library: LazyHash<Library>,
+    /// Metadata about all discovered fonts.
+    book: LazyHash<FontBook>,
+    /// Loaded font faces; indexed by position in `book`.
+    fonts: Vec<FontEntry>,
+
+    /// Per-file source/bytes cache for a single compilation.
+    // WHY: parking_lot::Mutex — World trait methods are synchronous and the
+    // lock is never held across an await point, so the tokio lock would add
+    // unnecessary overhead.
+    cache: Mutex<HashMap<FileId, CacheSlot>>,
+}
+
+#[derive(Default)]
+struct CacheSlot {
+    source: Option<FileResult<Source>>,
+    bytes: Option<FileResult<Bytes>>,
+}
+
+impl TypstWorld {
+    /// Create a world from a source string and optional serialized data bytes.
+    pub(crate) fn new(source: &str, data_bytes: Option<Vec<u8>>) -> Self {
+        let main_vpath = VirtualPath::new("main.typ");
+        let main = FileId::new(None, main_vpath);
+        let main_source = Source::new(main, source.to_owned());
+
+        let (data_id, data_bytes) = match data_bytes {
+            Some(bytes) => {
+                let id = FileId::new(None, VirtualPath::new(DATA_VPATH));
+                (Some(id), Some(Bytes::new(bytes)))
+            }
+            None => (None, None),
+        };
+
+        let (book, fonts) = discover_fonts();
+
+        Self {
+            main,
+            main_source,
+            data_id,
+            data_bytes,
+            library: LazyHash::new(Library::default()),
+            book: LazyHash::new(book),
+            fonts,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl World for TypstWorld {
+    fn library(&self) -> &LazyHash<Library> {
+        &self.library
+    }
+
+    fn book(&self) -> &LazyHash<FontBook> {
+        &self.book
+    }
+
+    fn main(&self) -> FileId {
+        self.main
+    }
+
+    fn source(&self, id: FileId) -> FileResult<Source> {
+        if id == self.main {
+            return Ok(self.main_source.clone());
+        }
+
+        let mut cache = self.cache.lock();
+        if let Some(slot) = cache.get(&id)
+            && let Some(ref r) = slot.source
+        {
+            return r.clone();
+        }
+
+        // No disk-backed sources: only the main file and data.json are known.
+        let path = id.vpath().as_rootless_path().to_path_buf();
+        let result: FileResult<Source> = Err(FileError::NotFound(path));
+        cache.entry(id).or_default().source = Some(result.clone());
+        result
+    }
+
+    fn file(&self, id: FileId) -> FileResult<Bytes> {
+        if let (Some(data_id), Some(data)) = (self.data_id, self.data_bytes.as_ref())
+            && id == data_id
+        {
+            return Ok(data.clone());
+        }
+
+        let mut cache = self.cache.lock();
+        if let Some(slot) = cache.get(&id)
+            && let Some(ref r) = slot.bytes
+        {
+            return r.clone();
+        }
+
+        let path = id.vpath().as_rootless_path().to_path_buf();
+        let result: FileResult<Bytes> = Err(FileError::NotFound(path));
+        cache.entry(id).or_default().bytes = Some(result.clone());
+        result
+    }
+
+    fn font(&self, index: usize) -> Option<Font> {
+        self.fonts.get(index).map(|e| e.font.clone())
+    }
+
+    fn today(&self, offset: Option<i64>) -> Option<Datetime> {
+        // WHY: typst requests today in local time (offset=None) or UTC+N (offset=Some).
+        let date = if let Some(hours) = offset {
+            let offset_secs = i32::try_from(hours.saturating_mul(3600)).ok()?;
+            let tz_offset = jiff::tz::Offset::from_seconds(offset_secs).ok()?;
+            let tz = jiff::tz::TimeZone::fixed(tz_offset);
+            jiff::Timestamp::now().to_zoned(tz).date()
+        } else {
+            jiff::Zoned::now().date()
+        };
+
+        Datetime::from_ymd(
+            i32::from(date.year()),
+            u8::try_from(date.month()).ok()?,
+            u8::try_from(date.day()).ok()?,
+        )
+    }
+}
+
+/// Format typst diagnostics into a human-readable string with source locations.
+pub(crate) fn format_diagnostics(world: &TypstWorld, diagnostics: &[SourceDiagnostic]) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    for diag in diagnostics {
+        let severity = match diag.severity {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        };
+
+        // WHY: WorldExt::range handles both numbered and raw-range span encodings.
+        let location = world
+            .range(diag.span)
+            .and_then(|range| {
+                let id = diag.span.id()?;
+                let source = world.source(id).ok()?;
+                let line = source.lines().byte_to_line(range.start)? + 1;
+                let col = source.lines().byte_to_column(range.start)? + 1;
+                let path = id.vpath().as_rootless_path().display().to_string();
+                Some(format!("{path}:{line}:{col}"))
+            })
+            .unwrap_or_else(|| "<unknown>".to_owned());
+
+        let _ = writeln!(out, "{severity}: {location}: {}", diag.message);
+        for hint in &diag.hints {
+            let _ = writeln!(out, "  hint: {hint}");
+        }
+    }
+    out
+}
+
+// ── Font discovery ────────────────────────────────────────────────────────────
+
+fn discover_fonts() -> (FontBook, Vec<FontEntry>) {
+    let dirs = system_font_dirs();
+    let mut book = FontBook::new();
+    let mut fonts = Vec::new();
+
+    for dir in dirs {
+        let Ok(read_dir) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        scan_font_dir(read_dir, &mut book, &mut fonts);
+    }
+
+    tracing::debug!(count = fonts.len(), "discovered system fonts");
+    (book, fonts)
+}
+
+fn scan_font_dir(read_dir: std::fs::ReadDir, book: &mut FontBook, fonts: &mut Vec<FontEntry>) {
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+
+        if path.is_dir() {
+            if let Ok(sub) = std::fs::read_dir(&path) {
+                scan_font_dir(sub, book, fonts);
+            }
+            continue;
+        }
+
+        if !is_font_file(&path) {
+            continue;
+        }
+
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
+        };
+        let bytes = Bytes::new(data);
+
+        for font in Font::iter(bytes) {
+            book.push(font.info().clone());
+            fonts.push(FontEntry { font });
+        }
+    }
+}
+
+fn is_font_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("ttf" | "otf" | "ttc" | "otc" | "woff" | "woff2")
+    )
+}
+
+fn system_font_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![
+        PathBuf::from("/usr/share/fonts"),
+        PathBuf::from("/usr/local/share/fonts"),
+    ];
+
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        dirs.push(home.join(".fonts"));
+        dirs.push(home.join(".local/share/fonts"));
+    }
+
+    // macOS system font directories.
+    dirs.push(PathBuf::from("/Library/Fonts"));
+    dirs.push(PathBuf::from("/System/Library/Fonts"));
+    if let Some(home) = std::env::var_os("HOME") {
+        dirs.push(PathBuf::from(home).join("Library/Fonts"));
+    }
+
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_font_file_accepts_font_extensions() {
+        assert!(is_font_file(Path::new("foo.ttf")), "must accept .ttf");
+        assert!(is_font_file(Path::new("foo.otf")), "must accept .otf");
+        assert!(is_font_file(Path::new("foo.ttc")), "must accept .ttc");
+        assert!(is_font_file(Path::new("foo.woff2")), "must accept .woff2");
+    }
+
+    #[test]
+    fn is_font_file_rejects_non_font() {
+        assert!(!is_font_file(Path::new("report.typ")), "must reject .typ");
+        assert!(!is_font_file(Path::new("data.json")), "must reject .json");
+    }
+
+    #[test]
+    fn system_font_dirs_contains_usr_share() {
+        let dirs = system_font_dirs();
+        assert!(
+            dirs.contains(&PathBuf::from("/usr/share/fonts")),
+            "must include /usr/share/fonts"
+        );
+    }
+}

--- a/crates/poiesis/typst/templates/default.typ
+++ b/crates/poiesis/typst/templates/default.typ
@@ -1,0 +1,59 @@
+// poiesis-typst default template.
+//
+// A minimal one-page report scaffold. The template loads JSON data injected
+// via `render_typst` and renders title, author, body paragraphs, and an
+// optional table. Keep this intentionally small — it is used for library
+// smoke tests and as a baseline for user templates.
+
+#let data = json("data.json")
+
+#set page(paper: "us-letter", margin: 0.75in)
+#set text(font: "Liberation Sans", size: 10pt)
+#set par(leading: 0.65em, spacing: 0.8em)
+
+// Title block
+#align(left)[
+  #text(18pt, weight: "bold")[#data.at("title", default: "Untitled Report")]
+  #if "author" in data [
+    #v(4pt)
+    #text(10pt, fill: rgb("#666666"))[By #data.author]
+  ]
+]
+
+#v(16pt)
+
+// Optional subtitle
+#if "subtitle" in data [
+  #text(12pt, style: "italic")[#data.subtitle]
+  #v(8pt)
+]
+
+// Body paragraphs
+#if "body" in data {
+  for paragraph in data.body [
+    #paragraph
+
+    #v(0.4em)
+  ]
+}
+
+// Optional table: data.table = (columns: n, header: [...], rows: [[...], ...])
+#if "table" in data {
+  let t = data.table
+  let columns = int(t.at("columns", default: t.header.len()))
+  v(8pt)
+  table(
+    columns: columns,
+    fill: (_, y) => if y == 0 { rgb("#333333") } else { none },
+    stroke: 0.5pt + rgb("#cccccc"),
+    inset: 6pt,
+    ..t.header.map(h => text(weight: "bold", fill: white, h)),
+    ..t.rows.flatten(),
+  )
+}
+
+// Optional footer note
+#if "footer" in data [
+  #v(12pt)
+  #text(9pt, fill: rgb("#666666"), style: "italic")[#data.footer]
+]

--- a/deny.toml
+++ b/deny.toml
@@ -46,6 +46,10 @@ allow = [
     "LGPL-3.0-or-later",    # priority-queue
     "CDLA-Permissive-2.0",  # webpki-roots, webpki-root-certs
     "bzip2-1.0.6",          # libbz2-rs-sys (via zip 7.x), standalone bzip2 license
+    # Apache-2.0 with LLVM's additional permission for compiled output.
+    # Pulled in by typst-eval -> stacker -> psm -> ar_archive_writer (build).
+    # LLVM exception is a superset of Apache-2.0 (strictly more permissive).
+    "Apache-2.0 WITH LLVM-exception",
 ]
 confidence-threshold = 0.8
 


### PR DESCRIPTION
## Summary

PR 2 of N in the #3450 arc: adopt sdr-style architecture for poiesis. Ships the Typst-based PDF renderer (the primary rendering backend per the issue body) and wires a `render_typst_report` tool into organon.

- **New crate `crates/poiesis/typst/`** — public API `render_typst(source, data) -> Vec<u8>` and `render_template(slug, data)`. Embeds the Typst compiler as a library (no CLI subprocess, no temp files, offline).
- **JSON data injection** — `data` is exposed to Typst as a virtual file read via `json("data.json")`, matching Typst's own built-in loader.
- **Default template** — `templates/default.typ` — minimal one-page report (title, author, body, optional table, footer). Embedded at compile time; registered by slug in `src/templates.rs`.
- **organon tool `render_typst_report`** — accepts `source` or `template`, optional `data` (JSON) and `out_path`. Returns a text summary plus a base64-encoded PDF `Document` content block.
- **Docs** — `crates/poiesis/typst/README.md` + updated `crates/poiesis/CLAUDE.md` to call Typst the primary renderer and document the slug convention.
- **deny.toml** — allow `Apache-2.0 WITH LLVM-exception` (typst-eval → stacker → psm → ar_archive_writer; strictly more permissive than Apache-2.0).

### Attribution

The compiler `World` implementation is adapted from `ergon_tools/sdr` (Cody's private code, freely adaptable per #3450). Changes from the sdr original: in-memory source (no disk root), synthesized `data.json` virtual file, `parking_lot::Mutex` (workspace disallows `std::sync::Mutex`).

### What this PR is **not** doing

Follow-ups for later sub-PRs in the #3450 arc: poiesis-sheet XLSX rendering pipeline alignment, poiesis-doc (DOCX), poiesis-slides (PPTX) revamp, poiesis-scaffold (`sdr new`), poiesis-intake (Slack → project), poiesis-diff, poiesis-inspect, eval-framework + knowledge-graph audit report integration. #3339 and #3445 stay open for their own sub-PRs.

## Test plan

- [x] `cargo test -p poiesis-typst` — 14 unit tests green (minimal render, template round-trip, data injection, diagnostics carry source location, unknown-slug error, malformed source error, empty-data fallback)
- [x] `cargo test -p organon` — 456 tests green, including 6 new `render_typst_report` tests (inline source, template + data, writes out_path, requires source-or-template, unknown template is error, malformed typst is error)
- [x] `cargo check --workspace` — green
- [x] `cargo clippy --workspace --all-targets -- -Dwarnings` — green
- [x] `cargo fmt --check` — green
- [x] `cargo deny check` — green (licenses, advisories, bans, sources)

Refs #3450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)