### PR TITLE
feat(pylon): ETag + conditional request middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6534,6 +6534,7 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "snafu",
  "symbolon",
  "taxis",

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -57,6 +57,12 @@ prometheus-client = { workspace = true }
 # Cryptographic random number generation (CSRF token generation)
 rand = { workspace = true }
 
+# Hashing for ETag computation
+sha2 = { workspace = true }
+
+# Body stream utilities for ETag middleware
+http-body-util = "0.1"
+
 # Internal crates
 koina = { path = "../koina" }
 taxis = { path = "../taxis" }

--- a/crates/pylon/src/middleware/deprecation.rs
+++ b/crates/pylon/src/middleware/deprecation.rs
@@ -122,12 +122,12 @@ where
             let mut response = inner.call(request).await?;
 
             if let Some(info) = info {
-                let _span = tracing::info_span!(
+                let span = tracing::info_span!(
                     "deprecation_middleware",
                     http.path = %key,
                     http.method = %method,
                 );
-                let _guard = _span.enter();
+                let _guard = span.enter();
 
                 // RFC 8594: Deprecation: @<unix-timestamp>
                 let deprecation_value = format!("@{}", info.deprecated_at.as_second());

--- a/crates/pylon/src/middleware/etag.rs
+++ b/crates/pylon/src/middleware/etag.rs
@@ -1,0 +1,234 @@
+//! `ETag` middleware: computes strong `ETags` from GET response bodies and
+//! supports conditional requests via `If-None-Match`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use axum::body::{Body, Bytes};
+use axum::extract::Request;
+use axum::http::{StatusCode, header};
+use axum::response::Response;
+use http_body_util::BodyStream;
+use sha2::{Digest, Sha256};
+use tokio_stream::Stream;
+use tower::{Layer, Service};
+use tracing::trace;
+
+/// Tower layer that adds strong `ETag` headers to GET responses and supports
+/// `If-None-Match` conditional requests.
+///
+/// # Escape hatch
+///
+/// The middleware automatically skips:
+/// - Non-GET requests.
+/// - Routes whose path matches known SSE endpoints (`/api/v1/events`,
+///   `/api/v1/sessions/{id}/turns/{turn_id}/events`).
+/// - Responses with `Content-Type: text/event-stream`.
+#[derive(Debug, Clone, Default)]
+pub struct ETagLayer;
+
+impl ETagLayer {
+    /// Create a new `ETag` layer.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for ETagLayer {
+    type Service = ETagService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ETagService { inner }
+    }
+}
+
+/// Tower service that computes `ETags` for GET responses.
+#[derive(Debug, Clone)]
+pub struct ETagService<S> {
+    inner: S,
+}
+
+impl<S> Service<Request> for ETagService<S>
+where
+    S: Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    #[tracing::instrument(skip(self, request), fields(http.method = %request.method(), http.path = %request.uri().path()))]
+    fn call(&mut self, request: Request) -> Self::Future {
+        let is_get = request.method() == axum::http::Method::GET;
+        let path = request.uri().path().to_owned();
+        let if_none_match = request
+            .headers()
+            .get(header::IF_NONE_MATCH)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let response = inner.call(request).await?;
+
+            // Only apply to GET 200 OK responses.
+            if !is_get || response.status() != StatusCode::OK {
+                return Ok(response);
+            }
+
+            // Skip SSE responses (defense in depth: path + content-type).
+            if is_sse_path(&path) || is_sse_response(&response) {
+                return Ok(response);
+            }
+
+            // Collect body and compute hash in a single pass.
+            let (parts, body) = response.into_parts();
+            let (bytes, etag) = match hash_body(body).await {
+                Ok(v) => v,
+                Err(e) => {
+                    trace!(error = %e, "failed to read response body for ETag");
+                    return Ok(Response::from_parts(parts, Body::empty()));
+                }
+            };
+
+            // Check conditional request.
+            if let Some(ref client_etag) = if_none_match
+                && strong_etag_matches(client_etag, &etag)
+            {
+                trace!(etag = %etag, "ETag match, returning 304 Not Modified");
+                let mut not_modified = Response::new(Body::empty());
+                *not_modified.status_mut() = StatusCode::NOT_MODIFIED;
+                if let Ok(hv) = etag.parse() {
+                    not_modified.headers_mut().insert(header::ETAG, hv);
+                }
+                return Ok(not_modified);
+            }
+
+            let mut response = Response::from_parts(parts, Body::from(bytes));
+            if let Ok(hv) = etag.parse() {
+                response.headers_mut().insert(header::ETAG, hv);
+            }
+            Ok(response)
+        })
+    }
+}
+
+/// Return `true` if the request path is a known SSE endpoint.
+///
+/// These paths are excluded because buffering a streaming response would
+/// break the SSE contract.
+fn is_sse_path(path: &str) -> bool {
+    path == "/api/v1/events"
+        || (path.starts_with("/api/v1/sessions/")
+            && path.contains("/turns/")
+            && path.ends_with("/events"))
+}
+
+/// Return `true` if the response already has an SSE content type.
+fn is_sse_response(response: &Response) -> bool {
+    response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("text/event-stream"))
+}
+
+/// Consume a body, hashing each chunk as it arrives, and return the collected
+/// bytes plus the hexadecimal strong `ETag`.
+///
+/// WHY: This performs hashing during the single read so the body is never
+/// buffered and then hashed in a second pass.
+async fn hash_body(body: Body) -> Result<(Bytes, String), axum::Error> {
+    let mut hasher = Sha256::new();
+    let mut buf = Vec::new();
+
+    let mut stream = BodyStream::new(body);
+    loop {
+        let next = std::future::poll_fn(|cx| Pin::new(&mut stream).poll_next(cx)).await;
+        match next {
+            None => break,
+            Some(Ok(frame)) => {
+                if let Some(data) = frame.data_ref() {
+                    hasher.update(data);
+                    buf.extend_from_slice(data);
+                }
+            }
+            Some(Err(e)) => return Err(e),
+        }
+    }
+
+    let digest = hasher.finalize();
+    let hex = digest.iter().fold(String::new(), |mut acc, b| {
+        let _ = std::fmt::Write::write_fmt(&mut acc, format_args!("{b:02x}"));
+        acc
+    });
+    let etag = format!("\"{hex}\"");
+    Ok((Bytes::from(buf), etag))
+}
+
+/// Strong comparison for `ETags`.
+///
+/// Returns `true` only when both `ETags` are strong (no `W/` prefix) and
+/// byte-identical.
+fn strong_etag_matches(client_etag: &str, server_etag: &str) -> bool {
+    let client = client_etag.trim();
+    let server = server_etag.trim();
+
+    // Weak ETags never match strongly.
+    if client.starts_with("W/") || server.starts_with("W/") {
+        return false;
+    }
+
+    client == server
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sse_path_matches_events() {
+        assert!(is_sse_path("/api/v1/events"));
+    }
+
+    #[test]
+    fn sse_path_matches_turn_events() {
+        assert!(is_sse_path("/api/v1/sessions/abc/turns/123/events"));
+    }
+
+    #[test]
+    fn sse_path_does_not_match_regular_get() {
+        assert!(!is_sse_path("/api/v1/nous"));
+        assert!(!is_sse_path("/api/v1/sessions"));
+        assert!(!is_sse_path("/api/health"));
+    }
+
+    #[test]
+    fn strong_match_requires_exact_equality() {
+        assert!(strong_etag_matches("\"abc\"", "\"abc\""));
+        assert!(!strong_etag_matches("\"abc\"", "\"def\""));
+    }
+
+    #[test]
+    fn weak_etag_never_matches_strongly() {
+        assert!(!strong_etag_matches("W/\"abc\"", "\"abc\""));
+        assert!(!strong_etag_matches("\"abc\"", "W/\"abc\""));
+    }
+
+    #[tokio::test]
+    async fn hash_body_produces_stable_etag() {
+        let body = Body::from("hello world");
+        let (bytes, etag) = hash_body(body).await.unwrap();
+        assert_eq!(bytes, "hello world");
+        assert!(etag.starts_with('\"') && etag.ends_with('\"'));
+    }
+}

