### PR TITLE
chore(episteme): remove dead imports + constants

### DIFF
--- a/crates/episteme/src/derived_rules.rs
+++ b/crates/episteme/src/derived_rules.rs
@@ -69,6 +69,13 @@ is_a[child, ancestor] :=
 ///
 /// The output feeds into the `:put derived_facts` write in
 /// [`KnowledgeStore::materialize_ontological_rules`].
+#[cfg_attr(
+    not(feature = "mneme-engine"),
+    expect(
+        dead_code,
+        reason = "materialization query consumed by knowledge_store::derived_rules with mneme-engine feature"
+    )
+)]
 pub(crate) const ONTOLOGICAL_MATERIALIZATION: &str = r"
 is_a[child, parent] :=
     *type_hierarchy{child_type: child, parent_type: parent}
@@ -97,6 +104,13 @@ is_a[child, ancestor] :=
 /// WHY: replaces the application-level BFS in `propagate_confidence`. The
 /// Datalog engine evaluates recursive rules to fixpoint in one query; the
 /// application no longer needs to iteratively fetch edges.
+#[cfg_attr(
+    not(feature = "mneme-engine"),
+    expect(
+        dead_code,
+        reason = "materialization query consumed by knowledge_store::derived_rules with mneme-engine feature"
+    )
+)]
 pub(crate) const CAUSAL_CHAIN_MATERIALIZATION: &str = r"
 causal_chain[cause, effect, conf] :=
     *causal_edges{cause: cause, effect: effect, confidence: conf}
@@ -166,6 +180,13 @@ active_default[entity_id, content, conf] :=
 /// `CozoDB` `not` is stratified negation: the `defaults` and `facts` base
 /// relations must be fully evaluated before the outer rule fires. This holds
 /// here because neither relation is derived by this script.
+#[cfg_attr(
+    not(feature = "mneme-engine"),
+    expect(
+        dead_code,
+        reason = "materialization query consumed by knowledge_store::derived_rules with mneme-engine feature"
+    )
+)]
 pub(crate) const DEFEASIBLE_SCOPED_MATERIALIZATION: &str = r"
 verified_for_entity[entity_id, tag] :=
     *fact_entities{fact_id: fid, entity_id: entity_id},

--- a/crates/episteme/src/graph_intelligence.rs
+++ b/crates/episteme/src/graph_intelligence.rs
@@ -15,30 +15,38 @@
     )
 )]
 
-use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "mneme-engine")]
+use std::collections::{BTreeMap, BinaryHeap, VecDeque};
 
 #[cfg(feature = "mneme-engine")]
 use snafu::ResultExt;
 
+#[cfg(feature = "mneme-engine")]
 /// Wrapper for `(cost, node)` that implements `Ord` so it can live in a
 /// `BinaryHeap` for Dijkstra's algorithm.
 #[derive(Debug, Clone)]
 struct DistState(f64, String);
 
+#[cfg(feature = "mneme-engine")]
 impl PartialEq for DistState {
     fn eq(&self, other: &Self) -> bool {
         self.0.to_bits() == other.0.to_bits() && self.1 == other.1
     }
 }
 
+#[cfg(feature = "mneme-engine")]
 impl Eq for DistState {}
 
+#[cfg(feature = "mneme-engine")]
 impl PartialOrd for DistState {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
+#[cfg(feature = "mneme-engine")]
 impl Ord for DistState {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0


### PR DESCRIPTION
Clear 4 pre-existing clippy violations in episteme so workspace-wide `cargo clippy -- -D warnings` passes.

**Deleted / kept:**
- `graph_intelligence.rs`: split `std::collections` imports so `BTreeMap`, `BinaryHeap`, `VecDeque` are only imported when `mneme-engine` is enabled (they are unused otherwise). Wrapped `DistState` and its trait impls in `#[cfg(feature = "mneme-engine")]` for the same reason.
- `derived_rules.rs`: added `#[cfg_attr(not(feature = "mneme-engine"), expect(dead_code, ...))]` to `ONTOLOGICAL_MATERIALIZATION`, `CAUSAL_CHAIN_MATERIALIZATION`, and `DEFEASIBLE_SCOPED_MATERIALIZATION` — these constants are consumed by `knowledge_store::derived_rules`, which is gated behind `mneme-engine`.

Closes #3819
Gate-Passed: kanon 0.1.0