### PR TITLE
refactor(lint): judgment-wave A -- aletheia/taxis/daemon/dianoia/diaporeia/mneme/basanos/thesauros

### DIFF
--- a/crates/basanos/src/error.rs
+++ b/crates/basanos/src/error.rs
@@ -35,4 +35,4 @@ pub enum Error {
 }
 
 /// Shorthand for fallible operations.
-pub type Result<T> = std::result::Result<T, Error>;
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/crates/daemon/src/cron_expr.rs
+++ b/crates/daemon/src/cron_expr.rs
@@ -38,21 +38,15 @@ impl CronExpr {
     /// Accepts 5-field (`min hour dom month dow`) or 6-field
     /// (`sec min hour dom month dow`) formats.
     #[expect(
-        clippy::indexing_slicing,
-        reason = "indices match the just-validated `fields.len()` arm above"
-    )]
-    #[expect(
         clippy::similar_names,
         reason = "field names mirror cron section names — disambiguating them with longer/shorter names hurts readability"
     )]
     pub(crate) fn parse(expr: &str) -> Result<Self, error::Error> {
         let fields: Vec<&str> = expr.split_whitespace().collect();
 
-        let (sec_str, minute_str, hour_str, dom_str, month_str, dow_str) = match fields.len() {
-            5 => ("0", fields[0], fields[1], fields[2], fields[3], fields[4]),
-            6 => (
-                fields[0], fields[1], fields[2], fields[3], fields[4], fields[5],
-            ),
+        let (sec_str, minute_str, hour_str, dom_str, month_str, dow_str) = match fields.as_slice() {
+            [min, hour, dom, month, dow] => ("0", *min, *hour, *dom, *month, *dow),
+            [sec, min, hour, dom, month, dow] => (*sec, *min, *hour, *dom, *month, *dow),
             _ => {
                 return Err(error::Error::CronParse {
                     expression: expr.to_owned(),
@@ -98,22 +92,22 @@ impl CronExpr {
     // either jiff or the parse_field validator below, so none can overflow,
     // wrap, or lose sign.
     #[expect(
-        clippy::as_conversions,
-        clippy::cast_sign_loss,
-        clippy::cast_possible_wrap,
         clippy::too_many_lines,
-        reason = "month/day/hour/minute/second all bounded 0..=59 (max); i8↔u8 round-trip is lossless. Function length: single cohesive cron field-walking state machine; splitting would scatter the carry logic across helpers and obscure rollover semantics"
+        reason = "single cohesive cron field-walking state machine; splitting would scatter the carry logic across helpers and obscure rollover semantics"
     )]
     pub(crate) fn next_after(&self, after: jiff::Timestamp) -> Option<jiff::Timestamp> {
         // Work in UTC civil datetime for field-level manipulation.
         let dt = after.to_zoned(jiff::tz::TimeZone::UTC).datetime();
 
         let mut year = dt.year();
-        let mut month = dt.month();
-        let mut day = dt.day();
-        let mut hour = dt.hour();
-        let mut minute = dt.minute();
-        let mut second = dt.second();
+        // WHY: jiff returns these signed (i8) but all cron-domain values (month 1..=12,
+        // day 1..=31, hour 0..=23, minute/second 0..=59) fit in u8 without loss;
+        // keeping them in u8 lets every try_from be lossless without saturation.
+        let mut month: u8 = u8::try_from(dt.month()).ok()?;
+        let mut day: u8 = u8::try_from(dt.day()).ok()?;
+        let mut hour: u8 = u8::try_from(dt.hour()).ok()?;
+        let mut minute: u8 = u8::try_from(dt.minute()).ok()?;
+        let mut second: u8 = u8::try_from(dt.second()).ok()?;
 
         // Advance by one second so we are strictly after `after`.
         second += 1;
@@ -139,10 +133,10 @@ impl CronExpr {
             }
 
             // --- Month ---
-            match next_value(&self.months, month as u8) {
-                Some(m) if m == month as u8 => { /* current month is valid */ }
+            match next_value(&self.months, month) {
+                Some(m) if m == month => { /* current month is valid */ }
                 Some(m) => {
-                    month = m as i8;
+                    month = m;
                     day = 1;
                     hour = 0;
                     minute = 0;
@@ -151,7 +145,7 @@ impl CronExpr {
                 None => {
                     // No valid month left this year — roll to next year.
                     year += 1;
-                    month = first_value(&self.months) as i8;
+                    month = first_value(&self.months);
                     day = 1;
                     hour = 0;
                     minute = 0;
@@ -163,9 +157,9 @@ impl CronExpr {
             // --- Day of month ---
             let dim = days_in_month(year, month);
             // Clamp day-of-month candidates to actual month length.
-            if let Some(d) = next_value_max(&self.days_of_month, day as u8, dim) {
-                if d != day as u8 {
-                    day = d as i8;
+            if let Some(d) = next_value_max(&self.days_of_month, day, dim) {
+                if d != day {
+                    day = d;
                     hour = 0;
                     minute = 0;
                     second = 0;
@@ -192,7 +186,7 @@ impl CronExpr {
                 hour = 0;
                 minute = 0;
                 second = 0;
-                if day as u8 > dim {
+                if day > dim {
                     month += 1;
                     if month > 12 {
                         month = 1;
@@ -204,10 +198,10 @@ impl CronExpr {
             }
 
             // --- Hour ---
-            match next_value(&self.hours, hour as u8) {
-                Some(h) if h == hour as u8 => {}
+            match next_value(&self.hours, hour) {
+                Some(h) if h == hour => {}
                 Some(h) => {
-                    hour = h as i8;
+                    hour = h;
                     minute = 0;
                     second = 0;
                 }
@@ -217,7 +211,7 @@ impl CronExpr {
                     hour = 0;
                     minute = 0;
                     second = 0;
-                    if day as u8 > dim {
+                    if day > dim {
                         month += 1;
                         if month > 12 {
                             month = 1;
@@ -230,10 +224,10 @@ impl CronExpr {
             }
 
             // --- Minute ---
-            match next_value(&self.minutes, minute as u8) {
-                Some(m) if m == minute as u8 => {}
+            match next_value(&self.minutes, minute) {
+                Some(m) if m == minute => {}
                 Some(m) => {
-                    minute = m as i8;
+                    minute = m;
                     second = 0;
                 }
                 None => {
@@ -243,7 +237,7 @@ impl CronExpr {
                     if hour > 23 {
                         hour = 0;
                         day += 1;
-                        if day as u8 > dim {
+                        if day > dim {
                             month += 1;
                             if month > 12 {
                                 month = 1;
@@ -257,10 +251,10 @@ impl CronExpr {
             }
 
             // --- Second ---
-            match next_value(&self.seconds, second as u8) {
-                Some(s) if s == second as u8 => {}
+            match next_value(&self.seconds, second) {
+                Some(s) if s == second => {}
                 Some(s) => {
-                    second = s as i8;
+                    second = s;
                 }
                 None => {
                     minute += 1;
@@ -271,7 +265,7 @@ impl CronExpr {
                         if hour > 23 {
                             hour = 0;
                             day += 1;
-                            if day as u8 > dim {
+                            if day > dim {
                                 month += 1;
                                 if month > 12 {
                                     month = 1;
@@ -286,8 +280,18 @@ impl CronExpr {
             }
 
             // All fields matched — construct result.
-            let civil =
-                jiff::civil::DateTime::new(year, month, day, hour, minute, second, 0).ok()?;
+            // WHY: jiff's civil DateTime API takes i8 for month/day/hour/minute/second;
+            // we keep them in u8 internally (cron domain bounded 0..=59) and convert
+            // fallibly at the boundary. Any failure bubbles out as None (no valid match).
+            let month_i8 = i8::try_from(month).ok()?;
+            let day_i8 = i8::try_from(day).ok()?;
+            let hour_i8 = i8::try_from(hour).ok()?;
+            let minute_i8 = i8::try_from(minute).ok()?;
+            let second_i8 = i8::try_from(second).ok()?;
+            let civil = jiff::civil::DateTime::new(
+                year, month_i8, day_i8, hour_i8, minute_i8, second_i8, 0,
+            )
+            .ok()?;
             let zoned = civil.to_zoned(jiff::tz::TimeZone::UTC).ok()?;
             return Some(zoned.timestamp());
         }
@@ -453,25 +457,30 @@ fn first_value(set: &BTreeSet<u8>) -> u8 {
 // ---------------------------------------------------------------------------
 
 /// Number of days in a given month (1-12) for a given year.
-fn days_in_month(year: i16, month: i8) -> u8 {
-    // Use jiff to get the correct answer including leap years.
-    // The `try_into().ok()` keeps the conversion safe — no `as` cast needed.
-    jiff::civil::Date::new(year, month, 1)
-        .ok()
-        .and_then(|d| d.days_in_month().try_into().ok())
-        .unwrap_or(30)
+///
+/// WHY `unwrap_or(30)`: cron callers pass month values already validated in 1..=12
+/// via `parse_field`, so construction cannot fail in practice. 30 is a conservative
+/// fallback (wrong by at most one day) for the defensive branch.
+fn days_in_month(year: i16, month: u8) -> u8 {
+    let Ok(month_i8) = i8::try_from(month) else {
+        return 30;
+    };
+    let Ok(date) = jiff::civil::Date::new(year, month_i8, 1) else {
+        return 30;
+    };
+    u8::try_from(date.days_in_month()).unwrap_or(30)
 }
 
 /// Day of week for a date: 0=Sunday, 1=Monday, ..., 6=Saturday.
 ///
 /// Uses Tomohiko Sakamoto's algorithm.
-fn day_of_week(year: i16, month: i8, day: i8) -> u8 {
+fn day_of_week(year: i16, month: u8, day: u8) -> u8 {
     static T: [i32; 12] = [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4];
     let mut y = i32::from(year);
     // WHY: month is guaranteed to be in 1..=12 by the caller (cron state machine
     // clamps month via parse_field's 1-12 range); saturate to 1 on unreachable
     // out-of-range rather than panic.
-    let m = usize::try_from(month.max(1)).unwrap_or(1).min(12);
+    let m = usize::from(month.max(1)).min(12);
     let d = i32::from(day);
     if m < 3 {
         y -= 1;
@@ -652,7 +661,9 @@ mod tests {
         let next = expr.next_after(base).unwrap();
         let dt = next.to_zoned(jiff::tz::TimeZone::UTC).datetime();
         // Verify it's a Monday
-        let dow = day_of_week(dt.year(), dt.month(), dt.day());
+        let month_u8 = u8::try_from(dt.month()).unwrap();
+        let day_u8 = u8::try_from(dt.day()).unwrap();
+        let dow = day_of_week(dt.year(), month_u8, day_u8);
         assert_eq!(dow, 1, "expected Monday (1), got {dow}");
     }
 

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -87,6 +87,14 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Invariant violation during maintenance (situation the caller believed impossible).
+    #[snafu(display("maintenance invariant violated: {context}"))]
+    MaintenanceInvariant {
+        context: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Convenience alias for `Result` with daemon's [`Error`] type.

--- a/crates/daemon/src/maintenance/drift_detection.rs
+++ b/crates/daemon/src/maintenance/drift_detection.rs
@@ -105,10 +105,6 @@ impl DriftDetector {
         Ok(report)
     }
 
-    #[expect(
-        clippy::expect_used,
-        reason = "path is obtained by walking example_root so strip_prefix is guaranteed to succeed"
-    )]
     fn walk_example(&self, dir: &Path, report: &mut DriftReport) -> error::Result<()> {
         let entries = fs::read_dir(dir).context(error::MaintenanceIoSnafu {
             context: format!("reading example dir {}", dir.display()),
@@ -121,7 +117,16 @@ impl DriftDetector {
             let path = entry.path();
             let relative = path
                 .strip_prefix(&self.config.example_root)
-                .expect("path is under example root");
+                .map_err(|_strip_err| {
+                    error::MaintenanceInvariantSnafu {
+                        context: format!(
+                            "path {} produced by walking {} did not carry example_root as prefix",
+                            path.display(),
+                            self.config.example_root.display()
+                        ),
+                    }
+                    .build()
+                })?;
 
             if self.is_ignored(relative) {
                 continue;

--- a/crates/daemon/src/maintenance/trace_rotation.rs
+++ b/crates/daemon/src/maintenance/trace_rotation.rs
@@ -83,10 +83,6 @@ impl TraceRotator {
     ///
     /// Trace rotation is a non-essential write. When disk space is critical,
     /// rotation is skipped entirely (returns an empty report).
-    #[expect(
-        clippy::expect_used,
-        reason = "file_name() is None only for paths ending in '..', which trace files never are"
-    )]
     pub fn rotate(&self) -> error::Result<RotationReport> {
         if let Some(ref monitor) = self.disk_monitor
             && !monitor.allow_non_essential_write()
@@ -135,10 +131,16 @@ impl TraceRotator {
         }
 
         for entry in to_rotate.iter().filter_map(|&i| entries.get(i)) {
-            let dest = self
-                .config
-                .archive_dir
-                .join(entry.path.file_name().expect("trace file has a file name"));
+            let file_name = entry.path.file_name().ok_or_else(|| {
+                error::MaintenanceInvariantSnafu {
+                    context: format!(
+                        "trace entry {} has no file name component",
+                        entry.path.display()
+                    ),
+                }
+                .build()
+            })?;
+            let dest = self.config.archive_dir.join(file_name);
 
             fs::rename(&entry.path, &dest).context(error::MaintenanceIoSnafu {
                 context: format!("moving {} to archive", entry.path.display()),

--- a/crates/daemon/src/probe.rs
+++ b/crates/daemon/src/probe.rs
@@ -176,12 +176,10 @@ impl ProbeSet {
         let confidence = if passed {
             1.0_f32
         } else {
-            #[expect(
-                clippy::cast_precision_loss,
-                clippy::as_conversions,
-                reason = "usize→f32: probe violation/missing counts are under 20 per probe, far below f32 mantissa 2^24"
-            )]
-            let penalty = total_issues as f32 * 0.25_f32;
+            // WHY: u16→f32 is lossless (f32 mantissa is 24 bits, u16 is 16 bits);
+            // clamp to u16::MAX so pathological count overflow caps at max-penalty.
+            let issues_u16 = u16::try_from(total_issues).unwrap_or(u16::MAX);
+            let penalty = f32::from(issues_u16) * 0.25_f32;
             (1.0_f32 - penalty).max(0.0_f32)
         };
 
@@ -200,7 +198,7 @@ impl ProbeSet {
     /// `responses` maps `probe.id` → response text. Probes with no entry in the
     /// map produce a `ProbeResult` with `passed = false` and a synthetic violation.
     #[must_use]
-    pub fn evaluate_all<'a>(
+    pub(crate) fn evaluate_all<'a>(
         &self,
         responses: impl Fn(&str) -> Option<&'a str>,
     ) -> Vec<ProbeResult> {
@@ -270,15 +268,13 @@ impl ProbeAuditSummary {
         let passed = results.iter().filter(|r| r.passed).count();
         let failed = total - passed;
 
-        #[expect(
-            clippy::cast_precision_loss,
-            clippy::as_conversions,
-            reason = "usize→f32: probe count in an audit is under 100, far below f32 mantissa 2^24"
-        )]
         let avg_confidence = if total == 0 {
             1.0_f32
         } else {
-            results.iter().map(|r| r.confidence).sum::<f32>() / total as f32
+            // WHY: u16→f32 is lossless (f32 mantissa 24 bits vs u16's 16 bits);
+            // clamp to u16::MAX so pathological counts still produce a finite average.
+            let total_u16 = u16::try_from(total).unwrap_or(u16::MAX);
+            results.iter().map(|r| r.confidence).sum::<f32>() / f32::from(total_u16)
         };
 
         Self {

--- a/crates/daemon/src/prosoche.rs
+++ b/crates/daemon/src/prosoche.rs
@@ -333,12 +333,12 @@ fn check_db_sizes(paths: &[PathBuf]) -> Vec<AttentionItem> {
     for path in paths {
         match std::fs::metadata(path) {
             Ok(meta) => {
-                #[expect(
-                    clippy::cast_precision_loss,
-                    clippy::as_conversions,
-                    reason = "u64→f64: file sizes on supported storage are well below f64 mantissa 2^53 ≈ 9 exabytes; display precision need is a single decimal place"
-                )]
-                let size_gb = meta.len() as f64 / ONE_GB as f64;
+                // WHY: compute GB in integer milli-GB (bytes / (GB/1024)) so the
+                // usize→f64 conversion is from u32 (lossless up to ~4 petabyte file
+                // sizes in milli-GB), avoiding a u64-as-f64 precision-loss cast.
+                let milli_gb = meta.len() / (ONE_GB / 1024);
+                let milli_gb_u32 = u32::try_from(milli_gb).unwrap_or(u32::MAX);
+                let size_gb = f64::from(milli_gb_u32) / 1024.0_f64;
                 // NOTE: single threshold — any file over 1 GB is High urgency.
                 items.extend(check_threshold(size_gb, 1.0, f64::INFINITY, |gb| {
                     format!("Database file large: {} is {gb:.1} GB", path.display())
@@ -367,12 +367,10 @@ fn check_memory() -> Vec<AttentionItem> {
     match read_process_rss_kb() {
         Ok(resident_kb) => {
             let rss_mb = resident_kb / 1024;
-            #[expect(
-                clippy::cast_precision_loss,
-                clippy::as_conversions,
-                reason = "u64→f64: process RSS in MB is bounded by host RAM (under 2^53 MB); cast is exact at practical scale"
-            )]
-            let rss_f64 = rss_mb as f64;
+            // WHY: RSS in MB is bounded by host RAM; clamp to u32::MAX (4TB)
+            // then f64::from(u32) is lossless, avoiding u64→f64 precision loss.
+            let rss_mb_u32 = u32::try_from(rss_mb).unwrap_or(u32::MAX);
+            let rss_f64 = f64::from(rss_mb_u32);
             let label = if rss_mb >= 2048 { "critical" } else { "high" };
             check_threshold(rss_f64, 1024.0, 2048.0, |mb| {
                 format!("Process memory {label}: {mb:.0} MB RSS")

--- a/crates/daemon/src/runner/lifecycle.rs
+++ b/crates/daemon/src/runner/lifecycle.rs
@@ -105,17 +105,19 @@ impl TaskRunner {
         let now = jiff::Timestamp::now();
         let now_instant = Instant::now();
 
-        // i is always in 0..self.tasks.len() so all self.tasks[i] accesses are valid
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "i ∈ 0..self.tasks.len() by for-loop bounds"
-        )]
         for i in 0..self.tasks.len() {
-            if !self.tasks[i].def.enabled {
+            // WHY: `get_mut` over the length we just read keeps the indexing
+            // fallible; `continue` on None leaves the loop lenient to concurrent
+            // resize (not possible here, but avoids the `[i]` suppression).
+            let Some(task) = self.tasks.get_mut(i) else {
+                continue;
+            };
+
+            if !task.def.enabled {
                 continue;
             }
 
-            let Some(next) = self.tasks[i].next_run else {
+            let Some(next) = task.next_run else {
                 continue;
             };
 
@@ -123,39 +125,48 @@ impl TaskRunner {
                 continue;
             }
 
-            if !Schedule::in_window(self.tasks[i].def.active_window) {
+            if !Schedule::in_window(task.def.active_window) {
                 continue;
             }
 
+            let task_def_id = task.def.id.clone();
+            let backoff_until = task.backoff_until;
+
             // WHY: skip tasks still in-flight to prevent overlapping executions.
-            if self.in_flight.contains_key(&self.tasks[i].def.id) {
+            if self.in_flight.contains_key(&task_def_id) {
                 tracing::debug!(
-                    task_id = %self.tasks[i].def.id,
+                    task_id = %task_def_id,
                     "skipping  -  previous execution still in progress"
                 );
                 continue;
             }
 
-            if let Some(backoff_until) = self.tasks[i].backoff_until
+            if let Some(backoff_until) = backoff_until
                 && now_instant < backoff_until
             {
                 tracing::debug!(
-                    task_id = %self.tasks[i].def.id,
+                    task_id = %task_def_id,
                     remaining_secs = (backoff_until - now_instant).as_secs(),
                     "skipping  -  in backoff period"
                 );
                 continue;
             }
 
+            // Re-borrow mutably to record last_run and collect the spawn inputs.
+            let Some(task) = self.tasks.get_mut(i) else {
+                continue;
+            };
+
             // WHY(#2212): record last_run BEFORE spawning the task so that a crash
             // during execution does not leave last_run stale, which would cause
             // the scheduler to re-execute the task immediately on recovery.
-            self.tasks[i].last_run = Some(jiff::Timestamp::now());
+            task.last_run = Some(jiff::Timestamp::now());
 
-            let action = self.tasks[i].def.action.clone();
-            let nous_id = self.tasks[i].def.nous_id.clone();
-            let task_id = self.tasks[i].def.id.clone();
-            let timeout = self.tasks[i].def.timeout;
+            let action = task.def.action.clone();
+            let nous_id = task.def.nous_id.clone();
+            let task_id = task.def.id.clone();
+            let timeout = task.def.timeout;
+            let task_name = task.def.name.clone();
 
             let bridge = self.bridge.clone();
             let maintenance = self.maintenance.clone();
@@ -165,7 +176,7 @@ impl TaskRunner {
             let span = tracing::info_span!(
                 "task_execute",
                 task_id = %task_id,
-                task_name = %self.tasks[i].def.name,
+                task_name = %task_name,
                 nous_id = %nous_id,
             );
 

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -241,20 +241,15 @@ pub(crate) fn compute_jitter(
     // u32::try_from on the masked value is lossless since the mask already
     // fits u32; the unwrap_or is unreachable defensive code.
     let low32 = u32::try_from(hash & u64::from(u32::MAX)).unwrap_or(u32::MAX);
-    let frac = f64::from(low32) / f64::from(u32::MAX);
 
     let max_nanos = max_jitter.as_nanos();
-    // NOTE: f64 multiplication then truncate back to i128.
-    // max_nanos is an i128 SignedDuration count with practical limits (at most
-    // a few hours of nanoseconds ≈ 1.3e13, well under f64 mantissa 2^53 ≈ 9e15)
-    // and frac is in [0, 1); the product stays inside both f64 and i128.
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_precision_loss,
-        clippy::cast_possible_truncation,
-        reason = "i128→f64→i128: max_nanos ≤ few-hour SignedDuration count (~1.3e13) is well below f64 mantissa 2^53; product × frac ∈ [0,1) stays inside i128"
-    )]
-    let jitter_nanos = (max_nanos as f64 * frac) as i128;
+    // WHY: compute jitter = max_nanos * low32 / u32::MAX in integer i128 space
+    // so there is no f64 precision-loss cast. max_nanos is a SignedDuration nanos
+    // count bounded to a few hours in practice (~1.3e13); multiplying by a 32-bit
+    // value stays inside i128 (~1.7e38) with room to spare.
+    let scale = i128::from(low32);
+    let denom = i128::from(u32::MAX);
+    let jitter_nanos = max_nanos.saturating_mul(scale) / denom;
 
     // SAFETY: jitter_nanos ≤ max_jitter nanos, which fits in the input SignedDuration
     jiff::SignedDuration::from_nanos(i64::try_from(jitter_nanos).unwrap_or_default())

--- a/crates/dianoia/src/intent.rs
+++ b/crates/dianoia/src/intent.rs
@@ -182,7 +182,7 @@ impl Intent {
 
     /// Return `true` if the intent is active: not resolved and not expired.
     #[must_use]
-    pub fn is_active(&self) -> bool {
+    pub(crate) fn is_active(&self) -> bool {
         if self.resolved {
             return false;
         }
@@ -256,7 +256,7 @@ impl IntentStore {
     /// # Errors
     ///
     /// Returns a deserialization error if the store file is malformed.
-    pub fn active_intents(&self) -> Result<Vec<Intent>> {
+    pub(crate) fn active_intents(&self) -> Result<Vec<Intent>> {
         let mut active: Vec<Intent> = self
             .load_all()?
             .into_iter()

--- a/crates/dianoia/src/phase.rs
+++ b/crates/dianoia/src/phase.rs
@@ -116,13 +116,11 @@ impl Phase {
                 )
             })
             .count();
-        #[expect(
-            clippy::cast_precision_loss,
-            clippy::as_conversions,
-            reason = "usize→f64: plan counts are small, precision loss is acceptable"
-        )]
-        let pct = done as f64 / self.plans.len() as f64 * 100.0;
-        pct
+        // WHY: u32→f64 is lossless; plan counts saturated to u32::MAX keep the
+        // computation non-`as` and avoid precision-loss casts.
+        let done_u32 = u32::try_from(done).unwrap_or(u32::MAX);
+        let total_u32 = u32::try_from(self.plans.len()).unwrap_or(u32::MAX);
+        f64::from(done_u32) / f64::from(total_u32) * 100.0
     }
 }
 

--- a/crates/dianoia/src/stuck.rs
+++ b/crates/dianoia/src/stuck.rs
@@ -174,11 +174,8 @@ impl StuckDetector {
     }
 
     fn check_repeated_error(&self) -> Option<StuckSignal> {
-        #[expect(
-            clippy::as_conversions,
-            reason = "u32→usize: threshold values are small, no truncation possible"
-        )]
-        let threshold = self.config.repeated_error_threshold as usize;
+        let threshold_u32 = self.config.repeated_error_threshold;
+        let threshold = usize::try_from(threshold_u32).unwrap_or(usize::MAX);
         if self.history.len() < threshold {
             return None;
         }
@@ -200,12 +197,7 @@ impl StuckDetector {
             Some(StuckSignal {
                 pattern: StuckPattern::RepeatedError {
                     message: first_message.clone(),
-                    #[expect(
-                        clippy::as_conversions,
-                        clippy::cast_possible_truncation,
-                        reason = "usize→u32: threshold originated as u32, roundtrip is lossless"
-                    )]
-                    count: threshold as u32,
+                    count: threshold_u32,
                 },
                 suggestion: format!(
                     "The same error has occurred {threshold} times consecutively. \
@@ -218,11 +210,8 @@ impl StuckDetector {
     }
 
     fn check_same_tool_same_args(&self) -> Option<StuckSignal> {
-        #[expect(
-            clippy::as_conversions,
-            reason = "u32→usize: threshold values are small, no truncation possible"
-        )]
-        let threshold = self.config.same_args_threshold as usize;
+        let threshold_u32 = self.config.same_args_threshold;
+        let threshold = usize::try_from(threshold_u32).unwrap_or(usize::MAX);
         if self.history.len() < threshold {
             return None;
         }
@@ -238,12 +227,7 @@ impl StuckDetector {
             Some(StuckSignal {
                 pattern: StuckPattern::SameToolSameArgs {
                     tool_name: first.tool_name.clone(),
-                    #[expect(
-                        clippy::as_conversions,
-                        clippy::cast_possible_truncation,
-                        reason = "usize→u32: threshold originated as u32, roundtrip is lossless"
-                    )]
-                    count: threshold as u32,
+                    count: threshold_u32,
                 },
                 suggestion: format!(
                     "Tool '{}' has been called with identical arguments {threshold} times. \
@@ -257,11 +241,8 @@ impl StuckDetector {
     }
 
     fn check_alternating_failure(&self) -> Option<StuckSignal> {
-        #[expect(
-            clippy::as_conversions,
-            reason = "u32→usize: threshold values are small, no truncation possible"
-        )]
-        let threshold = self.config.alternating_threshold as usize;
+        let threshold_u32 = self.config.alternating_threshold;
+        let threshold = usize::try_from(threshold_u32).unwrap_or(usize::MAX);
         let required = threshold.checked_mul(2)?;
         if self.history.len() < required {
             return None;
@@ -295,12 +276,7 @@ impl StuckDetector {
                 pattern: StuckPattern::AlternatingFailure {
                     tool_a: a_inv.tool_name.clone(),
                     tool_b: b_inv.tool_name.clone(),
-                    #[expect(
-                        clippy::as_conversions,
-                        clippy::cast_possible_truncation,
-                        reason = "usize→u32: threshold originated as u32, roundtrip is lossless"
-                    )]
-                    cycles: threshold as u32,
+                    cycles: threshold_u32,
                 },
                 suggestion: format!(
                     "Alternating between '{}' and '{}' without progress for {threshold} cycles. \
@@ -314,11 +290,8 @@ impl StuckDetector {
     }
 
     fn check_escalating_retry(&self) -> Option<StuckSignal> {
-        #[expect(
-            clippy::as_conversions,
-            reason = "u32→usize: threshold values are small, no truncation possible"
-        )]
-        let threshold = self.config.escalating_retry_threshold as usize;
+        let threshold =
+            usize::try_from(self.config.escalating_retry_threshold).unwrap_or(usize::MAX);
         if self.history.len() < threshold {
             return None;
         }
@@ -368,15 +341,11 @@ impl StuckDetector {
         let has_gap = span > matching_indices.len() - 1;
 
         if has_gap {
-            #[expect(
-                clippy::as_conversions,
-                clippy::cast_possible_truncation,
-                reason = "usize→u32: match count bounded by history_window which fits in u32"
-            )]
+            let count = u32::try_from(max_entry.3).unwrap_or(u32::MAX);
             Some(StuckSignal {
                 pattern: StuckPattern::EscalatingRetry {
                     tool_name: max_entry.0.to_string(),
-                    count: max_entry.3 as u32,
+                    count,
                 },
                 suggestion: format!(
                     "Tool '{}' has been retried {} times across the history window with the same error. \


### PR DESCRIPTION
## Summary

Judgment-heavy lint cleanup across 8 crates. Scoped baseline 306 → 249 (−57 violations). Scoped suppressions 273 → 255 (−18 removed, 0 added). Full-repo 2187 → 2130.

## Per-rule (scoped)

| Rule | Before | After | Delta |
|---|---|---|---|
| RUST/as-cast | 37 | 0 | −37 |
| RUST/indexing-slicing | 14 | 0 | −14 |
| RUST/expect | 2 | 0 | −2 |
| RUST/pub-visibility | 101 | 97 | −4 |

## Engineering patterns used

- **`cron_expr.rs` state machine**: recast in `u8` (cron domain fits); `i8` conversion at jiff boundary only. Killed 20 `as`-casts + 3 suppressions.
- **`probe.rs` / `prosoche.rs` / `phase.rs` / `stuck.rs`**: `usize`/`u64` → `f32`/`f64` via `u16`/`u32` clamp + `f32::from`/`f64::from` (lossless). Integer-space scaling where possible.
- **`schedule.rs`**: jitter in pure `i128` space, no `f64` intermediary.
- **`runner/lifecycle.rs`**: `self.tasks[i]` → `self.tasks.get_mut(i) else continue`.
- **`drift_detection.rs` / `trace_rotation.rs`**: `.expect()` → `.map_err(...)?` via new error variant `daemon::error::Error::MaintenanceInvariant { context, location }`.

## New typed-error variant

`daemon::error::Error::MaintenanceInvariant` -- surfaces maintenance-task invariants that were previously asserted via `.expect()`. Caller gets structured context + source location instead of a panic string.

## Flagged for operator (rule refinement candidates)

### 1. `RUST/pub-visibility` doesn't cross src→tests

97 remaining pub-visibility hits are genuine public API consumed by `crates/<c>/tests/public_api.rs` integration tests (and `basanos/tests/planning_falsifier_tests.rs`). The rule treats integration-tests as internal and flags the items as narrowable when they aren't. Proposed refinement: treat `crates/<c>/tests/**` as external callers for visibility analysis.

### 2. Dead-code blockers

Items that could narrow to `pub(crate)` but trigger `dead_code` because their only callers are `#[cfg(test)]` modules in the same crate. No-suppressions session rule blocks the `#[cfg_attr(not(test), expect(dead_code))]` escape. Proper fixes are delete / relocate / expose via `public_api`, out of scope for a mechanical pass:

- `Plan::{with_max_iterations, set_depends_on, detect_cycles}`
- `DaemonConfig::load`
- `IntentStore::{path_for, add_intent, list_intents, expire_intents, resolve_intent}`
- `Intent::new`
- `DEFAULT_TIMESTAMP_TOLERANCE_SECS`
- `registry::{specs_by_section, specs_affecting, spec_by_key}`

## Verification

- [x] `cargo check --workspace --features test-core --all-targets` clean
- [x] `cargo clippy --workspace --features test-core --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --features test-core --no-fail-fast` pass
- [x] `cargo fmt --all --check` clean
- [x] `kanon lint . --summary` 2187 → 2130

🤖 Generated with [Claude Code](https://claude.com/claude-code)