### PR TITLE
refactor(lint): judgment-wave B -- nous/hermeneus/melete/agora/koina/koilon

### DIFF
--- a/crates/hermeneus/src/complexity/mod.rs
+++ b/crates/hermeneus/src/complexity/mod.rs
@@ -478,14 +478,11 @@ fn tier_from_score(score: u32, low_threshold: u32, high_threshold: u32) -> Model
 /// Clamp an i32 score into the [0, 100] range.
 #[must_use]
 fn clamp_score(raw: i32) -> u32 {
-    #[expect(
-        clippy::cast_sign_loss,
-        clippy::as_conversions,
-        reason = "value is guaranteed non-negative after clamping to 0; as-cast is safe for 0..=100"
-    )]
-    {
-        raw.clamp(0, 100) as u32
-    }
+    // WHY `try_from().unwrap_or(0)`: `raw.clamp(0, 100)` guarantees
+    // non-negative, so `try_from` is infallible in practice; the `0`
+    // fallback would only fire for negative values (already clamped
+    // away) and matches the desired clamp semantics.
+    u32::try_from(raw.clamp(0, 100)).unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/crates/hermeneus/src/test_utils.rs
+++ b/crates/hermeneus/src/test_utils.rs
@@ -140,26 +140,42 @@ impl LlmProvider for MockProvider {
         request: &'a CompletionRequest,
     ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
         Box::pin(async {
+            // WHY `unwrap_or_else(|p| p.into_inner())`: a poisoned mutex
+            // here means a prior test panicked; the mock is observational
+            // so we recover the inner state and continue rather than
+            // cascading panics across the test suite.
             self.requests
                 .lock()
-                .expect("mock request lock poisoned")
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .push(request.clone());
 
             {
-                let mut err_guard = self.error.lock().expect("mock error lock poisoned");
+                let mut err_guard = self
+                    .error
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 if let Some(err) = err_guard.take() {
                     return Err(err);
                 }
             }
 
-            let mut responses = self.responses.lock().expect("mock response lock poisoned");
+            let mut responses = self
+                .responses
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             if responses.len() > 1 {
                 Ok(responses.remove(0))
             } else {
-                Ok(responses
-                    .first()
-                    .expect("MockProvider has no responses configured")
-                    .clone())
+                // WHY `.first().cloned().ok_or_else(...)`: the mock
+                // contract requires at least one configured response,
+                // but returning a typed error lets the test harness
+                // surface misconfiguration cleanly instead of panicking.
+                responses.first().cloned().ok_or_else(|| {
+                    error::ProviderInitSnafu {
+                        message: "MockProvider has no responses configured".to_owned(),
+                    }
+                    .build()
+                })
             }
         })
     }

--- a/crates/melete/src/dream/lock.rs
+++ b/crates/melete/src/dream/lock.rs
@@ -227,18 +227,12 @@ pub(crate) fn lock_mtime(path: &Path) -> Option<std::time::SystemTime> {
 /// Convert a `SystemTime` to a `jiff::Timestamp` (best-effort).
 pub(crate) fn system_time_to_timestamp(st: std::time::SystemTime) -> Option<jiff::Timestamp> {
     let duration = st.duration_since(std::time::UNIX_EPOCH).ok()?;
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_wrap,
-        reason = "u64→i64: Unix seconds fit in i64 until year 292 billion"
-    )]
-    let secs = duration.as_secs() as i64;
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_wrap,
-        reason = "u32→i32: nanosecond subseconds (0..999_999_999) always fit in i32"
-    )]
-    let nanos = duration.subsec_nanos() as i32;
+    // WHY `try_from`: Unix seconds fit in i64 until year 292 billion and
+    // subsec nanos are in 0..1_000_000_000 (well within i32), so both
+    // conversions succeed in practice; `?` returns `None` on the
+    // pathological overflow case instead of wrapping.
+    let secs = i64::try_from(duration.as_secs()).ok()?;
+    let nanos = i32::try_from(duration.subsec_nanos()).ok()?;
     jiff::Timestamp::new(secs, nanos).ok()
 }
 

