### PR TITLE
feat(poiesis-sheet): JSON-first render_xlsx + inspect_xlsx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,6 @@ dependencies = [
  "aletheia-lexica",
  "regex",
  "serde",
- "serde_json",
  "snafu",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
@@ -996,6 +995,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "calamine"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+dependencies = [
+ "byteorder",
+ "codepage",
+ "encoding_rs",
+ "log",
+ "quick-xml 0.31.0",
+ "serde",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -1320,6 +1334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -2160,21 +2183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
-]
-
-[[package]]
-name = "docx-rs"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed73cbf5e1c37baa23f4132569ac1187829f03922c206bd68fe109e3001a343d"
-dependencies = [
- "base64 0.22.1",
- "image",
- "quick-xml 0.36.2",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "zip 0.6.6",
 ]
 
 [[package]]
@@ -5690,12 +5698,8 @@ dependencies = [
  "koina",
  "landlock",
  "poiesis-core",
- "poiesis-doc",
- "poiesis-intake",
  "poiesis-lint",
- "poiesis-scaffold",
  "poiesis-sheet",
- "poiesis-slides",
  "poiesis-text",
  "poiesis-typst",
  "poiesis-verify",
@@ -6112,30 +6116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "poiesis-doc"
-version = "0.21.1"
-dependencies = [
- "docx-rs",
- "quick-xml 0.39.2",
- "serde",
- "serde_json",
- "snafu",
- "tracing",
- "zip 8.5.1",
-]
-
-[[package]]
-name = "poiesis-intake"
-version = "0.21.1"
-dependencies = [
- "aletheia-lexica",
- "serde",
- "serde_json",
- "snafu",
- "tracing",
-]
-
-[[package]]
 name = "poiesis-lint"
 version = "0.21.1"
 dependencies = [
@@ -6145,25 +6125,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "poiesis-scaffold"
-version = "0.21.1"
-dependencies = [
- "poiesis-core",
- "poiesis-sheet",
- "serde",
- "serde_json",
- "snafu",
- "tracing",
-]
-
-[[package]]
 name = "poiesis-sheet"
 version = "0.21.1"
 dependencies = [
+ "calamine",
  "poiesis-core",
  "rust_xlsxwriter",
+ "serde_json",
  "snafu",
  "spreadsheet-ods",
+ "tracing",
 ]
 
 [[package]]
@@ -6172,10 +6143,7 @@ version = "0.21.1"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
- "serde",
- "serde_json",
  "snafu",
- "tracing",
  "zip 8.5.1",
 ]
 
@@ -6652,9 +6620,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -11176,14 +11144,19 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "crc32fast",
  "crossbeam-utils",
+ "displaydoc",
  "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
 ]
 
 [[package]]

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -43,6 +43,8 @@ pub mod scaffold_report;
 pub mod render_docx_report;
 /// Render a JSON slide descriptor to PPTX.
 pub mod render_pptx_report;
+/// JSON-first XLSX report tool (`render_xlsx_report`).
+pub mod render_xlsx_report;
 /// Web research tools (web_fetch).
 pub mod research;
 /// `tool_schema` meta-tool: fetch full JSON schema for any named tool on demand.
@@ -182,5 +184,6 @@ pub(crate) fn register_domain_tools(
     scaffold_report::register(registry)?;
     render_docx_report::register(registry)?;
     render_pptx_report::register(registry)?;
+    render_xlsx_report::register(registry)?;
     Ok(())
 }

--- a/crates/organon/src/builtins/render_xlsx_report.rs
+++ b/crates/organon/src/builtins/render_xlsx_report.rs
@@ -1,0 +1,128 @@
+//! `render_xlsx_report` tool — JSON-first XLSX generation.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use hermeneus::types::{DocumentSource, ToolResultBlock};
+use indexmap::IndexMap;
+
+use crate::error::Result;
+use crate::registry::{ToolExecutor, ToolRegistry};
+use crate::types::{
+    InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
+    ToolInput, ToolResult,
+};
+
+fn extract_opt_str<'a>(args: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    args.get(key).and_then(serde_json::Value::as_str)
+}
+
+// ── render_xlsx_report ────────────────────────────────────────────────────────
+
+struct RenderXlsxReportExecutor;
+
+impl ToolExecutor for RenderXlsxReportExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        _ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async move {
+            let args = &input.arguments;
+
+            let data: serde_json::Value = if let Some(raw) = extract_opt_str(args, "data") {
+                match serde_json::from_str(raw) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!("data must be valid JSON: {e}")));
+                    }
+                }
+            } else {
+                serde_json::json!({})
+            };
+
+            let xlsx_result = poiesis_sheet::render_xlsx(&data);
+
+            let xlsx_bytes = match xlsx_result {
+                Ok(b) => b,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("xlsx render failed: {e}")));
+                }
+            };
+
+            // Optional: write to a caller-provided path in addition to returning bytes.
+            if let Some(out_path) = extract_opt_str(args, "out_path")
+                && let Err(e) = tokio::fs::write(out_path, &xlsx_bytes).await
+            {
+                return Ok(ToolResult::error(format!(
+                    "wrote 0 bytes to {out_path:?}: {e}"
+                )));
+            }
+
+            let encoded = koina::base64::encode(&xlsx_bytes);
+            let summary = format!("Rendered XLSX report: {} bytes", xlsx_bytes.len());
+
+            Ok(ToolResult::blocks(vec![
+                ToolResultBlock::Text { text: summary },
+                ToolResultBlock::Document {
+                    source: DocumentSource {
+                        source_type: "base64".to_owned(),
+                        media_type:
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                                .to_owned(),
+                        data: encoded,
+                    },
+                },
+            ]))
+        })
+    }
+}
+
+fn render_xlsx_report_def() -> ToolDef {
+    ToolDef {
+        name: koina::id::ToolName::from_static("render_xlsx_report"), // kanon:ignore RUST/expect
+        description: "Render a JSON workbook descriptor to an XLSX spreadsheet.".to_owned(),
+        extended_description: Some(
+            "The JSON blob passed as `data` must conform to the workbook schema: \
+             `{sheets: [{name, columns: [{header, width?}], rows: [[cell, ...]]}]}`. \
+             The result contains a text summary plus a base64-encoded XLSX document block; \
+             optionally also writes the XLSX to `out_path` on the filesystem."
+                .to_owned(),
+        ),
+        input_schema: InputSchema {
+            properties: IndexMap::from([
+                (
+                    "data".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description: "Inline JSON workbook descriptor.".to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
+                    "out_path".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::String,
+                        description:
+                            "Optional filesystem path to write the rendered XLSX to, in addition \
+                             to returning base64 bytes."
+                                .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+            ]),
+            required: vec![],
+        },
+        category: ToolCategory::Workspace,
+        reversibility: Reversibility::FullyReversible,
+        auto_activate: false,
+    }
+}
+
+/// Register the `render_xlsx_report` tool.
+pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
+    registry.register(render_xlsx_report_def(), Box::new(RenderXlsxReportExecutor))?;
+    Ok(())
+}

