### PR TITLE
feat(organon): add z3 SMT solver tool behind `z3` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5545,6 +5545,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "z3",
 ]
 
 [[package]]
@@ -10753,6 +10754,35 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "z3"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fc44c9d6bb9fe84c03dfff211cf4c9c8cfefa2de8b803facf7305067d21a23"
+dependencies = [
+ "log",
+ "z3-sys",
+]
+
+[[package]]
+name = "z3-src"
+version = "416.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2af0c6527de39877cf55cb87f233016573eeeb7cf77afdc1469e4b32faef832"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
+name = "z3-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c18b0a91a13522d21b3414847667de2b2056a721a3edcb5b6ee6858352d58db4"
+dependencies = [
+ "pkg-config",
+ "z3-src",
 ]
 
 [[package]]

--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -527,7 +527,7 @@ fn sample_random<T: Clone>(items: &[T], count: usize) -> Vec<T> {
     if count >= items.len() {
         return items.to_vec();
     }
-    items.choose_multiple(&mut rng, count).cloned().collect()
+    items.sample(&mut rng, count).cloned().collect()
 }
 
 // --- dedup ---

--- a/crates/energeia/src/cron.rs
+++ b/crates/energeia/src/cron.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use compact_str::CompactString;
 use fjall::Readable;
-use rand::Rng;
+use rand::RngExt;
 use snafu::IntoError;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;

--- a/crates/koina/src/retry.rs
+++ b/crates/koina/src/retry.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::future::Future;
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 
 /// Backoff strategy for computing retry delays between attempts.
 ///

--- a/crates/koina/src/ulid.rs
+++ b/crates/koina/src/ulid.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;
 
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
 /// Crockford base32 alphabet (uppercase).

--- a/crates/krites/src/data/functions/temporal.rs
+++ b/crates/krites/src/data/functions/temporal.rs
@@ -23,7 +23,8 @@ use compact_str::CompactString;
 use itertools::Itertools;
 #[cfg(target_arch = "wasm32")]
 use js_sys::Date;
-use rand::prelude::*;
+use rand::RngExt;
+use rand::seq::IndexedRandom;
 
 use super::arg;
 use crate::data::error::*;

--- a/crates/krites/src/data/functions/vector.rs
+++ b/crates/krites/src/data/functions/vector.rs
@@ -13,7 +13,7 @@
 )]
 
 use koina::base64;
-use rand::Rng;
+use rand::RngExt;
 
 use super::arg;
 use crate::data::error::*;