--- a/crates/melete/src/probe.rs
+++ b/crates/melete/src/probe.rs
@@ -104,21 +104,18 @@ impl ProbeReport {
 
     /// Pass rate as a fraction (0.0..=1.0).
     #[must_use]
-    #[expect(
-        clippy::cast_precision_loss,
-        reason = "probe counts are tiny (<100); f64 mantissa handles this exactly"
-    )]
-    #[expect(
-        clippy::as_conversions,
-        reason = "usize to f64 — probe counts are bounded and small"
-    )]
     pub fn pass_rate(&self) -> f64 {
         let total = self.total_probes();
         if total == 0 {
             return 1.0;
         }
         let passed = total - self.failure_count();
-        passed as f64 / total as f64
+        // WHY f64::from(u32): probe counts are tiny (<100); u32→f64 is
+        // an exact conversion; `try_from` saturating to u32::MAX guards
+        // the pathological case while keeping arithmetic lossless.
+        let passed_u32 = u32::try_from(passed).unwrap_or(u32::MAX);
+        let total_u32 = u32::try_from(total).unwrap_or(u32::MAX);
+        f64::from(passed_u32) / f64::from(total_u32)
     }
 }
 
@@ -308,10 +305,6 @@ impl ProbeVerifier {
 /// Heuristic: split on sentence boundaries and extract phrases containing
 /// proper nouns (capitalized words not at sentence start) or technical terms
 /// (words containing underscores, dots, or colons).
-#[expect(
-    clippy::indexing_slicing,
-    reason = "slice bounds guarded by explicit len checks immediately above each access"
-)]
 fn extract_key_phrases(content: &str) -> Vec<String> {
     let mut phrases = Vec::new();
 
@@ -333,12 +326,23 @@ fn extract_key_phrases(content: &str) -> Vec<String> {
         if words.len() <= 10 {
             phrases.push(trimmed.to_owned());
         } else {
-            // For longer sentences, extract the first and last meaningful chunks
-            let first_half: String = words[..5].join(" ");
+            // For longer sentences, extract the first and last meaningful chunks.
+            // WHY `.iter().take(5)`: equivalent to `words[..5]` but avoids the
+            // panic-on-out-of-bounds surface; the outer `words.len() > 10`
+            // guard makes the 5-prefix always available in practice.
+            let first_half: String = words.iter().take(5).copied().collect::<Vec<_>>().join(" ");
             phrases.push(first_half);
 
             if words.len() > 6 {
-                let last_half: String = words[words.len() - 4..].join(" ");
+                // WHY `.iter().skip(n)`: `words.len() - 4` is non-negative
+                // by the `words.len() > 6` guard; skipping avoids indexing.
+                let skip = words.len().saturating_sub(4);
+                let last_half: String = words
+                    .iter()
+                    .skip(skip)
+                    .copied()
+                    .collect::<Vec<_>>()
+                    .join(" ");
                 phrases.push(last_half);
             }
         }
@@ -373,14 +377,6 @@ fn tokenize(text: &str) -> Vec<String> {
 /// Compute Jaccard-style token overlap between two token sets.
 ///
 /// Returns the fraction of `fact_tokens` that appear in `transcript_tokens`.
-#[expect(
-    clippy::cast_precision_loss,
-    reason = "token counts are small (<1000); f64 mantissa handles this exactly"
-)]
-#[expect(
-    clippy::as_conversions,
-    reason = "usize to f64 — token counts are bounded and small"
-)]
 fn token_overlap(fact_tokens: &[String], transcript_tokens: &[String]) -> f64 {
     if fact_tokens.is_empty() {
         return 0.0;
@@ -389,7 +385,12 @@ fn token_overlap(fact_tokens: &[String], transcript_tokens: &[String]) -> f64 {
         .iter()
         .filter(|t| transcript_tokens.contains(t))
         .count();
-    matches as f64 / fact_tokens.len() as f64
+    // WHY f64::from(u32): token counts are small (<1000); u32→f64 is an
+    // exact conversion; `try_from` saturating to u32::MAX guards the
+    // pathological case.
+    let matches_u32 = u32::try_from(matches).unwrap_or(u32::MAX);
+    let total_u32 = u32::try_from(fact_tokens.len()).unwrap_or(u32::MAX);
+    f64::from(matches_u32) / f64::from(total_u32)
 }
 
 #[cfg(test)]

--- a/crates/melete/src/similarity.rs
+++ b/crates/melete/src/similarity.rs
@@ -30,13 +30,12 @@ impl PruningStats {
         if self.total_chunks == 0 {
             return 0.0;
         }
-        #[expect(
-            clippy::cast_precision_loss,
-            clippy::as_conversions,
-            reason = "usize->f64: chunk counts always fit in f64 mantissa"
-        )]
-        let result = (self.pruned_count as f64 / self.total_chunks as f64) * 100.0;
-        result
+        // WHY f64::from(u32): chunk counts fit in u32 (< 2^32); u32→f64 is
+        // an exact conversion; `try_from` saturating to u32::MAX guards
+        // the pathological case.
+        let pruned_u32 = u32::try_from(self.pruned_count).unwrap_or(u32::MAX);
+        let total_u32 = u32::try_from(self.total_chunks).unwrap_or(u32::MAX);
+        (f64::from(pruned_u32) / f64::from(total_u32)) * 100.0
     }
 }
 
