### PR TITLE
feat(hermeneus): add codex-provider feature-gated adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "agora",
  "anyhow",
@@ -177,11 +177,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.21.1"
+version = "0.22.1"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "jiff",
  "koina",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "futures",
  "jiff",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "jiff",
  "koina",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "eidos",
  "jiff",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "jiff",
  "koina",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "aletheia-routing",
  "chrono",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "async-trait",
  "candle-core",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "cargo_metadata",
  "parking_lot",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "criterion",
  "eidos",
@@ -3804,7 +3804,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "criterion",
  "jiff",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "keryx"
 version = "1.2.0"
-source = "git+http://127.0.0.1:7878/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
+source = "git+https://github.com/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
 dependencies = [
  "bytes",
  "dioxus",
@@ -4720,7 +4720,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "arboard",
  "clap",
@@ -4754,7 +4754,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "criterion",
  "fjall",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "eidos",
  "episteme",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6086,7 +6086,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6221,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "parodos"
 version = "1.2.0"
-source = "git+http://127.0.0.1:7878/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
+source = "git+https://github.com/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -6544,7 +6544,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "jiff",
  "snafu",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -6564,7 +6564,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "docx-rs",
  "quick-xml 0.39.2",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -6593,7 +6593,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -6605,7 +6605,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6614,7 +6614,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -6639,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "krilla 0.7.0",
  "poiesis-core",
@@ -6662,7 +6662,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "comemo",
  "jiff",
@@ -6678,7 +6678,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7065,7 +7065,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -8482,7 +8482,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8829,7 +8829,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -8948,7 +8948,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -9060,14 +9060,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -40,6 +40,8 @@ keyring = ["symbolon/keyring"]
 tui = ["dep:koilon"]
 # Claude Code subprocess provider: delegates LLM calls to the `claude` CLI.
 cc-provider = ["hermeneus/cc-provider"]
+# Codex subprocess provider: delegates LLM calls to the `codex` CLI.
+codex-provider = ["hermeneus/codex-provider"]
 # Dispatch orchestration (kanon phronesis port). Default off for incremental development.
 energeia = ["dep:energeia", "oikonomos/dispatch-cron"]
 # Test tiers (see docs/test-tiers.md)

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -167,6 +167,21 @@ pub(super) fn build_provider_registry(config: &AletheiaConfig, oikos: &Oikos) ->
         }
     }
 