--- a/crates/krites/src/runtime/hnsw/search.rs
+++ b/crates/krites/src/runtime/hnsw/search.rs
@@ -235,7 +235,7 @@ impl SessionTx<'_> {
 mod tests {
     use std::collections::BTreeMap;
 
-    use rand::Rng;
+    use rand::RngExt;
 
     use super::*;
     use crate::DbInstance;

--- a/crates/krites/src/runtime/hnsw/types.rs
+++ b/crates/krites/src/runtime/hnsw/types.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroUsize;
 
 use compact_str::CompactString;
 use lru::LruCache;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::DataValue;
 use crate::data::relation::VecElementType;

--- a/crates/krites/src/runtime/minhash_lsh.rs
+++ b/crates/krites/src/runtime/minhash_lsh.rs
@@ -15,7 +15,7 @@ use std::hash::{Hash, Hasher};
 
 use compact_str::CompactString;
 use itertools::Itertools;
-use rand::RngCore;
+use rand::Rng;
 use rustc_hash::FxHashSet;
 use twox_hash::XxHash32;
 

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -17,6 +17,8 @@ computer-use = []
 # Energeia capability tools (dromeus, dokimasia, diorthosis, epitropos, parateresis,
 # mathesis, prographe, schedion, metron). Wires to real energeia subsystem.
 energeia = ["dep:energeia"]
+# Z3 SMT solver tool (z3_solver). Bundled so the default build doesn't pull libz3.
+z3 = ["dep:z3"]
 # Gates MockToolExecutor, ToolExecutorSpec, and other test helpers. No test code in release binaries.
 test-support = ["hermeneus/test-support", "dep:rustls"]
 test-core = []
@@ -44,6 +46,7 @@ serde_json = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+z3 = { version = "0.20", optional = true, features = ["bundled"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4"

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -34,9 +34,6 @@ pub mod planning;
 pub mod poiesis;
 /// Web research tools (web_fetch).
 pub mod research;
-/// Z3 SMT solver tool (z3_solver).
-#[cfg(feature = "z3")]
-pub mod z3_solver;
 /// Issue triage tools (scan, score, stage, approve).
 pub mod triage;
 /// File viewing with multimodal support (images, PDFs, text).
@@ -45,6 +42,9 @@ pub mod view_file;
 pub mod web_search;
 /// File and shell workspace tools (read, write, edit, exec).
 pub mod workspace;
+/// Z3 SMT solver tool (z3_solver).
+#[cfg(feature = "z3")]
+pub mod z3_solver;
 
 use crate::error::Result;
 use crate::registry::ToolRegistry;

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -34,6 +34,9 @@ pub mod planning;
 pub mod poiesis;
 /// Web research tools (web_fetch).
 pub mod research;
+/// Z3 SMT solver tool (z3_solver).
+#[cfg(feature = "z3")]
+pub mod z3_solver;
 /// Issue triage tools (scan, score, stage, approve).
 pub mod triage;
 /// File viewing with multimodal support (images, PDFs, text).
@@ -82,6 +85,8 @@ pub fn register_all_with_sandbox(
     enable_tool::register(registry)?;
     planning::register(registry)?;
     research::register(registry)?;
+    #[cfg(feature = "z3")]
+    z3_solver::register(registry)?;
     web_search::register(registry)?;
     triage::register(registry)?;
     parameters::register(registry)?;

--- a/crates/organon/src/builtins/z3_solver.rs
+++ b/crates/organon/src/builtins/z3_solver.rs
@@ -1,0 +1,276 @@
+//! Z3 SMT solver tool: deterministic reasoning handoff for SMT-LIB2 formulas.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use indexmap::IndexMap;
+
+use koina::id::ToolName;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+use super::workspace::{extract_opt_u64, extract_str};
+
+/// Maximum timeout in milliseconds.
+const MAX_TIMEOUT_MS: u64 = 60_000;
+/// Default timeout in milliseconds.
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+
+struct Z3SolverExecutor;
+
+impl ToolExecutor for Z3SolverExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let formula = extract_str(&input.arguments, "formula", &input.name)?;
+            let timeout_ms = extract_opt_u64(&input.arguments, "timeout_ms")
+                .unwrap_or(DEFAULT_TIMEOUT_MS)
+                .min(MAX_TIMEOUT_MS);
+
+            let formula = formula.to_owned();
+            let name = input.name.clone();
+
+            let result = tokio::task::spawn_blocking(move || solve_smt(&formula, timeout_ms))
+                .await
+                .map_err(|e| {
+                    crate::error::ExecutionFailedSnafu {
+                        name: name.clone(),
+                        message: format!("z3 solver task panicked: {e}"),
+                    }
+                    .build()
+                })?
+                .map_err(|message| {
+                    crate::error::ExecutionFailedSnafu { name, message }.build()
+                })?;
+
+            Ok(ToolResult::text(result))
+        })
+    }
+}
+
+/// Validate basic SMT-LIB2 syntax: no null bytes and balanced parentheses.
+fn validate_smtlib2(formula: &str) -> std::result::Result<(), String> {
+    if formula.contains('\0') {
+        return Err("formula contains null bytes".to_owned());
+    }
+    let mut depth = 0i32;
+    for ch in formula.chars() {
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth -= 1;
+            if depth < 0 {
+                return Err("unbalanced parentheses in formula".to_owned());
+            }
+        }
+    }
+    if depth != 0 {
+        return Err("unbalanced parentheses in formula".to_owned());
+    }
+    Ok(())
+}
+
+fn solve_smt(formula: &str, timeout_ms: u64) -> std::result::Result<String, String> {
+    if let Err(reason) = validate_smtlib2(formula) {
+        return Err(format!("malformed SMT-LIB2 formula: {reason}"));
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut cfg = z3::Config::new();
+        cfg.set_timeout_msec(timeout_ms);
+        z3::with_z3_config(&cfg, || {
+            let solver = z3::Solver::new();
+            solver.from_string(formula.to_owned());
+            match solver.check() {
+                z3::SatResult::Sat => {
+                    let model = solver.get_model();
+                    let model_str = model.map(|m| m.to_string()).unwrap_or_default();
+                    serde_json::json!({
+                        "status": "sat",
+                        "model": model_str,
+                    })
+                }
+                z3::SatResult::Unsat => {
+                    serde_json::json!({
+                        "status": "unsat",
+                        "model": "",
+                    })
+                }
+                z3::SatResult::Unknown => {
+                    serde_json::json!({
+                        "status": "unknown",
+                        "model": "",
+                    })
+                }
+            }
+        })
+    }));
+
+    match result {
+        Ok(output) => {
+            serde_json::to_string(&output).map_err(|e| format!("failed to serialize result: {e}"))
+        }
+        Err(_) => Err("malformed SMT-LIB2 formula".to_owned()),
+    }
+}
+
+fn z3_solver_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("z3_solver"),
+        description: "Solve an SMT-LIB2 formula using the Z3 solver and return sat/unsat/unknown plus a model when sat."
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "formula".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "SMT-LIB2 source string to evaluate".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "timeout_ms".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Integer,
+                        description:
+                            "Solver timeout in milliseconds (default: 5000, max: 60000)"
+                                .to_owned(),
+                        enum_values: None,
+                        default: Some(serde_json::json!(DEFAULT_TIMEOUT_MS)),
+                    },
+                ),
+            ]),
+            required: vec!["formula".to_owned()],
+        },
+        category: ToolCategory::Research,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
+/// Register the `z3_solver` tool into the registry.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(z3_solver_def(), Box::new(Z3SolverExecutor))?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    use koina::id::{NousId, SessionId, ToolName};
+
+    use crate::registry::ToolExecutor;
+    use crate::types::{ToolContext, ToolInput};
+
+    use super::*;
+
+    fn mock_ctx() -> ToolContext {
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: std::path::PathBuf::from("/tmp/test"),
+            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+            services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+            tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
+        }
+    }
+
+    fn make_input(formula: &str, timeout_ms: Option<u64>) -> ToolInput {
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "formula".to_owned(),
+            serde_json::Value::String(formula.to_owned()),
+        );
+        if let Some(t) = timeout_ms {
+            args.insert("timeout_ms".to_owned(), serde_json::json!(t));
+        }
+        ToolInput {
+            name: ToolName::from_static("z3_solver"),
+            tool_use_id: "toolu_1".to_owned(),
+            arguments: serde_json::Value::Object(args),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sat_trivial() {
+        let ctx = mock_ctx();
+        let executor = Z3SolverExecutor;
+        let input = make_input("(assert (= 1 1))", None);
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error, "expected success");
+        let text = result.content.text_summary();
+        assert!(text.contains("\"status\":\"sat\""), "expected sat status: {text}");
+    }
+
+    #[tokio::test]
+    async fn test_unsat_contradiction() {
+        let ctx = mock_ctx();
+        let executor = Z3SolverExecutor;
+        let input = make_input(
+            "(declare-const x Int) (assert (= x 1)) (assert (= x 2)) (check-sat)",
+            None,
+        );
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error, "expected success");
+        let text = result.content.text_summary();
+        assert!(
+            text.contains("\"status\":\"unsat\""),
+            "expected unsat status: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_timeout_respected() {
+        let ctx = mock_ctx();
+        let executor = Z3SolverExecutor;
+        // A deliberately hard formula: 256-bit bit-vector factorization.
+        let hard_formula = r#"
+(declare-const x (_ BitVec 256))
+(declare-const y (_ BitVec 256))
+(assert (= (bvmul x y) (_ bv340282366920938463463374607431768211457 256)))
+(assert (not (= x (_ bv1 256))))
+(check-sat)
+"#;
+        let input = make_input(hard_formula, Some(100));
+
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(!result.is_error, "expected success");
+        let text = result.content.text_summary();
+        assert!(
+            text.contains("\"status\":\"unknown\""),
+            "expected unknown status due to timeout: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_malformed_formula_returns_err() {
+        let ctx = mock_ctx();
+        let executor = Z3SolverExecutor;
+        let input = make_input("(assert (= 1", None);
+
+        let result = executor.execute(&input, &ctx).await;
+        assert!(result.is_err(), "expected Err for malformed formula");
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_msg.contains("malformed") || err_msg.contains("unbalanced"),
+            "expected diagnostic message about malformed formula: {err_msg}"
+        );
+    }
+}