@@ -109,13 +108,12 @@ pub(crate) fn jaccard_similarity(a: &HashSet<String>, b: &HashSet<String>) -> f6
         return 0.0;
     }
 
-    #[expect(
-        clippy::cast_precision_loss,
-        clippy::as_conversions,
-        reason = "usize->f64: set counts always fit in f64 mantissa"
-    )]
-    let result = intersection as f64 / union as f64;
-    result
+    // WHY f64::from(u32): set counts fit in u32 (< 2^32); u32→f64 is an
+    // exact conversion; `try_from` saturating to u32::MAX guards the
+    // pathological case.
+    let i_u32 = u32::try_from(intersection).unwrap_or(u32::MAX);
+    let u_u32 = u32::try_from(union).unwrap_or(u32::MAX);
+    f64::from(i_u32) / f64::from(u_u32)
 }
 
 /// Remove near-duplicate messages by Jaccard similarity.

--- a/crates/nous/src/audit.rs
+++ b/crates/nous/src/audit.rs
@@ -244,12 +244,12 @@ impl PromptAuditLog {
             poisoned.into_inner()
         });
 
-        let needs_rotation = match inner.current.as_ref() {
-            Some((d, _)) => *d != record_date,
-            None => true,
-        };
+        // WHY: compute once whether the currently-open file matches
+        // `record_date` so we can take the writable borrow from the right
+        // arm without a later `expect` on `Option::as_mut`.
+        let current_matches = matches!(inner.current.as_ref(), Some((d, _)) if *d == record_date);
 
-        if needs_rotation {
+        if !current_matches {
             if !self.log_dir.exists() {
                 std::fs::create_dir_all(&self.log_dir).context(CreateDirSnafu {
                     path: self.log_dir.clone(),
@@ -265,19 +265,14 @@ impl PromptAuditLog {
             inner.current = Some((record_date, file));
         }
 
-        // SAFETY: `needs_rotation` guarantees `current` is `Some` here.
-        #[expect(
-            clippy::expect_used,
-            reason = "current is Some: either it already was, or we just set it in the rotation branch above"
-        )]
-        let (_, file) = inner
-            .current
-            .as_mut()
-            .expect("current file populated above");
-
+        // WHY: `inner.current` is `Some` by construction -- either it
+        // already matched `record_date`, or we just replaced it in the
+        // rotation branch above. Use `if let` to avoid an `expect()`.
         let path = self.log_dir.join(format!("{record_date}.jsonl"));
-        writeln!(file, "{json}").context(WriteRecordSnafu { path: path.clone() })?;
-        file.flush().context(WriteRecordSnafu { path })?;
+        if let Some((_, file)) = inner.current.as_mut() {
+            writeln!(file, "{json}").context(WriteRecordSnafu { path: path.clone() })?;
+            file.flush().context(WriteRecordSnafu { path })?;
+        }
         Ok(())
     }
 }
@@ -335,16 +330,15 @@ pub(crate) fn build_audit_record(
     // already computed, plus the system-prompt byte length divided by a
     // conservative chars-per-token heuristic. Matches the order-of-magnitude
     // figure operators see in the tracing spans.
-    #[expect(
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation,
-        clippy::as_conversions,
-        reason = "i64→u32: per-message token estimates are positive and fit in u32 for practical turns"
-    )]
+    //
+    // WHY `try_from(...).unwrap_or(u32::MAX)`: per-message token estimates
+    // are positive for practical turns; if an implausible value ever
+    // overflowed u32 we prefer a saturated audit figure to a silent `as`
+    // truncation.
     let msg_tokens: u32 = ctx
         .messages
         .iter()
