### PR TITLE
test(pylon,graphe,gnosis): reviewer follow-ups — auth coverage + retention-executor registration + gnosis type_use gap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3592,6 +3592,7 @@ dependencies = [
  "fjall",
  "jiff",
  "koina",
+ "oikonomos",
  "prometheus-client",
  "proptest",
  "serde",
@@ -3599,6 +3600,7 @@ dependencies = [
  "snafu",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/crates/gnosis/src/query.rs
+++ b/crates/gnosis/src/query.rs
@@ -445,6 +445,28 @@ mod tests {
         );
     }
 
+    #[test]
+    #[expect(clippy::indexing_slicing, reason = "test assertion: len checked above")]
+    fn symbol_rdeps_target_crate_filter_excludes_type_use_edges() {
+        let conn = open_db();
+        let type_use_id = insert_symbol(&conn, "nous", "", "fn_type_use", "fn", "a.rs", 1);
+        insert_ref(
+            &conn,
+            type_use_id,
+            "hermeneus",
+            "types",
+            "Message",
+            "type_use",
+        );
+        let impl_id = insert_symbol(&conn, "melete", "", "Response", "impl", "b.rs", 2);
+        insert_ref(&conn, impl_id, "hermeneus", "types", "Message", "impl");
+
+        let rows = symbol_rdeps(&conn, "Message", Some("hermeneus")).expect("query filtered");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].symbol_name.as_deref(), Some("Response"));
+        assert_eq!(rows[0].ref_kind.as_deref(), Some("impl"));
+    }
+
     // ── impl_search ──────────────────────────────────────────────────────────
 
     #[test]

--- a/crates/graphe/Cargo.toml
+++ b/crates/graphe/Cargo.toml
@@ -31,9 +31,11 @@ tokio = { workspace = true, optional = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+oikonomos = { path = "../daemon" }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 criterion = { workspace = true }
+tokio-util = { workspace = true }
 
 # WHY: session create + message append are on the hot path of every
 # turn. Track regressions so schema or index changes surface in CI.

--- a/crates/graphe/tests/daemon_retention_registration.rs
+++ b/crates/graphe/tests/daemon_retention_registration.rs
@@ -1,0 +1,40 @@
+//! Integration test for the graphe retention path exposed through oikonomos.
+
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+use std::sync::Arc;
+
+use oikonomos::maintenance::{MaintenanceConfig, RetentionExecutor, RetentionSummary};
+use oikonomos::runner::TaskRunner;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug)]
+struct MockRetentionExecutor;
+
+impl RetentionExecutor for MockRetentionExecutor {
+    fn execute_retention(&self) -> oikonomos::error::Result<RetentionSummary> {
+        Ok(RetentionSummary::default())
+    }
+}
+
+#[test]
+fn daemon_registers_retention_executor_when_enabled() {
+    let token = CancellationToken::new();
+    let mut config = MaintenanceConfig::default();
+    config.retention.enabled = true;
+
+    let executor: Arc<dyn RetentionExecutor> = Arc::new(MockRetentionExecutor);
+    let mut runner = TaskRunner::new("system", token)
+        .with_maintenance(config)
+        .with_retention(executor);
+    runner.register_maintenance_tasks();
+
+    let statuses = runner.status();
+    let retention = statuses
+        .iter()
+        .find(|status| status.id == "retention-execution")
+        .expect("retention executor task should be registered");
+
+    assert_eq!(retention.name, "Data retention cleanup");
+    assert!(retention.enabled);
+}

--- a/crates/pylon/tests/common/mod.rs
+++ b/crates/pylon/tests/common/mod.rs
@@ -217,9 +217,13 @@ pub fn permissive_security() -> SecurityConfig {
 }
 
 pub fn issue_test_token(state: &AppState) -> String {
+    issue_test_token_as(state, Role::Operator)
+}
+
+pub fn issue_test_token_as(state: &AppState, role: Role) -> String {
     state
         .jwt_manager
-        .issue_access("test-user", Role::Operator, None)
+        .issue_access("test-user", role, None)
         .expect("issue test token")
 }
 

--- a/crates/pylon/tests/public_api_router_auth.rs
+++ b/crates/pylon/tests/public_api_router_auth.rs
@@ -6,14 +6,17 @@
 use std::sync::Arc;
 
 use axum::body::Body;
-use axum::http::{Request, StatusCode};
+use axum::http::{Method, Request, StatusCode};
 use tower::ServiceExt;
 
 use koina::http::{API_HEALTH, API_V1};
 use pylon::router::build_router;
+use symbolon::types::Role;
 
 mod common;
-use common::{TestEnv, bearer, issue_test_token, permissive_security, read_body_json};
+use common::{
+    TestEnv, bearer, issue_test_token, issue_test_token_as, permissive_security, read_body_json,
+};
 
 // Split: build_router construction + auth contracts.
 
@@ -254,4 +257,176 @@ async fn auth_mode_none_allows_access_without_bearer() {
         StatusCode::OK,
         "auth_mode=none must not require a bearer on protected routes"
     );
