### PR TITLE
fix(episteme): replace timeout-based BFS proximity with in-process traversal (closes #3725)

### DIFF
--- a/crates/episteme/src/graph_intelligence.rs
+++ b/crates/episteme/src/graph_intelligence.rs
@@ -220,34 +220,18 @@ pub(crate) const LOAD_GRAPH_SCORES: &str = r"
     *graph_scores{entity_id, score_type, score, cluster_id, updated_at}
 ";
 
-/// Bounded BFS Datalog script for proximity computation.
+/// Maximum hop distance returned by [`KnowledgeStore::compute_bfs_proximity`].
 ///
-/// Computes hop distances from a set of seed entity IDs up to 4 hops.
-/// Parameters: `$seeds` (list of entity IDs).
-///
-/// Returns rows of `[entity_id, hops]`.
+/// Entities reachable at a greater distance from any seed are excluded from
+/// the result. Matches the historical 4-hop Datalog bound (`hop0`..`hop4`).
 #[cfg_attr(
     not(feature = "mneme-engine"),
     expect(
         dead_code,
-        reason = "Datalog query used by mneme-engine graph pipeline"
+        reason = "bound consumed by mneme-engine BFS proximity traversal"
     )
 )]
-pub(crate) const BFS_PROXIMITY_4HOP: &str = r"
-seed[id] := id in $seeds
-
-hop0[id, h] := seed[id], h = 0
-hop1[dst, h] := hop0[src, _], *relationships{src, dst}, not hop0[dst, _], h = 1
-hop2[dst, h] := hop1[src, _], *relationships{src, dst}, not hop0[dst, _], not hop1[dst, _], h = 2
-hop3[dst, h] := hop2[src, _], *relationships{src, dst}, not hop0[dst, _], not hop1[dst, _], not hop2[dst, _], h = 3
-hop4[dst, h] := hop3[src, _], *relationships{src, dst}, not hop0[dst, _], not hop1[dst, _], not hop2[dst, _], not hop3[dst, _], h = 4
-
-?[entity_id, hops] := hop0[entity_id, hops]
-?[entity_id, hops] := hop1[entity_id, hops]
-?[entity_id, hops] := hop2[entity_id, hops]
-?[entity_id, hops] := hop3[entity_id, hops]
-?[entity_id, hops] := hop4[entity_id, hops]
-";
+pub(crate) const BFS_PROXIMITY_MAX_HOPS: u32 = 4;
 
 /// Datalog script for computing supersession chain lengths.
 ///
@@ -407,70 +391,63 @@ impl crate::knowledge_store::KnowledgeStore {
         Ok(ctx)
     }
 
-    /// Compute BFS proximity from seed entities up to 4 hops.
+    /// Compute BFS proximity from seed entities up to [`BFS_PROXIMITY_MAX_HOPS`]
+    /// hops.
     ///