-        .map(|m| m.token_estimate.max(0) as u32)
+        .map(|m| u32::try_from(m.token_estimate.max(0)).unwrap_or(u32::MAX))
         .sum();
     let cpt = usize::try_from(config.generation.chars_per_token.max(1)).unwrap_or(4);
     let sys_tokens = u32::try_from(system_prompt_bytes / cpt).unwrap_or(u32::MAX);

--- a/crates/nous/src/competence/mod.rs
+++ b/crates/nous/src/competence/mod.rs
@@ -566,12 +566,11 @@ impl CompetenceTracker {
         let overall_score = if domains.is_empty() {
             self.config.default_score
         } else {
-            #[expect(
-                clippy::cast_precision_loss,
-                clippy::as_conversions,
-                reason = "usize→f64: competence domain count is under 100 (one per skill area); far below f64 mantissa 2^53"
-            )]
-            let len = domains.len() as f64;
+            // WHY f64::from(u32): competence domain count is under 100
+            // (one per skill area), so `try_from` is infallible in
+            // practice; u32→f64 is an exact conversion.
+            let len_u32 = u32::try_from(domains.len()).unwrap_or(u32::MAX);
+            let len = f64::from(len_u32);
             domains.iter().map(|d| d.score).sum::<f64>() / len
         };
 

--- a/crates/nous/src/recipes.rs
+++ b/crates/nous/src/recipes.rs
@@ -118,15 +118,14 @@ impl Recipe {
 
     /// Average token reduction percentage across all validation records.
     #[must_use]
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_precision_loss,
-        reason = "token counts are approximate; percentage precision loss is acceptable for display metrics"
-    )]
     pub fn avg_reduction_pct(&self) -> f64 {
         if self.validation.is_empty() {
             return 0.0;
         }
+        // WHY f64::from(u32): token counts and validation list sizes are
+        // bounded in practice (< 2^32); u32→f64 is exact. `try_from`
+        // guards the rare pathological case by saturating to u32::MAX
+        // before conversion.
         let total: f64 = self
             .validation
             .iter()
@@ -135,26 +134,26 @@ impl Recipe {
                     0.0
                 } else {
                     let reduction = v.baseline_tokens.saturating_sub(v.recipe_tokens);
-                    (reduction as f64 / v.baseline_tokens as f64) * 100.0
+                    let r_u32 = u32::try_from(reduction).unwrap_or(u32::MAX);
+                    let b_u32 = u32::try_from(v.baseline_tokens).unwrap_or(u32::MAX);
+                    (f64::from(r_u32) / f64::from(b_u32)) * 100.0
                 }
             })
             .sum();
-        total / self.validation.len() as f64
+        let len_u32 = u32::try_from(self.validation.len()).unwrap_or(u32::MAX);
+        total / f64::from(len_u32)
     }
 
-    /// Success rate across validation records (0.0–1.0).
+    /// Success rate across validation records (0.0--1.0).
     #[must_use]
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_precision_loss,
-        reason = "count→f64: validation list length fits in f64 mantissa for percentage display"
-    )]
     pub fn success_rate(&self) -> f64 {
         if self.validation.is_empty() {
             return 0.0;
         }
         let successes = self.validation.iter().filter(|v| v.success).count();
-        successes as f64 / self.validation.len() as f64
+        let s_u32 = u32::try_from(successes).unwrap_or(u32::MAX);
+        let len_u32 = u32::try_from(self.validation.len()).unwrap_or(u32::MAX);
+        f64::from(s_u32) / f64::from(len_u32)
     }
 }
 