+}
+
+#[tokio::test]
+async fn knowledge_write_routes_reject_missing_bearer_token() {
+    let env = TestEnv::new().await;
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    for route in knowledge_write_routes() {
+        let response = router
+            .clone()
+            .oneshot(route.request(None))
+            .await
+            .expect("router response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "{} {}",
+            route.method,
+            route.path
+        );
+    }
+}
+
+#[tokio::test]
+async fn knowledge_write_routes_reject_invalid_bearer_token() {
+    let env = TestEnv::new().await;
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    for route in knowledge_write_routes() {
+        let response = router
+            .clone()
+            .oneshot(route.request(Some("Bearer not.a.valid.jwt".to_owned())))
+            .await
+            .expect("router response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "{} {}",
+            route.method,
+            route.path
+        );
+    }
+}
+
+#[tokio::test]
+async fn knowledge_write_routes_reject_valid_bearer_with_readonly_role() {
+    let env = TestEnv::new().await;
+    let token = issue_test_token_as(&env.state, Role::Readonly);
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    for route in knowledge_write_routes() {
+        let response = router
+            .clone()
+            .oneshot(route.request(Some(bearer(&token))))
+            .await
+            .expect("router response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "{} {}",
+            route.method,
+            route.path
+        );
+    }
+}
+
+#[tokio::test]
+async fn knowledge_write_routes_with_operator_bearer_reach_handlers() {
+    let env = TestEnv::new().await;
+    let token = issue_test_token(&env.state);
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    for route in knowledge_write_routes() {
+        let response = router
+            .clone()
+            .oneshot(route.request(Some(bearer(&token))))
+            .await
+            .expect("router response");
+
+        assert_eq!(
+            response.status(),
+            KnowledgeWriteRoute::expected_authorized_status(),
+            "{} {}",
+            route.method,
+            route.path
+        );
+    }
+}
+
+#[derive(Clone)]
+struct KnowledgeWriteRoute {
+    method: Method,
+    path: &'static str,
+    body: Option<serde_json::Value>,
+}
+
+impl KnowledgeWriteRoute {
+    fn request(&self, authorization: Option<String>) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method(self.method.clone())
+            .uri(self.path);
+        if self.body.is_some() {
+            builder = builder.header("content-type", "application/json");
+        }
+        if let Some(header) = authorization {
+            builder = builder.header("authorization", header);
+        }
+
+        match &self.body {
+            Some(body) => builder
+                .body(Body::from(
+                    serde_json::to_vec(&body).expect("serialize json body"),
+                ))
+                .expect("build request"),
+            None => builder.body(Body::empty()).expect("build request"),
+        }
+    }
+
+    fn expected_authorized_status() -> StatusCode {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
+}
+
+fn knowledge_write_routes() -> [KnowledgeWriteRoute; 7] {
+    [
+        KnowledgeWriteRoute {
+            method: Method::POST,
+            path: "/api/v1/knowledge/facts/import",
+            body: Some(serde_json::json!({ "facts": [] })),
+        },
+        KnowledgeWriteRoute {
+            method: Method::POST,
+            path: "/api/v1/knowledge/ingest",
+            body: Some(serde_json::json!({
+                "content": "alice remembers the deployment window",
+                "format": "text",
+                "nous_id": "syn"
+            })),
+        },
+        KnowledgeWriteRoute {
+            method: Method::POST,
+            path: "/api/v1/knowledge/ingest/webhook",
+            body: Some(serde_json::json!({
+                "nous_id": "syn",
+                "facts": [],
+                "source": "acme.corp"
+            })),
+        },
+        KnowledgeWriteRoute {
+            method: Method::POST,
+            path: "/api/v1/knowledge/facts/some-fact-id/forget",
+            body: Some(serde_json::json!({})),
+        },
+        KnowledgeWriteRoute {
+            method: Method::POST,
+            path: "/api/v1/knowledge/facts/some-fact-id/restore",
+            body: None,
+        },
+        KnowledgeWriteRoute {
+            method: Method::PUT,
+            path: "/api/v1/knowledge/facts/some-fact-id/confidence",
+            body: Some(serde_json::json!({ "confidence": 0.8 })),
+        },
+        KnowledgeWriteRoute {
+            method: Method::PUT,
+            path: "/api/v1/knowledge/facts/some-fact-id/sensitivity",
+            body: Some(serde_json::json!({ "sensitivity": "public" })),
+        },
+    ]
 }


### PR DESCRIPTION
## Summary

Rebase of `recovery/branch-tests-F-reviewer-followups` (commit `8f0268a55`) onto current `origin/main` (`29904575e`). Original branch left intact.

Carries reviewer follow-ups across three crates:
- **pylon**: auth coverage additions in `tests/public_api_router_auth.rs` + helper `issue_test_token_as` (closes #217)
- **graphe**: daemon retention-executor registration test (closes #218)
- **gnosis**: type_use edge filter test in `src/query.rs` `#[cfg(test)]` block (closes #219)

## Scope

6 files touched, all test-only by intent:

- `Cargo.lock`
- `crates/gnosis/src/query.rs` (test added inside `mod tests`)
- `crates/graphe/Cargo.toml` (dev-dependencies: `oikonomos`, `tokio-util`)
- `crates/graphe/tests/daemon_retention_registration.rs` (new)
- `crates/pylon/tests/common/mod.rs`
- `crates/pylon/tests/public_api_router_auth.rs`

## Rebase notes

- Merge-base: `4ea5d2de2`. Branch had 1 commit; main had 6 commits ahead.
- Clean rebase, no conflicts.
- Single new suppression: `#[expect(clippy::indexing_slicing, reason = "test assertion: len checked above")]` — compliant with kanon standards (no `#[allow]`).

## Test plan

- [ ] `cargo check -p gnosis -p graphe -p pylon` on menos (metis is build-forbidden per fleet policy).
- [ ] `cargo test -p pylon --test public_api_router_auth` runs to green.
- [ ] `cargo test -p graphe --test daemon_retention_registration` runs to green.
- [ ] `cargo test -p gnosis query::tests::symbol_rdeps_target_crate_filter_excludes_type_use_edges`.

Gate-Passed: kanon 0.1.0