### PR TITLE
fix(daemon): install prosoche heartbeat timer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "agora",
  "anyhow",
@@ -177,11 +177,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.25.1"
+version = "0.25.2"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "jiff",
  "koina",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "futures",
  "jiff",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "jiff",
  "koina",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "eidos",
  "jiff",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "jiff",
  "koina",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "aletheia-routing",
  "compact_str",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "cargo_metadata",
  "parking_lot",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "criterion",
  "eidos",
@@ -3766,7 +3766,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "criterion",
  "jiff",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -4693,7 +4693,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "arboard",
  "clap",
@@ -4727,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "criterion",
  "fjall",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5352,7 +5352,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "eidos",
  "episteme",
@@ -5670,7 +5670,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6454,7 +6454,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "jiff",
  "snafu",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "docx-rs",
  "quick-xml 0.39.2",
@@ -6487,7 +6487,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -6503,7 +6503,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -6515,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -6549,7 +6549,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -6562,7 +6562,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "krilla 0.7.0",
  "poiesis-core",
@@ -6572,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "comemo",
  "jiff",
@@ -6588,7 +6588,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6975,7 +6975,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -8392,7 +8392,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8739,7 +8739,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -8858,7 +8858,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -8970,14 +8970,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -10,6 +10,7 @@ use oikonomos::maintenance::{
     FjallBackupConfig, MaintenanceConfig, PromptAuditRetentionConfig, PromptAuditRotator,
     ProposeRulesConfig, TraceRotationConfig, TraceRotator,
 };
+use oikonomos::prosoche_audit::{ProsocheAuditRunner, ProsocheState};
 use oikonomos::runner::TaskRunner;
 use taxis::loader::load_config;
 use taxis::oikos::Oikos;
@@ -27,7 +28,7 @@ pub(crate) enum Action {
     },
     /// Run a specific maintenance task immediately
     Run {
-        /// Task name: trace-rotation, drift-detection, db-monitor, or all
+        /// Task name: trace-rotation, drift-detection, db-monitor, prosoche-self-audit, or all
         task: String,
         /// List individual files (drift-detection only)
         #[arg(long)]
@@ -35,7 +36,7 @@ pub(crate) enum Action {
     },
 }
 
-pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
+pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()> {
     let oikos = match instance_root {
         Some(root) => Oikos::from_root(root),
         None => Oikos::discover(),
@@ -78,7 +79,7 @@ pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()>
                 vec![task.as_str()]
             };
             for name in tasks {
-                run_task(name, &maint, verbose)?;
+                run_task(name, &maint, verbose).await?;
             }
         }
     }
@@ -86,7 +87,7 @@ pub(crate) fn run(action: Action, instance_root: Option<&PathBuf>) -> Result<()>
 }
 
 /// Execute a single maintenance task by name.
-fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> {
+async fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> {
     match name {
         "trace-rotation" => {
             let report = TraceRotator::new(maint.trace_rotation.clone())
@@ -177,8 +178,22 @@ fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Result<()> 
                 }
             }
         }
+        "prosoche-self-audit" => {
+            let runner = ProsocheAuditRunner::default_checks(&maint.prosoche_audit_dir);
+            let state = ProsocheState {
+                nous_id: String::from("system"),
+                checked_at: jiff::Timestamp::now().to_string(),
+                ..ProsocheState::default()
+            };
+            let report = runner.run_audit(&state).await;
+            println!(
+                "prosoche-self-audit: {} findings across {} checks",
+                report.findings.len(),
+                report.check_summary.len()
+            );
+        }
         other => whatever!(
-            "unknown task: {other}. Valid: trace-rotation, drift-detection, db-monitor, fjall-backup, prompt-audit-rotation, self-audit, all"
+            "unknown task: {other}. Valid: trace-rotation, drift-detection, db-monitor, fjall-backup, prompt-audit-rotation, self-audit, prosoche-self-audit, all"
         ),
     }
     Ok(())

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -159,44 +159,48 @@ async fn run_task(name: &str, maint: &MaintenanceConfig, verbose: bool) -> Resul
                 report.files_pruned, report.bytes_freed
             );
         }
-        "self-audit" => {
-            use nous::self_audit::{AuditTrigger, CheckContext, SelfAuditor};
-            let mut auditor = SelfAuditor::new();
-            auditor.register_defaults();
-            let ctx = CheckContext {
-                nous_id: String::from("system"),
-                ..Default::default()
-            };
-            let report = auditor.run_audit(&ctx, AuditTrigger::Manual);
-            for r in &report.results {
-                println!(
-                    "  {}: {} (score: {:.2})",
-                    r.check_name, r.result.status, r.result.score,
-                );
-                if r.result.status != nous::self_audit::CheckStatus::Pass {
-                    println!("    evidence: {}", r.result.evidence);
-                }
-            }
-        }
-        "prosoche-self-audit" => {
-            let runner = ProsocheAuditRunner::default_checks(&maint.prosoche_audit_dir);
-            let state = ProsocheState {
-                nous_id: String::from("system"),
-                checked_at: jiff::Timestamp::now().to_string(),
-                ..ProsocheState::default()
-            };
-            let report = runner.run_audit(&state).await;
-            println!(
-                "prosoche-self-audit: {} findings across {} checks",
-                report.findings.len(),
-                report.check_summary.len()
-            );
-        }
+        "self-audit" => run_self_audit(),
+        "prosoche-self-audit" => run_prosoche_self_audit(maint).await,
         other => whatever!(
             "unknown task: {other}. Valid: trace-rotation, drift-detection, db-monitor, fjall-backup, prompt-audit-rotation, self-audit, prosoche-self-audit, all"
         ),
     }
     Ok(())
