### PR TITLE
test(symbolon): regression tests for file_ops needs_refresh + lock primitives (closes #3712)

### DIFF
--- a/crates/symbolon/src/credential/file_ops.rs
+++ b/crates/symbolon/src/credential/file_ops.rs
@@ -237,9 +237,14 @@ impl CredentialFile {
 
     /// Whether the token needs refresh (expired or within threshold).
     #[must_use]
-    #[expect(
-        dead_code,
-        reason = "refresh logic inlined in refresh_loop; kept as public API"
+    // WHY: exercised only under `#[cfg(test)]`; non-test builds must still
+    // see this as intentionally-unused public-API surface.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "refresh logic inlined in refresh_loop; kept as public API"
+        )
     )]
     pub(crate) fn needs_refresh(&self) -> bool {
         match self.seconds_remaining() {
@@ -262,9 +267,14 @@ pub(super) struct CredentialFileLock {
 
 impl CredentialFileLock {
     /// Acquire a shared (read) lock on the credential file.
-    #[expect(
-        dead_code,
-        reason = "available for load() callers that need consistency"
+    // WHY: exercised only under `#[cfg(test)]`; non-test builds must still
+    // see this as intentionally-unused public-API surface.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "available for load() callers that need consistency"
+        )
     )]
     pub(super) fn shared(credential_path: &Path) -> std::io::Result<Self> {
         Self::lock(credential_path, rustix::fs::FlockOperation::LockShared)
@@ -311,3 +321,7 @@ impl CredentialFileLock {
 }
 
 // NOTE: lock is released when _file is dropped (flock semantics)
+
+#[cfg(test)]
+#[path = "file_ops_tests.rs"]
+mod file_ops_tests;

--- a/crates/symbolon/src/credential/file_ops_tests.rs
+++ b/crates/symbolon/src/credential/file_ops_tests.rs
@@ -1,0 +1,274 @@
+#![expect(clippy::unwrap_used, clippy::expect_used, reason = "test assertions")]
+//! Tests for `CredentialFile::needs_refresh` and `CredentialFileLock`.
+//!
+//! WHY: `cargo mutants` flagged 8 missed mutants in this file (issue #3712):
+//! `needs_refresh` returned a constant and the `<` threshold comparison was
+//! unchecked; `CredentialFileLock::shared`/`exclusive`/`lock` were never
+//! asserted on, so `Ok(Default::default())` replacements survived.
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use koina::secret::SecretString;
+
+use super::*;
+use crate::credential::{REFRESH_THRESHOLD_SECS, unix_epoch_ms};
+
+// --------------------------------------------------------------------
+// needs_refresh
+// --------------------------------------------------------------------
+
+/// Build a `CredentialFile` whose `expires_at` is exactly `offset_secs` seconds
+/// from `now`. Negative offsets produce an expired credential.
+fn cred_expiring_in(offset_secs: i64) -> CredentialFile {
+    let now_ms = i64::try_from(unix_epoch_ms()).unwrap_or(i64::MAX);
+    let expires_at_ms = now_ms.saturating_add(offset_secs.saturating_mul(1000));
+    let expires_at = u64::try_from(expires_at_ms.max(0)).unwrap_or(0);
+    CredentialFile {
+        token: SecretString::from("t"),
+        refresh_token: None,
+        expires_at: Some(expires_at),
+        scopes: None,
+        subscription_type: None,
+    }
+}
+
+#[test]
+fn needs_refresh_false_when_well_before_expiry() {
+    // WHY: 2 * threshold puts expiry far outside the refresh window; kills the
+    // `-> true` body-replacement mutant.
+    let threshold_secs = i64::try_from(REFRESH_THRESHOLD_SECS).unwrap();
+    let cred = cred_expiring_in(threshold_secs.saturating_mul(2));
+    assert!(
+        !cred.needs_refresh(),
+        "credential expiring in 2x threshold should not need refresh"
+    );
+}
+
+#[test]
+fn needs_refresh_true_when_inside_window_before_expiry() {
+    // WHY: inside the refresh window but not yet expired; distinguishes the
+    // `<` comparison from `>` and `==`.
+    let threshold_secs = i64::try_from(REFRESH_THRESHOLD_SECS).unwrap();
+    let cred = cred_expiring_in(threshold_secs / 2);
+    assert!(
+        cred.needs_refresh(),
+        "credential expiring inside refresh window should need refresh"
+    );
+}
+
+#[test]
+fn needs_refresh_true_when_expired() {
+    // WHY: negative remaining is strictly less than the threshold; kills the
+    // `-> false` body-replacement mutant and the `< → <=` mutation by
+    // pairing with the boundary tests below.
+    let cred = cred_expiring_in(-3600);
+    assert!(cred.needs_refresh(), "expired credential must need refresh");
+}
+
+#[test]
+fn needs_refresh_true_at_expiry_instant() {
+    // WHY: at expiry, remaining is ~0 seconds — strictly less than the 3600s
+    // threshold, so the correct `<` comparator returns true. Together with
+    // the "well-before-expiry" test this pins down `<` against `>` and `>=`.
+    let cred = cred_expiring_in(0);
+    assert!(
+        cred.needs_refresh(),
+        "credential at expiry instant must need refresh"
+    );
+}
+
+#[test]
+fn needs_refresh_false_without_expiry() {
+    // WHY: the `None` arm is the only path that returns false for tokens with
+    // no expiry; covers the match arm directly.
+    let cred = CredentialFile {
+        token: SecretString::from("t"),
+        refresh_token: None,
+        expires_at: None,
+        scopes: None,
+        subscription_type: None,
+    };
+    assert!(
+        !cred.needs_refresh(),
+        "credential without expiry must not need refresh"
+    );
+}
+
+#[test]
+fn needs_refresh_boundary_just_outside_window_is_false() {
+    // WHY: one second beyond the window — the `<` comparator returns false
+    // (remaining == threshold + 1 is not `< threshold`). Together with the
+    // "inside window" test this distinguishes `<` from `<=` and from `==`.
+    let threshold_secs = i64::try_from(REFRESH_THRESHOLD_SECS).unwrap();
+    // Use +2 to tolerate one-second rounding during the seconds_remaining
+    // computation on slow test runners.
+    let cred = cred_expiring_in(threshold_secs.saturating_add(2));
+    assert!(
+        !cred.needs_refresh(),
+        "credential expiring just outside refresh window must not need refresh"
+    );
+}
+
+// --------------------------------------------------------------------
+// CredentialFileLock
+// --------------------------------------------------------------------
+
+/// Poll-with-timeout helper: spawn `work` on a background thread and wait up
+/// to `timeout` for it to finish. Returns `Some(result)` if it finished,
+/// `None` if it timed out (thread is then detached).
+fn run_with_timeout<T: Send + 'static, F: FnOnce() -> T + Send + 'static>(
+    work: F,
+    timeout: Duration,
+) -> Option<T> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let out = work();
+        // Receiver may have dropped after timeout; ignore send error.
+        let _ = tx.send(out);
+    });
+    rx.recv_timeout(timeout).ok()
+}
+
+#[test]
+fn lock_shared_allows_concurrent_shared_holders() {
+    // WHY: two shared (read) locks must coexist. Kills the
+    // `CredentialFileLock::shared -> Ok(Default::default())` mutant because
+    // a defaulted File on a dropped temp path cannot be held across threads
+    // in this sequence and because we actually assert the locks returned.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let path = dir.path().join(".credentials.json");
+
+    let guard_a = CredentialFileLock::shared(&path).expect("thread A: shared lock");
+
+    let path_b = path.clone();
+    let acquired_b = run_with_timeout(
+        move || CredentialFileLock::shared(&path_b).is_ok(),
+        Duration::from_secs(2),
+    )
+    .expect("thread B: shared-lock attempt did not complete in time");
+    assert!(
+        acquired_b,
+        "second shared lock should succeed while first is held"
+    );
+
+    drop(guard_a);
+}
+
+#[test]
+fn lock_exclusive_blocks_second_exclusive() {
+    // WHY: an exclusive lock must exclude another exclusive acquirer. Kills
+    // the `CredentialFileLock::exclusive -> Ok(Default::default())` mutant,
+    // which would make the second call return instantly instead of blocking.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let path = dir.path().join(".credentials.json");
+
+    let guard_a = CredentialFileLock::exclusive(&path).expect("thread A: exclusive lock");
+
+    let path_b = path.clone();
+    let completed = run_with_timeout(
+        move || CredentialFileLock::exclusive(&path_b).map(|_| ()),
+        Duration::from_millis(500),
+    );
+    assert!(
+        completed.is_none(),
+        "second exclusive lock must block while first is held"
+    );
+
+    drop(guard_a);
+}
+
+#[test]
+fn lock_exclusive_blocks_shared() {
+    // WHY: shared cannot be acquired while exclusive is held. Reinforces the
+    // `exclusive` and `lock` primitives: a defaulted return would let the
+    // shared call succeed immediately.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let path = dir.path().join(".credentials.json");
+
+    let guard_a = CredentialFileLock::exclusive(&path).expect("thread A: exclusive lock");
+
+    let path_b = path.clone();
+    let completed = run_with_timeout(
+        move || CredentialFileLock::shared(&path_b).map(|_| ()),
+        Duration::from_millis(500),
+    );
+    assert!(
+        completed.is_none(),
+        "shared lock must block while exclusive is held"
+    );
+
+    drop(guard_a);
+}
+
+#[test]
+fn lock_exclusive_released_on_drop() {
+    // WHY: dropping the guard must release the lock so a subsequent exclusive
+    // acquirer can proceed. Kills the `lock -> Ok(Default::default())`
+    // mutant: a defaulted File on drop wouldn't release the flock on the
+    // real sidecar file, so the follow-up acquisition would still block.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let path = dir.path().join(".credentials.json");
+
+    let guard = CredentialFileLock::exclusive(&path).expect("first exclusive lock");
+    drop(guard);
+
+    let path_b = path.clone();
+    let second = run_with_timeout(
+        move || CredentialFileLock::exclusive(&path_b).is_ok(),
+        Duration::from_secs(2),
+    )
+    .expect("second exclusive acquisition did not complete in time");
+    assert!(
+        second,
+        "exclusive lock must be reacquirable after previous guard is dropped"
+    );
+}
+
+#[test]
+fn lock_shared_released_on_drop_allows_exclusive() {
+    // WHY: after a shared lock is dropped, an exclusive lock must be
+    // acquirable. Cross-pairs `shared` and `exclusive` with the `lock`
+    // primitive — all three `Ok(Default::default())` mutants are killed
+    // when both acquisition and release are observed.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let path = dir.path().join(".credentials.json");
+
+    let shared_guard = CredentialFileLock::shared(&path).expect("shared lock");
+    drop(shared_guard);
+
+    let path_b = path.clone();
+    let acquired = run_with_timeout(
+        move || CredentialFileLock::exclusive(&path_b).is_ok(),
+        Duration::from_secs(2),
+    )
+    .expect("exclusive acquisition after shared drop did not complete in time");
+    assert!(
+        acquired,
+        "exclusive lock must succeed after prior shared guard is dropped"
+    );
+}
+
+#[test]
+fn lock_uses_sidecar_file_not_credential_path() {
+    // WHY: pins the invariant that the lock file is `<path>.json.lock`, not
+    // `<path>`. A `Default::default()` File wouldn't create any sidecar, so
+    // this asserts the real lock path side-effect.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let path = dir.path().join(".credentials.json");
+
+    assert!(!path.exists(), "credential file should not exist pre-lock");
+    let _guard = CredentialFileLock::exclusive(&path).expect("exclusive lock");
+
+    let lock_path = path.with_extension("json.lock");
+    assert!(
+        lock_path.exists(),
+        "exclusive lock should create sidecar at {}",
+        lock_path.display()
+    );
+    assert!(
+        !path.exists(),
+        "credential file itself must not be created by lock acquisition"
+    );
+}


