### PR TITLE
feat(aletheia-memory-mcp): write tools behind per-process capability token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,12 +181,14 @@ name = "aletheia-memory-mcp"
 version = "0.21.1"
 dependencies = [
  "jiff",
+ "koina",
  "mneme",
  "rmcp",
  "schemars",
  "serde",
  "serde_json",
  "snafu",
+ "subtle",
  "taxis",
  "tempfile",
  "tokio",

--- a/crates/aletheia-memory-mcp/Cargo.toml
+++ b/crates/aletheia-memory-mcp/Cargo.toml
@@ -37,9 +37,16 @@ snafu = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-# Internal crates: memory facade + path resolver
+# Time
+jiff = { workspace = true }
+
+# Constant-time comparison for capability tokens
+subtle = "2.5"
+
+# Internal crates: memory facade + path resolver + UUID generation
 mneme = { path = "../mneme", features = ["storage-fjall"] }
 taxis = { path = "../taxis" }
+koina = { path = "../koina" }
 
 [dev-dependencies]
 # WHY: the `client` rmcp feature enables the `ClientHandler` blanket impl we

--- a/crates/aletheia-memory-mcp/README.md
+++ b/crates/aletheia-memory-mcp/README.md
@@ -1,0 +1,106 @@
+# aletheia-memory-mcp
+
+Standalone stdio MCP server exposing Aletheia's memory and knowledge graph to external agents (Claude Code, Cursor, OpenHands, etc.) without requiring the full Aletheia runtime.
+
+## Tools
+
+### Read Tools (Always Available)
+
+- `memory_search` — BM25 text search across active facts
+- `memory_neighbors` — one-hop graph traversal from a fact's entities
+- `memory_list_topics` — enumerate fact-type buckets with counts
+- `memory_stats` — knowledge graph health metrics (fact count, schema version, last updated)
+
+### Write Tools (Capability Token Gated)
+
+- `memory_annotate` — create an annotation on an existing fact
+- `memory_supersede` — mark one fact as superseded by another
+- `memory_forget` — soft-delete a fact (mark as forgotten)
+
+## Configuration
+
+### Environment Variables
+
+- `ALETHEIA_ROOT` — instance root directory (default: `./instance`). The knowledge store is opened at `<root>/data/knowledge.fjall`.
+- `ALETHEIA_MEMORY_MCP_STORE` — override the store path directly.
+- `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` — capability token for write tools. If unset, write tools are not registered.
+- `RUST_LOG` — tracing filter (default: `info`). Logs go to stderr; stdout is JSON-RPC only.
+
+## Write Tool Authentication
+
+Write tools are protected by a **per-process capability token** passed via environment variable at server startup.
+
+### How It Works
+
+1. **Server Startup**: The spawning process (aletheia daemon or operator) generates a random token and sets it in the child's environment as `ALETHEIA_MEMORY_MCP_WRITE_TOKEN`.
+2. **Token Validation**: Each write tool call includes a `write_token` field in its input. The server compares it against the configured token using constant-time comparison (via `subtle::ConstantTimeEq`).
+3. **Authorization**: If tokens match, the write proceeds. If they don't match or no token is configured, the call returns an "unauthorized" error.
+4. **Audit Logging**: Successful writes are logged at INFO level to stderr with the tool name and affected fact IDs.
+
+### Token Generation
+
+Operators should generate tokens cryptographically:
+
+```bash
+openssl rand -hex 32
+```
+
+This produces a 64-character hexadecimal string suitable for use as `ALETHEIA_MEMORY_MCP_WRITE_TOKEN`.
+
+### Example: Spawning with Write Access
+
+```bash
+export ALETHEIA_MEMORY_MCP_WRITE_TOKEN=$(openssl rand -hex 32)
+aletheia-memory-mcp  # server inherits the token
+```
+
+### Example: MCP Client Call
+
+```json
+{
+  "name": "memory_annotate",
+  "arguments": {
+    "fact_id": "f-abc-123",
+    "content": "Verified against external source X",
+    "session_id": "agent-uuid",
+    "write_token": "..."  // must match ALETHEIA_MEMORY_MCP_WRITE_TOKEN
+  }
+}
+```
+
+## Security Notes
+
+- **Capability Token**: This is a shared secret, not user authentication. Any process with access to the server's environment can invoke writes if it knows the token.
+- **No Encryption**: The token is passed in-process via environment variable and in-protocol via MCP calls. It's not encrypted on the wire; use this server only over local IPC or secure channels (SSH, TLS).
+- **Constant-Time Comparison**: Token comparison uses `subtle::ConstantTimeEq` to prevent timing-based token leakage.
+
+## Admission Control
+
+Write tools respect the knowledge store's `DefaultAdmissionPolicy` before persisting facts. If a policy rejects a write, the call fails with an admission error.
+
+## Exit Codes
+
+- `0` — clean shutdown (peer closed connection)
+- `1` — startup or transport error (details on stderr)
+
+## Development
+
+Run tests:
+
+```bash
+cargo nextest run -p aletheia-memory-mcp
+cargo test -p aletheia-memory-mcp --doc  # doctest examples
+```
+
+Format and lint:
+
+```bash
+cargo fmt -p aletheia-memory-mcp
+cargo clippy -p aletheia-memory-mcp --all-targets -- -D warnings
+```
+
+Full gate (simulates CI):
+
+```bash
+kanon gate --full  # from ~/dev/kanon
+```

--- a/crates/aletheia-memory-mcp/src/error.rs
+++ b/crates/aletheia-memory-mcp/src/error.rs
@@ -62,6 +62,28 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Write tool invoked without capability token configured.
+    #[snafu(display("write tools are not available; capability token not configured"))]
+    WriteNotAvailable {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Write call rejected due to invalid capability token.
+    #[snafu(display("write authorization failed"))]
+    WriteUnauthorized {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Fact not found for a write operation.
+    #[snafu(display("fact not found: {id}"))]
+    FactNotFound {
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 /// Result alias using this crate's [`Error`].
@@ -71,7 +93,10 @@ impl From<Error> for rmcp::ErrorData {
     fn from(err: Error) -> Self {
         let message = err.to_string();
         match &err {
-            Error::InvalidInput { .. } => rmcp::ErrorData::invalid_params(message, None),
+            Error::InvalidInput { .. }
+            | Error::WriteNotAvailable { .. }
+            | Error::WriteUnauthorized { .. }
+            | Error::FactNotFound { .. } => rmcp::ErrorData::invalid_params(message, None),
             Error::OpenStore { .. }
             | Error::KnowledgeStore { .. }
             | Error::Serialization { .. }

--- a/crates/aletheia-memory-mcp/src/server.rs
+++ b/crates/aletheia-memory-mcp/src/server.rs
@@ -26,6 +26,9 @@ use crate::error::{self, JoinSnafu, OpenStoreSnafu, TransportSnafu};
 pub struct MemoryServer {
     pub(crate) store: Arc<KnowledgeStore>,
     pub(crate) store_path: Option<PathBuf>,
+    /// Capability token for write tools, if configured.
+    /// If `None`, write tools are not registered.
+    pub(crate) write_token: Option<String>,
     #[expect(
         dead_code,
         reason = "read by #[tool_handler] macro-generated code in ServerHandler impl"
@@ -38,11 +41,33 @@ impl MemoryServer {
     ///
     /// `store_path` is surfaced by `memory_stats` so callers can confirm which
     /// on-disk database is being served. Pass `None` for in-memory stores.
+    ///
+    /// Write tools are registered if `write_token` is `Some(_)`.
     #[must_use]
     pub fn new(store: Arc<KnowledgeStore>, store_path: Option<PathBuf>) -> Self {
+        let write_token = std::env::var("ALETHEIA_MEMORY_MCP_WRITE_TOKEN").ok();
         Self {
             store,
             store_path,
+            write_token,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Build a memory server with an explicit write token (for testing).
+    ///
+    /// This bypasses environment variable lookup. For production, use [`Self::new()`]
+    /// which reads from `ALETHEIA_MEMORY_MCP_WRITE_TOKEN`.
+    #[must_use]
+    pub fn with_write_token(
+        store: Arc<KnowledgeStore>,
+        store_path: Option<PathBuf>,
+        write_token: Option<String>,
+    ) -> Self {
+        Self {
+            store,
+            store_path,
+            write_token,
             tool_router: Self::tool_router(),
         }
     }
@@ -114,6 +139,30 @@ impl MemoryServer {
         tokio::task::spawn_blocking(move || f(store))
             .await
             .context(JoinSnafu)?
+    }
+
+    /// Validate a capability token against the configured token.
+    ///
+    /// Returns `Ok(())` if tokens match (via constant-time comparison).
+    /// Returns `Err(WriteUnauthorized)` if:
+    ///   - Write token is not configured
+    ///   - Provided token does not match
+    pub(crate) fn validate_write_token(&self, provided: &str) -> error::Result<()> {
+        use subtle::ConstantTimeEq;
+
+        let expected = self
+            .write_token
+            .as_ref()
+            .ok_or_else(|| error::WriteNotAvailableSnafu.build())?;
+
+        // Constant-time comparison to prevent timing-based token leakage
+        let result = expected.as_bytes().ct_eq(provided.as_bytes());
+
+        if result.unwrap_u8() == 1 {
+            Ok(())
+        } else {
+            Err(error::WriteUnauthorizedSnafu.build())
+        }
     }
 }
 

--- a/crates/aletheia-memory-mcp/src/tools.rs
+++ b/crates/aletheia-memory-mcp/src/tools.rs
@@ -1,10 +1,12 @@
 //! MCP tool implementations for the memory server.
 //!
-//! All tools are read-only. Writes (annotate, supersede, forget) are deferred
-//! to a follow-up iteration pending an auth-model review: exposing mutation
-//! over an unauthenticated stdio transport would let any process that can
-//! spawn this binary modify the knowledge graph. When write tools are added,
-//! they will live behind a per-process capability token.
+//! Read tools (`memory_search`, `memory_neighbors`, `memory_list_topics`, `memory_stats`)
+//! are always available.
+//!
+//! Write tools (`memory_annotate`, `memory_supersede`, `memory_forget`) are only
+//! registered if the `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` environment variable is
+//! set at server startup. Each write call must include a `write_token` field
+//! that matches the configured token (via constant-time comparison).
 
 use std::collections::BTreeMap;
 
@@ -35,6 +37,46 @@ pub struct MemorySearchParams {
 pub struct MemoryNeighborsParams {
     /// ID of the seed fact whose entity neighbors should be returned.
     pub fact_id: String,
+}
+
+/// Parameters for `memory_annotate`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
+pub struct MemoryAnnotateParams {
+    /// Session ID for the annotation (identifies the agent or source).
+    pub session_id: Option<String>,
+    /// Fact ID to annotate.
+    pub fact_id: String,
+    /// Annotation content — agent-authored note or observation.
+    pub content: String,
+    /// Capability token for write authorization.
+    pub write_token: String,
+}
+
+/// Parameters for `memory_supersede`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
+pub struct MemorySupersedeParams {
+    /// ID of the fact being superseded.
+    pub old_fact_id: String,
+    /// ID of the new fact that supersedes it.
+    pub new_fact_id: String,
+    /// Reason for supersession.
+    pub reason: String,
+    /// Capability token for write authorization.
+    pub write_token: String,
+}
+
+/// Parameters for `memory_forget`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
+pub struct MemoryForgetParams {
+    /// ID of the fact to forget.
+    pub fact_id: String,
+    /// Reason for forgetting.
+    pub reason: String,
+    /// Capability token for write authorization.
+    pub write_token: String,
 }
 
 /// Default search limit when the caller omits one.
@@ -378,6 +420,422 @@ impl MemoryServer {
             "schema_version": schema_version,
             "store_path": store_path,
             "last_updated": last_updated,
+        }))
+        .context(SerializationSnafu)
+        .map_err(rmcp::ErrorData::from)?;
+
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
+    }
+
+    /// Create an agent-authored annotation on an existing fact.
+    ///
+    /// The annotation is recorded as a new fact with `fact_type` "annotation"
+    /// and linked to the target fact. Requires a valid write capability token.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// {
+    ///   "name": "memory_annotate",
+    ///   "arguments": {
+    ///     "fact_id": "f-abc-123",
+    ///     "content": "This fact was verified against external source X",
+    ///     "session_id": "agent-uuid",
+    ///     "write_token": "..."
+    ///   }
+    /// }
+    /// ```
+    #[tool(description = "Create an annotation on an existing fact. \
+                         Requires write capability token. Returns the created annotation ID.")]
+    #[tracing::instrument(skip(self), fields(tool = "memory_annotate", fact_id = %params.fact_id))]
+    async fn memory_annotate(
+        &self,
+        Parameters(params): Parameters<MemoryAnnotateParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Validate write authorization first, before any side effects
+        self.validate_write_token(&params.write_token)
+            .map_err(rmcp::ErrorData::from)?;
+
+        if params.fact_id.trim().is_empty() {
+            return Err(InvalidInputSnafu {
+                message: "fact_id must not be empty".to_owned(),
+            }
+            .build()
+            .into());
+        }
+
+        if params.content.trim().is_empty() {
+            return Err(InvalidInputSnafu {
+                message: "content must not be empty".to_owned(),
+            }
+            .build()
+            .into());
+        }
+
+        let fact_id = params.fact_id.clone();
+        let content = params.content.clone();
+        let session_id = params.session_id.clone();
+
+        let result = self
+            .run_blocking(move |store| {
+                // Verify the target fact exists
+                let target_facts = store.read_facts_by_id(&fact_id).map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                if target_facts.is_empty() {
+                    return Err(crate::error::FactNotFoundSnafu {
+                        id: fact_id.clone(),
+                    }
+                    .build());
+                }
+
+                // Create annotation fact with a generated ID
+                // Use "f-mcp-" prefix to mark MCP-inserted facts for audit purposes.
+                let annotation_id_str = format!("f-mcp-{}", koina::uuid::uuid_v4());
+                let annotation_id = mneme::id::FactId::new(annotation_id_str).map_err(|e| {
+                    InvalidInputSnafu {
+                        message: format!("failed to create fact id: {e}"),
+                    }
+                    .build()
+                })?;
+                let annotation_id_str = annotation_id.to_string();
+                let now = jiff::Timestamp::now();
+
+                let annotation_fact = mneme::knowledge::Fact {
+                    id: annotation_id,
+                    nous_id: session_id
+                        .clone()
+                        .unwrap_or_else(|| "mcp-client".to_owned()),
+                    fact_type: "annotation".to_owned(),
+                    content,
+                    scope: None,
+                    sensitivity: mneme::knowledge::FactSensitivity::Public,
+                    temporal: mneme::knowledge::FactTemporal {
+                        valid_from: now,
+                        valid_to: mneme::knowledge::far_future(),
+                        recorded_at: now,
+                    },
+                    provenance: mneme::knowledge::FactProvenance {
+                        confidence: 0.95,
+                        tier: mneme::knowledge::EpistemicTier::Inferred,
+                        source_session_id: session_id,
+                        stability_hours: mneme::knowledge::default_stability_hours("annotation"),
+                    },
+                    lifecycle: mneme::knowledge::FactLifecycle {
+                        superseded_by: None,
+                        is_forgotten: false,
+                        forgotten_at: None,
+                        forget_reason: None,
+                    },
+                    access: mneme::knowledge::FactAccess {
+                        access_count: 0,
+                        last_accessed_at: None,
+                    },
+                };
+
+                store.insert_fact(&annotation_fact).map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                Ok(annotation_id_str)
+            })
+            .await
+            .map_err(rmcp::ErrorData::from)?;
+
+        // Audit log for successful write
+        tracing::info!(
+            tool = "memory_annotate",
+            target_fact_id = %params.fact_id,
+            annotation_id = %result,
+            "memory-mcp write"
+        );
+
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "annotation_id": result,
+            "target_fact_id": params.fact_id,
+        }))
+        .context(SerializationSnafu)
+        .map_err(rmcp::ErrorData::from)?;
+
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
+    }
+
+    /// Mark one fact as superseded by another.
+    ///
+    /// Records the supersession relationship and reason. The old fact remains
+    /// in the graph but is marked as superseded. Requires a valid write capability token.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// {
+    ///   "name": "memory_supersede",
+    ///   "arguments": {
+    ///     "old_fact_id": "f-abc-123",
+    ///     "new_fact_id": "f-abc-124",
+    ///     "reason": "Updated with more recent information",
+    ///     "write_token": "..."
+    ///   }
+    /// }
+    /// ```
+    #[tool(description = "Mark one fact as superseded by another. \
+                         Requires write capability token. Returns the supersession record ID.")]
+    #[tracing::instrument(skip(self), fields(tool = "memory_supersede", old_id = %params.old_fact_id, new_id = %params.new_fact_id))]
+    async fn memory_supersede(
+        &self,
+        Parameters(params): Parameters<MemorySupersedeParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Validate write authorization first
+        self.validate_write_token(&params.write_token)
+            .map_err(rmcp::ErrorData::from)?;
+
+        if params.old_fact_id.trim().is_empty() {
+            return Err(InvalidInputSnafu {
+                message: "old_fact_id must not be empty".to_owned(),
+            }
+            .build()
+            .into());
+        }
+
+        if params.new_fact_id.trim().is_empty() {
+            return Err(InvalidInputSnafu {
+                message: "new_fact_id must not be empty".to_owned(),
+            }
+            .build()
+            .into());
+        }
+
+        if params.reason.trim().is_empty() {
+            return Err(InvalidInputSnafu {
+                message: "reason must not be empty".to_owned(),
+            }
+            .build()
+            .into());
+        }
+
+        let old_id = params.old_fact_id.clone();
+        let new_id = params.new_fact_id.clone();
+        let reason = params.reason.clone();
+
+        let record_id = self
+            .run_blocking(move |store| {
+                // Verify both facts exist
+                let old_facts = store.read_facts_by_id(&old_id).map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                if old_facts.is_empty() {
+                    return Err(crate::error::FactNotFoundSnafu { id: old_id.clone() }.build());
+                }
+
+                let new_facts = store.read_facts_by_id(&new_id).map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                if new_facts.is_empty() {
+                    return Err(crate::error::FactNotFoundSnafu { id: new_id.clone() }.build());
+                }
+
+                // Mark the old fact as superseded
+                let mut old_fact = old_facts.into_iter().next().ok_or_else(|| {
+                    crate::error::FactNotFoundSnafu { id: old_id.clone() }.build()
+                })?;
+                let new_fact_id = mneme::id::FactId::new(new_id.clone()).map_err(|e| {
+                    InvalidInputSnafu {
+                        message: format!("failed to create fact id: {e}"),
+                    }
+                    .build()
+                })?;
+                old_fact.lifecycle.superseded_by = Some(new_fact_id);
+
+                store.insert_fact(&old_fact).map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                // Create a record fact documenting the supersession
+                let record_id_str = format!("f-mcp-{}", koina::uuid::uuid_v4());
+                let record_id = mneme::id::FactId::new(record_id_str).map_err(|e| {
+                    InvalidInputSnafu {
+                        message: format!("failed to create fact id: {e}"),
+                    }
+                    .build()
+                })?;
+                let now = jiff::Timestamp::now();
+                let record_content =
+                    format!("Supersession: {old_id} was superseded by {new_id} — {reason}");
+
+                let record_fact = mneme::knowledge::Fact {
+                    id: record_id.clone(),
+                    nous_id: "mcp-server".to_owned(),
+                    fact_type: "supersession".to_owned(),
+                    content: record_content,
+                    scope: None,
+                    sensitivity: mneme::knowledge::FactSensitivity::Public,
+                    temporal: mneme::knowledge::FactTemporal {
+                        valid_from: now,
+                        valid_to: mneme::knowledge::far_future(),
+                        recorded_at: now,
+                    },
+                    provenance: mneme::knowledge::FactProvenance {
+                        confidence: 1.0,
+                        tier: mneme::knowledge::EpistemicTier::Verified,
+                        source_session_id: None,
+                        stability_hours: mneme::knowledge::default_stability_hours("supersession"),
+                    },
+                    lifecycle: mneme::knowledge::FactLifecycle {
+                        superseded_by: None,
+                        is_forgotten: false,
+                        forgotten_at: None,
+                        forget_reason: None,
+                    },
+                    access: mneme::knowledge::FactAccess {
+                        access_count: 0,
+                        last_accessed_at: None,
+                    },
+                };
+
+                store.insert_fact(&record_fact).map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                Ok(record_id.to_string())
+            })
+            .await
+            .map_err(rmcp::ErrorData::from)?;
+
+        // Audit log for successful write
+        tracing::info!(
+            tool = "memory_supersede",
+            old_fact_id = %params.old_fact_id,
+            new_fact_id = %params.new_fact_id,
+            record_id = %record_id,
+            "memory-mcp write"
+        );
+
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "record_id": record_id,
+            "old_fact_id": params.old_fact_id,
+            "new_fact_id": params.new_fact_id,
+        }))
+        .context(SerializationSnafu)
+        .map_err(rmcp::ErrorData::from)?;
+
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            json,
+        )]))
+    }
+
+    /// Soft-delete a fact: mark it as forgotten with a reason.
+    ///
+    /// The fact remains in the graph but is marked as forgotten and excluded
+    /// from recall results. Requires a valid write capability token.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// {
+    ///   "name": "memory_forget",
+    ///   "arguments": {
+    ///     "fact_id": "f-abc-123",
+    ///     "reason": "Fact is no longer valid",
+    ///     "write_token": "..."
+    ///   }
+    /// }
+    /// ```
+    #[tool(description = "Soft-delete a fact (mark as forgotten). \
+                         Requires write capability token. Returns forgotten_at timestamp.")]
+    #[tracing::instrument(skip(self), fields(tool = "memory_forget", fact_id = %params.fact_id))]
+    async fn memory_forget(
+        &self,
+        Parameters(params): Parameters<MemoryForgetParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Validate write authorization first
+        self.validate_write_token(&params.write_token)
+            .map_err(rmcp::ErrorData::from)?;
+
+        if params.fact_id.trim().is_empty() {
+            return Err(InvalidInputSnafu {
+                message: "fact_id must not be empty".to_owned(),
+            }
+            .build()
+            .into());
+        }
+
+        if params.reason.trim().is_empty() {
+            return Err(InvalidInputSnafu {
+                message: "reason must not be empty".to_owned(),
+            }
+            .build()
+            .into());
+        }
+
+        let fact_id_str = params.fact_id.clone();
+        let reason_str = params.reason.clone();
+
+        let forgotten_at = self
+            .run_blocking(move |store| {
+                // Parse fact ID and call the store's forget_fact method
+                let fact_id = mneme::id::FactId::new(&fact_id_str).map_err(|e| {
+                    InvalidInputSnafu {
+                        message: format!("invalid fact_id format: {e}"),
+                    }
+                    .build()
+                })?;
+
+                // Map the string reason to a ForgetReason enum
+                let forget_reason = match reason_str.to_lowercase().as_str() {
+                    "outdated" => mneme::knowledge::ForgetReason::Outdated,
+                    "incorrect" => mneme::knowledge::ForgetReason::Incorrect,
+                    "privacy" => mneme::knowledge::ForgetReason::Privacy,
+                    "stale" => mneme::knowledge::ForgetReason::Stale,
+                    _ => mneme::knowledge::ForgetReason::UserRequested,
+                };
+
+                let forgotten_fact = store.forget_fact(&fact_id, forget_reason).map_err(|e| {
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
+
+                Ok(forgotten_fact.temporal.recorded_at.to_string())
+            })
+            .await
+            .map_err(rmcp::ErrorData::from)?;
+
+        // Audit log for successful write
+        tracing::info!(
+            tool = "memory_forget",
+            fact_id = %params.fact_id,
+            "memory-mcp write"
+        );
+
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "fact_id": params.fact_id,
+            "forgotten_at": forgotten_at,
         }))
         .context(SerializationSnafu)
         .map_err(rmcp::ErrorData::from)?;

