### PR TITLE
fix(hermeneus): propagate deployment_target to OpenAI-compat provider (sovereignty)

### DIFF
--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -527,7 +527,7 @@ fn sample_random<T: Clone>(items: &[T], count: usize) -> Vec<T> {
     if count >= items.len() {
         return items.to_vec();
     }
-    items.choose_multiple(&mut rng, count).cloned().collect()
+    items.sample(&mut rng, count).cloned().collect()
 }
 
 // --- dedup ---

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -14,7 +14,9 @@ use agora::semeion::client::SignalClient;
 use agora::types::ChannelProvider;
 use hermeneus::anthropic::{AnthropicProvider, ProviderBehavior};
 use hermeneus::openai::{OpenAiProvider, OpenAiProviderConfig};
-use hermeneus::provider::{ProviderConfig, ProviderRegistry};
+use hermeneus::provider::{
+    DeploymentTarget as HermeneusDeploymentTarget, ProviderConfig, ProviderRegistry,
+};
 use koina::credential::{CredentialProvider, CredentialSource};
 use koina::secret::SecretString;
 use mneme::embedding::{
@@ -189,6 +191,29 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
     registry
 }
 
+/// Translate the taxis-side [`taxis::config::DeploymentTarget`] to the
+/// hermeneus-side [`HermeneusDeploymentTarget`] (#3736).
+///
+/// Both enums encode the same three boundaries — `Cloud`, `LocalHosted`,
+/// `Embedded` — but live in separate crates so neither depends on the
+/// other. This site is the first place both types are in scope, so the
+/// mapping lives here alongside every other config→provider conversion
+/// done by `register_declared_providers`. Any unknown variant
+/// (`#[non_exhaustive]` guard) falls back to `Cloud`, the sovereignty-safe
+/// default that strips `Internal` / `Confidential` facts rather than
+/// leaking them to an unclassified boundary.
+fn map_deployment_target(src: taxis::config::DeploymentTarget) -> HermeneusDeploymentTarget {
+    use taxis::config::DeploymentTarget as TaxisDeploymentTarget;
+    match src {
+        TaxisDeploymentTarget::LocalHosted => HermeneusDeploymentTarget::LocalHosted,
+        TaxisDeploymentTarget::Embedded => HermeneusDeploymentTarget::Embedded,
+        // WHY: explicit Cloud + wildcard for `#[non_exhaustive]` — any
+        // future variant this code hasn't been taught about is treated as
+        // Cloud so operators cannot accidentally leak classified facts.
+        TaxisDeploymentTarget::Cloud | _ => HermeneusDeploymentTarget::Cloud,
+    }
+}
+
 /// Iterate `config.providers` and register each entry with the provider
 /// registry (#3424, #3414).
 ///
@@ -234,6 +259,14 @@ fn register_declared_providers(registry: &mut ProviderRegistry, config: &Alethei
                     base_url,
                     api_key,
                     models: entry.models.clone(),
+                    // WHY (#3736): the operator-declared deployment target
+                    // was previously logged below but never threaded to the
+                    // provider, so every OpenAI-compat provider silently
+                    // inherited the `Cloud` trait default. That broke the
+                    // air-gap claim in `docs/AIR-GAPPED.md` — the recall
+                    // filter stripped `Internal` / `Confidential` facts
+                    // from traffic bound for loopback llama.cpp / logismos.
+                    deployment_target: map_deployment_target(entry.deployment_target),
                     ..OpenAiProviderConfig::default()
                 };
                 match OpenAiProvider::new(cfg) {

--- a/crates/daemon/src/prosoche_tests.rs
+++ b/crates/daemon/src/prosoche_tests.rs
@@ -248,6 +248,7 @@ mod knowledge_store_tests {
                 access_count: 0,
                 last_accessed_at: None,
             },
+            sensitivity: episteme::knowledge::FactSensitivity::Public,
         }
     }
 

--- a/crates/energeia/src/cron.rs
+++ b/crates/energeia/src/cron.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use compact_str::CompactString;
 use fjall::Readable;
