### PR TITLE
feat(pylon): Deprecation + Sunset headers per RFC 8594

### DIFF
--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -109,6 +109,22 @@ pub async fn check(State(state): State<HealthState>) -> impl IntoResponse {
     )
 }
 
+/// GET /health: deprecated unversioned health check.
+///
+/// Use `/api/health` instead.
+#[deprecated = "Use /api/health instead"]
+#[utoipa::path(
+    get,
+    path = "/health",
+    responses(
+        (status = 200, description = "Health status", body = HealthResponse),
+        (status = 503, description = "Service unavailable", body = HealthResponse),
+    ),
+)]
+pub async fn deprecated_health_check(State(state): State<HealthState>) -> impl IntoResponse {
+    check(State(state)).await
+}
+
 /// Run a health check with a per-check timeout. If the check exceeds
 /// [`CHECK_TIMEOUT`], a "timeout" status is returned instead of blocking.
 async fn timed_check(

--- a/crates/pylon/src/middleware/deprecation.rs
+++ b/crates/pylon/src/middleware/deprecation.rs
@@ -1,0 +1,167 @@
+//! Deprecation middleware: injects `Deprecation` and `Sunset` headers per RFC 8594.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::extract::Request;
+use axum::response::Response;
+use jiff::Timestamp;
+use tower::{Layer, Service};
+use tracing::warn;
+
+/// Metadata for a deprecated endpoint.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct DeprecationInfo {
+    /// Unix timestamp when the endpoint was deprecated.
+    pub deprecated_at: Timestamp,
+    /// Unix timestamp when the endpoint will be removed.
+    pub sunset_at: Timestamp,
+    /// Optional URL to a migration guide.
+    pub link: Option<String>,
+}
+
+impl DeprecationInfo {
+    /// Create a new deprecation entry.
+    #[must_use]
+    pub fn new(deprecated_at: Timestamp, sunset_at: Timestamp, link: Option<String>) -> Self {
+        Self {
+            deprecated_at,
+            sunset_at,
+            link,
+        }
+    }
+}
+
+/// Map from route pattern (`METHOD /path`) to deprecation metadata.
+#[derive(Debug, Clone, Default)]
+pub struct DeprecationMap {
+    inner: HashMap<String, DeprecationInfo>,
+}
+
+/// Register a deprecation for a route pattern.
+///
+/// Returns a `(pattern, info)` tuple suitable for passing to
+/// [`DeprecationLayer::new`].
+#[must_use]
+pub fn deprecate(
+    pattern: impl Into<String>,
+    deprecated_at: Timestamp,
+    sunset_at: Timestamp,
+    link: Option<String>,
+) -> (String, DeprecationInfo) {
+    (
+        pattern.into(),
+        DeprecationInfo::new(deprecated_at, sunset_at, link),
+    )
+}
+
+/// Tower layer that injects `Deprecation` and `Sunset` headers on matching
+/// responses, per RFC 8594.
+#[derive(Debug, Clone)]
+pub struct DeprecationLayer {
+    deprecations: Arc<DeprecationMap>,
+}
+
+impl DeprecationLayer {
+    /// Create a new deprecation layer from a list of registered deprecations.
+    #[must_use]
+    pub fn new(deprecations: impl IntoIterator<Item = (String, DeprecationInfo)>) -> Self {
+        let mut map = DeprecationMap::default();
+        for (pattern, info) in deprecations {
+            map.inner.insert(pattern, info);
+        }
+        Self {
+            deprecations: Arc::new(map),
+        }
+    }
+}
+
+impl<S> Layer<S> for DeprecationLayer {
+    type Service = DeprecationService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        DeprecationService {
+            inner,
+            deprecations: Arc::clone(&self.deprecations),
+        }
+    }
+}
+
+/// Tower service that adds deprecation headers to responses.
+#[derive(Debug, Clone)]
+pub struct DeprecationService<S> {
+    inner: S,
+    deprecations: Arc<DeprecationMap>,
+}
+
+impl<S> Service<Request> for DeprecationService<S>
+where
+    S: Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let method = request.method().to_string();
+        let key = format!("{method} {}", request.uri().path());
+        let info = self.deprecations.inner.get(&key).cloned();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let mut response = inner.call(request).await?;
+
+            if let Some(info) = info {
+                let _span = tracing::info_span!(
+                    "deprecation_middleware",
+                    http.path = %key,
+                    http.method = %method,
+                );
+                let _guard = _span.enter();
+
+                // RFC 8594: Deprecation: @<unix-timestamp>
+                let deprecation_value = format!("@{}", info.deprecated_at.as_second());
+                if let Ok(header) = axum::http::HeaderValue::from_str(&deprecation_value) {
+                    response
+                        .headers_mut()
+                        .insert(axum::http::HeaderName::from_static("deprecation"), header);
+                }
+
+                // RFC 8594: Sunset: <HTTP-date> (RFC 7231)
+                let sunset = info
+                    .sunset_at
+                    .strftime("%a, %d %b %Y %H:%M:%S GMT")
+                    .to_string();
+                if let Ok(header) = axum::http::HeaderValue::from_str(&sunset) {
+                    response
+                        .headers_mut()
+                        .insert(axum::http::HeaderName::from_static("sunset"), header);
+                }
+
+                // RFC 8594: Link: <url>; rel="deprecation"
+                if let Some(link) = info.link {
+                    let link_value = format!("<{link}>; rel=\"deprecation\"");
+                    if let Ok(header) = axum::http::HeaderValue::from_str(&link_value) {
+                        response
+                            .headers_mut()
+                            .insert(axum::http::HeaderName::from_static("link"), header);
+                    }
+                }
+
+                warn!(path = %key, "request to deprecated endpoint");
+            }
+
+            Ok(response)
+        })
+    }
+}

