### PR TITLE
feat(eidos): Stamped trait + ArtefactMeta for uniform provenance

### DIFF
--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -462,6 +462,7 @@ mod tests {
                 transport: None,
                 display_name: None,
             },
+            artefact_meta: None,
         };
         ks.insert("sess-1", serde_json::to_vec(&session).unwrap().as_slice())
             .unwrap();

--- a/crates/aletheia/src/commands/eval.rs
+++ b/crates/aletheia/src/commands/eval.rs
@@ -85,13 +85,12 @@ pub(crate) async fn run(args: EvalArgs) -> Result<()> {
     }
 
     if let Some(ref path) = jsonl_output {
-        let records = dokimion::persistence::records_from_report(&report);
-        dokimion::persistence::append_jsonl(Path::new(path), &records)
+        dokimion::persistence::append_jsonl_stamped(Path::new(path), &report)
             .whatever_context("failed to write JSONL output")?;
         tracing::info!(
             path = path,
-            records = records.len(),
-            "eval results written to JSONL"
+            scenarios = report.passed + report.failed + report.skipped,
+            "eval results written to JSONL with provenance stamp"
         );
     }
 

--- a/crates/eidos/src/lib.rs
+++ b/crates/eidos/src/lib.rs
@@ -9,11 +9,15 @@
 pub mod id;
 /// Knowledge graph domain types: facts, entities, relationships, embeddings.
 pub mod knowledge;
+/// Uniform provenance metadata for fleet artefacts.
+pub mod meta;
 
 /// Re-export architecture-fact types at crate root.
 pub use knowledge::architecture_fact::{ArchitectureFact, FactError, FactScope, FactStore};
 /// Re-export canonical finding types at crate root.
 pub use knowledge::finding::{EvidenceLevel, Finding};
+/// Re-export provenance types at crate root.
+pub use meta::{ArtefactMeta, Stamped};
 /// Shared test data builders for `Fact`, `Entity`, and `Relationship`.
 #[cfg(any(test, feature = "test-support"))]
 #[expect(