--- a/crates/poiesis/sheet/Cargo.toml
+++ b/crates/poiesis/sheet/Cargo.toml
@@ -13,7 +13,9 @@ workspace = true
 
 [dependencies]
 poiesis-core = { path = "../core" }
+serde_json = { workspace = true }
 snafu = { workspace = true }
+tracing = { workspace = true }
 
 # XLSX backend
 rust_xlsxwriter = { version = "0.94", optional = true }
@@ -21,7 +23,10 @@ rust_xlsxwriter = { version = "0.94", optional = true }
 # ODS backend
 spreadsheet-ods = { version = "1.0", optional = true }
 
+# XLSX inspection
+calamine = { version = "0.26", optional = true }
+
 [features]
 default = ["xlsx", "ods"]
-xlsx = ["dep:rust_xlsxwriter"]
+xlsx = ["dep:rust_xlsxwriter", "dep:calamine"]
 ods = ["dep:spreadsheet-ods"]

--- a/crates/poiesis/sheet/src/error.rs
+++ b/crates/poiesis/sheet/src/error.rs
@@ -1,0 +1,30 @@
+//! Error types for the JSON-first XLSX API.
+
+use snafu::Snafu;
+
+/// Errors produced by [`render_xlsx`](crate::render_xlsx) and
+/// [`inspect_xlsx`](crate::inspect_xlsx).
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum Error {
+    /// The input JSON does not conform to the expected workbook schema.
+    #[snafu(display("invalid schema: {detail}"))]
+    InvalidSchema {
+        /// Human-readable description of the schema violation.
+        detail: String,
+    },
+
+    /// `rust_xlsxwriter` returned an error while writing the workbook.
+    #[snafu(display("XLSX write error: {message}"))]
+    XlsxWrite {
+        /// Human-readable error description.
+        message: String,
+    },
+
+    /// `calamine` returned an error while reading the workbook.
+    #[snafu(display("XLSX read error: {message}"))]
+    XlsxRead {
+        /// Human-readable error description.
+        message: String,
+    },
+}

