### PR TITLE
hotfix(energeia): resolve unresolved merge conflict markers on main

### DIFF
--- a/crates/energeia/src/lib.rs
+++ b/crates/energeia/src/lib.rs
@@ -37,13 +37,10 @@ pub mod dag;
 pub mod engine;
 /// Error types for energeia operations.
 pub mod error;
-<<<<<<< HEAD
 /// Friction capture: parse structured observations from PR bodies.
 pub mod friction;
-=======
 /// Parallel-execution frontier derivation from a [`dag::PromptDag`].
 pub mod frontier;
->>>>>>> 491a2163a (feat(energeia): restore frontier computation for parallel dispatch groups)
 /// Hermeneus-based dispatch engine with prompt caching.
 pub mod hermeneus_engine;
 /// HTTP/SSE dispatch engine: subprocess-based `DispatchEngine` and mock.


### PR DESCRIPTION
## Main is broken

`origin/main` tip has literal merge-conflict markers in `crates/energeia/src/lib.rs:40-46`, breaking `cargo check` fleet-wide. #3777 was admin-merged with the markers unresolved.

## Resolution

Keep both `pub mod friction` (#3788) and `pub mod frontier` (#3777) — parallel additions, textually adjacent.

## Follow-up

Will file kanon issue: admin-merge pre-flight must reject commits containing conflict markers. This class of bug should be impossible to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)