+    #[cfg(feature = "codex-provider")]
+    {
+        use hermeneus::codex::{CodexProvider, CodexProviderConfig};
+        let codex_config = CodexProviderConfig::default();
+        match CodexProvider::new(&codex_config) {
+            Ok(provider) => {
+                registry.register(Box::new(provider));
+                info!("Codex subprocess provider registered");
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "Codex provider unavailable");
+            }
+        }
+    }
+
     let behavior = ProviderBehavior {
         non_streaming_timeout: std::time::Duration::from_secs(
             config.provider_behavior.non_streaming_timeout_secs,

--- a/crates/hermeneus/Cargo.toml
+++ b/crates/hermeneus/Cargo.toml
@@ -29,6 +29,8 @@ tracing = { workspace = true }
 [features]
 # Claude Code subprocess provider (delegates to `claude` CLI).
 cc-provider = []
+# Codex subprocess provider (delegates to `codex` CLI).
+codex-provider = []
 # Shared mock LLM provider for tests across the workspace.
 # Use `test-support` (preferred); `test-utils` kept for compatibility.
 test-utils = []

--- a/crates/hermeneus/src/codex/mod.rs
+++ b/crates/hermeneus/src/codex/mod.rs
@@ -1,0 +1,10 @@
+//! Codex subprocess LLM provider.
+//!
+//! Delegates LLM calls to the `codex` CLI binary, which handles local
+//! OAuth authentication. Gated behind the `codex-provider` feature flag.
+
+mod parse;
+mod process;
+mod provider;
+
+pub use provider::{CodexProvider, CodexProviderConfig};

--- a/crates/hermeneus/src/codex/parse.rs
+++ b/crates/hermeneus/src/codex/parse.rs
@@ -1,0 +1,69 @@
+//! Parse Codex CLI plain-text output.
+//!
+//! `codex exec` emits plain text on stdout for headless invocations. The
+//! adapter buffers that output and maps it into Hermeneus' Anthropic-native
+//! response shape.
+
+use crate::error::{self, Result};
+use crate::types::{CompletionResponse, ContentBlock, StopReason, Usage};
+
+/// Normalize buffered Codex stdout into assistant text.
+pub(crate) fn parse_output(stdout: &str) -> Result<String> {
+    let text = stdout.trim_end_matches(['\r', '\n']).to_owned();
+    if text.trim().is_empty() {
+        return Err(error::ApiRequestSnafu {
+            message: "Codex subprocess produced no text output".to_owned(),
+        }
+        .build());
+    }
+    Ok(text)
+}
+
+/// Convert Codex plain text into a [`CompletionResponse`].
+pub(crate) fn text_to_response(text: &str, model: &str) -> CompletionResponse {
+    CompletionResponse {
+        id: format!("codex_{}", koina::uuid::uuid_v4()),
+        model: model.to_owned(),
+        stop_reason: StopReason::EndTurn,
+        content: vec![ContentBlock::Text {
+            text: text.to_owned(),
+            citations: None,
+        }],
+        usage: Usage::default(),
+        cost_usd: None,
+        duration_ms: None,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_output_trims_trailing_newlines() {
+        let text = parse_output("hello world\n\n").unwrap();
+        assert_eq!(text, "hello world");
+    }
+
+    #[test]
+    fn parse_output_preserves_internal_whitespace() {
+        let text = parse_output("line one\n\nline two\n").unwrap();
+        assert_eq!(text, "line one\n\nline two");
+    }
+
+    #[test]
+    fn parse_output_rejects_blank_output() {
+        let err = parse_output("  \n\t").unwrap_err();
+        assert!(err.to_string().contains("no text output"));
+    }
+
+    #[test]
+    fn text_to_response_wraps_text_block() {
+        let response = text_to_response("done", "gpt-5-codex");
+        assert!(response.id.starts_with("codex_"));
+        assert_eq!(response.model, "gpt-5-codex");
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+        assert_eq!(response.content.len(), 1);
+    }
+}

--- a/crates/hermeneus/src/codex/process.rs
+++ b/crates/hermeneus/src/codex/process.rs
@@ -1,0 +1,252 @@
+//! Codex subprocess management.
+//!
+//! Spawns `codex exec --dangerously-bypass-approvals-and-sandbox
+//! --skip-git-repo-check --color never -` and manages stdin feeding,
+//! bounded output collection, timeout, and cleanup.
+
+use std::path::PathBuf;
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+use crate::error::{self, Result};
+
+/// Maximum total bytes of collected stdout before aborting.
+///
+/// WHY: Prevent a runaway subprocess from growing memory without bound.
+pub(crate) const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
+
+/// Maximum total number of stdout lines before aborting.
+///
+/// WHY: Secondary guard for output with many small lines.
+pub(crate) const MAX_OUTPUT_LINES: usize = 100_000;
+
+/// Maximum length of a system prompt passed to the Codex subprocess.
+///
+/// WHY: The system prompt is folded into stdin for Codex. Keep parity with
+/// the CC adapter's prompt envelope and avoid excessive subprocess input.
+pub(crate) const MAX_SYSTEM_PROMPT_BYTES: usize = 100 * 1024;
+
+/// Outcome of a Codex subprocess invocation.
+#[derive(Debug)]
+pub(crate) struct CodexOutput {
+    /// Buffered stdout text.
+    pub stdout: String,
+}
+
+fn scrub_codex_auth_env(cmd: &mut Command) {
+    // WHY: Force Codex CLI to use its local OAuth credential store. Inherited
+    // API keys can switch the CLI onto the API-key auth path.
+    cmd.env_remove("OPENAI_API_KEY");
+}
+
+fn compose_stdin(system_prompt: Option<&str>, prompt: &str) -> Result<String> {
+    if let Some(system) = system_prompt {
+        if system.len() > MAX_SYSTEM_PROMPT_BYTES {
+            return Err(error::ApiRequestSnafu {
+                message: format!(
+                    "system prompt exceeds maximum size ({} bytes > {MAX_SYSTEM_PROMPT_BYTES} byte limit)",
+                    system.len(),
+                ),
+            }
+            .build());
+        }
+        return Ok(format!("System:\n{system}\n\nUser:\n{prompt}"));
+    }
+
+    Ok(prompt.to_owned())
+}
+
+/// Spawn Codex and run a completion, collecting bounded stdout.
+///
+/// # Errors
+///
+/// Returns errors on spawn failure, stdin write failure, timeout, output
+/// limits, invalid UTF-8 output, or nonzero subprocess exit.
+#[tracing::instrument(skip_all)]
+pub(crate) async fn run_completion(
+    codex_binary: &PathBuf,
+    system_prompt: Option<&str>,
+    prompt: &str,
+    timeout: Duration,
+) -> Result<CodexOutput> {
+    let stdin_payload = compose_stdin(system_prompt, prompt)?;
+
+    let mut cmd = Command::new(codex_binary);
+    cmd.arg("exec")
+        .arg("--dangerously-bypass-approvals-and-sandbox")
+        .arg("--skip-git-repo-check")
+        .arg("--color")
+        .arg("never")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    scrub_codex_auth_env(&mut cmd);
+
+    debug!(binary = %codex_binary.display(), "spawning Codex subprocess");
+
+    let mut child = cmd.spawn().map_err(|e| {
+        error::ProviderInitSnafu {
+            message: format!(
+                "failed to spawn codex CLI at {}: {e}",
+                codex_binary.display()
+            ),
+        }
+        .build()
+    })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(stdin_payload.as_bytes())
+            .await
+            .map_err(|e| {
+                error::ApiRequestSnafu {
+                    message: format!("failed to write to Codex stdin: {e}"),
+                }
+                .build()
+            })?;
+        drop(stdin);
+    }
+
+    let stdout = child.stdout.take().ok_or_else(|| {
+        error::ApiRequestSnafu {
+            message: "Codex subprocess stdout not captured".to_owned(),
+        }
+        .build()
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        error::ApiRequestSnafu {
+            message: "Codex subprocess stderr not captured".to_owned(),
+        }
+        .build()
+    })?;
+
+    let result = Box::pin(tokio::time::timeout(timeout, async {
+        let (stdout_result, stderr_result, status_result) = tokio::join!(
+            read_bounded(stdout, "stdout"),
+            read_bounded(stderr, "stderr"),
+            child.wait()
+        );
+
+        let stdout = stdout_result?;
+        let stderr = stderr_result?;
+        let status = status_result.map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("failed to wait for Codex process: {e}"),
+            }
+            .build()
+        })?;
+
+        finish_output(status, stdout, &stderr)
+    }))
+    .await;
+
+    match result {
+        Ok(output) => output,
+        Err(_elapsed) => {
+            warn!(
+                timeout_secs = timeout.as_secs(),
+                "Codex subprocess timed out, killing"
+            );
+            let _ = child.kill().await;
+            Err(error::ApiRequestSnafu {
+                message: format!("Codex subprocess timed out after {}s", timeout.as_secs()),
+            }
+            .build())
+        }
+    }
+}
+
+fn finish_output(status: ExitStatus, stdout: Vec<u8>, stderr: &[u8]) -> Result<CodexOutput> {
+    let stdout_text = String::from_utf8(stdout).map_err(|e| {
+        error::ApiRequestSnafu {
+            message: format!("Codex stdout was not valid UTF-8: {e}"),
+        }
+        .build()
+    })?;
+    let stderr_text = String::from_utf8_lossy(stderr);
+
+    if !status.success() {
+        return Err(error::ApiRequestSnafu {
+            message: format!(
+                "Codex process exited with {status}: {}",
+                if stderr_text.trim().is_empty() {
+                    "(no stderr)"
+                } else {
+                    stderr_text.trim()
+                }
+            ),
+        }
+        .build());
+    }
+
+    debug!(stdout_len = stdout_text.len(), "Codex subprocess completed");
+
+    Ok(CodexOutput {
+        stdout: stdout_text,
+    })
+}
+
+async fn read_bounded<R>(mut reader: R, stream_name: &str) -> Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut out = Vec::new();
+    let mut buf = [0_u8; 8192];
+    let mut lines = 0_usize;
+
+    loop {
+        let read = reader.read(&mut buf).await.map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("failed to read Codex {stream_name}: {e}"),
+            }
+            .build()
+        })?;
+        if read == 0 {
+            break;
+        }
+
+        let new_len = out.len().saturating_add(read);
+        if new_len > MAX_OUTPUT_BYTES {
+            return Err(error::ApiRequestSnafu {
+                message: format!(
+                    "Codex subprocess {stream_name} exceeds {MAX_OUTPUT_BYTES} byte limit (collected {new_len} bytes)"
+                ),
+            }
+            .build());
+        }
+
+        let chunk = buf.get(..read).ok_or_else(|| {
+            error::ApiRequestSnafu {
+                message: format!("failed to read Codex {stream_name}: read beyond buffer"),
+            }
+            .build()
+        })?;
+        for byte in chunk {
+            if *byte == b'\n' {
+                lines = lines.saturating_add(1);
+            }
+        }
+        if lines > MAX_OUTPUT_LINES {
+            return Err(error::ApiRequestSnafu {
+                message: format!(
+                    "Codex subprocess {stream_name} exceeds {MAX_OUTPUT_LINES} line limit"
+                ),
+            }
+            .build());
+        }
+
+        out.extend_from_slice(chunk);
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+#[path = "process_tests.rs"]
+mod process_tests;

