### PR TITLE
chore(theatron): pin deps to v1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ aletheia-lexica = { path = "crates/aletheia-lexica" }
 rayon = { version = "1", default-features = false }
 
 # theatron substrate (cross-repo git deps)
-# WHY: forkwright/aletheia#3870 — single source of truth for the v1.2.0 pin.
+# WHY: forkwright/aletheia#3870 — single source of truth for the v1.3.0 pin.
 # Member crates inherit via `<dep> = { workspace = true }`.
 # proskenion is excluded from the workspace (GTK/webkit2gtk) and uses its own
 # standalone [workspace.dependencies] block; pin is mirrored there manually.
@@ -249,28 +249,34 @@ loom = { version = "0.7", default-features = false }
 # readable. Cargo resolves them identically to inline form.
 [workspace.dependencies.parodos]
 git = "https://github.com/forkwright/theatron.git"
-tag = "v1.2.0"
+tag = "v1.3.0"
+version = "1.3.0"
 
 [workspace.dependencies.themelion]
 git = "https://github.com/forkwright/theatron.git"
-tag = "v1.2.0"
+tag = "v1.3.0"
+version = "1.3.0"
 
 [workspace.dependencies.skeue]
 git = "https://github.com/forkwright/theatron.git"
-tag = "v1.2.0"
+tag = "v1.3.0"
+version = "1.3.0"
 
 [workspace.dependencies.gramma]
 git = "https://github.com/forkwright/theatron.git"
-tag = "v1.2.0"
+tag = "v1.3.0"
+version = "1.3.0"
 
 [workspace.dependencies.bathron]
 git = "https://github.com/forkwright/theatron.git"
-tag = "v1.2.0"
+tag = "v1.3.0"
+version = "1.3.0"
 features = ["logging"]
 
 [workspace.dependencies.keryx]
 git = "https://github.com/forkwright/theatron.git"
-tag = "v1.2.0"
+tag = "v1.3.0"
+version = "1.3.0"
 
 [workspace.dependencies.serde]
 version = "1"

--- a/crates/theatron/proskenion/Cargo.toml
+++ b/crates/theatron/proskenion/Cargo.toml
@@ -8,10 +8,27 @@
 # in sync with the aletheia root workspace's [workspace.dependencies] block;
 # cargo cannot inherit across the workspace boundary.
 [workspace.dependencies]
-themelion = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-skeue = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-gramma = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0" }
-bathron = { git = "https://github.com/forkwright/theatron.git", tag = "v1.2.0", features = ["logging"] }
+
+[workspace.dependencies.themelion]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.3.0"
+version = "1.3.0"
+
+[workspace.dependencies.skeue]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.3.0"
+version = "1.3.0"
+
+[workspace.dependencies.gramma]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.3.0"
+version = "1.3.0"
+
+[workspace.dependencies.bathron]
+git = "https://github.com/forkwright/theatron.git"
+tag = "v1.3.0"
+version = "1.3.0"
+features = ["logging"]
 
 [package]
 name = "proskenion"
@@ -84,7 +101,7 @@ serde_json = "1"
 # Logging
 # WHY: tracing-appender + tracing-subscriber dropped in v1.2 migration —
 # proskenion now consumes `bathron::logging::init_with_stderr` (theatron
-# v1.2.0) which encapsulates the daily-rotated file appender + opt-in
+# v1.3.0) which encapsulates the daily-rotated file appender + opt-in
 # stderr layer behind a single function call. See `lib.rs::run` for the
 # call site and the `bathron` dep above with `features = ["logging"]`.
 tracing = "0.1"


### PR DESCRIPTION
## Summary
- move root workspace theatron git deps from `v1.2.0` to `v1.3.0`
- mirror the same v1.3.0 tag/version pin in proskenion standalone workspace deps
- expand proskenion tables to avoid long inline TOML entries

## Test plan
- Gate-Passed: cargo metadata --no-deps --format-version 1
- Gate-Passed: cargo metadata --no-deps --format-version 1 --manifest-path crates/theatron/proskenion/Cargo.toml

Closes #3931.
Refs forkwright/theatron#5.