### PR TITLE
feat(poiesis-slides): JSON-first render_pptx + inspect_pptx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,7 @@ dependencies = [
  "aletheia-lexica",
  "regex",
  "serde",
+ "serde_json",
  "snafu",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
@@ -5690,8 +5691,11 @@ dependencies = [
  "landlock",
  "poiesis-core",
  "poiesis-doc",
+ "poiesis-intake",
  "poiesis-lint",
+ "poiesis-scaffold",
  "poiesis-sheet",
+ "poiesis-slides",
  "poiesis-text",
  "poiesis-typst",
  "poiesis-verify",
@@ -6121,12 +6125,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "poiesis-intake"
+version = "0.21.1"
+dependencies = [
+ "aletheia-lexica",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tracing",
+]
+
+[[package]]
 name = "poiesis-lint"
 version = "0.21.1"
 dependencies = [
  "serde",
  "serde_json",
  "snafu",
+]
+
+[[package]]
+name = "poiesis-scaffold"
+version = "0.21.1"
+dependencies = [
+ "poiesis-core",
+ "poiesis-sheet",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tracing",
 ]
 
 [[package]]
@@ -6145,7 +6172,10 @@ version = "0.21.1"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
+ "serde",
+ "serde_json",
  "snafu",
+ "tracing",
  "zip 8.5.1",
 ]
 

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -38,6 +38,7 @@ poiesis-core = { path = "../poiesis/core" }
 poiesis-text = { path = "../poiesis/text" }
 poiesis-sheet = { path = "../poiesis/sheet" }
 poiesis-lint = { path = "../poiesis/lint" }
+poiesis-slides = { path = "../poiesis/slides" }
 poiesis-typst = { path = "../poiesis/typst" }
 poiesis-scaffold = { path = "../poiesis/scaffold" }
 poiesis-verify = { path = "../poiesis/verify" }

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -26,6 +26,8 @@ pub mod fs_ops;
 pub mod git_ops;
 /// Generic HTTP client (POST/PUT/DELETE/PATCH with headers + body).
 pub mod http_client;
+/// Intake report tool: parse Slack-style text into a structured scaffold.
+pub mod intake_report;
 /// Knowledge graph and session memory tools (remember, recall).
 pub mod memory;
 /// Parameter registry query tool (discover tunable parameters).
@@ -35,12 +37,12 @@ pub mod planning;
 /// Poiesis report tools: generate_document, lint_report, verify_report,
 /// render_typst_report, render_docx_report.
 pub mod poiesis;
-/// Intake report tool: parse Slack-style text into a structured scaffold.
-pub mod intake_report;
 /// Scaffold report tool: generates a new report project from embedded templates.
 pub mod scaffold_report;
 /// DOCX report rendering tool (render_docx_report).
 pub mod render_docx_report;
+/// Render a JSON slide descriptor to PPTX.
+pub mod render_pptx_report;
 /// Web research tools (web_fetch).
 pub mod research;
 /// `tool_schema` meta-tool: fetch full JSON schema for any named tool on demand.
@@ -179,5 +181,6 @@ pub(crate) fn register_domain_tools(
     intake_report::register(registry)?;
     scaffold_report::register(registry)?;
     render_docx_report::register(registry)?;
+    render_pptx_report::register(registry)?;
     Ok(())
 }

--- a/crates/organon/src/builtins/render_pptx_report.rs
+++ b/crates/organon/src/builtins/render_pptx_report.rs
@@ -1,0 +1,117 @@
+//! `render_pptx_report` organon tool — JSON-first PPTX generation.
+//!
+//! Wraps [`poiesis_slides::render_pptx`] so agents can produce PowerPoint
+//! presentations directly from a JSON slide descriptor.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use hermeneus::types::{DocumentSource, ToolResultBlock};
+use indexmap::IndexMap;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+struct RenderPptxReportExecutor;
+
+impl ToolExecutor for RenderPptxReportExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async move {
+            let args = &input.arguments;
+
+            let data: serde_json::Value =
+                if let Some(raw) = args.get("data").and_then(serde_json::Value::as_str) {
+                    match serde_json::from_str(raw) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            return Ok(ToolResult::error(format!("data must be valid JSON: {e}")));
+                        }
+                    }
+                } else {
+                    serde_json::json!({})
+                };
+
+            let pptx_bytes = match poiesis_slides::render_pptx(&data) {
+                Ok(b) => b,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("pptx render failed: {e}")));
+                }
+            };
+
+            // Optional: write to a caller-provided path in addition to returning bytes.
+            if let Some(out_path) = args.get("out_path").and_then(serde_json::Value::as_str)
+                && let Err(e) = tokio::fs::write(out_path, &pptx_bytes).await
+            {
+                return Ok(ToolResult::error(format!(
+                    "wrote 0 bytes to {out_path:?}: {e}"
+                )));
+            }
+
+            let encoded = koina::base64::encode(&pptx_bytes);
+            let summary = format!("Rendered PPTX report: {} bytes", pptx_bytes.len());
+
+            Ok(ToolResult::blocks(vec![
+                ToolResultBlock::Text { text: summary },
+                ToolResultBlock::Document {
+                    source: DocumentSource {
+                        source_type: "base64".to_owned(),
+                        media_type: "application/vnd.openxmlformats-officedocument.presentationml.presentation".to_owned(),
+                        data: encoded,
+                    },
+                },
+            ]))
+        })
+    }
+}
+
+fn render_pptx_report_def() -> ToolDef {
+    ToolDef {
+        name: koina::id::ToolName::from_static("render_pptx_report"), // kanon:ignore RUST/expect
+        description: "Render a JSON slide descriptor to a PPTX presentation.".to_owned(),
+        extended_description: Some(
+            "The JSON blob passed as `data` follows the schema: { slides: [{ title?, content: [{text?, bullets?: [..]}] }] }. \
+             The result contains a text summary plus a base64-encoded PPTX document block; optionally \
+             also writes the PPTX to `out_path` on the filesystem."
+                .to_owned(),
+        ),
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "data".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Inline JSON slide descriptor (slides array with title and content).".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "out_path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Optional filesystem path to write the rendered PPTX to, in addition to returning base64 bytes.".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
+/// Register the `render_pptx_report` tool.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(render_pptx_report_def(), Box::new(RenderPptxReportExecutor))
+}

--- a/crates/organon/src/builtins/scaffold_report.rs
+++ b/crates/organon/src/builtins/scaffold_report.rs
@@ -26,7 +26,9 @@ fn extract_str<'a>(
 }
 
 fn extract_bool(args: &serde_json::Value, key: &str, default: bool) -> bool {
-    args.get(key).and_then(serde_json::Value::as_bool).unwrap_or(default)
+    args.get(key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(default)
 }
 
 struct ScaffoldReportExecutor;
@@ -60,11 +62,11 @@ impl ToolExecutor for ScaffoldReportExecutor {
                 }
             };
 
