### PR TITLE
test(koilon,organon): install rustls crypto provider in tests (closes #3693)

### DIFF
--- a/crates/organon/src/builtins/web_search.rs
+++ b/crates/organon/src/builtins/web_search.rs
@@ -213,7 +213,20 @@ mod tests {
 
     use super::*;
 
+    // WHY(#3693): reqwest 0.13 requires a rustls crypto provider to be
+    // installed before any `Client` is constructed. `mock_ctx` builds a
+    // `reqwest::Client`; without this, the test panics with
+    // "No provider set". `install_default` fails if the process already
+    // installed one, so we swallow the result.
+    fn ensure_crypto_provider() {
+        static INIT: std::sync::Once = std::sync::Once::new();
+        INIT.call_once(|| {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        });
+    }
+
     fn mock_ctx() -> ToolContext {
+        ensure_crypto_provider();
         ToolContext {
             nous_id: NousId::new("alice").expect("valid"),
             session_id: SessionId::new(),

--- a/crates/theatron/koilon/src/config.rs
+++ b/crates/theatron/koilon/src/config.rs
@@ -224,8 +224,22 @@ fn write_config(path: &Path, content: &str) -> Result<()> {
 mod tests {
     use super::*;
 
+    // WHY(#3693): reqwest 0.13 requires a rustls crypto provider to be
+    // installed before any `Client` is constructed. `Config::load` builds
+    // a reqwest client via `try_discover`; without this, every test that
+    // calls `Config::load(...)` panics with "No provider set". Ignoring
+    // the result so the second install on the same process (from main or
+    // another test) is a no-op instead of a panic.
+    fn ensure_crypto_provider() {
+        static INIT: std::sync::Once = std::sync::Once::new();
+        INIT.call_once(|| {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        });
+    }
+
     #[test]
     fn cli_overrides_file_config() {
+        ensure_crypto_provider();
         let config = Config::load(
             Some("http://custom:9999".into()),
             Some("tok".into()),
@@ -242,6 +256,7 @@ mod tests {
 
     #[test]
     fn default_url_when_none() {
+        ensure_crypto_provider();
         let config = Config::load(None, None, None, None).unwrap();
         assert_eq!(config.url, DEFAULT_URL);
     }
@@ -280,6 +295,7 @@ mod tests {
 
     #[test]
     fn theme_parsing_light() {
+        ensure_crypto_provider();
         let config = Config::load(None, None, None, None).unwrap();
         // Default is auto (None) when no file setting
         let _ = config.theme;
@@ -287,6 +303,7 @@ mod tests {
 
     #[test]
     fn workspace_root_none_when_no_env_or_file() {
+        ensure_crypto_provider();
         // ALETHEIA_ROOT env var must not be set for this test to be meaningful.
         // We can't mutate env vars (unsafe-code is denied in this crate).
         // Verify that when neither env nor file provides workspace_root, it is None.
@@ -323,18 +340,21 @@ mod tests {
 
     #[test]
     fn config_load_detects_oauth_credential() {
+        ensure_crypto_provider();
         let config = Config::load(None, Some("sk-ant-oat-test123".into()), None, None).unwrap();
         assert_eq!(config.credential_label, CredentialLabel::OAuthToken);
     }
 
     #[test]
     fn config_load_detects_static_credential() {
+        ensure_crypto_provider();
         let config = Config::load(None, Some("sk-ant-api01-test".into()), None, None).unwrap();
         assert_eq!(config.credential_label, CredentialLabel::StaticApiKey);
     }
 
     #[test]
     fn config_load_no_credential() {
+        ensure_crypto_provider();
         let config = Config::load(None, None, None, None).unwrap();
         assert_eq!(config.credential_label, CredentialLabel::None);
     }


### PR DESCRIPTION
## Summary

- Add `ensure_crypto_provider()` (std::sync::Once over `rustls::crypto::ring::default_provider().install_default()`) to koilon's `config::tests` and organon's `builtins::web_search::tests`.
- Call it at the top of every test that reaches `Config::load` / `mock_ctx` — the paths that construct a `reqwest::Client` and were panicking with "No provider set" on reqwest 0.13.

## Why

reqwest 0.13 with the rustls backend requires an explicit crypto provider install before any `Client` is constructed. Production code already does this in koilon's `main.rs` (ring, expect-on-failure) and `app/test_helpers.rs`. The unit tests in `koilon::config` and `organon::builtins::web_search` did not, and each panicked at `reqwest-0.13.2/src/async_impl/client.rs:2461`.

Using `std::sync::Once` + `install_default().ok()` is idempotent: subsequent tests in the same process (or after `cargo test -p koilon --bin koilon` runs main) see a no-op.

## Test plan

- [x] `cargo nextest run -p koilon config::tests` — 11/11 pass
- [x] `cargo nextest run -p organon builtins::web_search::tests --features test-support` — 3/3 pass
- [x] `cargo clippy -p koilon --all-features -- -D warnings` clean
- [x] `cargo clippy -p organon --features test-support -- -D warnings` clean

Closes #3693