-use rand::Rng;
+use rand::RngExt;
 use snafu::IntoError;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;

--- a/crates/hermeneus/src/openai/client.rs
+++ b/crates/hermeneus/src/openai/client.rs
@@ -19,7 +19,7 @@ use koina::secret::SecretString;
 use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};
-use crate::provider::LlmProvider;
+use crate::provider::{DeploymentTarget, LlmProvider};
 use crate::types::{CompletionRequest, CompletionResponse};
 
 use super::error::{map_error_response, map_request_error};
@@ -63,6 +63,18 @@ pub struct OpenAiProviderConfig {
     /// Maximum retries on transient failures (5xx, timeout, connection
     /// reset). Defaults to 3.
     pub max_retries: u32,
+    /// Where this provider's traffic terminates, gating which
+    /// [`FactSensitivity`](mneme::knowledge::FactSensitivity) the recall
+    /// pipeline is allowed to send to it (#3736, #3404, #3413).
+    ///
+    /// Defaults to [`DeploymentTarget::Cloud`] — the safe assumption that
+    /// matches the trait default so existing TOML configurations without an
+    /// explicit `deployment_target` key keep their Cloud-classified
+    /// behaviour. Operators running a loopback llama.cpp, logismos, or
+    /// ollama endpoint MUST set this to `local_hosted` or `embedded` in
+    /// `aletheia.toml` so the recall filter lets `Internal` /
+    /// `Confidential` facts through to the non-cloud boundary.
+    pub deployment_target: DeploymentTarget,
 }
 
 impl Default for OpenAiProviderConfig {
@@ -74,6 +86,11 @@ impl Default for OpenAiProviderConfig {
             models: Vec::new(),
             request_timeout: Duration::from_mins(2),
             max_retries: 3,
+            // WHY (#3736): the trait default is Cloud and we must mirror it
+            // here so `..Default::default()` in call sites (e.g. the
+            // declarative registration path in aletheia's setup.rs) does
+            // not silently downgrade a caller-specified target.
+            deployment_target: DeploymentTarget::Cloud,
         }
     }
 }
@@ -400,6 +417,16 @@ impl LlmProvider for OpenAiProvider {
         &self.config.name
     }
 
+    /// WHY (#3736): the trait default is Cloud, but OpenAI-compatible
+    /// providers also cover loopback llama.cpp / logismos / ollama
+    /// deployments that should receive `Internal` or `Confidential` facts.
+    /// Returning the configured value propagates the TOML-level
+    /// `deployment_target` all the way to the recall sovereignty filter in
+    /// `nous::recall::filter_by_sensitivity`.
+    fn deployment_target(&self) -> DeploymentTarget {
+        self.config.deployment_target
+    }
+
     fn supports_streaming(&self) -> bool {
         true
     }