--- a/crates/hermeneus/src/codex/process_tests.rs
+++ b/crates/hermeneus/src/codex/process_tests.rs
@@ -1,0 +1,198 @@
+#![expect(clippy::unwrap_used, reason = "test assertions")]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt as _;
+
+use super::*;
+
+const ETXTBSY: i32 = 26;
+
+fn write_script(name: &str, body: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NONCE: AtomicU64 = AtomicU64::new(0);
+    let nonce = NONCE.fetch_add(1, Ordering::Relaxed);
+    let final_path = std::env::temp_dir().join(format!(
+        "hermeneus_codex_test_{name}_{}_{nonce}.sh",
+        std::process::id()
+    ));
+    let tmp_path = final_path.with_extension("sh.tmp");
+    let script = format!("#!/bin/sh\n{body}\n");
+    {
+        use std::io::Write;
+        let mut file = fs::File::create(&tmp_path).unwrap();
+        file.write_all(script.as_bytes()).unwrap();
+        file.sync_all().unwrap();
+    }
+    fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o755)).unwrap();
+    fs::rename(&tmp_path, &final_path).unwrap();
+
+    for _ in 0..200 {
+        match std::process::Command::new(&final_path)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(mut child) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return final_path;
+            }
+            Err(e) if e.raw_os_error() == Some(ETXTBSY) => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(_) => return final_path,
+        }
+    }
+
+    final_path
+}
+
+#[test]
+fn scrub_codex_auth_env_marks_openai_key_for_removal() {
+    let mut cmd = tokio::process::Command::new("codex");
+    cmd.env("OPENAI_API_KEY", "raw-api-key");
+
+    scrub_codex_auth_env(&mut cmd);
+
+    let envs: Vec<_> = cmd
+        .as_std_mut()
+        .get_envs()
+        .filter_map(|(key, value)| {
+            key.to_str()
+                .filter(|name| *name == "OPENAI_API_KEY")
+                .map(|name| (name.to_owned(), value.map(std::borrow::ToOwned::to_owned)))
+        })
+        .collect();
+
+    assert_eq!(envs, vec![("OPENAI_API_KEY".to_owned(), None)]);
+}
+
+#[test]
+fn compose_stdin_with_system_prompt() {
+    let input = compose_stdin(Some("Be terse."), "Say hi.").unwrap();
+    assert_eq!(input, "System:\nBe terse.\n\nUser:\nSay hi.");
+}
+
+#[test]
+fn compose_stdin_rejects_oversized_system_prompt() {
+    let big_prompt = "x".repeat(MAX_SYSTEM_PROMPT_BYTES + 1);
+    let err = compose_stdin(Some(&big_prompt), "hello").unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("system prompt exceeds maximum size")
+    );
+}
+
+#[tokio::test]
+async fn read_bounded_accepts_output_within_limits() {
+    let text = b"one\ntwo\n";
+    let output = read_bounded(text.as_slice(), "stdout").await.unwrap();
+    assert_eq!(output, text);
+}
+
+#[tokio::test]
+async fn read_bounded_rejects_oversized_output_by_bytes() {
+    let text = vec![b'x'; MAX_OUTPUT_BYTES + 1];
+    let err = read_bounded(text.as_slice(), "stdout").await.unwrap_err();
+    assert!(err.to_string().contains("byte limit"));
+}
+
+#[tokio::test]
+async fn read_bounded_rejects_too_many_lines() {
+    let text = "\n".repeat(MAX_OUTPUT_LINES + 1);
+    let err = read_bounded(text.as_bytes(), "stdout").await.unwrap_err();
+    assert!(err.to_string().contains("line limit"));
+}
+
+#[tokio::test]
+async fn run_completion_spawn_failure_reports_binary_path() {
+    let binary = PathBuf::from("/nonexistent/path/to/codex-binary");
+    let err = run_completion(&binary, None, "hello", Duration::from_secs(5))
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(msg.contains("/nonexistent/path/to/codex-binary"));
+    assert!(msg.contains("provider init failed"));
+}
+
+#[tokio::test]
+async fn run_completion_success_collects_plain_output() {
+    let script = write_script(
+        "completion_ok",
+        r#"test "$1" = "exec" || exit 31
+test "$2" = "--dangerously-bypass-approvals-and-sandbox" || exit 32
+test "$3" = "--skip-git-repo-check" || exit 33
+test "$4" = "--color" || exit 34
+test "$5" = "never" || exit 35
+test "$6" = "-" || exit 36
+test -z "${OPENAI_API_KEY+x}" || exit 37
+input="$(cat)"
+test "$input" = "prompt text" || exit 38
+printf 'codex says hello\n'"#,
+    );
+
+    let output = run_completion(&script, None, "prompt text", Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    assert_eq!(output.stdout, "codex says hello\n");
+    let _ = fs::remove_file(&script);
+}
+
+#[tokio::test]
+async fn run_completion_with_system_prompt_feeds_stdin() {
+    let script = write_script(
+        "completion_sys",
+        r#"input="$(cat)"
+test "$input" = "System:
+Be precise.
+
+User:
+prompt" || exit 41
+printf 'sys ok\n'"#,
+    );
+
+    let output = run_completion(
+        &script,
+        Some("Be precise."),
+        "prompt",
+        Duration::from_secs(10),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(output.stdout, "sys ok\n");
+    let _ = fs::remove_file(&script);
+}
+
+#[tokio::test]
+async fn run_completion_nonzero_exit_with_stderr_captured() {
+    let script = write_script(
+        "completion_fail",
+        r"cat > /dev/null
+printf 'not logged in\n' >&2
+exit 1",
+    );
+
+    let err = run_completion(&script, None, "prompt", Duration::from_secs(10))
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(msg.contains("not logged in"));
+    let _ = fs::remove_file(&script);
+}
+
+#[tokio::test]
+async fn run_completion_timeout_returns_error() {
+    let script = write_script("completion_sleep", "sleep 30");
+
+    let err = run_completion(&script, None, "prompt", Duration::from_millis(100))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("timed out"));
+    let _ = fs::remove_file(&script);
+}

--- a/crates/hermeneus/src/codex/provider.rs
+++ b/crates/hermeneus/src/codex/provider.rs
@@ -1,0 +1,308 @@
+//! `CodexProvider`: routes LLM calls through the Codex CLI subprocess.
+//!
+//! Codex handles OAuth authentication via its local CLI credential store.
+//! The provider only resolves the binary, formats requests, spawns the
+//! subprocess, and wraps plain-text output in Hermeneus response types.
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::time::Duration;
+
+use koina::system::{Environment, RealSystem};
+use tracing::{debug, info};
+
+use crate::error::{self, Result};
+use crate::provider::LlmProvider;
+use crate::types::{CompletionRequest, CompletionResponse, Content, ContentBlock, Role};
+
+use super::{parse, process};
+
+/// Model name prefix that routes requests to this provider.
+pub(crate) const CODEX_MODEL_PREFIX: &str = "codex/";
+
+/// Models Codex can route to. The CLI itself resolves aliases and availability.
+const SUPPORTED_MODELS: &[&str] = &["gpt-5-codex"];
+
+/// Configuration for the Codex subprocess provider.
+#[derive(Debug, Clone)]
+pub struct CodexProviderConfig {
+    /// Path to the `codex` binary. If `None`, resolved from `PATH`.
+    pub codex_binary: Option<PathBuf>,
+    /// Default model when the request doesn't specify one.
+    pub default_model: String,
+    /// Subprocess timeout (wall-clock).
+    pub timeout: Duration,
+}
+
+impl Default for CodexProviderConfig {
+    fn default() -> Self {
+        Self {
+            codex_binary: None,
+            default_model: "codex/gpt-5-codex".to_owned(),
+            timeout: Duration::from_mins(5),
+        }
+    }
+}
+
+/// Codex subprocess LLM provider.
+pub struct CodexProvider {
+    // kanon:ignore RUST/pub-visibility
+    codex_binary: PathBuf,
+    default_model: String,
+    timeout: Duration,
+}
+
+impl CodexProvider {
+    /// Create a new Codex provider, locating the `codex` binary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ProviderInit`] if the binary cannot be found.
+    pub fn new(config: &CodexProviderConfig) -> Result<Self> {
+        // kanon:ignore RUST/pub-visibility
+        let codex_binary = if let Some(ref path) = config.codex_binary {
+            if path.exists() {
+                path.clone()
+            } else {
+                return Err(error::ProviderInitSnafu {
+                    message: format!(
+                        "configured codex CLI path does not exist: {}",
+                        path.display()
+                    ),
+                }
+                .build());
+            }
+        } else {
+            find_codex_binary()?
+        };
+
+        info!(
+            binary = %codex_binary.display(),
+            default_model = %config.default_model,
+            timeout_secs = config.timeout.as_secs(),
+            "Codex subprocess provider initialized"
+        );
+
+        Ok(Self {
+            codex_binary,
+            default_model: config.default_model.clone(),
+            timeout: config.timeout,
+        })
+    }
+
+    /// Resolve the model: strip `codex/` prefix, fall back to default.
+    fn resolve_model<'a>(&'a self, model: &'a str) -> &'a str {
+        let selected = if model.is_empty() {
+            &self.default_model
+        } else {
+            model
+        };
+        let stripped = selected
+            .strip_prefix(CODEX_MODEL_PREFIX)
+            .unwrap_or(selected);
+        if stripped.is_empty() {
+            "gpt-5-codex"
+        } else {
+            stripped
+        }
+    }
+
+    /// Format message history into a single prompt string for Codex.
+    fn format_prompt(request: &CompletionRequest) -> String {
+        if request.messages.len() == 1
+            && let Some(msg) = request.messages.first()
+        {
+            return msg.content.text();
+        }
+
+        let mut parts = Vec::new();
+
+        for msg in &request.messages {
+            let label = match msg.role {
+                Role::User => "User",
+                Role::Assistant => "Assistant",
+                Role::System => "System",
+            };
+            let text = extract_text_content(&msg.content);
+            if !text.is_empty() {
+                parts.push(format!("{label}: {text}"));
+            }
+        }
+
+        parts.join("\n\n")
+    }
+
+    async fn execute(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
+        let model = self.resolve_model(&request.model);
+        let prompt = Self::format_prompt(request);
+
+        let output = Box::pin(process::run_completion(
+            &self.codex_binary,
+            request.system.as_deref(),
+            &prompt,
+            self.timeout,
+        ))
+        .await?;
+        let text = parse::parse_output(&output.stdout)?;
+
+        Ok(parse::text_to_response(&text, model))
+    }
+}
+
+fn extract_text_content(content: &Content) -> String {
+    match content {
+        Content::Text(s) => s.clone(),
+        Content::Blocks(blocks) => {
+            let parts: Vec<String> = blocks
+                .iter()
+                .filter_map(|block| match block {
+                    ContentBlock::Text { text, .. } if !text.is_empty() => Some(text.to_owned()),
+                    ContentBlock::ToolResult { content, .. } => {
+                        let summary = content.text_summary();
+                        if summary.is_empty() {
+                            None
+                        } else {
+                            Some(summary)
+                        }
+                    }
+                    _ => None,
+                })
+                .collect();
+            parts.join("\n")
+        }
+    }
+}
+
+impl std::fmt::Debug for CodexProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodexProvider")
+            .field("codex_binary", &self.codex_binary)
+            .field("default_model", &self.default_model)
+            .field("timeout_secs", &self.timeout.as_secs())
+            .finish_non_exhaustive()
+    }
+}
+
+impl LlmProvider for CodexProvider {
+    fn complete<'a>(
+        &'a self,
+        request: &'a CompletionRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
+        Box::pin(self.execute(request))
+    }
+
+    fn supported_models(&self) -> &[&str] {
+        SUPPORTED_MODELS
+    }
+
+    fn supports_model(&self, model: &str) -> bool {
+        model.starts_with(CODEX_MODEL_PREFIX) || SUPPORTED_MODELS.contains(&model)
+    }
+
+    fn name(&self) -> &'static str {
+        "codex"
+    }
+}
+
+fn find_codex_binary() -> Result<PathBuf> {
+    let paths = RealSystem.var_os("PATH").unwrap_or_default();
+    for dir in std::env::split_paths(&paths) {
+        let candidate = dir.join("codex");
+        if candidate.is_file() {
+            debug!(path = %candidate.display(), "found codex binary in PATH");
+            return Ok(candidate);
+        }
+    }
+
+    if let Some(home) = RealSystem.var_os("HOME") {
+        let home = PathBuf::from(home);
+        for subdir in &[".local/bin/codex", ".codex/bin/codex"] {
+            let candidate = home.join(subdir);
+            if candidate.is_file() {
+                info!(
+                    path = %candidate.display(),
+                    "found codex binary outside PATH (consider adding its directory to PATH)"
+                );
+                return Ok(candidate);
+            }
+        }
+    }
+
+    Err(error::ProviderInitSnafu {
+        message: "codex CLI binary not found in PATH or ~/.local/bin. Install Codex CLI before enabling codex-provider"
+            .to_owned(),
+    }
+    .build())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{CompletionRequest, Content, Message, Role};
+
+    #[test]
+    fn format_prompt_single_message() {
+        let request = CompletionRequest {
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hello world".to_owned()),
+                cache_breakpoint: false,
+            }],
+            ..Default::default()
+        };
+        let prompt = CodexProvider::format_prompt(&request);
+        assert_eq!(prompt, "hello world");
+    }
+
+    #[test]
+    fn format_prompt_multi_turn() {
+        let request = CompletionRequest {
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: Content::Text("What is 2+2?".to_owned()),
+                    cache_breakpoint: false,
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text("4".to_owned()),
+                    cache_breakpoint: false,
+                },
+                Message {
+                    role: Role::User,
+                    content: Content::Text("And 3+3?".to_owned()),
+                    cache_breakpoint: false,
+                },
+            ],
+            ..Default::default()
+        };
+        let prompt = CodexProvider::format_prompt(&request);
+        assert!(prompt.contains("User: What is 2+2?"));
+        assert!(prompt.contains("Assistant: 4"));
+        assert!(prompt.contains("User: And 3+3?"));
+    }
+
+    #[test]
+    fn resolve_model_strips_prefix() {
+        let provider = CodexProvider {
+            codex_binary: PathBuf::from("codex"),
+            default_model: "codex/gpt-5-codex".to_owned(),
+            timeout: Duration::from_secs(1),
+        };
+        assert_eq!(provider.resolve_model("codex/gpt-5-codex"), "gpt-5-codex");
+        assert_eq!(provider.resolve_model(""), "gpt-5-codex");
+    }
+
+    #[test]
+    fn supports_model_with_prefix() {
+        let provider = CodexProvider {
+            codex_binary: PathBuf::from("codex"),
+            default_model: "codex/gpt-5-codex".to_owned(),
+            timeout: Duration::from_secs(1),
+        };
+        assert!(provider.supports_model("codex/gpt-5-codex"));
+        assert!(provider.supports_model("gpt-5-codex"));
+        assert!(!provider.supports_model("claude-sonnet-4-6"));
+    }
+}

