### PR TITLE
refactor(lint): mechanical RUST cleanup -- imports + bare-assert + format-single-var + non-exhaustive-enum + spawn-instrument + [etc]

### DIFF
--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -904,10 +904,11 @@ pub(crate) async fn guard_knowledge_lock(url: &str) -> Result<()> {
 mod tests {
     use std::collections::HashMap;
 
-    use super::*;
     use graphe::portability::{
         AgentFile, ExportedMessage, ExportedNote, ExportedSession, NousInfo, WorkspaceData,
     };
+
+    use super::*;
 
     #[test]
     fn capitalize_first_letter() {

--- a/crates/aletheia/src/commands/benchmark.rs
+++ b/crates/aletheia/src/commands/benchmark.rs
@@ -64,7 +64,7 @@ pub(crate) struct RunArgs {
     #[arg(long, env = "ALETHEIA_JUDGE_ENDPOINT")]
     pub judge_endpoint: Option<String>,
     /// LLM-as-judge model identifier
-    #[arg(long, default_value = "gpt-4o", env = "ALETHEIA_JUDGE_MODEL")]
+    #[arg(long, default_value = dokimion::benchmarks::judge::DEFAULT_JUDGE_MODEL, env = "ALETHEIA_JUDGE_MODEL")]
     pub judge_model: String,
     /// LLM-as-judge API key
     #[arg(long, env = "ALETHEIA_JUDGE_API_KEY")]

--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -917,8 +917,9 @@ fn load_filtered_facts(
     std::collections::HashSet<String>,
     std::collections::HashMap<String, mneme::knowledge::FactSensitivity>,
 )> {
-    use mneme::knowledge::FactSensitivity;
     use std::collections::{HashMap, HashSet};
+
+    use mneme::knowledge::FactSensitivity;
 
     let facts = match nous_id {
         Some(id) => {

--- a/crates/aletheia/src/commands/migrate.rs
+++ b/crates/aletheia/src/commands/migrate.rs
@@ -326,7 +326,11 @@ fn normalize_toml_value(
                 normalize_toml_value(v, source_root, dest_root, rewritten);
             }
         }
-        _ => {}
+        // Scalars (bool, int, float, datetime): no path strings to rewrite.
+        toml_edit::Value::Boolean(_)
+        | toml_edit::Value::Integer(_)
+        | toml_edit::Value::Float(_)
+        | toml_edit::Value::Datetime(_) => {}
     }
 }
 
@@ -353,7 +357,8 @@ fn normalize_json_value(
                 normalize_json_value(v, source_root, dest_root, rewritten);
             }
         }
-        _ => {}
+        // Null, Bool, Number: no path strings to rewrite.
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
     }
 }
 

--- a/crates/aletheia/src/commands/repl.rs
+++ b/crates/aletheia/src/commands/repl.rs
@@ -127,7 +127,7 @@ fn run_repl(instance_root: Option<&PathBuf>) -> Result<()> {
                     run_query_and_print(&store, "::relations");
                     continue;
                 }
-                _ => {}
+                _ => {} // Not a REPL command; fall through to treat as query.
             }
         }
 