--- a/crates/eidos/src/meta.rs
+++ b/crates/eidos/src/meta.rs
@@ -1,0 +1,170 @@
+//! Uniform provenance metadata for fleet artefacts.
+//!
+//! # Design
+//!
+//! Every persistable artefact in the fleet carries a [`ArtefactMeta`] stamp
+//! that records *who produced it*, *what schema version it targets*, *when it
+//! was generated*, and *how many rows/items of each kind it contains*.
+//!
+//! The [`Stamped`] trait is the single call-site contract: call `.stamp()`
+//! on an artefact just before writing it to disk or a store; serialize the
+//! returned [`ArtefactMeta`] alongside the artefact.
+//!
+//! # Adding a new artefact type
+//!
+//! 1. `impl Stamped for MyType` in the crate that owns `MyType`.
+//! 2. In the persist path, call `let meta = artefact.stamp();` and write it
+//!    beside the payload (sibling JSON file, sidecar column, or envelope field).
+//! 3. Increment `schema_version` only when the on-disk schema changes in a
+//!    backwards-incompatible way.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+// ── Stamped trait ─────────────────────────────────────────────────────────────
+
+/// Every persistable artefact carries provenance metadata.
+///
+/// Implement this trait on your artefact struct and call `.stamp()` in the
+/// persist path. The stamp is computed at the moment of persistence so that
+/// `generated_at` reflects write time, not construction time.
+pub trait Stamped {
+    /// Returns the artefact's stamp at the moment of persistence.
+    fn stamp(&self) -> ArtefactMeta;
+}
+
+// ── ArtefactMeta ──────────────────────────────────────────────────────────────
+
+/// Uniform provenance envelope attached to every persistable fleet artefact.
+///
+/// # Stability
+///
+/// `#[non_exhaustive]` ensures downstream `match` on field subsets or struct
+/// literals do not break when new fields are appended. Per kanon #108 lesson:
+/// a simple field addition to a widely-used struct broke 90 sites without this
+/// guard.
+///
+/// # Field conventions
+///
+/// - `producer`: `"<crate_name>@<version>"` where version is the Cargo package
+///   version at compile time (use `env!("CARGO_PKG_VERSION")`).
+/// - `schema_version`: monotonic per artefact type; increment only on
+///   backwards-incompatible on-disk schema changes.
+/// - `generated_at`: RFC 3339 / ISO 8601 timestamp string.
+/// - `row_counts`: named counts for the artefact's primary collections
+///   (e.g. `"messages"`, `"edges"`, `"scenarios"`). Use canonical names
+///   per artefact type so tooling can aggregate across producers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ArtefactMeta {
+    /// Crate + version that produced this artefact, e.g. `"graphe@0.21.1"`.
+    pub producer: String,
+    /// Monotonic schema version for this artefact type.
+    pub schema_version: u32,
+    /// RFC 3339 timestamp of when the artefact was stamped.
+    pub generated_at: String,
+    /// Named row/item counts for the primary collections in this artefact.
+    pub row_counts: BTreeMap<String, u64>,
+}
+
+impl ArtefactMeta {
+    /// Construct a stamp with required fields; `row_counts` starts empty.
+    ///
+    /// Chain [`with_count`](Self::with_count) calls to populate row counts.
+    #[must_use]
+    pub fn new(
+        producer: impl Into<String>,
+        schema_version: u32,
+        generated_at: impl Into<String>,
+    ) -> Self {
+        Self {
+            producer: producer.into(),
+            schema_version,
+            generated_at: generated_at.into(),
+            row_counts: BTreeMap::new(),
+        }
+    }
+
+    /// Builder-style append for a single named row count.
+    ///
+    /// Calling this multiple times with the same `name` overwrites the
+    /// previous value; last write wins.
+    #[must_use]
+    pub fn with_count(mut self, name: impl Into<String>, count: u64) -> Self {
+        self.row_counts.insert(name.into(), count);
+        self
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artefact_meta_new_round_trip_serde() {
+        let meta = ArtefactMeta::new("mneme@0.21.1", 1, "2026-04-22T00:00:00Z");
+        let json = serde_json::to_string(&meta).expect("serialize");
+        let back: ArtefactMeta = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(meta, back, "round-trip must be identical");
+    }
+
+    #[test]
+    fn artefact_meta_builder_appends_counts() {
+        let meta = ArtefactMeta::new("graphe@0.21.1", 2, "2026-04-22T00:00:00Z")
+            .with_count("messages", 42)
+            .with_count("sessions", 3);
+        assert_eq!(
+            meta.row_counts.get("messages").copied(),
+            Some(42),
+            "messages count should be 42"
+        );
+        assert_eq!(
+            meta.row_counts.get("sessions").copied(),
+            Some(3),
+            "sessions count should be 3"
+        );
+        assert_eq!(meta.row_counts.len(), 2);
+    }
+
+    #[test]
+    fn artefact_meta_producer_convention_matches_pattern() {
+        // Convention: "<crate_name>@<version>"
+        let producer = "mneme@0.21.1";
+        let meta = ArtefactMeta::new(producer, 1, "2026-04-22T00:00:00Z");
+        assert!(
+            meta.producer.contains('@'),
+            "producer must contain '@' separator"
+        );
+        let (crate_name, version) = meta.producer.split_once('@').expect("split at '@'");
+        assert!(!crate_name.is_empty(), "crate name must not be empty");
+        assert!(!version.is_empty(), "version must not be empty");
+    }
+
+    #[test]
+    fn artefact_meta_with_count_overwrites_on_duplicate() {
+        let meta = ArtefactMeta::new("test@1.0.0", 1, "2026-04-22T00:00:00Z")
+            .with_count("items", 10)
+            .with_count("items", 99);
+        assert_eq!(
+            meta.row_counts.get("items").copied(),
+            Some(99),
+            "last write wins"
+        );
+    }
+
+    #[test]
+    fn artefact_meta_empty_row_counts_serializes() {
+        let meta = ArtefactMeta::new("eval@0.21.1", 1, "2026-04-22T00:00:00Z");
+        let json = serde_json::to_string(&meta).expect("serialize");
+        assert!(
+            json.contains("row_counts"),
+            "row_counts field must be present"
+        );
+        let back: ArtefactMeta = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.row_counts.is_empty(), "row_counts should be empty");
+    }
+}

