### PR TITLE
fix(theatron): switch skene keryx dep to GitHub URL (companion to #3867)

### DIFF
--- a/crates/theatron/skene/Cargo.toml
+++ b/crates/theatron/skene/Cargo.toml
@@ -13,7 +13,7 @@ test-full = []
 
 [dependencies]
 koina = { path = "../../koina" }
-keryx = { git = "http://127.0.0.1:7878/forkwright/theatron.git", tag = "v1.2.0" }
+keryx = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
 bytes = { workspace = true }
 futures-core = "0.3"
 futures-util = "0.3"


### PR DESCRIPTION
Companion to #3867 — that PR caught koilon + proskenion but missed `crates/theatron/skene/Cargo.toml:16` (keryx dep).

Same fix: swap forge URL to GitHub URL. Same v1.2.0 tag, same commit (`6225613827dcc21a0b7b1c1585f9ff8199affae9`).

## Verification

- `git ls-remote https://github.com/forkwright/theatron.git refs/tags/v1.2.0^{}` returns `6225613827dcc21a0b7b1c1585f9ff8199affae9`.
- Reproduces against current HEAD on verda: `cargo build --release --workspace` failed at `keryx as a dependency of package skene v0.22.0` after #3867 landed.

## Surface

1 line, 1 file. No code logic changes.