### PR TITLE
fix(hermeneus/cc): accept error-subtype result events that omit 'result' (closes #3717)

### DIFF
--- a/crates/hermeneus/src/cc/parse.rs
+++ b/crates/hermeneus/src/cc/parse.rs
@@ -20,6 +20,13 @@ pub(crate) enum CcEvent {
     Assistant { message: AssistantMessage },
 
     /// Final result event with usage and cost.
+    ///
+    /// WHY(#3717): `result` is only present on success-shaped events
+    /// (`subtype = "success"`). When CC hits `error_max_turns` or another
+    /// error subtype, it omits `result` entirely and populates `errors`
+    /// (array of messages) + `terminal_reason` instead. Making `result`
+    /// optional + surfacing `errors`/`terminal_reason` keeps the parser
+    /// from dropping the whole event on error-subtype terminations.
     #[serde(rename = "result")]
     Result {
         #[cfg_attr(
@@ -30,7 +37,8 @@ pub(crate) enum CcEvent {
             )
         )]
         subtype: String,
-        result: String,
+        #[serde(default)]
+        result: Option<String>,
         #[serde(default)]
         is_error: bool,
         #[serde(default)]
@@ -41,6 +49,14 @@ pub(crate) enum CcEvent {
         duration_ms: Option<u64>,
         #[serde(default)]
         session_id: Option<String>,
+        /// Error messages emitted when CC terminates before producing a
+        /// final `result` (e.g. `error_max_turns`).
+        #[serde(default)]
+        errors: Vec<String>,
+        /// Terminal reason string (`"max_turns"`, `"error"`, etc.) for
+        /// error-subtype result events.
+        #[serde(default)]
+        terminal_reason: Option<String>,
     },
 
     /// System event (connection info, etc.). Ignored.
@@ -197,7 +213,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(subtype, "success");
-                assert_eq!(result, "Hello");
+                assert_eq!(result.as_deref(), Some("Hello"));
                 assert!(!is_error);
                 assert_eq!(session_id.as_deref(), Some("sess_123"));
                 let u = usage.unwrap();
@@ -206,6 +222,51 @@ mod tests {
             }
             other => panic!("expected Result, got {other:?}"),
         }
+    }
+
+    // WHY(#3717): regression — when CC hits `error_max_turns` the `result`
+    // field is absent and the event instead carries `errors` + `terminal_reason`.
+    // Before this fix, `result: String` made the whole event fail to parse
+    // with "missing field `result`", dropping it and producing a
+    // pipeline_error upstream.
+    #[test]
+    fn parse_result_event_error_subtype_omits_result_field() {
+        let line = r#"{"type":"result","subtype":"error_max_turns","duration_ms":4065,"duration_api_ms":5062,"is_error":true,"num_turns":2,"stop_reason":"tool_use","session_id":"sess_456","total_cost_usd":0.125,"usage":{"input_tokens":1,"output_tokens":2},"permission_denials":[],"terminal_reason":"max_turns","fast_mode_state":"off","uuid":"u-1","errors":["Reached maximum number of turns (1)"]}"#;
+        let event = parse_event(line).unwrap();
+        match event {
+            CcEvent::Result {
+                subtype,
+                result,
+                is_error,
+                errors,
+                terminal_reason,
+                session_id,
+                ..
+            } => {
+                assert_eq!(subtype, "error_max_turns");
+                assert_eq!(result, None, "error subtype omits the `result` field");
+                assert!(is_error);
+                assert_eq!(
+                    errors,
+                    vec!["Reached maximum number of turns (1)".to_owned()]
+                );
+                assert_eq!(terminal_reason.as_deref(), Some("max_turns"));
+                assert_eq!(session_id.as_deref(), Some("sess_456"));
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
+    }
+
+    // WHY(#3717): regression — CC's stream-json emits a top-level
+    // `{"type":"user"}` envelope for tool_result messages. The parser must
+    // accept this variant and route it to the ignored `User` arm (the
+    // tool-result content is handled via the Assistant turn that preceded
+    // it; this echo is informational).
+    #[test]
+    fn parse_user_event_with_tool_result_message() {
+        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"File does not exist.","is_error":true,"tool_use_id":"toolu_abc"}]},"parent_tool_use_id":null,"session_id":"s-1","uuid":"u-2","timestamp":"2026-04-19T13:41:32.010Z","tool_use_result":"Error: File does not exist"}"#;
+        let event = parse_event(line).unwrap();
+        assert!(matches!(event, CcEvent::User { .. }));
     }
 
     #[test]

