### PR TITLE
chore(ci): add .kanon-ci.toml for forge-native CI (phase 05e cutover prep)

### DIFF
--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -1,0 +1,43 @@
+# Forge CI pipeline for forkwright/aletheia.
+#
+# Mirrors harmonia's .kanon-ci.toml with aletheia-specific adjustments:
+# feature flag (test-core) and longer timeouts for the larger workspace.
+#
+# Per-stage build + test concurrency pinned to 8. Without this cap cargo
+# defaults to num_cpus (64 on this Threadripper) and parallel rustc + nextest
+# processes peak well over 100GB RSS, enough to OOM menos when any other
+# fleet work is running. 8 is the budget that keeps a single CI run under
+# ~25GB peak so serial drains don't OOM with aletheia.service + dispatch
+# fleet resident.
+#
+# Keep in sync with:
+# - crates/archeion/src/ci_config.rs::default_rust_gate (upstream default)
+# - .github/workflows/ci.yml (until the GHA check+clippy+test workflow is
+#   disabled as part of the 05e cutover)
+#
+# NOTE: the `kanon lint` stage is intentionally omitted. Aletheia's current
+# lint baseline is 2502 open violations + 126 suppressed, so enforcing it
+# in CI would reject every PR until a dedicated cleanup arc reduces the
+# baseline to zero. GHA CI also never enforced it, so omission preserves
+# parity. Re-add the stage (matching harmonia's) once the baseline is clean.
+# Tracked in the phase plan at
+# `kanon/projects/aletheia/phases/aletheia-05e-forge-cutover.md`.
+
+[pipeline]
+stages = ["cargo fmt", "cargo check", "cargo clippy", "cargo nextest"]
+
+[stages."cargo fmt"]
+cmd = "cargo fmt --all -- --check"
+timeout_secs = 300
+
+[stages."cargo check"]
+cmd = "cargo check --workspace --features test-core --all-targets --jobs 8"
+timeout_secs = 1800
+
+[stages."cargo clippy"]
+cmd = "cargo clippy --workspace --features test-core --all-targets --jobs 8 -- -D warnings"
+timeout_secs = 1800
+
+[stages."cargo nextest"]
+cmd = "cargo nextest run --workspace --features test-core --build-jobs 8 --test-threads 8 --no-fail-fast"
+timeout_secs = 2400

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "fjall",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "jiff",
  "mneme",
@@ -661,7 +661,7 @@ checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "basanos"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "regex",
  "snafu",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "jiff",
  "koina",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "axum 0.8.8",
  "hermeneus",
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "koina",
  "organon",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "jiff",
  "serde",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "compact_str",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -3316,7 +3316,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "axum 0.8.8",
  "dokimion",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arboard",
  "clap",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "fjall",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "aho-corasick",
  "bytemuck",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "futures",
  "hermeneus",
@@ -5070,7 +5070,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "dianoia",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "axum 0.8.8",
  "energeia",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "energeia",
  "fjall",
@@ -5918,7 +5918,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "jiff",
  "snafu",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "poiesis-core",
  "rust_xlsxwriter",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "poiesis-core",
  "quick-xml",
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "krilla 0.7.0",
  "poiesis-core",
@@ -5965,7 +5965,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "comemo",
  "jiff",
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6351,7 +6351,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -7860,7 +7860,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8173,7 +8173,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -8285,7 +8285,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -8408,14 +8408,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",


### PR DESCRIPTION
## Summary

Adds `.kanon-ci.toml` so the forge (`kanon-server`) can orchestrate per-PR CI for aletheia, matching the pattern harmonia uses post-cutover. Ships with feature parity against today's GHA `check + clippy + test`.

## What this enables

Forge CI runs via `kanon ci run forkwright/aletheia <sha>` (or auto-triggered on push once the forge is configured to do so). 8-job concurrency cap on build + test prevents OOM on menos alongside the aletheia service and dispatch fleet.

Stages: `cargo fmt` -> `cargo check` -> `cargo clippy -D warnings` -> `cargo nextest`. All run with `--features test-core` to match the GHA matrix.

## `kanon lint` stage deliberately omitted

Aletheia lint baseline: **2502 open violations + 126 suppressed**. Enforcing the lint stage would reject every PR until a dedicated cleanup arc clears the baseline. GHA never enforced it, so dropping it from the initial forge pipeline preserves parity.

Re-adding the stage is tracked in the phase plan (`kanon/projects/aletheia/phases/aletheia-05e-forge-cutover.md`).

## Cargo.lock regenerated

Release-please #3631 bumped workspace package versions to 0.21.0 in `Cargo.toml` but didn't regenerate `Cargo.lock`. Local gate surfaced the drift; regenerated here.

## Test plan

- [x] `kanon gate --stamp` passes for cargo fmt, check, clippy, nextest
- [x] Values match harmonia's `.kanon-ci.toml` pattern
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --features test-core --all-targets -- -D warnings` clean

## Follow-ups

1. After merge: trigger `kanon ci run forkwright/aletheia <sha>` on the merge commit to verify the forge pipeline runs end-to-end.
2. Separate PR: disable GHA `check + clippy + test` workflow (keep cargo-deny, cargo-audit, PII scan, SonarCloud for 3rd-party + posture checks).
3. Dedicated arc: aletheia lint-cleanup (2502 -> 0) then re-enable the `kanon lint` stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)