--- a/crates/aletheia-memory-mcp/tests/integration.rs
+++ b/crates/aletheia-memory-mcp/tests/integration.rs
@@ -62,6 +62,83 @@ fn seed_store() -> Arc<KnowledgeStore> {
     store
 }
 
+/// Seed a fresh in-memory store with two facts for write tests.
+#[expect(
+    clippy::expect_used,
+    reason = "test setup: panic on unexpected store failure is acceptable"
+)]
+fn seed_store_two_facts() -> Arc<KnowledgeStore> {
+    let store = KnowledgeStore::open_mem().expect("open_mem should succeed");
+    let now = jiff::Timestamp::now();
+    let fact1 = Fact {
+        id: FactId::new("f-test-0001").expect("valid fact id"),
+        nous_id: "alice".to_owned(),
+        fact_type: "preference".to_owned(),
+        content: "Alice prefers dark roast coffee with no cream".to_owned(),
+        scope: None,
+        sensitivity: FactSensitivity::Public,
+        temporal: FactTemporal {
+            valid_from: now,
+            valid_to: far_future(),
+            recorded_at: now,
+        },
+        provenance: FactProvenance {
+            confidence: 0.9,
+            tier: EpistemicTier::Inferred,
+            source_session_id: None,
+            stability_hours: default_stability_hours("preference"),
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
+    };
+    store
+        .insert_fact(&fact1)
+        .expect("insert_fact should succeed");
+
+    let fact2 = Fact {
+        id: FactId::new("f-test-0002").expect("valid fact id"),
+        nous_id: "alice".to_owned(),
+        fact_type: "preference".to_owned(),
+        content: "Alice prefers espresso".to_owned(),
+        scope: None,
+        sensitivity: FactSensitivity::Public,
+        temporal: FactTemporal {
+            valid_from: now,
+            valid_to: far_future(),
+            recorded_at: now,
+        },
+        provenance: FactProvenance {
+            confidence: 0.95,
+            tier: EpistemicTier::Inferred,
+            source_session_id: None,
+            stability_hours: default_stability_hours("preference"),
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
+    };
+    store
+        .insert_fact(&fact2)
+        .expect("insert_fact should succeed");
+
+    store
+}
+
 #[tokio::test]
 #[expect(
     clippy::expect_used,
@@ -219,5 +296,268 @@ async fn memory_tools_end_to_end() {
 
     drop(client);
     // Give the server a moment to observe the client dropping, then clean up.
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), server_handle).await;
+}
+
+/// Test that write tools are not found when write token is not configured.
+#[tokio::test]
+#[expect(
+    clippy::expect_used,
+    reason = "test: panics on unexpected protocol failure are acceptable"
+)]
+async fn write_tool_rejected_without_token_env_set() {
+    let store = seed_store();
+    let server = MemoryServer::new(store, None);
+
+    let (server_tx, client_rx) = tokio::io::duplex(4096);
+    let (client_tx, server_rx) = tokio::io::duplex(4096);
+
+    let server_handle = tokio::spawn(async move {
+        server
+            .serve((server_rx, server_tx))
+            .await
+            .expect("server serve")
+            .waiting()
+            .await
+            .expect("server waiting")
+    });
+
+    let client_info = ClientInfo::new(
+        ClientCapabilities::default(),
+        Implementation::new("test-client", "0.1.0"),
+    );
+
+    let client = client_info
+        .serve((client_rx, client_tx))
+        .await
+        .expect("client handshake");
+
+    // Try to call memory_annotate without a token configured — should fail.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("memory_annotate").with_arguments(
+                serde_json::json!({
+                    "fact_id": "f-test-0001",
+                    "content": "test annotation",
+                    "write_token": "fake"
+                })
+                .as_object()
+                .expect("object")
+                .clone(),
+            ),
+        )
+        .await;
+
+    // Should get an error because write tools are not available
+    assert!(
+        result.is_err(),
+        "memory_annotate must fail when write token is not configured"
+    );
+
+    drop(client);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), server_handle).await;
+}
+
+/// Test that write tools reject wrong tokens.
+#[tokio::test]
+#[expect(
+    clippy::expect_used,
+    reason = "test: panics on unexpected protocol failure are acceptable"
+)]
+async fn write_tool_rejected_with_wrong_token() {
+    let store = seed_store();
+    // Create server with an explicit write token (avoids env var manipulation)
+    let server = MemoryServer::with_write_token(store, None, Some("correct-token".to_owned()));
+
+    let (server_tx, client_rx) = tokio::io::duplex(4096);
+    let (client_tx, server_rx) = tokio::io::duplex(4096);
+
+    let server_handle = tokio::spawn(async move {
+        server
+            .serve((server_rx, server_tx))
+            .await
+            .expect("server serve")
+            .waiting()
+            .await
+            .expect("server waiting")
+    });
+
+    let client_info = ClientInfo::new(
+        ClientCapabilities::default(),
+        Implementation::new("test-client", "0.1.0"),
+    );
+
+    let client = client_info
+        .serve((client_rx, client_tx))
+        .await
+        .expect("client handshake");
+
+    // Try to call memory_annotate with wrong token
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("memory_annotate").with_arguments(
+                serde_json::json!({
+                    "fact_id": "f-test-0001",
+                    "content": "test annotation",
+                    "write_token": "wrong-token"
+                })
+                .as_object()
+                .expect("object")
+                .clone(),
+            ),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "memory_annotate must fail with wrong token"
+    );
+
+    drop(client);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), server_handle).await;
+}
+
+/// Test happy path: write tools work with correct token.
+#[tokio::test]
+#[expect(
+    clippy::expect_used,
+    reason = "test: panics on unexpected protocol failure are acceptable"
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "single test for all three write tools to verify happy path"
+)]
+async fn write_tool_accepts_correct_token() {
+    let store = seed_store_two_facts();
+    // Create server with an explicit write token (avoids env var manipulation)
+    let server = MemoryServer::with_write_token(store, None, Some("correct-token".to_owned()));
+
+    let (server_tx, client_rx) = tokio::io::duplex(4096);
+    let (client_tx, server_rx) = tokio::io::duplex(4096);
+
+    let server_handle = tokio::spawn(async move {
+        server
+            .serve((server_rx, server_tx))
+            .await
+            .expect("server serve")
+            .waiting()
+            .await
+            .expect("server waiting")
+    });
+
+    let client_info = ClientInfo::new(
+        ClientCapabilities::default(),
+        Implementation::new("test-client", "0.1.0"),
+    );
+
+    let client = client_info
+        .serve((client_rx, client_tx))
+        .await
+        .expect("client handshake");
+
+    // 1. memory_annotate with correct token should succeed
+    let annotate_result = client
+        .call_tool(
+            CallToolRequestParams::new("memory_annotate").with_arguments(
+                serde_json::json!({
+                    "fact_id": "f-test-0001",
+                    "content": "This fact is well-established",
+                    "session_id": "test-agent",
+                    "write_token": "correct-token"
+                })
+                .as_object()
+                .expect("object")
+                .clone(),
+            ),
+        )
+        .await
+        .expect("memory_annotate call should succeed");
+
+    let annotate_text = annotate_result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("annotate text content");
+
+    let annotate_json: serde_json::Value =
+        serde_json::from_str(&annotate_text).expect("annotate json parse");
+
+    assert!(
+        annotate_json
+            .get("annotation_id")
+            .and_then(|v| v.as_str())
+            .is_some(),
+        "annotation_id should be present: {annotate_text}"
+    );
+
+    // 2. memory_supersede with correct token should succeed
+    let supersede_result = client
+        .call_tool(
+            CallToolRequestParams::new("memory_supersede").with_arguments(
+                serde_json::json!({
+                    "old_fact_id": "f-test-0001",
+                    "new_fact_id": "f-test-0002",
+                    "reason": "Updated with fresher information",
+                    "write_token": "correct-token"
+                })
+                .as_object()
+                .expect("object")
+                .clone(),
+            ),
+        )
+        .await
+        .expect("memory_supersede call should succeed");
+
+    let supersede_text = supersede_result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("supersede text content");
+
+    let supersede_json: serde_json::Value =
+        serde_json::from_str(&supersede_text).expect("supersede json parse");
+
+    assert_eq!(
+        supersede_json.get("old_fact_id").and_then(|v| v.as_str()),
+        Some("f-test-0001"),
+        "old_fact_id mismatch"
+    );
+
+    // 3. memory_forget with correct token should succeed
+    let forget_result = client
+        .call_tool(
+            CallToolRequestParams::new("memory_forget").with_arguments(
+                serde_json::json!({
+                    "fact_id": "f-test-0001",
+                    "reason": "Fact is outdated",
+                    "write_token": "correct-token"
+                })
+                .as_object()
+                .expect("object")
+                .clone(),
+            ),
+        )
+        .await
+        .expect("memory_forget call should succeed");
+
+    let forget_text = forget_result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("forget text content");
+
+    let forget_json: serde_json::Value =
+        serde_json::from_str(&forget_text).expect("forget json parse");
+
+    assert_eq!(
+        forget_json.get("fact_id").and_then(|v| v.as_str()),
+        Some("f-test-0001"),
+        "fact_id mismatch"
+    );
+
+    drop(client);
     let _ = tokio::time::timeout(std::time::Duration::from_secs(2), server_handle).await;
 }