-            let files = match poiesis_scaffold::scaffold_report(slug, description, format, confidential)
-            {
-                Ok(f) => f,
-                Err(e) => return Ok(ToolResult::error(e.to_string())),
-            };
+            let files =
+                match poiesis_scaffold::scaffold_report(slug, description, format, confidential) {
+                    Ok(f) => f,
+                    Err(e) => return Ok(ToolResult::error(e.to_string())),
+                };
 
             if let Some(dir) = extract_opt_str(args, "directory") {
                 if let Err(e) = tokio::fs::create_dir_all(dir).await {

--- a/crates/poiesis/slides/Cargo.toml
+++ b/crates/poiesis/slides/Cargo.toml
@@ -14,7 +14,10 @@ workspace = true
 [dependencies]
 poiesis-core = { path = "../core" }
 quick-xml = "0.39"
+serde = { workspace = true }
+serde_json = { workspace = true }
 snafu = { workspace = true }
+tracing = { workspace = true }
 zip = "8"
 
 [features]

--- a/crates/poiesis/slides/src/error.rs
+++ b/crates/poiesis/slides/src/error.rs
@@ -1,0 +1,36 @@
+//! Error types for poiesis-slides.
+
+use snafu::Snafu;
+
+/// Errors produced by JSON-first PPTX operations.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum Error {
+    /// The supplied JSON does not match the expected slide schema.
+    #[snafu(display("invalid slide JSON: {message}"))]
+    InvalidJson {
+        /// Human-readable description of the schema violation.
+        message: String,
+    },
+
+    /// An error occurred while reading the PPTX ZIP archive.
+    #[snafu(display("ZIP read error: {message}"))]
+    ZipRead {
+        /// Human-readable error description.
+        message: String,
+    },
+
+    /// An error occurred while parsing OOXML XML inside the PPTX archive.
+    #[snafu(display("XML parse error: {message}"))]
+    XmlParse {
+        /// Human-readable error description.
+        message: String,
+    },
+
+    /// An error occurred during PPTX generation via the hand-rolled emitter.
+    #[snafu(display("PPTX render error: {source}"))]
+    Render {
+        /// Underlying emitter error.
+        source: crate::pptx::PptxError,
+    },
+}

--- a/crates/poiesis/slides/src/lib.rs
+++ b/crates/poiesis/slides/src/lib.rs
@@ -1,11 +1,391 @@
 #![deny(missing_docs)]
 //! poiesis-slides: PPTX presentation rendering backend.
 //!
+//! This crate provides both a traditional [`Document`]-centric API via
+//! [`PptxRenderer`] and a new JSON-first API via [`render_pptx`] and
+//! [`inspect_pptx`].
+//!
+//! ## Decision: keep hand-rolled emitter
+//!
+//! The v1 JSON-first wrapper intentionally continues to use the existing
+//! hand-rolled ZIP/XML emitter rather than replacing it with `ppt-rs`.
+//! Migration to `ppt-rs` (or a fork) is tracked separately in #3445; that
+//! work is out of scope here so that this issue can land quickly without
+//! adding a new heavy dependency or destabilising the current output.
+//!
 //! Feature flags:
 //! - `pptx` (default): `PowerPoint` PPTX output via hand-rolled ZIP/XML emitter.
 
 #[cfg(feature = "pptx")]
 pub mod pptx;
 
+mod error;
+
 #[cfg(feature = "pptx")]
 pub use pptx::PptxRenderer;
+
+pub use error::Error;
+
+use poiesis_core::{Block, Document, ListItem, Metadata, Renderer, RichText, Span};
+use serde_json::Value;
+use tracing::instrument;
+
+/// Result alias for poiesis-slides operations.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Summary of a single slide extracted from an existing PPTX file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SlideSummary {
+    /// Slide title (first text run in the slide, typically the title placeholder).
+    pub title: String,
+    /// Bullet text extracted from the slide body.
+    pub bullets: Vec<String>,
+}
+
+/// Summary of a complete presentation extracted from PPTX bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PresentationSummary {
+    /// Per-slide summaries, ordered by slide position.
+    pub slides: Vec<SlideSummary>,
+    /// Total number of slides.
+    pub slide_count: usize,
+}
+
+/// Render a JSON slide descriptor to PPTX bytes.
+///
+/// The expected JSON schema is:
+/// ```json
+/// {
+///   "slides": [
+///     {
+///       "layout": "titleAndContent",
+///       "title": "Slide Title",
+///       "content": [
+///         { "text": "A paragraph." },
+///         { "bullets": ["First bullet", "Second bullet"] }
+///       ]
+///     }
+///   ]
+/// }
+/// ```
+///
+/// `layout` is optional and reserved for future use.
+/// Each item in `content` may contain `text` (a paragraph) and/or `bullets`
+/// (an unordered list).  The JSON is translated into a [`Document`] and
+/// rendered through the existing hand-rolled emitter.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidJson`] if the JSON does not conform to the
+/// expected schema, or [`Error::Render`] if the hand-rolled emitter fails.
+#[instrument(skip_all)]
+pub fn render_pptx(data: &Value) -> Result<Vec<u8>> {
+    let slides = data
+        .get("slides")
+        .and_then(Value::as_array)
+        .ok_or_else(|| Error::InvalidJson {
+            message: "missing top-level 'slides' array".to_owned(),
+        })?;
+
+    if slides.is_empty() {
+        return Err(Error::InvalidJson {
+            message: "'slides' array must contain at least one slide".to_owned(),
+        });
+    }
+
+    let mut blocks: Vec<Block> = Vec::new();
+    let mut first_title: Option<String> = None;
+
+    for (i, slide) in slides.iter().enumerate() {
+        let title = slide.get("title").and_then(Value::as_str).unwrap_or("");
+
+        if i == 0 {
+            first_title = Some(title.to_owned());
+        } else {
+            blocks.push(Block::Heading {
+                level: 1,
+                text: plain(title),
+            });
+        }
+
+        if let Some(content) = slide.get("content").and_then(Value::as_array) {
+            for item in content {
+                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                    blocks.push(Block::Paragraph(plain(text)));
+                }
+                if let Some(bullets) = item.get("bullets").and_then(Value::as_array) {
+                    let items: Vec<ListItem> = bullets
+                        .iter()
+                        .filter_map(|b| b.as_str())
+                        .map(|s| ListItem { content: plain(s) })
+                        .collect();
+                    blocks.push(Block::List {
+                        ordered: false,
+                        items,
+                    });
+                }
+            }
+        }
+    }
+
+    let doc = Document {
+        metadata: Metadata {
+            title: first_title.unwrap_or_default(),
+            author: None,
+            created: None,
+        },
+        content: blocks,
+    };
+
+    let renderer = PptxRenderer::new();
+    renderer
+        .render(&doc)
+        .map_err(|source| Error::Render { source })
+}
+
+/// Inspect an existing PPTX file and extract text per slide.
+///
+/// Uses the `zip` crate to read the OOXML archive and `quick-xml` to pull
+/// text runs (`<a:t>`) from each slide part.  The first text run in a slide
+/// is treated as the title; all subsequent runs are treated as bullets.
+///
+/// # Errors
+///
+/// Returns [`Error::ZipRead`] if the bytes are not a valid ZIP archive, or
+/// [`Error::XmlParse`] if a slide XML part cannot be parsed.
+#[instrument(skip_all, fields(bytes_len = bytes.len()))]
+pub fn inspect_pptx(bytes: &[u8]) -> Result<PresentationSummary> {
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| Error::ZipRead {
+        message: e.to_string(),
+    })?;
+
+    let mut slide_names: Vec<String> = Vec::new();
+    for i in 0..archive.len() {
+        let file = archive.by_index(i).map_err(|e| Error::ZipRead {
+            message: e.to_string(),
+        })?;
+        let name = file.name();
+        if name.starts_with("ppt/slides/slide")
+            && std::path::Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("xml"))
+        {
+            slide_names.push(name.to_owned());
+        }
+    }
+
+    // Sort by slide number so the order is deterministic.
+    slide_names.sort_by(|a, b| {
+        let num_a = extract_slide_number(a).unwrap_or(0);
+        let num_b = extract_slide_number(b).unwrap_or(0);
+        num_a.cmp(&num_b)
+    });
+
+    let mut summaries: Vec<SlideSummary> = Vec::with_capacity(slide_names.len());
+
+    for name in &slide_names {
+        let mut file = archive.by_name(name).map_err(|e| Error::ZipRead {
+            message: e.to_string(),
+        })?;
+        let mut xml = String::new();
+        std::io::Read::read_to_string(&mut file, &mut xml).map_err(|e| Error::ZipRead {
+            message: e.to_string(),
+        })?;
+
+        let texts = extract_text_runs(&xml)?;
+        let (title, bullets) = if texts.is_empty() {
+            (String::new(), Vec::new())
+        } else {
+            let mut iter = texts.into_iter();
+            let t = iter.next().unwrap_or_default();
+            (t, iter.collect())
+        };
+
+        summaries.push(SlideSummary { title, bullets });
+    }
+
+    let slide_count = summaries.len();
+    Ok(PresentationSummary {
+        slides: summaries,
+        slide_count,
+    })
+}
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+fn plain(s: &str) -> RichText {
+    RichText {
+        spans: vec![Span::Plain(s.to_owned())],
+    }
+}
+
+fn extract_slide_number(name: &str) -> Option<usize> {
+    // Name format: ppt/slides/slideN.xml
+    let stem = name.strip_prefix("ppt/slides/slide")?;
+    let num_str = stem.strip_suffix(".xml")?;
+    num_str.parse().ok()
+}
+
+fn extract_text_runs(xml: &str) -> Result<Vec<String>> {
+    use quick_xml::escape::unescape;
+    use quick_xml::events::Event;
+    use quick_xml::reader::Reader;
+
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut texts: Vec<String> = Vec::new();
+    let mut buf = Vec::new();
+    let mut current = String::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) if e.name().as_ref() == b"a:t" => {
+                current.clear();
+            }
+            Ok(Event::Text(e))
+                if let Ok(decoded) = e.decode()
+                    && let Ok(txt) = unescape(&decoded) =>
+            {
+                current.push_str(&txt);
+            }
+            Ok(Event::End(e)) if e.name().as_ref() == b"a:t" => {
+                texts.push(current.clone());
+                current.clear();
+            }
+            Ok(Event::Empty(e)) if e.name().as_ref() == b"a:t" => {
+                texts.push(String::new());
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(Error::XmlParse {
+                    message: e.to_string(),
+                });
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(texts)
+}
+
+// ------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_pptx_simple_json() {
+        let data = serde_json::json!({
+            "slides": [
+                {
+                    "title": "Hello World",
+                    "content": [
+                        { "text": "Welcome to the presentation." },
+                        { "bullets": ["Point A", "Point B"] }
+                    ]
+                }
+            ]
+        });
+        let bytes = render_pptx(&data).expect("render must succeed");
+        assert!(!bytes.is_empty(), "PPTX must not be empty");
+        assert_eq!(&bytes[..2], b"PK", "PPTX must be a valid ZIP");
+    }
+
+    #[test]
+    fn render_pptx_multi_slide() {
+        let data = serde_json::json!({
+            "slides": [
+                {
+                    "title": "First Slide",
+                    "content": [
+                        { "text": "Opening remarks." }
+                    ]
+                },
+                {
+                    "title": "Second Slide",
+                    "content": [
+                        { "bullets": ["Bullet 1", "Bullet 2"] }
+                    ]
+                },
+                {
+                    "title": "Third Slide",
+                    "content": [
+                        { "text": "Conclusion." },
+                        { "bullets": ["Takeaway 1"] }
+                    ]
+                }
+            ]
+        });
+        let bytes = render_pptx(&data).expect("render must succeed");
+        assert!(!bytes.is_empty());
+        assert_eq!(&bytes[..2], b"PK");
+
+        let summary = inspect_pptx(&bytes).expect("inspect must succeed");
+        assert_eq!(summary.slide_count, 3, "must have 3 slides");
+        assert_eq!(summary.slides[0].title, "First Slide");
+        assert_eq!(summary.slides[1].title, "Second Slide");
+        assert_eq!(summary.slides[2].title, "Third Slide");
+    }
+
+    #[test]
+    fn inspect_pptx_extracts_text() {
+        // Render a known presentation so we have valid bytes.
+        let data = serde_json::json!({
+            "slides": [
+                {
+                    "title": "Inspection Test",
+                    "content": [
+                        { "bullets": ["Alpha", "Beta"] }
+                    ]
+                }
+            ]
+        });
+        let bytes = render_pptx(&data).expect("render must succeed");
+        let summary = inspect_pptx(&bytes).expect("inspect must succeed");
+
+        assert_eq!(summary.slide_count, 1);
+        assert_eq!(summary.slides[0].title, "Inspection Test");
+        assert!(summary.slides[0].bullets.contains(&"Alpha".to_owned()));
+        assert!(summary.slides[0].bullets.contains(&"Beta".to_owned()));
+    }
+
+    #[test]
+    fn render_pptx_malformed_json_errors() {
+        let data = serde_json::json!({ "not_slides": [] });
+        let err = render_pptx(&data).expect_err("must error");
+        assert!(
+            matches!(err, Error::InvalidJson { .. }),
+            "expected InvalidJson, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn render_pptx_empty_slides_errors() {
+        let data = serde_json::json!({ "slides": [] });
+        let err = render_pptx(&data).expect_err("must error");
+        assert!(
+            matches!(err, Error::InvalidJson { .. }),
+            "expected InvalidJson for empty slides, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn inspect_pptx_invalid_zip_errors() {
+        let err = inspect_pptx(b"not a zip file").expect_err("must error");
+        assert!(
+            matches!(err, Error::ZipRead { .. }),
+            "expected ZipRead, got: {err:?}"
+        );
+    }
+}


### PR DESCRIPTION
Add JSON-first API to poiesis-slides while keeping the existing hand-rolled ZIP/XML emitter:

- `render_pptx(data: &Value) -> Result<Vec<u8>, Error>` — translates JSON slide descriptors into `Document` blocks and renders via `PptxRenderer`.
- `inspect_pptx(bytes: &[u8]) -> Result<PresentationSummary, Error>` — extracts text per slide from PPTX bytes using the `zip` crate.
- New `render_pptx_report` organon tool for agent-facing PPTX generation.

Decision: keep hand-rolled emitter. Migration to `ppt-rs` is tracked in #3445 and intentionally out of scope here.

Closes #3702

Gate-Passed: kanon 0.1.0