--- a/crates/hermeneus/src/cc/process.rs
+++ b/crates/hermeneus/src/cc/process.rs
@@ -252,6 +252,27 @@ pub(crate) async fn run_completion(
     }
 }
 
+/// Synthesize a human-readable error message from an error-subtype result
+/// event's `errors` array + `terminal_reason`.
+///
+/// WHY(#3717): when CC terminates with `subtype = "error_max_turns"` (or any
+/// other error subtype) it omits the `result` field entirely. Rather than
+/// bubble `None` up to `result_to_response` — which would need its own None
+/// handling — we synthesize a message here. Downstream `is_error = true`
+/// propagation turns this into an `ApiRequest` error with readable text.
+fn synthesize_error_text(errors: &[String], terminal_reason: Option<&str>) -> String {
+    let mut parts = Vec::new();
+    if let Some(reason) = terminal_reason {
+        parts.push(format!("terminal_reason={reason}"));
+    }
+    if errors.is_empty() {
+        parts.push("(no error messages reported)".to_owned());
+    } else {
+        parts.push(errors.join("; "));
+    }
+    parts.join(": ")
+}
+
 /// Read CC's stdout stream, collecting assistant deltas and the final result.
 ///
 /// Generic over the reader so unit tests can pass an in-memory buffer
@@ -313,9 +334,16 @@ where
                 cost_usd: c,
                 duration_ms: d,
                 session_id: s,
