### PR TITLE
docs(proskenion): gate desktop pin drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Check proskenion theatron pins
+        run: scripts/check-proskenion-pins.py
       - name: Configure git credentials for private fleet deps
         env:
           FLEET_REPO_TOKEN: ${{ secrets.FLEET_REPO_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
 # WHY: proskenion requires GTK3/webkit2gtk system libraries (via Dioxus
 # desktop/webview) which are not available in CI. Excluded from workspace to
 # avoid cargo-deny advisory failures on GTK deps and build failures on CI.
+# Build/install flow and system deps: docs/DESKTOP.md
 # Build standalone: `cargo build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml`
 exclude = [
     "crates/theatron/proskenion",
@@ -122,12 +123,6 @@ rayon = { version = "1", default-features = false }
 # Member crates inherit via `<dep> = { workspace = true }`.
 # proskenion is excluded from the workspace (GTK/webkit2gtk) and uses its own
 # standalone [workspace.dependencies] block; pin is mirrored there manually.
-parodos = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-themelion = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-skeue = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-gramma = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-bathron = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0", features = ["logging"] }
-keryx = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
 
 # Error handling
 snafu = "0.8"
@@ -249,9 +244,34 @@ wiremock = { version = "0.6", default-features = false }
 # Invoked as `RUSTFLAGS="--cfg loom" cargo test -p krites --release loom_tests`.
 loom = { version = "0.7", default-features = false }
 
-# WHY: serde, axum-server, regex, criterion declared as expanded tables at the
-# end to satisfy TOML/inline-table-too-long while keeping `[workspace.dependencies]`
-# block readable. Cargo resolves them identically to inline form.
+# WHY: long dependency specifications are declared as expanded tables at the end
+# to satisfy TOML/inline-table-too-long while keeping `[workspace.dependencies]`
+# readable. Cargo resolves them identically to inline form.
+[workspace.dependencies.parodos]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.2.0"
+
+[workspace.dependencies.themelion]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.2.0"
+
+[workspace.dependencies.skeue]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.2.0"
+
+[workspace.dependencies.gramma]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.2.0"
+
+[workspace.dependencies.bathron]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.2.0"
+features = ["logging"]
+
+[workspace.dependencies.keryx]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.2.0"
+
 [workspace.dependencies.serde]
 version = "1"
 default-features = false

--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 [[package]]
 name = "bathron"
 version = "1.2.0"
-source = "git+http://127.0.0.1:7878/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
+source = "git+https://github.com/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
 dependencies = [
  "dirs",
  "serde",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "gramma"
 version = "1.2.0"
-source = "git+http://127.0.0.1:7878/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
+source = "git+https://github.com/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
 dependencies = [
  "pulldown-cmark",
  "syntect",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "keryx"
 version = "1.2.0"
-source = "git+http://127.0.0.1:7878/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
+source = "git+https://github.com/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
 dependencies = [
  "bytes",
  "dioxus",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.21.1"
+version = "0.25.1"
 dependencies = [
  "jiff",
  "prometheus-client",
@@ -4992,7 +4992,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.21.1"
+version = "0.25.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5011,7 +5011,7 @@ dependencies = [
 [[package]]
 name = "skeue"
 version = "1.2.0"
-source = "git+http://127.0.0.1:7878/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
+source = "git+https://github.com/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
 dependencies = [
  "dioxus",
  "gramma",
@@ -5362,7 +5362,7 @@ dependencies = [
 [[package]]
 name = "themelion"
 version = "1.2.0"
-source = "git+http://127.0.0.1:7878/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
+source = "git+https://github.com/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
 dependencies = [
  "dioxus",
  "serde",

--- a/crates/theatron/proskenion/README.md
+++ b/crates/theatron/proskenion/README.md
@@ -4,3 +4,11 @@ Dioxus desktop UI for the Aletheia distributed cognition system.
 
 Excluded from the main workspace due to GTK/webkit2gtk system dependencies.
 See [docs/DESKTOP.md](../../../docs/DESKTOP.md) for build instructions.
+
+## Pin Discipline
+
+This crate is its own standalone Cargo workspace, so the theatron dependencies
+in its `[workspace.dependencies]` block must mirror the root Aletheia
+`[workspace.dependencies]` pins. Run `scripts/check-proskenion-pins.py` from
+the repository root before changing those pins; the installer and release
+workflow run the same check.

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -39,6 +39,18 @@ cargo build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml
 cargo build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml --release
 ```
 
+## Pin discipline
+
+`proskenion` has its own standalone workspace, so its theatron git dependencies cannot inherit from the root `[workspace.dependencies]` block. Keep the mirrored pins in `crates/theatron/proskenion/Cargo.toml` aligned with the root manifest.
+
+Run the pin check before changing the desktop pins:
+
+```bash
+scripts/check-proskenion-pins.py
+```
+
+The standard installer runs this check before building, and the release workflow runs it before the release test suite.
+
 ## Why excluded from workspace
 
 1. **CI compatibility.** GTK3 and webkit2gtk are not installed in the CI environment. Including the crate in the workspace would fail `cargo build --workspace` and `cargo clippy --workspace`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -14,6 +14,7 @@ The canonical version lives in `Cargo.toml` at `[workspace.package].version`. Al
 3. Review and merge the release PR
 4. release-please creates a git tag (`vX.Y.Z`) and GitHub Release
 5. The tag triggers `.github/workflows/release.yml`:
+   - Verifies proskenion's standalone theatron pins match the root workspace
    - Runs the full test suite
    - Builds cross-platform binaries (4 targets)
    - Generates SHA256 checksums per binary

--- a/scripts/check-proskenion-pins.py
+++ b/scripts/check-proskenion-pins.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Verify proskenion's standalone theatron pins match the root workspace."""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+import logging
+from pathlib import Path
+
+
+THEATRON_DEPS = ("bathron", "gramma", "skeue", "themelion")
+PIN_KEYS = ("git", "tag", "rev", "branch", "features", "default-features")
+LOGGER = logging.getLogger("check-proskenion-pins")
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def workspace_deps(manifest: Path) -> dict:
+    data = load_toml(manifest)
+    return data.get("workspace", {}).get("dependencies", {})
+
+
+def normalized_pin(dep: object) -> dict:
+    if not isinstance(dep, dict):
+        return {"value": dep}
+    return {key: dep.get(key) for key in PIN_KEYS if key in dep}
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    root_manifest = repo_root / "Cargo.toml"
+    proskenion_manifest = repo_root / "crates" / "theatron" / "proskenion" / "Cargo.toml"
+
+    root_deps = workspace_deps(root_manifest)
+    proskenion_deps = workspace_deps(proskenion_manifest)
+    errors: list[str] = []
+    root_missing = {dep_name for dep_name in THEATRON_DEPS if dep_name not in root_deps}
+    proskenion_missing = {
+        dep_name for dep_name in THEATRON_DEPS if dep_name not in proskenion_deps
+    }
+
+    for dep_name in THEATRON_DEPS:
+        if dep_name in root_missing:
+            errors.append(f"{dep_name}: missing from root [workspace.dependencies]")
+            continue
+        if dep_name in proskenion_missing:
+            errors.append(f"{dep_name}: missing from proskenion [workspace.dependencies]")
+            continue
+
+        root_pin = root_deps[dep_name]
+        proskenion_pin = proskenion_deps[dep_name]
+        root_norm = normalized_pin(root_pin)
+        proskenion_norm = normalized_pin(proskenion_pin)
+        if root_norm != proskenion_norm:
+            errors.append(
+                f"{dep_name}: root pin {root_norm!r} != proskenion pin {proskenion_norm!r}"
+            )
+
+    if errors:
+        LOGGER.error("proskenion theatron pin check failed:")
+        for error in errors:
+            LOGGER.error("  - %s", error)
+        LOGGER.error(
+            "Update crates/theatron/proskenion/Cargo.toml to mirror the root "
+            "[workspace.dependencies] pins."
+        )
+        return 1
+
+    LOGGER.info("proskenion theatron pins match root workspace")
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stderr)
+    raise SystemExit(main())

--- a/scripts/install-proskenion.sh
+++ b/scripts/install-proskenion.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MANIFEST="$REPO_ROOT/crates/theatron/proskenion/Cargo.toml"
+PIN_CHECK="$REPO_ROOT/scripts/check-proskenion-pins.py"
 DEFAULT_TARGET_DIR="$REPO_ROOT/crates/theatron/proskenion/target"
 TARGET_DIR="${CARGO_TARGET_DIR:-$DEFAULT_TARGET_DIR}"
 INSTALL_DIR="${PROSKENION_INSTALL_DIR:-$HOME/.cargo/bin}"
@@ -98,11 +99,19 @@ preflight_linux_deps() {
     log "Desktop system dependency preflight passed."
 }
 
+preflight_pin_alignment() {
+    if [[ ! -x "$PIN_CHECK" ]]; then
+        die "proskenion pin check is not executable at ${PIN_CHECK}"
+    fi
+    "$PIN_CHECK"
+}
+
 if [[ ! -f "$MANIFEST" ]]; then
     die "proskenion manifest not found at ${MANIFEST}"
 fi
 
 if [[ "$SKIP_PREFLIGHT" == false ]]; then
+    preflight_pin_alignment
     preflight_linux_deps
 else
     log "Skipping GTK/WebKit preflight by request."


### PR DESCRIPTION
## Summary
- add `scripts/check-proskenion-pins.py` to compare proskenion standalone theatron pins against the root workspace
- run the pin check from the proskenion installer and release workflow
- document the dual-workspace pin discipline and refresh the standalone Cargo.lock away from the old local forge URL
- cross-link the root workspace exclusion comment to `docs/DESKTOP.md`

Closes #3880.

## Validation
- `scripts/check-proskenion-pins.py`
- `scripts/install-proskenion.sh --dry-run`
- `CARGO_TARGET_DIR=/data/target/wt/issue-3880-proskenion-build-repro/target cargo +1.94 check -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml`
- `cargo +1.94 fmt --check`
- `RUST_LOG=error /home/ck/.local/bin/kanon lint --summary scripts/check-proskenion-pins.py`
- `RUST_LOG=error /home/ck/.local/bin/kanon lint --summary scripts/install-proskenion.sh`
- `RUST_LOG=error /home/ck/.local/bin/kanon lint --summary Cargo.toml`
- `RUST_LOG=error /home/ck/.local/bin/kanon lint --summary .github/workflows/release.yml`
- `RUST_LOG=error /home/ck/.local/bin/kanon lint --summary docs/DESKTOP.md`
- `RUST_LOG=error /home/ck/.local/bin/kanon lint --summary docs/RELEASING.md`
- `RUST_LOG=error /home/ck/.local/bin/kanon lint --summary crates/theatron/proskenion/README.md`
- `git diff --check`

## Known baseline
- `cargo +1.94 clippy -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml -- -D warnings` still fails on the existing proskenion lint backlog (72 pre-existing findings, e.g. collapsible-if, clone-on-copy, double-must-use). This PR does not touch the affected Rust sources.