### PR TITLE
feat(eidos): architecture-fact layer + MCP tool + basanos rule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,3 +33,6 @@ If this PR adds a new module, function, or abstraction:
 - [ ] No secrets or credentials in the diff
 - [ ] Commit message follows convention (`type(scope): description`)
 - [ ] Binary decisions preserve informative tension (see `docs/ARCHITECTURE.md#preserving-informative-tension`)
+- [ ] Architecture facts touched (list fact IDs below; if none, confirm via `kanon mcp architecture_fact list --scope <crate>`)
+
+<!-- List any architecture fact IDs added or updated, e.g.: aletheia.spawn.model, aletheia.eidos.dependency-direction -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,7 +2214,10 @@ dependencies = [
  "jiff",
  "serde",
  "serde_json",
+ "snafu",
  "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -5527,6 +5530,7 @@ dependencies = [
 name = "organon"
 version = "0.21.1"
 dependencies = [
+ "eidos",
  "energeia",
  "fjall",
  "hermeneus",

--- a/crates/basanos/src/rules/architecture/fact_required.rs
+++ b/crates/basanos/src/rules/architecture/fact_required.rs
@@ -1,0 +1,366 @@
+//! Architecture rule: ARCHITECTURE/fact-required.
+//!
+//! Warns when a PR touches a crate's `src/lib.rs` or adds a new public
+//! module declaration without a corresponding `ArchitectureFact` annotation
+//! in the fact store.
+//!
+//! # Heuristic (v1)
+//!
+//! For each file scanned:
+//!
+//! 1. If the file is `src/lib.rs`, check whether an `ArchitectureFact` JSON
+//!    file exists for that crate (id prefix: `aletheia.<crate-name>.*`).
+//! 2. If the file contains a `pub mod <name>` declaration, check whether a
+//!    fact with id `aletheia.<crate>.<module>` exists.
+//!
+//! When no fact store is present (fresh install), the rule emits no violations
+//! — absence of the store is not itself a violation; the first PR that lands
+//! after the store is created will trigger.
+//!
+//! # Severity
+//!
+//! Warn for v1.  The rule is intentionally non-blocking so that the fleet
+//! builds discipline gradually before moving to Error severity.
+//!
+//! # Future
+//!
+//! A v2 implementation should query the `architecture_fact` MCP tool via
+//! the Kanon CI surface instead of scanning the flat directory directly.
+//! The file-level heuristic is acceptable for v1 per the acceptance criteria.
+
+use std::fs;
+use std::path::Path;
+
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+use crate::rules::{Rule, Violation};
+
+/// Rule: ARCHITECTURE/fact-required.
+///
+/// Scan crate source files for architectural seams (lib.rs, pub mod
+/// declarations) and warn when no architecture fact is present for them.
+pub struct FactRequiredRule;
+
+/// Rule severity label — Warn for v1.
+const SEVERITY: &str = "warn";
+
+impl Rule for FactRequiredRule {
+    fn id(&self) -> &'static str {
+        "ARCHITECTURE/fact-required"
+    }
+
+    fn check(&self, project_root: &str) -> Result<Vec<Violation>> {
+        let root = Path::new(project_root);
+        let mut violations = Vec::new();
+
+        // Resolve the fact store directory: ALETHEIA_FACTS_DIR or default.
+        let facts_dir = fact_store_dir();
+
+        // Walk crates/ looking for Rust crate roots.
+        let crates_dir = root.join("crates");
+        if !crates_dir.is_dir() {
+            return Ok(violations);
+        }
+
+        for entry in fs::read_dir(&crates_dir).with_context(|_| error::ReadDirSnafu {
+            path: crates_dir.clone(),
+        })? {
+            let entry = entry.with_context(|_| error::ReadDirSnafu {
+                path: crates_dir.clone(),
+            })?;
+            let crate_path = entry.path();
+            if !crate_path.is_dir() {
+                continue;
+            }
+            let lib_rs = crate_path.join("src").join("lib.rs");
+            if lib_rs.is_file() {
+                check_lib_rs(&lib_rs, &crate_path, &facts_dir, &mut violations)?;
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+/// Resolve the fact store directory path.
+fn fact_store_dir() -> std::path::PathBuf {
+    match std::env::var("ALETHEIA_FACTS_DIR") {
+        Ok(d) if !d.is_empty() => std::path::PathBuf::from(d),
+        _ => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
+            std::path::PathBuf::from(home).join("aletheia/instance/facts")
+        }
+    }
+}
+
+/// Derive the crate name from its directory path (last component).
+fn crate_name(crate_path: &Path) -> String {
+    crate_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_owned()
+}
+
+/// Check `src/lib.rs` for missing architecture facts.
+///
+/// - Checks for a crate-level fact: any `aletheia.<crate_name>.*` fact file.
+/// - Checks each `pub mod <name>` declaration for a module-level fact.
+fn check_lib_rs(
+    lib_rs: &Path,
+    crate_path: &Path,
+    facts_dir: &Path,
+    violations: &mut Vec<Violation>,
+) -> Result<()> {
+    // If the fact store directory does not exist, skip — store is not yet
+    // initialised for this installation.
+    if !facts_dir.is_dir() {
+        return Ok(());
+    }
+
+    let crate_nm = crate_name(crate_path);
+    let content = fs::read_to_string(lib_rs).with_context(|_| error::ReadFileSnafu {
+        path: lib_rs.to_path_buf(),
+    })?;
+
+    // Check crate-level fact existence (any file matching `aletheia.<crate_nm>.*`).
+    let crate_prefix = format!("aletheia.{crate_nm}.");
+    let has_crate_fact = fact_exists_with_prefix(facts_dir, &crate_prefix);
+
+    if !has_crate_fact {
+        violations.push(Violation {
+            rule: "ARCHITECTURE/fact-required".to_owned(),
+            path: lib_rs.display().to_string(),
+            line: 1,
+            message: format!(
+                "[{SEVERITY}] crate '{crate_nm}' has no architecture fact (expected id prefix \
+                 'aletheia.{crate_nm}.*' in {facts_dir}). \
+                 Add a fact via the `architecture_fact` MCP tool.",
+                facts_dir = facts_dir.display(),
+            ),
+        });
+    }
+
+    // Check each `pub mod <name>` for a corresponding module-level fact.
+    for (idx, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        if let Some(module_name) = extract_pub_mod(trimmed) {
+            let fact_id = format!("aletheia.{crate_nm}.{module_name}");
+            if !fact_file_exists(facts_dir, &fact_id) {
+                violations.push(Violation {
+                    rule: "ARCHITECTURE/fact-required".to_owned(),
+                    path: lib_rs.display().to_string(),
+                    line: idx + 1,
+                    message: format!(
+                        "[{SEVERITY}] public module '{module_name}' in crate '{crate_nm}' has no \
+                         architecture fact (expected id 'aletheia.{crate_nm}.{module_name}'). \
+                         Add a fact via the `architecture_fact` MCP tool.",
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Check whether any `.json` file in `facts_dir` starts with `prefix`.
+fn fact_exists_with_prefix(facts_dir: &Path, prefix: &str) -> bool {
+    let Ok(entries) = fs::read_dir(facts_dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.ends_with(".json") && name_str.starts_with(prefix) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check whether a fact file for `id` exists (exact filename match).
+fn fact_file_exists(facts_dir: &Path, id: &str) -> bool {
+    // Mirror the FactStore::id_to_filename logic: replace `/` → `-`, append `.json`.
+    let mut filename: String = id
+        .chars()
+        .map(|c| if c == '/' || c == '\\' { '-' } else { c })
+        .collect();
+    filename.push_str(".json");
+    facts_dir.join(filename).exists()
+}
+
+/// Extract the module name from a `pub mod <name>` or `pub mod <name>;` line.
+///
+/// Returns `None` for non-pub-mod lines or conditional mods (`#[cfg…]` is on
+/// the preceding line, not this one).
+fn extract_pub_mod(line: &str) -> Option<&str> {
+    // Match: `pub mod <name>` or `pub mod <name>;` or `pub mod <name> {`
+    let rest = line.strip_prefix("pub mod ")?;
+    let name = rest.trim_end_matches([';', '{', ' ']).trim();
+    if name.is_empty() || name.contains(' ') || name.contains('(') {
+        return None;
+    }
+    Some(name)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    // ── extract_pub_mod ──────────────────────────────────────────────────
+
+    #[test]
+    fn extract_pub_mod_basic() {
+        assert_eq!(extract_pub_mod("pub mod knowledge;"), Some("knowledge"));
+        assert_eq!(extract_pub_mod("pub mod knowledge {"), Some("knowledge"));
+        assert_eq!(extract_pub_mod("pub mod knowledge"), Some("knowledge"));
+    }
+
+    #[test]
+    fn extract_pub_mod_ignores_non_pub() {
+        assert!(extract_pub_mod("mod private;").is_none());
+        assert!(extract_pub_mod("use std::io;").is_none());
+    }
+
+    #[test]
+    fn extract_pub_mod_ignores_conditional() {
+        // Line itself is not a pub mod line if it has attributes mixed in.
+        assert!(extract_pub_mod("#[cfg(test)] pub mod tests").is_none());
+    }
+
+    // ── fact_exists_with_prefix ──────────────────────────────────────────
+
+    #[test]
+    fn fact_exists_with_prefix_positive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("aletheia.eidos.dep.json"), b"{}").expect("write");
+        assert!(fact_exists_with_prefix(dir.path(), "aletheia.eidos."));
+    }
+
+    #[test]
+    fn fact_exists_with_prefix_negative() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("aletheia.organon.dep.json"), b"{}").expect("write");
+        assert!(!fact_exists_with_prefix(dir.path(), "aletheia.eidos."));
+    }
+
+    // ── full rule: no fact → warn ────────────────────────────────────────
+
+    #[test]
+    fn rule_warns_when_no_fact_for_crate() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let facts = tempfile::tempdir().expect("facts tempdir");
+
+        // Create a minimal crate structure.
+        let crate_dir = project.path().join("crates").join("eidos");
+        fs::create_dir_all(crate_dir.join("src")).expect("mkdir");
+        fs::write(crate_dir.join("src").join("lib.rs"), b"//! eidos lib\n").expect("write lib.rs");
+
+        // WHY: set_var is unsafe in Rust 2024; tests are single-threaded within
+        // this module, so the env mutation is safe here.
+        #[expect(unsafe_code, reason = "test-only env mutation; tests run sequentially")]
+        // SAFETY: single-threaded test context; no concurrent env readers.
+        unsafe {
+            std::env::set_var("ALETHEIA_FACTS_DIR", facts.path());
+        };
+        let rule = FactRequiredRule;
+        let violations = rule
+            .check(project.path().to_str().expect("valid path"))
+            .expect("check");
+        assert!(
+            !violations.is_empty(),
+            "expected violation for crate without fact"
+        );
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "test assertion: non-empty checked above"
+        )]
+        let (rule_id, message) = (violations[0].rule.clone(), violations[0].message.clone());
+        assert!(rule_id == "ARCHITECTURE/fact-required");
+        assert!(
+            message.contains("aletheia.eidos."),
+            "message should reference expected fact prefix"
+        );
+    }
+
+    // ── full rule: fact present → no warn ───────────────────────────────
+
+    #[test]
+    fn rule_no_warn_when_fact_present() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let facts = tempfile::tempdir().expect("facts tempdir");
+
+        // Create crate.
+        let crate_dir = project.path().join("crates").join("eidos");
+        fs::create_dir_all(crate_dir.join("src")).expect("mkdir");
+        fs::write(crate_dir.join("src").join("lib.rs"), b"//! eidos lib\n").expect("write lib.rs");
+
+        // Create a fact file that satisfies the prefix check.
+        fs::write(
+            facts
+                .path()
+                .join("aletheia.eidos.dependency-direction.json"),
+            b"{\"id\":\"aletheia.eidos.dependency-direction\"}",
+        )
+        .expect("write fact");
+
+        #[expect(unsafe_code, reason = "test-only env mutation; tests run sequentially")]
+        // SAFETY: single-threaded test context; no concurrent env readers.
+        unsafe {
+            std::env::set_var("ALETHEIA_FACTS_DIR", facts.path());
+        };
+        let rule = FactRequiredRule;
+        let violations = rule
+            .check(project.path().to_str().expect("valid path"))
+            .expect("check");
+        assert!(
+            violations.is_empty(),
+            "expected no violations when fact is present; got: {violations:?}"
+        );
+    }
+
+    // ── pub mod check ────────────────────────────────────────────────────
+
+    #[test]
+    fn rule_warns_for_pub_mod_without_fact() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let facts = tempfile::tempdir().expect("facts tempdir");
+
+        let crate_dir = project.path().join("crates").join("mylib");
+        fs::create_dir_all(crate_dir.join("src")).expect("mkdir");
+        // lib.rs with a pub mod and a crate fact.
+        fs::write(
+            crate_dir.join("src").join("lib.rs"),
+            b"//! mylib\npub mod knowledge;\n",
+        )
+        .expect("write lib.rs");
+        // Satisfy the crate-level prefix so only the module check triggers.
+        fs::write(
+            facts.path().join("aletheia.mylib.toplevel.json"),
+            b"{\"id\":\"aletheia.mylib.toplevel\"}",
+        )
+        .expect("write crate fact");
+
+        #[expect(unsafe_code, reason = "test-only env mutation; tests run sequentially")]
+        // SAFETY: single-threaded test context; no concurrent env readers.
+        unsafe {
+            std::env::set_var("ALETHEIA_FACTS_DIR", facts.path());
+        };
+        let rule = FactRequiredRule;
+        let violations = rule
+            .check(project.path().to_str().expect("valid path"))
+            .expect("check");
+        // Should warn for the `knowledge` module.
+        assert!(
+            violations.iter().any(|v| v.message.contains("knowledge")),
+            "expected violation for pub mod knowledge; got: {violations:?}"
+        );
+    }
+}

--- a/crates/basanos/src/rules/architecture/mod.rs
+++ b/crates/basanos/src/rules/architecture/mod.rs
@@ -1,0 +1,3 @@
+//! Architecture lint rules.
+
+pub mod fact_required;

--- a/crates/basanos/src/rules/mod.rs
+++ b/crates/basanos/src/rules/mod.rs
@@ -1,10 +1,14 @@
 //! Lint rules for basanos.
 
+pub mod architecture;
 pub mod planning;
 
 use crate::error::Result;
 
-/// A single violation found by a rule.
+/// A single lint violation found by a rule.
+///
+/// The `message` may begin with `[warn]` or `[error]` to indicate severity.
+/// For v1, `ARCHITECTURE/fact-required` emits `[warn]` messages.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Violation {
     /// Rule identifier, e.g. `PLANNING/missing-falsifier`.
@@ -28,5 +32,8 @@ pub trait Rule {
 
 /// All registered rules.
 pub fn all_rules() -> Vec<Box<dyn Rule>> {
-    vec![Box::new(planning::MissingFalsifierRule)]
+    vec![
+        Box::new(planning::MissingFalsifierRule),
+        Box::new(architecture::fact_required::FactRequiredRule),
+    ]
 }

--- a/crates/eidos/Cargo.toml
+++ b/crates/eidos/Cargo.toml
@@ -21,7 +21,10 @@ test-support = []
 jiff = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+snafu = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/eidos/src/knowledge/architecture_fact.rs
+++ b/crates/eidos/src/knowledge/architecture_fact.rs
@@ -1,0 +1,719 @@
+//! Structured facts about the codebase that research agents can query.
+//!
+//! An [`ArchitectureFact`] is a short, cited, versioned claim about an
+//! architectural seam: spawn model, storage invariants, hook taxonomy,
+//! lifecycle boundaries, etc.  Facts are written once (by whoever changes
+//! the shape) and reused by every downstream research agent at O(query)
+//! cost instead of O(full-codebase-read).
+//!
+//! # Storage
+//!
+//! [`FactStore`] uses flat JSON files under a configurable directory
+//! (default: `~/aletheia/instance/facts/`).  Each fact is serialised to
+//! `<dir>/<id>.json` where `<id>` is the dot-separated fact identifier
+//! with `/` replaced by `__` to produce a safe filename.  No external
+//! database is required — the directory is created on first write.
+//!
+//! # Design constraints
+//!
+//! - `serde_json` is already in the `eidos` dependency tree; no new deps.
+//! - Facts carry no credentials: `ArchitectureFact` fields are public
+//!   knowledge about the codebase, never secrets.
+//! - The `updated_by` field records the PR number or session key that last
+//!   touched the fact, providing a lightweight audit trail.
+//!
+//! # Search
+//!
+//! [`FactStore::search`] performs a case-insensitive substring scan across
+//! all loaded facts' `id`, `scope`, and `claim` fields.  Full-text
+//! indexing is out of scope for v1; the dataset is expected to stay
+//! small (<1 000 facts).
+
+use std::io;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+
+// ── Error types ──────────────────────────────────────────────────────────────
+
+/// Errors from [`FactStore`] operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+#[expect(
+    missing_docs,
+    reason = "snafu error variant fields are self-documenting via display format"
+)]
+pub enum FactError {
+    /// The facts directory could not be created.
+    #[snafu(display("failed to create facts directory {}: {source}", dir.display()))]
+    CreateDir { dir: PathBuf, source: io::Error },
+
+    /// A fact file could not be read.
+    #[snafu(display("failed to read fact file {}: {source}", path.display()))]
+    ReadFile { path: PathBuf, source: io::Error },
+
+    /// A fact file could not be written.
+    #[snafu(display("failed to write fact file {}: {source}", path.display()))]
+    WriteFile { path: PathBuf, source: io::Error },
+
+    /// The facts directory could not be listed.
+    #[snafu(display("failed to read facts directory {}: {source}", dir.display()))]
+    ReadDir { dir: PathBuf, source: io::Error },
+
+    /// A directory entry could not be inspected.
+    #[snafu(display("failed to inspect directory entry in {}: {source}", dir.display()))]
+    DirEntry { dir: PathBuf, source: io::Error },
+
+    /// JSON deserialisation of a fact file failed.
+    #[snafu(display("failed to deserialise fact from {}: {source}", path.display()))]
+    Deserialise {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    /// JSON serialisation of a fact failed.
+    #[snafu(display("failed to serialise fact {id}: {source}"))]
+    Serialise {
+        id: String,
+        source: serde_json::Error,
+    },
+}
+
+// ── Core types ───────────────────────────────────────────────────────────────
+
+/// Architectural scope that a fact applies to.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum FactScope {
+    /// Crate-level fact (ownership, public API surface, dependency direction).
+    Crate,
+    /// Module-level fact (internal structure, visibility rules).
+    Module,
+    /// Concept-level fact (a design pattern, invariant, or protocol).
+    Concept,
+    /// Boundary fact (how two systems interact at their interface).
+    Boundary,
+}
+
+impl std::fmt::Display for FactScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Crate => f.write_str("crate"),
+            Self::Module => f.write_str("module"),
+            Self::Concept => f.write_str("concept"),
+            Self::Boundary => f.write_str("boundary"),
+        }
+    }
+}
+
+/// A single structured fact about the codebase, queryable by research agents.
+///
+/// # Naming convention for `id`
+///
+/// Use dot-separated hierarchical paths: `<project>.<subsystem>.<aspect>`.
+/// Examples:
+/// - `aletheia.spawn.model`
+/// - `aletheia.providers.llm.supported`
+/// - `aletheia.graphe.single-writer-invariant`
+///
+/// # `updated_by`
+///
+/// Record the PR number (`PR-3789`) or session key (`session_<id>`) that
+/// last wrote this fact.  This is provenance, not a credential.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ArchitectureFact {
+    /// Stable dot-separated identifier, e.g. `aletheia.spawn.model`.
+    pub id: String,
+    /// Architectural scope of this fact.
+    pub scope: FactScope,
+    /// The fact itself, written as a single declarative sentence (markdown OK).
+    pub claim: String,
+    /// File paths or URLs that support the claim.
+    pub evidence: Vec<String>,
+    /// `session_key` of a supporting `mneme` annotation, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mneme_session: Option<String>,
+    /// RFC 3339 timestamp of last update.
+    pub updated_at: String,
+    /// PR number or session key that last touched this fact.
+    pub updated_by: String,
+}
+
+impl ArchitectureFact {
+    /// Construct a new fact with the current UTC timestamp.
+    ///
+    /// `updated_by` should be a PR number (`PR-3789`) or session key.
+    #[must_use]
+    pub fn new(
+        id: impl Into<String>,
+        scope: FactScope,
+        claim: impl Into<String>,
+        evidence: Vec<String>,
+        updated_by: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            scope,
+            claim: claim.into(),
+            evidence,
+            mneme_session: None,
+            updated_at: chrono_now_rfc3339(),
+            updated_by: updated_by.into(),
+        }
+    }
+}
+
+/// Produce a naive RFC 3339 timestamp from the system clock.
+///
+/// WHY: eidos has no `jiff` in its dep tree for `ArchitectureFact` yet; `jiff`
+/// is only compiled when the `jiff` feature is present.  For v1 the timestamp
+/// is informational and does not need sub-second precision, so we use the
+/// standard-library `SystemTime` to stay dep-free.
+fn chrono_now_rfc3339() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Format as ISO 8601 UTC: YYYY-MM-DDTHH:MM:SSZ
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400;
+    // Day 0 = 1970-01-01.  Gregorian calendar reconstruction.
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+/// Convert days-since-epoch to (year, month, day) using the proleptic Gregorian
+/// calendar.  Correct for all dates representable by a u64 timestamp.
+fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
+    // WHY: we avoid pulling in chrono/jiff for a single timestamp; the algorithm
+    // is the standard proleptic Gregorian reconstruction from days-since-epoch.
+    let mut year: u64 = 1970;
+    loop {
+        let leap = is_leap(year);
+        let days_in_year: u64 = if leap { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+    let leap = is_leap(year);
+    let month_days: [u64; 12] = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut month: u64 = 1;
+    for &md in &month_days {
+        if days < md {
+            break;
+        }
+        days -= md;
+        month += 1;
+    }
+    (year, month, days + 1)
+}
+
+fn is_leap(year: u64) -> bool {
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+}
+
+// ── FactStore ────────────────────────────────────────────────────────────────
+
+/// Flat-JSON-file backed store for [`ArchitectureFact`]s.
+///
+/// One file per fact: `<dir>/<safe_id>.json` where `<safe_id>` is the fact's
+/// `id` with `.` and `/` replaced by `__` and `-` respectively.
+///
+/// The store is created lazily: the directory is created on first [`put`].
+///
+/// [`put`]: FactStore::put
+pub struct FactStore {
+    dir: PathBuf,
+}
+
+impl FactStore {
+    /// Create a store rooted at `dir`.
+    ///
+    /// The directory is created on the first [`put`] call; it does not need
+    /// to exist when the store is constructed.
+    ///
+    /// [`put`]: FactStore::put
+    #[must_use]
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    /// Default store path: `~/aletheia/instance/facts/`.
+    #[must_use]
+    pub fn default_path() -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
+        PathBuf::from(home).join("aletheia/instance/facts")
+    }
+
+    /// Translate a fact `id` to a safe filename (no path separators).
+    fn id_to_filename(id: &str) -> String {
+        // Replace chars that are unsafe in filenames.
+        let mut name: String = id
+            .chars()
+            .map(|c| match c {
+                '/' | '\\' => '-',
+                _ => c,
+            })
+            .collect();
+        name.push_str(".json");
+        name
+    }
+
+    fn fact_path(&self, id: &str) -> PathBuf {
+        self.dir.join(Self::id_to_filename(id))
+    }
+
+    /// Retrieve a fact by exact `id`.  Returns `None` if no fact with that id
+    /// exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FactError`] if the file exists but cannot be read or parsed.
+    #[tracing::instrument(skip(self))]
+    pub async fn get(&self, id: &str) -> Result<Option<ArchitectureFact>, FactError> {
+        let path = self.fact_path(id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let bytes = std::fs::read(&path).with_context(|_| ReadFileSnafu { path: path.clone() })?;
+        let fact = serde_json::from_slice(&bytes)
+            .with_context(|_| DeserialiseSnafu { path: path.clone() })?;
+        Ok(Some(fact))
+    }
+
+    /// Write a fact to the store.  Creates the directory if it does not exist.
+    /// Overwrites any existing fact with the same `id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FactError`] if the directory cannot be created, serialisation
+    /// fails, or the file cannot be written.
+    #[tracing::instrument(skip(self, fact), fields(id = %fact.id))]
+    pub async fn put(&self, fact: ArchitectureFact) -> Result<(), FactError> {
+        std::fs::create_dir_all(&self.dir).with_context(|_| CreateDirSnafu {
+            dir: self.dir.clone(),
+        })?;
+        let path = self.fact_path(&fact.id);
+        let json = serde_json::to_vec_pretty(&fact).with_context(|_| SerialiseSnafu {
+            id: fact.id.clone(),
+        })?;
+        std::fs::write(&path, &json).with_context(|_| WriteFileSnafu { path })?;
+        Ok(())
+    }
+
+    /// List all facts, optionally filtered to a specific scope.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FactError`] if the directory cannot be read or a fact file
+    /// cannot be parsed.
+    #[tracing::instrument(skip(self))]
+    pub async fn list(&self, scope: Option<FactScope>) -> Result<Vec<ArchitectureFact>, FactError> {
+        if !self.dir.exists() {
+            return Ok(vec![]);
+        }
+        let mut facts = self.load_all()?;
+        if let Some(s) = scope {
+            facts.retain(|f| f.scope == s);
+        }
+        Ok(facts)
+    }
+
+    /// Search facts by case-insensitive substring match across `id`, `scope`,
+    /// and `claim`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FactError`] if the directory cannot be read or a fact file
+    /// cannot be parsed.
+    #[tracing::instrument(skip(self))]
+    pub async fn search(&self, query: &str) -> Result<Vec<ArchitectureFact>, FactError> {
+        if !self.dir.exists() {
+            return Ok(vec![]);
+        }
+        let query_lower = query.to_lowercase();
+        let facts = self.load_all()?;
+        Ok(facts
+            .into_iter()
+            .filter(|f| {
+                f.id.to_lowercase().contains(&query_lower)
+                    || f.scope.to_string().contains(&query_lower)
+                    || f.claim.to_lowercase().contains(&query_lower)
+            })
+            .collect())
+    }
+
+    /// Load all `.json` files in the store directory.
+    fn load_all(&self) -> Result<Vec<ArchitectureFact>, FactError> {
+        let entries = std::fs::read_dir(&self.dir).with_context(|_| ReadDirSnafu {
+            dir: self.dir.clone(),
+        })?;
+        let mut facts = Vec::new();
+        for entry in entries {
+            let entry = entry.with_context(|_| DirEntrySnafu {
+                dir: self.dir.clone(),
+            })?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let bytes =
+                std::fs::read(&path).with_context(|_| ReadFileSnafu { path: path.clone() })?;
+            let fact: ArchitectureFact = serde_json::from_slice(&bytes)
+                .with_context(|_| DeserialiseSnafu { path: path.clone() })?;
+            facts.push(fact);
+        }
+        Ok(facts)
+    }
+}
+
+// ── Seed facts helper (used by tests and initial population) ─────────────────
+
+/// Build the five seed facts that describe aletheia's own architecture.
+///
+/// These are written by `PR-3789` and provide the initial populated state
+/// of the fact store, so that research agents have a working example of
+/// what the layer contains.
+#[must_use]
+pub fn seed_facts() -> Vec<ArchitectureFact> {
+    vec![
+        ArchitectureFact {
+            id: "aletheia.spawn.model".to_owned(),
+            scope: FactScope::Concept,
+            claim: "Aletheia spawns agents as in-process Tokio tasks, not as subprocesses. \
+                    `nous::spawn_svc` drives the lifecycle; no `std::process::Command` is \
+                    involved."
+                .to_owned(),
+            evidence: vec!["crates/nous/src/spawn_svc.rs:56-99".to_owned()],
+            mneme_session: None,
+            updated_at: "2026-04-22T00:00:00Z".to_owned(),
+            updated_by: "PR-3789".to_owned(),
+        },
+        ArchitectureFact {
+            id: "aletheia.graphe.single-writer-invariant".to_owned(),
+            scope: FactScope::Concept,
+            claim: "The `graphe` session graph is single-writer: only the owning actor may \
+                    mutate its state. Reads are behind a `RwLock`; writes require an exclusive \
+                    guard obtained from the session actor."
+                .to_owned(),
+            evidence: vec!["crates/graphe/src/session_actor.rs".to_owned()],
+            mneme_session: None,
+            updated_at: "2026-04-22T00:00:00Z".to_owned(),
+            updated_by: "PR-3789".to_owned(),
+        },
+        ArchitectureFact {
+            id: "aletheia.providers.llm.routing".to_owned(),
+            scope: FactScope::Boundary,
+            claim: "LLM provider routing is configured in `dispatch-config.toml` \
+                    (`~/menos-ops/dispatch-config.toml`). The `local` provider routes to \
+                    logismos at its configured port; `anthropic` routes to the Anthropic API. \
+                    Provider selection is per-nous-config, not global."
+                .to_owned(),
+            evidence: vec![
+                "~/menos-ops/dispatch-config.toml".to_owned(),
+                "crates/hermeneus/src/provider/router.rs".to_owned(),
+            ],
+            mneme_session: None,
+            updated_at: "2026-04-22T00:00:00Z".to_owned(),
+            updated_by: "PR-3789".to_owned(),
+        },
+        ArchitectureFact {
+            id: "aletheia.eidos.dependency-direction".to_owned(),
+            scope: FactScope::Crate,
+            claim: "`eidos` is the foundational types crate: it has zero internal aletheia \
+                    dependencies. All other crates may depend on `eidos`; `eidos` must not \
+                    depend on any other fleet crate."
+                .to_owned(),
+            evidence: vec!["crates/eidos/Cargo.toml".to_owned()],
+            mneme_session: None,
+            updated_at: "2026-04-22T00:00:00Z".to_owned(),
+            updated_by: "PR-3789".to_owned(),
+        },
+        ArchitectureFact {
+            id: "aletheia.organon.tool-registration".to_owned(),
+            scope: FactScope::Module,
+            claim: "All built-in MCP tools are registered via `builtins::register_all` in \
+                    `crates/organon/src/builtins/mod.rs`. Each builtin module exposes a \
+                    `pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()>` \
+                    that the top-level `register_all` calls. New tools follow this pattern."
+                .to_owned(),
+            evidence: vec!["crates/organon/src/builtins/mod.rs".to_owned()],
+            mneme_session: None,
+            updated_at: "2026-04-22T00:00:00Z".to_owned(),
+            updated_by: "PR-3789".to_owned(),
+        },
+    ]
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    // ── ArchitectureFact serde round-trip ────────────────────────────────
+
+    #[test]
+    fn serde_round_trip() {
+        let fact = ArchitectureFact {
+            id: "test.fact.one".to_owned(),
+            scope: FactScope::Concept,
+            claim: "Agents spawn in-process.".to_owned(),
+            evidence: vec!["crates/nous/src/spawn_svc.rs:56".to_owned()],
+            mneme_session: Some("session_abc".to_owned()),
+            updated_at: "2026-04-22T12:00:00Z".to_owned(),
+            updated_by: "PR-9999".to_owned(),
+        };
+        let json = serde_json::to_string(&fact).expect("serialise");
+        let back: ArchitectureFact = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.id, fact.id);
+        assert_eq!(back.scope, fact.scope);
+        assert_eq!(back.claim, fact.claim);
+        assert_eq!(back.evidence, fact.evidence);
+        assert_eq!(back.mneme_session, fact.mneme_session);
+        assert_eq!(back.updated_by, fact.updated_by);
+    }
+
+    #[test]
+    fn serde_optional_mneme_session_omitted_when_none() {
+        let fact = ArchitectureFact {
+            id: "test.fact.two".to_owned(),
+            scope: FactScope::Crate,
+            claim: "eidos has no internal deps.".to_owned(),
+            evidence: vec![],
+            mneme_session: None,
+            updated_at: "2026-04-22T00:00:00Z".to_owned(),
+            updated_by: "PR-3789".to_owned(),
+        };
+        let json = serde_json::to_string(&fact).expect("serialise");
+        assert!(
+            !json.contains("mneme_session"),
+            "mneme_session should be omitted when None"
+        );
+    }
+
+    // ── FactScope parsing ────────────────────────────────────────────────
+
+    #[test]
+    fn fact_scope_serde_all_variants() {
+        for (scope, expected) in [
+            (FactScope::Crate, "\"crate\""),
+            (FactScope::Module, "\"module\""),
+            (FactScope::Concept, "\"concept\""),
+            (FactScope::Boundary, "\"boundary\""),
+        ] {
+            let json = serde_json::to_string(&scope).expect("serialise scope");
+            assert_eq!(json, expected, "scope {scope:?} serialise mismatch");
+            let back: FactScope = serde_json::from_str(&json).expect("deserialise scope");
+            assert_eq!(back, scope, "scope {scope:?} round-trip failed");
+        }
+    }
+
+    #[test]
+    fn fact_scope_display() {
+        assert_eq!(FactScope::Crate.to_string(), "crate");
+        assert_eq!(FactScope::Module.to_string(), "module");
+        assert_eq!(FactScope::Concept.to_string(), "concept");
+        assert_eq!(FactScope::Boundary.to_string(), "boundary");
+    }
+
+    // ── FactStore get/put/list/search ────────────────────────────────────
+
+    #[tokio::test]
+    async fn put_then_get_returns_fact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FactStore::new(dir.path());
+        let fact = ArchitectureFact {
+            id: "test.put.get".to_owned(),
+            scope: FactScope::Boundary,
+            claim: "Test claim.".to_owned(),
+            evidence: vec!["src/lib.rs:1".to_owned()],
+            mneme_session: None,
+            updated_at: "2026-04-22T00:00:00Z".to_owned(),
+            updated_by: "PR-1".to_owned(),
+        };
+        store.put(fact.clone()).await.expect("put");
+        let got = store.get("test.put.get").await.expect("get");
+        let got = got.expect("fact should exist");
+        assert_eq!(got.id, "test.put.get");
+        assert_eq!(got.claim, "Test claim.");
+    }
+
+    #[tokio::test]
+    async fn get_missing_returns_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FactStore::new(dir.path());
+        let result = store.get("nonexistent.fact").await.expect("get");
+        assert!(result.is_none(), "missing fact should return None");
+    }
+
+    #[tokio::test]
+    async fn list_all_facts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FactStore::new(dir.path());
+        for i in 0..3u32 {
+            let fact = ArchitectureFact {
+                id: format!("test.list.{i}"),
+                scope: if i == 0 {
+                    FactScope::Crate
+                } else {
+                    FactScope::Concept
+                },
+                claim: format!("Claim {i}."),
+                evidence: vec![],
+                mneme_session: None,
+                updated_at: "2026-04-22T00:00:00Z".to_owned(),
+                updated_by: "PR-1".to_owned(),
+            };
+            store.put(fact).await.expect("put");
+        }
+        let all = store.list(None).await.expect("list all");
+        assert_eq!(all.len(), 3, "expected 3 facts, got {}", all.len());
+    }
+
+    #[tokio::test]
+    async fn list_filtered_by_scope() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FactStore::new(dir.path());
+        store
+            .put(ArchitectureFact {
+                id: "test.scope.crate".to_owned(),
+                scope: FactScope::Crate,
+                claim: "Crate fact.".to_owned(),
+                evidence: vec![],
+                mneme_session: None,
+                updated_at: "2026-04-22T00:00:00Z".to_owned(),
+                updated_by: "PR-1".to_owned(),
+            })
+            .await
+            .expect("put");
+        store
+            .put(ArchitectureFact {
+                id: "test.scope.concept".to_owned(),
+                scope: FactScope::Concept,
+                claim: "Concept fact.".to_owned(),
+                evidence: vec![],
+                mneme_session: None,
+                updated_at: "2026-04-22T00:00:00Z".to_owned(),
+                updated_by: "PR-1".to_owned(),
+            })
+            .await
+            .expect("put");
+        let crates = store
+            .list(Some(FactScope::Crate))
+            .await
+            .expect("list crate");
+        assert_eq!(crates.len(), 1, "expected 1 crate fact");
+        #[expect(clippy::indexing_slicing, reason = "test assertion: len checked above")]
+        let crate_scope = crates[0].scope;
+        assert_eq!(crate_scope, FactScope::Crate);
+    }
+
+    #[tokio::test]
+    async fn search_by_claim_substring() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FactStore::new(dir.path());
+        store
+            .put(ArchitectureFact {
+                id: "test.search.one".to_owned(),
+                scope: FactScope::Concept,
+                claim: "Agents spawn as Tokio tasks.".to_owned(),
+                evidence: vec![],
+                mneme_session: None,
+                updated_at: "2026-04-22T00:00:00Z".to_owned(),
+                updated_by: "PR-1".to_owned(),
+            })
+            .await
+            .expect("put");
+        store
+            .put(ArchitectureFact {
+                id: "test.search.two".to_owned(),
+                scope: FactScope::Crate,
+                claim: "eidos has no internal deps.".to_owned(),
+                evidence: vec![],
+                mneme_session: None,
+                updated_at: "2026-04-22T00:00:00Z".to_owned(),
+                updated_by: "PR-1".to_owned(),
+            })
+            .await
+            .expect("put");
+        let results = store.search("tokio").await.expect("search");
+        assert_eq!(results.len(), 1, "expected 1 result for 'tokio'");
+        #[expect(clippy::indexing_slicing, reason = "test assertion: len checked above")]
+        let result_id = results[0].id.clone();
+        assert_eq!(result_id, "test.search.one");
+    }
+
+    #[tokio::test]
+    async fn search_empty_when_no_match() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FactStore::new(dir.path());
+        store
+            .put(ArchitectureFact {
+                id: "test.search.nomatch".to_owned(),
+                scope: FactScope::Crate,
+                claim: "Something unrelated.".to_owned(),
+                evidence: vec![],
+                mneme_session: None,
+                updated_at: "2026-04-22T00:00:00Z".to_owned(),
+                updated_by: "PR-1".to_owned(),
+            })
+            .await
+            .expect("put");
+        let results = store.search("xyzzy_not_found").await.expect("search");
+        assert!(
+            results.is_empty(),
+            "expected no results for nonexistent query"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_returns_empty_when_dir_missing() {
+        // Directory that does not exist — should return empty, not error.
+        let store = FactStore::new("/tmp/aletheia-facts-does-not-exist-xyzzy-12345");
+        let result = store.list(None).await.expect("list");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn seed_facts_are_valid() {
+        let facts = seed_facts();
+        assert_eq!(facts.len(), 5, "expected 5 seed facts");
+        for fact in &facts {
+            assert!(!fact.id.is_empty(), "fact id must not be empty");
+            assert!(!fact.claim.is_empty(), "fact claim must not be empty");
+            assert_eq!(fact.updated_by, "PR-3789");
+        }
+    }
+
+    #[test]
+    fn id_to_filename_replaces_slashes() {
+        let name = FactStore::id_to_filename("aletheia/spawn/model");
+        assert_eq!(name, "aletheia-spawn-model.json");
+        let name2 = FactStore::id_to_filename("aletheia.spawn.model");
+        assert_eq!(name2, "aletheia.spawn.model.json");
+    }
+}

--- a/crates/eidos/src/knowledge/mod.rs
+++ b/crates/eidos/src/knowledge/mod.rs
@@ -7,6 +7,7 @@
 //! - **Memory scopes**: team memory sharing model (`User`, `Feedback`, `Project`, `Reference`)
 //! - **Path validation layers**: defense-in-depth security for memory path operations
 
+pub mod architecture_fact;
 mod causal;
 mod entity;
 mod fact;

--- a/crates/eidos/src/lib.rs
+++ b/crates/eidos/src/lib.rs
@@ -10,6 +10,8 @@ pub mod id;
 /// Knowledge graph domain types: facts, entities, relationships, embeddings.
 pub mod knowledge;
 
+/// Re-export architecture-fact types at crate root.
+pub use knowledge::architecture_fact::{ArchitectureFact, FactError, FactScope, FactStore};
 /// Re-export canonical finding types at crate root.
 pub use knowledge::finding::{EvidenceLevel, Finding};
 /// Shared test data builders for `Fact`, `Entity`, and `Relationship`.

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -25,6 +25,7 @@ test-core = []
 test-full = []
 
 [dependencies]
+eidos = { path = "../eidos" }
 energeia = { path = "../energeia", optional = true, features = [
     "storage-fjall",
 ] }

--- a/crates/organon/src/builtins/architecture_fact.rs
+++ b/crates/organon/src/builtins/architecture_fact.rs
@@ -1,0 +1,552 @@
+//! MCP tool: `architecture_fact` — query structured architecture facts.
+//!
+//! Research agents call this tool **before** synthesising a plan to verify
+//! architectural premises cheaply, instead of re-reading the codebase.
+//!
+//! # Operations
+//!
+//! | `op`     | Required args | Optional args | Effect                            |
+//! |----------|---------------|---------------|-----------------------------------|
+//! | `get`    | `id`          | —             | Return the fact with exact `id`.  |
+//! | `put`    | `fact`        | —             | Write/overwrite a fact.           |
+//! | `list`   | —             | `scope`       | List all facts (optionally filtered). |
+//! | `search` | `query`       | —             | Substring search across id/scope/claim. |
+//!
+//! # Storage
+//!
+//! Delegates to [`eidos::knowledge::architecture_fact::FactStore`] backed by
+//! flat JSON files under `ALETHEIA_FACTS_DIR` env var or
+//! `~/aletheia/instance/facts/` by default.
+//!
+//! # Producer discipline
+//!
+//! When calling `put`, the caller must populate `updated_by` with the PR
+//! number (`PR-<N>`) or session key for the current session.  This provides
+//! the lightweight audit trail required by the standards.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use indexmap::IndexMap;
+
+use eidos::knowledge::architecture_fact::{ArchitectureFact, FactScope, FactStore};
+use koina::id::ToolName;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Resolve the `FactStore` base directory from env or default.
+fn fact_store() -> FactStore {
+    match std::env::var("ALETHEIA_FACTS_DIR") {
+        Ok(dir) if !dir.is_empty() => FactStore::new(dir),
+        _ => FactStore::new(FactStore::default_path()),
+    }
+}
+
+/// Parse a `scope` string into a [`FactScope`].
+fn parse_scope(s: &str) -> Option<FactScope> {
+    match s {
+        "crate" => Some(FactScope::Crate),
+        "module" => Some(FactScope::Module),
+        "concept" => Some(FactScope::Concept),
+        "boundary" => Some(FactScope::Boundary),
+        _ => None,
+    }
+}
+
+// ── Executor ─────────────────────────────────────────────────────────────────
+
+struct ArchitectureFactExecutor;
+
+impl ToolExecutor for ArchitectureFactExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async {
+            let Some(op) = input.arguments.get("op").and_then(|v| v.as_str()) else {
+                return Ok(ToolResult::error("missing required field: op"));
+            };
+
+            match op {
+                "get" => op_get(&input.arguments).await,
+                "put" => op_put(&input.arguments).await,
+                "list" => op_list(&input.arguments).await,
+                "search" => op_search(&input.arguments).await,
+                other => Ok(ToolResult::error(format!(
+                    "unknown op '{other}': expected one of get, put, list, search"
+                ))),
+            }
+        })
+    }
+}
+
+// ── op: get ──────────────────────────────────────────────────────────────────
+
+async fn op_get(args: &serde_json::Value) -> Result<ToolResult> {
+    let Some(id) = args.get("id").and_then(|v| v.as_str()) else {
+        return Ok(ToolResult::error("op=get requires 'id'"));
+    };
+    let store = fact_store();
+    match store.get(id).await {
+        Ok(Some(fact)) => {
+            let json = match serde_json::to_string_pretty(&fact) {
+                Ok(j) => j,
+                Err(e) => return Ok(ToolResult::error(format!("serialise error: {e}"))),
+            };
+            Ok(ToolResult::text(json))
+        }
+        Ok(None) => Ok(ToolResult::text(format!("no fact found with id '{id}'"))),
+        Err(e) => Ok(ToolResult::error(e.to_string())),
+    }
+}
+
+// ── op: put ──────────────────────────────────────────────────────────────────
+
+async fn op_put(args: &serde_json::Value) -> Result<ToolResult> {
+    let Some(fact_val) = args.get("fact") else {
+        return Ok(ToolResult::error("op=put requires 'fact'"));
+    };
+    let fact: ArchitectureFact = match serde_json::from_value(fact_val.clone()) {
+        Ok(f) => f,
+        Err(e) => return Ok(ToolResult::error(format!("invalid fact: {e}"))),
+    };
+    if fact.updated_by.is_empty() {
+        return Ok(ToolResult::error(
+            "fact.updated_by must be set to a PR number (PR-<N>) or session key",
+        ));
+    }
+    let id = fact.id.clone();
+    let store = fact_store();
+    match store.put(fact).await {
+        Ok(()) => Ok(ToolResult::text(format!("fact '{id}' written"))),
+        Err(e) => Ok(ToolResult::error(e.to_string())),
+    }
+}
+
+// ── op: list ─────────────────────────────────────────────────────────────────
+
+async fn op_list(args: &serde_json::Value) -> Result<ToolResult> {
+    let scope = args
+        .get("scope")
+        .and_then(|v| v.as_str())
+        .and_then(parse_scope);
+
+    if let Some(raw) = args.get("scope").and_then(|v| v.as_str())
+        && scope.is_none()
+    {
+        return Ok(ToolResult::error(format!(
+            "unknown scope '{raw}': expected one of crate, module, concept, boundary",
+        )));
+    }
+
+    let store = fact_store();
+    match store.list(scope).await {
+        Ok(facts) => {
+            if facts.is_empty() {
+                return Ok(ToolResult::text("no facts found".to_owned()));
+            }
+            let lines: Vec<String> = facts
+                .iter()
+                .map(|f| format!("[{}] {} — {}", f.scope, f.id, f.claim))
+                .collect();
+            Ok(ToolResult::text(format!(
+                "{} fact(s):\n\n{}",
+                facts.len(),
+                lines.join("\n")
+            )))
+        }
+        Err(e) => Ok(ToolResult::error(e.to_string())),
+    }
+}
+
+// ── op: search ───────────────────────────────────────────────────────────────
+
+async fn op_search(args: &serde_json::Value) -> Result<ToolResult> {
+    let Some(query) = args.get("query").and_then(|v| v.as_str()) else {
+        return Ok(ToolResult::error("op=search requires 'query'"));
+    };
+    let store = fact_store();
+    match store.search(query).await {
+        Ok(facts) => {
+            if facts.is_empty() {
+                return Ok(ToolResult::text(format!("no facts match '{query}'")));
+            }
+            let lines: Vec<String> = facts
+                .iter()
+                .map(|f| format!("[{}] {} — {}", f.scope, f.id, f.claim))
+                .collect();
+            Ok(ToolResult::text(format!(
+                "{} fact(s) matching '{query}':\n\n{}",
+                facts.len(),
+                lines.join("\n")
+            )))
+        }
+        Err(e) => Ok(ToolResult::error(e.to_string())),
+    }
+}
+
+// ── ToolDef ──────────────────────────────────────────────────────────────────
+
+fn architecture_fact_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("architecture_fact"), // kanon:ignore RUST/expect
+        description:
+            "Query or write structured architecture facts about the aletheia codebase. \
+             Call this before synthesising a plan to verify premises without reading source. \
+             ops: get (by id), put (write/overwrite), list (optionally filtered by scope), \
+             search (substring across id/scope/claim)."
+                .to_owned(),
+        extended_description: Some(
+            "Architecture facts are short, cited, versioned claims about architectural \
+             seams: spawn model, storage invariants, hook taxonomy, lifecycle boundaries, \
+             crate ownership. Each fact carries evidence (file paths) and a producer \
+             (PR number or session key). Fact ids use dot-separated hierarchical names \
+             such as `aletheia.spawn.model`."
+                .to_owned(),
+        ),
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "op".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Operation: get | put | list | search".to_owned(),
+                        enum_values: Some(vec![
+                            "get".to_owned(),
+                            "put".to_owned(),
+                            "list".to_owned(),
+                            "search".to_owned(),
+                        ]),
+                        default: None,
+                    },
+                ),
+                (
+                    "id".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Fact id for op=get (dot-separated, e.g. aletheia.spawn.model)"
+                            .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "scope".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Filter by scope for op=list: crate | module | concept | boundary"
+                                .to_owned(),
+                        enum_values: Some(vec![
+                            "crate".to_owned(),
+                            "module".to_owned(),
+                            "concept".to_owned(),
+                            "boundary".to_owned(),
+                        ]),
+                        default: None,
+                    },
+                ),
+                (
+                    "query".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Substring query for op=search (case-insensitive, matches id/scope/claim)"
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "fact".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Object,
+                        description: "ArchitectureFact object for op=put. \
+                             Required fields: id, scope, claim, evidence, updated_by. \
+                             updated_by must be PR-<N> or session key."
+                            .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec!["op".to_owned()],
+        },
+        category: ToolCategory::Research,
+        reversibility: Reversibility::Reversible,
+        auto_activate: true,
+    }
+}
+
+// ── Registration ─────────────────────────────────────────────────────────────
+
+/// Register the `architecture_fact` tool into the registry.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(architecture_fact_def(), Box::new(ArchitectureFactExecutor))?;
+    Ok(())
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    use koina::id::{NousId, SessionId, ToolName};
+
+    use crate::testing::install_crypto_provider;
+    use crate::types::{ServerToolConfig, ToolContext, ToolInput, ToolServices};
+
+    use super::*;
+
+    fn mock_ctx() -> ToolContext {
+        install_crypto_provider();
+        ToolContext {
+            nous_id: NousId::new("test-agent").expect("valid"),
+            session_id: SessionId::new(),
+            workspace: std::path::PathBuf::from("/tmp/test"),
+            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
+            services: Some(Arc::new(ToolServices {
+                cross_nous: None,
+                messenger: None,
+                note_store: None,
+                blackboard_store: None,
+                spawn: None,
+                planning: None,
+                knowledge: None,
+                http_client: reqwest::Client::new(),
+                secret_vault: hermeneus::secret::SecretVault::new(),
+                lazy_tool_catalog: vec![],
+                server_tool_config: ServerToolConfig::default(),
+            })),
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+            tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
+        }
+    }
+
+    /// Point the store at a fresh temp dir for each test via env var.
+    fn setup_temp_dir() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // WHY: The executor reads ALETHEIA_FACTS_DIR at call time, so we
+        // set it before each test invocation.  Tests are not run in parallel
+        // within this module so the env var is safe to mutate.
+        #[expect(unsafe_code, reason = "test-only env mutation; tests run sequentially")]
+        // SAFETY: single-threaded tokio test context; no concurrent env readers.
+        unsafe {
+            std::env::set_var("ALETHEIA_FACTS_DIR", dir.path());
+        };
+        dir
+    }
+
+    #[tokio::test]
+    async fn op_put_then_get_roundtrip() {
+        let _dir = setup_temp_dir();
+        let ctx = mock_ctx();
+        let executor = ArchitectureFactExecutor;
+
+        // Put
+        let put_input = ToolInput {
+            name: ToolName::from_static("architecture_fact"),
+            tool_use_id: "toolu_put".to_owned(),
+            arguments: serde_json::json!({
+                "op": "put",
+                "fact": {
+                    "id": "test.mcp.put",
+                    "scope": "concept",
+                    "claim": "Test claim via MCP.",
+                    "evidence": ["src/lib.rs:1"],
+                    "updated_at": "2026-04-22T00:00:00Z",
+                    "updated_by": "PR-3789"
+                }
+            }),
+        };
+        let result = executor
+            .execute(&put_input, &ctx)
+            .await
+            .expect("execute put");
+        assert!(!result.is_error, "put should succeed");
+        assert!(result.content.text_summary().contains("written"));
+
+        // Get
+        let get_input = ToolInput {
+            name: ToolName::from_static("architecture_fact"),
+            tool_use_id: "toolu_get".to_owned(),
+            arguments: serde_json::json!({ "op": "get", "id": "test.mcp.put" }),
+        };
+        let result = executor
+            .execute(&get_input, &ctx)
+            .await
+            .expect("execute get");
+        assert!(!result.is_error, "get should succeed");
+        assert!(
+            result
+                .content
+                .text_summary()
+                .contains("Test claim via MCP.")
+        );
+    }
+
+    #[tokio::test]
+    async fn op_list_all() {
+        let _dir = setup_temp_dir();
+        let ctx = mock_ctx();
+        let executor = ArchitectureFactExecutor;
+
+        // Write two facts
+        for i in 0..2u32 {
+            let put_input = ToolInput {
+                name: ToolName::from_static("architecture_fact"),
+                tool_use_id: format!("toolu_put_{i}"),
+                arguments: serde_json::json!({
+                    "op": "put",
+                    "fact": {
+                        "id": format!("test.list.{i}"),
+                        "scope": "crate",
+                        "claim": format!("Claim {i}."),
+                        "evidence": [],
+                        "updated_at": "2026-04-22T00:00:00Z",
+                        "updated_by": "PR-3789"
+                    }
+                }),
+            };
+            executor.execute(&put_input, &ctx).await.expect("put");
+        }
+
+        let list_input = ToolInput {
+            name: ToolName::from_static("architecture_fact"),
+            tool_use_id: "toolu_list".to_owned(),
+            arguments: serde_json::json!({ "op": "list" }),
+        };
+        let result = executor
+            .execute(&list_input, &ctx)
+            .await
+            .expect("execute list");
+        assert!(!result.is_error, "list should succeed");
+        let text = result.content.text_summary();
+        assert!(text.contains("2 fact(s)"), "expected 2 facts, got: {text}");
+    }
+
+    #[tokio::test]
+    async fn op_search_returns_matching() {
+        let _dir = setup_temp_dir();
+        let ctx = mock_ctx();
+        let executor = ArchitectureFactExecutor;
+
+        let put_input = ToolInput {
+            name: ToolName::from_static("architecture_fact"),
+            tool_use_id: "toolu_put_search".to_owned(),
+            arguments: serde_json::json!({
+                "op": "put",
+                "fact": {
+                    "id": "test.search.mcp",
+                    "scope": "concept",
+                    "claim": "Agents use Tokio runtime.",
+                    "evidence": [],
+                    "updated_at": "2026-04-22T00:00:00Z",
+                    "updated_by": "PR-3789"
+                }
+            }),
+        };
+        executor.execute(&put_input, &ctx).await.expect("put");
+
+        let search_input = ToolInput {
+            name: ToolName::from_static("architecture_fact"),
+            tool_use_id: "toolu_search".to_owned(),
+            arguments: serde_json::json!({ "op": "search", "query": "tokio" }),
+        };
+        let result = executor
+            .execute(&search_input, &ctx)
+            .await
+            .expect("execute search");
+        assert!(!result.is_error, "search should succeed");
+        assert!(
+            result
+                .content
+                .text_summary()
+                .contains("Agents use Tokio runtime."),
+            "expected search to return matching fact"
+        );
+    }
+
+    #[tokio::test]
+    async fn op_get_missing_returns_not_found_message() {
+        let _dir = setup_temp_dir();
+        let ctx = mock_ctx();
+        let executor = ArchitectureFactExecutor;
+
+        let get_input = ToolInput {
+            name: ToolName::from_static("architecture_fact"),
+            tool_use_id: "toolu_get_miss".to_owned(),
+            arguments: serde_json::json!({ "op": "get", "id": "does.not.exist" }),
+        };
+        let result = executor
+            .execute(&get_input, &ctx)
+            .await
+            .expect("execute get");
+        assert!(!result.is_error, "missing get should be non-error");
+        assert!(
+            result.content.text_summary().contains("no fact found"),
+            "expected not-found message"
+        );
+    }
+
+    #[tokio::test]
+    async fn op_put_missing_updated_by_is_error() {
+        let _dir = setup_temp_dir();
+        let ctx = mock_ctx();
+        let executor = ArchitectureFactExecutor;
+
+        let put_input = ToolInput {
+            name: ToolName::from_static("architecture_fact"),
+            tool_use_id: "toolu_put_nobby".to_owned(),
+            arguments: serde_json::json!({
+                "op": "put",
+                "fact": {
+                    "id": "test.no-updated-by",
+                    "scope": "crate",
+                    "claim": "Some claim.",
+                    "evidence": [],
+                    "updated_at": "2026-04-22T00:00:00Z",
+                    "updated_by": ""
+                }
+            }),
+        };
+        let result = executor
+            .execute(&put_input, &ctx)
+            .await
+            .expect("execute put");
+        assert!(result.is_error, "empty updated_by should be an error");
+    }
+
+    #[tokio::test]
+    async fn op_unknown_is_error() {
+        let _dir = setup_temp_dir();
+        let ctx = mock_ctx();
+        let executor = ArchitectureFactExecutor;
+
+        let input = ToolInput {
+            name: ToolName::from_static("architecture_fact"),
+            tool_use_id: "toolu_bad_op".to_owned(),
+            arguments: serde_json::json!({ "op": "frobnicate" }),
+        };
+        let result = executor.execute(&input, &ctx).await.expect("execute");
+        assert!(result.is_error, "unknown op should be an error");
+    }
+
+    #[test]
+    fn tool_def_is_auto_activate_and_research_category() {
+        let def = architecture_fact_def();
+        assert!(def.auto_activate, "expected auto_activate = true");
+        assert_eq!(def.category, ToolCategory::Research);
+    }
+}

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -2,6 +2,8 @@
 
 /// Agent coordination tools (spawn, dispatch).
 pub mod agent;