### PR DESCRIPTION
## Summary

Close 8 missed mutants in `crates/symbolon/src/credential/file_ops.rs` from the substance-audit baseline (#3509/#3697). Split tests into sibling `file_ops_tests.rs` (convention mirror). +12 new tests.

## Mutant coverage

- `needs_refresh` body replacements (→ `true`/`false` stubs) — paired `needs_refresh_false_when_well_before_expiry` vs `needs_refresh_true_when_expired` / `_at_expiry_instant` / `_when_inside_window`
- `needs_refresh` comparison operator (`<` → `==`/`>`/`<=`) — `needs_refresh_boundary_just_outside_window_is_false` + `_true_at_expiry_instant` + `_true_when_inside_window`
- `CredentialFileLock::shared`/`exclusive`/`lock` → `Ok(Default::default())` — six lock tests covering shared/shared compat, exclusive/exclusive block, exclusive/shared block, drop-release for both modes, and `.json.lock` sidecar creation

## Production touch

Two pre-existing `#[expect(dead_code)]` attributes scoped to `#[cfg_attr(not(test), expect(dead_code))]` so the expectation still fires in production builds but not under test (where the symbol is now reached). No new suppressions introduced.

## Test plan

- [x] `cargo test -p symbolon --features test-support` — 172 + 17 + 2 pass
- [x] `cargo clippy -p symbolon -- -D warnings` clean
- [x] `cargo clippy -p symbolon --tests --features test-support -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `kanon lint . --summary` — 2942/126 matches main baseline

Closes #3712

🤖 Generated with [Claude Code](https://claude.com/claude-code)