### PR TITLE
test(proskenion): cover residual pylon API contracts

### DIFF
--- a/crates/integration-tests/tests/proskenion_contract.rs
+++ b/crates/integration-tests/tests/proskenion_contract.rs
@@ -13,6 +13,7 @@
 )]
 
 use axum::http::StatusCode;
+use hermeneus::test_utils::MockProvider;
 use integration_tests::harness::{TEST_NOUS_ID, TestHarness, body_json, body_string};
 use serde_json::Value;
 use tower::ServiceExt;
@@ -89,6 +90,25 @@ fn array_field<'a>(json: &'a Value, field: &str, context: &str) -> &'a Vec<Value
     })
 }
 
+fn object_field<'a>(
+    json: &'a Value,
+    field: &str,
+    context: &str,
+) -> &'a serde_json::Map<String, Value> {
+    json.get(field).and_then(Value::as_object).unwrap_or_else(|| {
+        panic!(
+            "proskenion contract mismatch in {context}: expected object field `{field}`, got {json}"
+        )
+    })
+}
+
+fn numeric_field(json: &Value, field: &str, context: &str) {
+    assert!(
+        json.get(field).is_some_and(Value::is_number),
+        "proskenion contract mismatch in {context}: expected numeric field `{field}`, got {json}"
+    );
+}
+
 fn assert_event_type(event: &SseDataEvent) {
     let event_type = string_field(&event.data, "type", "SSE data envelope");
     assert_eq!(
@@ -97,6 +117,283 @@ fn assert_event_type(event: &SseDataEvent) {
          event line={}; data={}",
         event.event, event.data
     );
+}
+
+struct RawResponse {
+    status: u16,
+    body: Vec<u8>,
+}
+
+impl RawResponse {
+    fn body_json(&self) -> Value {
+        serde_json::from_slice(&self.body).expect("proskenion contract JSON body")
+    }
+}
+
+async fn raw_get(addr: std::net::SocketAddr, path: &str, token: &str) -> RawResponse {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect proskenion contract TCP server");
+    let request = format!(
+        "GET {path} HTTP/1.1\r\n\
+         Host: {addr}\r\n\
+         Authorization: Bearer {token}\r\n\
+         Connection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write proskenion contract HTTP request");
+
+    let mut buf = Vec::new();
+    stream
+        .read_to_end(&mut buf)
+        .await
+        .expect("read proskenion contract HTTP response");
+
+    parse_http_response(&buf)
+}
+
+fn parse_http_response(bytes: &[u8]) -> RawResponse {
+    let header_end = bytes
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .expect("HTTP response missing header terminator");
+    let head =
+        std::str::from_utf8(&bytes[..header_end]).expect("HTTP response headers must be UTF-8");
+    let mut lines = head.lines();
+    let status_line = lines.next().expect("HTTP response missing status line");
+    let status = status_line
+        .split_whitespace()
+        .nth(1)
+        .expect("HTTP response missing status code")
+        .parse::<u16>()
+        .expect("HTTP response status code must be numeric");
+
+    let encoded_body = &bytes[header_end + 4..];
+    let body = if head
+        .lines()
+        .any(|line| line.eq_ignore_ascii_case("transfer-encoding: chunked"))
+    {
+        decode_chunked(encoded_body)
+    } else {
+        encoded_body.to_vec()
+    };
+
+    RawResponse { status, body }
+}
+
+fn decode_chunked(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        let line_end = bytes[index..]
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .expect("chunk size line terminator");
+        let size_str =
+            std::str::from_utf8(&bytes[index..index + line_end]).expect("chunk size UTF-8");
+        let size = usize::from_str_radix(size_str.trim(), 16).expect("chunk size hex");
+        index += line_end + 2;
+        if size == 0 {
+            break;
+        }
+        out.extend_from_slice(&bytes[index..index + size]);
+        index += size + 2;
+    }
+    out
+}
+
+fn server_addr(base_url: &str) -> std::net::SocketAddr {
+    base_url
+        .strip_prefix("http://")
+        .unwrap_or(base_url)
+        .parse()
+        .expect("parse proskenion contract server address")
+}
+
+async fn authed_get_json(addr: std::net::SocketAddr, token: &str, path: &str) -> Value {
+    let resp = raw_get(addr, path, token).await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK.as_u16(),
+        "proskenion contract mismatch: GET {path} must return 200"
+    );
+    resp.body_json()
+}
+
+#[tokio::test]
+async fn proskenion_contract_nous_surfaces_match_desktop() {
+    let harness = TestHarness::build_with_provider_and_tools(
+        Box::new(MockProvider::new("Hello from mock!").models(&["mock-model"])),
+        true,
+    )
+    .await;
+    let (base_url, token, _harness) = harness.start_tcp_server().await;
+    let addr = server_addr(&base_url);
+
+    let listed = authed_get_json(addr, &token, "/api/v1/nous").await;
+    let nous = array_field(&listed, "nous", "nous list");
+    let agent = nous
+        .iter()
+        .find(|item| item.get("id").and_then(Value::as_str) == Some(TEST_NOUS_ID))
+        .unwrap_or_else(|| {
+            panic!(
+                "proskenion contract mismatch: nous list did not include {TEST_NOUS_ID}; \
+                 body={listed}"
+            )
+        });
+    assert_eq!(
+        string_field(agent, "name", "nous list item"),
+        TEST_NOUS_ID,
+        "proskenion contract mismatch: list item should expose display name; item={agent}"
+    );
+    assert_eq!(
+        string_field(agent, "model", "nous list item"),
+        "mock-model",
+        "proskenion contract mismatch: list item should expose model; item={agent}"
+    );
+    assert_eq!(
+        string_field(agent, "status", "nous list item"),
+        "active",
+        "proskenion contract mismatch: list item should expose active status; item={agent}"
+    );
+
+    let status = authed_get_json(addr, &token, &format!("/api/v1/nous/{TEST_NOUS_ID}")).await;
+    assert_eq!(
+        string_field(&status, "id", "nous status"),
+        TEST_NOUS_ID,
+        "proskenion contract mismatch: status should keep requested nous id; body={status}"
+    );
+    assert_eq!(
+        string_field(&status, "model", "nous status"),
+        "mock-model",
+        "proskenion contract mismatch: status should expose model; body={status}"
+    );
+    numeric_field(&status, "context_window", "nous status");
+    numeric_field(&status, "max_output_tokens", "nous status");
+    numeric_field(&status, "thinking_budget", "nous status");
+    numeric_field(&status, "max_tool_iterations", "nous status");
+    assert!(
+        status
+            .get("thinking_enabled")
+            .and_then(Value::as_bool)
+            .is_some(),
+        "proskenion contract mismatch: status should expose boolean thinking_enabled; body={status}"
+    );
+    assert!(
+        status.get("status").and_then(Value::as_str).is_some(),
+        "proskenion contract mismatch: status should expose lifecycle status string; body={status}"
+    );
+
+    let tools = authed_get_json(addr, &token, &format!("/api/v1/nous/{TEST_NOUS_ID}/tools")).await;
+    let tool_items = array_field(&tools, "tools", "nous tools");
+    assert!(
+        !tool_items.is_empty(),
+        "proskenion contract mismatch: tools response should include registered built-in tools; body={tools}"
+    );
+    let first_tool = &tool_items[0];
+    for field in ["name", "description", "category"] {
+        assert!(
+            first_tool.get(field).and_then(Value::as_str).is_some(),
+            "proskenion contract mismatch: tool item missing string `{field}`; item={first_tool}"
+        );
+    }
+    assert!(
+        first_tool
+            .get("auto_activate")
+            .and_then(Value::as_bool)
+            .is_some(),
+        "proskenion contract mismatch: tool item should expose boolean auto_activate; item={first_tool}"
+    );
+}
+
+#[cfg(feature = "knowledge-store")]
+#[tokio::test]
+async fn proskenion_contract_knowledge_browse_surfaces_match_desktop() {
+    let harness = TestHarness::build_with_knowledge_store().await;
+    let (base_url, token, _harness) = harness.start_tcp_server().await;
+    let addr = server_addr(&base_url);
+
+    let facts = authed_get_json(addr, &token, "/api/v1/knowledge/facts?limit=25").await;
+    array_field(&facts, "facts", "knowledge facts");
+    numeric_field(&facts, "total", "knowledge facts");
+
+    let entities = authed_get_json(addr, &token, "/api/v1/knowledge/entities?limit=25").await;
+    array_field(&entities, "entities", "knowledge entities");
+    numeric_field(&entities, "total", "knowledge entities");
+
+    let timeline = authed_get_json(addr, &token, "/api/v1/knowledge/timeline?limit=25").await;
+    array_field(&timeline, "events", "knowledge timeline");
+    numeric_field(&timeline, "total", "knowledge timeline");
+
+    let relationships = authed_get_json(
+        addr,
+        &token,
+        "/api/v1/knowledge/entities/missing-entity/relationships",
+    )
+    .await;
+    array_field(
+        &relationships,
+        "relationships",
+        "knowledge entity relationships",
+    );
+}
+
+#[tokio::test]
+async fn proskenion_contract_metrics_surfaces_match_desktop() {
+    let harness = TestHarness::build().await;
+    let (base_url, token, _harness) = harness.start_tcp_server().await;
+    let addr = server_addr(&base_url);
+
+    let agents = authed_get_json(addr, &token, "/api/v1/metrics/agents").await;
+    let agent_metrics = array_field(&agents, "agents", "agent metrics");
+    assert!(
+        agents.get("anomalies").and_then(Value::as_array).is_some(),
+        "proskenion contract mismatch: agent metrics should expose anomalies array; body={agents}"
+    );
+    let test_agent = agent_metrics
+        .iter()
+        .find(|item| item.get("agent_id").and_then(Value::as_str) == Some(TEST_NOUS_ID))
+        .unwrap_or_else(|| {
+            panic!(
+                "proskenion contract mismatch: metrics agents did not include {TEST_NOUS_ID}; \
+                 body={agents}"
+            )
+        });
+    assert_eq!(
+        string_field(test_agent, "agent_name", "agent metrics item"),
+        TEST_NOUS_ID,
+        "proskenion contract mismatch: agent metrics should expose agent name; item={test_agent}"
+    );
+    for field in [
+        "avg_tokens_per_response",
+        "tool_calls_per_session",
+        "tool_success_rate",
+        "distillation_frequency",
+        "avg_context_before_distill",
+        "messages_per_session",
+        "sessions_per_day",
+        "errors_per_session",
+    ] {
+        numeric_field(test_agent, field, "agent metrics item");
+    }
+
+    let quality = authed_get_json(addr, &token, "/api/v1/metrics/quality").await;
+    let series = object_field(&quality, "series", "quality metrics");
+    for field in [
+        "avg_turn_length",
+        "response_to_question_ratio",
+        "tool_call_density",
+        "thinking_time_ratio",
+    ] {
+        assert!(
+            series.get(field).and_then(Value::as_array).is_some(),
+            "proskenion contract mismatch: quality series missing array `{field}`; body={quality}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/theatron/proskenion/src/views/ops/mod.rs
+++ b/crates/theatron/proskenion/src/views/ops/mod.rs
@@ -51,6 +51,25 @@ struct AgentEntry {
     tools: Vec<ToolEntryResp>,
 }
 
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged)]
+enum AgentListResponse {
+    Wrapped {
+        #[serde(default)]
+        nous: Vec<AgentEntry>,
+    },
+    Bare(Vec<AgentEntry>),
+}
+
+impl AgentListResponse {
+    fn into_agents(self) -> Vec<AgentEntry> {
+        match self {
+            Self::Wrapped { nous } => nous,
+            Self::Bare(agents) => agents,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 struct ToolEntryResp {
     #[serde(default)]
@@ -109,7 +128,7 @@ struct ConfigResponse {
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 struct FeatureFlagEntry {
     #[serde(default)]
-    key: String,
+    key: String, // kanon:ignore RUST/plain-string-secret -- feature flag identifier, not credential material
     #[serde(default)]
     description: String,
     #[serde(default)]
@@ -325,7 +344,10 @@ pub(crate) fn Ops() -> Element {
 
             let agents_data: Vec<AgentEntry> = match agents_res {
                 Ok(resp) if resp.status().is_success() => {
-                    resp.json::<Vec<AgentEntry>>().await.unwrap_or_default()
+                    resp.json::<AgentListResponse>()
+                        .await
+                        .map(AgentListResponse::into_agents)
+                        .unwrap_or_default()
                 }
                 Ok(resp) => {
                     dash_fetch.set(FetchState::Error(format!(


### PR DESCRIPTION
## Summary
- Adds TCP-backed proskenion contract coverage for residual desktop-consumed pylon shapes: `/api/v1/nous` list/detail/tools, knowledge facts/entities/timeline/entity relationships, and metrics agents/quality.
- Fixes the ops dashboard agent fetch to accept pylon's wrapped `{ "nous": [...] }` response while preserving legacy bare-array parsing.
- References #3883.

## Validation
- `CARGO_TARGET_DIR=/data/target/wt/proskenion-contract-residual/target cargo +1.94 fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/data/target/wt/proskenion-contract-residual/target cargo +1.94 test -p integration-tests --test proskenion_contract`
- `RUST_LOG=error kanon lint --summary --rust crates/integration-tests/tests/proskenion_contract.rs`
- `RUST_LOG=error kanon lint --summary --rust crates/theatron/proskenion/src/views/ops/mod.rs`
- `CARGO_TARGET_DIR=/data/target/wt/proskenion-contract-residual/target cargo +1.94 check` from `crates/theatron/proskenion`

## Remaining gaps for #3883
- Pylon still does not expose `/api/v1/metrics/costs` or `/api/v1/metrics/tokens`; the desktop metrics views reference those paths.
- Pylon still does not expose memory detail/mutation paths used by the desktop memory view: `/api/v1/knowledge/entities/{id}`, `/api/v1/knowledge/entities/{id}/memories`, `/api/v1/knowledge/entities/{id}/flag`, merge, or delete. This PR covers only the pylon knowledge browse endpoints that exist today.