+}
+
+fn run_self_audit() {
+    use nous::self_audit::{AuditTrigger, CheckContext, SelfAuditor};
+    let mut auditor = SelfAuditor::new();
+    auditor.register_defaults();
+    let ctx = CheckContext {
+        nous_id: String::from("system"),
+        ..Default::default()
+    };
+    let report = auditor.run_audit(&ctx, AuditTrigger::Manual);
+    for r in &report.results {
+        println!(
+            "  {}: {} (score: {:.2})",
+            r.check_name, r.result.status, r.result.score,
+        );
+        if r.result.status != nous::self_audit::CheckStatus::Pass {
+            println!("    evidence: {}", r.result.evidence);
+        }
+    }
+}
+
+async fn run_prosoche_self_audit(maint: &MaintenanceConfig) {
+    let runner = ProsocheAuditRunner::default_checks(&maint.prosoche_audit_dir);
+    let state = ProsocheState {
+        nous_id: String::from("system"),
+        checked_at: jiff::Timestamp::now().to_string(),
+        ..ProsocheState::default()
+    };
+    let report = runner.run_audit(&state).await;
+    println!(
+        "prosoche-self-audit: {} findings across {} checks",
+        report.findings.len(),
+        report.check_summary.len()
+    );
 }
 
 /// Build a `MaintenanceConfig` from the oikos layout and config settings.

--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -87,9 +87,9 @@ pub(crate) async fn dispatch(cmd: Command, instance_root: Option<&PathBuf>) -> R
             }
         }
         Command::Backup(a) => backup::run(instance_root, &a).map_err(Into::into),
-        Command::Maintenance { action } => {
-            maintenance::run(action, instance_root).map_err(Into::into)
-        }
+        Command::Maintenance { action } => maintenance::run(action, instance_root)
+            .await
+            .map_err(Into::into),
         Command::PromptAudit { action } => {
             prompt_audit::run(action, instance_root).map_err(Into::into)
         }

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -343,6 +343,22 @@ Healthy response:
 
 Status values: `healthy` (all pass), `degraded` (warnings, e.g. no LLM provider), `unhealthy` (failures).
 
+## Prosoche heartbeat timer
+
+The optional user timer checks the running server and then executes the local
+prosoche self-audit task. The timer starts one minute after activation and runs
+every five minutes.
+
+```bash
+install -m 0755 scripts/aletheia-heartbeat.sh ~/.local/bin/aletheia-heartbeat
+mkdir -p ~/.config/systemd/user
+cp instance.example/services/aletheia-health.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now aletheia-health.timer
+systemctl --user status aletheia-health.timer
+journalctl --user -u aletheia-health --since "30 minutes ago"
+```
+
 ## System status
 
 ```bash

--- a/docs/PROSOCHE.md
+++ b/docs/PROSOCHE.md
@@ -147,8 +147,19 @@ pub trait DaemonBridge: Send + Sync {
 # Check maintenance task status (includes prosoche)
 aletheia maintenance status
 
+# Run the local prosoche self-audit immediately
+aletheia maintenance run prosoche-self-audit
+
+# Install the user-systemd heartbeat timer
+install -m 0755 scripts/aletheia-heartbeat.sh ~/.local/bin/aletheia-heartbeat
+mkdir -p ~/.config/systemd/user
+cp instance.example/services/aletheia-health.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now aletheia-health.timer
+
 # View prosoche activity in logs
 journalctl --user -u aletheia --since "1 hour ago" | grep prosoche
+journalctl --user -u aletheia-health --since "1 hour ago"
 ```
 
 Prosoche workspace files have **priority 7** in the token budget; they are dropped before semi-static files (MEMORY, TOOLS) under budget pressure, but SOUL.md is never dropped.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -245,6 +245,17 @@ The attention subsystem runs periodic background checks. Your agent surveys its 
 
 Each agent has a `PROSOCHE.md` workspace file defining what to check. The default agent template includes a starter checklist. To configure the heartbeat schedule, see [PROSOCHE.md](PROSOCHE.md).
 
