### PR TITLE
feat(pylon): filtered SSE event subscription endpoint

### DIFF
--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -816,6 +816,7 @@ impl RuntimeBuilder {
             embedding_provider: Some(Arc::clone(&embedding_provider)),
             turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
             metrics_registry,
+            event_bus: Arc::new(pylon::event_bus::EventBus::new(256)),
         });
 
         Ok(Runtime {

--- a/crates/integration-tests/tests/config_hot_reload.rs
+++ b/crates/integration-tests/tests/config_hot_reload.rs
@@ -112,6 +112,7 @@ impl TestHarness {
             embedding_provider: None,
             turn_buffer_registry: std::sync::Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
             metrics_registry,
+            event_bus: std::sync::Arc::new(pylon::event_bus::EventBus::new(256)),
         });
 
         Self { state, _tmp: dir }

--- a/crates/integration-tests/tests/cross_crate_pipeline.rs
+++ b/crates/integration-tests/tests/cross_crate_pipeline.rs
@@ -289,6 +289,7 @@ impl TestHarness {
             embedding_provider: None,
             turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
             metrics_registry,
+            event_bus: Arc::new(pylon::event_bus::EventBus::new(256)),
         });
 
         Self {

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -203,6 +203,7 @@ impl TestHarness {
             embedding_provider: None,
             turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
             metrics_registry,
+            event_bus: Arc::new(pylon::event_bus::EventBus::new(256)),
         });
 
         Self {

--- a/crates/integration-tests/tests/eval_harness.rs
+++ b/crates/integration-tests/tests/eval_harness.rs
@@ -123,6 +123,7 @@ async fn start_test_server() -> (String, String, tempfile::TempDir) {
         embedding_provider: None,
         turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
         metrics_registry,
+        event_bus: Arc::new(pylon::event_bus::EventBus::new(256)),
     });
 
     let router = build_router(

--- a/crates/integration-tests/tests/sse_backpressure.rs
+++ b/crates/integration-tests/tests/sse_backpressure.rs
@@ -119,6 +119,7 @@ impl TestHarness {
             embedding_provider: None,
             turn_buffer_registry: std::sync::Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
             metrics_registry,
+            event_bus: std::sync::Arc::new(pylon::event_bus::EventBus::new(256)),
         });
 
         Self {

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -27,7 +27,7 @@ axum-server = { workspace = true, optional = true }
 
 # Async
 tokio = { workspace = true, features = ["process"] }
-tokio-stream = { workspace = true, features = ["time"] }
+tokio-stream = { workspace = true, features = ["time", "sync"] }
 tokio-util = { workspace = true }
 
 # Serialization

--- a/crates/pylon/src/event_bus.rs
+++ b/crates/pylon/src/event_bus.rs
@@ -1,0 +1,87 @@
+//! Lightweight in-process broadcast channel for domain events.
+//!
+//! Cross-system consumers subscribe via [`EventBus::subscribe`] and receive
+//! [`DomainEvent`] values filtered by topic.  Lagged subscribers are dropped
+//! gracefully with a warning rather than panicking.
+
+use serde::{Deserialize, Serialize};
+
+/// A domain event with a stable topic name and JSON payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DomainEvent {
+    /// Event topic (e.g. `fact.created`, `turn.complete`).
+    pub topic: String,
+    /// Structured event payload.
+    pub payload: serde_json::Value,
+    /// ISO-8601 timestamp of emission.
+    pub at: String,
+}
+
+impl DomainEvent {
+    /// Construct a new domain event with the current timestamp.
+    #[must_use]
+    pub fn new(topic: impl Into<String>, payload: serde_json::Value) -> Self {
+        Self {
+            topic: topic.into(),
+            payload,
+            at: jiff::Timestamp::now().to_string(),
+        }
+    }
+}
+
+/// In-process broadcast bus for domain events.
+///
+/// Holds a [`tokio::sync::broadcast::Sender`] and provides typed publish /
+/// subscribe methods.  The channel capacity is fixed at creation time;
+/// slow subscribers lag behind and are dropped gracefully.
+pub struct EventBus {
+    tx: tokio::sync::broadcast::Sender<DomainEvent>,
+}
+
+impl EventBus {
+    /// Create a new event bus with the given channel capacity.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _rx) = tokio::sync::broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    /// Publish a domain event to all current subscribers.
+    ///
+    /// Errors are silently ignored when there are no subscribers.
+    pub fn publish(&self, event: DomainEvent) {
+        let _ = self.tx.send(event);
+    }
+
+    /// Subscribe to the broadcast channel.
+    #[must_use]
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<DomainEvent> {
+        self.tx.subscribe()
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_bus_publish_and_receive() {
+        let bus = EventBus::new(16);
+        let mut rx = bus.subscribe();
+
+        bus.publish(DomainEvent::new("test.topic", serde_json::json!({"k": 1})));
+
+        let event = rx.try_recv().expect("should receive event");
+        assert_eq!(event.topic, "test.topic");
+        assert_eq!(event.payload.get("k"), Some(&serde_json::json!(1)));
+    }
+
+    #[test]
+    fn event_bus_no_subscriber_is_noop() {
+        let bus = EventBus::new(16);
+        bus.publish(DomainEvent::new("test.topic", serde_json::json!({})));
+        // Should not panic or error.
+    }
+}

--- a/crates/pylon/src/handlers/events.rs
+++ b/crates/pylon/src/handlers/events.rs
@@ -1,0 +1,126 @@
+//! Domain event subscription handlers.
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::response::IntoResponse;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use serde::Deserialize;
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+use tracing::{instrument, warn};
+
+use crate::error::ApiError;
+use crate::event_bus::DomainEvent;
+use crate::extract::Claims;
+use crate::state::EventBusState;
+
+/// Query parameters for the event subscription endpoint.
+#[derive(Debug, Deserialize)]
+pub struct SubscribeParams {
+    /// Comma-separated list of topics to subscribe to (e.g. `fact.created,turn.complete`).
+    pub topics: String,
+}
+
+/// GET /api/v1/events/subscribe
+///
+/// Opens an SSE stream filtered to the requested topics.
+/// Each event is delivered as `event: <topic>\ndata: <json>\n\n`.
+/// Periodic heartbeat comments keep the connection alive.
+#[utoipa::path(
+    get,
+    path = "/api/v1/events/subscribe",
+    params(
+        ("topics" = String, Query, description = "Comma-separated topic filter"),
+    ),
+    responses(
+        (status = 200, description = "Filtered SSE event stream", content_type = "text/event-stream"),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+/// # Cancel safety
+///
+/// Cancel-safe. Axum handler; cancellation drops the future with no
+/// side effects beyond not returning a response.
+#[instrument(skip(state, _claims))]
+pub async fn subscribe(
+    State(state): State<EventBusState>,
+    _claims: Claims,
+    Query(params): Query<SubscribeParams>,
+) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    let topics: Vec<String> = params
+        .topics
+        .split(',')
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if topics.is_empty() {
+        return Err(ApiError::BadRequest {
+            message: "topics query parameter must contain at least one topic".to_owned(),
+            location: snafu::location!(),
+        });
+    }
+
+    let heartbeat_secs = state
+        .config
+        .read()
+        .await
+        .gateway
+        .sse_heartbeat_interval_secs;
+    let rx = state.event_bus.subscribe();
+    let subscriber_id = koina::ulid::Ulid::new().to_string();
+
+    let stream = BroadcastStream::new(rx).filter_map(move |result| match result {
+        Ok(DomainEvent { topic, payload, .. }) if topics.contains(&topic) => {
+            match serde_json::to_string(&payload) {
+                Ok(data) => Some(Ok(Event::default().event(&topic).data(data))),
+                Err(e) => {
+                    warn!(error = %e, topic, "failed to serialize domain event payload");
+                    Some(Ok(Event::default()
+                        .event(&topic)
+                        .data(r#"{"error":"serialization failed"}"#)))
+                }
+            }
+        }
+        Ok(_) => None,
+        Err(BroadcastStreamRecvError::Lagged(n)) => {
+            warn!(subscriber_id = %subscriber_id, lagged_by = n, "event subscriber lagged");
+            None
+        }
+    });
+
+    Ok(Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(heartbeat_secs))
+            .text("heartbeat"),
+    ))
+}
+
+/// GET /api/v1/events/discovery
+///
+/// Returns the list of available event topics.  This is a static discovery
+/// endpoint; dynamic topic registration is not yet supported.
+#[utoipa::path(
+    get,
+    path = "/api/v1/events/discovery",
+    responses(
+        (status = 200, description = "Available event topics"),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+#[instrument(skip(_claims))]
+pub async fn discovery(_claims: Claims) -> impl IntoResponse {
+    let topics = vec![
+        "fact.created",
+        "turn.complete",
+        "session.started",
+        "session.ended",
+    ];
+    Json(topics)
+}

--- a/crates/pylon/src/handlers/knowledge/ingest.rs
+++ b/crates/pylon/src/handlers/knowledge/ingest.rs
@@ -130,6 +130,7 @@ pub async fn ingest(
     #[cfg(feature = "knowledge-store")]
     if let Some(ref store) = state.knowledge_store {
         let store = std::sync::Arc::clone(store);
+        let event_bus = std::sync::Arc::clone(&state.event_bus);
         let result = tokio::task::spawn_blocking(move || {
             let mut inserted = 0usize;
             let mut skipped = 0usize;
@@ -137,7 +138,17 @@ pub async fn ingest(
 
             for (index, fact) in facts.iter().enumerate() {
                 match store.insert_fact(fact) {
-                    Ok(()) => inserted += 1,
+                    Ok(()) => {
+                        inserted += 1;
+                        event_bus.publish(crate::event_bus::DomainEvent::new(
+                            "fact.created",
+                            serde_json::json!({
+                                "fact_id": fact.id.as_str(),
+                                "nous_id": fact.nous_id.as_str(),
+                                "content_preview": truncate(&fact.content, 200),
+                            }),
+                        ));
+                    }
                     Err(e) => {
                         errors.push(IngestFactError {
                             index,
@@ -176,4 +187,21 @@ pub async fn ingest(
         message: "knowledge store not available".to_owned(),
         location: snafu::location!(),
     })
+}
+
+/// Truncate a string to `max_len` bytes, adding an ellipsis if truncated.
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_owned()
+    } else {
+        let mut result = String::with_capacity(max_len + 3);
+        for ch in s.chars() {
+            if result.len() + ch.len_utf8() > max_len.saturating_sub(1) {
+                result.push('…');
+                break;
+            }
+            result.push(ch);
+        }
+        result
+    }
 }

--- a/crates/pylon/src/handlers/mod.rs
+++ b/crates/pylon/src/handlers/mod.rs
@@ -18,6 +18,8 @@
 
 /// Runtime configuration read/write.
 pub mod config;
+/// Domain event subscription and discovery.
+pub mod events;
 /// System health and readiness check.
 pub mod health;
 /// Knowledge graph browsing and management.

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -278,6 +278,7 @@ pub async fn send_message(
     );
     let shutdown_token = state.shutdown.child_token();
     let buf_handle_task = buf_handle.clone();
+    let event_bus = Arc::clone(&state.event_bus);
     let turn_handle = tokio::spawn(
         async move {
             // WHY(#2113): Emit an immediate acknowledgment so the client never sees an empty
@@ -315,6 +316,17 @@ pub async fn send_message(
                     )
                     .await;
                     buf_handle_task.mark_completed().await;
+
+                    event_bus.publish(crate::event_bus::DomainEvent::new(
+                        "turn.complete",
+                        serde_json::json!({
+                            "session_id": sid,
+                            "nous_id": session.nous_id,
+                            "turn_id": turn_id,
+                            "input_tokens": result.usage.input_tokens,
+                            "output_tokens": result.usage.output_tokens,
+                        }),
+                    ));
 
                     // NOTE: Store the turn summary so cache-hit replays return real data.
                     if let Some(ref key) = idem_key {
@@ -567,6 +579,7 @@ pub async fn stream_turn(
 
     let shutdown_token = state.shutdown.child_token();
     let buf_handle_task = buf_handle.clone();
+    let event_bus = Arc::clone(&state.event_bus);
     let stream_turn_handle = tokio::spawn(
         async move {
             // WHY: cancel the in-flight turn when the server shuts down so Axum's graceful
@@ -596,7 +609,7 @@ pub async fn stream_turn(
                     let event = PylonTurnStreamEvent::MessageComplete {
                         outcome: TurnOutcome {
                             text: result.content.clone(),
-                            nous_id: aid,
+                            nous_id: aid.clone(),
                             session_id: sid.clone(),
                             model,
                             tool_calls: result.tool_calls.len(),
@@ -609,6 +622,17 @@ pub async fn stream_turn(
                     let seq = record_turn_event(&buf_handle_task, &event).await;
                     let _ = turn_tx.send((seq, event)).await;
                     buf_handle_task.mark_completed().await;
+
+                    event_bus.publish(crate::event_bus::DomainEvent::new(
+                        "turn.complete",
+                        serde_json::json!({
+                            "session_id": sid,
+                            "nous_id": aid,
+                            "turn_id": turn_id,
+                            "input_tokens": result.usage.input_tokens,
+                            "output_tokens": result.usage.output_tokens,
+                        }),
+                    ));
                 }
                 Err(err) => {
                     // WHY: Log full error internally; span carries session/nous context (#844).

--- a/crates/pylon/src/lib.rs
+++ b/crates/pylon/src/lib.rs
@@ -6,6 +6,8 @@
 pub mod discovery;
 /// API error types with Axum HTTP status code mapping.
 pub(crate) mod error;
+/// In-process broadcast bus for domain events.
+pub mod event_bus;
 /// JWT auth extractor for Bearer token validation.
 pub mod extract;
 /// HTTP request handlers for health, nous, and session endpoints.

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -17,7 +17,7 @@ use tracing::info_span;
 use koina::http::{API_HEALTH, API_V1};
 
 use crate::error::{ApiError, ErrorBody, ErrorResponse};
-use crate::handlers::{config, health, knowledge, metrics, nous, planning, sessions};
+use crate::handlers::{config, events, health, knowledge, metrics, nous, planning, sessions};
 use crate::middleware::{
     CsrfState, DeprecationLayer, ETagLayer, RateLimiter, RequestId, UserRateLimiter, deprecate,
     enrich_error_response, inject_request_id, per_user_rate_limit, rate_limit, record_http_metrics,
@@ -87,6 +87,8 @@ pub fn build_router_with(
         )
         .route("/sessions/{id}/history", get(sessions::history))
         .route("/events", get(sessions::events))
+        .route("/events/subscribe", get(events::subscribe))
+        .route("/events/discovery", get(events::discovery))
         .route("/nous", get(nous::list).post(nous::create))
         .route("/nous/{id}", get(nous::get_status))
         .route("/nous/{id}/tools", get(nous::tools))

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -168,6 +168,7 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         embedding_provider: None,
         turn_buffer_registry: Arc::new(crate::turn_buffer::TurnBufferRegistry::new()),
         metrics_registry,
+        event_bus: Arc::new(crate::event_bus::EventBus::new(256)),
     });
 
     #[cfg(unix)]

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -19,6 +19,7 @@ use symbolon::jwt::JwtManager;
 use taxis::config::AletheiaConfig;
 use taxis::oikos::Oikos;
 
+use crate::event_bus::EventBus;
 use crate::idempotency::IdempotencyCache;
 use crate::turn_buffer::TurnBufferRegistry;
 
@@ -72,6 +73,8 @@ pub struct AppState {
     /// Crates register their metric families here at startup; the `/metrics`
     /// handler holds this to encode scrapes.
     pub metrics_registry: MetricsRegistry,
+    /// In-process broadcast bus for domain events.
+    pub event_bus: Arc<EventBus>,
 }
 
 impl AppState {
@@ -202,6 +205,8 @@ pub struct SessionsState {
     pub config: Arc<tokio::sync::RwLock<AletheiaConfig>>,
     /// Per-turn event buffer registry for SSE client recovery (#3276).
     pub turn_buffer_registry: Arc<TurnBufferRegistry>,
+    /// In-process broadcast bus for domain events.
+    pub event_bus: Arc<EventBus>,
 }
 
 impl FromRef<Arc<AppState>> for SessionsState {
@@ -214,6 +219,7 @@ impl FromRef<Arc<AppState>> for SessionsState {
             idempotency_cache: Arc::clone(&state.idempotency_cache),
             config: Arc::clone(&state.config),
             turn_buffer_registry: Arc::clone(&state.turn_buffer_registry),
+            event_bus: Arc::clone(&state.event_bus),
         }
     }
 }
@@ -226,6 +232,8 @@ pub struct KnowledgeState {
     pub knowledge_store: Option<Arc<KnowledgeStore>>,
     /// Runtime configuration for API limit reads.
     pub config: Arc<tokio::sync::RwLock<AletheiaConfig>>,
+    /// In-process broadcast bus for domain events.
+    pub event_bus: Arc<EventBus>,
 }
 
 impl FromRef<Arc<AppState>> for KnowledgeState {
@@ -234,6 +242,7 @@ impl FromRef<Arc<AppState>> for KnowledgeState {
             #[cfg(feature = "knowledge-store")]
             knowledge_store: state.knowledge_store.clone(),
             config: Arc::clone(&state.config),
+            event_bus: Arc::clone(&state.event_bus),
         }
     }
 }
@@ -243,6 +252,24 @@ const _: fn() = || {
     fn assert<T: Send + Sync>() {}
     assert::<AppState>();
 };
+
+/// State slice for the domain-event subscription handler.
+#[derive(Clone)]
+pub struct EventBusState {
+    /// In-process broadcast bus for domain events.
+    pub event_bus: Arc<EventBus>,
+    /// Runtime configuration for heartbeat interval reads.
+    pub config: Arc<tokio::sync::RwLock<AletheiaConfig>>,
+}
+
+impl FromRef<Arc<AppState>> for EventBusState {
+    fn from_ref(state: &Arc<AppState>) -> Self {
+        Self {
+            event_bus: Arc::clone(&state.event_bus),
+            config: Arc::clone(&state.config),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -256,5 +283,6 @@ mod tests {
         assert::<ConfigState>();
         assert::<SessionsState>();
         assert::<KnowledgeState>();
+        assert::<EventBusState>();
     };
 }

--- a/crates/pylon/src/tests/auth.rs
+++ b/crates/pylon/src/tests/auth.rs
@@ -148,6 +148,7 @@ async fn app_auth_disabled() -> (axum::Router, tempfile::TempDir) {
         embedding_provider: state.embedding_provider.clone(),
         turn_buffer_registry: Arc::clone(&state.turn_buffer_registry),
         metrics_registry: state.metrics_registry.clone(),
+        event_bus: Arc::clone(&state.event_bus),
     });
     (build_router(state, &test_security_config()), dir)
 }

--- a/crates/pylon/src/tests/helpers.rs
+++ b/crates/pylon/src/tests/helpers.rs
@@ -148,7 +148,8 @@ bind = "localhost"
 
     let jwt_manager = test_jwt_manager();
 
-    let default_config = taxis::config::AletheiaConfig::default();
+    let mut default_config = taxis::config::AletheiaConfig::default();
+    default_config.gateway.sse_heartbeat_interval_secs = 1;
     let (config_tx, _config_rx) = tokio::sync::watch::channel(default_config.clone());
 
     // WHY: pylon's /metrics handler requires a registry; tests need pylon's
@@ -175,6 +176,7 @@ bind = "localhost"
         embedding_provider: Some(Arc::new(MockEmbeddingProvider::new(384))),
         turn_buffer_registry: Arc::new(crate::turn_buffer::TurnBufferRegistry::new()),
         metrics_registry,
+        event_bus: Arc::new(crate::event_bus::EventBus::new(256)),
     });
 
     (state, dir)

--- a/crates/pylon/src/tests/mod.rs
+++ b/crates/pylon/src/tests/mod.rs
@@ -29,3 +29,4 @@ mod session;
 mod signal;
 mod sse_events;
 mod streaming;
+mod subscribe;

--- a/crates/pylon/src/tests/signal.rs
+++ b/crates/pylon/src/tests/signal.rs
@@ -124,5 +124,6 @@ fn minimal_app_state() -> Arc<AppState> {
         embedding_provider: None,
         turn_buffer_registry: Arc::new(crate::turn_buffer::TurnBufferRegistry::new()),
         metrics_registry,
+        event_bus: Arc::new(crate::event_bus::EventBus::new(256)),
     })
 }

--- a/crates/pylon/src/tests/subscribe.rs
+++ b/crates/pylon/src/tests/subscribe.rs
@@ -1,0 +1,107 @@
+//! Integration tests for the domain-event subscription endpoint.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::http::StatusCode;
+use tokio_stream::StreamExt;
+use tower::ServiceExt;
+
+use crate::event_bus::DomainEvent;
+
+use super::helpers::*;
+
+/// Collect SSE body chunks for up to `duration`, returning the concatenated bytes.
+async fn collect_sse_chunks(body: axum::body::Body, duration: Duration) -> Vec<u8> {
+    let mut stream = body.into_data_stream();
+    let deadline = tokio::time::Instant::now() + duration;
+    let mut collected = Vec::new();
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline - tokio::time::Instant::now();
+        match tokio::time::timeout(remaining, stream.next()).await {
+            Ok(Some(Ok(chunk))) => collected.extend_from_slice(&chunk),
+            _ => break,
+        }
+    }
+    collected
+}
+
+#[tokio::test]
+async fn subscribe_returns_matching_events() {
+    let (state, _dir) = test_state().await;
+    let router = build_router(Arc::clone(&state), &test_security_config());
+
+    let req = authed_get("/api/v1/events/subscribe?topics=fact.created");
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body();
+
+    state.event_bus.publish(DomainEvent::new(
+        "fact.created",
+        serde_json::json!({"fact_id": "f-1", "nous_id": "syn"}),
+    ));
+
+    let bytes = collect_sse_chunks(body, Duration::from_secs(2)).await;
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.contains("event: fact.created"),
+        "expected fact.created event, got: {text}"
+    );
+    assert!(text.contains("f-1"), "expected fact_id in payload");
+}
+
+#[tokio::test]
+async fn subscribe_filters_unwanted_topics() {
+    let (state, _dir) = test_state().await;
+    let router = build_router(Arc::clone(&state), &test_security_config());
+
+    let req = authed_get("/api/v1/events/subscribe?topics=turn.complete");
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body();
+
+    state.event_bus.publish(DomainEvent::new(
+        "fact.created",
+        serde_json::json!({"fact_id": "f-2", "nous_id": "syn"}),
+    ));
+
+    let bytes = collect_sse_chunks(body, Duration::from_secs(1)).await;
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        !text.contains("event: fact.created"),
+        "should not receive fact.created when subscribed to turn.complete"
+    );
+}
+
+#[tokio::test]
+async fn subscribe_heartbeat_keeps_connection_alive() {
+    let (state, _dir) = test_state().await;
+    let router = build_router(Arc::clone(&state), &test_security_config());
+
+    let req = authed_get("/api/v1/events/subscribe?topics=fact.created");
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body();
+
+    let bytes = collect_sse_chunks(body, Duration::from_secs(2)).await;
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.contains(": heartbeat"),
+        "expected heartbeat comment in SSE stream, got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn subscribe_auth_required() {
+    let (app, _dir) = app().await;
+    let resp = app
+        .oneshot(
+            axum::http::Request::get("/api/v1/events/subscribe?topics=fact.created")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/crates/pylon/tests/common/mod.rs
+++ b/crates/pylon/tests/common/mod.rs
@@ -188,6 +188,7 @@ impl TestEnvBuilder {
             embedding_provider: None,
             turn_buffer_registry: Arc::new(pylon::turn_buffer::TurnBufferRegistry::new()),
             metrics_registry,
+            event_bus: Arc::new(pylon::event_bus::EventBus::new(256)),
         });
 
         TestEnv { state, _tmp: tmp }

--- a/crates/taxis/src/config/gateway.rs
+++ b/crates/taxis/src/config/gateway.rs
@@ -25,6 +25,8 @@ pub struct GatewayConfig {
     pub csrf: CsrfConfig,
     /// Rate limiting settings.
     pub rate_limit: RateLimitConfig,
+    /// SSE heartbeat interval for event subscription streams, in seconds.
+    pub sse_heartbeat_interval_secs: u64,
 }
 
 impl Default for GatewayConfig {
@@ -38,6 +40,7 @@ impl Default for GatewayConfig {
             body_limit: BodyLimitConfig::default(),
             csrf: CsrfConfig::default(),
             rate_limit: RateLimitConfig::default(),
+            sse_heartbeat_interval_secs: 30,
         }
     }
 }


### PR DESCRIPTION
Closes #3270

## Summary

Adds a filtered SSE domain-event subscription endpoint and an in-process broadcast bus.

## What's in this PR

- **EventBus**: tokio::sync::broadcast based in-process bus (crates/pylon/src/event_bus.rs).
- **Subscribe endpoint**: GET /api/v1/events/subscribe?topics=fact.created,turn.complete opens an SSE stream with server-side filtering and configurable heartbeat.
- **Discovery endpoint**: GET /api/v1/events/discovery returns available topics.
- **Publishers wired**:
  - fact.created — published from the knowledge ingest handler after each successful insert_fact.
  - turn.complete — published from pylon streaming handlers (send_message, stream_turn) when a turn finalizes successfully.
- **Topics noted for follow-up**: session.started, session.ended (need hooks in session create/close).

## Tests

- subscribe_returns_matching_events
- subscribe_filters_unwanted_topics
- subscribe_heartbeat_keeps_connection_alive
- subscribe_auth_required

## Gate

- cargo fmt --all -- --check
- cargo check --workspace --features test-core --all-targets --jobs 8
- cargo clippy --workspace --features test-core --all-targets --jobs 8 -- -D warnings
- cargo nextest run -p pylon --features test-core --build-jobs 8 --test-threads 8 (449 passed, 1 skipped)

Gate-Passed: kanon 0.1.0
