### PR TITLE
feat(scripts): add install-proskenion script

### DIFF
--- a/crates/aletheia/src/commands/desktop.rs
+++ b/crates/aletheia/src/commands/desktop.rs
@@ -29,10 +29,9 @@ pub(crate) fn run(args: &DesktopArgs) -> anyhow::Result<()> {
     let binary = find_in_path().ok_or_else(|| {
         anyhow::anyhow!(
             "`{BINARY_NAME}` not found in PATH\n\n\
-             Build and install it from the workspace:\n  \
-             cd crates/theatron/proskenion && cargo build --release\n  \
-             cp target/release/{BINARY_NAME} ~/.cargo/bin/\n\n\
-             Or add its build directory to PATH."
+             Install the desktop binary with:\n  \
+             scripts/install-proskenion.sh\n\n\
+             Or add an existing `{BINARY_NAME}` build directory to PATH."
         )
     })?;
 

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -24,6 +24,14 @@ sudo dnf install gtk3-devel webkit2gtk4.1-devel libxdo-devel
 
 The desktop crate is excluded from the workspace because its GTK/webkit2gtk dependencies are not available in CI and would cause build failures and cargo-deny advisory noise.
 
+For the standard local install flow, run:
+
+```bash
+scripts/install-proskenion.sh
+```
+
+The installer verifies Linux GTK/webkit2gtk system libraries, builds the release binary through the standalone manifest, and installs `proskenion` to `~/.cargo/bin/`.
+
 Build it standalone using the manifest path:
 
 ```bash

--- a/scripts/install-proskenion.sh
+++ b/scripts/install-proskenion.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and install the proskenion desktop binary.
+#
+# Usage: scripts/install-proskenion.sh [--dry-run] [--skip-preflight]
+#
+# Environment:
+#   PROSKENION_INSTALL_DIR  Destination directory, default: ~/.cargo/bin
+#   PROSKENION_BINARY       Full destination path, default: PROSKENION_INSTALL_DIR/proskenion
+#   CARGO_TARGET_DIR        Cargo target directory, default: crates/theatron/proskenion/target
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$REPO_ROOT/crates/theatron/proskenion/Cargo.toml"
+DEFAULT_TARGET_DIR="$REPO_ROOT/crates/theatron/proskenion/target"
+TARGET_DIR="${CARGO_TARGET_DIR:-$DEFAULT_TARGET_DIR}"
+INSTALL_DIR="${PROSKENION_INSTALL_DIR:-$HOME/.cargo/bin}"
+BINARY_DST="${PROSKENION_BINARY:-$INSTALL_DIR/proskenion}"
+BINARY_SRC="$TARGET_DIR/release/proskenion"
+DRY_RUN=false
+SKIP_PREFLIGHT=false
+
+log() {
+    echo "[install-proskenion] $*"
+}
+
+die() {
+    log "ERROR: $*" >&2
+    exit 1
+}
+
+usage() {
+    sed -n '4,13p' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true; shift ;;
+        --skip-preflight) SKIP_PREFLIGHT=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) die "Unknown flag: $1" ;;
+    esac
+done
+
+install_hint() {
+    if [[ -r /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        case "${ID:-}" in
+            debian|ubuntu)
+                echo "sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev"
+                return
+                ;;
+            fedora)
+                echo "sudo dnf install gtk3-devel webkit2gtk4.1-devel libxdo-devel"
+                return
+                ;;
+        esac
+        case " ${ID_LIKE:-} " in
+            *" debian "*)
+                echo "sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev"
+                return
+                ;;
+            *" fedora "*|*" rhel "*)
+                echo "sudo dnf install gtk3-devel webkit2gtk4.1-devel libxdo-devel"
+                return
+                ;;
+        esac
+    fi
+    echo "Install GTK3 and webkit2gtk development packages for your distribution."
+}
+
+preflight_linux_deps() {
+    if [[ "$(uname -s)" != "Linux" ]]; then
+        log "Non-Linux host detected; GTK/WebKit preflight not required."
+        return 0
+    fi
+
+    command -v pkg-config >/dev/null 2>&1 || {
+        log "pkg-config is required to verify desktop system libraries."
+        log "Install hint: $(install_hint)"
+        exit 1
+    }
+
+    local missing=()
+    for pkg in gtk+-3.0 webkit2gtk-4.1; do
+        if ! pkg-config --exists "$pkg"; then
+            missing+=("$pkg")
+        fi
+    done
+
+    if (( ${#missing[@]} > 0 )); then
+        log "Missing pkg-config entries: ${missing[*]}"
+        log "Install hint: $(install_hint)"
+        exit 1
+    fi
+
+    log "Desktop system dependency preflight passed."
+}
+
+if [[ ! -f "$MANIFEST" ]]; then
+    die "proskenion manifest not found at ${MANIFEST}"
+fi
+
+if [[ "$SKIP_PREFLIGHT" == false ]]; then
+    preflight_linux_deps
+else
+    log "Skipping GTK/WebKit preflight by request."
+fi
+
+log "Building proskenion release binary..."
+log "Manifest: ${MANIFEST}"
+log "Target dir: ${TARGET_DIR}"
+
+if [[ "$DRY_RUN" == true ]]; then
+    log "[dry-run] Would run: CARGO_TARGET_DIR=${TARGET_DIR} cargo build -p proskenion --manifest-path ${MANIFEST} --release"
+    log "[dry-run] Would install ${BINARY_SRC} to ${BINARY_DST}"
+    log "[dry-run] Next step: aletheia desktop"
+    exit 0
+fi
+
+CARGO_TARGET_DIR="$TARGET_DIR" cargo build -p proskenion --manifest-path "$MANIFEST" --release
+
+if [[ ! -x "$BINARY_SRC" ]]; then
+    die "build finished but binary was not found at ${BINARY_SRC}"
+fi
+
+mkdir -p "$(dirname "$BINARY_DST")"
+install -m 0755 "$BINARY_SRC" "$BINARY_DST"
+
+log "Installed proskenion to ${BINARY_DST}"
+log "Next step: aletheia desktop"


### PR DESCRIPTION
## Summary
- add `scripts/install-proskenion.sh` to preflight GTK/webkit2gtk, build proskenion through its standalone manifest, and install it to `~/.cargo/bin/proskenion` by default
- update `aletheia desktop` missing-binary guidance to name the installer script
- cross-link the installer from `docs/DESKTOP.md`

Closes #3879.

## Validation
- `bash -n scripts/install-proskenion.sh`
- `scripts/install-proskenion.sh --skip-preflight --dry-run`
- `scripts/install-proskenion.sh --dry-run`
- `cargo +1.94 fmt --check`
- `CARGO_TARGET_DIR=/data/target/wt/issue-3879-install-proskenion/target cargo +1.94 check -p aletheia`
- `CARGO_TARGET_DIR=/data/target/wt/issue-3879-install-proskenion/target cargo +1.94 clippy -p aletheia -- -D warnings`
- `kanon lint --summary scripts/install-proskenion.sh`
- `kanon lint --summary docs/DESKTOP.md`
- `kanon lint --summary crates/aletheia/src/commands/desktop.rs`

Note: `shellcheck` is not installed on verda, so shellcheck was not run.