--- a/crates/nous/src/training/dpo.rs
+++ b/crates/nous/src/training/dpo.rs
@@ -293,12 +293,13 @@ impl DpoExtractor {
         let intersection: HashSet<&String> = original_words.intersection(&chosen_words).collect();
         let union: HashSet<&String> = original_words.union(&chosen_words).collect();
 
-        #[expect(
-            clippy::cast_precision_loss,
-            clippy::as_conversions,
-            reason = "set cardinalities for Jaccard similarity — precision loss above 2^53 elements is harmless for this small-vocabulary similarity heuristic"
-        )]
-        let similarity = intersection.len() as f64 / union.len() as f64;
+        // WHY f64::from(u32): set cardinalities for a small-vocabulary
+        // Jaccard similarity are bounded by the message word count
+        // (< 2^32), so `try_from` is infallible in practice; u32→f64 is
+        // an exact conversion.
+        let i_u32 = u32::try_from(intersection.len()).unwrap_or(u32::MAX);
+        let u_u32 = u32::try_from(union.len()).unwrap_or(u32::MAX);
+        let similarity = f64::from(i_u32) / f64::from(u_u32);
         similarity >= SEMANTIC_SIMILARITY_THRESHOLD
     }
 }

--- a/crates/nous/src/uncertainty.rs
+++ b/crates/nous/src/uncertainty.rs
@@ -525,12 +525,11 @@ fn compute_calibration_curve(points: &[(f64, bool)]) -> Vec<CalibrationBin> {
     let mut bins = Vec::with_capacity(NUM_BINS);
 
     for i in 0..NUM_BINS {
-        #[expect(
-            clippy::cast_precision_loss,
-            clippy::as_conversions,
-            reason = "usize→f64: bin index bounded by NUM_BINS (10); cast is exact, far below f64 mantissa 2^53"
-        )]
-        let low = i as f64 * BIN_WIDTH;
+        // WHY f64::from(u32): bin index is bounded by NUM_BINS (10), so
+        // `try_from` is infallible in practice; u32→f64 is an exact
+        // conversion (u32 values fit in f64 mantissa exactly).
+        let i_u32 = u32::try_from(i).unwrap_or(u32::MAX);
+        let low = f64::from(i_u32) * BIN_WIDTH;
         let high = low + BIN_WIDTH;
         let low_rounded = (low * 100.0).round() / 100.0;
         let high_rounded = (high * 100.0).round() / 100.0;
@@ -576,12 +575,11 @@ fn compute_brier_score(points: &[(f64, bool)]) -> f64 {
         })
         .sum();
 
-    #[expect(
-        clippy::cast_precision_loss,
-        clippy::as_conversions,
-        reason = "usize→f64: calibration point count bounded by MAX_CALIBRATION_POINTS (1000); far below f64 mantissa 2^53"
-    )]
-    let count = points.len() as f64;
+    // WHY f64::from(u32): calibration point count is bounded by
+    // MAX_CALIBRATION_POINTS (1000), so `try_from` is infallible in
+    // practice; u32→f64 is an exact conversion.
+    let count_u32 = u32::try_from(points.len()).unwrap_or(u32::MAX);
+    let count = f64::from(count_u32);
     sum / count
 }
 

--- a/crates/theatron/koilon/src/view/planning.rs
+++ b/crates/theatron/koilon/src/view/planning.rs
@@ -13,23 +13,22 @@ const HEADER_HEIGHT: u16 = 3;
 const STATUS_BAR_HEIGHT: u16 = 1;
 const CONTENT_MIN_HEIGHT: u16 = 5;
 
-#[expect(
-    clippy::indexing_slicing,
-    reason = "Layout.split() returns exactly as many Rects as constraints; indices match the three defined constraints"
-)]
 pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let layout = Layout::default()
+    // WHY `.areas::<3>()`: returns a const-sized array matching the three
+    // layout constraints, so destructuring lets us name each region
+    // without indexing into the dynamically-sized `.split()` result.
+    let [header, body, status] = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(HEADER_HEIGHT),
             Constraint::Min(CONTENT_MIN_HEIGHT),
             Constraint::Length(STATUS_BAR_HEIGHT),
         ])
-        .split(area);
+        .areas(area);
 
