### PR TITLE
test(hermeneus): eliminate ETXTBSY race in write_script helper (closes #3723)

### DIFF
--- a/crates/hermeneus/src/cc/process_tests.rs
+++ b/crates/hermeneus/src/cc/process_tests.rs
@@ -10,14 +10,25 @@ use super::*;
 const ETXTBSY: i32 = 26;
 
 /// Write a shell script to a unique temp path, make it executable, and
-/// verify the path is safe to `execve` before returning.
+/// verify the path is safe to exec before returning.
 ///
 /// Returns the final script path. The caller is responsible for cleanup
 /// (or letting the OS reclaim the temp dir on process exit).
 ///
-/// Defeats the Linux ETXTBSY (errno 26, "Text file busy") race that
-/// surfaces when execve runs on a freshly-written file whose writer's
-/// `__fput` has not yet been processed. See forkwright/aletheia#3723.
+/// Defeats the Linux ETXTBSY (errno 26, "Text file busy") race described
+/// in forkwright/aletheia#3723 with two layers of defense:
+///
+/// 1. Stage the script at a `.tmp` sibling and rename into place. The
+///    writer's file descriptor is tied to the tmp dentry and fully
+///    released before rename exposes the final inode, so the common
+///    case sees the final path land with a zero writer-count.
+/// 2. Probe the final path by sacrificially spawning it and killing the
+///    child immediately. An exec syscall is the only observer that
+///    fires when the inode still has an open writer, so a successful
+///    spawn is the definitive signal that the caller's real spawn
+///    cannot race. Transient ETXTBSY is swallowed and retried on a
+///    short sleep; the loop caps so a genuinely busy file surfaces an
+///    error rather than hanging.
 fn write_script(name: &str, body: &str) -> PathBuf {
     use std::sync::atomic::{AtomicU64, Ordering};
     static NONCE: AtomicU64 = AtomicU64::new(0);
@@ -26,25 +37,6 @@ fn write_script(name: &str, body: &str) -> PathBuf {
         "hermeneus_test_{name}_{}_{nonce}.sh",
         std::process::id()
     ));
-    // WHY: Writing directly to `final_path` and then execve()ing it races
-    // with the kernel's `i_writecount` accounting — under parallel test
-    // load, `__fput` for the writer can be deferred via the kernel's
-    // delayed-fput workqueue long enough for a sibling thread's spawn()
-    // to observe `i_writecount > 0` and return ETXTBSY (os error 26,
-    // "Text file busy"). See forkwright/aletheia#3723.
-    //
-    // Defense in depth:
-    //   1. Write to a `.tmp` sibling, fsync + chmod, then rename(2) it
-    //      into place. The writer-FD was tied to the tmp dentry and has
-    //      been fully released before rename observes the inode, so the
-    //      final path's inode lands with `i_writecount == 0` in the
-    //      common case.
-    //   2. Probe by sacrificially spawning the script itself and killing
-    //      it immediately. execve(2) is the *only* syscall that consults
-    //      i_writecount, so a successful spawn is the definitive signal
-    //      that the caller's real spawn() cannot race us. Swallow any
-    //      ETXTBSY and retry with a short sleep; cap the loop so we
-    //      don't hang if a genuinely-busy file is passed.
     let tmp_path = final_path.with_extension("sh.tmp");
     let script = format!("#!/bin/sh\n{body}\n");
     {

--- a/crates/hermeneus/src/cc/process_tests.rs
+++ b/crates/hermeneus/src/cc/process_tests.rs
@@ -5,41 +5,82 @@ use std::os::unix::fs::PermissionsExt as _;
 
 use super::*;
 
-/// Write a shell script to a unique temp path and make it executable.
+/// Linux `ETXTBSY` errno — `execve(2)` returns this when the target file
+/// has an open writable descriptor anywhere in the kernel.
+const ETXTBSY: i32 = 26;
+
+/// Write a shell script to a unique temp path, make it executable, and
+/// verify the path is safe to `execve` before returning.
 ///
-/// Returns the script path. The caller is responsible for cleanup (or letting
-/// the OS reclaim the temp dir on process exit).
+/// Returns the final script path. The caller is responsible for cleanup
+/// (or letting the OS reclaim the temp dir on process exit).
 ///
-/// Includes a per-thread nonce in the filename so concurrent tests never race
-/// on the same path, and a post-chmod readability probe to defeat the Linux
-/// ETXTBSY (errno 26) race where exec-after-write can still see the file as
-/// busy for a tick after our writer has closed and fsync'd.
+/// Defeats the Linux ETXTBSY (errno 26, "Text file busy") race that
+/// surfaces when execve runs on a freshly-written file whose writer's
+/// `__fput` has not yet been processed. See forkwright/aletheia#3723.
 fn write_script(name: &str, body: &str) -> PathBuf {
     use std::sync::atomic::{AtomicU64, Ordering};
     static NONCE: AtomicU64 = AtomicU64::new(0);
     let nonce = NONCE.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!(
+    let final_path = std::env::temp_dir().join(format!(
         "hermeneus_test_{name}_{}_{nonce}.sh",
         std::process::id()
     ));
+    // WHY: Writing directly to `final_path` and then execve()ing it races
+    // with the kernel's `i_writecount` accounting — under parallel test
+    // load, `__fput` for the writer can be deferred via the kernel's
+    // delayed-fput workqueue long enough for a sibling thread's spawn()
+    // to observe `i_writecount > 0` and return ETXTBSY (os error 26,
+    // "Text file busy"). See forkwright/aletheia#3723.
+    //
+    // Defense in depth:
+    //   1. Write to a `.tmp` sibling, fsync + chmod, then rename(2) it
+    //      into place. The writer-FD was tied to the tmp dentry and has
+    //      been fully released before rename observes the inode, so the
+    //      final path's inode lands with `i_writecount == 0` in the
+    //      common case.
+    //   2. Probe by sacrificially spawning the script itself and killing
+    //      it immediately. execve(2) is the *only* syscall that consults
+    //      i_writecount, so a successful spawn is the definitive signal
+    //      that the caller's real spawn() cannot race us. Swallow any
+    //      ETXTBSY and retry with a short sleep; cap the loop so we
+    //      don't hang if a genuinely-busy file is passed.
+    let tmp_path = final_path.with_extension("sh.tmp");
     let script = format!("#!/bin/sh\n{body}\n");
     {
         use std::io::Write;
-        let mut f = fs::File::create(&path).unwrap();
+        let mut f = fs::File::create(&tmp_path).unwrap();
         f.write_all(script.as_bytes()).unwrap();
         f.sync_all().unwrap();
     }
-    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
-    // WHY: On busy CI runners the exec path occasionally sees the file as
-    // Text file busy for a moment after the writer closed. Poll metadata so
-    // the file is at least visible to subsequent syscalls before returning.
-    for _ in 0..50 {
-        if fs::metadata(&path).is_ok() {
-            return path;
+    fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o755)).unwrap();
+    fs::rename(&tmp_path, &final_path).unwrap();
+
+    for _ in 0..200 {
+        match std::process::Command::new(&final_path)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(mut child) => {
+                // Kill + reap immediately; we only care that execve passed.
+                let _ = child.kill();
+                let _ = child.wait();
+                return final_path;
+            }
+            Err(e) if e.raw_os_error() == Some(ETXTBSY) => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(_) => {
+                // Any other error (ENOENT, EACCES, …) is not our race —
+                // return the path and let the caller surface the error
+                // with its own context.
+                return final_path;
+            }
         }
-        std::thread::sleep(std::time::Duration::from_millis(10));
     }
-    path
+    final_path
 }
 
 /// Build a multi-line stream-json buffer from individual event JSON strings.


### PR DESCRIPTION
## Summary

Fix the ETXTBSY (`Text file busy`, os error 26) race in `hermeneus::cc::process_tests::write_script` that has been flaking `cc::process::process_tests::*` under CI load, blocking PRs #3699, #3718, and #3721.

## Why O_RDONLY probe wasn't enough

Issue #3723 suggested Option 2 (an `open(path, O_RDONLY)` / close probe). Local reproduction under parallel load on Fedora 43 showed the probe succeeds while `execve(2)` still returns ETXTBSY — `File::open(O_RDONLY)` doesn't consult the kernel's `i_writecount`, so a successful read-open doesn't imply the write-mapping has drained. Only `execve(2)` actually checks `i_writecount`.

## Fix

Two-part defense:

1. **`rename(2)`-into-place** from a `.tmp` sibling — decouples the writer FD's lifetime from the final path. By the time the file appears at its final name, the writer FD has been closed by the kernel.
2. **Sacrificial `Command::spawn` + immediate `kill`** as the readiness probe. `execve(2)` is the only syscall that reads `i_writecount`, so a successful probe-spawn is the definitive "safe to exec" signal. Swallow transient ETXTBSY, retry 200×10ms, cap to avoid hanging on genuine failures.

## Test plan

- [x] `cargo test -p hermeneus --features cc-provider cc::process::process_tests` — 27/27 pass, 20 consecutive runs, zero ETXTBSY
- [x] Full hermeneus suite: 358 lib + 17 integration + 2 doctests pass
- [x] `cargo clippy -p hermeneus --features cc-provider --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean

## Unblocks

- PR #3699 (poiesis-typst)
- PR #3718 (nous dispatch-split)
- PR #3721 (cc-stream-json-variants)

Closes #3723

🤖 Generated with [Claude Code](https://claude.com/claude-code)