### PR TITLE
fix(nous): suppress pii-allow on synthetic SSN test fixture

### DIFF
--- a/crates/nous/src/pipeline/triage.rs
+++ b/crates/nous/src/pipeline/triage.rs
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn triage_detects_confidential_sensitivity() {
-        let result = TriageStage::classify("my ssn is 123-45-6789");
+        let result = TriageStage::classify("my ssn is 123-45-6789"); // pii-allow: test fixture for SSN detection — synthetic value
         assert_eq!(result.sensitivity, FactSensitivity::Confidential);
     }
 


### PR DESCRIPTION
## Summary

- Adds `pii-allow:` inline marker to the `triage_detects_confidential_sensitivity` test, which uses a synthetic 123-45-6789 SSN to verify the triage classifier catches PII-shaped input.
- The PII scanner (`scripts/scan-pii.sh`) flagged the test literal as an unsuppressed finding; this suppresses it correctly per the scanner's per-line override mechanism.
- No logic change; test behaviour is identical.

## Test plan

- [ ] `bash scripts/scan-pii.sh` returns `scan-pii: clean`
- [ ] `cargo test -p aletheia-nous` still passes (no functional change)