### PR TITLE
fix(skene): configure discovery candidates

### DIFF
--- a/crates/theatron/koilon/src/config.rs
+++ b/crates/theatron/koilon/src/config.rs
@@ -59,6 +59,36 @@ pub(crate) struct ConfigFile {
     pub(crate) keybindings: Option<HashMap<String, String>>,
     /// Theme mode: "dark", "light", or "auto" (default).
     pub(crate) theme: Option<String>,
+    /// Optional auto-discovery candidates used when `url` is not set.
+    pub(crate) discovery: Option<DiscoveryFileConfig>,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryFileConfig {
+    pub(crate) port: Option<u16>,
+    pub(crate) urls: Option<Vec<String>>,
+    pub(crate) lan_hostnames: Option<Vec<String>>,
+    pub(crate) tailscale_ips: Option<Vec<String>>,
+}
+
+impl DiscoveryFileConfig {
+    fn to_discovery_config(&self) -> skene::discovery::DiscoveryConfig {
+        let mut config = skene::discovery::DiscoveryConfig::default();
+        if let Some(port) = self.port {
+            config.port = port;
+        }
+        if let Some(urls) = self.urls.clone() {
+            config.base_urls = urls;
+        }
+        if let Some(hostnames) = self.lan_hostnames.clone() {
+            config.lan_hostnames = hostnames;
+        }
+        if let Some(ips) = self.tailscale_ips.clone() {
+            config.tailscale_ips = ips;
+        }
+        config
+    }
 }
 
 impl std::fmt::Debug for ConfigFile {
@@ -68,6 +98,10 @@ impl std::fmt::Debug for ConfigFile {
             .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
             .field("default_agent", &self.default_agent)
             .field("default_session", &self.default_session)
+            .field(
+                "discovery",
+                &self.discovery.as_ref().map(|_| "[configured]"),
+            )
             .finish()
     }
 }
@@ -131,13 +165,18 @@ impl Config {
 
         let resolved_token = cli_token.or(file_config.token);
         let credential_label = detect_credential_label(resolved_token.as_deref());
+        let discovery_config = file_config
+            .discovery
+            .as_ref()
+            .map(DiscoveryFileConfig::to_discovery_config)
+            .unwrap_or_default();
 
         // WHY: When neither CLI flag nor config file provides a URL, attempt
         // auto-discovery before falling back to the compiled default.
         // Discovery runs a blocking runtime because Config::load is sync.
-        let url = cli_url
-            .or(file_config.url)
-            .unwrap_or_else(|| Self::try_discover().unwrap_or_else(|| DEFAULT_URL.to_string()));
+        let url = cli_url.or(file_config.url).unwrap_or_else(|| {
+            Self::try_discover(&discovery_config).unwrap_or_else(|| DEFAULT_URL.to_string())
+        });
 
         Ok(Config {
             url,
@@ -160,14 +199,14 @@ impl Config {
     /// blocking task to run discovery without deadlocking the current runtime.
     /// If no runtime is active (e.g. tests without `#[tokio::test]`), we create
     /// a temporary one.
-    fn try_discover() -> Option<String> {
+    fn try_discover(config: &skene::discovery::DiscoveryConfig) -> Option<String> {
         tracing::info!("no server URL configured, attempting auto-discovery");
 
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             // We are inside a tokio runtime. Spawn a blocking task to avoid
             // blocking the async executor while discovery probes run.
             std::thread::scope(|s| {
-                s.spawn(|| handle.block_on(skene::discovery::discover_server()))
+                s.spawn(|| handle.block_on(skene::discovery::discover_server_with_config(config)))
                     .join()
                     .ok()
                     .flatten()
@@ -178,7 +217,7 @@ impl Config {
                 .enable_all()
                 .build()
                 .ok()?;
-            rt.block_on(skene::discovery::discover_server())
+            rt.block_on(skene::discovery::discover_server_with_config(config))
         }
     }
 
@@ -274,6 +313,12 @@ mod tests {
             bell: Some(true),
             keybindings: Some(keybindings),
             theme: Some("light".into()),
+            discovery: Some(DiscoveryFileConfig {
+                port: Some(18790),
+                urls: Some(vec!["https://aletheia.example".into()]),
+                lan_hostnames: Some(vec!["metis".into()]),
+                tailscale_ips: Some(vec!["100.64.0.10".into()]),
+            }),
         };
         let toml_str = toml::to_string(&file).unwrap();
         let back: ConfigFile = toml::from_str(&toml_str).unwrap();
@@ -291,6 +336,20 @@ mod tests {
             Some("Ctrl+G")
         );
         assert_eq!(file.theme, back.theme);
+        let discovery = back.discovery.expect("discovery config should roundtrip");
+        assert_eq!(discovery.port, Some(18790));
+        assert_eq!(
+            discovery.urls.as_deref(),
+            Some(&["https://aletheia.example".to_string()][..])
+        );
+        assert_eq!(
+            discovery.lan_hostnames.as_deref(),
+            Some(&["metis".to_string()][..])
+        );
+        assert_eq!(
+            discovery.tailscale_ips.as_deref(),
+            Some(&["100.64.0.10".to_string()][..])
+        );
     }
 
     #[test]

--- a/crates/theatron/skene/src/discovery.rs
+++ b/crates/theatron/skene/src/discovery.rs
@@ -4,8 +4,9 @@
 //! the first that responds successfully. The probe order is:
 //!
 //! 1. `http://localhost:{port}/api/health` -- same machine
-//! 2. `http://{host}.lan:{port}/api/health` -- for each known LAN hostname
-//! 3. `http://{ip}:{port}/api/health` -- for each known Tailscale IP
+//! 2. configured base URLs
+//! 3. `http://{host}.lan:{port}/api/health` -- for each configured LAN hostname
+//! 4. `http://{ip}:{port}/api/health` -- for each configured Tailscale IP
 //!
 //! Each probe has a per-attempt timeout (default 2 s). The entire discovery
 //! sequence has a total timeout (default 10 s) to avoid blocking the UI.
@@ -35,17 +36,88 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Total wall-clock budget for the entire discovery sequence.
 const TOTAL_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Known LAN hostnames to probe. These correspond to hosts that commonly run
-/// aletheia in a typical homelab setup.
-///
-/// WHY: kept as a small static list rather than mDNS/DNS-SD because the
-/// deployment is a known, fixed fleet. mDNS adds a dependency and complexity
-/// disproportionate to the benefit for this use case.
-const LAN_HOSTNAMES: &[&str] = &["menos", "metis"];
+/// LAN hostnames probed when callers do not provide discovery config.
+const DEFAULT_LAN_HOSTNAMES: &[&str] = &["menos", "metis"];
 
-/// Known Tailscale IPs that may host an aletheia instance.
-/// Uses RFC 5737 TEST-NET addresses (198.51.100.0/24) for documentation.
-const TAILSCALE_IPS: &[&str] = &["198.51.100.1", "198.51.100.2"];
+/// Configured server discovery candidates.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveryConfig {
+    /// Gateway port to use for generated localhost, LAN, and Tailscale candidates.
+    pub port: u16,
+    /// Base URLs to probe exactly as configured, before generated LAN candidates.
+    pub base_urls: Vec<String>,
+    /// LAN hostnames to probe with the `.lan` suffix.
+    pub lan_hostnames: Vec<String>,
+    /// Tailscale IPs to probe directly.
+    pub tailscale_ips: Vec<String>,
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            port: DEFAULT_PORT,
+            base_urls: Vec::new(),
+            lan_hostnames: DEFAULT_LAN_HOSTNAMES
+                .iter()
+                .map(|host| (*host).to_string())
+                .collect(),
+            tailscale_ips: Vec::new(),
+        }
+    }
+}
+
+impl DiscoveryConfig {
+    /// Return the default discovery configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the default LAN hostnames.
+    #[must_use]
+    pub fn with_lan_hostnames<I, S>(mut self, hostnames: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.lan_hostnames = hostnames
+            .into_iter()
+            .map(Into::into)
+            .filter(|host| !host.trim().is_empty())
+            .collect();
+        self
+    }
+
+    /// Replace configured Tailscale IP candidates.
+    #[must_use]
+    pub fn with_tailscale_ips<I, S>(mut self, ips: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tailscale_ips = ips
+            .into_iter()
+            .map(Into::into)
+            .filter(|ip| !ip.trim().is_empty())
+            .collect();
+        self
+    }
+
+    /// Replace configured base URL candidates.
+    #[must_use]
+    pub fn with_base_urls<I, S>(mut self, urls: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.base_urls = urls
+            .into_iter()
+            .map(Into::into)
+            .filter(|url| !url.trim().is_empty())
+            .collect();
+        self
+    }
+}
 
 /// Candidate endpoint to probe during discovery.
 #[derive(Debug, Clone)]
@@ -57,32 +129,46 @@ struct Candidate {
 }
 
 /// Build the ordered list of candidate URLs to probe.
-fn build_candidates() -> Vec<Candidate> {
-    let mut candidates = Vec::with_capacity(1 + LAN_HOSTNAMES.len() + TAILSCALE_IPS.len());
+fn build_candidates(config: &DiscoveryConfig) -> Vec<Candidate> {
+    let mut candidates = Vec::with_capacity(
+        1 + config.base_urls.len() + config.lan_hostnames.len() + config.tailscale_ips.len(),
+    );
 
     // 1. Localhost -- most common case, check first.
     candidates.push(Candidate {
-        base_url: format!("http://localhost:{DEFAULT_PORT}"),
+        base_url: format!("http://localhost:{}", config.port),
         label: "localhost",
     });
 
-    // 2. LAN hostnames via .lan DNS suffix (AdGuard rewrites).
-    for host in LAN_HOSTNAMES {
+    // 2. Explicit URLs from config.
+    for url in &config.base_urls {
         candidates.push(Candidate {
-            base_url: format!("http://{host}.lan:{DEFAULT_PORT}"), // SAFE: trusted LAN, no public traversal // kanon:ignore SECURITY/insecure-transport -- LAN discovery, trusted network
+            base_url: normalize_base_url(url),
+            label: "configured",
+        });
+    }
+
+    // 3. LAN hostnames via .lan DNS suffix (AdGuard rewrites).
+    for host in &config.lan_hostnames {
+        candidates.push(Candidate {
+            base_url: format!("http://{host}.lan:{}", config.port), // SAFE: trusted LAN, no public traversal // kanon:ignore SECURITY/insecure-transport -- LAN discovery, trusted network
             label: "lan",
         });
     }
 
-    // 3. Tailscale IPs -- direct IP probe as fallback.
-    for ip in TAILSCALE_IPS {
+    // 4. Tailscale IPs -- direct IP probe as a configured fallback.
+    for ip in &config.tailscale_ips {
         candidates.push(Candidate {
-            base_url: format!("http://{ip}:{DEFAULT_PORT}"), // SAFE: Tailscale WireGuard tunnel, encrypted in transit // kanon:ignore SECURITY/insecure-transport -- Tailscale WireGuard tunnel, encrypted in transit
+            base_url: format!("http://{ip}:{}", config.port), // SAFE: Tailscale WireGuard tunnel, encrypted in transit // kanon:ignore SECURITY/insecure-transport -- Tailscale WireGuard tunnel, encrypted in transit
             label: "tailscale",
         });
     }
 
     candidates
+}
+
+fn normalize_base_url(url: &str) -> String {
+    url.trim().trim_end_matches('/').to_string()
 }
 
 /// Probe a single candidate URL by hitting its health endpoint.
@@ -135,6 +221,15 @@ async fn probe(client: &reqwest::Client, candidate: &Candidate) -> Option<String
 /// to [`crate::api::ApiClient::new`].
 #[instrument]
 pub async fn discover_server() -> Option<String> {
+    discover_server_with_config(&DiscoveryConfig::default()).await
+}
+
+/// Discover a running aletheia server using explicit discovery candidates.
+///
+/// This is the configured form of [`discover_server`]. It keeps fleet-specific
+/// addresses out of the binary while preserving the same probe behavior.
+#[instrument(skip(config))]
+pub async fn discover_server_with_config(config: &DiscoveryConfig) -> Option<String> {
     let client = reqwest::Client::builder()
         .timeout(PROBE_TIMEOUT)
         // WHY: Minimal client with no default headers. Discovery only hits
@@ -143,7 +238,7 @@ pub async fn discover_server() -> Option<String> {
         .build()
         .ok()?;
 
-    let candidates = build_candidates();
+    let candidates = build_candidates(config);
     tracing::info!(count = candidates.len(), "starting server discovery");
 
     // WHY: tokio::time::timeout wraps the entire sequential probe loop so we
@@ -179,7 +274,7 @@ mod tests {
 
     #[test]
     fn build_candidates_includes_localhost_first() {
-        let candidates = build_candidates();
+        let candidates = build_candidates(&DiscoveryConfig::default());
         let Some(first) = candidates.first() else {
             panic!("build_candidates always returns at least one entry");
         };
@@ -192,30 +287,60 @@ mod tests {
 
     #[test]
     fn build_candidates_includes_lan_hosts() {
-        let candidates = build_candidates();
+        let config =
+            DiscoveryConfig::default().with_lan_hostnames(["menos".to_string(), "metis".into()]);
+        let candidates = build_candidates(&config);
         let lan_count = candidates.iter().filter(|c| c.label == "lan").count();
-        assert_eq!(lan_count, LAN_HOSTNAMES.len());
+        assert_eq!(lan_count, 2);
     }
 
     #[test]
-    fn build_candidates_includes_tailscale() {
-        let candidates = build_candidates();
+    fn build_candidates_includes_configured_tailscale() {
+        let config = DiscoveryConfig::default().with_tailscale_ips(["100.64.0.10"]);
+        let candidates = build_candidates(&config);
         let ts_count = candidates.iter().filter(|c| c.label == "tailscale").count();
-        assert_eq!(ts_count, TAILSCALE_IPS.len());
+        assert_eq!(ts_count, 1);
+        assert!(
+            candidates
+                .iter()
+                .any(|c| c.base_url == "http://100.64.0.10:18789")
+        );
+    }
+
+    #[test]
+    fn build_candidates_has_no_default_tailscale_ips() {
+        let candidates = build_candidates(&DiscoveryConfig::default());
+        assert!(!candidates.iter().any(|c| c.label == "tailscale"));
+    }
+
+    #[test]
+    fn build_candidates_includes_configured_base_urls() {
+        let config = DiscoveryConfig::default().with_base_urls(["https://example.test/"]);
+        let candidates = build_candidates(&config);
+        assert!(
+            candidates
+                .iter()
+                .any(|c| { c.label == "configured" && c.base_url == "https://example.test" })
+        );
     }
 
     #[test]
     fn build_candidates_total_count() {
-        let candidates = build_candidates();
+        let config = DiscoveryConfig::default()
+            .with_lan_hostnames(["menos"])
+            .with_tailscale_ips(["100.64.0.10"])
+            .with_base_urls(["https://example.test"]);
+        let candidates = build_candidates(&config);
         assert_eq!(
             candidates.len(),
-            1 + LAN_HOSTNAMES.len() + TAILSCALE_IPS.len()
+            1 + config.lan_hostnames.len() + config.tailscale_ips.len() + config.base_urls.len()
         );
     }
 
     #[test]
     fn build_candidates_no_trailing_slash() {
-        for candidate in build_candidates() {
+        let config = DiscoveryConfig::default().with_base_urls(["https://example.test/"]);
+        for candidate in build_candidates(&config) {
             assert!(
                 !candidate.base_url.ends_with('/'),
                 "candidate URL should not have trailing slash: {}",
@@ -226,7 +351,11 @@ mod tests {
 
     #[test]
     fn build_candidates_uses_default_port() {
-        for candidate in build_candidates() {
+        let config = DiscoveryConfig::default().with_tailscale_ips(["100.64.0.10"]);
+        for candidate in build_candidates(&config)
+            .into_iter()
+            .filter(|c| c.label != "configured")
+        {
             assert!(
                 candidate.base_url.contains(&format!(":{DEFAULT_PORT}")),
                 "candidate URL should use port {DEFAULT_PORT}: {}",


### PR DESCRIPTION
## Summary
- replace hard-coded placeholder Tailscale discovery IPs with explicit discovery config
- add `discover_server_with_config` while keeping the default no-arg discovery path
- wire koilon `tui.toml` discovery candidates into auto-discovery

Closes #3878.

## Validation
- `CARGO_TARGET_DIR=/data/target/wt/issue-3878-discovery-config/target cargo +1.94 check -p skene -p koilon`
- `CARGO_TARGET_DIR=/data/target/wt/issue-3878-discovery-config/target cargo +1.94 test -p skene discovery`
- `CARGO_TARGET_DIR=/data/target/wt/issue-3878-discovery-config/target cargo +1.94 test -p koilon config`
- `CARGO_TARGET_DIR=/data/target/wt/issue-3878-discovery-config/target cargo +1.94 clippy -p skene -p koilon -- -D warnings`
- `RUST_LOG=error /home/ck/.local/bin/kanon lint --rust --summary crates/theatron/skene/src/discovery.rs`
- `RUST_LOG=error /home/ck/.local/bin/kanon lint --rust --summary crates/theatron/koilon/src/config.rs`
- `rg -n "TAILSCALE_IPS|198\.51\.100|192\.0\.2|203\.0\.113|TEST-NET" crates/theatron/skene/src/discovery.rs crates/theatron/koilon/src/config.rs`
- `git diff --check`