+For the user-systemd heartbeat, install the entrypoint and timer:
+
+```bash
+install -m 0755 scripts/aletheia-heartbeat.sh ~/.local/bin/aletheia-heartbeat
+mkdir -p ~/.config/systemd/user
+cp instance.example/services/aletheia-health.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now aletheia-health.timer
+systemctl --user status aletheia-health.timer
+```
+
 ---
 
 ## Upgrade

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -83,15 +83,23 @@ curl -sf http://localhost:18789/api/health | jq .
 ## Health monitoring
 
 ```bash
-# One-off check:
+# One-off health check:
 scripts/health-monitor.sh
 
 # With Signal notification on failure:
 scripts/health-monitor.sh --notify
 
-# Systemd timer (every 5 minutes):
+# One-off prosoche heartbeat:
+scripts/aletheia-heartbeat.sh
+
+# User systemd prosoche timer (first tick after 60s, then every 5 minutes):
+install -m 0755 scripts/aletheia-heartbeat.sh ~/.local/bin/aletheia-heartbeat
+mkdir -p ~/.config/systemd/user
 cp instance.example/services/aletheia-health.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
 systemctl --user enable --now aletheia-health.timer
+systemctl --user status aletheia-health.timer
+journalctl --user -u aletheia-health --since "30 minutes ago"
 ```
 
 ---

--- a/instance.example/services/aletheia-health.service
+++ b/instance.example/services/aletheia-health.service
@@ -1,9 +1,11 @@
 [Unit]
-Description=Aletheia health check
+Description=Aletheia prosoche heartbeat
+Requires=aletheia.service
 After=aletheia.service
 
 [Service]
 Type=oneshot
-ExecStart=%h/aletheia/scripts/health-monitor.sh  # CUSTOMIZE: path to health-monitor.sh
-StandardOutput=append:%h/aletheia/instance/logs/health.log  # CUSTOMIZE: path to instance logs
-StandardError=append:%h/aletheia/instance/logs/health.log  # CUSTOMIZE: path to instance logs
+Environment=ALETHEIA_URL=http://127.0.0.1:18789
+ExecStart=%h/.local/bin/aletheia-heartbeat
+StandardOutput=journal
+StandardError=journal

--- a/instance.example/services/aletheia-health.timer
+++ b/instance.example/services/aletheia-health.timer
@@ -1,5 +1,6 @@
 [Unit]
-Description=Aletheia health check timer
+Description=Aletheia prosoche heartbeat timer
+Requires=aletheia.service
 
 [Timer]
 OnActiveSec=60

--- a/scripts/aletheia-heartbeat.sh
+++ b/scripts/aletheia-heartbeat.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# User-systemd entrypoint for the D3 prosoche heartbeat.
+
+ALETHEIA_BIN="${ALETHEIA_BIN:-aletheia}"
+ALETHEIA_URL="${ALETHEIA_URL:-http://127.0.0.1:18789}"
+HEARTBEAT_TASK="${ALETHEIA_HEARTBEAT_TASK:-prosoche-self-audit}"
+
+timestamp() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+log() {
+    printf '%s %s\n' "$(timestamp)" "$*"
+}
+
+log "heartbeat: checking server at ${ALETHEIA_URL}"
+if ! "${ALETHEIA_BIN}" health --url "${ALETHEIA_URL}"; then
+    log "heartbeat: server unavailable or unhealthy"
+    exit 1
+fi
+
+log "heartbeat: running maintenance task ${HEARTBEAT_TASK}"
+if ! "${ALETHEIA_BIN}" maintenance run "${HEARTBEAT_TASK}"; then
+    log "heartbeat: maintenance task failed: ${HEARTBEAT_TASK}"
+    exit 1
+fi
+
+log "heartbeat: complete"


### PR DESCRIPTION
## Summary
- add `prosoche-self-audit` as a runnable maintenance task
- make the maintenance CLI async so it can invoke the prosoche audit runner directly
- add `scripts/aletheia-heartbeat.sh` to health-check the daemon and run the audit task
- wire the sample `aletheia-health` systemd service/timer to the heartbeat script and document install/status checks

Closes #3907.
Closes #3908.

## Validation
- `bash -n scripts/aletheia-heartbeat.sh`
- `cargo +1.94 fmt --check`
- `CARGO_TARGET_DIR=/data/target/wt/d3-prosoche-heartbeat/target cargo +1.94 check -p aletheia -p oikonomos`
- `CARGO_TARGET_DIR=/data/target/wt/d3-prosoche-heartbeat/target cargo +1.94 clippy -p aletheia -p oikonomos -- -D warnings`
- `kanon lint --summary crates/aletheia/src/commands/mod.rs`
- `kanon lint --summary crates/aletheia/src/commands/maintenance.rs`
- `kanon lint --summary scripts/aletheia-heartbeat.sh`
- `kanon lint --summary instance.example/services/aletheia-health.service`
- `kanon lint --summary instance.example/services/aletheia-health.timer`
- `kanon lint --summary docs/RUNBOOK.md`
- `kanon lint --summary docs/PROSOCHE.md`
- `kanon lint --summary docs/QUICKSTART.md`
- `kanon lint --summary docs/DEPLOYMENT.md`
- `git diff --check origin/main`
