### PR TITLE
fix(theatron): switch koilon + proskenion deps to GitHub URL

### DIFF
--- a/crates/theatron/koilon/Cargo.toml
+++ b/crates/theatron/koilon/Cargo.toml
@@ -18,7 +18,7 @@ test-full = []
 [dependencies]
 koina = { path = "../../koina" }
 skene = { path = "../skene" }
-parodos = { git = "http://127.0.0.1:7878/forkwright/theatron.git", tag = "v1.2.0" }
+parodos = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
 
 # Core TUI — ratatui 0.30 defaults to crossterm 0.29
 ratatui = "0.30"

--- a/crates/theatron/proskenion/Cargo.toml
+++ b/crates/theatron/proskenion/Cargo.toml
@@ -22,10 +22,10 @@ koina = { path = "../../koina" }
 # WHY: chalkeion plan Phase 1+2 — proskenion consumes theatron incrementally.
 # AGPL-3.0+ proskenion can consume Apache-2.0 OR MIT theatron via the
 # Apache-2.0 path — license-compatible.
-themelion = { git = "http://127.0.0.1:7878/forkwright/theatron.git", tag = "v1.2.0" }
-skeue = { git = "http://127.0.0.1:7878/forkwright/theatron.git", tag = "v1.2.0" }
-gramma = { git = "http://127.0.0.1:7878/forkwright/theatron.git", tag = "v1.2.0" }
-bathron = { git = "http://127.0.0.1:7878/forkwright/theatron.git", tag = "v1.2.0", features = ["logging"] }
+themelion = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+skeue = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+gramma = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+bathron = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0", features = ["logging"] }
 
 # UI framework
 # WHY: Pinned to the same exact patch theatron's workspace pins (=0.7.6).


### PR DESCRIPTION
Closes the desktop-build-path gap from the aletheia readiness report (2026-05-21) § 4 row 2.

## Problem

`crates/theatron/koilon/Cargo.toml` + `crates/theatron/proskenion/Cargo.toml` declare 5 theatron git deps via `git = "http://127.0.0.1:7878/forkwright/theatron.git"` (local kanon forge). With the forge offline (menos firmware brick 2026-05-09), any aletheia build from a host without a local forge instance fails on the first cargo Updating step.

Observed on verda (a dedicated 120-core build host) running `cargo build --release --workspace` against v0.22.0:

```
warning: spurious network error (3 tries remaining): failed to connect to 127.0.0.1: Connection refused
error: failed to get `parodos` as a dependency of package `koilon v0.22.0`
Caused by: Unable to update http://127.0.0.1:7878/forkwright/theatron.git?tag=v1.2.0#62256138
```

## Fix

Swap `http://127.0.0.1:7878/forkwright/theatron.git` → `https://github.com/forkwright/theatron.git`. The GitHub mirror carries the identical `v1.2.0` tag at the same commit (`6225613827dcc21a0b7b1c1585f9ff8199affae9`), so Cargo resolves to the same content and the lockfile remains valid.

## Verification

- `git ls-remote https://github.com/forkwright/theatron.git refs/tags/v1.2.0^{}` returns `6225613827dcc21a0b7b1c1585f9ff8199affae9` — matches the forge pin.
- After merge: `cargo build --release --workspace` on a host without a local forge succeeds (verda smoke build is the canonical test).

## Surface

5 lines across 2 files. No code logic changes. Cargo.lock not regenerated in this PR — Cargo will refresh the registry entry path on next build without changing the resolved commit SHA.