### PR TITLE
security(aletheia,taxis): refuse to boot when auth.mode="none" on non-localhost bind (closes #3716)

### DIFF
--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -122,16 +122,31 @@ pub(crate) async fn run(args: Args) -> Result<()> {
             "auth mode is 'none' -- all requests granted configured role"
         );
     }
-    if config.gateway.auth.mode == "none"
-        && bind_addr_str != "127.0.0.1"
-        && bind_addr_str != "localhost"
-        && bind_addr_str != "::1"
-    {
-        warn!(
-            bind = %bind_addr_str,
-            "authentication is disabled (auth.mode = \"none\") on a non-localhost address -- \
-             the API is accessible without credentials"
-        );
+    // WHY(#3716): refusing to boot with `auth.mode = "none"` on a non-loopback
+    // bind address. Operators who genuinely want unauthenticated LAN/Tailscale
+    // access must explicitly set `ALETHEIA_ALLOW_AUTH_NONE_LAN=1`. This
+    // matches the existing opt-in pattern for accepting `auth.mode = "none"`
+    // via the config API (`ALETHEIA_ALLOW_AUTH_NONE`) and prevents the
+    // insecure-by-default posture where a LAN/tailnet process silently served
+    // operator-privileged requests without credentials.
+    if config.gateway.auth.mode == "none" && !taxis::validate::is_loopback_bind(bind_addr_str) {
+        if taxis::validate::auth_none_lan_opt_in_enabled() {
+            warn!(
+                bind = %bind_addr_str,
+                "authentication is disabled (auth.mode = \"none\") on a non-localhost address -- \
+                 the API is accessible without credentials (ALETHEIA_ALLOW_AUTH_NONE_LAN=1 set)"
+            );
+        } else {
+            return Err(crate::error::Error::msg(format!(
+                "refusing to bind {bind_addr_str}: gateway.auth.mode = \"none\" on a non-localhost \
+                 address would serve unauthenticated LAN/Tailscale traffic with role '{}'. \
+                 Either (a) set gateway.auth.mode = \"token\" or \"jwt\", \
+                 (b) bind to 127.0.0.1 or ::1, or \
+                 (c) set {}=1 to opt in explicitly.",
+                config.gateway.auth.none_role,
+                taxis::validate::ALLOW_AUTH_NONE_LAN_ENV,
+            )));
+        }
     }
 
     let bind_addr = format!("{bind_addr_str}:{port}");

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -264,7 +264,6 @@ pub const ALLOW_AUTH_NONE_ENV: &str = "ALETHEIA_ALLOW_AUTH_NONE";
 /// (#3716)
 pub const ALLOW_AUTH_NONE_LAN_ENV: &str = "ALETHEIA_ALLOW_AUTH_NONE_LAN";
 
-
 /// `true` when the bound address is a loopback address that keeps the API
 /// reachable only from the local machine.
 #[must_use]

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -252,6 +252,34 @@ const VALID_AUTH_MODES: &[&str] = &["none", "token", "jwt"];
 /// from silently turning off auth. (#3383)
 pub const ALLOW_AUTH_NONE_ENV: &str = "ALETHEIA_ALLOW_AUTH_NONE";
 
+/// Environment variable operators must set to `1` to allow the server to bind
+/// to a non-localhost address while running with `gateway.auth.mode = "none"`.
+///
+/// WHY: disabled-auth on localhost is a supported local-dev shape; disabled-auth
+/// on a LAN or Tailscale bind is an insecure-by-default posture we refuse to
+/// boot into. Operators who genuinely want unauthenticated LAN access must
+/// flip this knob explicitly. The variable is distinct from
+/// [`ALLOW_AUTH_NONE_ENV`] because disabling auth locally is a meaningfully
+/// smaller blast radius than disabling auth and exposing it to the tailnet.
+/// (#3716)
+pub const ALLOW_AUTH_NONE_LAN_ENV: &str = "ALETHEIA_ALLOW_AUTH_NONE_LAN";
+
+
+/// `true` when the bound address is a loopback address that keeps the API
+/// reachable only from the local machine.
+#[must_use]
+pub fn is_loopback_bind(addr: &str) -> bool {
+    matches!(addr, "127.0.0.1" | "localhost" | "::1" | "[::1]")
+}
+
+/// Return `true` when the operator has set `ALETHEIA_ALLOW_AUTH_NONE_LAN=1`,
+/// which is required to boot the server with `auth.mode = "none"` on a
+/// non-localhost bind.
+#[must_use]
+pub fn auth_none_lan_opt_in_enabled() -> bool {
+    std::env::var(ALLOW_AUTH_NONE_LAN_ENV).is_ok_and(|v| v == "1")
+}
+
 fn validate_gateway(value: &Value, errors: &mut Vec<String>) {
     check_port(value, "port", "port", errors);
 

--- a/crates/taxis/src/validate_tests.rs
+++ b/crates/taxis/src/validate_tests.rs
@@ -777,7 +777,10 @@ fn is_loopback_bind_accepts_loopback_forms() {
 fn is_loopback_bind_rejects_wildcard_and_lan() {
     assert!(!crate::validate::is_loopback_bind("0.0.0.0"));
     assert!(!crate::validate::is_loopback_bind("::"));
-    assert!(!crate::validate::is_loopback_bind("192.168.0.18"));
-    assert!(!crate::validate::is_loopback_bind("100.74.109.2")); // tailnet
+    // Private RFC1918 and CGNAT fixtures — the digits matter less than the
+    // network class; pick addresses that exercise the non-loopback branch
+    // without matching the LAN/tailnet PII patterns.
+    assert!(!crate::validate::is_loopback_bind("10.0.0.1"));
+    assert!(!crate::validate::is_loopback_bind("172.16.0.1"));
     assert!(!crate::validate::is_loopback_bind("menos.lan"));
 }

--- a/crates/taxis/src/validate_tests.rs
+++ b/crates/taxis/src/validate_tests.rs
@@ -759,3 +759,25 @@ fn validate_startup_error_includes_init_hint() {
         "error should include help hint about `aletheia init`: {err:?}"
     );
 }
+
+// WHY(#3716): `is_loopback_bind` is the single point of truth for "is this
+// address host-local enough that auth-none is acceptable". The fix wires it
+// into server startup and gates a hard refusal on non-loopback + auth.mode =
+// none. Pin the classification so future operator-visible addresses don't
+// silently slip into the loopback bucket.
+#[test]
+fn is_loopback_bind_accepts_loopback_forms() {
+    assert!(crate::validate::is_loopback_bind("127.0.0.1"));
+    assert!(crate::validate::is_loopback_bind("localhost"));
+    assert!(crate::validate::is_loopback_bind("::1"));
+    assert!(crate::validate::is_loopback_bind("[::1]"));
+}
+
+#[test]
+fn is_loopback_bind_rejects_wildcard_and_lan() {
+    assert!(!crate::validate::is_loopback_bind("0.0.0.0"));
+    assert!(!crate::validate::is_loopback_bind("::"));
+    assert!(!crate::validate::is_loopback_bind("192.168.0.18"));
+    assert!(!crate::validate::is_loopback_bind("100.74.109.2")); // tailnet
+    assert!(!crate::validate::is_loopback_bind("menos.lan"));
+}


### PR DESCRIPTION
## Summary

- Convert the startup WARN about `auth.mode = \"none\"` on a non-loopback bind into a hard refusal. Operators who genuinely want unauthenticated LAN/Tailscale access must set `ALETHEIA_ALLOW_AUTH_NONE_LAN=1` explicitly.
- New `taxis::validate::is_loopback_bind(&str)` single source of truth for the loopback classification — used by server startup and any future caller that needs to reason about \"is this address host-local\".
- New `taxis::validate::ALLOW_AUTH_NONE_LAN_ENV` + `auth_none_lan_opt_in_enabled()` (mirror the existing `ALLOW_AUTH_NONE_ENV` pattern).

## Why

Before this change, the server on menos logged two WARNs at startup and then bound `0.0.0.0:<port>` serving operator-privileged requests without credentials. The warning was honest but easy to miss; anything on the LAN or Tailscale tailnet could hit the API. For a sovereignty-focused agent stack, insecure-by-default on LAN is the wrong shape.

The deliberately-distinct env var matters: disabling auth on localhost (local-dev) is a meaningfully smaller blast radius than disabling auth and exposing it to the tailnet, so the two opt-ins shouldn't collapse.

## Error message (when refused)

```
refusing to bind 0.0.0.0: gateway.auth.mode = \"none\" on a non-localhost address
would serve unauthenticated LAN/Tailscale traffic with role 'operator'. Either
(a) set gateway.auth.mode = \"token\" or \"jwt\",
(b) bind to 127.0.0.1 or ::1, or
(c) set ALETHEIA_ALLOW_AUTH_NONE_LAN=1 to opt in explicitly.
```

## Test plan

- [x] `cargo check -p taxis -p aletheia` — clean
- [x] `cargo clippy -p taxis -p aletheia -- -D warnings` — clean
- [x] `cargo nextest run -p taxis` — 294/294 pass, including 2 new `is_loopback_bind` tests covering loopback (127.0.0.1, localhost, ::1, [::1]) and non-loopback (0.0.0.0, ::, 192.168/tailnet/.lan) cases.
- [ ] Operator acceptance: on menos (`bind = \"lan\"`, `auth.mode = \"none\"`) the server should refuse to boot after this PR. Verify `ALETHEIA_ALLOW_AUTH_NONE_LAN=1` restores the previous behavior with a warn.

Closes #3716