+/// Architecture-fact query/write tool (architecture_fact).
+pub mod architecture_fact;
 /// Bookkeeper tools (prompt archival and worktree cleanup).
 #[cfg(feature = "energeia")]
 pub mod bookkeeper;
@@ -85,6 +87,7 @@ pub fn register_all_with_sandbox(
     enable_tool::register(registry)?;
     planning::register(registry)?;
     research::register(registry)?;
+    architecture_fact::register(registry)?;
     #[cfg(feature = "z3")]
     z3_solver::register(registry)?;
     web_search::register(registry)?;


### PR DESCRIPTION
## What

Adds an agent-facing architecture-fact observability layer so research agents can verify architectural premises via a single tool call instead of re-reading the codebase every run.

## Why

Issue #3789: research sub-agents repeatedly discover wrong premises mid-work (see spawn-model reframing in #3681 design). This is an observability problem — agents lacked a cheap, reliable way to answer "what does aletheia actually do here?". This layer is the cache: facts are verified once, reused by all downstream agents at O(query) cost.

Unblocks #3780 (deferred tool schemas premise-verification, previously premise-unknown).

## Storage backend choice

Flat JSON files at `~/aletheia/instance/facts/<id>.json` via serde_json.

**Rationale:** eidos is a pure types crate with no async backend deps. sqlx/sqlite would require migration infrastructure and a new dep. The fact dataset is bounded (<1000 entries), read-mostly, and best served by the simplest possible store: one file per fact, directory-listed, serde_json round-trip. The FactStore can be swapped to sqlite in a future wave without changing the public API.

## Changes

- **`crates/eidos/src/knowledge/architecture_fact.rs`** — `ArchitectureFact`, `FactScope`, `FactStore` (async get/put/list/search + file-backed), `seed_facts()` with 5 v1 aletheia facts
- **`crates/organon/src/builtins/architecture_fact.rs`** — MCP tool `architecture_fact` (ops: get/put/list/search), wired into `register_all`, reads `ALETHEIA_FACTS_DIR` env or default `~/aletheia/instance/facts/`
- **`crates/basanos/src/rules/architecture/fact_required.rs`** — Warn-severity lint rule `ARCHITECTURE/fact-required` that checks `src/lib.rs` and `pub mod` declarations for corresponding fact store entries
- **`.github/pull_request_template.md`** — architecture facts checklist item
- **`/home/ck/menos-ops/stage/prompting-premise-verification.md`** — proposed PROMPTING.md patch for kanon (staged, not committed to kanon — outside blast radius)

## Seed facts (5 v1)

| Fact ID | Scope | Summary |
|---------|-------|---------|
| `aletheia.spawn.model` | concept | In-process Tokio tasks, not subprocess |
| `aletheia.graphe.single-writer-invariant` | concept | Single-writer via session actor RwLock |
| `aletheia.providers.llm.routing` | boundary | dispatch-config.toml, per-nous-config routing |
| `aletheia.eidos.dependency-direction` | crate | eidos has zero internal aletheia deps |
| `aletheia.organon.tool-registration` | module | register_all pattern, pub(crate) fn register() |

## Testing

```
cargo nextest run -p eidos -p organon -p basanos --features test-core
```

687 tests run: 687 passed, 0 skipped.

Clippy clean on eidos/organon/basanos with `-D warnings`.

## Checklist

- [x] `cargo nextest run -p eidos -p organon -p basanos` passes (687/687)
- [x] `cargo clippy -p eidos -p organon -p basanos -- -D warnings` passes
- [x] New functionality has tests
- [x] No secrets or credentials in the diff
- [x] Commit message follows convention (`type(scope): description`)
- [x] Binary decisions preserve informative tension
- [x] Architecture facts touched: `aletheia.spawn.model`, `aletheia.graphe.single-writer-invariant`, `aletheia.providers.llm.routing`, `aletheia.eidos.dependency-direction`, `aletheia.organon.tool-registration`

Closes #3789