--- a/crates/pylon/src/middleware/mod.rs
+++ b/crates/pylon/src/middleware/mod.rs
@@ -254,10 +254,12 @@ pub async fn record_http_metrics(request: Request, next: Next) -> Response {
 /// expired. Uses `std::sync::Mutex` (not tokio): the critical section is
 /// short and contains no `.await` points.
 mod deprecation;
+mod etag;
 mod rate_limiter;
 mod user_rate_limiter;
 
 pub use deprecation::{DeprecationInfo, DeprecationLayer, DeprecationMap, deprecate};
+pub use etag::{ETagLayer, ETagService};
 pub use rate_limiter::{RateLimiter, rate_limit};
 pub use user_rate_limiter::{
     EndpointCategory, UserRateLimiter, per_user_rate_limit, spawn_stale_cleanup,

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -19,7 +19,7 @@ use koina::http::{API_HEALTH, API_V1};
 use crate::error::{ApiError, ErrorBody, ErrorResponse};
 use crate::handlers::{config, health, knowledge, metrics, nous, planning, sessions};
 use crate::middleware::{
-    CsrfState, DeprecationLayer, RateLimiter, RequestId, UserRateLimiter, deprecate,
+    CsrfState, DeprecationLayer, ETagLayer, RateLimiter, RequestId, UserRateLimiter, deprecate,
     enrich_error_response, inject_request_id, per_user_rate_limit, rate_limit, record_http_metrics,
     require_csrf_header, spawn_stale_cleanup,
 };
@@ -206,6 +206,8 @@ pub fn build_router_with(
     )]));
 
     router = router.layer(axum::middleware::from_fn(record_http_metrics));