--- a/crates/daemon/src/prosoche_tests.rs
+++ b/crates/daemon/src/prosoche_tests.rs
@@ -257,8 +257,9 @@ mod knowledge_store_tests {
         fact_id: &str,
         entity_id: &str,
     ) {
-        use episteme::engine::DataValue;
         use std::collections::BTreeMap;
+
+        use episteme::engine::DataValue;
 
         let now = episteme::knowledge::format_timestamp(&jiff::Timestamp::now());
         let mut params = BTreeMap::new();

--- a/crates/daemon/src/runner/lifecycle.rs
+++ b/crates/daemon/src/runner/lifecycle.rs
@@ -40,21 +40,24 @@ impl TaskRunner {
         #[cfg(feature = "dispatch-cron")]
         let _cron_handle = self.cron_scheduler.clone().map(|scheduler| {
             let cancel = self.shutdown.child_token();
-            tokio::spawn(async move {
-                let _ = scheduler
-                    .run(cancel, |task| {
-                        let name = task.name.clone();
-                        let project = task.dispatch_spec.project.clone();
-                        async move {
-                            tracing::info!(
-                                task = %name,
-                                project = %project,
-                                "cron dispatch task fired"
-                            );
-                        }
-                    })
-                    .await;
-            })
+            tokio::spawn(
+                async move {
+                    let _ = scheduler
+                        .run(cancel, |task| {
+                            let name = task.name.clone();
+                            let project = task.dispatch_spec.project.clone();
+                            async move {
+                                tracing::info!(
+                                    task = %name,
+                                    project = %project,
+                                    "cron dispatch task fired"
+                                );
+                            }
+                        })
+                        .await;
+                }
+                .instrument(tracing::info_span!("daemon.cron_scheduler")),
+            )
         });
 
         loop {

--- a/crates/daemon/src/runner/mod.rs
+++ b/crates/daemon/src/runner/mod.rs
@@ -4,13 +4,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
 use crate::bridge::DaemonBridge;
 use crate::error::Result;
 use crate::maintenance::{KnowledgeMaintenanceExecutor, MaintenanceConfig, RetentionExecutor};
-use crate::schedule::TaskDef;
-use serde::{Deserialize, Serialize};
-use tokio_util::sync::CancellationToken;
 // WHY: tests use `use super::*` and reference Schedule/BuiltinTask/TaskAction directly.
+use crate::schedule::TaskDef;
 #[cfg(test)]
 use crate::schedule::{BuiltinTask, Schedule, TaskAction};
 

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -4,8 +4,9 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
-use crate::error::Result;
 use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
 
 /// When a task should run.
 #[non_exhaustive]

--- a/crates/dianoia/src/research/mod.rs
+++ b/crates/dianoia/src/research/mod.rs
@@ -240,6 +240,7 @@ fn format_markdown(findings: &[ResearchFinding]) -> String {
 
 /// Research depth level (0-3), determining how many researchers to dispatch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ResearchLevel {
     /// Well-understood domain, existing patterns. No research needed.
     Skip,

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -10,6 +10,7 @@ use rmcp::model::CallToolResult;
 use rmcp::service::RequestContext;
 use rmcp::{tool, tool_router};
 use snafu::{OptionExt as _, ResultExt as _};
+use tracing::Instrument as _;
 
 use koina::http::BEARER_PREFIX;
 use koina::id::SessionId;
@@ -325,7 +326,10 @@ impl DiaporeiaServer {
 
         // Drain stream events in background so the channel doesn't back-pressure
         // the actor. MCP doesn't support server-push, so events are discarded.
-        let drain = tokio::spawn(async move { while stream_rx.recv().await.is_some() {} });
+        let drain = tokio::spawn(
+            async move { while stream_rx.recv().await.is_some() {} }
+                .instrument(tracing::info_span!("diaporeia.mcp.stream_drain")),
+        );
 
         let result = handle
             .send_turn_streaming(&params.session_key, &params.content, stream_tx)

--- a/crates/eidos/tests/public_api.rs
+++ b/crates/eidos/tests/public_api.rs
@@ -158,8 +158,8 @@ mod epistemic_tier {
 
     #[test]
     fn display_matches_as_str() {
-        assert_eq!(format!("{}", EpistemicTier::Verified), "verified");
-        assert_eq!(format!("{}", EpistemicTier::Training), "training");
+        assert_eq!(EpistemicTier::Verified.to_string(), "verified");
+        assert_eq!(EpistemicTier::Training.to_string(), "training");
     }
 
     #[test]

--- a/crates/energeia/src/agent_sdk.rs
+++ b/crates/energeia/src/agent_sdk.rs
@@ -81,12 +81,8 @@ impl AgentSdkEngine {
             .fail();
         }
 
-        // NOTE: In a full implementation, this would:
-        // 1. Validate OAuth token if provided
-        // 2. Initialize MCP plugin system if not disabled
-        // 3. Set up permission system if not skipped
-        // 4. Verify agent SDK binary availability
-
+        // Future-work: validate OAuth token, init MCP plugin system, set up
+        // permission system, verify SDK binary availability.
         Ok(Self {
             config,
             binary: "claude".to_owned(),

--- a/crates/energeia/src/cron.rs
+++ b/crates/energeia/src/cron.rs
@@ -326,8 +326,9 @@ fn apply_jitter(base: DateTime<Utc>, jitter: Duration) -> DateTime<Utc> {
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use super::*;
     use chrono::TimeZone;
+
+    use super::*;
 
     fn parse_schedule(expr: &str) -> cron::Schedule {
         expr.parse().expect("valid cron expression")

--- a/crates/energeia/src/metrics/cost.rs
+++ b/crates/energeia/src/metrics/cost.rs
@@ -331,9 +331,9 @@ fn build_daily_velocity(
     reason = "test assertions on collections with known length"
 )]
 mod tests {
-    use super::*;
     use tempfile::TempDir;
 
+    use super::*;
     use crate::store::EnergeiaStore;
     use crate::store::records::SessionUpdate;
     use crate::types::{DispatchSpec, SessionStatus};

--- a/crates/energeia/src/metrics/mod.rs
+++ b/crates/energeia/src/metrics/mod.rs
@@ -116,8 +116,9 @@ impl std::fmt::Debug for MetricsService {
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(clippy::float_cmp, reason = "test assertions compare exact f64 zero")]
 mod tests {
-    use super::*;
     use tempfile::TempDir;
+
+    use super::*;
 
     fn setup() -> (TempDir, MetricsService) {
         let dir = TempDir::new().unwrap();

--- a/crates/energeia/src/metrics/status.rs
+++ b/crates/energeia/src/metrics/status.rs
@@ -228,9 +228,9 @@ fn build_project_summaries(
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(clippy::float_cmp, reason = "test assertions on exact float values")]
 mod tests {
-    use super::*;
     use tempfile::TempDir;
 
+    use super::*;
     use crate::store::EnergeiaStore;
     use crate::store::records::SessionUpdate;
     use crate::types::{DispatchSpec, SessionStatus};

--- a/crates/energeia/src/store/fjall_store_tests.rs
+++ b/crates/energeia/src/store/fjall_store_tests.rs
@@ -5,8 +5,9 @@
 )]
 #![expect(clippy::float_cmp, reason = "test assertions on exact float values")]
 
-use super::*;
 use tempfile::TempDir;
+
+use super::*;
 
 fn setup_test_store() -> (TempDir, EnergeiaStore) {
     let temp_dir = TempDir::new().unwrap();

--- a/crates/episteme/src/admission.rs
+++ b/crates/episteme/src/admission.rs
@@ -17,6 +17,7 @@ use crate::knowledge::Fact;
 
 /// Result of an admission check.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum AdmissionDecision {
     /// Fact should be admitted to the knowledge graph.
     Admit,
@@ -42,6 +43,7 @@ pub struct AdmissionRejection {
 
 /// The factor that caused a rejection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RejectionFactor {
     /// The fact's predicted future utility is too low.
     LowUtility,

--- a/crates/episteme/src/causal.rs
+++ b/crates/episteme/src/causal.rs
@@ -17,10 +17,10 @@
 
 use std::collections::{HashMap, HashSet};
 
+use eidos::id::{CausalEdgeId, FactId};
 use snafu::Snafu;
 
 use crate::knowledge::{CausalEdge, CausalRelationType, TemporalOrdering};
-use eidos::id::{CausalEdgeId, FactId};
 
 // ── Error type ────────────────────────────────────────────────────────────────
 

--- a/crates/episteme/src/ingest.rs
+++ b/crates/episteme/src/ingest.rs
@@ -12,6 +12,7 @@ use crate::knowledge::{
 /// Supported ingestion formats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum IngestFormat {
     /// Markdown with optional YAML frontmatter.
     Markdown,

--- a/crates/episteme/src/knowledge_portability.rs
+++ b/crates/episteme/src/knowledge_portability.rs
@@ -200,9 +200,15 @@ mod tests {
     #[test]
     fn knowledge_import_result_default_starts_at_zero() {
         let result = KnowledgeImportResult::default();
-        assert_eq!(result.facts_imported, 0);
-        assert_eq!(result.entities_imported, 0);
-        assert_eq!(result.relationships_imported, 0);
+        assert_eq!(result.facts_imported, 0, "default facts_imported must be 0");
+        assert_eq!(
+            result.entities_imported, 0,
+            "default entities_imported must be 0"
+        );
+        assert_eq!(
+            result.relationships_imported, 0,
+            "default relationships_imported must be 0"
+        );
     }
 
     #[test]
@@ -212,8 +218,14 @@ mod tests {
             entities_imported: 3,
             relationships_imported: 2,
         };
-        assert_eq!(result.facts_imported, 5);
-        assert_eq!(result.entities_imported, 3);
-        assert_eq!(result.relationships_imported, 2);
+        assert_eq!(result.facts_imported, 5, "facts_imported should preserve 5");
+        assert_eq!(
+            result.entities_imported, 3,
+            "entities_imported should preserve 3"
+        );
+        assert_eq!(
+            result.relationships_imported, 2,
+            "relationships_imported should preserve 2"
+        );
     }
 }

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -1058,7 +1058,11 @@ mod tests {
         let results = store
             .query_facts("alice", "2026-06-01", 100)
             .expect("query single fact");
-        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results.len(),
+            1,
+            "single stored fact should return 1 result"
+        );
         assert_eq!(results[0].id.as_str(), "q-single");
     }
 
@@ -1393,7 +1397,11 @@ mod tests {
         let results = store
             .query_facts("alice", "2026-06-01", 100)
             .expect("query after confidence update");
-        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results.len(),
+            1,
+            "confidence update should not duplicate fact"
+        );
         assert!(
             (results[0].provenance.confidence - 0.5).abs() < f64::EPSILON,
             "persisted confidence should be 0.5"

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -816,14 +816,20 @@ mod tests {
     fn tool_overlap_identical_sets() {
         let a = vec!["read".to_owned(), "write".to_owned(), "bash".to_owned()];
         let b = vec!["read".to_owned(), "write".to_owned(), "bash".to_owned()];
-        assert!((compute_tool_overlap(&a, &b) - 1.0).abs() < f64::EPSILON);
+        assert!(
+            (compute_tool_overlap(&a, &b) - 1.0).abs() < f64::EPSILON,
+            "identical sets should yield overlap 1.0"
+        );
     }
 
     #[test]
     fn tool_overlap_disjoint_sets() {
         let a = vec!["read".to_owned(), "write".to_owned()];
         let b = vec!["bash".to_owned(), "grep".to_owned()];
-        assert!(compute_tool_overlap(&a, &b).abs() < f64::EPSILON);
+        assert!(
+            compute_tool_overlap(&a, &b).abs() < f64::EPSILON,
+            "disjoint sets should yield overlap 0.0"
+        );
     }
 
     #[test]
@@ -842,14 +848,20 @@ mod tests {
     fn tool_overlap_both_empty_returns_one() {
         let a: Vec<String> = Vec::new();
         let b: Vec<String> = Vec::new();
-        assert!((compute_tool_overlap(&a, &b) - 1.0).abs() < f64::EPSILON);
+        assert!(
+            (compute_tool_overlap(&a, &b) - 1.0).abs() < f64::EPSILON,
+            "both-empty tool sets should yield overlap 1.0"
+        );
     }
 
     #[test]
     fn tool_overlap_one_empty_returns_zero() {
         let a = vec!["read".to_owned()];
         let b: Vec<String> = Vec::new();
-        assert!(compute_tool_overlap(&a, &b).abs() < f64::EPSILON);
+        assert!(
+            compute_tool_overlap(&a, &b).abs() < f64::EPSILON,
+            "one-empty tool set should yield overlap 0.0"
+        );
     }
 
     #[test]
@@ -857,7 +869,10 @@ mod tests {
         // Duplicates in input should be collapsed by the HashSet
         let a = vec!["read".to_owned(), "read".to_owned(), "write".to_owned()];
         let b = vec!["read".to_owned(), "write".to_owned()];
-        assert!((compute_tool_overlap(&a, &b) - 1.0).abs() < f64::EPSILON);
+        assert!(
+            (compute_tool_overlap(&a, &b) - 1.0).abs() < f64::EPSILON,
+            "duplicates in sets should not affect overlap 1.0"
+        );
     }
 
     // ─────────────────────────────────────────────────────────
@@ -866,19 +881,28 @@ mod tests {
 
     #[test]
     fn name_similarity_identical() {
-        assert!((compute_name_similarity("Alice", "Alice") - 1.0).abs() < f64::EPSILON);
+        assert!(
+            (compute_name_similarity("Alice", "Alice") - 1.0).abs() < f64::EPSILON,
+            "identical names should yield similarity 1.0"
+        );
     }
 
     #[test]
     fn name_similarity_case_insensitive() {
         // LCS runs on lowercased strings
-        assert!((compute_name_similarity("Alice", "alice") - 1.0).abs() < f64::EPSILON);
+        assert!(
+            (compute_name_similarity("Alice", "alice") - 1.0).abs() < f64::EPSILON,
+            "case-insensitive match should yield similarity 1.0"
+        );
     }
 
     #[test]
     fn name_similarity_completely_different() {
         // "abc" vs "xyz" — LCS length 0, ratio 0.0
-        assert!(compute_name_similarity("abc", "xyz").abs() < f64::EPSILON);
+        assert!(
+            compute_name_similarity("abc", "xyz").abs() < f64::EPSILON,
+            "disjoint names should yield similarity 0.0"
+        );
     }
 
     #[test]
@@ -893,12 +917,18 @@ mod tests {
 
     #[test]
     fn name_similarity_both_empty() {
-        assert!((compute_name_similarity("", "") - 1.0).abs() < f64::EPSILON);
+        assert!(
+            (compute_name_similarity("", "") - 1.0).abs() < f64::EPSILON,
+            "both-empty names should yield similarity 1.0"
+        );
     }
 
     #[test]
     fn name_similarity_one_empty() {
-        assert!(compute_name_similarity("hello", "").abs() < f64::EPSILON);
+        assert!(
+            compute_name_similarity("hello", "").abs() < f64::EPSILON,
+            "one-empty name should yield similarity 0.0"
+        );
     }
 
     // ─────────────────────────────────────────────────────────
@@ -909,7 +939,11 @@ mod tests {
     fn lcs_exact_match() {
         let a: Vec<char> = "abc".chars().collect();
         let b: Vec<char> = "abc".chars().collect();
-        assert_eq!(lcs_char_length(&a, &b), 3);
+        assert_eq!(
+            lcs_char_length(&a, &b),
+            3,
+            "LCS of exact match should equal input length"
+        );
     }
 
     #[test]
@@ -917,23 +951,35 @@ mod tests {
         // "abcde" vs "ace" → LCS = "ace" (3)
         let a: Vec<char> = "abcde".chars().collect();
         let b: Vec<char> = "ace".chars().collect();
-        assert_eq!(lcs_char_length(&a, &b), 3);
+        assert_eq!(
+            lcs_char_length(&a, &b),
+            3,
+            "LCS of abcde vs ace should be 3"
+        );
     }
 
     #[test]
     fn lcs_no_match() {
         let a: Vec<char> = "abc".chars().collect();
         let b: Vec<char> = "xyz".chars().collect();
-        assert_eq!(lcs_char_length(&a, &b), 0);
+        assert_eq!(
+            lcs_char_length(&a, &b),
+            0,
+            "LCS of disjoint char sets should be 0"
+        );
     }
 
     #[test]
     fn lcs_empty_inputs() {
         let empty: Vec<char> = Vec::new();
         let a: Vec<char> = "abc".chars().collect();
-        assert_eq!(lcs_char_length(&empty, &a), 0);
-        assert_eq!(lcs_char_length(&a, &empty), 0);
-        assert_eq!(lcs_char_length(&empty, &empty), 0);
+        assert_eq!(lcs_char_length(&empty, &a), 0, "LCS(empty, a) should be 0");
+        assert_eq!(lcs_char_length(&a, &empty), 0, "LCS(a, empty) should be 0");
+        assert_eq!(
+            lcs_char_length(&empty, &empty),
+            0,
+            "LCS(empty, empty) should be 0"
+        );
     }
 
     // ─────────────────────────────────────────────────────────
@@ -951,28 +997,35 @@ mod tests {
     fn extract_str_rejects_non_str() {
         let val = DataValue::from(42i64);
         let result = extract_str(&val);
-        assert!(result.is_err());
+        assert!(result.is_err(), "extract_str on int should return Err");
     }
 
     #[test]
     fn extract_optional_str_from_null() {
         let val = DataValue::Null;
         let result = extract_optional_str(&val).expect("should extract");
-        assert!(result.is_none());
+        assert!(result.is_none(), "Null DataValue should map to None");
     }
 
     #[test]
     fn extract_optional_str_from_str_value() {
         let val = DataValue::Str("present".into());
         let result = extract_optional_str(&val).expect("should extract");
-        assert_eq!(result.as_deref(), Some("present"));
+        assert_eq!(
+            result.as_deref(),
+            Some("present"),
+            "extract_optional_str should yield the inner str"
+        );
     }
 
     #[test]
     fn extract_optional_str_rejects_other_types() {
         let val = DataValue::Bool(true);
         let result = extract_optional_str(&val);
-        assert!(result.is_err());
+        assert!(
+            result.is_err(),
+            "extract_optional_str on Bool should return Err"
+        );
     }
 
     // ─────────────────────────────────────────────────────────
@@ -983,49 +1036,52 @@ mod tests {
     fn extract_float_from_float_value() {
         let val = DataValue::from(1.5_f64);
         let result = extract_float(&val).expect("should extract");
-        assert!((result - 1.5).abs() < f64::EPSILON);
+        assert!(
+            (result - 1.5).abs() < f64::EPSILON,
+            "extract_float should return input 1.5"
+        );
     }
 
     #[test]
     fn extract_float_rejects_str() {
         let val = DataValue::Str("not a number".into());
         let result = extract_float(&val);
-        assert!(result.is_err());
+        assert!(result.is_err(), "extract_float on Str should return Err");
     }
 
     #[test]
     fn extract_int_from_int_value() {
         let val = DataValue::from(42i64);
         let result = extract_int(&val).expect("should extract");
-        assert_eq!(result, 42);
+        assert_eq!(result, 42, "extract_int should return input 42");
     }
 
     #[test]
     fn extract_int_rejects_str() {
         let val = DataValue::Str("42".into());
         let result = extract_int(&val);
-        assert!(result.is_err());
+        assert!(result.is_err(), "extract_int on Str should return Err");
     }
 
     #[test]
     fn extract_bool_true() {
         let val = DataValue::Bool(true);
         let result = extract_bool(&val).expect("should extract");
-        assert!(result);
+        assert!(result, "extract_bool on Bool(true) should be true");
     }
 
     #[test]
     fn extract_bool_false() {
         let val = DataValue::Bool(false);
         let result = extract_bool(&val).expect("should extract");
-        assert!(!result);
+        assert!(!result, "extract_bool on Bool(false) should be false");
     }
 
     #[test]
     fn extract_bool_rejects_int() {
         let val = DataValue::from(1i64);
         let result = extract_bool(&val);
-        assert!(result.is_err());
+        assert!(result.is_err(), "extract_bool on int should return Err");
     }
 
     // ─────────────────────────────────────────────────────────
@@ -1034,25 +1090,49 @@ mod tests {
 
     #[test]
     fn parse_verified_tier() {
-        assert_eq!(parse_epistemic_tier("verified"), EpistemicTier::Verified);
+        assert_eq!(
+            parse_epistemic_tier("verified"),
+            EpistemicTier::Verified,
+            "`verified` tier string should map to Verified"
+        );
     }
 
     #[test]
     fn parse_inferred_tier() {
-        assert_eq!(parse_epistemic_tier("inferred"), EpistemicTier::Inferred);
+        assert_eq!(
+            parse_epistemic_tier("inferred"),
+            EpistemicTier::Inferred,
+            "`inferred` tier string should map to Inferred"
+        );
     }
 
     #[test]
     fn parse_assumed_tier() {
-        assert_eq!(parse_epistemic_tier("assumed"), EpistemicTier::Assumed);
+        assert_eq!(
+            parse_epistemic_tier("assumed"),
+            EpistemicTier::Assumed,
+            "`assumed` tier string should map to Assumed"
+        );
     }
 
     #[test]
     fn parse_unknown_tier_defaults_to_assumed() {
         // Unknown strings fall back to Assumed (with a warn log)
-        assert_eq!(parse_epistemic_tier("bogus"), EpistemicTier::Assumed);
-        assert_eq!(parse_epistemic_tier(""), EpistemicTier::Assumed);
-        assert_eq!(parse_epistemic_tier("VERIFIED"), EpistemicTier::Assumed);
+        assert_eq!(
+            parse_epistemic_tier("bogus"),
+            EpistemicTier::Assumed,
+            "unknown tier should default to Assumed"
+        );
+        assert_eq!(
+            parse_epistemic_tier(""),
+            EpistemicTier::Assumed,
+            "empty tier should default to Assumed"
+        );
+        assert_eq!(
+            parse_epistemic_tier("VERIFIED"),
+            EpistemicTier::Assumed,
+            "uppercase tier name should not match (case-sensitive)"
+        );
     }
 
     // ─────────────────────────────────────────────────────────

--- a/crates/episteme/src/knowledge_store/tests/derived_rules.rs
+++ b/crates/episteme/src/knowledge_store/tests/derived_rules.rs
@@ -8,12 +8,13 @@
 #![expect(clippy::expect_used, reason = "test assertions")]
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 
+use eidos::id::{CausalEdgeId, EntityId, FactId};
+
 use crate::knowledge::{
     CausalEdge, CausalRelationType, Entity, EpistemicTier, Fact, FactAccess, FactLifecycle,
     FactProvenance, FactSensitivity, FactTemporal, TemporalOrdering, far_future,
 };
 use crate::knowledge_store::KnowledgeStore;
-use eidos::id::{CausalEdgeId, EntityId, FactId};
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 

--- a/crates/episteme/src/knowledge_store/tests/proptests.rs
+++ b/crates/episteme/src/knowledge_store/tests/proptests.rs
@@ -7,9 +7,10 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use proptest::prelude::*;
+
 use crate::knowledge_store::KnowledgeStore;
 use crate::test_fixtures::{make_entity, make_fact, make_relationship, make_store};
-use proptest::prelude::*;
 
 proptest! {
     #[test]

--- a/crates/episteme/src/staleness.rs
+++ b/crates/episteme/src/staleness.rs
@@ -37,6 +37,7 @@ pub struct StalenessResult {
 
 /// Whether a fact is still consistent with its source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StalenessStatus {
     /// Fact content is still grounded in the source.
     Fresh,

--- a/crates/eval/src/benchmarks/judge.rs
+++ b/crates/eval/src/benchmarks/judge.rs
@@ -36,11 +36,17 @@ pub struct LlmJudgeConfig {
     pub temperature: f32,
 }
 
+/// Default LLM-judge model. Overridable via [`LlmJudgeConfig::model`].
+pub const DEFAULT_JUDGE_MODEL: &str = "gpt-4o";
+
+/// Default LLM-judge endpoint.
+pub const DEFAULT_JUDGE_ENDPOINT: &str = "https://api.openai.com/v1/chat/completions";
+
 impl Default for LlmJudgeConfig {
     fn default() -> Self {
         Self {
-            endpoint: "https://api.openai.com/v1/chat/completions".to_owned(),
-            model: "gpt-4o".to_owned(),
+            endpoint: DEFAULT_JUDGE_ENDPOINT.to_owned(),
+            model: DEFAULT_JUDGE_MODEL.to_owned(),
             api_key: None,
             max_tokens: 256,
             temperature: 0.0,

--- a/crates/eval/src/stats/effect_size.rs
+++ b/crates/eval/src/stats/effect_size.rs
@@ -16,6 +16,7 @@ use super::bootstrap::{BootstrapCi, Lcg64};
 /// Interpretation of an effect size magnitude.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum EffectSizeInterpretation {
     /// |d| < 0.2 (Cohen 1988).
     Negligible,

--- a/crates/eval/src/stats/fdr.rs
+++ b/crates/eval/src/stats/fdr.rs
@@ -18,6 +18,7 @@ use crate::error::{Error, StatsSnafu};
 
 /// FDR correction method.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum FdrMethod {
     /// Benjamini-Hochberg (1995): controls FDR under independence or PRDS.
     /// Appropriate for independent or positively-correlated tests.

--- a/crates/eval/src/stats/finding.rs
+++ b/crates/eval/src/stats/finding.rs
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 /// Mirrors the `evidence_level` field in `shared/agent_format.py`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum EvidenceLevel {
     /// Survives FDR correction, n is large enough for inference.
     Statistical,

--- a/crates/graphe/benches/session_store.rs
+++ b/crates/graphe/benches/session_store.rs
@@ -13,9 +13,9 @@
 
 #![expect(clippy::expect_used, reason = "bench setup")]
 
-use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
+use criterion::{Criterion, criterion_group, criterion_main};
 use graphe::store::SessionStore;
 use graphe::types::Role;
 use koina::ulid::Ulid;

--- a/crates/hermeneus/benches/parser.rs
+++ b/crates/hermeneus/benches/parser.rs
@@ -22,12 +22,12 @@
 
 #![expect(clippy::expect_used, reason = "bench setup; fatal on fixture failure")]
 
-use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use criterion::{Criterion, criterion_group, criterion_main};
 use hermeneus::complexity::{ComplexityInput, score_complexity};
 use hermeneus::concurrency::{AdaptiveConcurrencyLimiter, ConcurrencyConfig, RequestOutcome};
 use hermeneus::types::{StopReason, ToolResultType, Usage};

--- a/crates/hermeneus/src/concurrency.rs
+++ b/crates/hermeneus/src/concurrency.rs
@@ -14,7 +14,6 @@
 //! A tower `Layer`/`Service` wrapper (`ConcurrencyLayer`/`ConcurrencyService`)
 //! is provided for middleware-style integration.
 
-use parking_lot::Mutex;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -22,6 +21,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
+use parking_lot::Mutex;
 use tokio::sync::Notify;
 use tower::{Layer, Service};
 

--- a/crates/hermeneus/src/openai/wire/request.rs
+++ b/crates/hermeneus/src/openai/wire/request.rs
@@ -246,9 +246,7 @@ fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
                                     tool_call_id: Some(tool_use_id.clone()),
                                 });
                             }
-                            // Thinking / server-side blocks have no inbound
-                            // user-side equivalent; skip.
-                            _ => {}
+                            _ => {} // Thinking/server-side blocks have no user-side equivalent.
                         }
                     }
                     if !text_parts.is_empty() {
@@ -294,11 +292,7 @@ fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
                                     },
                                 });
                             }
-                            // WHY: thinking blocks and server-side blocks
-                            // have no OpenAI equivalent; skipped silently
-                            // (thinking is warned once at request build
-                            // time, server_tools is rejected outright).
-                            _ => {}
+                            _ => {} // Thinking/server-side blocks have no OpenAI equivalent (thinking warned at request build; server_tools rejected).
                         }
                     }
                 }

--- a/crates/hermeneus/tests/public_api.rs
+++ b/crates/hermeneus/tests/public_api.rs
@@ -93,8 +93,9 @@ mod model_constants {
 // --- StopReason enum ---
 
 mod stop_reason {
-    use super::StopReason;
     use std::str::FromStr;
+
+    use super::StopReason;
 
     #[test]
     fn round_trips_through_as_str_and_from_str() {

--- a/crates/integration-tests/tests/sse_backpressure.rs
+++ b/crates/integration-tests/tests/sse_backpressure.rs
@@ -2,16 +2,13 @@
 
 #![expect(clippy::expect_used, reason = "test assertions")]
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use http_body_util::BodyExt;
-use std::time::Instant;
-use tower::ServiceExt;
-
 use hermeneus::provider::ProviderRegistry;
 use hermeneus::test_utils::MockProvider;
+use http_body_util::BodyExt;
 use mneme::store::SessionStore;
 use nous::config::{NousConfig, PipelineConfig};
 use nous::manager::NousManager;
@@ -23,6 +20,7 @@ use symbolon::types::Role;
 use taxis::oikos::Oikos;
 use tokio::sync::Mutex as TokioMutex;
 use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
 
 struct TestHarness {
     state: std::sync::Arc<AppState>,

--- a/crates/koina/benches/ids.rs
+++ b/crates/koina/benches/ids.rs
@@ -11,9 +11,9 @@
 
 #![expect(clippy::expect_used, reason = "bench setup")]
 
-use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
+use criterion::{Criterion, criterion_group, criterion_main};
 use koina::ulid::Ulid;
 use koina::uuid::{Uuid, uuid_v4};
 

--- a/crates/koina/src/fjall.rs
+++ b/crates/koina/src/fjall.rs
@@ -133,6 +133,7 @@ impl FjallDb {
 ///
 /// Callers map these into their crate-specific error type.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FjallOpenError {
     /// Failed to create the store directory.
     CreateDir {

--- a/crates/krites/src/data/tests/values.rs
+++ b/crates/krites/src/data/tests/values.rs
@@ -75,20 +75,17 @@ fn utf8() {
 #[test]
 fn display_datavalues() {
     // Verify Display trait implementations for DataValue variants
-    assert_eq!(format!("{}", DataValue::Null), "null");
-    assert_eq!(format!("{}", DataValue::from(true)), "true");
-    assert_eq!(format!("{}", DataValue::from(-1)), "-1");
+    assert_eq!(DataValue::Null.to_string(), "null");
+    assert_eq!(DataValue::from(true).to_string(), "true");
+    assert_eq!(DataValue::from(-1).to_string(), "-1");
     assert_eq!(
-        format!("{}", DataValue::from(-1_121_212_121.331_212_f64)),
+        DataValue::from(-1_121_212_121.331_212_f64).to_string(),
         "-1121212121.331212"
     );
     // Special floats display as function calls that reconstruct them
+    assert_eq!(DataValue::from(f64::NAN).to_string(), r#"to_float("NAN")"#);
     assert_eq!(
-        format!("{}", DataValue::from(f64::NAN)),
-        r#"to_float("NAN")"#
-    );
-    assert_eq!(
-        format!("{}", DataValue::from(f64::NEG_INFINITY)),
+        DataValue::from(f64::NEG_INFINITY).to_string(),
         r#"to_float("NEG_INF")"#
     );
 

--- a/crates/melete/src/dream/mod.rs
+++ b/crates/melete/src/dream/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
 
 use snafu::ResultExt;
-use tracing::instrument;
+use tracing::{Instrument as _, instrument};
 
 use hermeneus::provider::LlmProvider;
 use hermeneus::types::Message;
@@ -307,48 +307,48 @@ impl DreamEngine {
         let target = Arc::clone(target);
         let provider = Arc::clone(provider);
 
-        tokio::spawn(async move {
-            let span = tracing::info_span!("auto_dream_consolidation");
-            let _guard = span.enter();
+        tokio::spawn(
+            async move {
+                tracing::info!("auto-dream consolidation started");
+                let start = std::time::Instant::now();
 
-            tracing::info!("auto-dream consolidation started");
-            let start = std::time::Instant::now();
-
-            match engine
-                .run_consolidation(
-                    acquired,
-                    source.as_ref(),
-                    target.as_ref(),
-                    provider.as_ref(),
-                )
-                .await
-            {
-                Ok(report) => {
-                    let duration_ms = start.elapsed().as_millis().min(u64::MAX.into());
-                    let duration_ms = u64::try_from(duration_ms).unwrap_or_default();
-                    tracing::info!(
-                        facts_added = report.facts_added,
-                        facts_deduped = report.facts_deduped,
-                        facts_stale = report.facts_stale,
-                        duration_ms,
-                        "auto-dream consolidation completed"
-                    );
-                    crate::metrics::record_distillation(
-                        "auto-dream",
-                        start.elapsed().as_secs_f64(),
-                        true,
-                    );
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "auto-dream consolidation failed");
-                    crate::metrics::record_distillation(
-                        "auto-dream",
-                        start.elapsed().as_secs_f64(),
-                        false,
-                    );
+                match engine
+                    .run_consolidation(
+                        acquired,
+                        source.as_ref(),
+                        target.as_ref(),
+                        provider.as_ref(),
+                    )
+                    .await
+                {
+                    Ok(report) => {
+                        let duration_ms = start.elapsed().as_millis().min(u64::MAX.into());
+                        let duration_ms = u64::try_from(duration_ms).unwrap_or_default();
+                        tracing::info!(
+                            facts_added = report.facts_added,
+                            facts_deduped = report.facts_deduped,
+                            facts_stale = report.facts_stale,
+                            duration_ms,
+                            "auto-dream consolidation completed"
+                        );
+                        crate::metrics::record_distillation(
+                            "auto-dream",
+                            start.elapsed().as_secs_f64(),
+                            true,
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "auto-dream consolidation failed");
+                        crate::metrics::record_distillation(
+                            "auto-dream",
+                            start.elapsed().as_secs_f64(),
+                            false,
+                        );
+                    }
                 }
             }
-        });
+            .instrument(tracing::info_span!("auto_dream_consolidation")),
+        );
     }
 
     /// Execute the consolidation pipeline.

--- a/crates/melete/src/probe.rs
+++ b/crates/melete/src/probe.rs
@@ -35,6 +35,7 @@ pub struct Probe {
 
 /// Which category of flush item a probe targets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ProbeCategory {
     /// A key decision.
     Decision,

--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -2,17 +2,14 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
-use tokio::sync::Mutex;
-use tracing::{Instrument, debug, info, warn};
-
+use hermeneus::provider::ProviderRegistry;
 #[cfg(feature = "knowledge-store")]
 use mneme::knowledge_store::KnowledgeStore;
 use mneme::store::SessionStore;
-
-use hermeneus::provider::ProviderRegistry;
-
-use std::time::Duration;
+use tokio::sync::Mutex;
+use tracing::{Instrument, debug, info, warn};
 
 use super::{MAX_SPAWNED_TASKS, NousActor};
 

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -613,10 +613,11 @@ impl NousActor {
     /// Degrades gracefully: any I/O or deserialization error is logged and
     /// returns an empty vec so the pipeline is never blocked by intent load failures.
     pub(crate) fn resolve_intent_sections(&self) -> Vec<BootstrapSection> {
-        use crate::bootstrap::{BootstrapSection, SectionPriority};
-        use crate::budget::CharEstimator;
         use dianoia::intent::IntentStore;
         use tracing::warn;
+
+        use crate::bootstrap::{BootstrapSection, SectionPriority};
+        use crate::budget::CharEstimator;
 
         let agent_dir = self.services.oikos.nous_dir(&self.id);
         let store = IntentStore::new(agent_dir);

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -2,21 +2,18 @@
 
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-
-use tokio::sync::mpsc;
-use tracing::{Instrument, debug, error, warn};
+use std::time::Duration;
 
 use koina::id::{NousId, SessionId};
 use organon::types::ToolContext;
+use tokio::sync::mpsc;
+use tracing::{Instrument, debug, error, warn};
 
+use super::{NousActor, NousLifecycle};
 use crate::drift::{DriftConfig, DriftDetector, TurnMetrics};
 use crate::pipeline::TurnResult;
 use crate::session::SessionState;
 use crate::stream::TurnStreamEvent;
-
-use std::time::Duration;
-
-use super::{NousActor, NousLifecycle};
 
 /// Drop guard that drops the streaming sender when the turn completes or is cancelled.
 /// Signals the receiver that no more data is coming, preventing hung SSE connections.

--- a/crates/nous/src/execute/tests/edge_cases.rs
+++ b/crates/nous/src/execute/tests/edge_cases.rs
@@ -3,9 +3,9 @@
     reason = "test: vec indices are valid after asserting len"
 )]
 //! Edge case and utility tests.
-use super::*;
-
 use organon::types::ToolDiagnostics;
+
+use super::*;
 
 struct DiagnosticExecutor;
 

--- a/crates/nous/src/hooks/builtins/correction.rs
+++ b/crates/nous/src/hooks/builtins/correction.rs
@@ -13,10 +13,10 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
 use serde::{Deserialize, Serialize};
+use taxis::config::AgentBehaviorDefaults;
 use tracing::{debug, warn};
 
 use crate::hooks::{HookResult, QueryContext, TurnContext, TurnHook};
-use taxis::config::AgentBehaviorDefaults;
 
 /// Filename for the corrections store within the agent workspace.
 const CORRECTIONS_FILENAME: &str = "corrections.json";

--- a/crates/nous/src/recall/search/search_impl.rs
+++ b/crates/nous/src/recall/search/search_impl.rs
@@ -4,13 +4,12 @@
 use std::sync::Arc;
 
 #[cfg(feature = "knowledge-store")]
-use crate::error;
-
-#[cfg(feature = "knowledge-store")]
 use mneme::knowledge::RecallResult as KnowledgeRecallResult;
 #[cfg(feature = "knowledge-store")]
 use mneme::knowledge_store::KnowledgeStore;
 
+#[cfg(feature = "knowledge-store")]
+use crate::error;
 #[cfg(feature = "knowledge-store")]
 use crate::recall::search::TextSearch;
 #[cfg(feature = "knowledge-store")]

--- a/crates/nous/src/recipes.rs
+++ b/crates/nous/src/recipes.rs
@@ -297,7 +297,7 @@ impl RecipeRegistry {
                 None => {
                     best = Some((recipe, score));
                 }
-                _ => {}
+                _ => {} // Lower-scoring candidate; keep current best.
             }
         }
 

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -9,6 +9,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, warn};
 
 use hermeneus::provider::ProviderRegistry;
+use koina::defaults::{
+    BOOTSTRAP_MAX_TOKENS, CONTEXT_TOKENS, DEFAULT_MODEL, MAX_OUTPUT_TOKENS, MAX_TOOL_ITERATIONS,
+    MAX_TOOL_RESULT_BYTES,
+};
 use organon::registry::ToolRegistry;
 use organon::types::{SpawnRequest, SpawnResult, SpawnService};
 use taxis::oikos::Oikos;
@@ -16,11 +20,6 @@ use taxis::oikos::Oikos;
 use crate::actor;
 use crate::config::{NousConfig, PipelineConfig, StageBudget};
 use crate::roles::Role;
-
-use koina::defaults::{
-    BOOTSTRAP_MAX_TOKENS, CONTEXT_TOKENS, DEFAULT_MODEL, MAX_OUTPUT_TOKENS, MAX_TOOL_ITERATIONS,
-    MAX_TOOL_RESULT_BYTES,
-};
 
 const SONNET_MODEL: &str = DEFAULT_MODEL;
 

--- a/crates/nous/src/training/mod.rs
+++ b/crates/nous/src/training/mod.rs
@@ -118,6 +118,7 @@ pub type Result<T> = std::result::Result<T, TrainingCaptureError>;
 /// captures just what the quality gate needs. Callers parse the string stop
 /// reason into this enum at the call site.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CaptureStopReason {
     /// Normal end of turn — safe to capture.
     EndTurn,

--- a/crates/nous/src/tuning/mod.rs
+++ b/crates/nous/src/tuning/mod.rs
@@ -56,6 +56,7 @@ pub struct ParameterProposal {
 
 /// Outcome of evaluating a parameter proposal against operator bounds.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ProposalOutcome {
     /// The proposal was accepted and the parameter was changed.
     Applied {

--- a/crates/organon/src/builtins/agent.rs
+++ b/crates/organon/src/builtins/agent.rs
@@ -364,11 +364,10 @@ mod tests {
     use std::sync::{Arc, RwLock};
 
     use koina::id::{NousId, SessionId, ToolName};
+    use taxis::config::ToolLimitsConfig;
 
     use crate::registry::ToolRegistry;
     use crate::testing::install_crypto_provider;
-    use taxis::config::ToolLimitsConfig;
-
     use crate::types::{
         ServerToolConfig, SpawnRequest, SpawnResult, SpawnService, ToolContext, ToolInput,
         ToolServices,

--- a/crates/organon/src/types/mod.rs
+++ b/crates/organon/src/types/mod.rs
@@ -3,8 +3,12 @@
 mod context;
 mod services;
 
-pub use context::*;
-pub use services::*;
+pub use context::{ServerToolConfig, ToolContext, ToolServices};
+pub use services::{
+    BlackboardEntry, BlackboardStore, CrossNousService, DatalogResult, FactSummary,
+    KnowledgeSearchService, MemoryResult, MessageService, NoteEntry, NoteStore, PlanningService,
+    SpawnRequest, SpawnResult, SpawnService,
+};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};

--- a/crates/poiesis/lint/src/error.rs
+++ b/crates/poiesis/lint/src/error.rs
@@ -5,6 +5,7 @@ use snafu::Snafu;
 /// Errors that can occur during lint operations.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum LintError {
     /// Failed to read the input file.
     #[snafu(display("failed to read file {path:?}: {source}"))]

--- a/crates/poiesis/lint/src/lib.rs
+++ b/crates/poiesis/lint/src/lib.rs
@@ -35,6 +35,7 @@ pub struct Finding {
 
 /// Category of a lint finding.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FindingKind {
     /// A banned word or phrase was found.
     BannedWord,

--- a/crates/poiesis/sheet/src/ods.rs
+++ b/crates/poiesis/sheet/src/ods.rs
@@ -13,6 +13,7 @@ use spreadsheet_ods::{Sheet, WorkBook, write_ods_buf};
 
 /// Errors produced by the ODS renderer.
 #[derive(Debug, Snafu)]
+#[non_exhaustive]
 pub enum OdsRendererError {
     /// `spreadsheet-ods` returned an error while writing the ODS file.
     #[snafu(display("ODS error: {message}"))]
@@ -127,8 +128,9 @@ fn truncate_sheet_name(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use poiesis_core::{Block, Document, Metadata, RichText, Span, block::Table};
+
+    use super::*;
 
     fn sample_doc() -> Document {
         Document {

--- a/crates/poiesis/sheet/src/xlsx.rs
+++ b/crates/poiesis/sheet/src/xlsx.rs
@@ -13,6 +13,7 @@ use snafu::Snafu;
 
 /// Errors produced by the XLSX renderer.
 #[derive(Debug, Snafu)]
+#[non_exhaustive]
 pub enum XlsxRendererError {
     /// `rust_xlsxwriter` returned an error.
     #[snafu(display("XLSX error: {message}"))]
@@ -160,8 +161,9 @@ fn sanitize_sheet_name(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use poiesis_core::{Block, Document, Metadata, RichText, Span, block::Table};
+
+    use super::*;
 
     fn sample_doc() -> Document {
         Document {

--- a/crates/poiesis/slides/src/pptx.rs
+++ b/crates/poiesis/slides/src/pptx.rs
@@ -67,6 +67,7 @@ const NS_OFFICE_DOC_RELS: &str =
 
 /// Errors produced by the PPTX renderer.
 #[derive(Debug, Snafu)]
+#[non_exhaustive]
 pub enum PptxError {
     /// An error occurred while generating the presentation.
     #[snafu(display("PPTX error: {message}"))]
@@ -263,7 +264,7 @@ fn write_entry(
 
 /// Escape text for XML character data using `quick-xml`.
 fn xml_escape(s: &str) -> String {
-    format!("{}", escape(s))
+    escape(s).to_string()
 }
 
 fn build_content_types(slides: &[SlideContent]) -> String {
@@ -636,8 +637,9 @@ static THEME: LazyLock<String> = LazyLock::new(|| {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use poiesis_core::{Block, Document, Metadata, RichText, Span};
+
+    use super::*;
 
     fn sample_doc() -> Document {
         Document {

--- a/crates/poiesis/text/src/odt.rs
+++ b/crates/poiesis/text/src/odt.rs
@@ -20,6 +20,7 @@ use zip::write::SimpleFileOptions;
 
 /// Errors produced by the ODT renderer.
 #[derive(Debug, Snafu)]
+#[non_exhaustive]
 pub enum OdtError {
     /// A ZIP I/O error occurred while building the ODT package.
     #[snafu(display("ODT zip error: {message}"))]
@@ -318,8 +319,9 @@ fn xml_escape(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use poiesis_core::{Block, Document, Metadata, RichText, Span, block::Table};
+
+    use super::*;
 
     fn sample_doc() -> Document {
         Document {

--- a/crates/poiesis/text/src/pdf.rs
+++ b/crates/poiesis/text/src/pdf.rs
@@ -38,6 +38,7 @@ const USABLE_W: f32 = PAGE_W - 2.0 * MARGIN_X;
 
 /// Errors produced by the PDF renderer.
 #[derive(Debug, Snafu)]
+#[non_exhaustive]
 pub enum PdfError {
     /// No usable system font was found. Install a font (e.g. `liberation-sans-fonts`
     /// or `google-noto-sans-fonts`) and verify it is readable.
@@ -353,8 +354,9 @@ fn wrap_words(text: &str, max_chars: usize) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use poiesis_core::{Block, Document, Metadata, RichText, Span};
+
+    use super::*;
 
     fn minimal_doc() -> Document {
         Document {

--- a/crates/poiesis/typst/src/error.rs
+++ b/crates/poiesis/typst/src/error.rs
@@ -5,6 +5,7 @@ use snafu::Snafu;
 /// Errors returned by the Typst rendering pipeline.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum PoiesisError {
     /// Data injection produced invalid JSON.
     #[snafu(display("failed to serialize injected data: {detail}"))]

--- a/crates/poiesis/verify/src/error.rs
+++ b/crates/poiesis/verify/src/error.rs
@@ -5,6 +5,7 @@ use snafu::Snafu;
 /// Errors that can occur during verify operations.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum VerifyError {
     /// Failed to evaluate an arithmetic formula.
     #[snafu(display("arithmetic evaluation failed for formula {formula:?}: {detail}"))]

--- a/crates/poiesis/verify/src/manifest.rs
+++ b/crates/poiesis/verify/src/manifest.rs
@@ -42,6 +42,7 @@ pub struct Claim {
 /// A single source backing a claim.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum Source {
     /// A SQL query (stored for record-keeping; execution not performed by this crate).
     Sql {

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -320,8 +320,8 @@ async fn check_config_readable(state: &HealthState) -> HealthCheck {
     };
 
     match tokio::fs::metadata(&config_path).await {
-        Ok(_metadata) => {
-            if std::fs::metadata(&config_path).is_ok_and(|m| m.is_file()) {
+        Ok(metadata) => {
+            if metadata.is_file() {
                 // Also verify we can read the current config in memory
                 let _config = state.config.read().await;
                 HealthCheck {
@@ -627,10 +627,11 @@ mod tests {
             reason = "compile-time shape assertion: proves field types via unused local fn"
         )]
         fn assert_health_state_fields(state: &HealthState) {
+            use std::sync::Arc;
+
             use hermeneus::provider::ProviderRegistry;
             use mneme::store::SessionStore;
             use nous::manager::NousManager;
-            use std::sync::Arc;
             use taxis::config::AletheiaConfig;
             use taxis::oikos::Oikos;
 

--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -579,9 +579,10 @@ mod tests {
             reason = "compile-time shape assertion: proves field types via unused local fn"
         )]
         fn assert_nous_state_fields(state: &NousState) {
+            use std::sync::Arc;
+
             use nous::manager::NousManager;
             use organon::registry::ToolRegistry;
-            use std::sync::Arc;
 
             let _: &Arc<NousManager> = &state.nous_manager;
             let _: &Arc<ToolRegistry> = &state.tool_registry;

--- a/crates/pylon/src/handlers/sessions/streaming_tests.rs
+++ b/crates/pylon/src/handlers/sessions/streaming_tests.rs
@@ -1,7 +1,8 @@
 #![expect(clippy::expect_used, reason = "test assertions")]
 
-use super::*;
 use axum::http::HeaderMap;
+
+use super::*;
 
 /// Default max key length for tests (matches `ApiLimitsConfig::default()`).
 const TEST_MAX_KEY_LEN: usize = 64;

--- a/crates/pylon/src/turn_buffer.rs
+++ b/crates/pylon/src/turn_buffer.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::sync::{Mutex, Notify};
-use tracing::{debug, warn};
+use tracing::{Instrument as _, debug, warn};
 
 /// Default time-to-live for completed turn buffers before they are reaped.
 const DEFAULT_COMPLETED_TTL: Duration = Duration::from_mins(5);
@@ -256,20 +256,23 @@ pub(crate) fn spawn_reaper(
     registry: Arc<TurnBufferRegistry>,
     shutdown: tokio_util::sync::CancellationToken,
 ) {
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_mins(1));
-        loop {
-            tokio::select! {
-                _ = interval.tick() => {
-                    registry.reap_expired().await;
-                }
-                () = shutdown.cancelled() => {
-                    debug!("turn buffer reaper shutting down");
-                    return;
+    tokio::spawn(
+        async move {
+            let mut interval = tokio::time::interval(Duration::from_mins(1));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        registry.reap_expired().await;
+                    }
+                    () = shutdown.cancelled() => {
+                        debug!("turn buffer reaper shutting down");
+                        return;
+                    }
                 }
             }
         }
-    });
+        .instrument(tracing::info_span!("pylon.turn_buffer_reaper")),
+    );
 }
 
 #[cfg(test)]

--- a/crates/symbolon/src/credential/pkce.rs
+++ b/crates/symbolon/src/credential/pkce.rs
@@ -419,7 +419,7 @@ fn parse_callback_request(reader: &mut BufReader<&TcpStream>) -> Result<Option<C
                 "state" => data.state = Some(value),
                 "error" => data.error = Some(value),
                 "error_description" => data.error_description = Some(value),
-                _ => {}
+                _ => {} // Ignore unknown query parameters.
             }
         }
     }

--- a/crates/taxis/src/registry.rs
+++ b/crates/taxis/src/registry.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 
 /// Classification of who should tune a parameter and when.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[non_exhaustive]
 pub enum ParameterTier {
     /// Operator sets at deployment time; not self-tunable.
     Deployment,

--- a/crates/theatron/skene/src/api/types/mod.rs
+++ b/crates/theatron/skene/src/api/types/mod.rs
@@ -1,7 +1,10 @@
 //! Request and response types for the Aletheia REST API.
 
 pub mod verification;
-pub use verification::*;
+pub use verification::{
+    ProjectVerificationResult, RequirementPriority, RequirementVerification, VerificationEvidence,
+    VerificationGap, VerificationStatus,
+};
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
## Summary

Mechanical, Rust-source lint cleanup. 51 violations cleared across import-order, bare-assert, format-single-var, empty-match-arm, commented-code, blocking-in-async, spawn-no-instrument, barrel-reexport, non-exhaustive-enum, and hardcoded-model. Zero new suppressions. Suppressed count unchanged at 126.

## Per-rule (before -> after)

- `RUST/import-order` 47 -> 0
- `RUST/bare-assert` 4 -> 0 (added messages to `assert_eq!` in episteme/marshal)
- `RUST/format-single-var` 10 -> 1 (remaining is in proskenion, workspace-excluded)
- `RUST/empty-match-arm` 7 -> 0
- `RUST/commented-code` 1 -> 0 (agent_sdk.rs)
- `RUST/blocking-in-async` 1 -> 0 (reused `tokio::fs::metadata` result)
- `RUST/spawn-no-instrument` 9 -> 5 (4 fixed: daemon/runner, diaporeia, melete/dream, pylon/turn_buffer; 2 proskenion excluded; 2 skene false-positives where `.instrument()` IS present >50 lines past spawn)
- `RUST/barrel-reexport` 3 -> 0 (organon + skene explicit re-export lists)
- `RUST/non-exhaustive-enum` 28 -> 5 (5 reverted: `Block`/`Span`/`FactSensitivity`/`ParameterValue`/`TuningDirection` -- adding `#[non_exhaustive]` broke exhaustive matching in same workspace; cascading fix is not mechanical)
- `RUST/hardcoded-model` 2 -> 1 (lifted to `DEFAULT_JUDGE_MODEL` const)

## Deliberately skipped (judgment-heavy follow-up wave)

- `RUST/allow-not-expect` 11: 7 are macro / cross-compilation cases with documented WHY-comments explaining that `#[expect]` fires `unfulfilled_lint_expectations` under conditional compilation; 4 are string-literal false-positives in `mechanical.rs` (a lint-detector source where antipatterns live as data).
- `RUST/unwrap` 1: false positive, string literal in antipattern detector
- `RUST/std-mutex-in-async` 3: all sync methods with no `.await`; conversion to `tokio::sync::Mutex` is architectural
- `RUST/banned-crate:chrono` 2: `cron` crate API is locked to `DateTime<Utc>`; jiff migration is architectural

## Verification

- [x] `cargo check --workspace --features test-core --all-targets` clean
- [x] `cargo clippy --workspace --features test-core --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `kanon lint . --summary` -- 2420 -> 2369 (-51), suppressed unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)