### PR TITLE
test(integration): cover residual proskenion D2 contracts

### DIFF
--- a/crates/integration-tests/tests/proskenion_contract.rs
+++ b/crates/integration-tests/tests/proskenion_contract.rs
@@ -219,7 +219,8 @@ async fn authed_get_json(addr: std::net::SocketAddr, token: &str, path: &str) ->
     assert_eq!(
         resp.status,
         StatusCode::OK.as_u16(),
-        "proskenion contract mismatch: GET {path} must return 200"
+        "proskenion contract mismatch: GET {path} must return 200; body={}",
+        String::from_utf8_lossy(&resp.body)
     );
     resp.body_json()
 }
@@ -393,6 +394,108 @@ async fn proskenion_contract_metrics_surfaces_match_desktop() {
             series.get(field).and_then(Value::as_array).is_some(),
             "proskenion contract mismatch: quality series missing array `{field}`; body={quality}"
         );
+    }
+
+    let tokens = authed_get_json(
+        addr,
+        &token,
+        "/api/v1/metrics/tokens?granularity=daily&from=2026-01-01&to=2026-12-31",
+    )
+    .await;
+    array_field(&tokens, "series", "token metrics");
+    array_field(&tokens, "agents", "token metrics");
+    array_field(&tokens, "models", "token metrics");
+    for field in [
+        "today_input",
+        "today_output",
+        "week_input",
+        "week_output",
+        "month_input",
+        "month_output",
+        "prev_today_input",
+        "prev_today_output",
+        "prev_week_input",
+        "prev_week_output",
+        "prev_month_input",
+        "prev_month_output",
+    ] {
+        numeric_field(&tokens, field, "token metrics");
+    }
+    let token_agents = array_field(&tokens, "agents", "token metrics");
+    let token_agent = token_agents
+        .iter()
+        .find(|item| item.get("id").and_then(Value::as_str) == Some(TEST_NOUS_ID))
+        .unwrap_or_else(|| {
+            panic!(
+                "proskenion contract mismatch: token metrics should include desktop agent row \
+                 with id/name/input_tokens/output_tokens/session_count; body={tokens}"
+            )
+        });
+    assert_eq!(
+        string_field(token_agent, "name", "token metrics agent row"),
+        TEST_NOUS_ID,
+        "proskenion contract mismatch: token metrics agent row should expose display name; \
+         row={token_agent}"
+    );
+    for field in ["input_tokens", "output_tokens", "session_count"] {
+        numeric_field(token_agent, field, "token metrics agent row");
+    }
+    let token_models = array_field(&tokens, "models", "token metrics");
+    let token_model = token_models
+        .iter()
+        .find(|item| item.get("model").and_then(Value::as_str) == Some("mock-model"))
+        .unwrap_or_else(|| {
+            panic!(
+                "proskenion contract mismatch: token metrics should include desktop model row \
+                 with model/input_tokens/output_tokens/session_count; body={tokens}"
+            )
+        });
+    for field in ["input_tokens", "output_tokens", "session_count"] {
+        numeric_field(token_model, field, "token metrics model row");
+    }
+
+    let costs = authed_get_json(
+        addr,
+        &token,
+        "/api/v1/metrics/costs?granularity=daily&from=2026-01-01&to=2026-12-31",
+    )
+    .await;
+    array_field(&costs, "series", "cost metrics");
+    let cost_agents = array_field(&costs, "agents", "cost metrics");
+    for field in [
+        "today_cost",
+        "week_cost",
+        "month_cost",
+        "prev_today_cost",
+        "prev_week_cost",
+        "prev_month_cost",
+    ] {
+        numeric_field(&costs, field, "cost metrics");
+    }
+    let cost_agent = cost_agents
+        .iter()
+        .find(|item| item.get("id").and_then(Value::as_str) == Some(TEST_NOUS_ID))
+        .unwrap_or_else(|| {
+            panic!(
+                "proskenion contract mismatch: cost metrics should include desktop agent row \
+                 with id/name/total_cost/message_count/session_count/output_tokens/prev_period_cost; \
+                 body={costs}"
+            )
+        });
+    assert_eq!(
+        string_field(cost_agent, "name", "cost metrics agent row"),
+        TEST_NOUS_ID,
+        "proskenion contract mismatch: cost metrics agent row should expose display name; \
+         row={cost_agent}"
+    );
+    for field in [
+        "total_cost",
+        "message_count",
+        "session_count",
+        "output_tokens",
+        "prev_period_cost",
+    ] {
+        numeric_field(cost_agent, field, "cost metrics agent row");
     }
 }
 