+                errors,
+                terminal_reason,
                 ..
             } => {
-                result_text = result;
+                // WHY(#3717): error-subtype result events omit `result` and
+                // populate `errors` + `terminal_reason` instead. Synthesize
+                // a human-readable `result_text` so downstream is_error
+                // propagation keeps working without losing the reason.
+                result_text = result
+                    .unwrap_or_else(|| synthesize_error_text(&errors, terminal_reason.as_deref()));
                 is_error = err;
                 usage = u;
                 cost_usd = c;
@@ -529,9 +557,14 @@ where
                 cost_usd: c,
                 duration_ms: d,
                 session_id: s,
+                errors,
+                terminal_reason,
                 ..
             } => {
-                result_text = result;
+                // WHY(#3717): error-subtype result events omit `result`.
+                // See read_stream.
+                result_text = result
+                    .unwrap_or_else(|| synthesize_error_text(&errors, terminal_reason.as_deref()));
                 is_error = err;
                 usage = u;
                 cost_usd = c;

--- a/crates/hermeneus/src/cc/process_tests.rs
+++ b/crates/hermeneus/src/cc/process_tests.rs
@@ -214,6 +214,51 @@ async fn read_stream_propagates_is_error_flag() {
     assert_eq!(output.result_text, "rate limit");
 }
 
+// WHY(#3717): regression — when CC terminates with `subtype = "error_max_turns"`
+// (or any error subtype) it omits the `result` field entirely, populating
+// `errors` + `terminal_reason` instead. Before the fix, the event failed
+// deserialization ("missing field `result`") and the whole turn was
+// dropped as pipeline_error. Now we parse it, propagate is_error=true,
+// and synthesize a human-readable result_text from terminal_reason +
+// errors for downstream error mapping.
+#[tokio::test]
+async fn read_stream_error_subtype_without_result_field() {
+    let buf = stream_buf(&[
+        r#"{"type":"result","subtype":"error_max_turns","duration_ms":4065,"is_error":true,"num_turns":2,"session_id":"sess_err","terminal_reason":"max_turns","errors":["Reached maximum number of turns (1)"]}"#,
+    ]);
+    let output = read_stream(buf.as_slice()).await.unwrap();
+    assert!(output.is_error);
+    assert!(
+        output.result_text.contains("max_turns"),
+        "synthesized text should name the terminal reason: {}",
+        output.result_text
+    );
+    assert!(
+        output
+            .result_text
+            .contains("Reached maximum number of turns (1)"),
+        "synthesized text should include the error message: {}",
+        output.result_text
+    );
+    assert_eq!(output.session_id.as_deref(), Some("sess_err"));
+}
+
+// WHY(#3717): regression — CC also emits `{"type":"user"}` echo events
+// carrying `tool_result` content blocks. These must parse without
+// emitting the `unknown variant \`user\`` warning and must not end the
+// read_stream loop. Verify by feeding a user event followed by a normal
+// result event and checking the result survives.
+#[tokio::test]
+async fn read_stream_ignores_user_tool_result_event() {
+    let buf = stream_buf(&[
+        r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"File not found","is_error":true,"tool_use_id":"toolu_x"}]},"session_id":"s","uuid":"u"}"#,
+        r#"{"type":"result","subtype":"success","result":"recovered","is_error":false}"#,
+    ]);
+    let output = read_stream(buf.as_slice()).await.unwrap();
+    assert!(!output.is_error);
+    assert_eq!(output.result_text, "recovered");
+}
+
 // ── parse_oauth_token_from_json ───────────────────────────────────────────
 // WHY: Tests target the JSON-parsing helper rather than read_oauth_token
 // directly. read_oauth_token wraps parse_oauth_token_from_json with I/O


### PR DESCRIPTION
## Summary

Two related parser gaps for CC stream-json, both surfaced on aletheia.service runs 2026-04-19:

- **Error-subtype result events**: when CC terminates via `max_turns` (or any error subtype like `error_max_turns`) it omits the `result` field and populates `errors` + `terminal_reason`. The deserializer's `result: String` failed with \"missing field \`result\`\" and dropped the whole event, surfacing as `pipeline_error` upstream. Downgrade to `Option<String>` and add `errors: Vec<String>` + `terminal_reason: Option<String>`. Callers in `process.rs` synthesize a readable `result_text` (e.g. `\"terminal_reason=max_turns: Reached maximum number of turns (1)\"`) so `is_error=true` propagation continues to work.
- **`{\"type\":\"user\"}` envelopes**: the tool_result echo event. The parser already has a `User` variant (added in #3168); the stale-log warning in the issue is from an older binary. Adding a regression test pins this shape so a future refactor can't re-break it.

## Why

Every nous turn that hit max_turns or used tool_result was dropping into pipeline_error today on demiurge/akron/syl/syn prosoche runs.

## Test plan

- [x] `cargo fmt -p hermeneus`
- [x] `cargo check -p hermeneus --features cc-provider` — clean
- [x] `cargo clippy -p hermeneus --features cc-provider -- -D warnings` — clean
- [x] 2 new unit tests in `parse.rs`:
  - `parse_result_event_error_subtype_omits_result_field` (fixture from issue body verbatim)
  - `parse_user_event_with_tool_result_message` (fixture from issue body verbatim)
- [x] 2 new end-to-end tests in `process_tests.rs`:
  - `read_stream_error_subtype_without_result_field` — verifies `is_error` propagates and the synthesized text names `terminal_reason` + error messages.
  - `read_stream_ignores_user_tool_result_event` — verifies the user echo doesn't end the read loop.
- [x] All 79 cc tests pass under `--features cc-provider`.

Closes #3717