### PR TITLE
test(integration): add proskenion contract smoke harness

### DIFF
--- a/crates/integration-tests/tests/proskenion_contract.rs
+++ b/crates/integration-tests/tests/proskenion_contract.rs
@@ -276,15 +276,16 @@ async fn proskenion_contract_chat_stream_sse_matches_desktop() {
         assert_event_type(event);
     }
 
-    let start = events
+    let start_index = events
         .iter()
-        .find(|event| event.event == "message_start")
+        .position(|event| event.event == "message_start")
         .unwrap_or_else(|| {
             panic!(
                 "proskenion SSE contract mismatch: expected message_start event \
                  before deltas; events={events:?}; body={body}"
             )
         });
+    let start = &events[start_index];
     assert!(
         start
             .data
@@ -298,15 +299,28 @@ async fn proskenion_contract_chat_stream_sse_matches_desktop() {
         start.data
     );
 
-    let complete = events
+    let complete_index = events
         .iter()
-        .find(|event| event.event == "message_complete")
+        .position(|event| event.event == "message_complete")
         .unwrap_or_else(|| {
             panic!(
                 "proskenion SSE contract mismatch: expected terminal message_complete; \
                  events={events:?}; body={body}"
             )
         });
+    assert_eq!(
+        complete_index,
+        events.len() - 1,
+        "proskenion SSE contract mismatch: message_complete must be the final \
+         terminal event because desktop clients stop after terminal events; \
+         events={events:?}; body={body}"
+    );
+    assert!(
+        start_index < complete_index,
+        "proskenion SSE contract mismatch: message_start must precede \
+         message_complete; events={events:?}; body={body}"
+    );
+    let complete = &events[complete_index];
     let outcome = complete
         .data
         .get("outcome")

--- a/crates/integration-tests/tests/proskenion_contract.rs
+++ b/crates/integration-tests/tests/proskenion_contract.rs
@@ -1,0 +1,347 @@
+//! Proskenion live-server contract tests.
+//!
+//! These tests exercise the HTTP/SSE protocol surface consumed by the desktop
+//! client without driving the GTK/WebKit UI.
+
+#![expect(
+    clippy::expect_used,
+    reason = "contract tests fail fast on setup errors"
+)]
+#![expect(
+    clippy::indexing_slicing,
+    reason = "JSON contract assertions intentionally show exact response bodies"
+)]
+
+use axum::http::StatusCode;
+use integration_tests::harness::{TEST_NOUS_ID, TestHarness, body_json, body_string};
+use serde_json::Value;
+use tower::ServiceExt;
+
+#[derive(Debug)]
+struct SseDataEvent {
+    event: String,
+    data: Value,
+}
+
+fn parse_sse_data_events(body: &str) -> Vec<SseDataEvent> {
+    let mut events = Vec::new();
+    let mut event_name: Option<String> = None;
+    let mut data_lines = Vec::new();
+
+    for line in body.lines() {
+        if line.is_empty() {
+            if !data_lines.is_empty() {
+                let raw_data = data_lines.join("\n");
+                let data = serde_json::from_str(&raw_data).unwrap_or_else(|err| {
+                    panic!(
+                        "proskenion SSE contract mismatch: data line was not JSON: {err}; \
+                         event={event_name:?}; data={raw_data:?}; full body={body}"
+                    )
+                });
+                events.push(SseDataEvent {
+                    event: event_name.take().unwrap_or_else(|| "message".to_owned()),
+                    data,
+                });
+                data_lines.clear();
+            } else {
+                event_name = None;
+            }
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("event:") {
+            event_name = Some(value.trim().to_owned());
+        } else if let Some(value) = line.strip_prefix("data:") {
+            data_lines.push(value.trim().to_owned());
+        }
+    }
+
+    if !data_lines.is_empty() {
+        let raw_data = data_lines.join("\n");
+        let data = serde_json::from_str(&raw_data).unwrap_or_else(|err| {
+            panic!(
+                "proskenion SSE contract mismatch: trailing data line was not JSON: {err}; \
+                 event={event_name:?}; data={raw_data:?}; full body={body}"
+            )
+        });
+        events.push(SseDataEvent {
+            event: event_name.unwrap_or_else(|| "message".to_owned()),
+            data,
+        });
+    }
+
+    events
+}
+
+fn string_field<'a>(json: &'a Value, field: &str, context: &str) -> &'a str {
+    json.get(field).and_then(Value::as_str).unwrap_or_else(|| {
+        panic!(
+            "proskenion contract mismatch in {context}: expected string field `{field}`, got {json}"
+        )
+    })
+}
+
+fn array_field<'a>(json: &'a Value, field: &str, context: &str) -> &'a Vec<Value> {
+    json.get(field).and_then(Value::as_array).unwrap_or_else(|| {
+        panic!(
+            "proskenion contract mismatch in {context}: expected array field `{field}`, got {json}"
+        )
+    })
+}
+
+fn assert_event_type(event: &SseDataEvent) {
+    let event_type = string_field(&event.data, "type", "SSE data envelope");
+    assert_eq!(
+        event.event, event_type,
+        "proskenion SSE contract mismatch: `event:` must match JSON `type`; \
+         event line={}; data={}",
+        event.event, event.data
+    );
+}
+
+#[tokio::test]
+async fn proskenion_contract_session_create_list_history_matches_desktop() {
+    let harness = TestHarness::build().await;
+    let router = harness.router();
+
+    let req = harness.authed_request(
+        "POST",
+        "/api/v1/sessions",
+        Some(serde_json::json!({
+            "nous_id": TEST_NOUS_ID,
+            "session_key": "proskenion-contract"
+        })),
+    );
+    let resp = router
+        .clone()
+        .oneshot(req)
+        .await
+        .expect("POST /api/v1/sessions");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "proskenion contract mismatch: session create must return 201"
+    );
+    let created = body_json(resp).await;
+    let session_id = string_field(&created, "id", "session create");
+    assert_eq!(
+        string_field(&created, "nous_id", "session create"),
+        TEST_NOUS_ID,
+        "proskenion contract mismatch: created session should keep requested nous_id; body={created}"
+    );
+    assert_eq!(
+        string_field(&created, "session_key", "session create"),
+        "proskenion-contract",
+        "proskenion contract mismatch: created session should keep requested session_key; body={created}"
+    );
+    assert_eq!(
+        string_field(&created, "status", "session create"),
+        "active",
+        "proskenion contract mismatch: created sessions should be active; body={created}"
+    );
+    assert!(
+        created
+            .get("message_count")
+            .and_then(Value::as_i64)
+            .is_some(),
+        "proskenion contract mismatch: create response must expose numeric message_count; body={created}"
+    );
+    assert!(
+        created.get("created_at").and_then(Value::as_str).is_some()
+            && created.get("updated_at").and_then(Value::as_str).is_some(),
+        "proskenion contract mismatch: create response must expose created_at and updated_at; body={created}"
+    );
+
+    let req = harness.authed_get("/api/v1/sessions?limit=25");
+    let resp = router
+        .clone()
+        .oneshot(req)
+        .await
+        .expect("GET /api/v1/sessions");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "proskenion contract mismatch: session list must return 200"
+    );
+    let listed = body_json(resp).await;
+    let items = array_field(&listed, "items", "session list");
+    assert!(
+        listed.get("has_more").and_then(Value::as_bool).is_some(),
+        "proskenion contract mismatch: session list must expose boolean has_more; body={listed}"
+    );
+    let listed_session = items
+        .iter()
+        .find(|item| item.get("id").and_then(Value::as_str) == Some(session_id))
+        .unwrap_or_else(|| {
+            panic!(
+                "proskenion contract mismatch: session list did not include created session \
+                 id={session_id}; body={listed}"
+            )
+        });
+    assert_eq!(
+        string_field(listed_session, "session_key", "session list item"),
+        "proskenion-contract",
+        "proskenion contract mismatch: list item must expose session_key; item={listed_session}"
+    );
+
+    let req = harness.authed_request(
+        "POST",
+        &format!("/api/v1/sessions/{session_id}/messages"),
+        Some(serde_json::json!({ "content": "hello from proskenion contract" })),
+    );
+    let resp = router
+        .clone()
+        .oneshot(req)
+        .await
+        .expect("POST /api/v1/sessions/{id}/messages");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "proskenion contract mismatch: message send must return 200"
+    );
+    let _stream_body = body_string(resp).await;
+
+    let req = harness.authed_get(&format!("/api/v1/sessions/{session_id}/history"));
+    let resp = router
+        .oneshot(req)
+        .await
+        .expect("GET /api/v1/sessions/{id}/history");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "proskenion contract mismatch: history must return 200"
+    );
+    let history = body_json(resp).await;
+    let messages = array_field(&history, "messages", "history");
+    assert!(
+        messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("user")
+                && message.get("content").and_then(Value::as_str)
+                    == Some("hello from proskenion contract")
+        }),
+        "proskenion contract mismatch: history must contain the user message as \
+         {{role, content}} strings; body={history}"
+    );
+    assert!(
+        messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message.get("content").and_then(Value::as_str).is_some()
+        }),
+        "proskenion contract mismatch: history must contain an assistant message \
+         with string content; body={history}"
+    );
+}
+
+#[tokio::test]
+async fn proskenion_contract_chat_stream_sse_matches_desktop() {
+    let harness = TestHarness::build().await;
+    let router = harness.router();
+
+    let req = harness.authed_request(
+        "POST",
+        "/api/v1/sessions/stream",
+        Some(serde_json::json!({
+            "nous_id": TEST_NOUS_ID,
+            "session_key": "proskenion-stream-contract",
+            "message": "stream this for desktop"
+        })),
+    );
+    let resp = router
+        .oneshot(req)
+        .await
+        .expect("POST /api/v1/sessions/stream");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "proskenion SSE contract mismatch: stream endpoint must return 200"
+    );
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "proskenion SSE contract mismatch: stream endpoint must return \
+         text/event-stream content-type, got {content_type:?}"
+    );
+    let body = body_string(resp).await;
+    let events = parse_sse_data_events(&body);
+    assert!(
+        !events.is_empty(),
+        "proskenion SSE contract mismatch: stream returned no data events; body={body}"
+    );
+    for event in &events {
+        assert_event_type(event);
+    }
+
+    let start = events
+        .iter()
+        .find(|event| event.event == "message_start")
+        .unwrap_or_else(|| {
+            panic!(
+                "proskenion SSE contract mismatch: expected message_start event \
+                 before deltas; events={events:?}; body={body}"
+            )
+        });
+    assert!(
+        start
+            .data
+            .get("session_id")
+            .and_then(Value::as_str)
+            .is_some()
+            && start.data.get("nous_id").and_then(Value::as_str) == Some(TEST_NOUS_ID)
+            && start.data.get("turn_id").and_then(Value::as_str).is_some(),
+        "proskenion SSE contract mismatch: message_start must expose \
+         session_id, nous_id, and turn_id strings; data={}",
+        start.data
+    );
+
+    let complete = events
+        .iter()
+        .find(|event| event.event == "message_complete")
+        .unwrap_or_else(|| {
+            panic!(
+                "proskenion SSE contract mismatch: expected terminal message_complete; \
+                 events={events:?}; body={body}"
+            )
+        });
+    let outcome = complete
+        .data
+        .get("outcome")
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| {
+            panic!(
+                "proskenion SSE contract mismatch: message_complete must carry \
+                 object outcome; data={}",
+                complete.data
+            )
+        });
+    for field in [
+        "text",
+        "nous_id",
+        "session_id",
+        "tool_calls",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+    ] {
+        assert!(
+            outcome.contains_key(field),
+            "proskenion SSE contract mismatch: outcome missing `{field}`; \
+             outcome={outcome:?}; complete={}",
+            complete.data
+        );
+    }
+    assert!(
+        outcome
+            .get("text")
+            .and_then(Value::as_str)
+            .is_some_and(|text| !text.is_empty()),
+        "proskenion SSE contract mismatch: mock stream may complete without \
+         intermediate text_delta, but terminal outcome.text must be non-empty; \
+         outcome={outcome:?}; events={events:?}; body={body}"
+    );
+}