--- a/crates/hermeneus/src/lib.rs
+++ b/crates/hermeneus/src/lib.rs
@@ -17,6 +17,12 @@ pub mod anthropic;
 pub mod cc;
 /// Circuit breaker (Closed / Open / HalfOpen) with exponential backoff for LLM provider health.
 pub mod circuit_breaker;
+/// Codex subprocess provider: delegates LLM calls to the `codex` CLI.
+///
+/// Uses Codex CLI OAuth credentials and is gated behind the `codex-provider`
+/// feature flag.
+#[cfg(feature = "codex-provider")]
+pub mod codex;
 /// Complexity-based model routing: scores queries and routes to Haiku/Sonnet/Opus.
 pub mod complexity;
 /// Adaptive concurrency limiter (AIMD) for LLM calls based on response latency.


### PR DESCRIPTION
## Summary

Adds a Codex subprocess provider mirroring the existing cc/ adapter shape. Spawns the `codex` CLI non-interactively, pipes prompt via stdin, parses stdout, returns `CompletionResponse`. OAuth is handled by the CLI; the adapter scrubs `OPENAI_API_KEY` before spawning.

## Module layout under `crates/hermeneus/src/codex/`

- `mod.rs` module entrypoint + pub use
- `parse.rs` output parser
- `process.rs` command spawn + read-bounded streams
- `provider.rs` `CodexProvider` + `CodexProviderConfig` + `LlmProvider` impl
- `process_tests.rs` unit tests for parse helpers + spawn smoke

## Feature gates

- `crates/hermeneus/Cargo.toml`: `codex-provider = []`
- `crates/aletheia/Cargo.toml`: `codex-provider = ["hermeneus/codex-provider"]`
- `crates/hermeneus/src/lib.rs`: `cfg`-gated `pub mod codex`
- `crates/aletheia/src/runtime/setup.rs`: `cfg`-gated provider registration

## Output envelope

Mirrors cc adapter: `MAX_OUTPUT_BYTES = 10 MB`, `MAX_OUTPUT_LINES = 100_000`, `MAX_SYSTEM_PROMPT_BYTES = 100 KB`. Model prefix `codex/` routes through `LlmProvider` trait.

## Verifier

- \`cargo check -p hermeneus --features codex-provider\` succeeds on verda
- Sibling PR adds kimi-provider with the same shape

## Context

Wave-3 O-A part 1. See `~/.claude/projects/-home-ck-metis-ops/memory/project_agent_runtime_oauth.md` for the OAuth-via-local-CLI architecture decision.