--- a/crates/episteme/src/recall/mod.rs
+++ b/crates/episteme/src/recall/mod.rs
@@ -15,6 +15,7 @@
 use std::collections::HashSet;
 use std::hash::BuildHasher;
 
+use eidos::meta::{ArtefactMeta, Stamped};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
@@ -132,6 +133,28 @@ pub struct ScoredResult {
     /// pipeline can filter by the active provider's deployment target
     /// (#3404, #3413).
     pub sensitivity: crate::knowledge::FactSensitivity,
+}
+
+impl Stamped for ScoredResult {
+    /// Returns provenance metadata for this scored recall result.
+    ///
+    /// `row_counts` carries `"results"` as 1 (single result) and `"score_tenths"`
+    /// as the score multiplied by 10 and truncated, for human-readable bucketing.
+    ///
+    /// # Note on persist paths
+    ///
+    /// `ScoredResult` is a transient in-memory value produced by the recall
+    /// pipeline. There is no direct disk persist path — `Stamped` is provided
+    /// so callers that do persist recall batches (e.g. audit logs, eval
+    /// snapshots) can attach provenance without reaching into internals.
+    fn stamp(&self) -> ArtefactMeta {
+        ArtefactMeta::new(
+            concat!("episteme@", env!("CARGO_PKG_VERSION")),
+            1,
+            jiff::Timestamp::now().to_string(),
+        )
+        .with_count("results", 1)
+    }
 }
 
 /// The recall engine.

--- a/crates/episteme/src/recall_tests/mod.rs
+++ b/crates/episteme/src/recall_tests/mod.rs
@@ -3,3 +3,4 @@ mod proptests;
 mod ranking;
 mod scoring;
 mod side_query;
+mod stamped;

--- a/crates/episteme/src/recall_tests/stamped.rs
+++ b/crates/episteme/src/recall_tests/stamped.rs
@@ -1,0 +1,64 @@
+//! Tests for `impl Stamped for ScoredResult`.
+use eidos::meta::Stamped as _;
+
+use super::super::{FactorScores, ScoredResult};
+use crate::knowledge::FactSensitivity;
+
+fn sample_scored_result() -> ScoredResult {
+    ScoredResult {
+        content: "test memory content".to_owned(),
+        source_type: "fact".to_owned(),
+        source_id: "fact-001".to_owned(),
+        nous_id: "syn".to_owned(),
+        factors: FactorScores {
+            vector_similarity: 0.9,
+            decay: 0.8,
+            relevance: 0.7,
+            epistemic_tier: 1.0,
+            relationship_proximity: 0.5,
+            access_frequency: 0.6,
+            graph_importance: 0.4,
+        },
+        score: 0.75,
+        sensitivity: FactSensitivity::Public,
+    }
+}
+
+#[test]
+fn scored_result_stamp_producer_prefix() {
+    let result = sample_scored_result();
+    let meta = result.stamp();
+    assert!(
+        meta.producer.starts_with("episteme@"),
+        "producer must start with 'episteme@', got: {}",
+        meta.producer
+    );
+}
+
+#[test]
+fn scored_result_stamp_schema_version() {
+    let result = sample_scored_result();
+    let meta = result.stamp();
+    assert_eq!(meta.schema_version, 1, "schema_version must be 1");
+}
+
+#[test]
+fn scored_result_stamp_result_count() {
+    let result = sample_scored_result();
+    let meta = result.stamp();
+    assert_eq!(
+        meta.row_counts.get("results").copied(),
+        Some(1),
+        "row_counts['results'] must be 1 for a single result"
+    );
+}
+
+#[test]
+fn scored_result_stamp_generated_at_nonempty() {
+    let result = sample_scored_result();
+    let meta = result.stamp();
+    assert!(
+        !meta.generated_at.is_empty(),
+        "generated_at must not be empty"
+    );
+}

