### PR TITLE
docs(nous): bound D3 prosoche heartbeat checklist

### DIFF
--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -190,6 +190,68 @@ mod pronoea_template {
         include_str!("../../../../instance.example/nous/_default/WORKFLOWS.md");
 }
 
+#[cfg(test)]
+mod tests {
+    use super::pronoea_template;
+
+    const TEMPLATE_PROSOCHE: &str =
+        include_str!("../../../../instance.example/nous/_template/PROSOCHE.md");
+
+    #[test]
+    fn prosoche_templates_keep_heartbeat_bounded() {
+        for (name, content) in [
+            ("_default/PROSOCHE.md", pronoea_template::PROSOCHE),
+            ("_template/PROSOCHE.md", TEMPLATE_PROSOCHE),
+        ] {
+            assert!(
+                content.contains("60 seconds"),
+                "{name} must state the heartbeat time budget"
+            );
+            assert!(
+                content.contains("5 tool calls"),
+                "{name} must state the heartbeat tool-call budget"
+            );
+            assert!(
+                content.contains("only the numbered"),
+                "{name} must keep the daemon prompt bounded to numbered checks"
+            );
+            assert!(
+                content.contains("Do not investigate") || content.contains("Do NOT investigate"),
+                "{name} must forbid investigation during heartbeat"
+            );
+            assert!(
+                !content.contains("gcal"),
+                "{name} must not reference stale calendar tooling"
+            );
+            assert!(
+                !contains_tw_command(content),
+                "{name} must not reference stale taskwarrior tooling"
+            );
+            assert!(
+                numbered_check_count(content) <= 5,
+                "{name} must fit within the 5-tool-call heartbeat budget"
+            );
+        }
+    }
+
+    fn contains_tw_command(content: &str) -> bool {
+        content.lines().any(|line| {
+            let command = line.trim();
+            command == "tw" || command.starts_with("tw ")
+        })
+    }
+
+    fn numbered_check_count(content: &str) -> usize {
+        content
+            .lines()
+            .filter(|line| {
+                let heading = line.trim_start_matches('#').trim_start();
+                heading.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+            })
+            .count()
+    }
+}
+
 pub(super) fn render_config(a: &Answers) -> String {
     // WHY: workspace is stored relative to the instance root so the config
     // works regardless of where the instance directory is placed on disk.

--- a/instance.example/nous/_default/PROSOCHE.md
+++ b/instance.example/nous/_default/PROSOCHE.md
@@ -4,6 +4,8 @@ Prosoche (προσοχή) = directed attention. Checked on each heartbeat tick. 
 
 ## Heartbeat checklist
 
+On each heartbeat tick, execute only the numbered checks below. Stay within 60 seconds and 5 tool calls total. Do not investigate, research, or explore beyond these checks.
+
 ### 1. Instance health
 ```bash
 aletheia health
@@ -30,6 +32,7 @@ Something needs attention: one line per item. No investigation, no research. Jus
 
 ## Rules
 
+- 60 seconds maximum per tick
 - 5 tool calls maximum per tick
 - Check and report. Do not fix, investigate, or research during heartbeat.
 - If a check fails, skip it and note the failure

--- a/instance.example/nous/_template/PROSOCHE.md
+++ b/instance.example/nous/_template/PROSOCHE.md
@@ -4,27 +4,22 @@ Prosoche (προσοχή) = directed attention. This file defines what the agent
 
 ## Heartbeat checklist
 
-On each heartbeat tick, execute **only** the numbered items below. Do not investigate, research, or explore beyond these checks.
+On each heartbeat tick, execute only the numbered checks below. Stay within 60 seconds and 5 tool calls total. Do not investigate, research, or explore beyond these checks.
 
-## 1. Calendar (next 4 hours)
+## 1. Instance health
 ```bash
-# Replace with your calendar command(s)
-gcal today -c your@calendar.id
+aletheia health
 ```
-Flag anything starting within 4 hours that the operator might not be aware of.
+Flag if the instance is unhealthy or unreachable.
 
-## 2. Tasks due today
-```bash
-# Replace with your task manager command
-tw
-```
-Flag any tasks due today or overdue.
+## 2. Active goals
+Scan GOALS.md for anything overdue or blocked.
 
-## 3. System health
-```bash
-nous-health
-```
-Flag any agent that's unhealthy or unreachable.
+## 3. Memory hygiene
+Is MEMORY.md current? Any stale entries? Any recent session observations that should be recorded?
+
+## 4. Workspace cleanliness
+Any temp files, orphaned state, or cruft that accumulated?
 
 ## Response format
 
@@ -39,6 +34,7 @@ If something needs attention, send a brief alert to the operator. One line per i
 - Do NOT read other agents' workspaces
 - Do NOT run sudo commands
 - Do NOT investigate or research - just check and report
+- Finish within 60 seconds
 - Maximum 5 tool calls per tick
 - If a check fails, skip it and note the failure
 
@@ -48,4 +44,5 @@ Add or remove checklist items as needed for your deployment. The key constraints
 - **Numbered items only** - the heartbeat cron references this checklist directly
 - **Commands, not prose** - each item should have a concrete command to run
 - **Hard ceiling on tool calls** - keep the total under 5 to avoid token waste
+- **Hard ceiling on time** - keep the tick under 60 seconds
 - **Binary response** - either HEARTBEAT_OK or actionable alerts, nothing in between


### PR DESCRIPTION
## Summary
- bound default and template PROSOCHE heartbeat checklists to 60 seconds and 5 tool calls
- removed stale calendar/taskwarrior references from the template checklist
- added a smoke-style unit test that keeps PROSOCHE heartbeat prompts bounded and non-investigative

Closes #3909.

## Validation
- cargo +1.94 fmt --check
- git diff --check
- CARGO_TARGET_DIR=/data/target/wt/d3-prosoche-budget/target cargo +1.94 test -p aletheia prosoche_templates_keep_heartbeat_bounded
- kanon lint --summary instance.example/nous/_default/PROSOCHE.md
- kanon lint --summary instance.example/nous/_template/PROSOCHE.md
- kanon lint --summary crates/aletheia/src/init/scaffold.rs