### PR TITLE
test(organon): assert on file-content invariant for read-only Landlock test (closes #3707)

### DIFF
--- a/crates/organon/src/sandbox/policy_tests.rs
+++ b/crates/organon/src/sandbox/policy_tests.rs
@@ -1099,45 +1099,61 @@ fn temp_directory_access() {
 }
 
 /// Test read-only paths are actually read-only.
-// WHY: Test asserts on shell exit string ("exit_status=1" or
-// "Permission denied") which is kernel-specific. Fails on GitHub
-// Actions ubuntu-latest runner kernel (Landlock rejects the write
-// but the shell surfaces exit 2, not 1). Passes on Linux 6.19 dev
-// host. Re-ignored to unblock CI while the assertion is rewritten
-// to check file-content invariant (see #3707).
+// WHY(#3707): assert on the filesystem invariant, not the shell exit
+// string. The Landlock restriction we're testing is "file-under-
+// read_paths is not modified". Different kernel versions surface that
+// as different shell exit codes (1 on fedora 43's 6.19 kernel, 2 on
+// GitHub's ubuntu-latest), and the test used to branch on a brittle
+// string match. The security invariant is: file contents unchanged +
+// child did not report success.
 #[cfg(target_os = "linux")]
 #[test]
-#[ignore = "kernel-dependent shell exit string, tracked in forkwright/aletheia#3707"]
 fn read_only_paths_cannot_be_written() {
     let read_only_dir = tempfile::tempdir().expect("create read-only dir");
     let test_file = read_only_dir.path().join("readonly.txt");
+    const ORIGINAL_CONTENTS: &str = "original";
     #[expect(
         clippy::disallowed_methods,
         reason = "test setup requires direct filesystem access"
     )]
-    std::fs::write(&test_file, "original").expect("write test file");
+    std::fs::write(&test_file, ORIGINAL_CONTENTS).expect("write test file");
 
     let workspace = tempfile::tempdir().expect("create workspace");
     let mut policy = policy_with_system_paths(workspace.path());
     // Add read-only dir to read_paths but NOT write_paths
     policy.read_paths.push(read_only_dir.path().to_path_buf());
 
-    let cmd_str = format!(
-        "echo 'modified' > {} 2>&1; echo exit_status=$?",
-        test_file.display()
-    );
+    let cmd_str = format!("echo 'modified' > {}", test_file.display());
 
     let mut cmd = Command::new("sh");
     cmd.arg("-c").arg(&cmd_str);
     apply_sandbox(&mut cmd, policy).expect("apply sandbox");
 
     let output = cmd.output().expect("spawn child");
-    let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Should fail - read-only paths should not be writable
+    // Invariant 1: the file on disk is unchanged. Landlock enforcement
+    // is visible here regardless of shell exit conventions.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test assertion requires direct filesystem access"
+    )]
+    let after = std::fs::read_to_string(&test_file).expect("read test file");
+    assert_eq!(
+        after,
+        ORIGINAL_CONTENTS,
+        "read-only path was modified despite Landlock policy; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // Invariant 2: the child reported a non-zero exit (some signal of
+    // failure). We don't depend on *which* non-zero code — the shell
+    // picks 1 on some kernels and 2 on others for redirection failure.
     assert!(
-        stdout.contains("exit_status=1") || stdout.contains("Permission denied"),
-        "writing to read-only path should fail: {stdout}"
+        !output.status.success(),
+        "child reported success despite read-only Landlock policy; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
     );
 }
 

--- a/crates/organon/src/sandbox/policy_tests.rs
+++ b/crates/organon/src/sandbox/policy_tests.rs
@@ -1106,17 +1106,22 @@ fn temp_directory_access() {
 // GitHub's ubuntu-latest), and the test used to branch on a brittle
 // string match. The security invariant is: file contents unchanged +
 // child did not report success.
+/// Original contents written to the read-only fixture before the
+/// sandboxed child attempts to overwrite it. Declared at module scope
+/// so the body of `read_only_paths_cannot_be_written` has no item-
+/// after-statements (`clippy::items_after_statements` on stable).
+const READONLY_TEST_ORIGINAL: &str = "original";
+
 #[cfg(target_os = "linux")]
 #[test]
 fn read_only_paths_cannot_be_written() {
     let read_only_dir = tempfile::tempdir().expect("create read-only dir");
     let test_file = read_only_dir.path().join("readonly.txt");
-    const ORIGINAL_CONTENTS: &str = "original";
     #[expect(
         clippy::disallowed_methods,
         reason = "test setup requires direct filesystem access"
     )]
-    std::fs::write(&test_file, ORIGINAL_CONTENTS).expect("write test file");
+    std::fs::write(&test_file, READONLY_TEST_ORIGINAL).expect("write test file");
 
     let workspace = tempfile::tempdir().expect("create workspace");
     let mut policy = policy_with_system_paths(workspace.path());
@@ -1133,14 +1138,10 @@ fn read_only_paths_cannot_be_written() {
 
     // Invariant 1: the file on disk is unchanged. Landlock enforcement
     // is visible here regardless of shell exit conventions.
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "test assertion requires direct filesystem access"
-    )]
     let after = std::fs::read_to_string(&test_file).expect("read test file");
     assert_eq!(
         after,
-        ORIGINAL_CONTENTS,
+        READONLY_TEST_ORIGINAL,
         "read-only path was modified despite Landlock policy; stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),


### PR DESCRIPTION
## Summary

- Rewrite `read_only_paths_cannot_be_written` to assert the file on disk is unchanged after the sandboxed child exits, rather than grep the shell's stdout for `exit_status=1` or `Permission denied`.
- Remove the `#[ignore]` added in #3697 — the test now passes across kernels because it checks the Landlock-level invariant, not shell-level string conventions.
- Keep a secondary `!output.status.success()` assertion as a loose signal-of-failure check, with no string match.

## Why

The original assertion was kernel-coupled. fedora 43 (kernel 6.19) surfaces Landlock's write refusal as shell exit 1 from redirection failure; GitHub Actions' `ubuntu-latest` surfaces it as exit 2. The test passed on the dev host and failed in CI for the same-kind-of-security-success. Landlock's invariant is "file contents not modified" — so that's what this test now asserts.

## Test plan

- [x] `cargo nextest run -p organon sandbox::policy::policy_tests::read_only_paths_cannot_be_written --features test-support` — passes
- [x] `cargo clippy -p organon --features test-support -- -D warnings` clean
- [ ] CI (`ubuntu-latest`) passes the test without `#[ignore]`

Closes #3707