-    render_header(frame, layout[0], theme);
-    render_phases(app, frame, layout[1], theme);
-    render_status_bar(frame, layout[2], theme);
+    render_header(frame, header, theme);
+    render_phases(app, frame, body, theme);
+    render_status_bar(frame, status, theme);
 }
 
 fn render_header(frame: &mut Frame, area: Rect, theme: &Theme) {

--- a/crates/theatron/koilon/src/view/retrospective.rs
+++ b/crates/theatron/koilon/src/view/retrospective.rs
@@ -13,23 +13,21 @@ const HEADER_HEIGHT: u16 = 3;
 const STATUS_BAR_HEIGHT: u16 = 1;
 const CONTENT_MIN_HEIGHT: u16 = 5;
 
-#[expect(
-    clippy::indexing_slicing,
-    reason = "Layout.split() returns exactly as many Rects as constraints; indices match the three defined constraints"
-)]
 pub(crate) fn render(app: &App, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let layout = Layout::default()
+    // WHY `.areas::<3>()`: returns a const-sized array matching the three
+    // layout constraints, so destructuring names each region directly.
+    let [header, body, status] = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(HEADER_HEIGHT),
             Constraint::Min(CONTENT_MIN_HEIGHT),
             Constraint::Length(STATUS_BAR_HEIGHT),
         ])
-        .split(area);
+        .areas(area);
 
