### PR TITLE
fix(runtime): close NousGenerationConfig main breakage from #3775

### DIFF
--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -614,6 +614,8 @@ impl RuntimeBuilder {
                         chars_per_token: resolved.limits.chars_per_token,
                         prosoche_model: resolved.prosoche_model.to_string(),
                         complexity: hermeneus::complexity::ComplexityConfig::default(),
+                        extraction_model: None,
+                        distillation_model: None,
                     },
                     limits: nous::config::NousLimits {
                         max_tool_iterations: resolved.capabilities.max_tool_iterations,


### PR DESCRIPTION
## Summary

#3775 (tier-aware model resolution) added `extraction_model` and `distillation_model` Option<String> fields to `NousGenerationConfig` and wired the literal at `runtime/mod.rs:~640` used for `ExtractionConfig` construction. It missed the sibling literal at `runtime/mod.rs:607` used for the main nous-spawn path. Main has been failing `cargo check --features test-core` since that merge.

## Fix

Add `extraction_model: None, distillation_model: None` to the literal at line 607. Same default as the sibling + same default exactly as used in `NousGenerationConfig::default()`.

## Test plan

- [x] `cargo check --workspace --features test-core --all-targets` passes locally
- [ ] Forge CI green