+
+    router = router.layer(ETagLayer::new());
 
     router = router.layer(CompressionLayer::new());
 

--- a/crates/pylon/src/tests/middleware.rs
+++ b/crates/pylon/src/tests/middleware.rs
@@ -587,3 +587,110 @@ async fn sunset_header_format_rfc8594() {
         "Sunset header must be a valid RFC 7231 HTTP-date"
     );
 }
+
+#[tokio::test]
+async fn etag_set_on_200_get_response() {
+    let (app, _dir) = app().await;
+    let resp = app.oneshot(authed_get("/api/v1/nous")).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let etag = resp
+        .headers()
+        .get("etag")
+        .expect("ETag header must be present on GET 200");
+    assert!(
+        etag.to_str().unwrap().starts_with('"'),
+        "ETag must be a strong quoted string"
+    );
+}
+
+#[tokio::test]
+async fn if_none_match_returns_304_on_match() {
+    let (app, _dir) = app().await;
+
+    // First request to capture the ETag.
+    let first = app
+        .clone()
+        .oneshot(authed_get("/api/v1/nous"))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+    let etag = first
+        .headers()
+        .get("etag")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    // Replay with If-None-Match.
+    let req = Request::get("/api/v1/nous")
+        .header("authorization", format!("Bearer {}", default_token()))
+        .header("if-none-match", &etag)
+        .body(Body::empty())
+        .unwrap();
+    let second = app.oneshot(req).await.unwrap();
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(body_string(second).await, "", "304 must have empty body");
+}
+
+#[tokio::test]
+async fn if_none_match_returns_200_on_mismatch() {
+    let (app, _dir) = app().await;
+
+    let req = Request::get("/api/v1/nous")
+        .header("authorization", format!("Bearer {}", default_token()))
+        .header("if-none-match", "\"stale-etag-value\"")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let etag = resp.headers().get("etag").expect("ETag must be present");
+    assert_ne!(etag.to_str().unwrap(), "\"stale-etag-value\"");
+}
+
+#[tokio::test]
+async fn etag_stable_for_identical_body() {
+    let (app, _dir) = app().await;
+
+    let req1 = authed_get("/api/v1/nous");
+    let resp1 = app.clone().oneshot(req1).await.unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+    let etag1 = resp1
+        .headers()
+        .get("etag")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    let req2 = authed_get("/api/v1/nous");
+    let resp2 = app.oneshot(req2).await.unwrap();
+    assert_eq!(resp2.status(), StatusCode::OK);
+    let etag2 = resp2
+        .headers()
+        .get("etag")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    assert_eq!(etag1, etag2, "identical body must produce identical ETag");
+}
+
+#[tokio::test]
+async fn sse_endpoint_unaffected() {
+    let (app, _dir) = app().await;
+    let resp = app.oneshot(authed_get("/api/v1/events")).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        resp.headers().get("etag").is_none(),
+        "SSE endpoint must not have ETag header"
+    );
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .expect("SSE must have content-type");
+    assert!(ct.to_str().unwrap().starts_with("text/event-stream"));
+}


### PR DESCRIPTION
Closes #3274

## Summary

Adds Tower middleware that computes strong SHA-256 ETags for GET 200 responses and supports `If-None-Match` conditional requests (304 Not Modified on match).

## Changes

- `crates/pylon/src/middleware/etag.rs` — new Tower layer/service
- `crates/pylon/src/middleware/mod.rs` — exports `ETagLayer`
- `crates/pylon/src/router.rs` — wires layer inside compression
- `crates/pylon/Cargo.toml` — adds `sha2` and `http-body-util`
- `crates/pylon/src/tests/middleware.rs` — integration tests

## Escape hatch

SSE endpoints are excluded automatically by path and `Content-Type` detection.

## Tests

- `etag_set_on_200_get_response`
- `if_none_match_returns_304_on_match`
- `if_none_match_returns_200_on_mismatch`
- `etag_stable_for_identical_body`
- `sse_endpoint_unaffected`

Gate-Passed: kanon 0.1.0