### PR TITLE
feat(episteme): optional reranker stage in recall pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,6 +2344,7 @@ dependencies = [
 name = "episteme"
 version = "0.21.1"
 dependencies = [
+ "async-trait",
  "candle-core",
  "candle-nn",
  "candle-transformers",

--- a/crates/episteme/.kanon-lint-ignore
+++ b/crates/episteme/.kanon-lint-ignore
@@ -85,7 +85,7 @@ RUST/pub-visibility:src/knowledge_store/skills.rs
 RUST/pub-visibility:src/query/builders.rs
 RUST/pub-visibility:src/query/queries.rs
 RUST/pub-visibility:src/query/schema.rs
-RUST/pub-visibility:src/recall.rs
+RUST/pub-visibility:src/recall/mod.rs
 RUST/pub-visibility:src/skill.rs
 RUST/pub-visibility:src/skills/candidate.rs
 RUST/pub-visibility:src/skills/extract.rs
@@ -171,7 +171,7 @@ RUST/string-slice:src/skill.rs
 # clippy::cast_precision_loss)] with reason strings.
 RUST/as-cast:src/instinct.rs
 RUST/as-cast:src/query_rewrite.rs
-RUST/as-cast:src/recall.rs
+RUST/as-cast:src/recall/mod.rs
 RUST/as-cast:src/skills/extract.rs
 RUST/as-cast:src/skills/heuristics.rs
 RUST/as-cast:src/skills/signature.rs

--- a/crates/episteme/Cargo.toml
+++ b/crates/episteme/Cargo.toml
@@ -11,8 +11,9 @@ rust-version.workspace = true
 workspace = true
 
 [features]
-default = ["graph-algo"]
+default = ["graph-algo", "reranker"]
 graph-algo = []
+reranker = ["dep:async-trait"]
 test-support = []
 # WHY: mneme-engine brings in the Datalog knowledge store via krites and the
 # tokio blocking-task utilities graphe's engine errors need.
@@ -42,6 +43,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
+async-trait = { version = "0.1", optional = true }
 tokio = { workspace = true, optional = true }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/episteme/src/recall/mod.rs
+++ b/crates/episteme/src/recall/mod.rs
@@ -20,6 +20,12 @@ use tracing::instrument;
 
 use crate::knowledge::{EpistemicTier, FactType};
 
+#[cfg(feature = "reranker")]
+pub mod reranker;
+
+/// Type alias for a recall candidate used by rerankers.
+pub type RecallCandidate = ScoredResult;
+
 /// Tunable weights for the multi-factor recall scoring formula.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecallWeights {
@@ -129,11 +135,31 @@ pub struct ScoredResult {
 }
 
 /// The recall engine.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RecallEngine {
     weights: RecallWeights,
     /// Maximum access count for frequency normalization.
     max_access_count: f64,
+    /// Optional reranker applied to the top-K after baseline scoring.
+    #[cfg(feature = "reranker")]
+    pub reranker: Option<std::sync::Arc<dyn reranker::Reranker>>,
+    /// Number of top candidates to pass to the reranker.
+    #[cfg(feature = "reranker")]
+    pub reranker_top_k: usize,
+}
+
+impl std::fmt::Debug for RecallEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("RecallEngine");
+        d.field("weights", &self.weights)
+            .field("max_access_count", &self.max_access_count);
+        #[cfg(feature = "reranker")]
+        {
+            d.field("reranker", &self.reranker.as_ref().map(|r| r.name()));
+            d.field("reranker_top_k", &self.reranker_top_k);
+        }
+        d.finish()
+    }
 }
 
 impl RecallEngine {
@@ -148,6 +174,10 @@ impl RecallEngine {
         Self {
             weights: RecallWeights::default(),
             max_access_count: 100.0,
+            #[cfg(feature = "reranker")]
+            reranker: None,
+            #[cfg(feature = "reranker")]
+            reranker_top_k: 20,
         }
     }
 
@@ -172,6 +202,67 @@ impl RecallEngine {
     pub(crate) fn with_max_access_count(mut self, count: f64) -> Self {
         self.max_access_count = count;
         self
+    }
+
+    /// Attach an optional reranker to the engine.
+    #[cfg(feature = "reranker")]
+    #[must_use]
+    #[instrument(skip(self, reranker))]
+    pub fn with_reranker(
+        mut self,
+        reranker: Option<std::sync::Arc<dyn reranker::Reranker>>,
+    ) -> Self {
+        self.reranker = reranker;
+        self
+    }
+
+    /// Set how many top candidates are passed to the reranker.
+    #[cfg(feature = "reranker")]
+    #[must_use]
+    #[instrument(skip(self))]
+    pub fn with_reranker_top_k(mut self, top_k: usize) -> Self {
+        self.reranker_top_k = top_k;
+        self
+    }
+
+    /// Baseline rank followed by an optional reranker pass.
+    ///
+    /// When [`Self::reranker`] is `None` this is identical to [`Self::rank`].
+    /// When it is `Some`, the top [`Self::reranker_top_k`] candidates are
+    /// forwarded to the reranker and the result is concatenated with the
+    /// remaining tail.
+    #[cfg(feature = "reranker")]
+    #[must_use]
+    #[instrument(skip(self, candidates), fields(count = candidates.len()))]
+    pub async fn rank_and_rerank(
+        &self,
+        query: &str,
+        candidates: Vec<ScoredResult>,
+    ) -> Vec<ScoredResult> {
+        let mut ranked = self.rank(candidates);
+        if let Some(ref reranker) = self.reranker {
+            let top_k = self.reranker_top_k.min(ranked.len());
+            if top_k == 0 {
+                return ranked;
+            }
+            let tail = ranked.split_off(top_k);
+            let top_for_rerank = ranked.clone();
+            match reranker.rerank(query, top_for_rerank).await {
+                Ok(mut reranked_top) => {
+                    reranked_top.extend(tail);
+                    ranked = reranked_top;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = ?e,
+                        reranker = reranker.name(),
+                        "reranker failed; falling back to baseline ranking for top-k"
+                    );
+                    ranked.extend(tail);
+                }
+            }
+        }
+        ranked
     }
 
     /// Compute the vector similarity score from cosine distance.
@@ -563,5 +654,5 @@ pub fn pre_filter_by_side_query<S: BuildHasher>(
 }
 
 #[cfg(test)]
-#[path = "recall_tests/mod.rs"]
+#[path = "../recall_tests/mod.rs"]
 mod test_suite;

--- a/crates/episteme/src/recall/reranker.rs
+++ b/crates/episteme/src/recall/reranker.rs
@@ -1,0 +1,272 @@
+//! Optional reranker stage for the recall pipeline.
+//!
+//! Provides a [`Reranker`] trait and a lightweight [`NaiveReranker`]
+//! implementation based on a simplified BM25 keyword-match score.
+//!
+//! Gated behind the `reranker` feature (enabled by default).
+
+use async_trait::async_trait;
+use snafu::Snafu;
+use tracing::instrument;
+
+use super::RecallCandidate;
+
+/// Errors that can occur in the episteme recall pipeline.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+#[expect(
+    missing_docs,
+    reason = "snafu error variant fields are self-documenting via display format"
+)]
+pub enum EpistemeError {
+    /// Reranker operation failed.
+    #[snafu(display("reranker failed: {message}"))]
+    RerankerFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Trait for reranking recall candidates.
+///
+/// Implementations receive the top-K candidates from the baseline 6-factor
+/// ranking and may return them in a refined order.
+#[async_trait]
+pub trait Reranker: Send + Sync {
+    /// Reorder `candidates` for the given `query`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EpistemeError::RerankerFailed`] when the reranker cannot
+    /// complete its scoring (e.g. network timeout for a remote cross-encoder).
+    async fn rerank(
+        &self,
+        query: &str,
+        candidates: Vec<RecallCandidate>,
+    ) -> Result<Vec<RecallCandidate>, EpistemeError>;
+
+    /// Human-readable name for diagnostics and metrics.
+    fn name(&self) -> &'static str;
+}
+
+/// A lightweight BM25-ish keyword-match reranker.
+///
+/// Tokenises the query and each candidate's content by whitespace, computes a
+/// simplified BM25 score per candidate, and returns them sorted by that score.
+/// No external dependencies or network calls are required.
+#[derive(Debug, Clone, Copy)]
+pub struct NaiveReranker;
+
+#[async_trait]
+impl Reranker for NaiveReranker {
+    #[instrument(skip(self, candidates))]
+    async fn rerank(
+        &self,
+        query: &str,
+        mut candidates: Vec<RecallCandidate>,
+    ) -> Result<Vec<RecallCandidate>, EpistemeError> {
+        let query_tokens: Vec<String> = query
+            .to_lowercase()
+            .split_whitespace()
+            .map(String::from)
+            .collect();
+
+        if query_tokens.is_empty() || candidates.is_empty() {
+            return Ok(candidates);
+        }
+
+        let total_len: usize = candidates
+            .iter()
+            .map(|c| c.content.split_whitespace().count())
+            .sum();
+        #[expect(
+            clippy::cast_precision_loss,
+            clippy::as_conversions,
+            reason = "usize→f64: token counts fit in f64"
+        )]
+        let avgdl = total_len as f64 / candidates.len().max(1) as f64;
+        let k1 = 1.2;
+        let b = 0.75;
+
+        for candidate in &mut candidates {
+            let doc_tokens: Vec<String> = candidate
+                .content
+                .to_lowercase()
+                .split_whitespace()
+                .map(String::from)
+                .collect();
+            #[expect(
+                clippy::cast_precision_loss,
+                clippy::as_conversions,
+                reason = "usize→f64: token counts fit in f64"
+            )]
+            let dl = doc_tokens.len() as f64;
+            let mut score = 0.0;
+
+            for qt in &query_tokens {
+                #[expect(
+                    clippy::cast_precision_loss,
+                    clippy::as_conversions,
+                    reason = "usize→f64: token counts fit in f64"
+                )]
+                let f = doc_tokens.iter().filter(|t| t == &qt).count() as f64;
+                if f > 0.0 {
+                    // Simplified IDF: assume every term appears in roughly half
+                    // the documents.  This avoids needing corpus-level statistics.
+                    let idf = 2.0f64.ln();
+                    let denom = f + k1 * (1.0 - b + b * dl / avgdl.max(1.0));
+                    score += idf * f * (k1 + 1.0) / denom;
+                }
+            }
+
+            candidate.score = score;
+        }
+
+        let mut indexed: Vec<(usize, RecallCandidate)> =
+            candidates.into_iter().enumerate().collect();
+        indexed.sort_by(|(ia, a), (ib, b)| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| ia.cmp(ib))
+        });
+
+        Ok(indexed.into_iter().map(|(_, c)| c).collect())
+    }
+
+    fn name(&self) -> &'static str {
+        "naive-bm25"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "test assertions")]
+    #![expect(
+        clippy::indexing_slicing,
+        reason = "recall reranker tests: bounded indexing on known-small vecs"
+    )]
+
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::knowledge::FactSensitivity;
+    use crate::recall::{FactorScores, RecallEngine, ScoredResult};
+
+    fn make_candidate(content: &str, vector_similarity: f64) -> ScoredResult {
+        ScoredResult {
+            content: content.to_owned(),
+            source_type: "fact".to_owned(),
+            source_id: content.to_owned(),
+            nous_id: "syn".to_owned(),
+            factors: FactorScores {
+                vector_similarity,
+                ..FactorScores::default()
+            },
+            score: 0.0,
+            sensitivity: FactSensitivity::Public,
+        }
+    }
+
+    #[tokio::test]
+    async fn naive_reranker_preserves_order_on_identical_scores() {
+        let reranker = NaiveReranker;
+        let candidates = vec![
+            make_candidate("aaa bbb ccc", 0.5),
+            make_candidate("ddd eee fff", 0.5),
+            make_candidate("ggg hhh iii", 0.5),
+        ];
+
+        let result = reranker
+            .rerank("xyz unrelated", candidates.clone())
+            .await
+            .expect("naive reranker should not fail");
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].source_id, candidates[0].source_id);
+        assert_eq!(result[1].source_id, candidates[1].source_id);
+        assert_eq!(result[2].source_id, candidates[2].source_id);
+    }
+
+    #[tokio::test]
+    async fn naive_reranker_boosts_exact_keyword_match() {
+        let reranker = NaiveReranker;
+        let candidates = vec![
+            make_candidate("foo bar baz", 0.9),
+            make_candidate("query term exact match", 0.1),
+        ];
+
+        let result = reranker
+            .rerank("query term", candidates)
+            .await
+            .expect("naive reranker should not fail");
+
+        assert_eq!(
+            result[0].source_id, "query term exact match",
+            "candidate with exact keyword matches should be boosted to first place"
+        );
+    }
+
+    #[tokio::test]
+    async fn recall_pipeline_with_reranker_none_matches_baseline() {
+        let engine = RecallEngine::new();
+        let candidates = vec![
+            make_candidate("alpha", 0.9),
+            make_candidate("beta", 0.5),
+            make_candidate("gamma", 0.1),
+        ];
+
+        let baseline = engine.rank(candidates.clone());
+        let with_reranker = engine.rank_and_rerank("test", candidates).await;
+
+        assert_eq!(baseline.len(), with_reranker.len());
+        for (b, w) in baseline.iter().zip(with_reranker.iter()) {
+            assert_eq!(b.source_id, w.source_id);
+            assert!(
+                (b.score - w.score).abs() < f64::EPSILON,
+                "score should match baseline: {} vs {}",
+                b.score,
+                w.score
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn recall_pipeline_with_reranker_naive_reorders_topk() {
+        let engine = RecallEngine::new()
+            .with_reranker(Some(Arc::new(NaiveReranker)))
+            .with_reranker_top_k(20);
+
+        let candidates = vec![
+            make_candidate("foo bar baz", 0.9),
+            make_candidate("query term exact match", 0.1),
+        ];
+
+        let baseline = engine.rank(candidates.clone());
+        assert_eq!(
+            baseline[0].source_id, "foo bar baz",
+            "baseline should rank high-vector candidate first"
+        );
+
+        let reranked = engine.rank_and_rerank("query term", candidates).await;
+        assert_eq!(
+            reranked[0].source_id, "query term exact match",
+            "naive reranker should reorder top-k based on keyword match"
+        );
+    }
+
+    #[test]
+    fn episteme_error_display_includes_message() {
+        let err = EpistemeError::RerankerFailed {
+            message: "test failure".to_owned(),
+            location: snafu::location!(),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("test failure"),
+            "error display should contain message: {msg}"
+        );
+    }
+}


### PR DESCRIPTION
## What

Adds an optional reranker stage to the `episteme` recall pipeline, gated behind the `reranker` Cargo feature (enabled by default).

## Before

```
vector search → 6-factor scoring → rank → finalize
```

## After

```
vector search → 6-factor scoring → rank → [optional reranker top-k] → finalize
```

When `RecallEngine::reranker` is `Some`, the top `reranker_top_k` candidates (default 20) are passed to the reranker after baseline ranking.  When it is `None` the pipeline is identical to the current behaviour.

## Feature flag

| Feature | Default | Effect |
|---------|---------|--------|
| `reranker` | ✅ yes | Compiles the `recall::reranker` module, trait, and `NaiveReranker` impl. |

Disabling the feature removes the module and the conditional fields on `RecallEngine`, keeping baseline recall untouched for air-gapped builds.

## Callers

No caller required a config update.  Existing constructors (`RecallEngine::new`, `RecallEngine::with_weights`) default to `reranker: None`.  `nous::recall::RecallStage`, integration tests, and `aletheia::knowledge_maintenance` compile unchanged.

## Tests added

- `naive_reranker_preserves_order_on_identical_scores`
- `naive_reranker_boosts_exact_keyword_match`
- `recall_pipeline_with_reranker_none_matches_baseline`
- `recall_pipeline_with_reranker_naive_reorders_topk`
- `episteme_error_display_includes_message`

Closes #3744