--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "jiff",
  "prometheus-client",
@@ -4992,7 +4992,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "bytes",
  "futures-core",

--- a/crates/theatron/proskenion/src/api/streaming.rs
+++ b/crates/theatron/proskenion/src/api/streaming.rs
@@ -395,12 +395,45 @@ mod tests {
     }
 
     #[test]
+    fn parse_message_start_snake_case_valid() {
+        let data = r#"{"type":"message_start","session_id":"s1","nous_id":"syn","turn_id":"t1"}"#;
+        let result = parse_stream_event("message_start", data);
+        if let Some(StreamEvent::TurnStart {
+            session_id,
+            nous_id,
+            turn_id,
+        }) = result
+        {
+            assert_eq!(&*session_id, "s1");
+            assert_eq!(&*nous_id, "syn");
+            assert_eq!(&*turn_id, "t1");
+        } else {
+            panic!("expected TurnStart");
+        }
+    }
+
+    #[test]
     fn parse_turn_complete_valid() {
         let data = r#"{"outcome":{"text":"done","nousId":"syn","sessionId":"s1","model":"gpt","toolCalls":0,"inputTokens":100,"outputTokens":50,"cacheReadTokens":0,"cacheWriteTokens":0}}"#;
         let result = parse_stream_event("turn_complete", data);
         if let Some(StreamEvent::TurnComplete { outcome }) = result {
             assert_eq!(outcome.text, "done");
             assert_eq!(&*outcome.nous_id, "syn");
+        } else {
+            panic!("expected TurnComplete");
+        }
+    }
+
+    #[test]
+    fn parse_message_complete_snake_case_valid() {
+        let data = r#"{"type":"message_complete","outcome":{"text":"done","nous_id":"syn","session_id":"s1","model":"gpt","tool_calls":0,"input_tokens":100,"output_tokens":50,"cache_read_tokens":0,"cache_write_tokens":0}}"#;
+        let result = parse_stream_event("message_complete", data);
+        if let Some(StreamEvent::TurnComplete { outcome }) = result {
+            assert_eq!(outcome.text, "done");
+            assert_eq!(&*outcome.nous_id, "syn");
+            assert_eq!(&*outcome.session_id, "s1");
+            assert_eq!(outcome.input_tokens, 100);
+            assert_eq!(outcome.output_tokens, 50);
         } else {
             panic!("expected TurnComplete");
         }
@@ -428,6 +461,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_tool_result_snake_case_valid() {
+        let data = r#"{"type":"tool_result","tool_name":"exec","tool_id":"t1","is_error":false,"duration_ms":150,"result":"ok"}"#;
+        let result = parse_stream_event("tool_result", data);
+        if let Some(StreamEvent::ToolResult {
+            tool_name,
+            tool_id,
+            is_error,
+            duration_ms,
+            result: tool_result,
+        }) = result
+        {
+            assert_eq!(tool_name, "exec");
+            assert_eq!(&*tool_id, "t1");
+            assert!(!is_error);
+            assert_eq!(duration_ms, 150);
+            assert_eq!(tool_result.as_deref(), Some("ok"));
+        } else {
+            panic!("expected ToolResult");
+        }
+    }
+
+    #[test]
     fn parse_tool_start_valid() {
         let data = r#"{"toolName":"read_file","toolId":"t1"}"#;
         let result = parse_stream_event("tool_start", data);
@@ -437,6 +492,24 @@ mod tests {
         {
             assert_eq!(tool_name, "read_file");
             assert_eq!(&*tool_id, "t1");
+        } else {
+            panic!("expected ToolStart");
+        }
+    }
+
+    #[test]
+    fn parse_tool_use_snake_case_valid() {
+        let data = r#"{"type":"tool_use","tool_name":"read_file","tool_id":"t1","input":{"path":"README.md"}}"#;
+        let result = parse_stream_event("tool_use", data);
+        if let Some(StreamEvent::ToolStart {
+            tool_name,
+            tool_id,
+            input,
+        }) = result
+        {
+            assert_eq!(tool_name, "read_file");
+            assert_eq!(&*tool_id, "t1");
+            assert!(input.is_some());
         } else {
             panic!("expected ToolStart");
         }

--- a/crates/theatron/proskenion/src/api/streaming.rs
+++ b/crates/theatron/proskenion/src/api/streaming.rs
@@ -74,24 +74,29 @@ pub(crate) fn stream_turn(
         .header("Accept", "text/event-stream");
 
     let span = tracing::info_span!("stream_turn");
-    tokio::spawn(
-        async move {
+    let task = async move {
             let resp = match tokio::select! {
                 biased;
                 _ = cancel.cancelled() => {
                     tracing::info!("stream cancelled before connect");
-                    let _ = tx.send(StreamEvent::TurnAbort {
+                    if tx.send(StreamEvent::TurnAbort {
                         reason: "cancelled by user".to_string(),
-                    }).await;
+                    }).await.is_err() {
+                        tracing::debug!("stream receiver dropped before cancellation notice");
+                    }
                     return;
                 }
                 result = builder.send() => result,
             } {
                 Ok(resp) => resp,
                 Err(e) => {
-                    let _ = tx
+                    if tx
                         .send(StreamEvent::Error(format!("failed to connect: {e}")))
-                        .await;
+                        .await
+                        .is_err()
+                    {
+                        tracing::debug!("stream receiver dropped before connect error");
+                    }
                     return;
                 }
             };
@@ -101,7 +106,9 @@ pub(crate) fn stream_turn(
                 let reason = status.canonical_reason().unwrap_or("Unknown");
                 let body = resp.text().await.unwrap_or_default();
                 let message = extract_error_message(&body, status.as_u16(), reason);
-                let _ = tx.send(StreamEvent::Error(message)).await;
+                if tx.send(StreamEvent::Error(message)).await.is_err() {
+                    tracing::debug!("stream receiver dropped before HTTP error");
+                }
                 return;
             }
 
@@ -112,9 +119,11 @@ pub(crate) fn stream_turn(
                     biased;
                     _ = cancel.cancelled() => {
                         tracing::info!("stream cancelled by user");
-                        let _ = tx.send(StreamEvent::TurnAbort {
+                        if tx.send(StreamEvent::TurnAbort {
                             reason: "cancelled by user".to_string(),
-                        }).await;
+                        }).await.is_err() {
+                            tracing::debug!("stream receiver dropped before cancellation notice");
+                        }
                         return;
                     }
                     event = es.next() => event,
@@ -137,9 +146,8 @@ pub(crate) fn stream_turn(
                     }
                 }
             }
-        }
-        .instrument(span),
-    );
+        };
+    tokio::spawn(task.instrument(span));
 
     rx
 }
@@ -162,6 +170,24 @@ fn str_field<'a>(json: &'a serde_json::Value, field: &str, event_type: &str) -> 
         tracing::warn!(event_type, field, "missing required field in stream event");
         None
     })