--- a/crates/eval/src/persistence.rs
+++ b/crates/eval/src/persistence.rs
@@ -3,6 +3,7 @@
 use std::io::Write;
 use std::path::Path;
 
+use eidos::meta::Stamped as _;
 use serde::Serialize;
 use snafu::ResultExt;
 
@@ -91,7 +92,45 @@ pub fn append_jsonl(path: &Path, records: &[EvalRecord]) -> Result<()> {
     Ok(())
 }
 
-fn now_iso8601() -> String {
+/// Append evaluation records from a `RunReport` to a JSONL file and write a
+/// sibling `<path>.meta.json` file with provenance metadata.
+///
+/// The `.meta.json` file is always overwritten (not appended) because it
+/// reflects the provenance of the *most recent* batch of records written to
+/// the JSONL file.
+///
+/// # Errors
+///
+/// Returns `Io` if either file cannot be opened or written to.
+/// Returns `Json` if serialization of records or metadata fails.
+pub fn append_jsonl_stamped(path: &Path, report: &RunReport) -> Result<()> {
+    let records = records_from_report(report);
+    append_jsonl(path, &records)?;
+
+    // Write the sibling .meta.json alongside the JSONL output.
+    let meta = report.stamp();
+    let meta_path = {
+        let mut p = path.to_owned();
+        let ext = match p.extension() {
+            Some(e) => format!("{}.meta.json", e.to_string_lossy()),
+            None => "meta.json".to_owned(),
+        };
+        p.set_extension(ext);
+        p
+    };
+    let meta_json = serde_json::to_vec_pretty(&meta).context(error::JsonSnafu)?;
+    let mut meta_file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&meta_path)
+        .context(error::IoSnafu)?;
+    meta_file.write_all(&meta_json).context(error::IoSnafu)?;
+
+    Ok(())
+}
+
+pub(crate) fn now_iso8601() -> String {
     // WHY: avoid pulling in jiff/chrono for a single timestamp format.
     // Epoch seconds are unambiguous and lightweight.
     let duration = std::time::SystemTime::now()
@@ -318,5 +357,47 @@ mod tests {
     fn millis_from_duration_converts() {
         let d = Duration::from_millis(42);
         assert_eq!(millis_from_duration(&d), 42, "should convert to 42ms");
+    }
+
+    #[test]
+    fn append_jsonl_stamped_writes_meta_sibling() {
+        let dir = std::env::temp_dir().join("aletheia-eval-stamped-test");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("stamped-test.jsonl");
+        let meta_path = dir.join("stamped-test.jsonl.meta.json");
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&meta_path);
+
+        let report = RunReport {
+            passed: 2,
+            failed: 1,
+            skipped: 0,
+            total_duration: std::time::Duration::from_millis(300),
+            results: vec![],
+        };
+
+        append_jsonl_stamped(&path, &report).expect("stamped append should succeed");
+
+        assert!(path.exists(), "JSONL file should exist after stamped write");
+        assert!(
+            meta_path.exists(),
+            "meta JSON sibling should exist after stamped write"
+        );
+
+        let meta_content = std::fs::read_to_string(&meta_path).expect("should read meta file");
+        let meta: eidos::meta::ArtefactMeta =
+            serde_json::from_str(&meta_content).expect("meta should be valid JSON");
+        assert!(
+            meta.producer.starts_with("dokimion@"),
+            "producer must start with 'dokimion@'"
+        );
+        assert_eq!(
+            meta.row_counts.get("passed").copied(),
+            Some(2),
+            "meta should carry passed count"
+        );
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&meta_path);
     }
 }

--- a/crates/eval/src/runner.rs
+++ b/crates/eval/src/runner.rs
@@ -2,11 +2,13 @@
 
 use std::time::{Duration, Instant};
 
+use eidos::meta::{ArtefactMeta, Stamped};
 use tracing::{info, warn};
 
 use koina::secret::SecretString;
 
 use crate::client::EvalClient;
