### PR TITLE
style: cargo fmt cleanup across Wave 7 merged crates

### DIFF
--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -41,8 +41,6 @@ pub mod planning;
 /// Poiesis report tools: generate_document, lint_report, verify_report,
 /// render_typst_report, render_docx_report.
 pub mod poiesis;
-/// Scaffold report tool: generates a new report project from embedded templates.
-pub mod scaffold_report;
 /// DOCX report rendering tool (render_docx_report).
 pub mod render_docx_report;
 /// Render a JSON slide descriptor to PPTX.
@@ -51,6 +49,8 @@ pub mod render_pptx_report;
 pub mod render_xlsx_report;
 /// Web research tools (web_fetch).
 pub mod research;
+/// Scaffold report tool: generates a new report project from embedded templates.
+pub mod scaffold_report;
 /// `tool_schema` meta-tool: fetch full JSON schema for any named tool on demand.
 ///
 /// Always compiled (not feature-gated) so the tool is available even when

--- a/crates/poiesis/intake/src/lib.rs
+++ b/crates/poiesis/intake/src/lib.rs
@@ -157,10 +157,7 @@ fn contains_any(haystack: &str, needles: &[&str]) -> bool {
 
 /// Generate a URL-safe slug from the first few words of a description.
 fn slugify(description: &str) -> String {
-    let words: Vec<&str> = description
-        .split_whitespace()
-        .take(8)
-        .collect();
+    let words: Vec<&str> = description.split_whitespace().take(8).collect();
     let raw = words.join(" ");
     raw.to_lowercase()
         .replace(|c: char| !c.is_alphanumeric() && c != ' ', "-")

--- a/crates/poiesis/scaffold/src/lib.rs
+++ b/crates/poiesis/scaffold/src/lib.rs
@@ -159,7 +159,9 @@ fn xlsx_files(
     };
 
     let renderer = poiesis_sheet::XlsxRenderer::new();
-    let bytes = renderer.render(&doc).map_err(|e| Error::XlsxRender { source: e })?;
+    let bytes = renderer
+        .render(&doc)
+        .map_err(|e| Error::XlsxRender { source: e })?;
 
     Ok(vec![ScaffoldFile {
         path: PathBuf::from("report.xlsx"),
@@ -204,8 +206,8 @@ mod tests {
     #[test]
     #[expect(clippy::expect_used, reason = "test assertion")]
     fn scaffold_with_confidential_injects_header() {
-        let files =
-            scaffold_report("secret", "Top secret", Format::Typst, true).expect("scaffold must succeed");
+        let files = scaffold_report("secret", "Top secret", Format::Typst, true)
+            .expect("scaffold must succeed");
         let typst = files
             .iter()
             .find(|f| f.path == PathBuf::from("report.typ"))


### PR DESCRIPTION
Accumulated formatting drift from parallel Wave 7 merges:

- `crates/organon/src/builtins/mod.rs` — scaffold_report declaration reordered alphabetically (3 concurrent PRs added modules around it)
- `crates/poiesis/intake/src/lib.rs` — slugify let-binding collapsed to one line
- `crates/poiesis/scaffold/src/lib.rs` — minor rustfmt alignment

No behavior change. Closes the pending `cargo fmt` failure on dependabot PR #3802 (surfaced via kanon #125 admin-merge preflight friction).