--- a/crates/pylon/src/handlers/insights.rs
+++ b/crates/pylon/src/handlers/insights.rs
@@ -12,8 +12,9 @@ use crate::error::{ApiError, InternalSnafu, NousNotFoundSnafu};
 use crate::insights::anomaly::detect_anomalies;
 use crate::state::InsightsState;
 use crate::types::insights::{
-    AgentPerformance, AgentPerformanceListResponse, JournalEvent, JournalQuery,
-    QualityMetricsResponse, QualitySeries, TimeSeriesPoint,
+    AgentCostRow, AgentPerformance, AgentPerformanceListResponse, AgentTokenRow,
+    CostMetricsResponse, CostSeriesPoint, JournalEvent, JournalQuery, MetricsQuery, ModelTokenRow,
+    QualityMetricsResponse, QualitySeries, TimeSeriesPoint, TokenMetricsResponse, TokenSeriesPoint,
 };
 
 // -- Safe numeric conversions ------------------------------------------------
@@ -197,6 +198,47 @@ pub async fn get_quality_metrics(
     Json(QualityMetricsResponse { series })
 }
 
+// -- GET /api/v1/metrics/tokens ----------------------------------------------
+
+/// GET /api/v1/metrics/tokens: token usage envelope consumed by desktop metrics.
+#[utoipa::path(
+    get,
+    path = "/api/v1/metrics/tokens",
+    params(MetricsQuery),
+    responses(
+        (status = 200, description = "Token metrics", body = TokenMetricsResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn get_token_metrics(
+    State(state): State<InsightsState>,
+    Query(query): Query<MetricsQuery>,
+) -> Json<TokenMetricsResponse> {
+    Json(load_token_metrics(state, query).await)
+}
+
+// -- GET /api/v1/metrics/costs -----------------------------------------------
+
+/// GET /api/v1/metrics/costs: cost metrics envelope consumed by desktop metrics.
+#[utoipa::path(
+    get,
+    path = "/api/v1/metrics/costs",
+    params(MetricsQuery),
+    responses(
+        (status = 200, description = "Cost metrics", body = CostMetricsResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn get_cost_metrics(
+    State(state): State<InsightsState>,
+    Query(query): Query<MetricsQuery>,
+) -> Json<CostMetricsResponse> {
+    let tokens = load_token_metrics(state, query).await;
+    Json(costs_from_tokens(&tokens))
+}
+
 // -- GET /api/v1/journal -----------------------------------------------------
 
 /// GET /api/v1/journal: queryable system event log.
@@ -308,6 +350,270 @@ fn compute_agent_performance(
         sessions_per_day,
         errors_per_session: 0.0,
         tokens_per_response_series,
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct TokenTotals {
+    input_tokens: u64,
+    output_tokens: u64,
+    session_count: u64,
+}
+
+impl TokenTotals {
+    fn add_tokens(&mut self, input_tokens: u64, output_tokens: u64) {
+        self.input_tokens = self.input_tokens.saturating_add(input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(output_tokens);
+    }
+
+    fn add_session(&mut self) {
+        self.session_count = self.session_count.saturating_add(1);
+    }
+}
+
+async fn load_token_metrics(state: InsightsState, query: MetricsQuery) -> TokenMetricsResponse {
+    let agent_configs: Vec<(String, String, String)> = state
+        .nous_manager
+        .configs()
+        .into_iter()
+        .map(|c| {
+            (
+                c.id.to_string(),
+                c.name
+                    .clone()
+                    .filter(|n| !n.is_empty())
+                    .unwrap_or_else(|| c.id.to_string()),
+                c.generation.model.clone(),
+            )
+        })
+        .collect();
+    let model_by_agent: HashMap<String, String> = agent_configs
+        .iter()
+        .map(|(id, _, model)| (id.clone(), model.clone()))
+        .collect();
+
+    let state_clone = state.clone();
+    let all_sessions_res = tokio::task::spawn_blocking(move || {
+        let store = state_clone.session_store.blocking_lock();
+        let sessions = store.list_sessions(None).map_err(ApiError::from)?;
+        let mut rows = Vec::with_capacity(sessions.len());
+        for session in sessions {
+            let messages = store.get_history(&session.id, None).unwrap_or_else(|err| {
+                warn!(
+                    session_id = %session.id,
+                    error = %err,
+                    "failed to load session history for token metrics"
+                );
+                Vec::new()
+            });
+            rows.push((session, messages));
+        }
+        Ok::<_, ApiError>(rows)
+    })
+    .await
+    .unwrap_or_else(|e| {
+        Err(InternalSnafu {
+            message: format!("task join failed: {e}"),
+        }
+        .build())
+    });
+
+    let session_rows = all_sessions_res.unwrap_or_else(|err| {
+        warn!(error = %err, "failed to list sessions for token metrics");
+        Vec::new()
+    });
+
+    build_token_metrics(&agent_configs, &model_by_agent, &session_rows, &query)
+}
+
+fn build_token_metrics(
+    agent_configs: &[(String, String, String)],
+    model_by_agent: &HashMap<String, String>,
+    session_rows: &[(Session, Vec<Message>)],
+    query: &MetricsQuery,
+) -> TokenMetricsResponse {
+    let mut total = TokenTotals::default();
+    let mut agents: HashMap<String, (String, TokenTotals)> = agent_configs
+        .iter()
+        .map(|(id, name, _)| (id.clone(), (name.clone(), TokenTotals::default())))
+        .collect();
+    let mut models: HashMap<String, TokenTotals> = agent_configs
+        .iter()
+        .map(|(_, _, model)| (model.clone(), TokenTotals::default()))
+        .collect();
+    let mut series: HashMap<String, TokenTotals> = HashMap::new();
+
+    for (session, messages) in session_rows {
+        if !date_in_range(&session.created_at, query) {
+            continue;
+        }
+
+        let (input_tokens, output_tokens) = message_token_split(messages);
+        total.add_tokens(input_tokens, output_tokens);
+        total.add_session();
+
+        let agent_entry = agents
+            .entry(session.nous_id.clone())
+            .or_insert_with(|| (session.nous_id.clone(), TokenTotals::default()));
+        agent_entry.1.add_tokens(input_tokens, output_tokens);
+        agent_entry.1.add_session();
+
+        let model = session
+            .model
+            .clone()
+            .or_else(|| model_by_agent.get(&session.nous_id).cloned())
+            .unwrap_or_else(|| "unknown".to_owned());
+        let model_entry = models.entry(model).or_default();
+        model_entry.add_tokens(input_tokens, output_tokens);
+        model_entry.add_session();
+
+        let bucket = bucket_date(&session.created_at, query.granularity.as_deref());
+        series
+            .entry(bucket)
+            .or_default()
+            .add_tokens(input_tokens, output_tokens);
+    }
+
+    TokenMetricsResponse {
+        series: series_points(series),
+        agents: agent_rows(agents),
+        models: model_rows(models),
+        today_input: total.input_tokens,
+        today_output: total.output_tokens,
+        week_input: total.input_tokens,
+        week_output: total.output_tokens,
+        month_input: total.input_tokens,
+        month_output: total.output_tokens,
+        prev_today_input: 0,
+        prev_today_output: 0,
+        prev_week_input: 0,
+        prev_week_output: 0,
+        prev_month_input: 0,
+        prev_month_output: 0,
+    }
+}
+
+fn message_token_split(messages: &[Message]) -> (u64, u64) {
+    let mut input_tokens = 0_u64;
+    let mut output_tokens = 0_u64;
+
+    for message in messages {
+        let tokens = u64::try_from(message.token_estimate).unwrap_or(0);
+        if message.role == Role::Assistant {
+            output_tokens = output_tokens.saturating_add(tokens);
+        } else {
+            input_tokens = input_tokens.saturating_add(tokens);
+        }
+    }
+
+    (input_tokens, output_tokens)
+}
+
+fn date_in_range(timestamp: &str, query: &MetricsQuery) -> bool {
+    let Some(date) = timestamp.get(..10) else {
+        return true;
+    };
+    if let Some(from) = query.from.as_deref()
+        && !from.is_empty()
+        && date < from
+    {
+        return false;
+    }
+    if let Some(to) = query.to.as_deref()
+        && !to.is_empty()
+        && date > to
+    {
+        return false;
+    }
+    true
+}
+
+fn bucket_date(timestamp: &str, granularity: Option<&str>) -> String {
+    let date = timestamp.get(..10).unwrap_or("1970-01-01");
+    match granularity {
+        Some("monthly") => date.get(..7).unwrap_or(date).to_owned(),
+        Some("weekly") => {
+            let year = date.get(..4).unwrap_or("1970");
+            let month_day = date.get(5..10).unwrap_or("01-01");
+            format!("{year}-W{month_day}")
+        }
+        _ => date.to_owned(),
+    }
+}
+
+fn series_points(series: HashMap<String, TokenTotals>) -> Vec<TokenSeriesPoint> {
+    let mut points: Vec<TokenSeriesPoint> = series
+        .into_iter()
+        .map(|(date, totals)| TokenSeriesPoint {
+            date,
+            input_tokens: totals.input_tokens,
+            output_tokens: totals.output_tokens,
+        })
+        .collect();
+    points.sort_by(|a, b| a.date.cmp(&b.date));
+    points
+}
+
+fn agent_rows(agents: HashMap<String, (String, TokenTotals)>) -> Vec<AgentTokenRow> {
+    let mut rows: Vec<AgentTokenRow> = agents
+        .into_iter()
+        .map(|(id, (name, totals))| AgentTokenRow {
+            id,
+            name,
+            input_tokens: totals.input_tokens,
+            output_tokens: totals.output_tokens,
+            session_count: totals.session_count,
+        })
+        .collect();
+    rows.sort_by(|a, b| a.id.cmp(&b.id));
+    rows
+}
+
+fn model_rows(models: HashMap<String, TokenTotals>) -> Vec<ModelTokenRow> {
+    let mut rows: Vec<ModelTokenRow> = models
+        .into_iter()
+        .map(|(model, totals)| ModelTokenRow {
+            model,
+            input_tokens: totals.input_tokens,
+            output_tokens: totals.output_tokens,
+            session_count: totals.session_count,
+        })
+        .collect();
+    rows.sort_by(|a, b| a.model.cmp(&b.model));
+    rows
+}
+
+fn costs_from_tokens(tokens: &TokenMetricsResponse) -> CostMetricsResponse {
+    let agents = tokens
+        .agents
+        .iter()
+        .map(|agent| AgentCostRow {
+            id: agent.id.clone(),
+            name: agent.name.clone(),
+            total_cost: 0.0,
+            message_count: 0,
+            session_count: agent.session_count,
+            output_tokens: agent.output_tokens,
+            prev_period_cost: 0.0,
+        })
+        .collect();
+
+    CostMetricsResponse {
+        series: tokens
+            .series
+            .iter()
+            .map(|point| CostSeriesPoint {
+                date: point.date.clone(),
+                cost_usd: 0.0,
+            })
+            .collect(),
+        agents,
+        today_cost: 0.0,
+        week_cost: 0.0,
+        month_cost: 0.0,
+        prev_today_cost: 0.0,
+        prev_week_cost: 0.0,
+        prev_month_cost: 0.0,
     }
 }
 

--- a/crates/pylon/src/openapi.rs
+++ b/crates/pylon/src/openapi.rs
@@ -5,15 +5,14 @@
 )]
 #![allow(clippy::needless_for_each)] // triggered by utoipa OpenApi derive macro
 
+use std::sync::Arc;
+
 use axum::extract::State;
 use axum::http::header;
 use axum::response::IntoResponse;
-
 use utoipa::OpenApi;
 
 use koina::http::CONTENT_TYPE_JSON;
-
-use std::sync::Arc;
 
 use crate::state::AppState;
 
@@ -70,6 +69,8 @@ use crate::state::AppState;
         crate::handlers::insights::get_agent_perf,
         crate::handlers::insights::get_agent_perf_one,
         crate::handlers::insights::get_quality_metrics,
+        crate::handlers::insights::get_token_metrics,
+        crate::handlers::insights::get_cost_metrics,
         crate::handlers::insights::get_journal,
         crate::handlers::planning::get_verification,
         crate::handlers::planning::refresh_verification,
@@ -118,6 +119,13 @@ use crate::state::AppState;
         crate::types::insights::QualityMetricsResponse,
         crate::types::insights::QualitySeries,
         crate::types::insights::TimeSeriesPoint,
+        crate::types::insights::TokenMetricsResponse,
+        crate::types::insights::TokenSeriesPoint,
+        crate::types::insights::AgentTokenRow,
+        crate::types::insights::ModelTokenRow,
+        crate::types::insights::CostMetricsResponse,
+        crate::types::insights::CostSeriesPoint,
+        crate::types::insights::AgentCostRow,
         crate::types::insights::JournalEvent,
     )),
     modifiers(&VersionFromCrate),

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -134,6 +134,8 @@ pub fn build_router_with(
         .route("/metrics/agents", get(insights::get_agent_perf))
         .route("/metrics/agents/{id}", get(insights::get_agent_perf_one))
         .route("/metrics/quality", get(insights::get_quality_metrics))
+        .route("/metrics/tokens", get(insights::get_token_metrics))
+        .route("/metrics/costs", get(insights::get_cost_metrics))
         .route("/journal", get(insights::get_journal))
         // WHY(#3266): planning routes belong under the versioned prefix.
         // The desktop app (proskenion) adapts to the API, not the reverse.

--- a/crates/pylon/src/types/insights.rs
+++ b/crates/pylon/src/types/insights.rs
@@ -88,6 +88,143 @@ pub struct QualityMetricsResponse {
     pub series: QualitySeries,
 }
 
+/// Query parameters shared by desktop metrics views.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct MetricsQuery {
+    /// Series granularity: daily, weekly, or monthly.
+    #[serde(default)]
+    pub granularity: Option<String>,
+    /// Inclusive start date (`YYYY-MM-DD`).
+    #[serde(default)]
+    pub from: Option<String>,
+    /// Inclusive end date (`YYYY-MM-DD`).
+    #[serde(default)]
+    pub to: Option<String>,
+}
+
+/// A single token time-series point.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct TokenSeriesPoint {
+    /// Bucket date (`YYYY-MM-DD`, ISO week, or `YYYY-MM`).
+    pub date: String,
+    /// Input tokens in this bucket.
+    pub input_tokens: u64,
+    /// Output tokens in this bucket.
+    pub output_tokens: u64,
+}
+
+/// Per-agent token usage row.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentTokenRow {
+    /// Agent identifier.
+    pub id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// Input tokens attributed to this agent.
+    pub input_tokens: u64,
+    /// Output tokens attributed to this agent.
+    pub output_tokens: u64,
+    /// Sessions attributed to this agent.
+    pub session_count: u64,
+}
+
+/// Per-model token usage row.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ModelTokenRow {
+    /// Model identifier.
+    pub model: String,
+    /// Input tokens attributed to this model.
+    pub input_tokens: u64,
+    /// Output tokens attributed to this model.
+    pub output_tokens: u64,
+    /// Sessions attributed to this model.
+    pub session_count: u64,
+}
+
+/// Response for `GET /api/v1/metrics/tokens`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct TokenMetricsResponse {
+    /// Token usage over time.
+    pub series: Vec<TokenSeriesPoint>,
+    /// Token usage grouped by agent.
+    pub agents: Vec<AgentTokenRow>,
+    /// Token usage grouped by model.
+    pub models: Vec<ModelTokenRow>,
+    /// Input tokens used today.
+    pub today_input: u64,
+    /// Output tokens used today.
+    pub today_output: u64,
+    /// Input tokens used this week.
+    pub week_input: u64,
+    /// Output tokens used this week.
+    pub week_output: u64,
+    /// Input tokens used this month.
+    pub month_input: u64,
+    /// Output tokens used this month.
+    pub month_output: u64,
+    /// Input tokens used in the previous equivalent day.
+    pub prev_today_input: u64,
+    /// Output tokens used in the previous equivalent day.
+    pub prev_today_output: u64,
+    /// Input tokens used in the previous equivalent week.
+    pub prev_week_input: u64,
+    /// Output tokens used in the previous equivalent week.
+    pub prev_week_output: u64,
+    /// Input tokens used in the previous equivalent month.
+    pub prev_month_input: u64,
+    /// Output tokens used in the previous equivalent month.
+    pub prev_month_output: u64,
+}
+
+/// A single cost time-series point.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CostSeriesPoint {
+    /// Bucket date (`YYYY-MM-DD`, ISO week, or `YYYY-MM`).
+    pub date: String,
+    /// Estimated cost in USD for this bucket.
+    pub cost_usd: f64,
+}
+
+/// Per-agent estimated cost row.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentCostRow {
+    /// Agent identifier.
+    pub id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// Estimated cost in USD.
+    pub total_cost: f64,
+    /// Message count attributed to this agent.
+    pub message_count: u64,
+    /// Sessions attributed to this agent.
+    pub session_count: u64,
+    /// Output tokens attributed to this agent.
+    pub output_tokens: u64,
+    /// Cost from the previous equivalent period.
+    pub prev_period_cost: f64,
+}
+
+/// Response for `GET /api/v1/metrics/costs`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CostMetricsResponse {
+    /// Estimated cost over time.
+    pub series: Vec<CostSeriesPoint>,
+    /// Estimated costs grouped by agent.
+    pub agents: Vec<AgentCostRow>,
+    /// Estimated cost today.
+    pub today_cost: f64,
+    /// Estimated cost this week.
+    pub week_cost: f64,
+    /// Estimated cost this month.
+    pub month_cost: f64,
+    /// Estimated cost for the previous equivalent day.
+    pub prev_today_cost: f64,
+    /// Estimated cost for the previous equivalent week.
+    pub prev_week_cost: f64,
+    /// Estimated cost for the previous equivalent month.
+    pub prev_month_cost: f64,
+}
+
 /// A single journal event.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct JournalEvent {