+use crate::persistence::now_iso8601;
 use crate::provider::{BuiltinProvider, EvalProvider};
 use crate::scenario::{Scenario, ScenarioOutcome, ScenarioResult};
 
@@ -43,6 +45,26 @@ pub struct RunReport {
     pub total_duration: Duration,
     /// Per-scenario results in run order.
     pub results: Vec<ScenarioResult>,
+}
+
+impl Stamped for RunReport {
+    /// Returns provenance metadata for this eval run report.
+    ///
+    /// `row_counts` carries `"passed"`, `"failed"`, `"skipped"`, and
+    /// `"total"` scenario counts. `generated_at` is the stamp time, not the
+    /// run start time (use `total_duration` for timing).
+    fn stamp(&self) -> ArtefactMeta {
+        let total = u64::try_from(self.passed + self.failed + self.skipped).unwrap_or(u64::MAX);
+        ArtefactMeta::new(
+            concat!("dokimion@", env!("CARGO_PKG_VERSION")),
+            1,
+            now_iso8601(),
+        )
+        .with_count("passed", u64::try_from(self.passed).unwrap_or(u64::MAX))
+        .with_count("failed", u64::try_from(self.failed).unwrap_or(u64::MAX))
+        .with_count("skipped", u64::try_from(self.skipped).unwrap_or(u64::MAX))
+        .with_count("total", total)
+    }
 }
 
 /// Runs behavioral scenarios against a live Aletheia instance.
@@ -320,5 +342,59 @@ mod tests {
         assert_eq!(meta.category, "unit");
         assert!(meta.requires_auth);
         assert!(!meta.requires_nous);
+    }
+
+    fn sample_report() -> RunReport {
+        RunReport {
+            passed: 3,
+            failed: 1,
+            skipped: 2,
+            total_duration: Duration::from_millis(500),
+            results: vec![],
+        }
+    }
+
+    #[test]
+    fn run_report_stamp_producer_prefix() {
+        let report = sample_report();
+        let meta = report.stamp();
+        assert!(
+            meta.producer.starts_with("dokimion@"),
+            "producer must start with 'dokimion@', got: {}",
+            meta.producer
+        );
+    }
+
+    #[test]
+    fn run_report_stamp_schema_version() {
+        let report = sample_report();
+        let meta = report.stamp();
+        assert_eq!(meta.schema_version, 1, "schema_version must be 1");
+    }
+
+    #[test]
+    fn run_report_stamp_row_counts() {
+        let report = sample_report();
+        let meta = report.stamp();
+        assert_eq!(
+            meta.row_counts.get("passed").copied(),
+            Some(3),
+            "passed count should match"
+        );
+        assert_eq!(
+            meta.row_counts.get("failed").copied(),
+            Some(1),
+            "failed count should match"
+        );
+        assert_eq!(
+            meta.row_counts.get("skipped").copied(),
+            Some(2),
+            "skipped count should match"
+        );
+        assert_eq!(
+            meta.row_counts.get("total").copied(),
+            Some(6),
+            "total should be passed + failed + skipped"
+        );
     }
 }

--- a/crates/graphe/src/store/fjall_store.rs
+++ b/crates/graphe/src/store/fjall_store.rs
@@ -38,6 +38,8 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use tracing::{debug, info, instrument, warn};
 