--- a/crates/pylon/src/middleware/mod.rs
+++ b/crates/pylon/src/middleware/mod.rs
@@ -253,9 +253,11 @@ pub async fn record_http_metrics(request: Request, next: Next) -> Response {
 /// Each IP gets a fixed window of `window` duration. The window resets when
 /// expired. Uses `std::sync::Mutex` (not tokio): the critical section is
 /// short and contains no `.await` points.
+mod deprecation;
 mod rate_limiter;
 mod user_rate_limiter;
 
+pub use deprecation::{DeprecationInfo, DeprecationLayer, DeprecationMap, deprecate};
 pub use rate_limiter::{RateLimiter, rate_limit};
 pub use user_rate_limiter::{
     EndpointCategory, UserRateLimiter, per_user_rate_limit, spawn_stale_cleanup,

--- a/crates/pylon/src/openapi.rs
+++ b/crates/pylon/src/openapi.rs
@@ -22,6 +22,7 @@ use koina::http::CONTENT_TYPE_JSON;
     ),
     paths(
         crate::handlers::health::check,
+        crate::handlers::health::deprecated_health_check,
         crate::handlers::metrics::expose,
         crate::handlers::sessions::list_sessions,
         crate::handlers::sessions::create,

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -19,8 +19,9 @@ use koina::http::{API_HEALTH, API_V1};
 use crate::error::{ApiError, ErrorBody, ErrorResponse};
 use crate::handlers::{config, health, knowledge, metrics, nous, planning, sessions};
 use crate::middleware::{
-    CsrfState, RateLimiter, RequestId, UserRateLimiter, enrich_error_response, inject_request_id,
-    per_user_rate_limit, rate_limit, record_http_metrics, require_csrf_header, spawn_stale_cleanup,
+    CsrfState, DeprecationLayer, RateLimiter, RequestId, UserRateLimiter, deprecate,
+    enrich_error_response, inject_request_id, per_user_rate_limit, rate_limit, record_http_metrics,
+    require_csrf_header, spawn_stale_cleanup,
 };
 use crate::openapi;
 use crate::security::SecurityConfig;
@@ -41,6 +42,10 @@ pub fn build_router(state: Arc<AppState>, security: &SecurityConfig) -> Router {
 #[expect(
     clippy::too_many_lines,
     reason = "router construction requires assembling all routes and ordered middleware layers; extraction would obscure the stack ordering"
+)]
+#[expect(
+    deprecated,
+    reason = "deprecated_health_check is intentionally wired as the demonstration endpoint for #3280"
 )]
 pub fn build_router_with(
     state: Arc<AppState>,
@@ -132,7 +137,7 @@ pub fn build_router_with(
     let mut router = Router::new()
         .nest(API_V1, v1)
         .route(API_HEALTH, get(health::check))
-        .route("/health", get(health::check))
+        .route("/health", get(health::deprecated_health_check))
         .route("/api/docs/openapi.json", get(openapi::openapi_json))
         .route("/metrics", get(metrics::expose));
 
@@ -188,6 +193,17 @@ pub fn build_router_with(
     // WARNING: Must be inside compression (body uncompressed) but outside
     // rate_limit and CSRF so their error responses get request_id injected.
     router = router.layer(axum::middleware::from_fn(enrich_error_response));
+
+    let deprecated_at = jiff::Timestamp::now();
+    let sunset_at = deprecated_at
+        .checked_add(jiff::SignedDuration::from_secs(365 * 24 * 60 * 60))
+        .unwrap_or(deprecated_at);
+    router = router.layer(DeprecationLayer::new([deprecate(
+        "GET /health",
+        deprecated_at,
+        sunset_at,
+        Some("https://docs.aletheia.dev/migration/health".to_owned()),
+    )]));
 
     router = router.layer(axum::middleware::from_fn(record_http_metrics));
 

--- a/crates/pylon/src/tests/middleware.rs
+++ b/crates/pylon/src/tests/middleware.rs
@@ -495,3 +495,95 @@ async fn post_on_health_returns_405() {
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
 }
+
+#[tokio::test]
+async fn deprecation_header_present_for_registered_route() {
+    let (app, _dir) = app().await;
+    let resp = app
+        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let deprecation = resp
+        .headers()
+        .get("deprecation")
+        .expect("Deprecation header must be present");
+    assert!(
+        deprecation.to_str().unwrap().starts_with('@'),
+        "Deprecation header must be a timestamp prefixed with @"
+    );
+    assert!(
+        resp.headers().get("sunset").is_some(),
+        "Sunset header must be present"
+    );
+}
+
+#[tokio::test]
+async fn non_deprecated_route_has_no_headers() {
+    let (app, _dir) = app().await;
+    let resp = app
+        .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        resp.headers().get("deprecation").is_none(),
+        "non-deprecated route must not have Deprecation header"
+    );
+    assert!(
+        resp.headers().get("sunset").is_none(),
+        "non-deprecated route must not have Sunset header"
+    );
+    assert!(
+        resp.headers().get("link").is_none(),
+        "non-deprecated route must not have Link header"
+    );
+}
+
+#[tokio::test]
+async fn link_header_included_when_set() {
+    let (app, _dir) = app().await;
+    let resp = app
+        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let link = resp
+        .headers()
+        .get("link")
+        .expect("Link header must be present for deprecated route with link");
+    assert!(
+        link.to_str().unwrap().contains("rel=\"deprecation\""),
+        "Link header must contain rel=\"deprecation\""
+    );
+}
+
+#[tokio::test]
+async fn sunset_header_format_rfc8594() {
+    let (app, _dir) = app().await;
+    let resp = app
+        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let sunset = resp
+        .headers()
+        .get("sunset")
+        .expect("Sunset header must be present");
+    let sunset_str = sunset.to_str().unwrap();
+
+    // RFC 7231 HTTP-date ends with "GMT"
+    let (datetime_part, tz) = sunset_str.rsplit_once(' ').expect("valid HTTP-date format");
+    assert_eq!(tz, "GMT", "Sunset header must use GMT timezone");
+
+    // Verify the datetime portion parses with the expected format
+    let parsed = jiff::civil::DateTime::strptime("%a, %d %b %Y %H:%M:%S", datetime_part);
+    assert!(
+        parsed.is_ok(),
+        "Sunset header must be a valid RFC 7231 HTTP-date"
+    );
+}


### PR DESCRIPTION
Adds RFC 8594 deprecation signalling to pylon.

- New `DeprecationLayer` middleware injects `Deprecation`, `Sunset`, and `Link` headers on flagged routes.
- Example wire-in: `GET /health` is deprecated in favour of `GET /api/health`.
- OpenAPI spec marks the deprecated endpoint.

Closes #3280