-    render_header(frame, layout[0], theme);
-    render_completed_phases(app, frame, layout[1], theme);
-    render_status_bar(frame, layout[2], theme);
+    render_header(frame, header, theme);
+    render_completed_phases(app, frame, body, theme);
+    render_status_bar(frame, status, theme);
 }
 
 fn render_header(frame: &mut Frame, area: Rect, theme: &Theme) {

--- a/crates/theatron/koilon/src/wizard/state.rs
+++ b/crates/theatron/koilon/src/wizard/state.rs
@@ -113,9 +113,15 @@ impl EditState {
 
     pub(crate) fn delete_before(&mut self) {
         if self.cursor > 0 {
-            let prev = self.buffer[..self.cursor]
-                .char_indices()
-                .next_back()
+            // WHY `.get(..cursor)`: cursor is maintained on char
+            // boundaries by construction, so the slice is always valid;
+            // `.get()` returns `None` only for an inconsistent cursor
+            // invariant, and treating that as a no-op is safer than a
+            // panic in a hot-path UI state update.
+            let prev = self
+                .buffer
+                .get(..self.cursor)
+                .and_then(|s| s.char_indices().next_back())
                 .map_or(0, |(i, _)| i);
             self.buffer.remove(prev);
             self.cursor = prev;
@@ -124,9 +130,13 @@ impl EditState {
 
     pub(crate) fn move_left(&mut self) {
         if self.cursor > 0 {
-            self.cursor = self.buffer[..self.cursor]
-                .char_indices()
-                .next_back()
+            // WHY `.get(..cursor)`: see `delete_before` -- `.get()` avoids
+            // the panic surface of direct byte-slicing when cursor drifts
+            // off a char boundary.
+            self.cursor = self
+                .buffer
+                .get(..self.cursor)
+                .and_then(|s| s.char_indices().next_back())
                 .map_or(0, |(i, _)| i);
         }
     }

--- a/crates/theatron/koilon/src/wizard/view.rs
+++ b/crates/theatron/koilon/src/wizard/view.rs
@@ -231,7 +231,11 @@ fn editing_span(edit: &EditState, secret: bool, theme: &Theme) -> Span<'static> 
         s.push('▎');
         s
     } else {
-        let before = &edit.buffer[..edit.cursor];
+        // WHY `.get(..cursor)`: cursor is a byte offset maintained on
+        // char boundaries, so `.get()` returns `Some` in the invariant
+        // case; fall back to the whole buffer if the invariant drifts,
+        // which is safer than a panic inside a hot-path render.
+        let before = edit.buffer.get(..edit.cursor).unwrap_or(&edit.buffer);
         format!("{before}▎")
     };
 
@@ -348,10 +352,6 @@ fn keybinding_next_back_spans(
 // ─── Layout helper ───────────────────────────────────────────────────────────
 
 /// Split `area` vertically into fixed-height rows.  A height of `0` means fill remaining space.
-#[expect(
-    clippy::indexing_slicing,
-    reason = "slice built from caller-supplied array; len matches N, so indexing [0..N] is valid"
-)]
 fn split_vertical<const N: usize>(area: Rect, heights: &[u16; N]) -> [Rect; N] {
     let constraints: Vec<Constraint> = heights
         .iter()
@@ -369,9 +369,13 @@ fn split_vertical<const N: usize>(area: Rect, heights: &[u16; N]) -> [Rect; N] {
         .constraints(constraints)
         .split(area);
 
+    // WHY `.get().copied().unwrap_or_default()`: `Layout::split` returns
+    // exactly `N` rects for `N` constraints, so `.get(i)` is `Some` in
+    // practice; falling back to `Rect::default()` keeps rendering safe
+    // if ratatui ever changes the contract.
     let mut result = [Rect::default(); N];
-    for i in 0..N {
-        result[i] = chunks[i];
+    for (i, slot) in result.iter_mut().enumerate() {
+        *slot = chunks.get(i).copied().unwrap_or_default();
     }
     result
 }


### PR DESCRIPTION
## Summary

Scoped to 6 crates. 442 → 412 in-scope violations (−30). Smaller drop than other waves because two architectural walls dominate the remaining count — detailed below.

## Per-rule (scoped)

| Crate | as-cast | expect | indexing | pub-vis | string-slice | lock-exp | unreachable |
|---|---|---|---|---|---|---|---|
| nous | 9→1 | 3→2 | 3→3 | 0→0 | 3→3 | 0→0 | 0→0 |
| hermeneus | 1→0 | 12→12 | 0→0 | 0→0 | 0→0 | 2→0 | 0→0 |
| melete | 6→0 | 0→0 | 0→0 | 0→0 | 1→0 | 0→0 | 0→0 |
| agora | 0→0 | 2→2 | 0→0 | 24→24 | 0→0 | 0→0 | 0→0 |
| koina | 69→69 | 6→6 | 18→18 | 34→34 | 2→2 | 2→2 | 4→4 |
| koilon | 14→14 | 3→3 | 95→88 | 3→3 | 9→5 | 0→0 | 1→1 |

## Techniques applied

- `try_from().unwrap_or(u32::MAX)` saturating for lossy→safe token-count casts
- `f64::from(u32)` for exact numeric promotion (8 sites: recipes/competence/dpo/uncertainty/melete)
- `PoisonError::into_inner` for non-cascading lock recovery (hermeneus -2 lock-expect-panics)
- `Layout::areas::<N>` destructuring for ratatui split without indexing (koilon)
- `.get(..n)` + fallback for char-boundary string slicing
- `audit.rs` rotation branch refactored to eliminate `Option::as_mut().expect(...)`

## Flagged for operator (architectural walls)

### 1. `LazyLock<Regex>` compile-time statics

10 expects in `hermeneus/complexity`, 2 in `nous/training/pii`, plus koina `ulid.rs` / `uuid.rs` blocks. The codebase universally wraps these in `#[expect(clippy::expect_used)]`. `unwrap_or_else(|_| unreachable!())` trades `RUST/expect` for `RUST/unreachable-in-match`. Fix needs either a compile-time regex crate (e.g. `regex-lite` + `OnceLock` with proc-macro validation) or a kanon-rule waiver for `LazyLock<T> = LazyLock::new(|| compile_static())`.

### 2. koina `ulid.rs` DECODE const-table

63× as-cast + 17× indexing all live in a single compile-time `const DECODE: [u8; 256]` lookup table. Crockford-base32 ASCII invariants guarantee safety; fix needs stable `const TryFrom` assignment which is awkward.

### 3. `u64 → f64` precision-loss cast for ratio arithmetic

`nous/compact/full.rs:58` token-budget trigger. `f64::from(u32)` works where values fit u32 (applied elsewhere). For genuine u64 magnitudes, no clean suppression-free path without O(N) workarounds.

### 4. agora (24) and koina (34) pub-visibility

Many impl methods on pub structs flagged; narrowing impl visibility below the owning type creates asymmetric API surface. Rule needs to understand impl-method visibility inheritance.

## Verification

- [x] `cargo check --workspace --features test-core --all-targets` clean
- [x] `cargo clippy --workspace --features test-core --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --features test-core --no-fail-fast` pass
- [x] `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)