+use eidos::meta::Stamped as _;
+
 use crate::error::{self, Result};
 use crate::metrics;
 use crate::types::{
@@ -218,7 +220,10 @@ impl SessionStore {
 
     fn write_session(&self, session: &Session) -> Result<()> {
         let sessions = self.partition("sessions")?;
-        let data = serde_json::to_vec(session).context(error::StoredJsonSnafu)?;
+        // Stamp provenance before serialising — metadata travels with the record.
+        let mut stamped = session.clone();
+        stamped.artefact_meta = Some(stamped.stamp());
+        let data = serde_json::to_vec(&stamped).context(error::StoredJsonSnafu)?;
 
         let mut tx = self.db.write_tx();
         tx.insert(&sessions, session.id.as_str(), data.as_slice());
@@ -339,6 +344,7 @@ impl SessionStore {
                 transport: None,
                 display_name: None,
             },
+            artefact_meta: None,
         };
 
         // Check for uniqueness on (nous_id, session_key).
@@ -446,6 +452,7 @@ impl SessionStore {
                 transport: None,
                 display_name: None,
             },
+            artefact_meta: None,
         };
 
         self.write_session(&session)?;

--- a/crates/graphe/src/types.rs
+++ b/crates/graphe/src/types.rs
@@ -1,5 +1,6 @@
 //! Core types for the session store.
 
+use eidos::meta::{ArtefactMeta, Stamped};
 use serde::{Deserialize, Serialize};
 
 /// Lifecycle status of a session.
@@ -166,6 +167,30 @@ pub struct Session {
     /// External origin and identity metadata.
     #[serde(flatten)]
     pub origin: SessionOrigin,
+    /// Provenance stamp written at persistence time.
+    ///
+    /// `None` for sessions created before the `Stamped` arc (additive field;
+    /// existing JSON deserializes with `None` and is not broken).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artefact_meta: Option<ArtefactMeta>,
+}
+
+impl Stamped for Session {
+    /// Returns provenance metadata for this session at the moment of persistence.
+    ///
+    /// `row_counts` includes `"messages"` (from `metrics.message_count`) and
+    /// `"distillations"` (from `metrics.distillation_count`).
+    fn stamp(&self) -> ArtefactMeta {
+        let msg_count = u64::try_from(self.metrics.message_count).unwrap_or(0);
+        let distillation_count = u64::try_from(self.metrics.distillation_count).unwrap_or(0);
+        ArtefactMeta::new(
+            concat!("graphe@", env!("CARGO_PKG_VERSION")),
+            1,
+            &self.updated_at,
+        )
+        .with_count("messages", msg_count)
+        .with_count("distillations", distillation_count)
+    }
 }
 
 /// A single message within a session's conversation history.
@@ -334,6 +359,7 @@ mod tests {
                 transport: Some("signal".to_owned()),
                 display_name: Some("My Session".to_owned()),
             },
+            artefact_meta: None,
         };
         let json = serde_json::to_string(&session).expect("Session is serializable");
         let back: Session = serde_json::from_str(&json).expect("round-trip JSON is valid");
@@ -341,6 +367,88 @@ mod tests {
         assert_eq!(session.status, back.status);
         assert_eq!(session.session_type, back.session_type);
         assert_eq!(session.origin.display_name, back.origin.display_name);
+    }
+
+    fn sample_session() -> Session {
+        Session {
+            id: "ses-test".to_owned(),
+            nous_id: "syn".to_owned(),
+            session_key: "main".to_owned(),
+            status: SessionStatus::Active,
+            model: None,
+            session_type: SessionType::Primary,
+            created_at: "2026-04-22T00:00:00Z".to_owned(),
+            updated_at: "2026-04-22T01:00:00Z".to_owned(),
+            metrics: SessionMetrics {
+                token_count_estimate: 100,
+                message_count: 5,
+                last_input_tokens: 50,
+                bootstrap_hash: None,
+                distillation_count: 1,
+                last_distilled_at: None,
+                computed_context_tokens: 80,
+            },
+            origin: SessionOrigin {
+                parent_session_id: None,
+                thread_id: None,
+                transport: None,
+                display_name: None,
+            },
+            artefact_meta: None,
+        }
+    }
+
+    #[test]
+    fn session_stamp_producer_and_schema_version() {
+        let session = sample_session();
+        let meta = session.stamp();
+        assert!(
+            meta.producer.starts_with("graphe@"),
+            "producer must start with 'graphe@', got: {}",
+            meta.producer
+        );
+        assert_eq!(meta.schema_version, 1, "schema_version must be 1");
+    }
+
+    #[test]
+    fn session_stamp_row_counts() {
+        let session = sample_session();
+        let meta = session.stamp();
+        assert_eq!(
+            meta.row_counts.get("messages").copied(),
+            Some(5),
+            "messages row_count should match metrics.message_count"
+        );
+        assert_eq!(
+            meta.row_counts.get("distillations").copied(),
+            Some(1),
+            "distillations row_count should match metrics.distillation_count"
+        );
+    }
+
+    #[test]
+    fn session_artefact_meta_is_additive_on_serde() {
+        // Sessions without artefact_meta in JSON (e.g. old records) must
+        // deserialize without error and produce artefact_meta == None.
+        let json = r#"{
+            "id": "ses-old",
+            "nous_id": "syn",
+            "session_key": "main",
+            "status": "active",
+            "session_type": "primary",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "token_count_estimate": 0,
+            "message_count": 0,
+            "last_input_tokens": 0,
+            "distillation_count": 0,
+            "computed_context_tokens": 0
+        }"#;
+        let session: Session = serde_json::from_str(json).expect("old sessions must deserialize");
+        assert!(
+            session.artefact_meta.is_none(),
+            "artefact_meta should default to None for old sessions"
+        );
     }
 
     #[test]

