### PR TITLE
feat(hermeneus): add OpenAI Responses provider path

### DIFF
--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -13,7 +13,9 @@ use agora::semeion::SignalProvider;
 use agora::semeion::client::SignalClient;
 use agora::types::ChannelProvider;
 use hermeneus::anthropic::{AnthropicProvider, ProviderBehavior};
-use hermeneus::openai::{OpenAiProvider, OpenAiProviderConfig};
+use hermeneus::openai::{
+    OpenAiApiFamily as HermeneusOpenAiApiFamily, OpenAiProvider, OpenAiProviderConfig,
+};
 use hermeneus::provider::{
     DeploymentTarget as HermeneusDeploymentTarget, ProviderConfig, ProviderRegistry,
 };
@@ -245,6 +247,33 @@ fn map_deployment_target(src: taxis::config::DeploymentTarget) -> HermeneusDeplo
     }
 }
 
+fn map_openai_api_family(src: taxis::config::OpenAiApiFamily) -> HermeneusOpenAiApiFamily {
+    use taxis::config::OpenAiApiFamily as TaxisOpenAiApiFamily;
+    match src {
+        TaxisOpenAiApiFamily::Responses => HermeneusOpenAiApiFamily::Responses,
+        // WHY: future taxis variants should not silently move local
+        // OpenAI-compatible endpoints onto a cloud-only wire contract.
+        TaxisOpenAiApiFamily::ChatCompletions | _ => HermeneusOpenAiApiFamily::ChatCompletions,
+    }
+}
+
+fn configured_openai_api_family(
+    entry: &taxis::config::LlmProviderConfig,
+) -> HermeneusOpenAiApiFamily {
+    use taxis::config::ProviderKind;
+
+    entry.api_family.map_or_else(
+        || {
+            if entry.kind == ProviderKind::OpenAi {
+                HermeneusOpenAiApiFamily::Responses
+            } else {
+                HermeneusOpenAiApiFamily::ChatCompletions
+            }
+        },
+        map_openai_api_family,
+    )
+}
+
 /// Iterate `config.providers` and register each entry with the provider
 /// registry (#3424, #3414).
 ///