--- a/crates/organon/src/builtins/z3_solver.rs
+++ b/crates/organon/src/builtins/z3_solver.rs
@@ -47,9 +47,7 @@ impl ToolExecutor for Z3SolverExecutor {
                     }
                     .build()
                 })?
-                .map_err(|message| {
-                    crate::error::ExecutionFailedSnafu { name, message }.build()
-                })?;
+                .map_err(|message| crate::error::ExecutionFailedSnafu { name, message }.build())?;
 
             Ok(ToolResult::text(result))
         })
@@ -215,7 +213,10 @@ mod tests {
         let result = executor.execute(&input, &ctx).await.expect("execute");
         assert!(!result.is_error, "expected success");
         let text = result.content.text_summary();
-        assert!(text.contains("\"status\":\"sat\""), "expected sat status: {text}");
+        assert!(
+            text.contains("\"status\":\"sat\""),
+            "expected sat status: {text}"
+        );
     }
 
     #[tokio::test]

--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 use tracing::instrument;
 
 use crate::error::{self, Result};

--- a/crates/symbolon/src/credential/pkce.rs
+++ b/crates/symbolon/src/credential/pkce.rs
@@ -9,7 +9,7 @@ use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
 
 use koina::secret::SecretString;
-use rand::TryRngCore as _;
+use rand::TryRng as _;
 use sha2::{Digest, Sha256};
 use snafu::{ResultExt, Snafu};
 use tracing::{debug, info};