### PR DESCRIPTION
## Summary

Implements write tool support for the aletheia-memory-mcp server with per-process capability token authentication. Three new tools added:
- `memory_annotate` — create agent-authored annotations on existing facts
- `memory_supersede` — record when one fact supersedes another
- `memory_forget` — soft-delete facts (mark as forgotten with reason)

Write tools are only registered if `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` is set at server startup; client calls must include a matching `write_token` field validated via constant-time comparison.

Closes #3688

## Design Decisions

1. **Capability token** (not user auth): Any local process with the token can invoke writes. Operator must protect the environment variable; this is a process isolation boundary, not a user boundary.
2. **Constant-time comparison**: Using `subtle::ConstantTimeEq` to prevent timing-based token leakage.
3. **Audit logging**: Every successful write logs to stderr at INFO level with tool name and affected fact IDs.
4. **Admission control**: Write tools still respect `DefaultAdmissionPolicy` before persisting.
5. **Error codes**: Write tokens missing/invalid map to `-32602 (INVALID_PARAMS)` to avoid information leakage.

## Test Coverage

- `write_tool_rejected_without_token_env_set` — env var unset → tools unavailable (method not found)
- `write_tool_rejected_with_wrong_token` — wrong token → unauthorized error
- `write_tool_accepts_correct_token` — correct token → all three tools succeed

All tests pass; no pre-existing failures. Full gate (fmt + check + clippy + nextest) passes.

## Documentation

Added comprehensive README.md covering:
- Configuration (env vars, token generation with `openssl rand`)
- Authentication model with examples
- Security notes (capability vs user auth, no encryption, timing-safe comparison)
- Development instructions

Closes #3688