### PR TITLE
chore(security): pii-allow annotations for HIGH (c) findings

### DIFF
--- a/crates/koina/src/redact.rs
+++ b/crates/koina/src/redact.rs
@@ -47,14 +47,14 @@ mod tests {
 
     #[test]
     fn redacts_anthropic_api_key() {
-        let input = "using key sk-ant-api03-abcdef123456_789XYZ for requests";
+        let input = "using key sk-ant-api03-abcdef123456_789XYZ for requests"; // pii-allow: synthetic Anthropic key shape, redactor self-test
         let output = redact_sensitive(input);
         assert_eq!(output, "using key sk-ant-*** for requests");
     }
 
     #[test]
     fn redacts_generic_sk_key() {
-        let input = "key: sk-proj-abcdefghij1234567890abcdef";
+        let input = "key: sk-proj-abcdefghij1234567890abcdef"; // pii-allow: synthetic OpenAI proj-token shape, redactor self-test
         let output = redact_sensitive(input);
         assert_eq!(output, "key: sk-***");
     }

--- a/crates/koina/src/redacting_layer.rs
+++ b/crates/koina/src/redacting_layer.rs
@@ -285,7 +285,7 @@ mod tests {
         let (buf, sub) = setup(&[], &[], 200);
         tracing::subscriber::with_default(sub, || {
             tracing::info!(
-                details = "key is sk-proj-abcdefghij1234567890abcdef end",
+                details = "key is sk-proj-abcdefghij1234567890abcdef end", // pii-allow: synthetic OpenAI proj-token shape, redactor self-test
                 "api check"
             );
         });

--- a/crates/nous/src/training/pii.rs
+++ b/crates/nous/src/training/pii.rs
@@ -293,7 +293,7 @@ mod tests {
 
     #[test]
     fn redacts_phone_e164() {
-        let (out, changed) = redact("my number is +15125550199");
+        let (out, changed) = redact("my number is +15125550199"); // pii-allow: synthetic NANP test number, redaction self-test
         assert!(changed);
         assert!(out.contains("[REDACTED:phone]"));
     }
@@ -334,10 +334,10 @@ mod tests {
 
     #[test]
     fn redacts_openai_api_key() {
-        let (out, changed) = redact("OPENAI=sk-proj-abcdefghij1234567890ABCDEF0123456789");
+        let (out, changed) = redact("OPENAI=sk-proj-abcdefghij1234567890ABCDEF0123456789"); // pii-allow: synthetic OpenAI key shape, redactor self-test
         assert!(changed);
         assert!(out.contains("[REDACTED:"));
-        assert!(!out.contains("sk-proj-abcdefghij1234567890ABCDEF0123456789"));
+        assert!(!out.contains("sk-proj-abcdefghij1234567890ABCDEF0123456789")); // pii-allow: synthetic OpenAI key shape, redactor self-test
     }
 
     #[test]
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn redacts_github_token() {
-        let (out, changed) = redact("export TOKEN=ghp_1234567890abcdefghij1234567890ABCD");
+        let (out, changed) = redact("export TOKEN=ghp_1234567890abcdefghij1234567890ABCD"); // pii-allow: synthetic GitHub PAT shape, redactor self-test
         assert!(changed);
         assert!(out.contains("[REDACTED:"));
         assert!(!out.contains("ghp_1234567890abcdefghij1234567890ABCD"));
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn redacts_aws_access_key_id() {
-        let (out, changed) = redact("AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE");
+        let (out, changed) = redact("AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"); // pii-allow: AWS canonical example access key id, redactor self-test
         assert!(changed);
         assert!(out.contains("[REDACTED:"));
     }
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn redacts_jwt() {
         let (out, changed) = redact(
-            "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", // pii-allow: jwt.io canonical example token, redactor self-test
         );
         assert!(changed);
         assert!(out.contains("[REDACTED:jwt]"));

--- a/crates/pylon/src/handlers/health.rs
+++ b/crates/pylon/src/handlers/health.rs
@@ -942,7 +942,7 @@ mod tests {
         // Create a JWT with known exp claim: exp = 1234567890
         // Payload: {"exp":1234567890}
         // base64url: eyJleHAiOjEyMzQ1Njc4OTB9
-        let token = "header.eyJleHAiOjEyMzQ1Njc4OTB9.signature";
+        let token = "header.eyJleHAiOjEyMzQ1Njc4OTB9.signature"; // pii-allow: synthetic JWT structure, exp-decoder self-test
         let exp = decode_jwt_exp(token);
         assert_eq!(exp, Some(1_234_567_890));
     }

--- a/crates/pylon/src/handlers/sessions/streaming_tests.rs
+++ b/crates/pylon/src/handlers/sessions/streaming_tests.rs
@@ -325,7 +325,7 @@ fn nous_guard_rejected_includes_reason() {
 
 #[test]
 fn redact_strips_anthropic_api_key() {
-    let msg = "invalid key sk-ant-abc123def456ghi789";
+    let msg = "invalid key sk-ant-abc123def456ghi789"; // pii-allow: synthetic Anthropic key shape, redactor self-test
     let redacted = redact_secrets(msg);
     assert!(
         !redacted.contains("sk-ant-"),
@@ -336,7 +336,7 @@ fn redact_strips_anthropic_api_key() {
 
 #[test]
 fn redact_strips_generic_sk_key() {
-    let msg = "auth error with sk-abcdefghijklmnopqrstuvwxyz";
+    let msg = "auth error with sk-abcdefghijklmnopqrstuvwxyz"; // pii-allow: synthetic generic sk- shape, redactor self-test
     let redacted = redact_secrets(msg);
     assert!(
         !redacted.contains("sk-abcdef"),
@@ -354,7 +354,7 @@ fn redact_preserves_normal_messages() {
 
 #[test]
 fn redact_strips_bearer_token() {
-    let msg = "rejected bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload";
+    let msg = "rejected bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload"; // pii-allow: synthetic Bearer/JWT shape, redactor self-test
     let redacted = redact_secrets(msg);
     assert!(
         !redacted.contains("eyJh"),

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -215,7 +215,7 @@ aletheia health           # verify
 Talk to your agents over Signal. Requires [signal-cli](https://github.com/AsamK/signal-cli) running as a JSON-RPC daemon.
 
 1. Install and register signal-cli with your phone number
-2. Start signal-cli in JSON-RPC mode: `signal-cli -a +15551234567 jsonRpc`
+2. Start signal-cli in JSON-RPC mode: `signal-cli -a +15551234567 jsonRpc` <!-- pii-allow: NANP 555 reserved-for-fiction number, doc example -->
 3. Add to `instance/config/aletheia.toml`:
 
 ```toml
@@ -223,7 +223,7 @@ Talk to your agents over Signal. Requires [signal-cli](https://github.com/AsamK/
 enabled = true
 
 [channels.signal.accounts.default]
-account = "+15551234567"
+account = "+15551234567" <!-- pii-allow: NANP 555 reserved-for-fiction number, doc example -->
 http_host = "localhost"
 http_port = 8080
 

--- a/instance.example/config/credentials/README.md
+++ b/instance.example/config/credentials/README.md
@@ -16,7 +16,7 @@ For OAuth credentials (auto-refreshes):
 For static API keys:
 ```json
 {
-  "token": "sk-ant-api03-your-key-here"
+  "token": "sk-ant-api03-your-key-here" <!-- pii-allow: credential file shape placeholder -->
 }
 ```
 

--- a/tests/pii-scanner/test_scanner.bats
+++ b/tests/pii-scanner/test_scanner.bats
@@ -38,7 +38,7 @@ write_positive_fixture() {
         echo "Employee SSN 987-65-4321 rotated."
         echo "Test card: 4242 4242 4242 4242"
         echo "Amex: 3782 822463 10005"
-        echo "aws = \"AKIAIOSFODNN7EXAMPLE\""
+        echo "aws = \"AKIAIOSFODNN7EXAMPLE\"" # pii-allow: AWS canonical example access key id, scanner positive fixture
         echo "sts = \"ASIAIOSFODNN7EXAMPLE\""
         echo "anthropic=${s}-${a}-api03-${long}"
         echo "openai=${s}-${long}0123456789"
@@ -48,7 +48,7 @@ write_positive_fixture() {
         echo "maps=AIza${fake}${fake}${fake}ZZZ"
         echo "stripe=${s}_${t}_${long}"
         echo "jwt=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.${long}"
-        echo "-----BEGIN RSA PRIVATE KEY-----"
+        echo "-----BEGIN RSA PRIVATE KEY-----" # pii-allow: PEM header marker, scanner positive fixture
         echo "db=postgres://appuser:hunter2secret@db.internal:5432/prod"
         printf '%s\n' "${p}" > /dev/null  # suppress unused-var in shellcheck
     } > "${out}"


### PR DESCRIPTION
Adds `pii-allow:` trailing annotations to the 18 unique file:line targets identified in the security triage as class (c) — synthetic test fixtures or canonical example identifiers safe to retain.

Reference: /home/ck/metis-ops/projects/_recovery/aletheia-security-triage-2026-05-21.md § (c) Action queue

Gate-Passed: kanon 0.1.0