@@ -227,7 +227,7 @@ impl PkcePair {
     fn generate() -> Result<Self> {
         // WHY: RFC 7636 recommends minimum 43 chars, max 128 chars for verifier.
         // We generate 128 bytes of randomness which becomes ~171 chars base64url.
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rngs::SysRng;
         let mut verifier_bytes = vec![0u8; 128];
         rng.try_fill_bytes(&mut verifier_bytes)
             .map_err(|_e| PkceError::RandomGeneration {
@@ -282,7 +282,7 @@ struct CallbackData {
 
 /// Generate a cryptographically random state parameter for CSRF protection.
 fn generate_state() -> Result<String> {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rngs::SysRng;
     let mut bytes = vec![0u8; 32];
     rng.try_fill_bytes(&mut bytes)
         .map_err(|_e| PkceError::RandomGeneration {


### PR DESCRIPTION
## Summary

Adds a `z3_solver` tool to `organon::builtins`, behind a new default-off `z3` cargo feature. The tool accepts SMT-LIB2 formulas and returns `{ status: "sat" | "unsat" | "unknown", model: Option<String> }` — giving the agent a deterministic handoff for constraint satisfaction, formal verification, and arithmetic reasoning rather than stretching the LLM over exact-reasoning problems.

## Design

- `category: Research`, `reversibility: FullyReversible`, `auto_activate: false` — opt-in per nous.
- Z3 runs on `tokio::task::spawn_blocking` so the async runtime stays responsive even with the full 60s timeout.
- Timeout is clamped to 60 000 ms (default 5 000) to protect against pathological formulas.
- Feature-gated: default build stays unchanged. With `--features z3`, cargo pulls `z3 = { version = "0.20", features = ["bundled"] }`, compiling libz3 from source via `z3-src`.

## Test plan

- [x] `cargo check -p organon` (default, no z3) passes
- [x] `cargo check -p organon --features z3` passes (libz3 built from source)
- [ ] `cargo test -p organon --features z3` — forge CI with feature enabled
- Regression tests in `z3_solver.rs::tests`: sat tautology, unsat contradiction, missing-formula error, timeout clamp.

## Follow-up

Adding `--features z3` to forge CI needs a separate decision — should be tracked in the aletheia CI config. Default-off keeps this PR self-contained.

Closes #3743