### PR TITLE
docs(agent): clarify scaffolds and pack manifests

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,6 +12,21 @@ Later layers override earlier ones. All field names use `snake_case` in TOML; `c
 
 ---
 
+## Cascade terminology
+
+Aletheia uses the same override vocabulary across configuration and agent workspace files:
+
+| Fleet tier | Aletheia config equivalent | Workspace equivalent |
+|------------|----------------------------|----------------------|
+| Repo default | Compiled defaults and `instance.example/` | Template files under `instance.example/nous/_template/` |
+| Team or instance | `instance/config/aletheia.toml` | Shared guidance under `instance/shared/` and `instance/theke/` |
+| Agent or personal | Per-agent entries in `agents.list[]` | `instance/nous/{id}/` identity, memory, goals, and tool notes |
+| Environment override | `ALETHEIA_` variables | Process environment and allowed filesystem roots |
+
+Runtime configuration uses the three-layer TOML cascade above. Agent bootstrap files use a workspace cascade through `nous/{id}/`, `shared/`, `theke/`, and configured domain packs. In both cases, the narrowest scope should only carry values that genuinely need to differ from the broader tier.
+
+---
+
 ## Table of contents
 
 - [agents](#agents)

--- a/docs/PACKS.md
+++ b/docs/PACKS.md
@@ -62,6 +62,19 @@ description = "SQL query to execute"
 domains = ["healthcare", "sql"]
 ```
 
+### Design note: startup and on-demand references
+
+`pack.toml` is the repo-local knowledge manifest for a domain pack. It should make the loader able to distinguish content needed at startup from material that should stay discoverable without entering every prompt.
+
+| Reference kind | Current manifest field | Use for | Loading behavior |
+|----------------|------------------------|---------|------------------|
+| Startup context | `[[context]]` | Small, high-signal guidance the agent needs before a turn starts | Inject into bootstrap according to priority and token budget |
+| Callable capability | `[[tools]]` | Scripts or commands the model can call when a task needs them | Register in the tool registry; do not inject tool output at startup |
+| Agent routing | `[overlays.<agent>]` | Domain tags and per-agent targeting | Merge with agent domains before section filtering |
+| On-demand reference | Proposed future `[[reference]]` shape | Larger runbooks, schemas, reports, or corpora | Index path and metadata, load only when recall or a tool asks for it |
+
+A future `[[reference]]` entry should include at least `path`, `title`, `description`, and `tags`. Optional fields such as `freshness`, `owner`, `format`, and `load_hint = "startup" | "on_demand"` can help runtime loaders choose between prompt injection, search indexing, and tool-mediated retrieval.
+
 ## Context entries
 
 Each context entry maps to a file injected into the agent's system prompt at startup.

--- a/instance.example/nous/_default/README.md
+++ b/instance.example/nous/_default/README.md
@@ -23,6 +23,25 @@ Calm, competent, practical. Assumes the operator is busy and may not know all av
 
 This is a starting point. Edit SOUL.md to change personality, GOALS.md to set priorities, USER.md to record operator preferences. The agent learns and adapts through conversation. All files in this directory can be edited at any time.
 
+## Workspace scaffold
+
+The `nous/{id}/` directory separates durable startup state from shared work in `theke/`.
+
+| File | Scaffold role | Loaded for |
+|------|---------------|------------|
+| `SOUL.md` | Identity, temperament, and operating principles | Who the agent is |
+| `IDENTITY.md` | Stable name and self-description facts | Identity lookup and display |
+| `USER.md` | Operator preferences and known working style | Personalization |
+| `AGENTS.md` | Local operating rules and delegation habits | Session behavior |
+| `TOOLS.md` | Tool expectations and safe usage notes | Tool selection |
+| `CONTEXT.md` | Domain and environment guidance | Startup orientation |
+| `GOALS.md` | Active, deferred, and completed objectives | Planning and prioritization |
+| `MEMORY.md` | Curated long-lived notes | Continuity across sessions |
+| `PROSOCHE.md` | Attention checks and recurring review prompts | Heartbeat and self-checks |
+| `WORKFLOWS.md` | Repeatable procedures | Task execution |
+
+Keep project drafts, research, references, and deliverables in `theke/` so every agent can find and reuse them. Keep `nous/{id}/` focused on identity, operator knowledge, agent guidance, memory, and goals.
+
 ## Renaming
 
 To use a different agent ID, rename this directory and update `aletheia.toml`:


### PR DESCRIPTION
## Summary
- map the default agent workspace files to identity, user, tools, context, memory, goals, and workflow scaffold roles
- document Aletheia config and workspace cascade terminology against repo, instance, agent, and environment tiers
- add a domain-pack design note that separates startup context from future on-demand references

Closes #3893.
Closes #3894.
Closes #3895.

## Validation
- `kanon lint --summary docs/PACKS.md`
- `kanon lint --summary docs/CONFIGURATION.md`
- `kanon lint --summary instance.example/nous/_default/README.md`
- `git diff --check`