-    /// Uses a 5ms timeout budget. Falls back to the existing 2-hop neighborhood
-    /// query if the budget is exceeded.
+    /// Loads the full relationship set once, then runs a standard queue-based
+    /// multi-source BFS in-process. Seeds are included at hop 0. First-visit
+    /// wins, so cycles terminate naturally and shortest-path hop counts are
+    /// preserved.
+    ///
+    /// WHY in-process rather than Datalog: the previous implementation issued a
+    /// 4-hop recursive Datalog query under a 5 ms wall-clock budget and, on
+    /// timeout, degraded to a buggy 2-hop fallback (wrong column index, wrong
+    /// horizon). The timeout fired on slower CI runners (notably macOS),
+    /// producing platform-dependent hop counts. A direct traversal over the
+    /// materialized adjacency list is both faster for small/medium graphs and
+    /// platform-independent.
     pub(crate) fn compute_bfs_proximity(
         &self,
         seed_entity_ids: &[String],
     ) -> crate::error::Result<HashMap<String, u32>> {
-        use crate::engine::DataValue;
-
         if seed_entity_ids.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let seeds_list: Vec<DataValue> = seed_entity_ids
-            .iter()
-            .map(|s| DataValue::Str(s.as_str().into()))
-            .collect();
+        let adj = self.build_adjacency_list()?;
 
-        let mut params = std::collections::BTreeMap::new();
-        params.insert("seeds".to_owned(), DataValue::List(seeds_list));
+        let mut hops: HashMap<String, u32> = HashMap::new();
+        let mut queue: VecDeque<(String, u32)> = VecDeque::new();
 
-        let timeout = std::time::Duration::from_millis(5);
-        match self.run_query_with_timeout(BFS_PROXIMITY_4HOP, params, Some(timeout)) {
-            Ok(result) => Ok(parse_hop_rows(&result.rows, 1)),
-            Err(crate::error::Error::QueryTimeout { .. }) => {
-                tracing::debug!("4-hop BFS exceeded 5ms budget, falling back to 2-hop");
-                Ok(self.bfs_fallback_2hop(seed_entity_ids))
+        for seed in seed_entity_ids {
+            // Multi-source BFS: every seed starts at hop 0. `or_insert(0)` keeps
+            // duplicate seeds idempotent.
+            if hops.insert(seed.clone(), 0).is_none() {
+                queue.push_back((seed.clone(), 0));
             }
-            Err(e) => Err(e),
         }
-    }
 
-    /// 2-hop fallback when 4-hop BFS exceeds the time budget.
-    fn bfs_fallback_2hop(&self, seed_entity_ids: &[String]) -> HashMap<String, u32> {
-        let mut proximity = HashMap::new();
-        for seed_id in seed_entity_ids {
-            // WHY: callers rely on the seed appearing at hop 0 in the result
-            // regardless of which implementation served the query. The 4-hop
-            // Datalog path includes seeds; mirror that here so behaviour does
-            // not silently diverge under the slower CI path.
-            proximity.insert(seed_id.clone(), 0);
-            let Ok(entity_id) = crate::id::EntityId::new(seed_id) else {
+        while let Some((node, dist)) = queue.pop_front() {
+            if dist >= BFS_PROXIMITY_MAX_HOPS {
+                // Respect the 4-hop bound: do not expand past the horizon so
+                // entities at hop 5+ never appear in the result.
+                continue;
+            }
+            let Some(neighbors) = adj.get(&node) else {
                 continue;
             };
-            if let Ok(neighborhood) = self.entity_neighborhood(&entity_id) {
-                for row in &neighborhood.rows {
-                    if let Some(neighbor_id) = row.first().and_then(|v| v.get_str()) {
-                        let hops = row
-                            .get(2)
-                            .and_then(crate::engine::DataValue::get_int)
-                            .unwrap_or(2);
-                        let hops_u32 = i64_to_u32(hops);
-                        proximity
-                            .entry(neighbor_id.to_owned())
-                            .and_modify(|existing: &mut u32| {
-                                *existing = (*existing).min(hops_u32);
-                            })
-                            .or_insert(hops_u32);
-                    }
+            let next = dist + 1;
+            for (neighbor, _weight) in neighbors {
+                if let std::collections::hash_map::Entry::Vacant(slot) =
+                    hops.entry(neighbor.clone())
+                {
+                    slot.insert(next);
+                    queue.push_back((neighbor.clone(), next));
                 }
             }
         }
-        proximity
+
+        Ok(hops)
     }
 
     /// Compute supersession chain lengths for all facts.

--- a/crates/episteme/src/graph_intelligence_tests/engine_dependent.rs
+++ b/crates/episteme/src/graph_intelligence_tests/engine_dependent.rs
@@ -335,10 +335,6 @@ mod engine_tests {
     }
 
     #[test]
-    #[cfg_attr(
-        target_os = "macos",
-        ignore = "engine traversal ordering drift on macOS; tracked in #3573"
-    )]
     fn bfs_proximity_5hop_chain_excludes_5th_node() {
         let store = test_store();
 


### PR DESCRIPTION
## Summary

Fix `bfs_proximity_hop_counts` and `bfs_proximity_cycle_no_infinite_loop` which failed only on `macos-latest` CI. The failure was deterministic, not flaky: macOS CI's Datalog evaluator takes longer than the 5 ms budget allotted in `compute_bfs_proximity`, so execution falls into a broken fallback that (a) reads `entity_type` (a string column) as a hop count via `get_int(...).unwrap_or(2)`, making every direct neighbor report `hop == 2`, and (b) only computes a 2-hop horizon, silently dropping hop-3 and hop-4 entities. Linux never observed the bug because the 4-hop Datalog path finished inside the timeout.

## Fix

Replace `compute_bfs_proximity` with an in-process multi-source BFS over the already-materialized adjacency list, bounded by `BFS_PROXIMITY_MAX_HOPS = 4`. Same pattern as the existing `compute_bfs_proximity_decay` (which has never drifted across platforms). Removes `BFS_PROXIMITY_4HOP`, `bfs_fallback_2hop`, and the misleading `#[cfg_attr(target_os = "macos", ignore = "… #3573")]` (unrelated issue). Platform-independent — no `cfg` gates.

## Test plan

- [x] `cargo test -p episteme --features mneme-engine graph_intelligence` — 60/60 pass (including the previously macOS-ignored `bfs_proximity_5hop_chain_excludes_5th_node`)
- [x] `cargo test -p episteme --features mneme-engine` — 1148 lib + 34 bin + 2 doctests all pass
- [x] `cargo clippy -p episteme --features mneme-engine --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `kanon lint . --summary` — 2942 violations / 126 suppressed, matches main baseline (zero new debt)

## Unblocks

- PR #3699 (poiesis-typst) macOS track
- PR #3721 (cc-stream-json-variants) macOS track

Closes #3725

🤖 Generated with [Claude Code](https://claude.com/claude-code)