### PR TITLE
fix(rand): migrate 0.9 → 0.10 API (RngExt, SysRng, TryRng renames)

### DIFF
--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -527,7 +527,7 @@ fn sample_random<T: Clone>(items: &[T], count: usize) -> Vec<T> {
     if count >= items.len() {
         return items.to_vec();
     }
-    items.choose_multiple(&mut rng, count).cloned().collect()
+    items.sample(&mut rng, count).cloned().collect()
 }
 
 // --- dedup ---

--- a/crates/energeia/src/cron.rs
+++ b/crates/energeia/src/cron.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use compact_str::CompactString;
 use fjall::Readable;
-use rand::Rng;
+use rand::RngExt;
 use snafu::IntoError;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;

--- a/crates/koina/src/retry.rs
+++ b/crates/koina/src/retry.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::future::Future;
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 
 /// Backoff strategy for computing retry delays between attempts.
 ///

--- a/crates/koina/src/ulid.rs
+++ b/crates/koina/src/ulid.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;
 
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
 /// Crockford base32 alphabet (uppercase).

--- a/crates/krites/src/data/functions/temporal.rs
+++ b/crates/krites/src/data/functions/temporal.rs
@@ -23,7 +23,8 @@ use compact_str::CompactString;
 use itertools::Itertools;
 #[cfg(target_arch = "wasm32")]
 use js_sys::Date;
-use rand::prelude::*;
+use rand::RngExt;
+use rand::seq::IndexedRandom;
 
 use super::arg;
 use crate::data::error::*;

--- a/crates/krites/src/data/functions/vector.rs
+++ b/crates/krites/src/data/functions/vector.rs
@@ -13,7 +13,7 @@
 )]
 
 use koina::base64;
-use rand::Rng;
+use rand::RngExt;
 
 use super::arg;
 use crate::data::error::*;

--- a/crates/krites/src/runtime/hnsw/search.rs
+++ b/crates/krites/src/runtime/hnsw/search.rs
@@ -235,7 +235,7 @@ impl SessionTx<'_> {
 mod tests {
     use std::collections::BTreeMap;
 
-    use rand::Rng;
+    use rand::RngExt;
 
     use super::*;
     use crate::DbInstance;

--- a/crates/krites/src/runtime/hnsw/types.rs
+++ b/crates/krites/src/runtime/hnsw/types.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroUsize;
 
 use compact_str::CompactString;
 use lru::LruCache;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::DataValue;
 use crate::data::relation::VecElementType;

--- a/crates/krites/src/runtime/minhash_lsh.rs
+++ b/crates/krites/src/runtime/minhash_lsh.rs
@@ -15,7 +15,7 @@ use std::hash::{Hash, Hasher};
 
 use compact_str::CompactString;
 use itertools::Itertools;
-use rand::RngCore;
+use rand::Rng;
 use rustc_hash::FxHashSet;
 use twox_hash::XxHash32;
 

--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 use tracing::instrument;
 
 use crate::error::{self, Result};

--- a/crates/symbolon/src/credential/pkce.rs
+++ b/crates/symbolon/src/credential/pkce.rs
@@ -9,7 +9,7 @@ use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
 
 use koina::secret::SecretString;
-use rand::TryRngCore as _;
+use rand::TryRng as _;
 use sha2::{Digest, Sha256};
 use snafu::{ResultExt, Snafu};
 use tracing::{debug, info};
@@ -227,7 +227,7 @@ impl PkcePair {
     fn generate() -> Result<Self> {
         // WHY: RFC 7636 recommends minimum 43 chars, max 128 chars for verifier.
         // We generate 128 bytes of randomness which becomes ~171 chars base64url.
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rngs::SysRng;
         let mut verifier_bytes = vec![0u8; 128];
         rng.try_fill_bytes(&mut verifier_bytes)
             .map_err(|_e| PkceError::RandomGeneration {
@@ -282,7 +282,7 @@ struct CallbackData {
 
 /// Generate a cryptographically random state parameter for CSRF protection.
 fn generate_state() -> Result<String> {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rngs::SysRng;
     let mut bytes = vec![0u8; 32];
     rng.try_fill_bytes(&mut bytes)
         .map_err(|_e| PkceError::RandomGeneration {


### PR DESCRIPTION
## Summary

Dependabot PR #3756 bumped `rand` from 0.9 → 0.10 without a clippy gate (phase-05e cutover moved clippy to the forge but the GH auto-merge path didn't block on forge-CI). Main has been red since: `cargo clippy --workspace --all-targets -- -D warnings` failed because rand 0.10 moves the free-function surface behind the new `RngExt` trait and renames a handful of APIs.

This PR applies the minimum mechanical migration across every affected call site so main builds clean again.

## API changes applied

| rand 0.9 | rand 0.10 | sites |
|---|---|---|
| `use rand::Rng` | `use rand::RngExt` | 7 files |
| `use rand::RngCore` (for `next_u32`) | `use rand::Rng` | `minhash_lsh.rs` |
| `use rand::prelude::*` | explicit `use rand::RngExt` + `use rand::seq::IndexedRandom` | `temporal.rs`, `vector.rs` |
| `.choose_multiple(...)` | `.sample(...)` | `memory/mod.rs` |
| `rand::rngs::OsRng` | `rand::rngs::SysRng` | `api_key.rs`, `pkce.rs` |
| `rand::TryRngCore` | `rand::TryRng` | `pkce.rs` |

## Files touched

- `crates/koina/src/retry.rs`
- `crates/koina/src/ulid.rs`
- `crates/krites/src/runtime/hnsw/types.rs`
- `crates/krites/src/runtime/hnsw/search.rs`
- `crates/krites/src/runtime/minhash_lsh.rs`
- `crates/krites/src/data/functions/vector.rs`
- `crates/krites/src/data/functions/temporal.rs`
- `crates/energeia/src/cron.rs`
- `crates/symbolon/src/api_key.rs`
- `crates/symbolon/src/credential/pkce.rs`
- `crates/aletheia/src/commands/memory/mod.rs`

11 files, surface expansion over the issue body's 10 listed sites picked up during compilation (`memory/mod.rs` + `pkce.rs` had 0.10-affected call sites that weren't listed).

## Related follow-up work

- #3768 closes the auto-merge-without-clippy gap that let this land.
- #3766 closes the forge-CI-not-triggered-on-GH-merge gap that hid this from forge CI for a day.

## Test plan

- [x] `cargo check --workspace --features test-core --all-targets --jobs 8` passes
- [x] `cargo clippy --workspace --features test-core --all-targets --jobs 8 -- -D warnings` passes
- [ ] `cargo nextest run --workspace --features test-core --build-jobs 8 --test-threads 8` (running in forge CI)
- [ ] Forge CI green on the merge SHA

Closes #3767