### PR TITLE
refactor(theatron): inherit deps from workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,18 @@ disallowed_types = "deny"
 aletheia-lexica = { path = "crates/aletheia-lexica" }
 rayon = { version = "1", default-features = false }
 
+# theatron substrate (cross-repo git deps)
+# WHY: forkwright/aletheia#3870 — single source of truth for the v1.2.0 pin.
+# Member crates inherit via `<dep> = { workspace = true }`.
+# proskenion is excluded from the workspace (GTK/webkit2gtk) and uses its own
+# standalone [workspace.dependencies] block; pin is mirrored there manually.
+parodos = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+themelion = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+skeue = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+gramma = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+bathron = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0", features = ["logging"] }
+keryx = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+
 # Error handling
 snafu = "0.8"
 

--- a/crates/theatron/koilon/Cargo.toml
+++ b/crates/theatron/koilon/Cargo.toml
@@ -18,7 +18,7 @@ test-full = []
 [dependencies]
 koina = { path = "../../koina" }
 skene = { path = "../skene" }
-parodos = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+parodos = { workspace = true }
 
 # Core TUI — ratatui 0.30 defaults to crossterm 0.29
 ratatui = "0.30"

--- a/crates/theatron/proskenion/Cargo.toml
+++ b/crates/theatron/proskenion/Cargo.toml
@@ -2,6 +2,17 @@
 # workspace and failing with "not in workspace" when building standalone.
 [workspace]
 
+# WHY: theatron deps declared here (single source of truth within this
+# standalone workspace) so the 4 consumers below inherit via
+# `<dep> = { workspace = true }`. forkwright/aletheia#3870. Pin must be kept
+# in sync with the aletheia root workspace's [workspace.dependencies] block;
+# cargo cannot inherit across the workspace boundary.
+[workspace.dependencies]
+themelion = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+skeue = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+gramma = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+bathron = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0", features = ["logging"] }
+
 [package]
 name = "proskenion"
 # WHY: explicit values instead of workspace inheritance because this crate
@@ -22,10 +33,10 @@ koina = { path = "../../koina" }
 # WHY: chalkeion plan Phase 1+2 — proskenion consumes theatron incrementally.
 # AGPL-3.0+ proskenion can consume Apache-2.0 OR MIT theatron via the
 # Apache-2.0 path — license-compatible.
-themelion = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-skeue = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-gramma = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-bathron = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0", features = ["logging"] }
+themelion = { workspace = true }
+skeue = { workspace = true }
+gramma = { workspace = true }
+bathron = { workspace = true }
 
 # UI framework
 # WHY: Pinned to the same exact patch theatron's workspace pins (=0.7.6).

--- a/crates/theatron/skene/Cargo.toml
+++ b/crates/theatron/skene/Cargo.toml
@@ -13,7 +13,7 @@ test-full = []
 
 [dependencies]
 koina = { path = "../../koina" }
-keryx = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
+keryx = { workspace = true }
 bytes = { workspace = true }
 futures-core = "0.3"
 futures-util = "0.3"


### PR DESCRIPTION
## Summary

- Move 6 theatron git deps (parodos, themelion, skeue, gramma, bathron, keryx) into `[workspace.dependencies]` at the aletheia workspace root.
- Member crates `koilon` and `skene` switch to `<dep> = { workspace = true }` inheritance.
- `proskenion` is excluded from the workspace (GTK/webkit2gtk) and cannot inherit from the root — its own standalone `[workspace]` gains a `[workspace.dependencies]` table so its 4 theatron deps reference `{ workspace = true }`. URL+tag mirrored once instead of four times.
- No code (`.rs`) changes; only the 4 Cargo.toml manifests touched.
- Same `v1.2.0` tag, same `bathron` `["logging"]` features — pin behavior preserved verbatim.

## Why

#3870 surfaced the friction: PRs #3867 + #3869 had to fix the same forge-URL swap twice because the dep declaration was duplicated across koilon / proskenion / skene. Workspace inheritance gives a single source of truth so the next URL/tag/feature change is one-line.

## Cargo constraint flagged

Cargo's `workspace = true` inheritance is bounded by the nearest enclosing `[workspace]` walking up. proskenion declares its own `[workspace]` (intentionally, to build standalone with GTK system libs absent from CI) — so it cannot inherit from aletheia's root. The intra-file deduplication still applies; the cross-file deduplication is a cargo design limit, not a refactor gap.

## Test plan

- [x] `cargo metadata --no-deps --format-version 1` parses cleanly on the aletheia root workspace.
- [x] `cargo metadata --no-deps --format-version 1` parses cleanly on the standalone proskenion workspace.
- [x] `cargo check --workspace --no-default-features` exits 0.
- [ ] CI green (cargo-deny, fmt, clippy, build matrix).

Closes #3870