--- a/crates/poiesis/sheet/src/lib.rs
+++ b/crates/poiesis/sheet/src/lib.rs
@@ -6,6 +6,12 @@
 //! - `ods` (default): `OpenDocument` Spreadsheet output via `spreadsheet-ods`.
 
 #[cfg(feature = "xlsx")]
+pub mod error;
+
+#[cfg(feature = "xlsx")]
+pub use error::Error;
+
+#[cfg(feature = "xlsx")]
 pub mod xlsx;
 
 #[cfg(feature = "ods")]
@@ -16,3 +22,340 @@ pub use xlsx::XlsxRenderer;
 
 #[cfg(feature = "ods")]
 pub use ods::OdsRenderer;
+
+#[cfg(feature = "xlsx")]
+use rust_xlsxwriter::Workbook;
+
+#[cfg(feature = "xlsx")]
+use tracing::instrument;
+
+/// Summary of a workbook returned by [`inspect_xlsx`].
+#[cfg(feature = "xlsx")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct WorkbookSummary {
+    /// Per-sheet summaries.
+    pub sheets: Vec<SheetSummary>,
+    /// Total number of non-empty cells across all sheets.
+    pub cell_count: usize,
+}
+
+/// Summary of a single sheet returned by [`inspect_xlsx`].
+#[cfg(feature = "xlsx")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SheetSummary {
+    /// Sheet name.
+    pub name: String,
+    /// Number of rows with data.
+    pub row_count: usize,
+    /// Number of columns with data.
+    pub column_count: usize,
+}
+
+/// Render a JSON workbook descriptor to XLSX bytes.
+///
+/// # JSON Schema
+///
+/// ```json
+/// {
+///   "sheets": [
+///     {
+///       "name": "Sheet1",
+///       "columns": [
+///         { "header": "Name", "width": 20.0 },
+///         { "header": "Score" }
+///       ],
+///       "rows": [
+///         ["Alice", 95],
+///         ["Bob", 87]
+///       ]
+///     }
+///   ]
+/// }
+/// ```
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidSchema`] if the JSON is missing required fields,
+/// or [`Error::XlsxWrite`] if `rust_xlsxwriter` fails.
+#[cfg(feature = "xlsx")]
+#[instrument(skip(data))]
+pub fn render_xlsx(data: &serde_json::Value) -> Result<Vec<u8>, Error> {
+    let sheets = data
+        .get("sheets")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| Error::InvalidSchema {
+            detail: "missing required field: sheets (array)".to_owned(),
+        })?;
+
+    let mut workbook = Workbook::new();
+
+    for (sheet_idx, sheet_val) in sheets.iter().enumerate() {
+        let name = sheet_val
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| Error::InvalidSchema {
+                detail: format!("sheet {sheet_idx}: missing required field: name"),
+            })?;
+
+        let columns = sheet_val
+            .get("columns")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| Error::InvalidSchema {
+                detail: format!("sheet {sheet_idx}: missing required field: columns (array)"),
+            })?;
+
+        let rows = sheet_val
+            .get("rows")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| Error::InvalidSchema {
+                detail: format!("sheet {sheet_idx}: missing required field: rows (array)"),
+            })?;
+
+        let worksheet = workbook.add_worksheet();
+        worksheet.set_name(name).map_err(|e| Error::XlsxWrite {
+            message: e.to_string(),
+        })?;
+
+        // Header row
+        for (col_idx, col_val) in columns.iter().enumerate() {
+            let header = col_val
+                .get("header")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| Error::InvalidSchema {
+                    detail: format!(
+                        "sheet {sheet_idx}, column {col_idx}: missing required field: header"
+                    ),
+                })?;
+
+            let col_u16 = u16::try_from(col_idx).map_err(|e| Error::XlsxWrite {
+                message: format!("column index {col_idx} exceeds u16 max: {e}"),
+            })?;
+
+            worksheet
+                .write(0, col_u16, header)
+                .map_err(|e| Error::XlsxWrite {
+                    message: e.to_string(),
+                })?;
+
+            if let Some(width) = col_val.get("width").and_then(serde_json::Value::as_f64) {
+                worksheet
+                    .set_column_width(col_u16, width)
+                    .map_err(|e| Error::XlsxWrite {
+                        message: e.to_string(),
+                    })?;
+            }
+        }
+
+        // Data rows
+        for (row_idx, row_val) in rows.iter().enumerate() {
+            let cells = row_val.as_array().ok_or_else(|| Error::InvalidSchema {
+                detail: format!("sheet {sheet_idx}, row {row_idx}: each row must be an array"),
+            })?;
+
+            for (col_idx, cell) in cells.iter().enumerate() {
+                let col_u16 = u16::try_from(col_idx).map_err(|e| Error::XlsxWrite {
+                    message: format!("column index {col_idx} exceeds u16 max: {e}"),
+                })?;
+
+                let cell_text = match cell {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    serde_json::Value::Bool(b) => b.to_string(),
+                    serde_json::Value::Null => String::new(),
+                    other => other.to_string(),
+                };
+
+                worksheet
+                    .write(
+                        u32::try_from(row_idx).map_err(|e| Error::XlsxWrite {
+                            message: format!("row index {row_idx} exceeds u32 max: {e}"),
+                        })? + 1,
+                        col_u16,
+                        cell_text.as_str(),
+                    )
+                    .map_err(|e| Error::XlsxWrite {
+                        message: e.to_string(),
+                    })?;
+            }
+        }
+    }
+
+    workbook.save_to_buffer().map_err(|e| Error::XlsxWrite {
+        message: e.to_string(),
+    })
+}
+
+/// Inspect an XLSX byte slice and return a structural summary.
+///
+/// # Errors
+///
+/// Returns [`Error::XlsxRead`] if `calamine` cannot parse the input.
+#[cfg(feature = "xlsx")]
+pub fn inspect_xlsx(bytes: &[u8]) -> Result<WorkbookSummary, Error> {
+    use calamine::{Reader, Xlsx};
+
+    let cursor = std::io::Cursor::new(bytes);
+    let mut workbook = Xlsx::new(cursor).map_err(|e| Error::XlsxRead {
+        message: e.to_string(),
+    })?;
+
+    let sheet_names = workbook.sheet_names().clone();
+    let mut sheets = Vec::with_capacity(sheet_names.len());
+    let mut cell_count: usize = 0;
+
+    for name in &sheet_names {
+        let range = workbook
+            .worksheet_range(name)
+            .map_err(|e| Error::XlsxRead {
+                message: e.to_string(),
+            })?;
+
+        let row_count = range.height();
+        let column_count = range.width();
+        cell_count += row_count.saturating_mul(column_count);
+
+        sheets.push(SheetSummary {
+            name: name.clone(),
+            row_count,
+            column_count,
+        });
+    }
+
+    Ok(WorkbookSummary { sheets, cell_count })
+}
+
+#[cfg(all(test, feature = "xlsx"))]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod json_api_tests {
+    use super::*;
+    use calamine::Reader;
+
+    #[test]
+    fn render_xlsx_simple_json_round_trips_through_calamine() {
+        let data = serde_json::json!({
+            "sheets": [
+                {
+                    "name": "Scores",
+                    "columns": [
+                        { "header": "Name", "width": 20.0 },
+                        { "header": "Score" }
+                    ],
+                    "rows": [
+                        ["Alice", 95],
+                        ["Bob", 87],
+                        ["Carol", 92]
+                    ]
+                }
+            ]
+        });
+
+        let bytes = render_xlsx(&data).expect("render must succeed");
+
+        // Round-trip through calamine
+        let cursor = std::io::Cursor::new(&bytes);
+        let mut workbook = calamine::Xlsx::new(cursor).expect("calamine must open xlsx");
+        let sheet_names = workbook.sheet_names();
+        assert_eq!(sheet_names.len(), 1);
+        assert_eq!(sheet_names.first().expect("one sheet"), "Scores");
+
+        let range = workbook
+            .worksheet_range("Scores")
+            .expect("sheet must exist");
+
+        // Header row + 3 data rows
+        assert_eq!(range.height(), 4);
+        assert_eq!(range.width(), 2);
+
+        let rows: Vec<Vec<String>> = range
+            .rows()
+            .map(|row| {
+                row.iter()
+                    .map(|cell| match cell {
+                        calamine::Data::String(s)
+                        | calamine::Data::DateTimeIso(s)
+                        | calamine::Data::DurationIso(s) => s.clone(),
+                        calamine::Data::Float(f) => f.to_string(),
+                        calamine::Data::Int(i) => i.to_string(),
+                        calamine::Data::Bool(b) => b.to_string(),
+                        calamine::Data::DateTime(d) => d.to_string(),
+                        calamine::Data::Error(e) => e.to_string(),
+                        calamine::Data::Empty => String::new(),
+                    })
+                    .collect()
+            })
+            .collect();
+
+        assert_eq!(rows.first().expect("header row"), &vec!["Name", "Score"]);
+        assert_eq!(rows.get(1).expect("row 1"), &vec!["Alice", "95"]);
+        assert_eq!(rows.get(2).expect("row 2"), &vec!["Bob", "87"]);
+        assert_eq!(rows.get(3).expect("row 3"), &vec!["Carol", "92"]);
+    }
+
+    #[test]
+    fn render_xlsx_multi_sheet() {
+        let data = serde_json::json!({
+            "sheets": [
+                {
+                    "name": "Q1",
+                    "columns": [{ "header": "Revenue" }],
+                    "rows": [[100]]
+                },
+                {
+                    "name": "Q2",
+                    "columns": [{ "header": "Revenue" }],
+                    "rows": [[120]]
+                }
+            ]
+        });
+
+        let bytes = render_xlsx(&data).expect("render must succeed");
+        let summary = inspect_xlsx(&bytes).expect("inspect must succeed");
+
+        assert_eq!(summary.sheets.len(), 2);
+        assert_eq!(summary.sheets.first().expect("sheet 0").name, "Q1");
+        assert_eq!(summary.sheets.get(1).expect("sheet 1").name, "Q2");
+        assert!(summary.cell_count > 0);
+    }
+
+    #[test]
+    fn inspect_xlsx_returns_summary() {
+        let data = serde_json::json!({
+            "sheets": [
+                {
+                    "name": "Inventory",
+                    "columns": [
+                        { "header": "Item" },
+                        { "header": "Qty" }
+                    ],
+                    "rows": [
+                        ["Widget", 42],
+                        ["Gadget", 7]
+                    ]
+                }
+            ]
+        });
+
+        let bytes = render_xlsx(&data).expect("render must succeed");
+        let summary = inspect_xlsx(&bytes).expect("inspect must succeed");
+
+        assert_eq!(summary.sheets.len(), 1);
+        let sheet = summary.sheets.first().expect("one sheet");
+        assert_eq!(sheet.name, "Inventory");
+        // Header + 2 data rows = 3 rows, 2 columns, 6 cells
+        assert_eq!(sheet.row_count, 3);
+        assert_eq!(sheet.column_count, 2);
+        assert_eq!(summary.cell_count, 6);
+    }
+
+    #[test]
+    fn render_xlsx_malformed_json_errors() {
+        let data = serde_json::json!({ "title": "No sheets here" });
+        let err = render_xlsx(&data).expect_err("must error");
+        assert!(
+            matches!(err, Error::InvalidSchema { .. }),
+            "expected InvalidSchema, got: {err:?}"
+        );
+    }
+}


### PR DESCRIPTION
Extend poiesis-sheet with a JSON-first API alongside the existing Document/Renderer trait.

- `render_xlsx(data: &Value) -> Result<Vec<u8>, Error>` writes XLSX via rust_xlsxwriter from a JSON workbook descriptor.
- `inspect_xlsx(bytes: &[u8]) -> Result<WorkbookSummary, Error>` reads XLSX structure via calamine.
- New `Error` enum in error.rs with snafu derives.
- `WorkbookSummary` / `SheetSummary` structs with `#[non_exhaustive]`.

New organon tool `render_xlsx_report` mirrors `render_typst_report`:
- Takes inline JSON data and optional out_path.
- Returns a base64-encoded XLSX document block.

Tests:
- render_xlsx_simple_json_round_trips_through_calamine
- render_xlsx_multi_sheet
- inspect_xlsx_returns_summary
- render_xlsx_malformed_json_errors

Closes #3700