### PR TITLE
docs(proskenion): sync D2 contract coverage

### DIFF
--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -51,7 +51,7 @@ bash -n scripts/smoke-proskenion.sh
 scripts/smoke-proskenion.sh --server-url http://127.0.0.1:3000 --proskenion-binary ~/.cargo/bin/proskenion
 ```
 
-The `proskenion_contract` integration test exercises the protocol surface the app consumes: session create/list/history and `POST /api/v1/sessions/stream` SSE event names, terminal events, and JSON field shape. If it fails, file the failure as a server/client runtime-contract mismatch and include the assertion text, full response body printed by the test, endpoint, and expected proskenion field or event name.
+The `proskenion_contract` integration test exercises the protocol surface the app consumes: agent list/status/tool envelopes, knowledge browse endpoints, metrics/cost/token envelopes, session create/list/history, and `POST /api/v1/sessions/stream` SSE event names, terminal events, and JSON field shape. If it fails, file the failure as a server/client runtime-contract mismatch and include the assertion text, full response body printed by the test, endpoint, and expected proskenion field or event name.
 
 The smoke script starts a local server when no `--server-url` is supplied, or connects to the supplied URL. It writes a temporary desktop config, uses `xvfb-run` when no `DISPLAY` is available, enforces a bounded runtime, captures logs, and fails on known display/startup/connectivity patterns. Missing Xvfb or a missing `proskenion` binary exits with a clear skip status instead of silently passing.
 


### PR DESCRIPTION
Closes #3883

Validation:
- `git diff --check`
- `bash -n scripts/smoke-proskenion.sh`
- `RUST_LOG=error kanon lint --summary docs/DESKTOP.md`
- `CARGO_TARGET_DIR=/data/target/wt/d2-agent-memory-contracts/target cargo +1.94 test -p integration-tests --features test-core proskenion_contract -- --nocapture`

Notes:
- The D2 contract and smoke harness work is already shipped on `origin/main` through #3921, #3922, and #3926.
- This PR updates the desktop docs to name the full shipped contract surface: nous list/status/tools, knowledge browse, metrics/cost/token, sessions/history, and SSE.