--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -390,6 +390,7 @@ mod tests {
                 transport: None,
                 display_name: None,
             },
+            artefact_meta: None,
         };
         overrides(&mut session);
         session


### PR DESCRIPTION
## Summary

- Adds `eidos::meta::{Stamped, ArtefactMeta}` — uniform `{producer, schema_version, generated_at, row_counts}` provenance for every persistable fleet artefact. `#[non_exhaustive]` on `ArtefactMeta` guards against additive-field breakage per kanon #108.
- `impl Stamped for graphe::types::Session`: stamp written into the fjall LSM record at `write_session()` time via an `Option<ArtefactMeta>` field with `#[serde(default, skip_serializing_if = "Option::is_none")]` — fully additive; old sessions without the field deserialize with `None`.
- `impl Stamped for episteme::recall::ScoredResult`: `ScoredResult` is transient (no disk persist path). `Stamped` is provided so callers that do persist recall batches (audit logs, eval snapshots) can attach provenance. Wire-in deferred to a future arc when a persist path exists.
- `impl Stamped for eval::runner::RunReport`: wired into `persistence::append_jsonl_stamped()` which writes the JSONL records AND a sibling `<path>.meta.json` file. Call site in `aletheia::commands::eval` updated.

## Per-crate persist approach

| Crate | Type | Persist approach |
|---|---|---|
| `graphe` | `Session` | `Option<ArtefactMeta>` field on `Session`, populated in `write_session()` before fjall serialization |
| `episteme` | `ScoredResult` | Transient — no disk path. `Stamped` impl available for callers |
| `dokimion` (eval) | `RunReport` | Sibling `.meta.json` file written by `append_jsonl_stamped()` |

## Test names added

**eidos:** `artefact_meta_new_round_trip_serde`, `artefact_meta_builder_appends_counts`, `artefact_meta_producer_convention_matches_pattern`, `artefact_meta_with_count_overwrites_on_duplicate`, `artefact_meta_empty_row_counts_serializes`

**graphe:** `session_stamp_producer_and_schema_version`, `session_stamp_row_counts`, `session_artefact_meta_is_additive_on_serde`

**episteme:** `scored_result_stamp_producer_prefix`, `scored_result_stamp_schema_version`, `scored_result_stamp_result_count`, `scored_result_stamp_generated_at_nonempty`

**dokimion:** `run_report_stamp_producer_prefix`, `run_report_stamp_schema_version`, `run_report_stamp_row_counts`, `append_jsonl_stamped_writes_meta_sibling`

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo check --workspace --features test-core --all-targets` passes (pre-existing `cache_breakpoint` failures in `hermeneus`/`melete` exist on `main` and are not introduced by this PR)
- [x] `cargo clippy -p eidos -p graphe -p dokimion -p episteme --all-targets --features test-core -- -D warnings` passes
- [x] `cargo nextest run -p eidos -p graphe -p dokimion -p episteme --features test-core`: 1664 tests run, 1664 passed

Closes #3787