+}
+
+fn str_any_field<'a>(
+    json: &'a serde_json::Value,
+    fields: &[&str],
+    event_type: &str,
+) -> Option<&'a str> {
+    fields
+        .iter()
+        .find_map(|field| json.get(field).and_then(|v| v.as_str()))
+        .or_else(|| {
+            tracing::warn!(
+                event_type,
+                fields = ?fields,
+                "missing required field in stream event"
+            );
+            None
+        })
 }
 
 fn u32_field(json: &serde_json::Value, field: &str, event_type: &str) -> Option<u32> {
@@ -188,10 +214,16 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
     };
 
     match event_type {
-        "turn_start" => Some(StreamEvent::TurnStart {
-            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
-            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
-            turn_id: TurnId::from(str_field(&json, "turnId", event_type)?.to_string()),
+        "message_start" | "turn_start" => Some(StreamEvent::TurnStart {
+            session_id: SessionId::from(
+                str_any_field(&json, &["session_id", "sessionId"], event_type)?.to_string(),
+            ),
+            nous_id: NousId::from(
+                str_any_field(&json, &["nous_id", "nousId"], event_type)?.to_string(),
+            ),
+            turn_id: TurnId::from(
+                str_any_field(&json, &["turn_id", "turnId"], event_type)?.to_string(),
+            ),
         }),
         "text_delta" => Some(StreamEvent::TextDelta(
             str_field(&json, "text", event_type)?.to_string(),
@@ -199,29 +231,39 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
         "thinking_delta" => Some(StreamEvent::ThinkingDelta(
             str_field(&json, "text", event_type)?.to_string(),
         )),
-        "tool_start" => Some(StreamEvent::ToolStart {
-            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
-            tool_id: ToolId::from(str_field(&json, "toolId", event_type)?.to_string()),
+        "tool_use" | "tool_start" => Some(StreamEvent::ToolStart {
+            tool_name: str_any_field(&json, &["tool_name", "toolName"], event_type)?.to_string(),
+            tool_id: ToolId::from(
+                str_any_field(&json, &["tool_id", "toolId"], event_type)?.to_string(),
+            ),
             input: json.get("input").cloned(),
         }),
         "tool_result" => {
-            let tool_name = str_field(&json, "toolName", event_type)?.to_string();
-            let tool_id = ToolId::from(str_field(&json, "toolId", event_type)?.to_string());
-            let is_error = json.get("isError").and_then(|v| v.as_bool()).or_else(|| {
-                tracing::warn!(
-                    event_type,
-                    field = "isError",
-                    "missing required field in stream event"
-                );
-                None
-            })?;
+            let tool_name =
+                str_any_field(&json, &["tool_name", "toolName"], event_type)?.to_string();
+            let tool_id = ToolId::from(
+                str_any_field(&json, &["tool_id", "toolId"], event_type)?.to_string(),
+            );
+            let is_error = json
+                .get("is_error")
+                .or_else(|| json.get("isError"))
+                .and_then(|v| v.as_bool())
+                .or_else(|| {
+                    tracing::warn!(
+                        event_type,
+                        field = "is_error",
+                        "missing required field in stream event"
+                    );
+                    None
+                })?;
             let duration_ms = json
-                .get("durationMs")
+                .get("duration_ms")
+                .or_else(|| json.get("durationMs"))
                 .and_then(|v| v.as_u64())
                 .or_else(|| {
                     tracing::warn!(
                         event_type,
-                        field = "durationMs",
+                        field = "duration_ms",
                         "missing required field in stream event"
                     );
                     None
@@ -238,9 +280,13 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
             })
         }
         "tool_approval_required" => Some(StreamEvent::ToolApprovalRequired {
-            turn_id: TurnId::from(str_field(&json, "turnId", event_type)?.to_string()),
-            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
-            tool_id: ToolId::from(str_field(&json, "toolId", event_type)?.to_string()),
+            turn_id: TurnId::from(
+                str_any_field(&json, &["turn_id", "turnId"], event_type)?.to_string(),
+            ),
+            tool_name: str_any_field(&json, &["tool_name", "toolName"], event_type)?.to_string(),
+            tool_id: ToolId::from(
+                str_any_field(&json, &["tool_id", "toolId"], event_type)?.to_string(),
+            ),
             input: json
                 .get("input")
                 .cloned()
@@ -249,10 +295,12 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
             reason: str_field(&json, "reason", event_type)?.to_string(),
         }),
         "tool_approval_resolved" => Some(StreamEvent::ToolApprovalResolved {
-            tool_id: ToolId::from(str_field(&json, "toolId", event_type)?.to_string()),
+            tool_id: ToolId::from(
+                str_any_field(&json, &["tool_id", "toolId"], event_type)?.to_string(),
+            ),
             decision: str_field(&json, "decision", event_type)?.to_string(),
         }),
-        "turn_complete" => {
+        "message_complete" | "turn_complete" => {
             let outcome = json
                 .get("outcome")
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
@@ -279,16 +327,24 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
             Some(StreamEvent::PlanProposed { plan })
         }
         "plan_step_start" => Some(StreamEvent::PlanStepStart {
-            plan_id: PlanId::from(str_field(&json, "planId", event_type)?.to_string()),
-            step_id: u32_field(&json, "stepId", event_type)?,
+            plan_id: PlanId::from(
+                str_any_field(&json, &["plan_id", "planId"], event_type)?.to_string(),
+            ),
+            step_id: u32_field(&json, "step_id", event_type)
+                .or_else(|| u32_field(&json, "stepId", event_type))?,
         }),
         "plan_step_complete" => Some(StreamEvent::PlanStepComplete {
-            plan_id: PlanId::from(str_field(&json, "planId", event_type)?.to_string()),
-            step_id: u32_field(&json, "stepId", event_type)?,
+            plan_id: PlanId::from(
+                str_any_field(&json, &["plan_id", "planId"], event_type)?.to_string(),
+            ),
+            step_id: u32_field(&json, "step_id", event_type)
+                .or_else(|| u32_field(&json, "stepId", event_type))?,
             status: str_field(&json, "status", event_type)?.to_string(),
         }),
         "plan_complete" => Some(StreamEvent::PlanComplete {
-            plan_id: PlanId::from(str_field(&json, "planId", event_type)?.to_string()),
+            plan_id: PlanId::from(
+                str_any_field(&json, &["plan_id", "planId"], event_type)?.to_string(),
+            ),
             status: str_field(&json, "status", event_type)?.to_string(),
         }),
         "queue_drained" => {

--- a/crates/theatron/skene/src/api/streaming.rs
+++ b/crates/theatron/skene/src/api/streaming.rs
@@ -354,6 +354,24 @@ mod tests {
     }
 
     #[test]
+    fn parse_message_start_snake_case_valid() {
+        let data = r#"{"type":"message_start","session_id":"s1","nous_id":"syn","turn_id":"t1"}"#;
+        let result = parse_stream_event("message_start", data);
+        if let Some(StreamEvent::TurnStart {
+            session_id,
+            nous_id,
+            turn_id,
+        }) = result
+        {
+            assert_eq!(&*session_id, "s1");
+            assert_eq!(&*nous_id, "syn");
+            assert_eq!(&*turn_id, "t1");
+        } else {
+            panic!("expected TurnStart");
+        }
+    }
+
+    #[test]
     fn parse_turn_complete_valid() {
         let data = r#"{"outcome":{"text":"done","nousId":"syn","sessionId":"s1","model":"gpt","toolCalls":0,"inputTokens":100,"outputTokens":50,"cacheReadTokens":0,"cacheWriteTokens":0}}"#;
         let result = parse_stream_event("turn_complete", data);
@@ -361,6 +379,22 @@ mod tests {
         if let Some(StreamEvent::TurnComplete { outcome }) = result {
             assert_eq!(outcome.text, "done");
             assert_eq!(&*outcome.nous_id, "syn");
+        } else {
+            panic!("expected TurnComplete");
+        }
+    }
+
+    #[test]
+    fn parse_message_complete_snake_case_valid() {
+        let data = r#"{"type":"message_complete","outcome":{"text":"done","nous_id":"syn","session_id":"s1","model":"gpt","tool_calls":0,"input_tokens":100,"output_tokens":50,"cache_read_tokens":0,"cache_write_tokens":0}}"#;
+        let result = parse_stream_event("message_complete", data);
+        assert!(result.is_some());
+        if let Some(StreamEvent::TurnComplete { outcome }) = result {
+            assert_eq!(outcome.text, "done");
+            assert_eq!(&*outcome.nous_id, "syn");
+            assert_eq!(&*outcome.session_id, "s1");
+            assert_eq!(outcome.input_tokens, 100);
+            assert_eq!(outcome.output_tokens, 50);
         } else {
             panic!("expected TurnComplete");
         }
@@ -383,6 +417,41 @@ mod tests {
             assert_eq!(duration_ms, 150);
         } else {
             panic!("expected ToolResult");
+        }
+    }
+
+    #[test]
+    fn parse_tool_result_snake_case_valid() {
+        let data = r#"{"type":"tool_result","tool_name":"exec","tool_id":"t1","is_error":false,"duration_ms":150,"result":"ok"}"#;
+        let result = parse_stream_event("tool_result", data);
+        assert!(result.is_some());
+        if let Some(StreamEvent::ToolResult {
+            tool_name,
+            is_error,
+            duration_ms,
+            ..
+        }) = result
+        {
+            assert_eq!(tool_name, "exec");
+            assert!(!is_error);
+            assert_eq!(duration_ms, 150);
+        } else {
+            panic!("expected ToolResult");
+        }
+    }
+
+    #[test]
+    fn parse_tool_use_snake_case_valid() {
+        let data = r#"{"type":"tool_use","tool_name":"read_file","tool_id":"t1","input":{"path":"README.md"}}"#;
+        let result = parse_stream_event("tool_use", data);
+        if let Some(StreamEvent::ToolStart {
+            tool_name, tool_id, ..
+        }) = result
+        {
+            assert_eq!(tool_name, "read_file");
+            assert_eq!(&*tool_id, "t1");
+        } else {
+            panic!("expected ToolStart");
         }
     }
 

--- a/crates/theatron/skene/src/api/streaming.rs
+++ b/crates/theatron/skene/src/api/streaming.rs
@@ -58,77 +58,91 @@ pub fn stream_message(
         nous.id = nous_id,
         session.key = session_key
     );
-    tokio::spawn(
-        async move {
-            let resp = match builder.send().await {
-                Ok(resp) => resp,
+    let task = async move {
+        let resp = match builder.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                if tx
+                    .send(StreamEvent::Error(format!("failed to connect: {e}")))
+                    .await
+                    .is_err()
+                {
+                    tracing::debug!("stream receiver dropped before connect error");
+                }
+                return;
+            }
+        };
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let reason = status.canonical_reason().unwrap_or("Unknown");
+            let body = match resp.text().await {
+                Ok(body) => body,
                 Err(e) => {
-                    let _ = tx
-                        .send(StreamEvent::Error(format!("failed to connect: {e}")))
-                        .await;
-                    return;
+                    tracing::warn!(error = %e, "failed to read stream error response body");
+                    String::new()
+                }
+            };
+            let message = if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+                json.get("message")
+                    .or_else(|| json.get("error"))
+                    .and_then(|v| v.as_str())
+                    .map_or_else(
+                        || format!("{} {}", status.as_u16(), reason),
+                        std::string::ToString::to_string,
+                    )
+            } else {
+                format!("{} {}", status.as_u16(), reason)
+            };
+            if tx.send(StreamEvent::Error(message)).await.is_err() {
+                tracing::debug!("stream receiver dropped before HTTP error");
+            }
+            return;
+        }
+
+        let mut es = SseStream::new(resp.bytes_stream());
+
+        loop {
+            let maybe_event = tokio::time::timeout(READ_TIMEOUT, es.next()).await;
+            let event = match maybe_event {
+                Ok(Some(event)) => event,
+                Ok(None) => break,
+                Err(_elapsed) => {
+                    // WHY: No event received within READ_TIMEOUT. A healthy
+                    // server sends data more frequently than this window, so
+                    // silence here indicates a hung or dropped connection.
+                    tracing::warn!(
+                        timeout_secs = READ_TIMEOUT.as_secs(),
+                        "stream read timeout — treating as error"
+                    );
+                    if tx
+                        .send(StreamEvent::Error("stream timeout".to_string()))
+                        .await
+                        .is_err()
+                    {
+                        tracing::debug!("stream receiver dropped before timeout error");
+                    }
+                    break;
                 }
             };
 
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let reason = status.canonical_reason().unwrap_or("Unknown");
-                let body = resp.text().await.unwrap_or_default();
-                let message = if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
-                    json.get("message")
-                        .or_else(|| json.get("error"))
-                        .and_then(|v| v.as_str())
-                        .map_or_else(
-                            || format!("{} {}", status.as_u16(), reason),
-                            std::string::ToString::to_string,
-                        )
-                } else {
-                    format!("{} {}", status.as_u16(), reason)
-                };
-                let _ = tx.send(StreamEvent::Error(message)).await;
-                return;
-            }
-
-            let mut es = SseStream::new(resp.bytes_stream());
-
-            loop {
-                let maybe_event = tokio::time::timeout(READ_TIMEOUT, es.next()).await;
-                let event = match maybe_event {
-                    Ok(Some(event)) => event,
-                    Ok(None) => break,
-                    Err(_elapsed) => {
-                        // WHY: No event received within READ_TIMEOUT. A healthy
-                        // server sends data more frequently than this window, so
-                        // silence here indicates a hung or dropped connection.
-                        tracing::warn!(
-                            timeout_secs = READ_TIMEOUT.as_secs(),
-                            "stream read timeout — treating as error"
-                        );
-                        let _ = tx
-                            .send(StreamEvent::Error("stream timeout".to_string()))
-                            .await;
-                        break;
-                    }
-                };
-
-                if let Some(parsed) = parse_stream_event(&event.event, &event.data) {
-                    let is_terminal = matches!(
-                        &parsed,
-                        StreamEvent::TurnComplete { .. }
-                            | StreamEvent::TurnAbort { .. }
-                            | StreamEvent::Error(_)
-                    );
-                    if tx.send(parsed).await.is_err() {
-                        break;
-                    }
-                    if is_terminal {
-                        break;
-                    }
+            if let Some(parsed) = parse_stream_event(&event.event, &event.data) {
+                let is_terminal = matches!(
+                    &parsed,
+                    StreamEvent::TurnComplete { .. }
+                        | StreamEvent::TurnAbort { .. }
+                        | StreamEvent::Error(_)
+                );
+                if tx.send(parsed).await.is_err() {
+                    break;
+                }
+                if is_terminal {
+                    break;
                 }
             }
         }
-        .instrument(span),
-    );
+    };
+    tokio::spawn(task.instrument(span));
 
     rx
 }
@@ -138,6 +152,52 @@ fn str_field<'a>(json: &'a serde_json::Value, field: &str, event_type: &str) -> 
         tracing::warn!(event_type, field, "missing required field in stream event");
         None
     })
+}
+
+fn str_any_field<'a>(
+    json: &'a serde_json::Value,
+    fields: &[&str],
+    event_type: &str,
+) -> Option<&'a str> {
+    fields
+        .iter()
+        .find_map(|field| json.get(field).and_then(|v| v.as_str()))
+        .or_else(|| {
+            tracing::warn!(
+                event_type,
+                fields = ?fields,
+                "missing required field in stream event"
+            );
+            None
+        })
+}
+
+fn bool_any_field(json: &serde_json::Value, fields: &[&str], event_type: &str) -> Option<bool> {
+    fields
+        .iter()
+        .find_map(|field| json.get(field).and_then(serde_json::Value::as_bool))
+        .or_else(|| {
+            tracing::warn!(
+                event_type,
+                fields = ?fields,
+                "missing required field in stream event"
+            );
+            None
+        })
+}
+
+fn u64_any_field(json: &serde_json::Value, fields: &[&str], event_type: &str) -> Option<u64> {
+    fields
+        .iter()
+        .find_map(|field| json.get(field).and_then(serde_json::Value::as_u64))
+        .or_else(|| {
+            tracing::warn!(
+                event_type,
+                fields = ?fields,
+                "missing required field in stream event"
+            );
+            None
+        })
 }
 
 #[expect(
@@ -154,10 +214,16 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
     };
 
     match event_type {
-        "turn_start" => Some(StreamEvent::TurnStart {
-            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
-            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
-            turn_id: TurnId::from(str_field(&json, "turnId", event_type)?.to_string()),
+        "message_start" | "turn_start" => Some(StreamEvent::TurnStart {
+            session_id: SessionId::from(
+                str_any_field(&json, &["session_id", "sessionId"], event_type)?.to_string(),
+            ),
+            nous_id: NousId::from(
+                str_any_field(&json, &["nous_id", "nousId"], event_type)?.to_string(),
+            ),
+            turn_id: TurnId::from(
+                str_any_field(&json, &["turn_id", "turnId"], event_type)?.to_string(),
+            ),
         }),
         "text_delta" => Some(StreamEvent::TextDelta(
             str_field(&json, "text", event_type)?.to_string(),
@@ -165,36 +231,20 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
         "thinking_delta" => Some(StreamEvent::ThinkingDelta(
             str_field(&json, "text", event_type)?.to_string(),
         )),
-        "tool_start" => Some(StreamEvent::ToolStart {
-            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
-            tool_id: ToolId::from(str_field(&json, "toolId", event_type)?.to_string()),
+        "tool_use" | "tool_start" => Some(StreamEvent::ToolStart {
+            tool_name: str_any_field(&json, &["tool_name", "toolName"], event_type)?.to_string(),
+            tool_id: ToolId::from(
+                str_any_field(&json, &["tool_id", "toolId"], event_type)?.to_string(),
+            ),
             input: json.get("input").cloned(),
         }),
         "tool_result" => {
-            let tool_name = str_field(&json, "toolName", event_type)?.to_string();
-            let tool_id = ToolId::from(str_field(&json, "toolId", event_type)?.to_string());
-            let is_error = json
-                .get("isError")
-                .and_then(serde_json::Value::as_bool)
-                .or_else(|| {
-                    tracing::warn!(
-                        event_type,
-                        field = "isError",
-                        "missing required field in stream event"
-                    );
-                    None
-                })?;
-            let duration_ms = json
-                .get("durationMs")
-                .and_then(serde_json::Value::as_u64)
-                .or_else(|| {
-                    tracing::warn!(
-                        event_type,
-                        field = "durationMs",
-                        "missing required field in stream event"
-                    );
-                    None
-                })?;
+            let tool_name =
+                str_any_field(&json, &["tool_name", "toolName"], event_type)?.to_string();
+            let tool_id =
+                ToolId::from(str_any_field(&json, &["tool_id", "toolId"], event_type)?.to_string());
+            let is_error = bool_any_field(&json, &["is_error", "isError"], event_type)?;
+            let duration_ms = u64_any_field(&json, &["duration_ms", "durationMs"], event_type)?;
             let result = json
                 .get("result")
                 .and_then(|v| v.as_str())
@@ -208,9 +258,13 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
             })
         }
         "tool_approval_required" => Some(StreamEvent::ToolApprovalRequired {
-            turn_id: TurnId::from(str_field(&json, "turnId", event_type)?.to_string()),
-            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
-            tool_id: ToolId::from(str_field(&json, "toolId", event_type)?.to_string()),
+            turn_id: TurnId::from(
+                str_any_field(&json, &["turn_id", "turnId"], event_type)?.to_string(),
+            ),
+            tool_name: str_any_field(&json, &["tool_name", "toolName"], event_type)?.to_string(),
+            tool_id: ToolId::from(
+                str_any_field(&json, &["tool_id", "toolId"], event_type)?.to_string(),
+            ),
             input: json
                 .get("input")
                 .cloned()
@@ -219,7 +273,9 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
             reason: str_field(&json, "reason", event_type)?.to_string(),
         }),
         "tool_approval_resolved" => Some(StreamEvent::ToolApprovalResolved {
-            tool_id: ToolId::from(str_field(&json, "toolId", event_type)?.to_string()),
+            tool_id: ToolId::from(
+                str_any_field(&json, &["tool_id", "toolId"], event_type)?.to_string(),
+            ),
             decision: str_field(&json, "decision", event_type)?.to_string(),
         }),
         "plan_proposed" => {
@@ -233,47 +289,33 @@ fn parse_stream_event(event_type: &str, data: &str) -> Option<StreamEvent> {
             Some(StreamEvent::PlanProposed { plan })
         }
         "plan_step_start" => {
-            let step_id_u64 = json
-                .get("stepId")
-                .and_then(serde_json::Value::as_u64)
-                .or_else(|| {
-                    tracing::warn!(
-                        event_type,
-                        field = "stepId",
-                        "missing required field in stream event"
-                    );
-                    None
-                })?;
+            let step_id_u64 = u64_any_field(&json, &["step_id", "stepId"], event_type)?;
             let step_id = u32::try_from(step_id_u64).unwrap_or(u32::MAX);
             Some(StreamEvent::PlanStepStart {
-                plan_id: PlanId::from(str_field(&json, "planId", event_type)?.to_string()),
+                plan_id: PlanId::from(
+                    str_any_field(&json, &["plan_id", "planId"], event_type)?.to_string(),
+                ),
                 step_id,
             })
         }
         "plan_step_complete" => {
-            let step_id_u64 = json
-                .get("stepId")
-                .and_then(serde_json::Value::as_u64)
-                .or_else(|| {
-                    tracing::warn!(
-                        event_type,
-                        field = "stepId",
-                        "missing required field in stream event"
-                    );
-                    None
-                })?;
+            let step_id_u64 = u64_any_field(&json, &["step_id", "stepId"], event_type)?;
             let step_id = u32::try_from(step_id_u64).unwrap_or(u32::MAX);
             Some(StreamEvent::PlanStepComplete {
-                plan_id: PlanId::from(str_field(&json, "planId", event_type)?.to_string()),
+                plan_id: PlanId::from(
+                    str_any_field(&json, &["plan_id", "planId"], event_type)?.to_string(),
+                ),
                 step_id,
                 status: str_field(&json, "status", event_type)?.to_string(),
             })
         }
         "plan_complete" => Some(StreamEvent::PlanComplete {
-            plan_id: PlanId::from(str_field(&json, "planId", event_type)?.to_string()),
+            plan_id: PlanId::from(
+                str_any_field(&json, &["plan_id", "planId"], event_type)?.to_string(),
+            ),
             status: str_field(&json, "status", event_type)?.to_string(),
         }),
-        "turn_complete" => {
+        "message_complete" | "turn_complete" => {
             let outcome = json
                 .get("outcome")
                 .and_then(|v| serde_json::from_value(v.clone()).ok())

--- a/crates/theatron/skene/src/api/types/mod.rs
+++ b/crates/theatron/skene/src/api/types/mod.rs
@@ -38,7 +38,7 @@ impl Agent {
 }
 
 /// A session within an agent.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)] // kanon:ignore RUST/no-debug-derive-on-public-types
 pub struct Session {
     /// Session identifier.
     pub id: SessionId,
@@ -127,27 +127,27 @@ pub struct TurnOutcome {
     /// Final text output.
     pub text: String,
     /// Agent that processed this turn.
-    #[serde(rename = "nousId")]
+    #[serde(rename = "nousId", alias = "nous_id")]
     pub nous_id: NousId,
     /// Session this turn belongs to.
-    #[serde(rename = "sessionId")]
+    #[serde(rename = "sessionId", alias = "session_id")]
     pub session_id: SessionId,
     /// Model used for this turn.
     pub model: String,
     /// Number of tool calls made.
-    #[serde(rename = "toolCalls", default)]
+    #[serde(rename = "toolCalls", alias = "tool_calls", default)]
     pub tool_calls: u32,
     /// Input tokens consumed.
-    #[serde(rename = "inputTokens", default)]
+    #[serde(rename = "inputTokens", alias = "input_tokens", default)]
     pub input_tokens: u32,
     /// Output tokens generated.
-    #[serde(rename = "outputTokens", default)]
+    #[serde(rename = "outputTokens", alias = "output_tokens", default)]
     pub output_tokens: u32,
     /// Tokens read from cache.
-    #[serde(rename = "cacheReadTokens", default)]
+    #[serde(rename = "cacheReadTokens", alias = "cache_read_tokens", default)]
     pub cache_read_tokens: u32,
     /// Tokens written to cache.
-    #[serde(rename = "cacheWriteTokens", default)]
+    #[serde(rename = "cacheWriteTokens", alias = "cache_write_tokens", default)]
     pub cache_write_tokens: u32,
     /// Error message, if the turn errored.
     #[serde(default)]
@@ -396,6 +396,7 @@ pub struct AgentsResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionsResponse {
     /// List of sessions.
+    #[serde(alias = "items")]
     pub sessions: Vec<Session>,
 }
 

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -39,6 +39,22 @@ cargo build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml
 cargo build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml --release
 ```
 
+## Contract and smoke checks
+
+The desktop crate is outside the main workspace, so acceptance uses two focused checks instead of a full GUI driver:
+
+```bash
+CARGO_TARGET_DIR=/data/target/wt/proskenion-contract-smoke/target \
+  cargo +1.94 test -p integration-tests --features test-core proskenion_contract -- --nocapture
+
+bash -n scripts/smoke-proskenion.sh
+scripts/smoke-proskenion.sh --server-url http://127.0.0.1:3000 --proskenion-binary ~/.cargo/bin/proskenion
+```
+
+The `proskenion_contract` integration test exercises the protocol surface the app consumes: session create/list/history and `POST /api/v1/sessions/stream` SSE event names, terminal events, and JSON field shape. If it fails, file the failure as a server/client runtime-contract mismatch and include the assertion text, full response body printed by the test, endpoint, and expected proskenion field or event name.
+
+The smoke script starts a local server when no `--server-url` is supplied, or connects to the supplied URL. It writes a temporary desktop config, uses `xvfb-run` when no `DISPLAY` is available, enforces a bounded runtime, captures logs, and fails on known display/startup/connectivity patterns. Missing Xvfb or a missing `proskenion` binary exits with a clear skip status instead of silently passing.
+
 ## Pin discipline
 
 `proskenion` has its own standalone workspace, so its theatron git dependencies cannot inherit from the root `[workspace.dependencies]` block. Keep the mirrored pins in `crates/theatron/proskenion/Cargo.toml` aligned with the root manifest.

--- a/scripts/smoke-proskenion.sh
+++ b/scripts/smoke-proskenion.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 #   ALETHEIA_URL          Existing server URL.
 #   ALETHEIA_AUTH_TOKEN   Bearer token written to the temporary desktop config.
 #   PROSKENION_RUNTIME    Runtime budget in seconds, default: 20.
+#   ALETHEIA_SMOKE_KEEP_LOGS  Preserve temporary logs on success when set to 1.
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROSKENION_BINARY="${PROSKENION_BINARY:-$REPO_ROOT/crates/theatron/proskenion/target/release/proskenion}"
@@ -23,6 +24,7 @@ SERVER_BINARY="${ALETHEIA_BINARY:-$REPO_ROOT/target/debug/aletheia}"
 SERVER_URL="${ALETHEIA_URL:-}"
 AUTH_TOKEN="${ALETHEIA_AUTH_TOKEN:-}"
 RUNTIME="${PROSKENION_RUNTIME:-20}"
+KEEP_LOGS="${ALETHEIA_SMOKE_KEEP_LOGS:-0}"
 START_SERVER=false
 TMPDIR=""
 SERVER_PID=""
@@ -46,12 +48,17 @@ usage() {
 }
 
 cleanup() {
+    local status=$?
     if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
         kill "$SERVER_PID" >/dev/null 2>&1 || true # best-effort cleanup
         wait "$SERVER_PID" >/dev/null 2>&1 || true # process may already be gone
     fi
     if [[ -n "${TMPDIR:-}" ]]; then
-        rm -rf "$TMPDIR"
+        if [[ "$status" -ne 0 || "$KEEP_LOGS" == "1" ]]; then
+            log "$(printf 'preserving logs under %s' "$LOGDIR")"
+        else
+            rm -rf "$TMPDIR"
+        fi
     fi
 }
 trap cleanup EXIT
@@ -121,6 +128,16 @@ mkdir -p "$LOGDIR" "$CONFIG_HOME/aletheia" "$INSTANCE_ROOT"
 if [[ "$START_SERVER" == true ]]; then
     PORT="${ALETHEIA_SMOKE_PORT:-$(( 39000 + (RANDOM % 2000) ))}"
     SERVER_URL="$(printf 'http://127.0.0.1:%s' "$PORT")"
+    mkdir -p "$INSTANCE_ROOT/config"
+    {
+        echo "[gateway]"
+        echo 'bind = "localhost"'
+        printf 'port = %s\n' "$PORT"
+        echo
+        echo "[gateway.auth]"
+        echo 'mode = "none"'
+        echo 'none_role = "operator"'
+    } >"$INSTANCE_ROOT/config/aletheia.toml"
     log "$(printf 'starting server: %s --instance-root %s --bind 127.0.0.1 --port %s serve' "$SERVER_BINARY" "$INSTANCE_ROOT" "$PORT")"
     "$SERVER_BINARY" \
         --instance-root "$INSTANCE_ROOT" \
@@ -181,4 +198,8 @@ if grep -Eiq "$ERROR_PATTERN" "$PROSKENION_LOG"; then
     die "$(printf 'known startup/display/connection error pattern found in %s' "$PROSKENION_LOG")"
 fi
 
-log "$(printf 'pass; logs were captured under %s' "$LOGDIR")"
+if [[ "$KEEP_LOGS" == "1" ]]; then
+    log "$(printf 'pass; logs captured under %s' "$LOGDIR")"
+else
+    log "pass; temporary logs will be removed (set ALETHEIA_SMOKE_KEEP_LOGS=1 to retain them)"
+fi

--- a/scripts/smoke-proskenion.sh
+++ b/scripts/smoke-proskenion.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke-test proskenion startup against a live or script-started Aletheia server.
+#
+# This is intentionally a process/display/connectivity smoke, not a GUI driver.
+#
+# Usage:
+#   scripts/smoke-proskenion.sh [--server-url URL] [--auth-token TOKEN]
+#                              [--proskenion-binary PATH] [--server-binary PATH]
+#                              [--runtime SECONDS]
+#
+# Environment:
+#   PROSKENION_BINARY     Existing proskenion binary to run.
+#   ALETHEIA_BINARY       Existing aletheia server binary to start when no URL is supplied.
+#   ALETHEIA_URL          Existing server URL.
+#   ALETHEIA_AUTH_TOKEN   Bearer token written to the temporary desktop config.
+#   PROSKENION_RUNTIME    Runtime budget in seconds, default: 20.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROSKENION_BINARY="${PROSKENION_BINARY:-$REPO_ROOT/crates/theatron/proskenion/target/release/proskenion}"
+SERVER_BINARY="${ALETHEIA_BINARY:-$REPO_ROOT/target/debug/aletheia}"
+SERVER_URL="${ALETHEIA_URL:-}"
+AUTH_TOKEN="${ALETHEIA_AUTH_TOKEN:-}"
+RUNTIME="${PROSKENION_RUNTIME:-20}"
+START_SERVER=false
+TMPDIR=""
+SERVER_PID=""
+
+log() {
+    echo "[smoke-proskenion] $*"
+}
+
+die() {
+    log "ERROR: $*" >&2
+    exit 1
+}
+
+degrade() {
+    log "SKIP: $*" >&2
+    exit 2
+}
+
+usage() {
+    sed -n '4,18p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+cleanup() {
+    if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+        kill "$SERVER_PID" >/dev/null 2>&1 || true # best-effort cleanup
+        wait "$SERVER_PID" >/dev/null 2>&1 || true # process may already be gone
+    fi
+    if [[ -n "${TMPDIR:-}" ]]; then
+        rm -rf "$TMPDIR"
+    fi
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --server-url)
+            SERVER_URL="$2"
+            shift 2
+            ;;
+        --auth-token)
+            AUTH_TOKEN="$2"
+            shift 2
+            ;;
+        --proskenion-binary)
+            PROSKENION_BINARY="$2"
+            shift 2
+            ;;
+        --server-binary)
+            SERVER_BINARY="$2"
+            shift 2
+            ;;
+        --runtime)
+            RUNTIME="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+[[ "$RUNTIME" =~ ^[0-9]+$ ]] || die "--runtime must be an integer number of seconds"
+(( RUNTIME > 0 )) || die "--runtime must be positive"
+
+if [[ ! -x "$PROSKENION_BINARY" ]]; then
+    degrade "$(printf 'proskenion binary not found or not executable at %s; build it with scripts/install-proskenion.sh or pass --proskenion-binary' "$PROSKENION_BINARY")"
+fi
+
+if [[ -z "$SERVER_URL" ]]; then
+    if [[ ! -x "$SERVER_BINARY" ]]; then
+        degrade "$(printf 'no --server-url was supplied and aletheia server binary is unavailable at %s; pass --server-url or --server-binary' "$SERVER_BINARY")"
+    fi
+    START_SERVER=true
+fi
+
+if [[ -z "${DISPLAY:-}" ]]; then
+    if command -v xvfb-run >/dev/null 2>&1; then
+        RUNNER=(xvfb-run -a)
+    else
+        degrade "DISPLAY is unset and xvfb-run is unavailable; install Xvfb or run from an active desktop session"
+    fi
+else
+    RUNNER=()
+fi
+
+TMPDIR="$(mktemp -d)"
+LOGDIR="$TMPDIR/logs"
+CONFIG_HOME="$TMPDIR/config"
+INSTANCE_ROOT="$TMPDIR/instance"
+mkdir -p "$LOGDIR" "$CONFIG_HOME/aletheia" "$INSTANCE_ROOT"
+
+if [[ "$START_SERVER" == true ]]; then
+    PORT="${ALETHEIA_SMOKE_PORT:-$(( 39000 + (RANDOM % 2000) ))}"
+    SERVER_URL="$(printf 'http://127.0.0.1:%s' "$PORT")"
+    log "$(printf 'starting server: %s --instance-root %s --bind 127.0.0.1 --port %s serve' "$SERVER_BINARY" "$INSTANCE_ROOT" "$PORT")"
+    "$SERVER_BINARY" \
+        --instance-root "$INSTANCE_ROOT" \
+        --bind 127.0.0.1 \
+        --port "$PORT" \
+        serve >"$LOGDIR/server.log" 2>&1 &
+    SERVER_PID=$!
+
+    for _ in $(seq 1 100); do
+        if curl -fsS "$SERVER_URL/health" >/dev/null 2>&1; then
+            break
+        fi
+        if ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+            degrade "$(printf 'started server exited before health check passed; see %s/server.log' "$LOGDIR")"
+        fi
+        sleep 0.1
+    done
+fi
+
+if ! curl -fsS "$SERVER_URL/health" >/dev/null 2>&1; then
+    degrade "$(printf 'server health check failed for %s; provide a live --server-url or inspect %s/server.log' "$SERVER_URL" "$LOGDIR")"
+fi
+
+{
+    echo "[connection]"
+    printf 'server_url = "%s"\n' "$SERVER_URL"
+    echo "auto_reconnect = false"
+    echo "connect_timeout_secs = 5"
+    if [[ -n "$AUTH_TOKEN" ]]; then
+        printf 'auth_token = "%s"\n' "$AUTH_TOKEN"
+    fi
+} >"$CONFIG_HOME/aletheia/desktop.toml"
+chmod 600 "$CONFIG_HOME/aletheia/desktop.toml"
+
+PROSKENION_LOG="$LOGDIR/proskenion.log"
+log "$(printf 'running proskenion for %ss against %s' "$RUNTIME" "$SERVER_URL")"
+set +e
+XDG_CONFIG_HOME="$CONFIG_HOME" \
+RUST_LOG="${RUST_LOG:-info}" \
+timeout --preserve-status "$RUNTIME" "${RUNNER[@]}" "$PROSKENION_BINARY" \
+    >"$PROSKENION_LOG" 2>&1
+STATUS=$?
+set -e
+
+case "$STATUS" in
+    0|143)
+        ;;
+    124)
+        log "runtime budget elapsed; treating bounded timeout as expected smoke completion"
+        ;;
+    *)
+        die "$(printf 'proskenion exited with status %s; see %s' "$STATUS" "$PROSKENION_LOG")"
+        ;;
+esac
+
+ERROR_PATTERN='cannot open display|Gtk-WARNING|WebKitWebProcess.*ERROR|readPIDFromPeer|failed to connect|connection refused|error sending request|panic|panicked'
+if grep -Eiq "$ERROR_PATTERN" "$PROSKENION_LOG"; then
+    die "$(printf 'known startup/display/connection error pattern found in %s' "$PROSKENION_LOG")"
+fi
+
+log "$(printf 'pass; logs were captured under %s' "$LOGDIR")"


### PR DESCRIPTION
Closes #3883

Summary:
- Adds proskenion contract integration tests for session create/list/history and `/api/v1/sessions/stream` SSE payload shape.
- Adds `scripts/smoke-proskenion.sh` with bounded runtime, Xvfb handling, optional server startup, temp config/log capture, and startup/display/connection failure detection.
- Documents the contract/smoke flow in `docs/DESKTOP.md` and fixes proskenion/skene stream parsing for current server event names and snake_case fields.

Validation:
- `CARGO_TARGET_DIR=/data/target/wt/proskenion-contract-smoke/target cargo +1.94 test -p integration-tests --features test-core proskenion_contract -- --nocapture` passed.
- `bash -n scripts/smoke-proskenion.sh` passed.
- `RUST_LOG=error kanon lint --summary docs/DESKTOP.md` passed.
- `RUST_LOG=error kanon lint --summary scripts/smoke-proskenion.sh` passed.
- `RUST_LOG=error kanon lint --summary crates/integration-tests/tests/proskenion_contract.rs` passed.
- `RUST_LOG=error kanon lint --summary crates/theatron/proskenion/src/api/streaming.rs` passed.
- `RUST_LOG=error kanon lint --summary crates/theatron/skene/src/api/streaming.rs` passed.
- `RUST_LOG=error kanon lint --summary crates/theatron/skene/src/api/types/mod.rs` passed with reviewed suppressions only.
- `CARGO_TARGET_DIR=/data/target/wt/proskenion-contract-smoke/target cargo +1.94 test -p skene` passed.
- `cargo +1.94 fmt --check` passed.
- `git diff --check` passed.

Residual risk:
- The smoke harness was syntax/lint validated here, but not run end-to-end against a real proskenion binary/display stack in this environment.
- This intentionally remains a process/display/connectivity smoke plus HTTP/SSE contract coverage, not a full GUI driver.