### PR TITLE
fix(energeia): migrate cron scheduler to jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "agora",
  "anyhow",
@@ -177,11 +177,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.23.0"
+version = "0.23.1"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "jiff",
  "koina",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "futures",
  "jiff",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1666,17 +1666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cron"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
-dependencies = [
- "chrono",
- "once_cell",
- "winnow 0.6.26",
-]
-
-[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "jiff",
  "koina",
@@ -2112,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2561,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "eidos",
  "jiff",
@@ -2635,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "jiff",
  "koina",
@@ -2682,16 +2671,15 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aletheia-routing",
- "chrono",
  "compact_str",
- "cron",
  "eidos",
  "fjall",
  "hermeneus",
  "jiff",
+ "jiff-cron",
  "koina",
  "parking_lot",
  "prometheus-client",
@@ -2799,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "async-trait",
  "candle-core",
@@ -3543,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "cargo_metadata",
  "parking_lot",
@@ -3560,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "criterion",
  "eidos",
@@ -3779,7 +3767,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "criterion",
  "jiff",
@@ -4419,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -4543,6 +4531,17 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-cron"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4804a5e6441082f7b8f2e840c639e489902aba5533c1e95c2fb7f0ab23d96c"
+dependencies = [
+ "jiff",
+ "phf 0.13.1",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4695,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "arboard",
  "clap",
@@ -4729,7 +4728,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "criterion",
  "fjall",
@@ -4874,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5354,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5458,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "eidos",
  "episteme",
@@ -5672,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -5893,7 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6007,7 +6006,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6456,7 +6455,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "jiff",
  "snafu",
@@ -6464,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -6476,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "docx-rs",
  "quick-xml 0.39.2",
@@ -6489,7 +6488,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -6505,7 +6504,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -6517,7 +6516,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6526,7 +6525,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -6538,7 +6537,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -6551,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -6564,7 +6563,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "krilla 0.7.0",
  "poiesis-core",
@@ -6574,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "comemo",
  "jiff",
@@ -6590,7 +6589,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6977,7 +6976,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -8394,7 +8393,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8741,7 +8740,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -8860,7 +8859,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -8972,14 +8971,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "futures",
  "indexmap 2.14.0",
@@ -11058,15 +11057,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/crates/energeia/Cargo.toml
+++ b/crates/energeia/Cargo.toml
@@ -18,8 +18,6 @@ storage-fjall = ["dep:fjall", "koina/fjall"]
 [dependencies]
 aletheia-routing = { path = "../aletheia-routing" }
 compact_str = { workspace = true }
-chrono = "0.4"
-cron = "=0.15.0"
 koina = { path = "../koina" }
 eidos = { path = "../eidos" }
 hermeneus = { path = "../hermeneus" }
@@ -28,6 +26,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 fjall = { version = "3", optional = true }
 jiff = { workspace = true, features = ["serde"] }
+jiff-cron = "0.3"
 parking_lot = { version = "0.12", default-features = false }
 reqwest = { workspace = true }
 rmp-serde = "1.2"

--- a/crates/energeia/src/cron.rs
+++ b/crates/energeia/src/cron.rs
@@ -1,6 +1,6 @@
 //! Cron scheduler for recurring dispatch tasks.
 //!
-//! Uses the standard `cron` crate with chrono datetimes, plus fjall-backed
+//! Uses the `jiff-cron` crate with jiff datetimes, plus fjall-backed
 //! distributed locking to prevent duplicate fires across restarts.
 //!
 //! # Observability
@@ -18,9 +18,9 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
 use compact_str::CompactString;
 use fjall::Readable;
+use jiff::{SignedDuration, Timestamp, Zoned, tz::TimeZone};
 use rand::RngExt;
 use snafu::IntoError;
 use tokio_util::sync::CancellationToken;
@@ -39,7 +39,7 @@ pub struct CronTask {
     /// Unique task identifier.
     pub name: CompactString,
     /// Cron schedule.
-    pub cron: cron::Schedule,
+    pub cron: jiff_cron::Schedule,
     /// Maximum jitter to apply (+/- this duration).
     pub jitter: Duration,
     /// What to dispatch when this task fires.
@@ -113,7 +113,7 @@ impl CronLockStore {
     /// # Errors
     ///
     /// Returns [`Error::Store`] on fjall I/O failure.
-    pub fn try_acquire(&self, task_name: &str, scheduled_time: DateTime<Utc>) -> Result<bool> {
+    pub fn try_acquire(&self, task_name: &str, scheduled_time: Timestamp) -> Result<bool> {
         let _guard = self.lock.lock();
         let existing = self.get_last_fired(task_name)?;
         if let Some(ts) = existing
@@ -125,7 +125,7 @@ impl CronLockStore {
             .db
             .keyspace(LOCK_PARTITION, fjall::KeyspaceCreateOptions::default)
             .map_err(|e| store_err("open cron_locks partition", e))?;
-        let value = scheduled_time.to_rfc3339();
+        let value = scheduled_time.to_string();
         let mut tx = self.db.write_tx();
         tx.insert(&partition, task_name.as_bytes(), value.as_bytes());
         tx.commit().map_err(|e| store_err("commit cron lock", e))?;
@@ -137,11 +137,11 @@ impl CronLockStore {
     /// # Errors
     ///
     /// Returns [`Error::Store`] on fjall I/O failure.
-    pub fn last_fired(&self, task_name: &str) -> Result<Option<DateTime<Utc>>> {
+    pub fn last_fired(&self, task_name: &str) -> Result<Option<Timestamp>> {
         self.get_last_fired(task_name)
     }
 
-    fn get_last_fired(&self, task_name: &str) -> Result<Option<DateTime<Utc>>> {
+    fn get_last_fired(&self, task_name: &str) -> Result<Option<Timestamp>> {
         let partition = self
             .db
             .keyspace(LOCK_PARTITION, fjall::KeyspaceCreateOptions::default)
@@ -159,14 +159,12 @@ impl CronLockStore {
                     }
                     .build()
                 })?;
-                let dt = DateTime::parse_from_rfc3339(s)
-                    .map_err(|e| {
-                        error::StoreSnafu {
-                            message: format!("invalid RFC 3339 in cron lock for {task_name}: {e}"),
-                        }
-                        .build()
-                    })?
-                    .with_timezone(&Utc);
+                let dt = s.parse::<Timestamp>().map_err(|e| {
+                    error::StoreSnafu {
+                        message: format!("invalid RFC 3339 in cron lock for {task_name}: {e}"),
+                    }
+                    .build()
+                })?;
                 Ok(Some(dt))
             }
             None => Ok(None),
@@ -195,8 +193,8 @@ impl CronScheduler {
     ///
     /// Returns `None` if the schedule has no future occurrences.
     #[must_use]
-    pub fn next_fire_after(&self, task: &CronTask, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
-        task.cron.after(&now).next()
+    pub fn next_fire_after(&self, task: &CronTask, now: Zoned) -> Option<Zoned> {
+        task.cron.after(now).next()
     }
 
     /// Run the scheduler loop until `cancel` is triggered.
@@ -215,18 +213,19 @@ impl CronScheduler {
         Fut: Future<Output = ()> + Send + 'static,
     {
         loop {
-            let now = Utc::now();
-            let mut earliest: Option<(DateTime<Utc>, &CronTask, DateTime<Utc>)> = None;
+            let now = Timestamp::now().to_zoned(TimeZone::UTC);
+            let mut earliest: Option<(Zoned, &CronTask, Timestamp)> = None;
 
             for task in &self.tasks {
-                if let Some(base) = self.next_fire_after(task, now) {
+                if let Some(base) = self.next_fire_after(task, now.clone()) {
+                    let base_scheduled = base.timestamp();
                     let jittered = apply_jitter(base, task.jitter);
                     if let Some((ref best_time, _, _)) = earliest {
-                        if jittered < *best_time {
-                            earliest = Some((jittered, task, base));
+                        if jittered.timestamp() < best_time.timestamp() {
+                            earliest = Some((jittered, task, base_scheduled));
                         }
                     } else {
-                        earliest = Some((jittered, task, base));
+                        earliest = Some((jittered, task, base_scheduled));
                     }
                 }
             }
@@ -236,7 +235,9 @@ impl CronScheduler {
                 return Ok(());
             };
 
-            let sleep_duration = (jittered_next - now).to_std().unwrap_or(Duration::ZERO);
+            let sleep_duration =
+                Duration::try_from(jittered_next.timestamp().duration_since(now.timestamp()))
+                    .unwrap_or(Duration::ZERO);
 
             tracing::info!(
                 task = %task.name,
@@ -255,8 +256,8 @@ impl CronScheduler {
                 () = tokio::time::sleep(sleep_duration) => {}
             }
 
-            let fire_now = Utc::now();
-            if fire_now < jittered_next {
+            let fire_now = Timestamp::now();
+            if fire_now < jittered_next.timestamp() {
                 // Time may have shifted backward or sleep fired early; recompute.
                 continue;
             }
@@ -311,13 +312,14 @@ fn store_err(context: &str, e: impl std::fmt::Display) -> error::Error {
 /// Apply a random signed jitter to a base timestamp.
 ///
 /// The offset is uniformly distributed in `[-jitter, +jitter]`.
-fn apply_jitter(base: DateTime<Utc>, jitter: Duration) -> DateTime<Utc> {
+fn apply_jitter(base: Zoned, jitter: Duration) -> Zoned {
     if jitter.is_zero() {
         return base;
     }
     let max_secs = i64::try_from(jitter.as_secs()).unwrap_or(i64::MAX);
     let offset_secs = rand::rng().random_range(-max_secs..=max_secs);
-    base + chrono::Duration::seconds(offset_secs)
+    base.checked_add(SignedDuration::from_secs(offset_secs))
+        .unwrap_or(base)
 }
 
 // ---------------------------------------------------------------------------
@@ -330,12 +332,17 @@ fn apply_jitter(base: DateTime<Utc>, jitter: Duration) -> DateTime<Utc> {
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use chrono::TimeZone;
-
     use super::*;
 
-    fn parse_schedule(expr: &str) -> cron::Schedule {
+    fn parse_schedule(expr: &str) -> jiff_cron::Schedule {
         expr.parse().expect("valid cron expression")
+    }
+
+    fn utc_datetime(year: i16, month: i8, day: i8, hour: i8, minute: i8, second: i8) -> Zoned {
+        jiff::civil::date(year, month, day)
+            .at(hour, minute, second, 0)
+            .to_zoned(TimeZone::UTC)
+            .unwrap()
     }
 
     fn dummy_lock_store() -> CronLockStore {
@@ -358,11 +365,11 @@ mod tests {
             jitter: Duration::ZERO,
             dispatch_spec: DispatchSpec::new("test".to_owned(), vec![]),
         };
-        let now = Utc::now();
-        let next =
-            CronScheduler::new(vec![], Arc::new(dummy_lock_store())).next_fire_after(&task, now);
+        let now = Timestamp::now().to_zoned(TimeZone::UTC);
+        let next = CronScheduler::new(vec![], Arc::new(dummy_lock_store()))
+            .next_fire_after(&task, now.clone());
         assert!(next.is_some(), "daily cron should have a next occurrence");
-        assert!(next.unwrap() > now);
+        assert!(next.unwrap().timestamp() > now.timestamp());
     }
 
     #[test]
@@ -374,24 +381,28 @@ mod tests {
             dispatch_spec: DispatchSpec::new("test".to_owned(), vec![]),
         };
         let scheduler = CronScheduler::new(vec![], Arc::new(dummy_lock_store()));
-        let now = Utc.with_ymd_and_hms(2026, 4, 17, 12, 30, 0).unwrap();
+        let now = utc_datetime(2026, 4, 17, 12, 30, 0);
         let next = scheduler.next_fire_after(&task, now);
         assert_eq!(
-            next,
-            Some(Utc.with_ymd_and_hms(2026, 4, 17, 13, 0, 0).unwrap())
+            next.map(|zoned| zoned.timestamp()),
+            Some(utc_datetime(2026, 4, 17, 13, 0, 0).timestamp())
         );
     }
 
     #[test]
     fn jitter_applies_signed_offset() {
-        let base = Utc.with_ymd_and_hms(2026, 4, 17, 12, 0, 0).unwrap();
+        let base = utc_datetime(2026, 4, 17, 12, 0, 0);
         let jitter = Duration::from_mins(5);
         let mut seen_different = false;
         for _ in 0..100 {
-            let result = apply_jitter(base, jitter);
-            let diff = (result - base).num_seconds().abs();
+            let result = apply_jitter(base.clone(), jitter);
+            let diff = result
+                .timestamp()
+                .duration_since(base.timestamp())
+                .as_secs()
+                .abs();
             assert!(diff <= 300, "jitter offset {diff} exceeds max 300");
-            if result != base {
+            if result.timestamp() != base.timestamp() {
                 seen_different = true;
             }
         }
@@ -499,14 +510,14 @@ mod tests {
     #[test]
     fn try_acquire_allows_first_fire() {
         let store = dummy_lock_store();
-        let now = Utc::now();
+        let now = Timestamp::now();
         assert!(store.try_acquire("task-a", now).unwrap());
     }
 
     #[test]
     fn try_acquire_denies_repeat_within_same_window() {
         let store = dummy_lock_store();
-        let now = Utc::now();
+        let now = Timestamp::now();
         assert!(store.try_acquire("task-b", now).unwrap());
         assert!(!store.try_acquire("task-b", now).unwrap());
     }
@@ -514,8 +525,8 @@ mod tests {
     #[test]
     fn try_acquire_allows_next_window() {
         let store = dummy_lock_store();
-        let t1 = Utc::now();
-        let t2 = t1 + chrono::Duration::hours(1);
+        let t1 = Timestamp::now();
+        let t2 = t1.checked_add(SignedDuration::from_hours(1)).unwrap();
         assert!(store.try_acquire("task-c", t1).unwrap());
         assert!(store.try_acquire("task-c", t2).unwrap());
     }
@@ -523,7 +534,7 @@ mod tests {
     #[test]
     fn last_fired_roundtrip() {
         let store = dummy_lock_store();
-        let now = Utc.with_ymd_and_hms(2026, 4, 17, 10, 0, 0).unwrap();
+        let now = utc_datetime(2026, 4, 17, 10, 0, 0).timestamp();
         assert!(store.last_fired("task-d").unwrap().is_none());
         store.try_acquire("task-d", now).unwrap();
         let read = store.last_fired("task-d").unwrap();

--- a/crates/energeia/src/error.rs
+++ b/crates/energeia/src/error.rs
@@ -7,11 +7,11 @@ use snafu::Snafu;
 /// Errors from dispatch orchestration operations.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "snafu error variant fields are self-documenting via display format"
 )]
+#[non_exhaustive]
 pub enum Error {
     /// I/O error reading or listing prompt files.
     #[snafu(display("I/O error for '{}': {source}", path.display()))]
@@ -157,7 +157,7 @@ pub enum Error {
     #[snafu(display("invalid cron expression '{expression}': {source}"))]
     CronParse {
         expression: String,
-        source: cron::error::Error,
+        source: jiff_cron::error::Error,
         #[snafu(implicit)]
         location: snafu::Location,
     },


### PR DESCRIPTION
## Summary
- replace energeia cron scheduling from chrono-backed `cron` to `jiff-cron` and `jiff` timestamps
- persist cron lock timestamps as `jiff::Timestamp` strings and parse them through jiff
- update cron scheduler tests to cover jiff-based scheduling and lock round trips

Closes #3889.

## Validation
- `cargo +1.94 fmt --check`
- `CARGO_TARGET_DIR=/data/target/wt/issue-3889-jiff-cron/target cargo +1.94 check -p energeia --features storage-fjall`
- `CARGO_TARGET_DIR=/data/target/wt/issue-3889-jiff-cron/target cargo +1.94 test -p energeia --features storage-fjall cron -- --nocapture`
- `CARGO_TARGET_DIR=/data/target/wt/issue-3889-jiff-cron/target cargo +1.94 clippy -p energeia --features storage-fjall -- -D warnings`
- `kanon lint --rust --summary crates/energeia/src/cron.rs`
- `kanon lint --rust --summary crates/energeia/src/error.rs`