### PR TITLE
feat(episteme): add OpenAI-compatible embedding provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,6 +2391,8 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "regex",
+ "reqwest 0.13.2",
+ "rustls",
  "serde",
  "serde_json",
  "snafu",
@@ -2401,6 +2403,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -77,6 +77,7 @@ pub(crate) async fn run(
         model: config.embedding.model.clone(),
         dimension: Some(config.embedding.dimension),
         api_key: None,
+        base_url: None,
     };
     let embedder: Arc<dyn EmbeddingProvider> = match create_provider(&embedding_config) {
         Ok(p) => {

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -384,6 +384,7 @@ impl LazyEmbeddingProvider {
                     model: self.settings.model.clone(),
                     dimension: Some(self.settings.dimension),
                     api_key: None,
+                    base_url: None,
                 };
                 #[expect(
                     clippy::as_conversions,

--- a/crates/episteme/Cargo.toml
+++ b/crates/episteme/Cargo.toml
@@ -20,6 +20,7 @@ test-support = []
 mneme-engine = ["dep:krites", "dep:tokio", "graphe/mneme-engine"]
 storage-fjall = ["mneme-engine", "krites/storage-fjall"]
 embed-candle = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers", "dep:hf-hub"]
+openai-embed = ["dep:reqwest", "dep:tokio", "dep:rustls"]
 # WHY: candle embedding tests download config.json from HuggingFace at test
 # time. macOS GitHub runners intermittently fail DNS lookup for huggingface.co
 # (see #3683). Gate those network-dependent tests behind `online-tests` so the
@@ -64,6 +65,9 @@ tokenizers = { version = "0.22", optional = true, default-features = false, feat
 hf-hub = { version = "0.5", optional = true, default-features = false, features = [
     "ureq",
 ] }
+# OpenAI-compatible embedding provider (HTTP)
+reqwest = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -72,6 +76,7 @@ proptest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
+wiremock = { workspace = true }
 
 # WHY: extract::observation parsers run on every PR scraped by the bookkeeper.
 # Track them here so regressions in the regex/tag pipeline surface in CI.

--- a/crates/episteme/README.md
+++ b/crates/episteme/README.md
@@ -1,0 +1,39 @@
+# episteme
+
+Knowledge pipeline for Aletheia. Extraction, storage, recall, and maintenance
+of the knowledge graph.
+
+## Embedding providers
+
+### OpenAI-compatible HTTP provider
+
+Enable the `openai-embed` feature and set `provider = "openai-compat"` in the
+embedding configuration. This offloads embedding inference to any endpoint that
+implements the OpenAI `/v1/embeddings` surface — OpenAI, Voyage, Cohere (with a
+shim), or a local **llama-server**.
+
+```toml
+[embedding]
+provider = "openai-compat"
+base_url = "http://127.0.0.1:5005/v1"
+model = "qwen-embed"
+dimension = 384
+```
+
+On **menos**, the Tier-1 embed service runs Qwen3-Embedding-0.6B at port `5005`
+with an OpenAI-shim (`llama-server --embedding`). Pointing `base_url` at
+`http://127.0.0.1:5005/v1` keeps weights in a single process, eliminating the
+~2GB duplicate VRAM load that occurs when candle runs in-process alongside the
+inference server. See `menos-ops/CLAUDE.md` § "AI Service Surface" for the live
+service topology.
+
+For authenticated cloud endpoints, add an `api_key`:
+
+```toml
+[embedding]
+provider = "openai-compat"
+base_url = "https://api.openai.com/v1"
+model = "text-embedding-3-small"
+dimension = 1536
+api_key = "sk-..."
+```

--- a/crates/episteme/src/embedding.rs
+++ b/crates/episteme/src/embedding.rs
@@ -2,6 +2,7 @@
 //!
 //! Defines the interface for text→vector embedding. Multiple backends:
 //! - `candle` (local, pure Rust, no C++ deps, default for development)
+//! - `openai-compat` (HTTP, any OpenAI-compatible endpoint; requires `openai-embed` feature)
 //! - Voyage AI (production quality, API key required)
 //! - Future: Ollama local models
 //!
@@ -422,6 +423,11 @@ mod candle_provider {
 #[cfg(feature = "embed-candle")]
 pub use candle_provider::CandelProvider;
 
+#[cfg(feature = "openai-embed")]
+mod openai;
+#[cfg(feature = "openai-embed")]
+pub use openai::{OpenAiCompatConfig, OpenAiEmbeddingProvider};
+
 /// Embedding provider configuration.
 ///
 /// Available providers:
@@ -429,7 +435,7 @@ pub use candle_provider::CandelProvider;
 /// - `"candle"`: local pure-Rust embeddings via candle (requires `embed-candle` feature)
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EmbeddingConfig {
-    /// Provider type: `mock`, `candle`, `voyage`.
+    /// Provider type: `mock`, `candle`, `openai-compat`, `voyage`.
     pub provider: String,
     /// Model name (provider-specific).
     pub model: Option<String>,
@@ -437,6 +443,8 @@ pub struct EmbeddingConfig {
     pub dimension: Option<usize>,
     /// API key (for cloud providers).
     pub api_key: Option<koina::secret::SecretString>,
+    /// Base URL for OpenAI-compatible endpoints (e.g. `http://127.0.0.1:5005/v1`).
+    pub base_url: Option<String>,
 }
 
 impl Default for EmbeddingConfig {
@@ -446,6 +454,7 @@ impl Default for EmbeddingConfig {
             model: None,
             dimension: Some(384),
             api_key: None,
+            base_url: None,
         }
     }
 }
@@ -507,6 +516,29 @@ pub fn create_provider(config: &EmbeddingConfig) -> EmbeddingResult<Box<dyn Embe
             let model = config.model.as_deref();
             Ok(Box::new(CandelProvider::new(model)?))
         }
+        #[cfg(feature = "openai-embed")]
+        "openai-compat" => {
+            let base_url = config
+                .base_url
+                .as_deref()
+                .unwrap_or("http://127.0.0.1:5005/v1")
+                .to_owned();
+            let model = config.model.clone().unwrap_or_else(|| "default".to_owned());
+            let dim = config.dimension.unwrap_or(384);
+            let cfg = OpenAiCompatConfig {
+                base_url,
+                api_key: config.api_key.clone(),
+                model,
+                dimension: dim,
+            };
+            Ok(Box::new(OpenAiEmbeddingProvider::new(&cfg)?))
+        }
+        #[cfg(not(feature = "openai-embed"))]
+        "openai-compat" => InitFailedSnafu {
+            message: "openai-embed feature not enabled — build with --features openai-embed"
+                .to_owned(),
+        }
+        .fail(),
         #[cfg(not(feature = "embed-candle"))]
         "candle" => InitFailedSnafu {
             message: "embed-candle feature not enabled — build with --features embed-candle"

--- a/crates/episteme/src/embedding/openai.rs
+++ b/crates/episteme/src/embedding/openai.rs
@@ -1,0 +1,426 @@
+//! `OpenAI`-compatible HTTP embedding provider.
+//!
+//! Talks to any endpoint that exposes the `OpenAI` `/v1/embeddings`
+//! surface — `OpenAI` itself, llama.cpp `--server`, or any compatible proxy.
+//! Enabled by the `openai-embed` Cargo feature.
+//!
+//! # Local llama-server
+//!
+//! Point `base_url` at `http://127.0.0.1:5005/v1` (menos convention for the
+//! Qwen3-Embedding-0.6B service; see `menos-ops/CLAUDE.md` § AI Service Surface).
+
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+use super::{EmbedFailedSnafu, EmbeddingProvider, EmbeddingResult, InitFailedSnafu};
+
+/// Configuration for an `OpenAI`-compatible embedding provider.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub struct OpenAiCompatConfig {
+    /// Base URL for the target endpoint — typically ends in `/v1`. Example:
+    /// `http://127.0.0.1:5005/v1` for a local llama.cpp server.
+    pub base_url: String,
+    /// Optional bearer token for authenticated endpoints. Loopback llama.cpp
+    /// accepts any value (or no auth at all); `OpenAI` requires a real key.
+    pub api_key: Option<koina::secret::SecretString>,
+    /// Model ID to request from the endpoint.
+    pub model: String,
+    /// Expected output dimension. Used by [`EmbeddingProvider::dimension`].
+    pub dimension: usize,
+}
+
+/// `OpenAI` `/v1/embeddings`-compatible embedding provider.
+///
+/// Holds a dedicated Tokio runtime so the sync [`EmbeddingProvider`] trait can
+/// drive async HTTP requests. In the Aletheia runtime this is invoked from
+/// `tokio::task::spawn_blocking`, which is a safe context for
+/// `Runtime::block_on`.
+pub struct OpenAiEmbeddingProvider {
+    client: Client,
+    runtime: tokio::runtime::Runtime,
+    base_url: String,
+    api_key: Option<koina::secret::SecretString>,
+    model: String,
+    dimension: usize,
+}
+
+impl std::fmt::Debug for OpenAiEmbeddingProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiEmbeddingProvider")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("dimension", &self.dimension)
+            .field("authenticated", &self.api_key.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Wire request body for `/v1/embeddings`.
+#[derive(Debug, Serialize)]
+struct EmbeddingRequest<'a> {
+    model: &'a str,
+    input: &'a [String],
+}
+
+/// Single embedding entry in the response.
+#[derive(Debug, Deserialize)]
+struct EmbeddingEntry {
+    embedding: Vec<f32>,
+    index: usize,
+}
+
+/// Wire response body from `/v1/embeddings`.
+#[derive(Debug, Deserialize)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingEntry>,
+    #[expect(dead_code, reason = "captured for completeness; not dispatched on yet")]
+    model: String,
+}
+
+impl OpenAiEmbeddingProvider {
+    /// Create a provider from the given config.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EmbeddingError::InitFailed` if the HTTP client or Tokio runtime
+    /// cannot be built.
+    #[instrument]
+    pub fn new(config: &OpenAiCompatConfig) -> EmbeddingResult<Self> {
+        // WHY: reqwest with rustls-no-provider needs an explicit crypto provider.
+        // This is idempotent — subsequent calls silently fail and are ignored.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let runtime = tokio::runtime::Runtime::new().map_err(|e| {
+            InitFailedSnafu {
+                message: format!("failed to build Tokio runtime: {e}"),
+            }
+            .build()
+        })?;
+
+        let client = Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_mins(1))
+            .build()
+            .map_err(|e| {
+                InitFailedSnafu {
+                    message: format!("failed to build HTTP client: {e}"),
+                }
+                .build()
+            })?;
+
+        Ok(Self {
+            client,
+            runtime,
+            base_url: config.base_url.trim_end_matches('/').to_owned(),
+            api_key: config.api_key.clone(),
+            model: config.model.clone(),
+            dimension: config.dimension,
+        })
+    }
+
+    async fn embed_async(&self, texts: &[String]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let url = format!("{}/embeddings", self.base_url);
+        let body = EmbeddingRequest {
+            model: &self.model,
+            input: texts,
+        };
+
+        let mut request = self
+            .client
+            .post(&url)
+            .json(&body)
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .build()
+            .map_err(|e| {
+                EmbedFailedSnafu {
+                    message: format!("failed to build request: {e}"),
+                }
+                .build()
+            })?;
+
+        if let Some(key) = &self.api_key {
+            let value = reqwest::header::HeaderValue::from_str(&format!(
+                "Bearer {}",
+                key.expose_secret()
+            ))
+            .map_err(|e| {
+                EmbedFailedSnafu {
+                    message: format!("invalid API key for header: {e}"),
+                }
+                .build()
+            })?;
+            request
+                .headers_mut()
+                .insert(reqwest::header::AUTHORIZATION, value);
+        }
+
+        let response = self.client.execute(request).await.map_err(|e| {
+            EmbedFailedSnafu {
+                message: format!("HTTP request failed: {e}"),
+            }
+            .build()
+        })?;
+
+        let status = response.status().as_u16();
+        if !response.status().is_success() {
+            let body = response.text().await.unwrap_or_default();
+            // WHY: bounded slice so we do not paste a multi-megabyte HTML
+            // error page into the error chain.
+            let trimmed: String = body.chars().take(512).collect();
+            return EmbedFailedSnafu {
+                message: format!("embedding API returned HTTP {status}: {trimmed}"),
+            }
+            .fail();
+        }
+
+        let parsed: EmbeddingResponse = response.json().await.map_err(|e| {
+            EmbedFailedSnafu {
+                message: format!("failed to parse embedding response: {e}"),
+            }
+            .build()
+        })?;
+
+        let mut results = vec![Vec::new(); texts.len()];
+        for entry in parsed.data {
+            if entry.index >= texts.len() {
+                return EmbedFailedSnafu {
+                    message: format!(
+                        "embedding response index {} out of bounds (batch size {})",
+                        entry.index,
+                        texts.len()
+                    ),
+                }
+                .fail();
+            }
+            match results.get_mut(entry.index) {
+                Some(slot) => *slot = entry.embedding,
+                None => {
+                    return EmbedFailedSnafu {
+                        message: format!("missing embedding for index {}", entry.index),
+                    }
+                    .fail();
+                }
+            }
+        }
+
+        for (i, result) in results.iter().enumerate() {
+            if result.is_empty() {
+                return EmbedFailedSnafu {
+                    message: format!("missing embedding for index {i}"),
+                }
+                .fail();
+            }
+        }
+
+        Ok(results)
+    }
+
+    fn embed_inner(&self, texts: &[String]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        self.runtime.block_on(self.embed_async(texts))
+    }
+}
+
+impl EmbeddingProvider for OpenAiEmbeddingProvider {
+    #[instrument(skip(self, text))]
+    fn embed(&self, text: &str) -> EmbeddingResult<Vec<f32>> {
+        let mut results = self.embed_inner(&[text.to_owned()])?;
+        results.pop().ok_or_else(|| {
+            EmbedFailedSnafu {
+                message: "OpenAI embedding returned empty result".to_owned(),
+            }
+            .build()
+        })
+    }
+
+    #[instrument(skip(self, texts), fields(batch_size = texts.len()))]
+    fn embed_batch(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        let owned: Vec<String> = texts.iter().map(|s| (*s).to_owned()).collect();
+        self.embed_inner(&owned)
+    }
+
+    #[instrument(skip(self))]
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    #[instrument(skip(self))]
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test: indices asserted valid by construction"
+)]
+mod tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn mock_provider(server: &MockServer) -> OpenAiEmbeddingProvider {
+        OpenAiEmbeddingProvider::new(&OpenAiCompatConfig {
+            base_url: format!("{}/v1", server.uri()),
+            api_key: None,
+            model: "qwen-embed".to_owned(),
+            dimension: 384,
+        })
+        .expect("mock provider construct")
+    }
+
+    fn embedding_response(vectors: Vec<Vec<f32>>) -> serde_json::Value {
+        let data: Vec<serde_json::Value> = vectors
+            .into_iter()
+            .enumerate()
+            .map(|(i, vec)| {
+                serde_json::json!({
+                    "object": "embedding",
+                    "embedding": vec,
+                    "index": i
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "object": "list",
+            "data": data,
+            "model": "qwen-embed",
+            "usage": { "prompt_tokens": 10, "total_tokens": 10 }
+        })
+    }
+
+    #[test]
+    fn parse_embedding_response_single_vec() {
+        std::thread::spawn(|| {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let server = rt.block_on(async {
+                let server = MockServer::start().await;
+                let expected = vec![0.1_f32, 0.2, 0.3];
+                Mock::given(method("POST"))
+                    .and(path("/v1/embeddings"))
+                    .respond_with(
+                        ResponseTemplate::new(200)
+                            .set_body_json(embedding_response(vec![expected.clone()])),
+                    )
+                    .expect(1)
+                    .mount(&server)
+                    .await;
+                server
+            });
+
+            let provider = mock_provider(&server);
+            let result = provider.embed("hello").expect("embed should succeed");
+            assert_eq!(result, vec![0.1_f32, 0.2, 0.3]);
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn parse_embedding_response_batch() {
+        std::thread::spawn(|| {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let server = rt.block_on(async {
+                let server = MockServer::start().await;
+                let v1 = vec![1.0_f32, 2.0, 3.0];
+                let v2 = vec![4.0_f32, 5.0, 6.0];
+                let v3 = vec![7.0_f32, 8.0, 9.0];
+
+                // Return out of order to verify index-based reconstruction.
+                let response = serde_json::json!({
+                    "object": "list",
+                    "data": [
+                        { "object": "embedding", "embedding": v2.clone(), "index": 1 },
+                        { "object": "embedding", "embedding": v3.clone(), "index": 2 },
+                        { "object": "embedding", "embedding": v1.clone(), "index": 0 }
+                    ],
+                    "model": "qwen-embed",
+                    "usage": { "prompt_tokens": 10, "total_tokens": 10 }
+                });
+
+                Mock::given(method("POST"))
+                    .and(path("/v1/embeddings"))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(response))
+                    .expect(1)
+                    .mount(&server)
+                    .await;
+                server
+            });
+
+            let provider = mock_provider(&server);
+            let result = provider
+                .embed_batch(&["first", "second", "third"])
+                .expect("batch embed should succeed");
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(result[0], vec![1.0, 2.0, 3.0]);
+            assert_eq!(result[1], vec![4.0, 5.0, 6.0]);
+            assert_eq!(result[2], vec![7.0, 8.0, 9.0]);
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn embed_error_on_non_200() {
+        std::thread::spawn(|| {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let server = rt.block_on(async {
+                let server = MockServer::start().await;
+                Mock::given(method("POST"))
+                    .and(path("/v1/embeddings"))
+                    .respond_with(
+                        ResponseTemplate::new(500).set_body_string("internal server error"),
+                    )
+                    .expect(1)
+                    .mount(&server)
+                    .await;
+                server
+            });
+
+            let provider = mock_provider(&server);
+            let result = provider.embed("hello");
+            let err = result.expect_err("should error on 500");
+            let msg = err.to_string();
+            assert!(msg.contains("500"), "error should contain status: {msg}");
+            assert!(
+                msg.contains("internal server error"),
+                "error should contain body: {msg}"
+            );
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn empty_input_returns_empty_vec_without_http() {
+        std::thread::spawn(|| {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let server = rt.block_on(async {
+                let server = MockServer::start().await;
+                // No mock mounted — if we made an HTTP request it would fail.
+                server
+            });
+
+            let provider = mock_provider(&server);
+            let result = provider
+                .embed_batch(&[])
+                .expect("empty batch should succeed");
+            assert!(result.is_empty(), "empty input should return empty vec");
+        })
+        .join()
+        .unwrap();
+    }
+}

--- a/crates/episteme/src/embedding_tests.rs
+++ b/crates/episteme/src/embedding_tests.rs
@@ -274,6 +274,7 @@ fn create_provider_mock_config() {
         model: Some("custom-model".to_owned()),
         dimension: Some(768),
         api_key: None,
+        base_url: None,
     };
     let provider = create_provider(&config).expect("create mock provider with full config");
     assert_eq!(

--- a/crates/episteme/src/knowledge_store/tests/search.rs
+++ b/crates/episteme/src/knowledge_store/tests/search.rs
@@ -41,6 +41,7 @@ fn knowledge_store_builds_and_bm25_works_with_degraded_embedding() {
         model: None,
         dimension: Some(4),
         api_key: None,
+        base_url: None,
     };
     assert!(
         create_provider(&bad_config).is_err(),


### PR DESCRIPTION
Closes #3741

## Summary

Add `OpenAiEmbeddingProvider` implementing the existing `EmbeddingProvider` trait. This enables episteme to offload embedding inference to any OpenAI-compatible HTTP endpoint (OpenAI, Voyage, Cohere with shim, or local llama-server) instead of loading candle in-process.

## Changes

- **New provider** (`crates/episteme/src/embedding/openai.rs`):
  - `OpenAiEmbeddingProvider` with async reqwest + dedicated Tokio runtime
  - Custom `Debug` redacts `api_key`
  - `embed_batch` reconstructs response order by `index` field
  - Short-circuits empty input without HTTP round-trip
  - Snafu errors with HTTP status + body on non-200

- **Config extension** (`crates/episteme/src/embedding.rs`):
  - `EmbeddingConfig` gains `base_url: Option<String>`
  - `create_provider` handles `provider = "openai-compat"`
  - Falls back to `http://127.0.0.1:5005/v1` when `base_url` is omitted

- **Feature flag** (`crates/episteme/Cargo.toml`):
  - New `openai-embed` feature (default-off)
  - Pulls in `reqwest`, `tokio`, `rustls`

- **Tests** (`crates/episteme/src/embedding/openai.rs`):
  - `parse_embedding_response_single_vec` — happy path
  - `parse_embedding_response_batch` — out-of-order index reconstruction
  - `embed_error_on_non_200` — status + body in error
  - `empty_input_returns_empty_vec_without_http` — short-circuit

- **Docs** (`crates/episteme/README.md`):
  - Section on configuring the OpenAI-compat provider
  - Cites menos port 5005 convention for local llama-server

## Gate status

- `cargo fmt --all -- --check` ✅
- `cargo check --workspace --features test-core --all-targets --jobs 8` ✅
- `cargo check --workspace --features test-core,openai-embed --all-targets --jobs 8` ✅
- `cargo clippy -p episteme --features test-core,openai-embed --all-targets -- -D warnings` ✅
- `cargo nextest run -p episteme --features test-core,openai-embed --build-jobs 8 --test-threads 8` ✅ (1195 passed)

## Follow-up issues

- **Candle deprecation** — once all fleet callers migrate to `openai-compat`, remove `embed-candle` feature and `CandelProvider`
- **Caller migration** — `nous` and `aletheia` runtime config may need TOML changes to opt into the new provider; this PR only makes it available