### PR DESCRIPTION
Refs #3883

Validation:
- `CARGO_TARGET_DIR=/data/target/wt/d2-contract-residual/target cargo +1.94 fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/data/target/wt/d2-contract-residual/target cargo +1.94 test -p integration-tests --test proskenion_contract -- --nocapture`
- `CARGO_TARGET_DIR=/data/target/wt/d2-contract-residual/target cargo +1.94 check -p pylon`
- `CARGO_TARGET_DIR=/data/target/wt/d2-contract-residual/target cargo +1.94 clippy -p pylon -- -D warnings`
- `RUST_LOG=error kanon lint --summary --rust crates/integration-tests/tests/proskenion_contract.rs`
- `RUST_LOG=error kanon lint --summary --rust crates/pylon/src/handlers/insights.rs`
- `RUST_LOG=error kanon lint --summary --rust crates/pylon/src/router.rs`
- `RUST_LOG=error kanon lint --summary --rust crates/pylon/src/types/insights.rs`
- `RUST_LOG=error kanon lint --summary --rust crates/pylon/src/openapi.rs` (reports pre-existing OpenAPI `RUST/expect` debt only; the PR-scope import-order issue is clean)

Notes:
- Adds live-server contract assertions for desktop-consumed `/api/v1/metrics/tokens` and `/api/v1/metrics/costs` envelopes.
- Wires minimal pylon handlers for those endpoints, deriving token rows from session history and returning zero-valued cost envelopes until a concrete pricing-backed cost source is available.
- Registers the new endpoints and response schemas in the aggregate OpenAPI document.