@@ -259,6 +288,7 @@ fn register_declared_providers(registry: &mut ProviderRegistry, config: &Alethei
     for entry in &config.providers {
         match entry.kind {
             ProviderKind::OpenAi | ProviderKind::OpenAiCompatible => {
+                let api_family = configured_openai_api_family(entry);
                 let base_url = if entry.kind == ProviderKind::OpenAi {
                     entry
                         .base_url
@@ -297,6 +327,7 @@ fn register_declared_providers(registry: &mut ProviderRegistry, config: &Alethei
                     base_url,
                     api_key,
                     models: entry.models.clone(),
+                    api_family,
                     // WHY (#3736): the operator-declared deployment target
                     // was previously logged below but never threaded to the
                     // provider, so every OpenAI-compat provider silently
@@ -312,8 +343,9 @@ fn register_declared_providers(registry: &mut ProviderRegistry, config: &Alethei
                         info!(
                             provider = %entry.name,
                             target = ?entry.deployment_target,
+                            api_family = ?api_family,
                             models = ?entry.models,
-                            "OpenAI-compatible provider registered"
+                            "OpenAI provider registered"
                         );
                         registry.register(Box::new(provider));
                     }
@@ -735,5 +767,31 @@ mod tests {
         assert!(message.contains("failed to register channel provider 'signal'"));
         let source = error.source().expect("duplicate channel source");
         assert!(source.to_string().contains("duplicate channel: signal"));
+    }
+
+    #[test]
+    fn openai_api_family_mapping_and_defaults_are_explicit() {
+        use taxis::config::{DeploymentTarget, LlmProviderConfig, ProviderKind};
+
+        let mut entry = LlmProviderConfig {
+            name: "openai-cloud".to_owned(),
+            kind: ProviderKind::OpenAi,
+            base_url: None,
+            api_key_env: None,
+            api_family: None,
+            deployment_target: DeploymentTarget::Cloud,
+            models: vec!["gpt-5".to_owned()],
+        };
+        assert_eq!(
+            configured_openai_api_family(&entry),
+            HermeneusOpenAiApiFamily::Responses
+        );
+
+        entry.kind = ProviderKind::OpenAiCompatible;
+        entry.base_url = Some("http://127.0.0.1:8088/v1".to_owned());
+        assert_eq!(
+            configured_openai_api_family(&entry),
+            HermeneusOpenAiApiFamily::ChatCompletions
+        );
     }
 }

--- a/crates/hermeneus/src/openai/client.rs
+++ b/crates/hermeneus/src/openai/client.rs
@@ -1,9 +1,10 @@
-//! OpenAI-compatible HTTP client implementing [`LlmProvider`].
+//! OpenAI HTTP client implementing [`LlmProvider`].
 //!
-//! Talks to any endpoint that exposes the OpenAI `/v1/chat/completions`
-//! surface — OpenAI itself, llama.cpp `--server`, ollama, vllm, or any
-//! compatible proxy. The wire translation lives in [`super::wire`]; this
-//! module is the transport, retry, and registration shell.
+//! Talks to either the first-party OpenAI `/v1/responses` surface or the
+//! OpenAI-compatible `/v1/chat/completions` surface used by llama.cpp
+//! `--server`, ollama, vllm, and compatible proxies. The wire translation
+//! lives in [`super::wire`]; this module is the transport, retry, and
+//! registration shell.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -23,12 +24,47 @@ use crate::provider::{DeploymentTarget, LlmProvider};
 use crate::types::{CompletionRequest, CompletionResponse};
 
 use super::error::{map_error_response, map_request_error};
-use super::wire::{ChatCompletionRequest, ChatCompletionResponse, parse_sse_response};
+use super::wire::{
+    ChatCompletionRequest, ChatCompletionResponse, ResponsesRequest, ResponsesResponse,
+    parse_chat_sse_response, parse_responses_sse_response,
+};
+
+/// OpenAI HTTP API family used by this provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum OpenAiApiFamily {
+    /// OpenAI `/v1/chat/completions` and compatible local/proxy endpoints.
+    #[default]
+    ChatCompletions,
+    /// OpenAI first-party `/v1/responses` endpoint.
+    Responses,
+}
+
+impl OpenAiApiFamily {
+    fn endpoint_path(self) -> &'static str {
+        match self {
+            Self::ChatCompletions => "chat/completions",
+            Self::Responses => "responses",
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ChatCompletions => "chat-completions",
+            Self::Responses => "responses",
+        }
+    }
+}
 
 /// Build an HTTP client with sensible timeouts shared by Anthropic and
 /// OpenAI-compatible providers.
 fn build_http_client() -> Result<Client> {
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    if rustls::crypto::ring::default_provider()
+        .install_default()
+        .is_err()
+    {
+        tracing::debug!("rustls crypto provider was already installed");
+    }
     Client::builder()
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_mins(2))
@@ -42,7 +78,7 @@ fn build_http_client() -> Result<Client> {
 }
 
 /// Configuration for an OpenAI-compatible provider instance.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct OpenAiProviderConfig {
     /// Operator-facing label used for logs, metrics, and `name()`.
     pub name: String,
@@ -63,6 +99,10 @@ pub struct OpenAiProviderConfig {
     /// Maximum retries on transient failures (5xx, timeout, connection
     /// reset). Defaults to 3.
     pub max_retries: u32,
+    /// Which OpenAI API family to speak. Defaults to Chat Completions for
+    /// backwards-compatible local `OpenAI`-compatible endpoints; Aletheia's
+    /// first-party `openai` config path sets this to [`OpenAiApiFamily::Responses`].
+    pub api_family: OpenAiApiFamily,
     /// Where this provider's traffic terminates, gating which
     /// [`FactSensitivity`](mneme::knowledge::FactSensitivity) the recall
     /// pipeline is allowed to send to it (#3736, #3404, #3413).
@@ -77,6 +117,21 @@ pub struct OpenAiProviderConfig {
     pub deployment_target: DeploymentTarget,
 }
 
+impl std::fmt::Debug for OpenAiProviderConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiProviderConfig")
+            .field("name", &self.name)
+            .field("base_url", &self.base_url)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .field("models", &self.models)
+            .field("request_timeout", &self.request_timeout)
+            .field("max_retries", &self.max_retries)
+            .field("api_family", &self.api_family)
+            .field("deployment_target", &self.deployment_target)
+            .finish()
+    }
+}
+
 impl Default for OpenAiProviderConfig {
     fn default() -> Self {
         Self {
@@ -86,6 +141,7 @@ impl Default for OpenAiProviderConfig {
             models: Vec::new(),
             request_timeout: Duration::from_mins(2),
             max_retries: 3,
+            api_family: OpenAiApiFamily::ChatCompletions,
             // WHY (#3736): the trait default is Cloud and we must mirror it
             // here so `..Default::default()` in call sites (e.g. the
             // declarative registration path in aletheia's setup.rs) does
@@ -139,9 +195,10 @@ impl OpenAiProvider {
         info!(
             provider = %config.name,
             base_url = %config.base_url,
+            api_family = %config.api_family.as_str(),
             models = ?config.models,
             authenticated = config.api_key.is_some(),
-            "OpenAI-compatible provider initialized"
+            "OpenAI provider initialized"
         );
 
         Ok(Self {
@@ -193,10 +250,6 @@ impl OpenAiProvider {
         self.execute_inner(request).instrument(span).await
     }
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "retry loop with span recording and metric emission at each exit point"
-    )]
     async fn execute_inner(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
         if let Err(health) = self.health.check_available() {
             return Err(error::ApiRequestSnafu {
@@ -206,18 +259,9 @@ impl OpenAiProvider {
         }
 
         let start = Instant::now();
-        let wire = ChatCompletionRequest::from_request(request, None)?;
-        let body = serde_json::to_string(&wire).map_err(|e| {
-            error::ApiRequestSnafu {
-                message: format!("failed to serialize request: {e}"),
-            }
-            .build()
-        })?;
-
-        let url = format!(
-            "{}/chat/completions",
-            self.config.base_url.trim_end_matches('/')
-        );
+        let body = self.serialize_request(request, None)?;
+        let url = self.endpoint_url();
+        let api_family = self.config.api_family.as_str();
 
         let mut last_error: Option<error::Error> = None;
 
@@ -256,15 +300,7 @@ impl OpenAiProvider {
                     }
                     .build()
                 })?;
-                let parsed: ChatCompletionResponse = serde_json::from_str(&text).map_err(|e| {
-                    error::ApiRequestSnafu {
-                        message: format!("failed to parse OpenAI response: {e}"),
-                    }
-                    .build()
-                })?;
-                let mut resp = parsed
-                    .into_response()
-                    .map_err(|msg| error::ApiRequestSnafu { message: msg }.build())?;
+                let mut resp = self.parse_response_body(&text)?;
                 self.health.record_success();
                 resp.duration_ms =
                     Some(u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX));
@@ -274,10 +310,11 @@ impl OpenAiProvider {
                 tracing::Span::current().record("llm.retries", attempt);
                 info!(
                     provider = %self.config.name,
+                    api_family,
                     model = %request.model,
                     tokens_in = resp.usage.input_tokens,
                     tokens_out = resp.usage.output_tokens,
-                    "OpenAI-compatible call complete"
+                    "OpenAI call complete"
                 );
                 crate::metrics::record_completion(
                     &self.config.name,
@@ -331,17 +368,8 @@ impl OpenAiProvider {
             .build());
         }
 
-        let wire = ChatCompletionRequest::from_request(request, Some(true))?;
-        let body = serde_json::to_string(&wire).map_err(|e| {
-            error::ApiRequestSnafu {
-                message: format!("failed to serialize request: {e}"),
-            }
-            .build()
-        })?;
-        let url = format!(
-            "{}/chat/completions",
-            self.config.base_url.trim_end_matches('/')
-        );
+        let body = self.serialize_request(request, Some(true))?;
+        let url = self.endpoint_url();
         let headers = self.build_headers()?;
 
         let mut response = self
@@ -360,9 +388,74 @@ impl OpenAiProvider {
             );
         }
 
-        let resp = parse_sse_response(&mut response, on_event).await?;
+        let resp = match self.config.api_family {
+            OpenAiApiFamily::ChatCompletions => {
+                parse_chat_sse_response(&mut response, on_event).await?
+            }
+            OpenAiApiFamily::Responses => {
+                parse_responses_sse_response(&mut response, on_event).await?
+            }
+        };
         self.health.record_success();
         Ok(resp)
+    }
+
+    fn endpoint_url(&self) -> String {
+        format!(
+            "{}/{}",
+            self.config.base_url.trim_end_matches('/'),
+            self.config.api_family.endpoint_path()
+        )
+    }
+
+    fn serialize_request(
+        &self,
+        request: &CompletionRequest,
+        stream: Option<bool>,
+    ) -> Result<String> {
+        let body = match self.config.api_family {
+            OpenAiApiFamily::ChatCompletions => {
+                let wire = ChatCompletionRequest::from_request(request, stream)?;
+                serde_json::to_string(&wire)
+            }
+            OpenAiApiFamily::Responses => {
+                let wire = ResponsesRequest::from_request(request, stream)?;
+                serde_json::to_string(&wire)
+            }
+        };
+        body.map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("failed to serialize request: {e}"),
+            }
+            .build()
+        })
+    }
+
+    fn parse_response_body(&self, text: &str) -> Result<CompletionResponse> {
+        match self.config.api_family {
+            OpenAiApiFamily::ChatCompletions => {
+                let parsed: ChatCompletionResponse = serde_json::from_str(text).map_err(|e| {
+                    error::ApiRequestSnafu {
+                        message: format!("failed to parse OpenAI chat response: {e}"),
+                    }
+                    .build()
+                })?;
+                parsed
+                    .into_response()
+                    .map_err(|msg| error::ApiRequestSnafu { message: msg }.build())
+            }
+            OpenAiApiFamily::Responses => {
+                let parsed: ResponsesResponse = serde_json::from_str(text).map_err(|e| {
+                    error::ApiRequestSnafu {
+                        message: format!("failed to parse OpenAI Responses response: {e}"),
+                    }
+                    .build()
+                })?;
+                parsed
+                    .into_response()
+                    .map_err(|msg| error::ApiRequestSnafu { message: msg }.build())
+            }
+        }
     }
 }
 
@@ -397,6 +490,7 @@ impl std::fmt::Debug for OpenAiProvider {
         f.debug_struct("OpenAiProvider")
             .field("name", &self.config.name)
             .field("base_url", &self.config.base_url)
+            .field("api_family", &self.config.api_family)
             .field("models", &self.config.models)
             .field("authenticated", &self.config.api_key.is_some())
             .finish_non_exhaustive()
@@ -484,7 +578,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deployment_target_propagates_from_config() {
+    fn deployment_target_propagates_from_config() {
         // WHY (#3736): regression for the sovereignty bug where
         // OpenAiProviderConfig.deployment_target was accepted in TOML,
         // logged at startup, then silently discarded. The recall

--- a/crates/hermeneus/src/openai/error.rs
+++ b/crates/hermeneus/src/openai/error.rs
@@ -48,7 +48,13 @@ pub(crate) async fn map_error_response(
     let status = response.status().as_u16();
     let retry_after_ms = extract_retry_after(&response);
 
-    let body = response.text().await.unwrap_or_default();
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(err) => {
+            tracing::debug!(error = %err, "failed to read OpenAI error response body");
+            String::new()
+        }
+    };
 
     let detail = serde_json::from_str::<WireErrorResponse>(&body)
         .ok()

--- a/crates/hermeneus/src/openai/mod.rs
+++ b/crates/hermeneus/src/openai/mod.rs
@@ -5,12 +5,13 @@
 // brand, so the lint is opted out at the module root only.
 #![allow(clippy::doc_markdown)]
 
-//! OpenAI Chat Completions-compatible LLM provider.
+//! OpenAI LLM provider.
 //!
-//! Talks to any endpoint that exposes the OpenAI `/v1/chat/completions`
-//! wire format — OpenAI itself, llama.cpp `--server`, ollama, vllm, or a
-//! compatible proxy. Intended primary use: local LLMs for air-gapped
-//! operation (#3414) and non-Anthropic cloud alternatives (#3424).
+//! Talks to the first-party OpenAI `/v1/responses` API or to endpoints
+//! exposing the OpenAI `/v1/chat/completions` wire format — llama.cpp
+//! `--server`, ollama, vllm, or a compatible proxy. Intended primary use:
+//! local LLMs for air-gapped operation (#3414) and non-Anthropic cloud
+//! alternatives (#3424).
 //!
 //! # Feature negotiation
 //!
@@ -47,7 +48,7 @@ mod client;
 mod error;
 mod wire;
 
-pub use client::{OpenAiProvider, OpenAiProviderConfig};
+pub use client::{OpenAiApiFamily, OpenAiProvider, OpenAiProviderConfig};
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]

--- a/crates/hermeneus/src/openai/tests.rs
+++ b/crates/hermeneus/src/openai/tests.rs
@@ -8,7 +8,7 @@
 use wiremock::matchers::{body_string_contains, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use crate::openai::{OpenAiProvider, OpenAiProviderConfig};
+use crate::openai::{OpenAiApiFamily, OpenAiProvider, OpenAiProviderConfig};
 use crate::provider::{LlmProvider, ProviderRegistry};
 use crate::types::{
     CompletionRequest, Content, ContentBlock, Message, Role, StopReason, ThinkingConfig,
@@ -24,6 +24,18 @@ fn mock_provider(server: &MockServer, models: Vec<String>) -> OpenAiProvider {
         ..OpenAiProviderConfig::default()
     };
     OpenAiProvider::new(cfg).expect("mock provider construct")
+}
+
+fn mock_responses_provider(server: &MockServer, models: Vec<String>) -> OpenAiProvider {
+    let cfg = OpenAiProviderConfig {
+        name: "test-openai-responses".to_owned(),
+        base_url: format!("{}/v1", server.uri()),
+        api_key: None,
+        models,
+        api_family: OpenAiApiFamily::Responses,
+        ..OpenAiProviderConfig::default()
+    };
+    OpenAiProvider::new(cfg).expect("mock responses provider construct")
 }
 
 fn basic_request(model: &str) -> CompletionRequest {
@@ -73,6 +85,46 @@ async fn non_streaming_text_round_trip() {
 }
 
 #[tokio::test]
+async fn responses_non_streaming_text_round_trip_uses_responses_endpoint() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .and(body_string_contains("\"model\":\"gpt-5\""))
+        .and(body_string_contains(
+            "\"instructions\":\"You are helpful.\"",
+        ))
+        .and(body_string_contains("\"max_output_tokens\":64"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "resp-1",
+            "model": "gpt-5",
+            "status": "completed",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "text": "hello from responses" }]
+            }],
+            "usage": { "input_tokens": 7, "output_tokens": 3, "total_tokens": 10 }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = mock_responses_provider(&server, vec!["gpt-5".to_owned()]);
+    let resp = provider
+        .complete(&basic_request("gpt-5"))
+        .await
+        .expect("completion succeeds");
+    assert_eq!(resp.id, "resp-1");
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+    assert_eq!(resp.usage.input_tokens, 7);
+    assert_eq!(resp.usage.output_tokens, 3);
+    match &resp.content[0] {
+        ContentBlock::Text { text, .. } => assert_eq!(text, "hello from responses"),
+        other => panic!("expected Text, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn tool_use_round_trip_maps_both_directions() {
     let server = MockServer::start().await;
 
@@ -105,6 +157,58 @@ async fn tool_use_round_trip_maps_both_directions() {
     let provider = mock_provider(&server, vec!["qwen".to_owned()]);
     let request = CompletionRequest {
         model: "qwen".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("weather in Paris?".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 64,
+        tools: vec![ToolDefinition {
+            name: "get_weather".to_owned(),
+            description: "Fetch weather".to_owned(),
+            input_schema: serde_json::json!({"type": "object"}),
+            disable_passthrough: None,
+        }],
+        ..Default::default()
+    };
+
+    let resp = provider.complete(&request).await.expect("completion");
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+    match &resp.content[0] {
+        ContentBlock::ToolUse { id, name, input } => {
+            assert_eq!(id, "call_7");
+            assert_eq!(name, "get_weather");
+            assert_eq!(input["city"], "Paris");
+        }
+        other => panic!("expected ToolUse, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn responses_tool_use_round_trip_maps_both_directions() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .and(body_string_contains("\"type\":\"function\""))
+        .and(body_string_contains("\"name\":\"get_weather\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "resp-tool",
+            "model": "gpt-5",
+            "status": "completed",
+            "output": [{
+                "type": "function_call",
+                "call_id": "call_7",
+                "name": "get_weather",
+                "arguments": "{\"city\":\"Paris\"}"
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = mock_responses_provider(&server, vec!["gpt-5".to_owned()]);
+    let request = CompletionRequest {
+        model: "gpt-5".to_owned(),
         messages: vec![Message {
             role: Role::User,
             content: Content::Text("weather in Paris?".to_owned()),
@@ -199,6 +303,74 @@ async fn auth_header_sent_when_api_key_present() {
     let provider = OpenAiProvider::new(cfg).expect("construct");
     let resp = provider.complete(&basic_request("qwen")).await.expect("ok");
     assert_eq!(resp.stop_reason, StopReason::EndTurn);
+}
+
+#[tokio::test]
+async fn responses_error_envelope_maps_to_provider_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "error": {
+                "message": "model does not support requested tool",
+                "type": "invalid_request_error",
+                "code": "unsupported_tool"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = mock_responses_provider(&server, vec!["gpt-5".to_owned()]);
+    let err = provider
+        .complete(&basic_request("gpt-5"))
+        .await
+        .expect_err("request should fail");
+    assert!(
+        err.to_string()
+            .contains("model does not support requested tool")
+    );
+}
+
+#[tokio::test]
+async fn responses_streaming_text_round_trip() {
+    let server = MockServer::start().await;
+    let sse = concat!(
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-stream\",\"model\":\"gpt-5\",\"status\":\"in_progress\",\"output\":[]}}\n\n",
+        "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"output_index\":0,\"content_index\":0,\"delta\":\"Hel\"}\n\n",
+        "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"output_index\":0,\"content_index\":0,\"delta\":\"lo\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-stream\",\"model\":\"gpt-5\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\"}]}],\"usage\":{\"input_tokens\":4,\"output_tokens\":1,\"total_tokens\":5}}}\n\n"
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .and(body_string_contains("\"stream\":true"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = mock_responses_provider(&server, vec!["gpt-5".to_owned()]);
+    let mut events = Vec::new();
+    let resp = provider
+        .complete_streaming(&basic_request("gpt-5"), &mut |event| events.push(event))
+        .await
+        .expect("streaming completion succeeds");
+
+    assert_eq!(resp.id, "resp-stream");
+    assert_eq!(resp.usage.input_tokens, 4);
+    match &resp.content[0] {
+        ContentBlock::Text { text, .. } => assert_eq!(text, "Hello"),
+        other => panic!("expected Text, got {other:?}"),
+    }
+    assert!(
+        events.iter().any(
+            |e| matches!(e, crate::anthropic::StreamEvent::TextDelta { text } if text == "Hel")
+        ),
+    );
 }
 
 #[tokio::test]

--- a/crates/hermeneus/src/openai/wire/mod.rs
+++ b/crates/hermeneus/src/openai/wire/mod.rs
@@ -1,4 +1,4 @@
-//! Wire types for the OpenAI Chat Completions API.
+//! Wire types for OpenAI Chat Completions and Responses APIs.
 //!
 //! Split by direction: [`request`] serializes outgoing requests,
 //! [`response`] deserializes non-streaming responses, [`stream`] parses
@@ -9,6 +9,6 @@ pub(crate) mod request;
 pub(crate) mod response;
 pub(crate) mod stream;
 
-pub(crate) use request::ChatCompletionRequest;
-pub(crate) use response::ChatCompletionResponse;
-pub(crate) use stream::parse_sse_response;
+pub(crate) use request::{ChatCompletionRequest, ResponsesRequest};
+pub(crate) use response::{ChatCompletionResponse, ResponsesResponse};
+pub(crate) use stream::{parse_chat_sse_response, parse_responses_sse_response};

--- a/crates/hermeneus/src/openai/wire/request.rs
+++ b/crates/hermeneus/src/openai/wire/request.rs
@@ -84,6 +84,58 @@ pub(crate) struct ChatFunctionDef<'a> {
     pub parameters: &'a serde_json::Value,
 }
 
+/// Top-level OpenAI Responses request body.
+#[derive(Debug, Serialize)]
+pub(crate) struct ResponsesRequest<'a> {
+    pub model: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    pub input: Vec<ResponsesInputItem>,
+    pub max_output_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ResponsesTool<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(crate) enum ResponsesInputItem {
+    Message {
+        role: &'static str,
+        content: String,
+    },
+    FunctionCall {
+        #[serde(rename = "type")]
+        item_type: &'static str,
+        call_id: String,
+        name: String,
+        arguments: String,
+    },
+    FunctionCallOutput {
+        #[serde(rename = "type")]
+        item_type: &'static str,
+        call_id: String,
+        output: String,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ResponsesTool<'a> {
+    #[serde(rename = "type")]
+    pub tool_type: &'static str,
+    pub name: &'a str,
+    pub description: &'a str,
+    pub parameters: &'a serde_json::Value,
+    pub strict: bool,
+}
+
 impl<'a> ChatCompletionRequest<'a> {
     /// Build an OpenAI-format request from a hermeneus [`CompletionRequest`].
     ///
@@ -187,6 +239,96 @@ impl<'a> ChatCompletionRequest<'a> {
     }
 }
 
+impl<'a> ResponsesRequest<'a> {
+    /// Build an OpenAI Responses request from a hermeneus [`CompletionRequest`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request carries provider-side server tools
+    /// whose OpenAI Responses equivalents are not represented in
+    /// [`ServerToolDefinition`](crate::types::ServerToolDefinition) yet.
+    pub(crate) fn from_request(req: &'a CompletionRequest, stream: Option<bool>) -> Result<Self> {
+        if !req.server_tools.is_empty() {
+            return Err(error::ProviderInitSnafu {
+                message: "OpenAI Responses providers do not yet support hermeneus \
+                          server-side tool definitions. Route these requests to an \
+                          Anthropic provider, or remove the server_tools from the \
+                          request."
+                    .to_owned(),
+            }
+            .build());
+        }
+
+        if let Some(thinking) = &req.thinking
+            && thinking.enabled
+        {
+            tracing::warn!(
+                budget_tokens = thinking.budget_tokens,
+                "thinking budget set on request routed to OpenAI Responses provider; \
+                 dropping until the Responses reasoning knob is represented in hermeneus"
+            );
+        }
+
+        if req.cache_system || req.cache_tools || req.cache_turns {
+            tracing::warn!(
+                cache_system = req.cache_system,
+                cache_tools = req.cache_tools,
+                cache_turns = req.cache_turns,
+                "prompt-cache flags set on request routed to OpenAI Responses provider; \
+                 dropping (no hermeneus mapping for Responses prompt cache controls)"
+            );
+        }
+
+        if req.citations.is_some() {
+            tracing::debug!(
+                "citations config set on request routed to OpenAI Responses provider; \
+                 ignored until Responses annotations are mapped"
+            );
+        }
+
+        let mut instructions = Vec::new();
+        if let Some(system) = req.system.as_deref()
+            && !system.is_empty()
+        {
+            instructions.push(system.to_owned());
+        }
+
+        let mut input = Vec::with_capacity(req.messages.len());
+        for msg in &req.messages {
+            translate_responses_message(msg, &mut instructions, &mut input);
+        }
+
+        let tools = req
+            .tools
+            .iter()
+            .map(|tool| ResponsesTool {
+                tool_type: "function",
+                name: &tool.name,
+                description: &tool.description,
+                parameters: &tool.input_schema,
+                strict: false,
+            })
+            .collect();
+
+        let user = req.metadata.as_ref().and_then(|m| m.user_id.as_deref());
+
+        Ok(Self {
+            model: &req.model,
+            instructions: (!instructions.is_empty()).then(|| instructions.join("\n")),
+            input,
+            max_output_tokens: req.max_tokens,
+            temperature: req.temperature,
+            tools,
+            tool_choice: req
+                .tool_choice
+                .as_ref()
+                .map(translate_responses_tool_choice),
+            stream,
+            user,
+        })
+    }
+}
+
 /// Translate one hermeneus [`Message`] into one or more [`ChatMessage`]s.
 ///
 /// Messages with mixed content (text + `tool_use` + `tool_result`) expand
@@ -210,8 +352,8 @@ fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
         }
         Role::User => {
             // User messages with tool_result blocks split into one
-            // `role: "tool"` per result, plus any remaining text as a
-            // follow-up user message.
+            // `role: "tool"` per result, plus one message for remaining
+            // user text.
             match &msg.content {
                 Content::Text(text) => {
                     out.push(ChatMessage {
@@ -327,6 +469,97 @@ fn tool_result_to_string(content: &ToolResultContent) -> String {
     }
 }
 
+fn translate_responses_message(
+    msg: &Message,
+    instructions: &mut Vec<String>,
+    out: &mut Vec<ResponsesInputItem>,
+) {
+    match msg.role {
+        Role::System => {
+            let text = msg.content.text();
+            if !text.is_empty() {
+                instructions.push(text);
+            }
+        }
+        Role::User => translate_responses_user_message(msg, out),
+        Role::Assistant => translate_responses_assistant_message(msg, out),
+    }
+}
+
+fn translate_responses_user_message(msg: &Message, out: &mut Vec<ResponsesInputItem>) {
+    match &msg.content {
+        Content::Text(text) => {
+            out.push(ResponsesInputItem::Message {
+                role: "user",
+                content: text.clone(),
+            });
+        }
+        Content::Blocks(blocks) => {
+            let mut text_parts = Vec::new();
+            for block in blocks {
+                match block {
+                    ContentBlock::Text { text, .. } if !text.is_empty() => {
+                        text_parts.push(text.clone());
+                    }
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        ..
+                    } => out.push(ResponsesInputItem::FunctionCallOutput {
+                        item_type: "function_call_output",
+                        call_id: tool_use_id.clone(),
+                        output: tool_result_to_string(content),
+                    }),
+                    _ => {
+                        // Images/documents have no Responses input mapping yet.
+                    }
+                }
+            }
+            if !text_parts.is_empty() {
+                out.push(ResponsesInputItem::Message {
+                    role: "user",
+                    content: text_parts.join("\n"),
+                });
+            }
+        }
+    }
+}
+
+fn translate_responses_assistant_message(msg: &Message, out: &mut Vec<ResponsesInputItem>) {
+    let mut text_parts = Vec::new();
+    match &msg.content {
+        Content::Text(text) => text_parts.push(text.clone()),
+        Content::Blocks(blocks) => {
+            for block in blocks {
+                match block {
+                    ContentBlock::Text { text, .. } if !text.is_empty() => {
+                        text_parts.push(text.clone());
+                    }
+                    ContentBlock::ToolUse { id, name, input } => {
+                        let arguments =
+                            serde_json::to_string(input).unwrap_or_else(|_| "{}".to_owned());
+                        out.push(ResponsesInputItem::FunctionCall {
+                            item_type: "function_call",
+                            call_id: id.clone(),
+                            name: name.clone(),
+                            arguments,
+                        });
+                    }
+                    _ => {
+                        // Tool results and non-text media are not assistant output items.
+                    }
+                }
+            }
+        }
+    }
+    if !text_parts.is_empty() {
+        out.push(ResponsesInputItem::Message {
+            role: "assistant",
+            content: text_parts.join("\n"),
+        });
+    }
+}
+
 fn translate_tool_choice(choice: &ToolChoice) -> serde_json::Value {
     match choice {
         ToolChoice::Auto => serde_json::Value::String("auto".to_owned()),
@@ -339,241 +572,22 @@ fn translate_tool_choice(choice: &ToolChoice) -> serde_json::Value {
     }
 }
 
+fn translate_responses_tool_choice(choice: &ToolChoice) -> serde_json::Value {
+    match choice {
+        ToolChoice::Auto => serde_json::Value::String("auto".to_owned()),
+        ToolChoice::Any => serde_json::Value::String("required".to_owned()),
+        ToolChoice::Tool { name } => serde_json::json!({
+            "type": "function",
+            "name": name
+        }),
+    }
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(
     clippy::indexing_slicing,
     reason = "test: indices asserted valid by construction"
 )]
-mod tests {
-    use super::*;
-    use crate::types::{
-        CompletionRequest, Content, ContentBlock, Message, Role, ThinkingConfig, ToolDefinition,
-        ToolResultContent,
-    };
-
-    #[test]
-    fn system_prompt_becomes_first_system_message() {
-        let req = CompletionRequest {
-            model: "qwen".to_owned(),
-            system: Some("You are a helpful assistant.".to_owned()),
-            messages: vec![Message {
-                role: Role::User,
-                content: Content::Text("hi".to_owned()),
-                cache_breakpoint: false,
-            }],
-            max_tokens: 128,
-            ..Default::default()
-        };
-        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
-        assert_eq!(wire.messages.len(), 2);
-        assert_eq!(wire.messages[0].role, "system");
-        assert_eq!(
-            wire.messages[0].content.as_deref(),
-            Some("You are a helpful assistant.")
-        );
-        assert_eq!(wire.messages[1].role, "user");
-    }
-
-    #[test]
-    fn tool_definitions_map_to_function_tools() {
-        let req = CompletionRequest {
-            model: "qwen".to_owned(),
-            messages: vec![Message {
-                role: Role::User,
-                content: Content::Text("use a tool".to_owned()),
-                cache_breakpoint: false,
-            }],
-            max_tokens: 128,
-            tools: vec![ToolDefinition {
-                name: "get_weather".to_owned(),
-                description: "Fetch weather for a city".to_owned(),
-                input_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": { "city": { "type": "string" } }
-                }),
-                disable_passthrough: None,
-            }],
-            ..Default::default()
-        };
-        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
-        assert_eq!(wire.tools.len(), 1);
-        let tool = &wire.tools[0];
-        assert_eq!(tool.tool_type, "function");
-        assert_eq!(tool.function.name, "get_weather");
-    }
-
-    #[test]
-    fn assistant_tool_use_block_becomes_tool_calls() {
-        let req = CompletionRequest {
-            model: "qwen".to_owned(),
-            messages: vec![
-                Message {
-                    role: Role::User,
-                    content: Content::Text("call get_weather".to_owned()),
-                    cache_breakpoint: false,
-                },
-                Message {
-                    role: Role::Assistant,
-                    content: Content::Blocks(vec![
-                        ContentBlock::Text {
-                            text: "Sure".to_owned(),
-                            citations: None,
-                        },
-                        ContentBlock::ToolUse {
-                            id: "call_1".to_owned(),
-                            name: "get_weather".to_owned(),
-                            input: serde_json::json!({ "city": "Paris" }),
-                        },
-                    ]),
-                    cache_breakpoint: false,
-                },
-            ],
-            max_tokens: 128,
-            ..Default::default()
-        };
-        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
-        let assistant = wire
-            .messages
-            .iter()
-            .find(|m| m.role == "assistant")
-            .unwrap();
-        assert_eq!(assistant.tool_calls.len(), 1);
-        assert_eq!(assistant.tool_calls[0].id, "call_1");
-        assert_eq!(assistant.tool_calls[0].function.name, "get_weather");
-        assert!(assistant.tool_calls[0].function.arguments.contains("Paris"));
-    }
-
-    #[test]
-    fn user_tool_result_block_becomes_role_tool_message() {
-        let req = CompletionRequest {
-            model: "qwen".to_owned(),
-            messages: vec![Message {
-                role: Role::User,
-                content: Content::Blocks(vec![ContentBlock::ToolResult {
-                    tool_use_id: "call_1".to_owned(),
-                    content: ToolResultContent::Text("sunny".to_owned()),
-                    is_error: None,
-                }]),
-                cache_breakpoint: false,
-            }],
-            max_tokens: 128,
-            ..Default::default()
-        };
-        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
-        let tool_msg = wire.messages.iter().find(|m| m.role == "tool").unwrap();
-        assert_eq!(tool_msg.tool_call_id.as_deref(), Some("call_1"));
-        assert_eq!(tool_msg.content.as_deref(), Some("sunny"));
-    }
-
-    #[test]
-    fn thinking_block_is_dropped_and_warned() {
-        let req = CompletionRequest {
-            model: "qwen".to_owned(),
-            messages: vec![Message {
-                role: Role::User,
-                content: Content::Text("hi".to_owned()),
-                cache_breakpoint: false,
-            }],
-            max_tokens: 128,
-            thinking: Some(ThinkingConfig {
-                enabled: true,
-                budget_tokens: 1024,
-            }),
-            ..Default::default()
-        };
-        // No thinking field in the wire request; confirm it serializes.
-        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
-        let json = serde_json::to_string(&wire).unwrap();
-        assert!(!json.contains("thinking"));
-        assert!(!json.contains("budget_tokens"));
-    }
-
-    #[test]
-    fn server_tools_rejected_with_clear_error() {
-        let req = CompletionRequest {
-            model: "qwen".to_owned(),
-            messages: vec![Message {
-                role: Role::User,
-                content: Content::Text("hi".to_owned()),
-                cache_breakpoint: false,
-            }],
-            max_tokens: 128,
-            server_tools: vec![crate::types::ServerToolDefinition {
-                tool_type: "web_search_20250305".to_owned(),
-                name: "web_search".to_owned(),
-                max_uses: Some(3),
-                allowed_domains: None,
-                blocked_domains: None,
-                user_location: None,
-            }],
-            ..Default::default()
-        };
-        let err = ChatCompletionRequest::from_request(&req, None).unwrap_err();
-        assert!(err.to_string().contains("server-side tools"));
-    }
-
-    #[test]
-    fn cache_flags_dropped_without_error() {
-        let req = CompletionRequest {
-            model: "qwen".to_owned(),
-            system: Some("sys".to_owned()),
-            messages: vec![Message {
-                role: Role::User,
-                content: Content::Text("hi".to_owned()),
-                cache_breakpoint: false,
-            }],
-            max_tokens: 128,
-            cache_system: true,
-            cache_tools: true,
-            cache_turns: true,
-            ..Default::default()
-        };
-        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
-        let json = serde_json::to_string(&wire).unwrap();
-        assert!(!json.contains("cache_control"));
-    }
-
-    #[test]
-    fn tool_choice_any_maps_to_required() {
-        let req = CompletionRequest {
-            model: "qwen".to_owned(),
-            messages: vec![Message {
-                role: Role::User,
-                content: Content::Text("hi".to_owned()),
-                cache_breakpoint: false,
-            }],
-            max_tokens: 128,
-            tool_choice: Some(ToolChoice::Any),
-            ..Default::default()
-        };
-        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
-        assert_eq!(
-            wire.tool_choice,
-            Some(serde_json::Value::String("required".to_owned()))
-        );
-    }
-
-    #[test]
-    fn tool_arguments_serialized_as_json_string() {
-        let req = CompletionRequest {
-            model: "qwen".to_owned(),
-            messages: vec![Message {
-                role: Role::Assistant,
-                content: Content::Blocks(vec![ContentBlock::ToolUse {
-                    id: "c1".to_owned(),
-                    name: "f".to_owned(),
-                    input: serde_json::json!({ "x": 1 }),
-                }]),
-                cache_breakpoint: false,
-            }],
-            max_tokens: 64,
-            ..Default::default()
-        };
-        let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
-        let tc = &wire.messages[0].tool_calls[0];
-        // arguments must be a JSON-encoded string containing the object.
-        let parsed: serde_json::Value = serde_json::from_str(&tc.function.arguments).unwrap();
-        assert_eq!(parsed["x"], 1);
-    }
-}
+#[path = "request_tests.rs"]
+mod tests;

--- a/crates/hermeneus/src/openai/wire/request_tests.rs
+++ b/crates/hermeneus/src/openai/wire/request_tests.rs
@@ -1,0 +1,258 @@
+use super::*;
+use crate::types::{
+    CompletionRequest, Content, ContentBlock, Message, Role, ThinkingConfig, ToolDefinition,
+    ToolResultContent,
+};
+
+#[test]
+fn system_prompt_becomes_first_system_message() {
+    let req = CompletionRequest {
+        model: "qwen".to_owned(),
+        system: Some("You are a helpful assistant.".to_owned()),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("hi".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    assert_eq!(wire.messages.len(), 2);
+    assert_eq!(wire.messages[0].role, "system");
+    assert_eq!(
+        wire.messages[0].content.as_deref(),
+        Some("You are a helpful assistant.")
+    );
+    assert_eq!(wire.messages[1].role, "user");
+}
+
+#[test]
+fn tool_definitions_map_to_function_tools() {
+    let req = CompletionRequest {
+        model: "qwen".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("use a tool".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        tools: vec![ToolDefinition {
+            name: "get_weather".to_owned(),
+            description: "Fetch weather for a city".to_owned(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": { "city": { "type": "string" } }
+            }),
+            disable_passthrough: None,
+        }],
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    assert_eq!(wire.tools.len(), 1);
+    let tool = &wire.tools[0];
+    assert_eq!(tool.tool_type, "function");
+    assert_eq!(tool.function.name, "get_weather");
+}
+
+#[test]
+fn responses_tool_definitions_preserve_non_strict_schema_behavior() {
+    let req = CompletionRequest {
+        model: "gpt-5".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("use a tool".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        tools: vec![ToolDefinition {
+            name: "get_weather".to_owned(),
+            description: "Fetch weather for a city".to_owned(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": { "city": { "type": "string" } }
+            }),
+            disable_passthrough: None,
+        }],
+        ..Default::default()
+    };
+
+    let wire = ResponsesRequest::from_request(&req, None).unwrap();
+    let json = serde_json::to_value(&wire).unwrap();
+
+    assert_eq!(json["tools"][0]["type"], "function");
+    assert_eq!(json["tools"][0]["name"], "get_weather");
+    assert_eq!(json["tools"][0]["strict"], false);
+}
+
+#[test]
+fn assistant_tool_use_block_becomes_tool_calls() {
+    let req = CompletionRequest {
+        model: "qwen".to_owned(),
+        messages: vec![
+            Message {
+                role: Role::User,
+                content: Content::Text("call get_weather".to_owned()),
+                cache_breakpoint: false,
+            },
+            Message {
+                role: Role::Assistant,
+                content: Content::Blocks(vec![
+                    ContentBlock::Text {
+                        text: "Sure".to_owned(),
+                        citations: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "call_1".to_owned(),
+                        name: "get_weather".to_owned(),
+                        input: serde_json::json!({ "city": "Paris" }),
+                    },
+                ]),
+                cache_breakpoint: false,
+            },
+        ],
+        max_tokens: 128,
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    let assistant = wire
+        .messages
+        .iter()
+        .find(|m| m.role == "assistant")
+        .unwrap();
+    assert_eq!(assistant.tool_calls.len(), 1);
+    assert_eq!(assistant.tool_calls[0].id, "call_1");
+    assert_eq!(assistant.tool_calls[0].function.name, "get_weather");
+    assert!(assistant.tool_calls[0].function.arguments.contains("Paris"));
+}
+
+#[test]
+fn user_tool_result_block_becomes_role_tool_message() {
+    let req = CompletionRequest {
+        model: "qwen".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Blocks(vec![ContentBlock::ToolResult {
+                tool_use_id: "call_1".to_owned(),
+                content: ToolResultContent::Text("sunny".to_owned()),
+                is_error: None,
+            }]),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    let tool_msg = wire.messages.iter().find(|m| m.role == "tool").unwrap();
+    assert_eq!(tool_msg.tool_call_id.as_deref(), Some("call_1"));
+    assert_eq!(tool_msg.content.as_deref(), Some("sunny"));
+}
+
+#[test]
+fn thinking_block_is_dropped_and_warned() {
+    let req = CompletionRequest {
+        model: "qwen".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("hi".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        thinking: Some(ThinkingConfig {
+            enabled: true,
+            budget_tokens: 1024,
+        }),
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    let json = serde_json::to_string(&wire).unwrap();
+    assert!(!json.contains("thinking"));
+    assert!(!json.contains("budget_tokens"));
+}
+
+#[test]
+fn server_tools_rejected_with_clear_error() {
+    let req = CompletionRequest {
+        model: "qwen".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("hi".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        server_tools: vec![crate::types::ServerToolDefinition {
+            tool_type: "web_search_20250305".to_owned(),
+            name: "web_search".to_owned(),
+            max_uses: Some(3),
+            allowed_domains: None,
+            blocked_domains: None,
+            user_location: None,
+        }],
+        ..Default::default()
+    };
+    let err = ChatCompletionRequest::from_request(&req, None).unwrap_err();
+    assert!(err.to_string().contains("server-side tools"));
+}
+
+#[test]
+fn cache_flags_dropped_without_error() {
+    let req = CompletionRequest {
+        model: "qwen".to_owned(),
+        system: Some("sys".to_owned()),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("hi".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        cache_system: true,
+        cache_tools: true,
+        cache_turns: true,
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    let json = serde_json::to_string(&wire).unwrap();
+    assert!(!json.contains("cache_control"));
+}
+
+#[test]
+fn tool_choice_any_maps_to_required() {
+    let req = CompletionRequest {
+        model: "qwen".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("hi".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        tool_choice: Some(ToolChoice::Any),
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    assert_eq!(
+        wire.tool_choice,
+        Some(serde_json::Value::String("required".to_owned()))
+    );
+}
+
+#[test]
+fn tool_arguments_serialized_as_json_string() {
+    let req = CompletionRequest {
+        model: "qwen".to_owned(),
+        messages: vec![Message {
+            role: Role::Assistant,
+            content: Content::Blocks(vec![ContentBlock::ToolUse {
+                id: "c1".to_owned(),
+                name: "f".to_owned(),
+                input: serde_json::json!({ "x": 1 }),
+            }]),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 64,
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    let tc = &wire.messages[0].tool_calls[0];
+    let parsed: serde_json::Value = serde_json::from_str(&tc.function.arguments).unwrap();
+    assert_eq!(parsed["x"], 1);
+}

--- a/crates/hermeneus/src/openai/wire/response.rs
+++ b/crates/hermeneus/src/openai/wire/response.rs
@@ -62,6 +62,63 @@ pub(crate) struct ChatUsage {
     // OpenAI does not expose cache-tier tokens; leave zero.
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct ResponsesResponse {
+    pub id: String,
+    pub model: String,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub incomplete_details: Option<ResponsesIncompleteDetails>,
+    #[serde(default)]
+    pub output: Vec<ResponsesOutputItem>,
+    #[serde(default)]
+    pub usage: Option<ResponsesUsage>,
+    #[serde(default)]
+    pub output_text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ResponsesIncompleteDetails {
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum ResponsesOutputItem {
+    #[serde(rename = "message")]
+    Message {
+        content: Vec<ResponsesOutputContent>,
+    },
+    #[serde(rename = "function_call")]
+    FunctionCall {
+        call_id: String,
+        name: String,
+        #[serde(default)]
+        arguments: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum ResponsesOutputContent {
+    #[serde(rename = "output_text")]
+    OutputText { text: String },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ResponsesUsage {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+}
+
 impl ChatCompletionResponse {
     /// Convert a successful OpenAI response into the Anthropic-shaped
     /// [`CompletionResponse`].
@@ -101,12 +158,7 @@ impl ChatCompletionResponse {
         for call in choice.message.tool_calls {
             // WHY: arguments is a JSON-encoded string on the wire. An empty
             // string means the tool takes no input — map to an empty object.
-            let input: serde_json::Value = if call.function.arguments.is_empty() {
-                serde_json::json!({})
-            } else {
-                serde_json::from_str(&call.function.arguments)
-                    .unwrap_or(serde_json::Value::String(call.function.arguments.clone()))
-            };
+            let input = parse_arguments(&call.function.arguments);
             content.push(ContentBlock::ToolUse {
                 id: call.id,
                 name: call.function.name,
@@ -132,6 +184,114 @@ impl ChatCompletionResponse {
             cost_usd: None,
             duration_ms: None,
         })
+    }
+}
+
+impl ResponsesResponse {
+    /// Convert a successful OpenAI Responses body into a hermeneus
+    /// [`CompletionResponse`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string when the response contains neither output
+    /// items nor an `output_text` convenience field.
+    pub(crate) fn into_response(self) -> Result<CompletionResponse, String> {
+        let Self {
+            id,
+            model,
+            status,
+            incomplete_details,
+            output,
+            usage,
+            output_text,
+        } = self;
+
+        let mut content = Vec::new();
+        let mut saw_function_call = false;
+
+        for item in output {
+            match item {
+                ResponsesOutputItem::Message { content: parts } => {
+                    for part in parts {
+                        if let ResponsesOutputContent::OutputText { text } = part
+                            && !text.is_empty()
+                        {
+                            content.push(ContentBlock::Text {
+                                text,
+                                citations: None,
+                            });
+                        }
+                    }
+                }
+                ResponsesOutputItem::FunctionCall {
+                    call_id,
+                    name,
+                    arguments,
+                } => {
+                    saw_function_call = true;
+                    content.push(ContentBlock::ToolUse {
+                        id: call_id,
+                        name,
+                        input: parse_arguments(&arguments),
+                    });
+                }
+                ResponsesOutputItem::Other => {}
+            }
+        }
+
+        if content.is_empty()
+            && let Some(text) = output_text
+            && !text.is_empty()
+        {
+            content.push(ContentBlock::Text {
+                text,
+                citations: None,
+            });
+        }
+
+        if content.is_empty() {
+            return Err("OpenAI Responses response had no output".to_owned());
+        }
+
+        let stop_reason = if saw_function_call {
+            StopReason::ToolUse
+        } else if status.as_deref() == Some("incomplete")
+            && incomplete_details
+                .as_ref()
+                .and_then(|details| details.reason.as_deref())
+                .is_some_and(|reason| reason == "max_output_tokens")
+        {
+            StopReason::MaxTokens
+        } else {
+            StopReason::EndTurn
+        };
+
+        let usage = usage
+            .map(|u| Usage {
+                input_tokens: u.input_tokens,
+                output_tokens: u.output_tokens,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+            })
+            .unwrap_or_default();
+
+        Ok(CompletionResponse {
+            id,
+            model,
+            stop_reason,
+            content,
+            usage,
+            cost_usd: None,
+            duration_ms: None,
+        })
+    }
+}
+
+pub(crate) fn parse_arguments(arguments: &str) -> serde_json::Value {
+    if arguments.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_str(arguments).unwrap_or(serde_json::Value::String(arguments.to_owned()))
     }
 }
 

--- a/crates/hermeneus/src/openai/wire/stream.rs
+++ b/crates/hermeneus/src/openai/wire/stream.rs
@@ -14,6 +14,8 @@ use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
 use crate::types::{CompletionResponse, ContentBlock, StopReason, Usage};
 
+use super::response::{ResponsesResponse, parse_arguments};
+
 #[derive(Debug, Deserialize)]
 struct ChatStreamChunk {
     #[serde(default)]
@@ -253,7 +255,7 @@ fn map_finish_reason(reason: &str) -> StopReason {
 /// Parse an OpenAI SSE stream from a `reqwest::Response`, emitting
 /// [`StreamEvent`]s and returning the finalized [`CompletionResponse`].
 #[tracing::instrument(skip_all)]
-pub(crate) async fn parse_sse_response(
+pub(crate) async fn parse_chat_sse_response(
     response: &mut Response,
     on_event: &mut (dyn FnMut(StreamEvent) + Send),
 ) -> Result<CompletionResponse> {
@@ -305,6 +307,312 @@ pub(crate) async fn parse_sse_response(
                     current_data.push_str(data);
                 }
                 // Ignore comments, empty `:` lines, event:, id:, retry:
+                line_buf.clear();
+            } else {
+                line_buf.push(byte);
+            }
+        }
+
+        if done {
+            break;
+        }
+    }
+
+    Ok(accumulator.finish(on_event))
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponsesStreamEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    response: Option<ResponsesResponse>,
+    #[serde(default)]
+    delta: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+    #[serde(default)]
+    call_id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    item_id: Option<String>,
+}
+
+struct ResponsesStreamAccumulator {
+    id: String,
+    model: String,
+    text_buf: String,
+    tool_calls: BTreeMap<String, PendingResponsesToolCall>,
+    completed: Option<CompletionResponse>,
+    usage: Usage,
+    text_block_open: bool,
+    message_started: bool,
+}
+
+struct PendingResponsesToolCall {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+impl ResponsesStreamAccumulator {
+    fn new() -> Self {
+        Self {
+            id: String::new(),
+            model: String::new(),
+            text_buf: String::new(),
+            tool_calls: BTreeMap::new(),
+            completed: None,
+            usage: Usage::default(),
+            text_block_open: false,
+            message_started: false,
+        }
+    }
+
+    fn process_event<F: FnMut(StreamEvent) + ?Sized>(
+        &mut self,
+        event: ResponsesStreamEvent,
+        on_event: &mut F,
+    ) -> Result<()> {
+        match event.event_type.as_str() {
+            "response.created" | "response.in_progress" => {
+                if let Some(response) = event.response {
+                    self.capture_response_metadata(&response, on_event);
+                }
+            }
+            "response.output_text.delta" => {
+                let delta = event.delta.unwrap_or_default();
+                if !delta.is_empty() {
+                    self.start_text(on_event);
+                    self.text_buf.push_str(&delta);
+                    on_event(StreamEvent::TextDelta { text: delta });
+                }
+            }
+            "response.function_call_arguments.delta" => {
+                let key = event
+                    .call_id
+                    .clone()
+                    .or(event.item_id.clone())
+                    .unwrap_or_default();
+                let pending = self.tool_calls.entry(key.clone()).or_insert_with(|| {
+                    PendingResponsesToolCall {
+                        id: key,
+                        name: event.name.clone().unwrap_or_default(),
+                        arguments: String::new(),
+                    }
+                });
+                if let Some(delta) = event.delta
+                    && !delta.is_empty()
+                {
+                    pending.arguments.push_str(&delta);
+                    on_event(StreamEvent::InputJsonDelta {
+                        partial_json: delta,
+                    });
+                }
+            }
+            "response.function_call_arguments.done" => {
+                let key = event
+                    .call_id
+                    .clone()
+                    .or(event.item_id.clone())
+                    .unwrap_or_default();
+                let pending = self.tool_calls.entry(key.clone()).or_insert_with(|| {
+                    PendingResponsesToolCall {
+                        id: key,
+                        name: String::new(),
+                        arguments: String::new(),
+                    }
+                });
+                if let Some(call_id) = event.call_id
+                    && !call_id.is_empty()
+                {
+                    pending.id = call_id;
+                }
+                if let Some(name) = event.name
+                    && !name.is_empty()
+                {
+                    pending.name = name;
+                }
+                if let Some(arguments) = event.arguments {
+                    pending.arguments = arguments;
+                }
+            }
+            "response.completed" => {
+                if let Some(response) = event.response {
+                    self.capture_response_metadata(&response, on_event);
+                    self.completed = Some(
+                        response
+                            .into_response()
+                            .map_err(|msg| error::ApiRequestSnafu { message: msg }.build())?,
+                    );
+                }
+            }
+            "response.failed" => {
+                return Err(error::ApiRequestSnafu {
+                    message: "OpenAI Responses stream failed".to_owned(),
+                }
+                .build());
+            }
+            "error" => {
+                return Err(error::ApiRequestSnafu {
+                    message: "OpenAI Responses stream emitted an error".to_owned(),
+                }
+                .build());
+            }
+            _ => {
+                // Ignore Responses event types this adapter does not surface.
+            }
+        }
+        Ok(())
+    }
+
+    fn capture_response_metadata<F: FnMut(StreamEvent) + ?Sized>(
+        &mut self,
+        response: &ResponsesResponse,
+        on_event: &mut F,
+    ) {
+        if self.id.is_empty() {
+            self.id.clone_from(&response.id);
+        }
+        if self.model.is_empty() {
+            self.model.clone_from(&response.model);
+        }
+        if let Some(usage) = &response.usage {
+            self.usage.input_tokens = usage.input_tokens;
+            self.usage.output_tokens = usage.output_tokens;
+        }
+        self.start_message(on_event);
+    }
+
+    fn start_message<F: FnMut(StreamEvent) + ?Sized>(&mut self, on_event: &mut F) {
+        if !self.message_started {
+            on_event(StreamEvent::MessageStart { usage: self.usage });
+            self.message_started = true;
+        }
+    }
+
+    fn start_text<F: FnMut(StreamEvent) + ?Sized>(&mut self, on_event: &mut F) {
+        self.start_message(on_event);
+        if !self.text_block_open {
+            on_event(StreamEvent::ContentBlockStart {
+                index: 0,
+                block_type: "text".to_owned(),
+            });
+            self.text_block_open = true;
+        }
+    }
+
+    fn finish<F: FnMut(StreamEvent) + ?Sized>(self, on_event: &mut F) -> CompletionResponse {
+        let Self {
+            id,
+            model,
+            text_buf,
+            tool_calls,
+            completed,
+            usage,
+            text_block_open,
+            ..
+        } = self;
+
+        if text_block_open {
+            on_event(StreamEvent::ContentBlockStop { index: 0 });
+        }
+
+        let resp = completed.unwrap_or_else(|| {
+            let mut content = Vec::new();
+            if !text_buf.is_empty() {
+                content.push(ContentBlock::Text {
+                    text: text_buf,
+                    citations: None,
+                });
+            }
+            for (_, call) in tool_calls {
+                content.push(ContentBlock::ToolUse {
+                    id: call.id,
+                    name: call.name,
+                    input: parse_arguments(&call.arguments),
+                });
+            }
+            let stop_reason = if content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::ToolUse { .. }))
+            {
+                StopReason::ToolUse
+            } else {
+                StopReason::EndTurn
+            };
+            CompletionResponse {
+                id,
+                model,
+                stop_reason,
+                content,
+                usage,
+                cost_usd: None,
+                duration_ms: None,
+            }
+        });
+
+        on_event(StreamEvent::MessageStop {
+            stop_reason: resp.stop_reason,
+            usage: resp.usage,
+        });
+        resp
+    }
+}
+
+/// Parse an OpenAI Responses SSE stream from a `reqwest::Response`, emitting
+/// [`StreamEvent`]s and returning the finalized [`CompletionResponse`].
+#[tracing::instrument(skip_all)]
+pub(crate) async fn parse_responses_sse_response(
+    response: &mut Response,
+    on_event: &mut (dyn FnMut(StreamEvent) + Send),
+) -> Result<CompletionResponse> {
+    let mut accumulator = ResponsesStreamAccumulator::new();
+    let mut line_buf: Vec<u8> = Vec::with_capacity(256);
+    let mut current_data = String::new();
+    let mut done = false;
+
+    loop {
+        let chunk = response.chunk().await.map_err(|e| {
+            error::ApiRequestSnafu {
+                message: format!("stream read error: {e}"),
+            }
+            .build()
+        })?;
+        let Some(bytes) = chunk else { break };
+
+        for &byte in &bytes {
+            if byte == b'\n' {
+                let line_cow = String::from_utf8_lossy(&line_buf);
+                let line = line_cow.trim_end_matches('\r');
+                if line.is_empty() {
+                    if !current_data.is_empty() {
+                        if current_data.trim() == "[DONE]" {
+                            done = true;
+                        } else {
+                            let event: ResponsesStreamEvent = serde_json::from_str(&current_data)
+                                .map_err(|e| {
+                                error::ApiRequestSnafu {
+                                    message: format!("Responses stream parse error: {e}"),
+                                }
+                                .build()
+                            })?;
+                            accumulator.process_event(event, on_event)?;
+                        }
+                    }
+                    current_data.clear();
+                } else if let Some(data) = line.strip_prefix("data: ") {
+                    if !current_data.is_empty() {
+                        current_data.push('\n');
+                    }
+                    current_data.push_str(data);
+                } else if let Some(data) = line.strip_prefix("data:") {
+                    if !current_data.is_empty() {
+                        current_data.push('\n');
+                    }
+                    current_data.push_str(data);
+                }
                 line_buf.clear();
             } else {
                 line_buf.push(byte);

--- a/crates/taxis/src/config/behavior/mod.rs
+++ b/crates/taxis/src/config/behavior/mod.rs
@@ -20,8 +20,8 @@ pub use knowledge::{BookkeepingProviderKind, ExtractionConfig, KnowledgeConfig};
 pub use messaging::MessagingConfig;
 pub use nous::NousBehaviorConfig;
 pub use provider::{
-    AnthropicConfig, DeploymentTarget, LlmProviderConfig, PromptCacheMode, ProviderBehaviorConfig,
-    ProviderKind,
+    AnthropicConfig, DeploymentTarget, LlmProviderConfig, OpenAiApiFamily, PromptCacheMode,
+    ProviderBehaviorConfig, ProviderKind,
 };
 pub use timeouts::{CapacityConfig, RetrySettings, TimeoutsConfig};
 pub use tools::ToolLimitsConfig;

--- a/crates/taxis/src/config/behavior/provider.rs
+++ b/crates/taxis/src/config/behavior/provider.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 /// All defaults match the current hardcoded constants in the `hermeneus` crate.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 #[serde(default)]
 pub struct ProviderBehaviorConfig {
     /// Timeout in seconds for non-streaming LLM requests. Default: 120.
@@ -51,6 +52,7 @@ impl Default for ProviderBehaviorConfig {
 /// Issues: #3406, #3410, #3409.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 #[serde(default)]
 pub struct AnthropicConfig {
     /// Prompt cache policy (#3410).
@@ -138,14 +140,26 @@ pub enum ProviderKind {
     ClaudeCode,
 }
 
+/// `OpenAI` HTTP API family for `OpenAI` and OpenAI-compatible providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum OpenAiApiFamily {
+    /// `OpenAI` `/v1/chat/completions` and compatible local/proxy endpoints.
+    ChatCompletions,
+    /// `OpenAI` first-party `/v1/responses` endpoint.
+    Responses,
+}
+
 /// Per-provider configuration entry. One of these is produced for every
 /// `[[providers]]` table in `aletheia.toml`.
 ///
 /// The full set of entries lives on `AletheiaConfig::providers`. At startup
 /// `build_provider_registry` iterates the vector and dispatches on
 /// [`kind`](Self::kind) to build the corresponding concrete provider.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct LlmProviderConfig {
     /// Operator-facing label for logs and diagnostics (e.g., `"local-qwen"`,
     /// `"anthropic-cloud"`). Must be unique across the provider list.
@@ -164,6 +178,11 @@ pub struct LlmProviderConfig {
     /// not require authentication.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key_env: Option<String>,
+    /// `OpenAI` API family to use. If omitted, `providerType = "openai"`
+    /// defaults to `responses`, while `openai-compatible` defaults to
+    /// `chat-completions` for local/proxy compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_family: Option<OpenAiApiFamily>,
     /// Where this provider's traffic terminates. Drives the
     /// factsensitivity filter (#3414) and air-gapped mode.
     #[serde(default)]
@@ -173,4 +192,18 @@ pub struct LlmProviderConfig {
     /// claims the requested model wins.
     #[serde(default)]
     pub models: Vec<String>,
+}
+
+impl std::fmt::Debug for LlmProviderConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LlmProviderConfig")
+            .field("name", &self.name)
+            .field("kind", &self.kind)
+            .field("base_url", &self.base_url)
+            .field("api_key_env", &self.api_key_env)
+            .field("api_family", &self.api_family)
+            .field("deployment_target", &self.deployment_target)
+            .field("models", &self.models)
+            .finish()
+    }
 }

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -14,8 +14,8 @@ pub use behavior::{
     AnthropicConfig, ApiLimitsConfig, BookkeepingProviderKind, CapacityConfig, CronTaskConfig,
     DaemonBehaviorConfig, DeploymentTarget, DispatchConfig, DispatchSpecConfig, ExtractionConfig,
     JwtSettings, KnowledgeConfig, LlmProviderConfig, MessagingConfig, NousBehaviorConfig,
-    PromptCacheMode, ProviderBehaviorConfig, ProviderKind, RetrySettings, TimeoutsConfig,
-    ToolLimitsConfig, TuningConfig,
+    OpenAiApiFamily, PromptCacheMode, ProviderBehaviorConfig, ProviderKind, RetrySettings,
+    TimeoutsConfig, ToolLimitsConfig, TuningConfig,
 };
 pub use gateway::{
     BodyLimitConfig, CorsConfig, CsrfConfig, GatewayAuthConfig, GatewayConfig,

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -772,7 +772,6 @@ fn validate_providers(value: &Value, errors: &mut Vec<String>) {
                 }
             }
         }
-
         if let Some(target) = entry.get("deploymentTarget").and_then(Value::as_str)
             && !matches!(
                 target,
@@ -783,9 +782,19 @@ fn validate_providers(value: &Value, errors: &mut Vec<String>) {
                 "providers[{i}].deploymentTarget '{target}' is not recognized (expected one of: cloud, localhosted, local_hosted, local-hosted, embedded)"
             ));
         }
+        if let Some(api_family) = entry.get("apiFamily").and_then(Value::as_str)
+            && !matches!(api_family, "chat-completions" | "responses")
+        {
+            errors.push(format!(
+                "providers[{i}].apiFamily '{api_family}' is not recognized (expected one of: chat-completions, responses)"
+            ));
+        }
     }
 }
 
 #[cfg(test)]
 #[path = "validate_tests.rs"]
 mod validate_tests;
+
+#[cfg(test)]
+mod validate_openai_api_family_tests;

--- a/crates/taxis/src/validate/validate_openai_api_family_tests.rs
+++ b/crates/taxis/src/validate/validate_openai_api_family_tests.rs
@@ -1,0 +1,37 @@
+use serde_json::json;
+
+use super::validate_section;
+
+#[test]
+fn accepts_openai_api_family_values() {
+    for api_family in ["chat-completions", "responses"] {
+        let section = json!([
+            {
+                "name": "openai-cloud",
+                "providerType": "openai",
+                "apiFamily": api_family,
+                "models": ["gpt-4.1"]
+            }
+        ]);
+
+        assert!(
+            validate_section("providers", &section).is_ok(),
+            "apiFamily '{api_family}' should validate"
+        );
+    }
+}
+
+#[test]
+fn rejects_unknown_openai_api_family() {
+    let section = json!([
+        {
+            "name": "openai-cloud",
+            "providerType": "openai",
+            "apiFamily": "edits",
+            "models": ["gpt-4.1"]
+        }
+    ]);
+
+    let err = validate_section("providers", &section).expect_err("apiFamily should fail");
+    assert!(err.to_string().contains("apiFamily 'edits'"));
+}


### PR DESCRIPTION
Closes #3910.

## Summary
- adds an OpenAI API-family selector with first-party `/v1/responses` request, response, and stream handling
- defaults declarative `providerType = "openai"` to Responses while keeping `openai-compatible` on Chat Completions
- validates `apiFamily`, preserves non-strict function schema behavior, and keeps local/proxy endpoints on the existing chat-completions path

## Validation
- `cargo +1.94 test -p hermeneus openai -- --nocapture`
- `cargo +1.94 test -p taxis openai_api_family -- --nocapture`
- `cargo +1.94 test -p taxis provider -- --nocapture`
- `cargo +1.94 test -p aletheia runtime::setup::tests::openai_api_family_mapping_and_defaults_are_explicit`
- `cargo +1.94 clippy -p hermeneus -p aletheia -p taxis -- -D warnings`
- `cargo +1.94 check -p hermeneus -p aletheia -p taxis`
- `cargo +1.94 fmt --check`
- `git diff --check`
- scoped `kanon lint --summary` on `crates/hermeneus/src/openai`, `crates/taxis/src/config/behavior/provider.rs`, `crates/taxis/src/validate/validate_openai_api_family_tests.rs`, and `crates/aletheia/src/runtime/setup.rs`

## Notes
- Responses built-in server tools, reasoning knobs, and citation annotations remain explicitly unmapped rather than silently translated.
- Responses function tools are serialized with `strict: false` to preserve existing best-effort tool-schema behavior.