### PR TITLE
feat(poiesis-intake): parse Slack-style request text into structured scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,8 +699,10 @@ version = "0.21.1"
 dependencies = [
  "aletheia-lexica",
  "regex",
+ "serde",
  "snafu",
  "tempfile",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
 ]
 
@@ -5514,6 +5516,7 @@ name = "oikonomos"
 version = "0.21.1"
 dependencies = [
  "axum 0.8.9",
+ "eidos",
  "energeia",
  "episteme",
  "fjall",
@@ -5671,6 +5674,7 @@ dependencies = [
  "koina",
  "landlock",
  "poiesis-core",
+ "poiesis-intake",
  "poiesis-lint",
  "poiesis-sheet",
  "poiesis-text",
@@ -6086,6 +6090,17 @@ version = "0.21.1"
 dependencies = [
  "jiff",
  "snafu",
+]
+
+[[package]]
+name = "poiesis-intake"
+version = "0.21.1"
+dependencies = [
+ "aletheia-lexica",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tracing",
 ]
 
 [[package]]
@@ -6532,6 +6547,7 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "snafu",
  "symbolon",
  "taxis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/poiesis/lint",
     "crates/poiesis/typst",
     "crates/poiesis/verify",
+    "crates/poiesis/intake",
 ]
 # WHY: proskenion requires GTK3/webkit2gtk system libraries (via Dioxus
 # desktop/webview) which are not available in CI. Excluded from workspace to

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -40,6 +40,7 @@ poiesis-sheet = { path = "../poiesis/sheet" }
 poiesis-lint = { path = "../poiesis/lint" }
 poiesis-typst = { path = "../poiesis/typst" }
 poiesis-verify = { path = "../poiesis/verify" }
+poiesis-intake = { path = "../poiesis/intake" }
 koina = { path = "../koina" }
 taxis = { path = "../taxis" }
 indexmap = { workspace = true }

--- a/crates/organon/src/builtins/intake_report.rs
+++ b/crates/organon/src/builtins/intake_report.rs
@@ -1,0 +1,100 @@
+//! Intake report tool: parse free-form Slack-style text into a structured
+//! report scaffold.
+//!
+//! Uses keyword-based classification (no LLM call) via [`poiesis_intake`].
+
+use std::future::Future;
+use std::pin::Pin;
+
+use indexmap::IndexMap;
+
+use koina::id::ToolName;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+struct IntakeReportExecutor;
+
+impl ToolExecutor for IntakeReportExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async move {
+            let args = &input.arguments;
+            let Some(text) = args.get("text").and_then(serde_json::Value::as_str) else {
+                return Ok(ToolResult::error(
+                    "intake_report requires 'text' argument".to_owned(),
+                ));
+            };
+
+            let req = match poiesis_intake::parse_intake(text) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("parse failed: {e}")));
+                }
+            };
+
+            let files = match poiesis_intake::generate_scaffold(&req) {
+                Ok(f) => f,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("scaffold failed: {e}")));
+                }
+            };
+
+            let mut output = format!(
+                "Kind: {:?}\nSlug: {}\nDescription: {}\n\nGenerated {} file(s):\n",
+                req.kind,
+                req.slug,
+                req.description,
+                files.len()
+            );
+
+            for f in &files {
+                let _ = std::fmt::Write::write_fmt(
+                    &mut output,
+                    format_args!("\n--- {} ---\n{}", f.path, f.content),
+                );
+            }
+
+            Ok(ToolResult::text(output))
+        })
+    }
+}
+
+fn intake_report_def() -> ToolDef {
+    ToolDef {
+        name: ToolName::from_static("intake_report"), // kanon:ignore RUST/expect
+        description: "Parse free-form Slack-style text into a structured report scaffold. \
+                      Classifies the request (Analysis, Report, Dashboard, or Unclassified) \
+                      via keyword matching and returns skeleton markdown files."
+            .to_owned(),
+        extended_description: None,
+        input_schema: InputSchema {
+            properties: IndexMap::from([(
+                "text".to_owned(),
+                PropertyDef {
+                    property_type: PropertyType::String,
+                    description: "Free-form intake text to classify and scaffold".to_owned(),
+                    enum_values: None,
+                    default: None,
+                },
+            )]),
+            required: vec!["text".to_owned()],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
+/// Register the `intake_report` tool into the registry.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(intake_report_def(), Box::new(IntakeReportExecutor))?;
+    Ok(())
+}

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -34,6 +34,8 @@ pub mod parameters;
 pub mod planning;
 /// Poiesis report tools: generate_document, lint_report, verify_report.
 pub mod poiesis;
+/// Intake report tool: parse Slack-style text into a structured scaffold.
+pub mod intake_report;
 /// Web research tools (web_fetch).
 pub mod research;
 /// `tool_schema` meta-tool: fetch full JSON schema for any named tool on demand.
@@ -169,5 +171,6 @@ pub(crate) fn register_domain_tools(
     #[cfg(feature = "energeia")]
     bookkeeper::register(registry)?;
     poiesis::register(registry)?;
+    intake_report::register(registry)?;
     Ok(())
 }

--- a/crates/poiesis/intake/Cargo.toml
+++ b/crates/poiesis/intake/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "poiesis-intake"
+version.workspace = true
+description = "Parse Slack-style request text into a structured report scaffold"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+aletheia-lexica = { workspace = true }
+serde = { workspace = true }
+snafu = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/poiesis/intake/src/lib.rs
+++ b/crates/poiesis/intake/src/lib.rs
@@ -1,0 +1,373 @@
+#![deny(missing_docs)]
+//! Parse Slack-style request text into a structured report scaffold.
+//!
+//! Keyword-based classification (no LLM call) for v1.  Reuses keyword patterns
+//! from [`aletheia_lexica`] where applicable.
+
+use snafu::Snafu;
+
+/// Classification of an intake request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RequestKind {
+    /// Research or analytical task.
+    Analysis,
+    /// Written report or narrative document.
+    Report,
+    /// Dashboard or visual panel.
+    Dashboard,
+    /// Could not be classified.
+    Unclassified,
+}
+
+/// A parsed intake request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct IntakeRequest {
+    /// Classified kind of the request.
+    pub kind: RequestKind,
+    /// URL-safe slug derived from the description.
+    pub slug: String,
+    /// Normalised description text.
+    pub description: String,
+    /// Extracted requirement bullets (empty if none found).
+    pub requirements: Vec<String>,
+}
+
+/// A single file in a generated scaffold.
+///
+/// WHY: Local definition while `poiesis-scaffold` (#3703) is in flight.
+/// Reconcile via a shared trait once both PRs land.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScaffoldFile {
+    /// Relative path for the file.
+    pub path: String,
+    /// File content (UTF-8).
+    pub content: String,
+}
+
+/// Errors from intake parsing or scaffold generation.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum Error {
+    /// The intake text could not be parsed.
+    #[snafu(display("intake parse failed: {message}"))]
+    ParseIntake {
+        /// Human-readable reason.
+        message: String,
+    },
+}
+
+/// Convenience alias.
+pub type Result<T> = std::result::Result<T, Error>;
+
+// ── Keyword lists ─────────────────────────────────────────────────────────────
+
+/// Keywords that map to [`RequestKind::Analysis`].
+const ANALYSIS_KEYWORDS: &[&str] = &[
+    "analyze",
+    "analysis",
+    "analyse",
+    "investigate",
+    "study",
+    "evaluate",
+    "assess",
+    "compare",
+    "review",
+    "break down",
+    "breakdown",
+];
+
+/// Keywords that map to [`RequestKind::Report`].
+const REPORT_KEYWORDS: &[&str] = &[
+    "report",
+    "write",
+    "document",
+    "summary",
+    "prose",
+    "narrative",
+    "brief",
+    "whitepaper",
+    "white paper",
+];
+
+/// Keywords that map to [`RequestKind::Dashboard`].
+const DASHBOARD_KEYWORDS: &[&str] = &[
+    "dashboard",
+    "panel",
+    "visual",
+    "chart",
+    "metric",
+    "kpi",
+    "graph",
+    "tableau",
+];
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+/// Parse free-form intake text into a structured [`IntakeRequest`].
+///
+/// Classification is keyword-based and case-insensitive.  The first matching
+/// category wins in the order: Analysis, Report, Dashboard.  If no keyword
+/// matches the request is [`RequestKind::Unclassified`].
+///
+/// # Errors
+///
+/// Returns [`Error::ParseIntake`] when the input is empty or cannot be
+/// normalised.
+pub fn parse_intake(text: &str) -> Result<IntakeRequest> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err(Error::ParseIntake {
+            message: "intake text is empty".to_owned(),
+        });
+    }
+
+    let normalised = trimmed.to_lowercase();
+    let kind = classify(&normalised);
+    let description = trimmed.to_owned();
+    let slug = slugify(&description);
+    let requirements = extract_requirements(&description);
+
+    Ok(IntakeRequest {
+        kind,
+        slug,
+        description,
+        requirements,
+    })
+}
+
+fn classify(normalised: &str) -> RequestKind {
+    if contains_any(normalised, ANALYSIS_KEYWORDS) {
+        return RequestKind::Analysis;
+    }
+    if contains_any(normalised, REPORT_KEYWORDS) {
+        return RequestKind::Report;
+    }
+    if contains_any(normalised, DASHBOARD_KEYWORDS) {
+        return RequestKind::Dashboard;
+    }
+    RequestKind::Unclassified
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|&n| haystack.contains(n))
+}
+
+/// Generate a URL-safe slug from the first few words of a description.
+fn slugify(description: &str) -> String {
+    let words: Vec<&str> = description
+        .split_whitespace()
+        .take(8)
+        .collect();
+    let raw = words.join(" ");
+    raw.to_lowercase()
+        .replace(|c: char| !c.is_alphanumeric() && c != ' ', "-")
+        .replace(' ', "-")
+        .trim_matches('-')
+        .to_string()
+}
+
+/// Extract bullet-looking requirements from the description.
+fn extract_requirements(description: &str) -> Vec<String> {
+    description
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with('-') || trimmed.starts_with('*') {
+                let without_bullet = trimmed
+                    .trim_start_matches('-')
+                    .trim_start_matches('*')
+                    .trim();
+                if without_bullet.is_empty() {
+                    None
+                } else {
+                    Some(without_bullet.to_owned())
+                }
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+// ── Scaffold generation ───────────────────────────────────────────────────────
+
+/// Generate a skeleton file list for the given intake request.
+///
+/// # Errors
+///
+/// Currently infallible, but returns [`Result`] for forward compatibility.
+pub fn generate_scaffold(req: &IntakeRequest) -> Result<Vec<ScaffoldFile>> {
+    let slug = &req.slug;
+    let files = match req.kind {
+        RequestKind::Analysis => vec![
+            ScaffoldFile {
+                path: format!("{slug}.md"),
+                content: analysis_template(&req.description, &req.requirements),
+            },
+            ScaffoldFile {
+                path: format!("{slug}_data.md"),
+                content: "# Data sources\n\n".to_owned(),
+            },
+        ],
+        RequestKind::Report => vec![
+            ScaffoldFile {
+                path: format!("{slug}.md"),
+                content: report_template(&req.description, &req.requirements),
+            },
+            ScaffoldFile {
+                path: format!("{slug}_appendix.md"),
+                content: "# Appendix\n\n".to_owned(),
+            },
+        ],
+        RequestKind::Dashboard => vec![
+            ScaffoldFile {
+                path: format!("{slug}.md"),
+                content: dashboard_template(&req.description, &req.requirements),
+            },
+            ScaffoldFile {
+                path: format!("{slug}_data.md"),
+                content: "# Data model\n\n".to_owned(),
+            },
+        ],
+        RequestKind::Unclassified => vec![ScaffoldFile {
+            path: format!("{slug}.md"),
+            content: generic_template(&req.description, &req.requirements),
+        }],
+    };
+    Ok(files)
+}
+
+fn analysis_template(description: &str, requirements: &[String]) -> String {
+    let mut out = format!("# Analysis: {description}\n\n## Objective\n\n");
+    if !requirements.is_empty() {
+        out.push_str("## Requirements\n\n");
+        for req in requirements {
+            let _ = std::fmt::Write::write_fmt(&mut out, format_args!("- {req}\n"));
+        }
+        out.push('\n');
+    }
+    out.push_str("## Methodology\n\n");
+    out.push_str("## Findings\n\n");
+    out.push_str("## Conclusion\n\n");
+    out
+}
+
+fn report_template(description: &str, requirements: &[String]) -> String {
+    let mut out = format!("# Report: {description}\n\n## Executive Summary\n\n");
+    if !requirements.is_empty() {
+        out.push_str("## Requirements\n\n");
+        for req in requirements {
+            let _ = std::fmt::Write::write_fmt(&mut out, format_args!("- {req}\n"));
+        }
+        out.push('\n');
+    }
+    out.push_str("## Background\n\n");
+    out.push_str("## Key Points\n\n");
+    out.push_str("## Recommendations\n\n");
+    out
+}
+
+fn dashboard_template(description: &str, requirements: &[String]) -> String {
+    let mut out = format!("# Dashboard: {description}\n\n## Overview\n\n");
+    if !requirements.is_empty() {
+        out.push_str("## Requirements\n\n");
+        for req in requirements {
+            let _ = std::fmt::Write::write_fmt(&mut out, format_args!("- {req}\n"));
+        }
+        out.push('\n');
+    }
+    out.push_str("## Metrics\n\n");
+    out.push_str("## Visualisations\n\n");
+    out.push_str("## Data Refresh\n\n");
+    out
+}
+
+fn generic_template(description: &str, requirements: &[String]) -> String {
+    let mut out = format!("# {description}\n\n");
+    if !requirements.is_empty() {
+        out.push_str("## Requirements\n\n");
+        for req in requirements {
+            let _ = std::fmt::Write::write_fmt(&mut out, format_args!("- {req}\n"));
+        }
+        out.push('\n');
+    }
+    out.push_str("## Notes\n\n");
+    out
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_intake_classifies_analysis() {
+        let req = parse_intake("analyze the Q3 revenue trends").expect("parse");
+        assert_eq!(req.kind, RequestKind::Analysis);
+        assert!(!req.slug.is_empty());
+        assert_eq!(req.description, "analyze the Q3 revenue trends");
+    }
+
+    #[test]
+    fn parse_intake_classifies_report() {
+        let req = parse_intake("write a report on customer churn").expect("parse");
+        assert_eq!(req.kind, RequestKind::Report);
+        assert!(!req.slug.is_empty());
+        assert_eq!(req.description, "write a report on customer churn");
+    }
+
+    #[test]
+    fn parse_intake_classifies_dashboard() {
+        let req = parse_intake("dashboard for server metrics").expect("parse");
+        assert_eq!(req.kind, RequestKind::Dashboard);
+        assert!(!req.slug.is_empty());
+        assert_eq!(req.description, "dashboard for server metrics");
+    }
+
+    #[test]
+    fn parse_intake_falls_back_to_unclassified() {
+        let req = parse_intake("hello world").expect("parse");
+        assert_eq!(req.kind, RequestKind::Unclassified);
+    }
+
+    #[test]
+    fn generate_scaffold_returns_files() {
+        let req = IntakeRequest {
+            kind: RequestKind::Analysis,
+            slug: "q3-revenue".to_owned(),
+            description: "Analyze Q3 revenue".to_owned(),
+            requirements: vec!["Include YoY comparison".to_owned()],
+        };
+        let files = generate_scaffold(&req).expect("scaffold");
+        assert!(!files.is_empty());
+        assert!(files.iter().any(|f| f.path == "q3-revenue.md"));
+        assert!(files.iter().any(|f| f.path == "q3-revenue_data.md"));
+        for f in &files {
+            assert!(!f.content.is_empty(), "{} must have content", f.path);
+        }
+    }
+
+    #[test]
+    fn parse_intake_extracts_requirements() {
+        let text = "analyze the data\n- must include charts\n- compare with last year";
+        let req = parse_intake(text).expect("parse");
+        assert_eq!(req.requirements.len(), 2);
+        assert_eq!(req.requirements[0], "must include charts");
+        assert_eq!(req.requirements[1], "compare with last year");
+    }
+
+    #[test]
+    fn parse_intake_empty_input_errors() {
+        let err = parse_intake("   ").expect_err("should fail");
+        match err {
+            Error::ParseIntake { message } => {
+                assert!(message.contains("empty"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #3704.

## What's new
- **Crate** `crates/poiesis/intake/`:
  - `IntakeRequest`, `RequestKind` (#[non_exhaustive])
  - `parse_intake(text) \-> Result<IntakeRequest, Error>` — keyword-based classification
  - `generate_scaffold(req) \-> Result<Vec<ScaffoldFile>, Error>` — skeleton files per kind
  - Local `ScaffoldFile` stub while #3703 is in flight
- **Organon tool** `intake_report` wired into `builtins/mod.rs`

## Test coverage
- `parse_intake_classifies_analysis`
- `parse_intake_classifies_report`
- `parse_intake_classifies_dashboard`
- `parse_intake_falls_back_to_unclassified`
- `generate_scaffold_returns_files`

## Note
`ScaffoldFile` is duplicated here and will be defined in #3703. A follow-up issue should share these via a common trait once both PRs land.

Gate-Passed: kanon 0.1.0