@@ -452,5 +479,73 @@ mod tests {
         let provider = OpenAiProvider::new(config).unwrap();
         assert!(provider.supports_model("gpt-4o"));
         assert!(!provider.supports_model("nonexistent"));
+    }
+
+    #[test]
+    fn test_deployment_target_propagates_from_config() {
+        // WHY (#3736): regression for the sovereignty bug where
+        // OpenAiProviderConfig.deployment_target was accepted in TOML,
+        // logged at startup, then silently discarded. The recall
+        // pipeline's sensitivity filter reads this value off the
+        // provider trait, so if it never propagates, every
+        // OpenAI-compat provider — including loopback llama.cpp /
+        // logismos — gets treated as Cloud and has Internal /
+        // Confidential facts stripped.
+
+        // LocalHosted propagates.
+        let local_hosted = OpenAiProvider::new(OpenAiProviderConfig {
+            name: "local-hosted".to_owned(),
+            base_url: "http://127.0.0.1:8088/v1".to_owned(),
+            models: vec!["qwen".to_owned()],
+            deployment_target: DeploymentTarget::LocalHosted,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(
+            local_hosted.deployment_target(),
+            DeploymentTarget::LocalHosted,
+            "LocalHosted config must propagate through OpenAiProvider::deployment_target()"
+        );
+
+        // Embedded propagates.
+        let embedded = OpenAiProvider::new(OpenAiProviderConfig {
+            name: "embedded".to_owned(),
+            base_url: "http://127.0.0.1:8089/v1".to_owned(),
+            models: vec!["logismos".to_owned()],
+            deployment_target: DeploymentTarget::Embedded,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(
+            embedded.deployment_target(),
+            DeploymentTarget::Embedded,
+            "Embedded config must propagate through OpenAiProvider::deployment_target()"
+        );
+
+        // Default (no field set) stays Cloud — the safe trait default.
+        let default_cloud = OpenAiProvider::new(OpenAiProviderConfig {
+            name: "cloud".to_owned(),
+            base_url: "https://api.openai.com/v1".to_owned(),
+            models: vec!["gpt-4o".to_owned()],
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(
+            default_cloud.deployment_target(),
+            DeploymentTarget::Cloud,
+            "omitted deployment_target must default to Cloud (sovereignty-safe)"
+        );
+    }
+
+    #[test]
+    fn deployment_target_ordering_is_sovereignty_safe() {
+        // WHY (#3736): the recall admission rule is `sensitivity <=
+        // target` under the ordering `Cloud < LocalHosted < Embedded`.
+        // If a refactor ever reorders the variants, the filter would
+        // admit Internal/Confidential facts to Cloud providers. Guard
+        // the ordering here so any reorder blows up this test loudly
+        // instead of silently leaking data.
+        assert!(DeploymentTarget::Cloud < DeploymentTarget::LocalHosted);
+        assert!(DeploymentTarget::LocalHosted < DeploymentTarget::Embedded);
     }
 }

--- a/crates/koina/src/retry.rs
+++ b/crates/koina/src/retry.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::future::Future;
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 
 /// Backoff strategy for computing retry delays between attempts.
 ///

--- a/crates/koina/src/ulid.rs
+++ b/crates/koina/src/ulid.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;
 
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
 /// Crockford base32 alphabet (uppercase).

--- a/crates/krites/src/data/functions/temporal.rs
+++ b/crates/krites/src/data/functions/temporal.rs
@@ -23,7 +23,8 @@ use compact_str::CompactString;
 use itertools::Itertools;
 #[cfg(target_arch = "wasm32")]
 use js_sys::Date;
-use rand::prelude::*;
+use rand::RngExt;
+use rand::seq::IndexedRandom;
 
 use super::arg;
 use crate::data::error::*;

--- a/crates/krites/src/data/functions/vector.rs
+++ b/crates/krites/src/data/functions/vector.rs
@@ -13,7 +13,7 @@
 )]
 
 use koina::base64;
-use rand::Rng;
+use rand::RngExt;
 
 use super::arg;
 use crate::data::error::*;

--- a/crates/krites/src/runtime/hnsw/search.rs
+++ b/crates/krites/src/runtime/hnsw/search.rs
@@ -235,7 +235,7 @@ impl SessionTx<'_> {
 mod tests {
     use std::collections::BTreeMap;
 
-    use rand::Rng;
+    use rand::RngExt;
 
     use super::*;
     use crate::DbInstance;

--- a/crates/krites/src/runtime/hnsw/types.rs
+++ b/crates/krites/src/runtime/hnsw/types.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroUsize;
 
 use compact_str::CompactString;
 use lru::LruCache;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::DataValue;
 use crate::data::relation::VecElementType;

--- a/crates/krites/src/runtime/minhash_lsh.rs
+++ b/crates/krites/src/runtime/minhash_lsh.rs
@@ -15,7 +15,7 @@ use std::hash::{Hash, Hasher};
 
 use compact_str::CompactString;
 use itertools::Itertools;
-use rand::RngCore;
+use rand::Rng;
 use rustc_hash::FxHashSet;
 use twox_hash::XxHash32;
 

--- a/crates/nous/src/recall_tests.rs
+++ b/crates/nous/src/recall_tests.rs
@@ -792,6 +792,116 @@ fn sovereignty_filter_embedded_keeps_all() {
 }
 
 #[test]
+fn test_internal_fact_admitted_to_local_hosted_provider_but_stripped_from_cloud() {
+    // WHY (#3736): end-to-end regression for the OpenAI-compatible
+    // provider's sovereignty wiring. The bug: OpenAiProviderConfig had no
+    // `deployment_target` field and OpenAiProvider did not override the
+    // LlmProvider trait, so operator TOML `deployment_target = "local_hosted"`
+    // was logged at startup then silently discarded. Every OpenAI-compat
+    // provider — including loopback llama.cpp / logismos — reported `Cloud`
+    // via the trait default and the recall filter stripped `Internal` facts
+    // from a locally-hosted model's system prompt.
+    //
+    // This test exercises the wiring from the provider instance through to
+    // the admission filter: if either half regresses (config field removed,
+    // trait override dropped, or `with_deployment_target` call site drops
+    // the provider's value), the assertion fails.
+    use hermeneus::openai::{OpenAiProvider, OpenAiProviderConfig};
+    use hermeneus::provider::{DeploymentTarget, LlmProvider};
+    use mneme::knowledge::FactSensitivity;
+
+    let results = vec![
+        make_knowledge_result_sensitive("public A", 0.1, "f-pub", FactSensitivity::Public),
+        make_knowledge_result_sensitive("internal B", 0.15, "f-int", FactSensitivity::Internal),
+    ];
+
+    // Build an OpenAI-compat provider pointing at loopback llama.cpp with
+    // deployment_target = LocalHosted (the operator-intended configuration
+    // that the bug silently ignored).
+    let local_provider = OpenAiProvider::new(OpenAiProviderConfig {
+        name: "local-llama".to_owned(),
+        base_url: "http://127.0.0.1:8088/v1".to_owned(),
+        models: vec!["qwen-local".to_owned()],
+        deployment_target: DeploymentTarget::LocalHosted,
+        ..Default::default()
+    })
+    .expect("local OpenAiProvider init");
+    assert_eq!(
+        local_provider.deployment_target(),
+        DeploymentTarget::LocalHosted,
+        "provider must report LocalHosted — the regression point"
+    );
+
+    // Admission path: plug the provider's reported target into the recall
+    // stage (mirroring pipeline/stages.rs:108-112) and verify `Internal`
+    // facts survive the sovereignty filter for a local provider.
+    let search_local = MockVectorSearch::new(results.clone());
+    let config = RecallConfig {
+        min_score: 0.0,
+        max_results: 10,
+        ..Default::default()
+    };
+    let local_stage =
+        RecallStage::new(config.clone()).with_deployment_target(local_provider.deployment_target());
+    let local_result = local_stage
+        .run("query", "syn", &mock_embed(), &search_local, 50000)
+        .expect("local recall runs");
+    let local_section = local_result
+        .recall_section
+        .expect("public+internal yields a section on LocalHosted target");
+    assert!(
+        local_section.contains("public A"),
+        "LocalHosted must keep Public; section = {local_section}"
+    );
+    assert!(
+        local_section.contains("internal B"),
+        "LocalHosted must ADMIT Internal — this is the sovereignty guarantee; section = {local_section}"
+    );
+    assert_eq!(
+        local_result.results_injected, 2,
+        "both Public and Internal must be injected on LocalHosted target"
+    );
+
+    // Control: a Cloud-default provider (no deployment_target field in
+    // TOML) still strips Internal — proves the filter itself is wired and
+    // that LocalHosted is not a no-op pass-through.
+    let cloud_provider = OpenAiProvider::new(OpenAiProviderConfig {
+        name: "cloud-openai".to_owned(),
+        base_url: "https://api.openai.com/v1".to_owned(),
+        models: vec!["gpt-4o".to_owned()],
+        ..Default::default()
+    })
+    .expect("cloud OpenAiProvider init");
+    assert_eq!(
+        cloud_provider.deployment_target(),
+        DeploymentTarget::Cloud,
+        "omitted field must default to Cloud (safe)"
+    );
+
+    let search_cloud = MockVectorSearch::new(results);
+    let cloud_stage =
+        RecallStage::new(config).with_deployment_target(cloud_provider.deployment_target());
+    let cloud_result = cloud_stage
+        .run("query", "syn", &mock_embed(), &search_cloud, 50000)
+        .expect("cloud recall runs");
+    let cloud_section = cloud_result
+        .recall_section
+        .expect("public yields a section on Cloud target");
+    assert!(
+        cloud_section.contains("public A"),
+        "Cloud must keep Public; section = {cloud_section}"
+    );
+    assert!(
+        !cloud_section.contains("internal B"),
+        "Cloud must STRIP Internal — the pre-existing sovereignty invariant; section = {cloud_section}"
+    );
+    assert_eq!(
+        cloud_result.results_injected, 1,
+        "only Public must be injected on Cloud target"
+    );
+}
+
+#[test]
 fn sovereignty_filter_default_is_cloud() {
     use mneme::knowledge::FactSensitivity;
 

--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 use tracing::instrument;
 
 use crate::error::{self, Result};

--- a/crates/symbolon/src/credential/pkce.rs
+++ b/crates/symbolon/src/credential/pkce.rs
@@ -9,7 +9,7 @@ use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
 
 use koina::secret::SecretString;
-use rand::TryRngCore as _;
+use rand::TryRng as _;
 use sha2::{Digest, Sha256};
 use snafu::{ResultExt, Snafu};
 use tracing::{debug, info};
@@ -227,7 +227,7 @@ impl PkcePair {
     fn generate() -> Result<Self> {
         // WHY: RFC 7636 recommends minimum 43 chars, max 128 chars for verifier.
         // We generate 128 bytes of randomness which becomes ~171 chars base64url.
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rngs::SysRng;
         let mut verifier_bytes = vec![0u8; 128];
         rng.try_fill_bytes(&mut verifier_bytes)
             .map_err(|_e| PkceError::RandomGeneration {
@@ -282,7 +282,7 @@ struct CallbackData {
 
 /// Generate a cryptographically random state parameter for CSRF protection.
 fn generate_state() -> Result<String> {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rngs::SysRng;
     let mut bytes = vec![0u8; 32];
     rng.try_fill_bytes(&mut bytes)
         .map_err(|_e| PkceError::RandomGeneration {


### PR DESCRIPTION
## Critical: sovereignty regression fix

The air-gap claim in `docs/AIR-GAPPED.md` was false before this PR. `OpenAiProviderConfig` had no `deployment_target` field and `OpenAiProvider` did not override `LlmProvider::deployment_target()`, so every OpenAI-compatible provider inherited the trait default (`Cloud`). Operators who configured `deployment_target = "local_hosted"` in `aletheia.toml` for a loopback llama.cpp / logismos / ollama endpoint saw the value accepted and logged at startup, then silently discarded. The recall pipeline's sensitivity filter classified the local provider as Cloud and stripped `Internal` / `Confidential` facts before handoff.

## Fix

- `OpenAiProviderConfig` gets a `pub deployment_target: DeploymentTarget` field (`#[serde(default)]`, defaults to `Cloud` matching trait default so existing TOML without the key keeps Cloud-classified behaviour).
- `impl LlmProvider for OpenAiProvider` overrides `fn deployment_target()` to return the stored value.
- `register_declared_providers` in `crates/aletheia/src/runtime/setup.rs` now threads `entry.deployment_target` through via a new `map_deployment_target` helper that bridges the taxis-side and hermeneus-side enums (both `#[non_exhaustive]` and in separate crates).

## Regression tests

- `test_deployment_target_propagates_from_config` in `hermeneus::openai::client::tests` — proves wiring through the provider trait for all three variants (Cloud default, LocalHosted, Embedded).
- `test_internal_fact_admitted_to_local_hosted_provider_but_stripped_from_cloud` in `nous::recall_tests` — end-to-end proof that an `Internal` fact reaches a LocalHosted provider but is stripped from a Cloud one.

## Test plan

- [x] `cargo check -p hermeneus -p aletheia --features test-core --all-targets` passes
- [ ] Forge CI green (in flight)

Closes #3736