### PR TITLE
chore(proskenion): record ui substrate lint metadata

### DIFF
--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "jiff",
  "prometheus-client",
@@ -4992,7 +4992,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bytes",
  "futures-core",

--- a/crates/theatron/proskenion/Cargo.toml
+++ b/crates/theatron/proskenion/Cargo.toml
@@ -24,6 +24,9 @@ rust-version = "1.94"
 description = "Dioxus desktop UI for the Aletheia distributed cognition system"
 publish = false
 
+[package.metadata.basanos]
+kind = "ui-substrate"
+
 [dependencies]
 skene = { path = "../skene" }
 # WHY: secret-wrapping for auth tokens and raw API keys handled in UI state.


### PR DESCRIPTION
## Summary
- update proskenion standalone lockfile pins for koina/skene to the shipped 0.26.1 workspace versions
- mark proskenion as a basanos `ui-substrate` so the dependency-count rule uses the documented UI error threshold
- record the D5 warning reality check without closing #3885; component library and full zero-violation lint remain follow-up work

## Validation
- `git diff --check`
- `scripts/check-proskenion-pins.py`
- `RUST_LOG=error kanon lint --summary --min-severity error crates/theatron/proskenion/Cargo.toml`
- `RUST_LOG=error kanon lint --summary --min-severity error crates/theatron/proskenion/Cargo.lock`
- `CARGO_TARGET_DIR=/data/target/wt/proskenion-d5-audit/target cargo +1.94 build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml --release` (0 `warning:` lines in captured log)

Note: a full `kanon lint --summary crates/theatron/proskenion` run was stopped after roughly 8 minutes with no output, stable RSS, and low CPU; the lockfile warning is now below error severity, but #3885 remains open for the larger D5 lint/component-library work.