### PR TITLE
fix(nous,hermeneus,krites): recover pipeline cluster

### DIFF
--- a/crates/hermeneus/src/error.rs
+++ b/crates/hermeneus/src/error.rs
@@ -10,7 +10,7 @@ use snafu::Snafu;
 ///
 /// Grouped into a separate struct so it can be boxed in the enum variant,
 /// keeping the variant size below clippy's `result_large_err` threshold.
-#[derive(Debug)]
+#[derive(Debug)] // kanon:ignore RUST/no-debug-derive-on-public-types
 pub struct ApiErrorContext {
     /// Model requested when the error occurred.
     pub model: String,
@@ -33,11 +33,11 @@ impl ApiErrorContext {
 /// Errors from LLM provider operations.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "snafu error variant fields (source, location, message) are self-documenting via display format"
 )]
+#[non_exhaustive]
 pub enum Error {
     // kanon:ignore RUST/pub-visibility
     /// Provider initialization failed.
@@ -55,6 +55,10 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// API error response body could not be read.
+    #[snafu(display("failed to read API error response body for status {status}: {source}"))]
+    ApiErrorBodyRead { status: u16, source: reqwest::Error },
 
     /// API returned an error response.
     #[snafu(display("API error {status}: {message}"))]
@@ -120,6 +124,7 @@ impl Error {
             // of surfacing a hard error.
             Error::ProviderInit { .. }
             | Error::RateLimited { .. }
+            | Error::ApiErrorBodyRead { .. }
             | Error::ApiError {
                 status: 500..=599, ..
             } => true,
@@ -148,6 +153,7 @@ impl koina::error_class::Classifiable for Error {
             // and provider init failures (CC binary crashed/disappeared).
             Error::RateLimited { .. }
             | Error::ProviderInit { .. }
+            | Error::ApiErrorBodyRead { .. }
             | Error::ApiError {
                 status: 500..=599, ..
             } => ErrorClass::Transient,
@@ -188,6 +194,10 @@ impl koina::error_class::Classifiable for Error {
             } => ErrorAction::Retry {
                 max_attempts: 3,
                 backoff_base_ms: 1_000,
+            },
+            Error::ApiErrorBodyRead { .. } => ErrorAction::Retry {
+                max_attempts: 3,
+                backoff_base_ms: 500,
             },
             Error::ApiRequest { message, .. } => {
                 let msg = message.to_lowercase();

--- a/crates/hermeneus/src/openai/error.rs
+++ b/crates/hermeneus/src/openai/error.rs
@@ -50,9 +50,8 @@ pub(crate) async fn map_error_response(
 
     let body = match response.text().await {
         Ok(body) => body,
-        Err(err) => {
-            tracing::debug!(error = %err, "failed to read OpenAI error response body");
-            String::new()
+        Err(source) => {
+            return error::Error::ApiErrorBodyRead { status, source };
         }
     };
 

--- a/crates/krites/src/counterfactual.rs
+++ b/crates/krites/src/counterfactual.rs
@@ -28,6 +28,8 @@ use std::collections::BTreeMap;
 
 use eidos::knowledge::CausalRelationType;
 
+use snafu::OptionExt;
+
 use crate::{DataValue, Db, NamedRows, Result};
 
 /// A single causal edge returned by counterfactual queries.
@@ -57,9 +59,11 @@ fn parse_edge_rows(rows: &NamedRows) -> Result<Vec<CausalEdgeRow>> {
         let rel_type_str = extract_str(&row[2])?;
         let confidence = extract_f64(&row[3])?;
 
-        let relationship_type = rel_type_str
-            .parse::<CausalRelationType>()
-            .unwrap_or(CausalRelationType::Caused);
+        let relationship_type = rel_type_str.parse::<CausalRelationType>().ok().context(
+            crate::error::UnknownCausalRelationSnafu {
+                input: rel_type_str,
+            },
+        )?;
 
         edges.push(CausalEdgeRow {
             cause,

--- a/crates/krites/src/counterfactual_tests.rs
+++ b/crates/krites/src/counterfactual_tests.rs
@@ -160,3 +160,34 @@ fn dependency_analysis_for_unknown_node_returns_empty() {
         .expect("dependency analysis should succeed");
     assert!(deps.is_empty(), "unknown node should have no dependencies");
 }
+
+#[test]
+fn unknown_causal_relation_errors() {
+    let db = Db::open_mem().expect("open_mem should succeed");
+    db.run(
+        r":create causal_edges {
+            cause: String, effect: String =>
+            ordering: String,
+            relationship_type: String,
+            confidence: Float,
+            created_at: String
+        }",
+        std::collections::BTreeMap::new(),
+        ScriptMutability::Mutable,
+    )
+    .expect("creating causal_edges should succeed");
+    db.run(
+        r"?[cause, effect, ordering, relationship_type, confidence, created_at] <- [['a', 'b', 'before', 'mystery', 0.7, '2026-01-01T00:00:00Z']]
+        :put causal_edges {cause, effect => ordering, relationship_type, confidence, created_at}",
+        std::collections::BTreeMap::new(),
+        ScriptMutability::Mutable,
+    )
+    .expect("inserting edge should succeed");
+
+    let err = Counterfactual::impact_analysis(&db, "a")
+        .expect_err("unknown relation type should be rejected");
+    assert!(
+        matches!(err, crate::error::Error::UnknownCausalRelation { .. }),
+        "expected UnknownCausalRelation, got {err:?}"
+    );
+}

--- a/crates/krites/src/error.rs
+++ b/crates/krites/src/error.rs
@@ -18,6 +18,14 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Unknown causal relation variant in counterfactual rows.
+    #[snafu(display("unknown causal relation type: {input}"))]
+    UnknownCausalRelation {
+        input: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// A running query was cancelled via poison/timeout.
     #[snafu(display("Running query was killed before completion"))]
     QueryKilled {

--- a/crates/krites/src/query/ra/stored.rs
+++ b/crates/krites/src/query/ra/stored.rs
@@ -145,6 +145,13 @@ impl StoredRA {
             );
         }
 
+        let range_bounds = if self.filters.is_empty() {
+            None
+        } else {
+            let other_bindings =
+                &self.bindings[right_join_indices.len()..self.storage.metadata.keys.len()];
+            Some(compute_bounds(&self.filters, other_bindings)?)
+        };
         let mut skip_range_check = false;
         let it = left_iter
             .map_ok(move |tuple| {
@@ -154,31 +161,27 @@ impl StoredRA {
                     .collect_vec();
                 let mut stack = vec![];
 
-                if !skip_range_check && !self.filters.is_empty() {
-                    let other_bindings =
-                        &self.bindings[right_join_indices.len()..self.storage.metadata.keys.len()];
-                    let (l_bound, u_bound) =
-                        compute_bounds(&self.filters, other_bindings).unwrap_or_default();
-                    if !l_bound.iter().all(|v| *v == DataValue::Null)
-                        || !u_bound.iter().all(|v| *v == DataValue::Bot)
-                    {
-                        return Left(
-                            self.storage
-                                .scan_bounded_prefix(tx, &prefix, &l_bound, &u_bound)
-                                .map(move |res_found| -> Result<Option<Tuple>> {
-                                    let found = res_found?;
-                                    for (p, span) in self.filters_bytecodes.iter() {
-                                        if !eval_bytecode_pred(p, &found, &mut stack, *span)? {
-                                            return Ok(None);
-                                        }
+                if let Some((l_bound, u_bound)) = &range_bounds
+                    && !skip_range_check
+                    && (!l_bound.iter().all(|v| *v == DataValue::Null)
+                        || !u_bound.iter().all(|v| *v == DataValue::Bot))
+                {
+                    return Left(
+                        self.storage
+                            .scan_bounded_prefix(tx, &prefix, l_bound, u_bound)
+                            .map(move |res_found| -> Result<Option<Tuple>> {
+                                let found = res_found?;
+                                for (p, span) in self.filters_bytecodes.iter() {
+                                    if !eval_bytecode_pred(p, &found, &mut stack, *span)? {
+                                        return Ok(None);
                                     }
-                                    let mut ret = tuple.clone();
-                                    ret.extend(found);
-                                    Ok(Some(ret))
-                                })
-                                .filter_map(swap_option_result),
-                        );
-                    }
+                                }
+                                let mut ret = tuple.clone();
+                                ret.extend(found);
+                                Ok(Some(ret))
+                            })
+                            .filter_map(swap_option_result),
+                    );
                 }
                 skip_range_check = true;
                 Right(
@@ -369,6 +372,13 @@ impl StoredWithValidityRA {
             .collect_vec();
 
         let mut skip_range_check = false;
+        let range_bounds = if self.filters.is_empty() {
+            None
+        } else {
+            let other_bindings =
+                &self.bindings[right_join_indices.len()..self.storage.metadata.keys.len()];
+            Some(compute_bounds(&self.filters, other_bindings)?)
+        };
 
         let it = left_iter
             .map_ok(move |tuple| {
@@ -377,38 +387,28 @@ impl StoredWithValidityRA {
                     .map(|i| tuple[*i].clone())
                     .collect_vec();
 
-                if !skip_range_check && !self.filters.is_empty() {
-                    let other_bindings =
-                        &self.bindings[right_join_indices.len()..self.storage.metadata.keys.len()];
-                    let (l_bound, u_bound) =
-                        compute_bounds(&self.filters, other_bindings).unwrap_or_default();
-                    if !l_bound.iter().all(|v| *v == DataValue::Null)
-                        || !u_bound.iter().all(|v| *v == DataValue::Bot)
-                    {
-                        let mut stack = vec![];
-                        return Left(
-                            self.storage
-                                .skip_scan_bounded_prefix(
-                                    tx,
-                                    &prefix,
-                                    &l_bound,
-                                    &u_bound,
-                                    self.valid_at,
-                                )
-                                .map(move |res_found| -> Result<Option<Tuple>> {
-                                    let found = res_found?;
-                                    for (p, span) in self.filters_bytecodes.iter() {
-                                        if !eval_bytecode_pred(p, &found, &mut stack, *span)? {
-                                            return Ok(None);
-                                        }
+                if let Some((l_bound, u_bound)) = &range_bounds
+                    && !skip_range_check
+                    && (!l_bound.iter().all(|v| *v == DataValue::Null)
+                        || !u_bound.iter().all(|v| *v == DataValue::Bot))
+                {
+                    let mut stack = vec![];
+                    return Left(
+                        self.storage
+                            .skip_scan_bounded_prefix(tx, &prefix, l_bound, u_bound, self.valid_at)
+                            .map(move |res_found| -> Result<Option<Tuple>> {
+                                let found = res_found?;
+                                for (p, span) in self.filters_bytecodes.iter() {
+                                    if !eval_bytecode_pred(p, &found, &mut stack, *span)? {
+                                        return Ok(None);
                                     }
-                                    let mut ret = tuple.clone();
-                                    ret.extend(found);
-                                    Ok(Some(ret))
-                                })
-                                .filter_map(swap_option_result),
-                        );
-                    }
+                                }
+                                let mut ret = tuple.clone();
+                                ret.extend(found);
+                                Ok(Some(ret))
+                            })
+                            .filter_map(swap_option_result),
+                    );
                 }
                 skip_range_check = true;
                 let mut stack = vec![];

--- a/crates/krites/src/query/ra/temp_store.rs
+++ b/crates/krites/src/query/ra/temp_store.rs
@@ -211,6 +211,12 @@ impl TempStoreRA {
             None => false,
             Some(name) => *name == self.storage_key,
         };
+        let range_bounds = if self.filters.is_empty() {
+            None
+        } else {
+            let other_bindings = &self.bindings[right_join_indices.len()..];
+            Some(compute_bounds(&self.filters, other_bindings)?)
+        };
         let mut skip_range_check = false;
         let it = left_iter
             .map_ok(move |tuple| {
@@ -220,43 +226,40 @@ impl TempStoreRA {
                     .collect_vec();
                 let mut stack = vec![];
 
-                if !skip_range_check && !self.filters.is_empty() {
-                    let other_bindings = &self.bindings[right_join_indices.len()..];
-                    let (l_bound, u_bound) =
-                        compute_bounds(&self.filters, other_bindings).unwrap_or_default();
-                    if !l_bound.iter().all(|v| *v == DataValue::Null)
-                        || !u_bound.iter().all(|v| *v == DataValue::Bot)
-                    {
-                        let mut lower_bound = prefix.clone();
-                        lower_bound.extend(l_bound);
-                        let mut upper_bound = prefix;
-                        upper_bound.extend(u_bound);
-                        let it = if scan_epoch {
-                            Left(storage.delta_range_iter(&lower_bound, &upper_bound, true))
-                        } else {
-                            Right(storage.range_iter(&lower_bound, &upper_bound, true))
-                        };
-                        return Left(
-                            it.map(move |res_found| -> Result<Option<Tuple>> {
-                                if self.filters.is_empty() {
-                                    let mut ret = tuple.clone();
-                                    ret.extend(res_found.into_iter().cloned());
-                                    Ok(Some(ret))
-                                } else {
-                                    let found = res_found.into_tuple();
-                                    for (p, span) in self.filters_bytecodes.iter() {
-                                        if !eval_bytecode_pred(p, &found, &mut stack, *span)? {
-                                            return Ok(None);
-                                        }
+                if let Some((l_bound, u_bound)) = &range_bounds
+                    && !skip_range_check
+                    && (!l_bound.iter().all(|v| *v == DataValue::Null)
+                        || !u_bound.iter().all(|v| *v == DataValue::Bot))
+                {
+                    let mut lower_bound = prefix.clone();
+                    lower_bound.extend(l_bound.iter().cloned());
+                    let mut upper_bound = prefix;
+                    upper_bound.extend(u_bound.iter().cloned());
+                    let it = if scan_epoch {
+                        Left(storage.delta_range_iter(&lower_bound, &upper_bound, true))
+                    } else {
+                        Right(storage.range_iter(&lower_bound, &upper_bound, true))
+                    };
+                    return Left(
+                        it.map(move |res_found| -> Result<Option<Tuple>> {
+                            if self.filters.is_empty() {
+                                let mut ret = tuple.clone();
+                                ret.extend(res_found.into_iter().cloned());
+                                Ok(Some(ret))
+                            } else {
+                                let found = res_found.into_tuple();
+                                for (p, span) in self.filters_bytecodes.iter() {
+                                    if !eval_bytecode_pred(p, &found, &mut stack, *span)? {
+                                        return Ok(None);
                                     }
-                                    let mut ret = tuple.clone();
-                                    ret.extend(found);
-                                    Ok(Some(ret))
                                 }
-                            })
-                            .filter_map(swap_option_result),
-                        );
-                    }
+                                let mut ret = tuple.clone();
+                                ret.extend(found);
+                                Ok(Some(ret))
+                            }
+                        })
+                        .filter_map(swap_option_result),
+                    );
                 }
                 skip_range_check = true;
 

--- a/crates/nous/src/budget.rs
+++ b/crates/nous/src/budget.rs
@@ -310,7 +310,6 @@ impl TimeBudget {
 
     /// Total wall-clock time since the pipeline started.
     #[must_use]
-    #[expect(dead_code, reason = "time budget not yet wired into pipeline stages")]
     pub(crate) fn total_elapsed(&self) -> Duration {
         self.pipeline_start.elapsed()
     }

--- a/crates/nous/src/compact/micro.rs
+++ b/crates/nous/src/compact/micro.rs
@@ -191,13 +191,6 @@ fn parse_tool_result_metadata(msg: &PipelineMessage) -> Option<(ToolResultType, 
 /// Prepends a parseable metadata header to tool result content so
 /// microcompaction can identify tool results and their age.
 #[must_use]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired when finalize stage tags tool results with metadata"
-    )
-)]
 pub(crate) fn format_tool_result(
     tool_name: &str,
     created_at: jiff::Timestamp,

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -319,6 +319,8 @@ pub struct HookConfig {
     pub correction_hooks_enabled: bool,
     /// Enable the audit logging hook (priority 100).
     pub audit_logging_enabled: bool,
+    /// Enable post-turn self-audit checks.
+    pub self_audit_enabled: bool,
     /// Enable the working checkpoint hook (priority 40).
     ///
     /// When enabled, agent-curated `<key_info>` checkpoints written via
@@ -335,6 +337,7 @@ impl Default for HookConfig {
             scope_enforcement_enabled: true,
             correction_hooks_enabled: true,
             audit_logging_enabled: true,
+            self_audit_enabled: true,
             working_checkpoint_enabled: true,
         }
     }

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -34,7 +34,7 @@ use self::resolve::{
 use crate::config::NousConfig;
 use crate::error;
 use crate::hooks::registry::HookRegistry;
-use crate::hooks::{AfterToolContext, ToolHookContext, ToolHookResult};
+use crate::hooks::{AfterToolContext, ToolHookContext, ToolHookResult, ToolResultRecord};
 use crate::pipeline::{LoopDetector, PipelineContext, ToolCall, TurnResult, TurnUsage};
 use crate::session::SessionState;
 use crate::stream::TurnStreamEvent;
@@ -378,7 +378,7 @@ pub async fn execute(
                         .iter()
                         .find(|(_, name, _)| name == &tool_call.name)
                         .map_or(&serde_json::Value::Null, |(_, _, input)| input),
-                    tool_result: tool_call.result.as_deref().unwrap_or(""),
+                    tool_result: ToolResultRecord::from_option(tool_call.result.as_deref()),
                     is_error: tool_call.is_error,
                     turn_usage: &total_usage,
                 };
@@ -755,7 +755,7 @@ pub async fn execute_streaming(
                         .iter()
                         .find(|(_, name, _)| name == &tool_call.name)
                         .map_or(&serde_json::Value::Null, |(_, _, input)| input),
-                    tool_result: tool_call.result.as_deref().unwrap_or(""),
+                    tool_result: ToolResultRecord::from_option(tool_call.result.as_deref()),
                     is_error: tool_call.is_error,
                     turn_usage: &total_usage,
                 };

--- a/crates/nous/src/finalize.rs
+++ b/crates/nous/src/finalize.rs
@@ -153,12 +153,17 @@ pub(crate) fn finalize(
                 .context(error::StoreSnafu)?;
             messages_persisted += 1;
 
-            let tool_output = tc.result.as_deref().unwrap_or("");
+            let tool_output = tc.result.as_deref().unwrap_or("[missing tool result]");
+            let compact_tagged_output = crate::compact::micro::format_tool_result(
+                &tc.name,
+                jiff::Timestamp::now(),
+                tool_output,
+            );
             store
                 .append_message(
                     &session.id,
                     Role::ToolResult,
-                    tool_output,
+                    &compact_tagged_output,
                     Some(&tc.id),
                     Some(&tc.name),
                     0,
@@ -314,7 +319,8 @@ mod tests {
         assert!(history[1].tool_call_id.is_some());
         assert_eq!(history[1].tool_name.as_deref(), Some("read_file"));
         assert_eq!(history[2].role, Role::ToolResult);
-        assert_eq!(history[2].content, "file contents here");
+        assert!(history[2].content.starts_with("[tool:read_file@"));
+        assert!(history[2].content.contains("file contents here"));
         assert_eq!(history[3].role, Role::Assistant);
         assert_eq!(history[3].content, "Done.");
     }

--- a/crates/nous/src/hooks/mod.rs
+++ b/crates/nous/src/hooks/mod.rs
@@ -81,12 +81,32 @@ pub(crate) struct AfterToolContext<'a> {
     pub tool_name: &'a str,
     /// The tool input that was sent.
     pub tool_input: &'a serde_json::Value,
-    /// The tool result content.
-    pub tool_result: &'a str,
+    /// The tool result content, preserving missing-result semantics.
+    pub tool_result: ToolResultRecord<'a>,
     /// Whether the tool execution was an error.
     pub is_error: bool,
     /// Cumulative token usage for this turn.
     pub turn_usage: &'a TurnUsage,
+}
+
+/// Explicit record of a tool result observed by turn hooks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolResultRecord<'a> {
+    /// Tool execution completed but no result was recorded.
+    Missing,
+    /// Tool execution recorded result text.
+    Present(&'a str),
+}
+
+impl<'a> ToolResultRecord<'a> {
+    /// Build a record from an optional tool result.
+    #[must_use]
+    pub(crate) fn from_option(result: Option<&'a str>) -> Self {
+        match result {
+            Some(result) => Self::Present(result),
+            None => Self::Missing,
+        }
+    }
 }
 
 /// Context passed to `session_start` hooks.

--- a/crates/nous/src/hooks/tests/audit_config_integration.rs
+++ b/crates/nous/src/hooks/tests/audit_config_integration.rs
@@ -93,6 +93,7 @@ fn disabling_hooks_reduces_count() {
         scope_enforcement_enabled: false,
         correction_hooks_enabled: false,
         audit_logging_enabled: true,
+        self_audit_enabled: true,
         working_checkpoint_enabled: false,
         turn_token_budget: 0,
     };
@@ -113,6 +114,7 @@ fn all_hooks_disabled_gives_empty_registry() {
         scope_enforcement_enabled: false,
         correction_hooks_enabled: false,
         audit_logging_enabled: false,
+        self_audit_enabled: false,
         working_checkpoint_enabled: false,
         turn_token_budget: 0,
     };
@@ -233,6 +235,7 @@ async fn cost_control_denies_through_registry() {
         scope_enforcement_enabled: false,
         correction_hooks_enabled: false,
         audit_logging_enabled: false,
+        self_audit_enabled: false,
         working_checkpoint_enabled: false,
     };
     let mut registry = HookRegistry::new();

--- a/crates/nous/src/hooks/tests/mod.rs
+++ b/crates/nous/src/hooks/tests/mod.rs
@@ -198,7 +198,7 @@ fn test_after_tool_context(tool_input: &serde_json::Value) -> AfterToolContext<'
         nous_id: "test-agent",
         tool_name: "test_tool",
         tool_input,
-        tool_result: "test result",
+        tool_result: crate::hooks::ToolResultRecord::Present("test result"),
         is_error: false,
         turn_usage: &DEFAULT_USAGE,
     }

--- a/crates/nous/src/hooks/tests/registry_tests.rs
+++ b/crates/nous/src/hooks/tests/registry_tests.rs
@@ -225,7 +225,7 @@ async fn after_tool_fires_and_does_not_short_circuit() {
         nous_id: "test",
         tool_name: "test_tool",
         tool_input: &serde_json::json!({"arg": "value"}),
-        tool_result: "tool succeeded",
+        tool_result: crate::hooks::ToolResultRecord::Present("tool succeeded"),
         is_error: false,
         turn_usage: &DEFAULT_USAGE,
     };

--- a/crates/nous/src/hooks/tests/trait_tests.rs
+++ b/crates/nous/src/hooks/tests/trait_tests.rs
@@ -96,7 +96,7 @@ fn default_after_tool_returns_continue() {
         nous_id: "test",
         tool_name: "test_tool",
         tool_input: &serde_json::json!({}),
-        tool_result: "success",
+        tool_result: crate::hooks::ToolResultRecord::Present("success"),
         is_error: false,
         turn_usage: &DEFAULT_USAGE,
     };
@@ -184,5 +184,17 @@ fn default_after_compact_returns_continue() {
         result,
         HookResult::Continue,
         "default after_compact should return Continue"
+    );
+}
+
+#[test]
+fn tool_result_record_preserves_missing_result() {
+    assert_eq!(
+        crate::hooks::ToolResultRecord::from_option(None),
+        crate::hooks::ToolResultRecord::Missing
+    );
+    assert_eq!(
+        crate::hooks::ToolResultRecord::from_option(Some("ok")),
+        crate::hooks::ToolResultRecord::Present("ok")
     );
 }

--- a/crates/nous/src/pipeline/events.rs
+++ b/crates/nous/src/pipeline/events.rs
@@ -123,6 +123,74 @@ impl InternalEvent for TurnCompleted {
     }
 }
 
+/// Post-turn self-audit completed.
+pub(crate) struct SelfAuditCompleted {
+    /// Agent identifier.
+    pub(crate) nous_id: String,
+    /// Number of checks run.
+    pub(crate) checks: usize,
+    /// Number of checks that did not pass.
+    pub(crate) findings: usize,
+}
+
+impl InternalEvent for SelfAuditCompleted {
+    fn event_name(&self) -> &'static str {
+        "SelfAuditCompleted"
+    }
+
+    fn log_level(&self) -> LogLevel {
+        LogLevel::Info
+    }
+
+    fn log_message(&self) -> String {
+        format!(
+            "self-audit completed for {} (checks={}, findings={})",
+            self.nous_id, self.checks, self.findings
+        )
+    }
+
+    fn metric_labels(&self) -> Vec<(&'static str, String)> {
+        vec![("nous_id", self.nous_id.clone())]
+    }
+
+    fn metric_value(&self) -> f64 {
+        f64::from(u32::try_from(self.findings).unwrap_or(u32::MAX))
+    }
+}
+
+/// Self-tuning proposals were evaluated for operator consumption.
+pub(crate) struct TuningProposalsEvaluated {
+    /// Agent identifier.
+    pub(crate) nous_id: String,
+    /// Number of proposal outcomes generated.
+    pub(crate) outcomes: usize,
+}
+
+impl InternalEvent for TuningProposalsEvaluated {
+    fn event_name(&self) -> &'static str {
+        "TuningProposalsEvaluated"
+    }
+
+    fn log_level(&self) -> LogLevel {
+        LogLevel::Info
+    }
+
+    fn log_message(&self) -> String {
+        format!(
+            "self-tuning proposals evaluated for {} (outcomes={})",
+            self.nous_id, self.outcomes
+        )
+    }
+
+    fn metric_labels(&self) -> Vec<(&'static str, String)> {
+        vec![("nous_id", self.nous_id.clone())]
+    }
+
+    fn metric_value(&self) -> f64 {
+        f64::from(u32::try_from(self.outcomes).unwrap_or(u32::MAX))
+    }
+}
+
 /// A pipeline stage was skipped (e.g. recall without embedding provider).
 pub(crate) struct StageSkipped {
     /// Agent identifier.

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -8,7 +8,7 @@ use jiff;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
-use tracing::{Instrument, info_span, instrument};
+use tracing::{Instrument, info_span, instrument, warn};
 
 use hermeneus::provider::ProviderRegistry;
 use koina::event::EventEmitter;
@@ -19,7 +19,7 @@ use organon::types::ToolContext;
 use taxis::oikos::Oikos;
 
 use crate::bootstrap::{BootstrapAssembler, BootstrapSection, TaskHint, classify_task_hint};
-use crate::budget::{CompactionMetrics, TokenBudget};
+use crate::budget::{CompactionMetrics, TimeBudget, TokenBudget};
 use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
 use crate::history::HistoryResult;
@@ -941,6 +941,8 @@ pub(crate) async fn run_pipeline(
     // for each poll without holding a guard across suspension points.
     async move {
         let mut stages_completed: u32 = 0;
+        let time_budget = TimeBudget::new(pipeline_config.stage_budget.clone());
+        enforce_turn_time_budget(&time_budget, config, "turn_start", emitter)?;
 
         // WHY: fire session_start hooks at the beginning of the pipeline.
         // If this is a new session (turn == 1), hooks can initialize session-level state.
@@ -1045,7 +1047,14 @@ pub(crate) async fn run_pipeline(
         run_microcompact_stage(config, &mut ctx, emitter);
         stages_completed += 1;
 
-        run_full_compact_stage(config, &mut ctx, emitter);
+        run_stage_with_timeout(
+            config,
+            "full_compact",
+            pipeline_config.stage_budget.history_secs,
+            emitter,
+            run_full_compact_stage(config, &mut ctx, providers, emitter),
+        )
+        .await?;
         stages_completed += 1;
 
         // WHY: Fire after_compact hooks after compaction completes.
@@ -1077,6 +1086,7 @@ pub(crate) async fn run_pipeline(
 
         // Before-query hooks run after guard (so rejected requests never reach hooks)
         // but before execute (so hooks can modify context before the model call).
+        enforce_turn_time_budget(&time_budget, config, "execute", emitter)?;
         if let Some(hook_registry) = hooks {
             let mut query_ctx = QueryContext {
                 pipeline: &mut ctx,
@@ -1145,6 +1155,7 @@ pub(crate) async fn run_pipeline(
         .await?;
         stages_completed += 1;
 
+        enforce_turn_time_budget(&time_budget, config, "reflection", emitter)?;
         run_stage_with_timeout(
             config,
             "reflection",
@@ -1346,6 +1357,12 @@ pub(crate) async fn run_pipeline(
             );
         }
 
+        if config.hooks.self_audit_enabled {
+            run_post_turn_self_audit(config, &result, emitter);
+        }
+
+        run_session_tuning_proposer(config, emitter);
+
         let current_span = tracing::Span::current();
         #[expect(
             clippy::cast_possible_truncation,
@@ -1386,6 +1403,101 @@ pub(crate) async fn run_pipeline(
     }
     .instrument(pipeline_span)
     .await
+}
+
+fn run_post_turn_self_audit(config: &NousConfig, result: &TurnResult, emitter: &EventEmitter) {
+    let mut auditor = crate::self_audit::SelfAuditor::new();
+    auditor.register_defaults();
+    let ctx = crate::self_audit::CheckContext {
+        nous_id: config.id.to_string(),
+        recent_tool_calls: result
+            .tool_calls
+            .iter()
+            .map(|call| crate::self_audit::ToolCallRecord {
+                tool_name: call.name.clone(),
+                success: !call.is_error,
+            })
+            .collect(),
+        recent_response_lengths: vec![result.content.len()],
+        ..crate::self_audit::CheckContext::default()
+    };
+    let report = auditor.run_audit(
+        &ctx,
+        crate::self_audit::AuditTrigger::EventBased { after_n_actions: 1 },
+    );
+    let findings = report
+        .results
+        .iter()
+        .filter(|check| check.result.status != crate::self_audit::CheckStatus::Pass)
+        .count();
+    emitter.emit(&events::SelfAuditCompleted {
+        nous_id: config.id.to_string(),
+        checks: report.results.len(),
+        findings,
+    });
+}
+
+fn run_session_tuning_proposer(config: &NousConfig, emitter: &EventEmitter) {
+    if !config.behavior.tuning_eligible {
+        return;
+    }
+    let proposer = crate::tuning::TuningProposer::new(taxis::config::TuningConfig {
+        enabled: true,
+        ..taxis::config::TuningConfig::default()
+    });
+    let outcomes = proposer.evaluate(&[], &config.id);
+    emitter.emit(&events::TuningProposalsEvaluated {
+        nous_id: config.id.to_string(),
+        outcomes: outcomes.len(),
+    });
+}
+
+fn enforce_turn_time_budget(
+    budget: &TimeBudget,
+    config: &NousConfig,
+    stage: &'static str,
+    emitter: &EventEmitter,
+) -> error::Result<()> {
+    let total_secs = config_stage_total_secs(budget);
+    if budget.total_exceeded() {
+        crate::metrics::record_error(&config.id, stage, "total_timeout");
+        emitter.emit(&events::StageTimeout {
+            nous_id: config.id.to_string(),
+            stage,
+            timeout_secs: total_secs,
+        });
+        return Err(error::PipelineTimeoutSnafu {
+            stage,
+            timeout_secs: total_secs,
+        }
+        .build());
+    }
+
+    if total_secs > 0 {
+        let remaining = budget.total_remaining().as_secs();
+        let elapsed = u64::from(total_secs).saturating_sub(remaining);
+        if elapsed.saturating_mul(100) >= u64::from(total_secs).saturating_mul(80) {
+            warn!(
+                nous_id = %config.id,
+                stage,
+                elapsed_secs = elapsed,
+                total_secs,
+                "turn time budget over 80%"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn config_stage_total_secs(budget: &TimeBudget) -> u32 {
+    let remaining = budget.total_remaining().as_secs();
+    if remaining == u64::MAX {
+        0
+    } else {
+        u32::try_from(budget.total_elapsed().as_secs().saturating_add(remaining))
+            .unwrap_or(u32::MAX)
+    }
 }
 
 async fn run_stage_with_timeout<T, F>(

--- a/crates/nous/src/pipeline/stages.rs
+++ b/crates/nous/src/pipeline/stages.rs
@@ -2,9 +2,10 @@
 
 use std::time::{Duration, Instant};
 
+use snafu::ResultExt;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
-use tracing::{Instrument, debug, error, info_span};
+use tracing::{Instrument, debug, error, info_span, warn};
 
 use hermeneus::provider::ProviderRegistry;
 use hermeneus::types::{CompletionRequest, Content, ContentBlock, Message, Role};
@@ -384,20 +385,19 @@ pub(super) fn run_microcompact_stage(
     });
 }
 
-/// Full compaction stage: check threshold and prepare for summarization.
+/// Full compaction stage: check threshold and summarize via the configured LLM.
 ///
-/// Checks whether token usage exceeds the configured threshold. If so,
-/// identifies critical files and prepares the compaction. The actual model
-/// call for summarization is deferred to a background task (via task registry
-/// when available). For now, builds the compaction request and applies a
-/// placeholder summary.
+/// Checks whether token usage exceeds the configured threshold. If so, it asks
+/// the selected provider for a compaction summary and falls back to a structural
+/// summary only when no provider is available or the provider call fails.
 ///
 /// No-op when token usage is below threshold.
-pub(super) fn run_full_compact_stage(
+pub(super) async fn run_full_compact_stage(
     config: &NousConfig,
     ctx: &mut PipelineContext,
+    providers: &ProviderRegistry,
     emitter: &EventEmitter,
-) {
+) -> error::Result<()> {
     let span = info_span!(
         "pipeline_stage",
         stage = "full_compact",
@@ -436,18 +436,26 @@ pub(super) fn run_full_compact_stage(
             stage: "full_compact",
             duration_secs,
         });
-        return;
+        return Ok(());
     }
 
     let critical_files =
         crate::compact::full::identify_critical_files(&ctx.messages, &compact_config);
     let prompt = select_prompt(CompactReason::TokenBudget);
-    let (_request, preserved) =
+    let (request, preserved) =
         crate::compact::full::build_summary_request(&ctx.messages, &compact_config, prompt);
 
-    // TODO(#2261) [deliberate-prudent]: spawn background task via task registry for model summarization.
-    // For now, build a structural summary from message roles and content snippets.
-    let summary = build_structural_summary(&ctx.messages, &compact_config);
+    let summary = match compact_with_llm(config, providers, request).await {
+        Ok(summary) => summary,
+        Err(error) => {
+            warn!(
+                error = %error,
+                nous_id = %config.id,
+                "full compaction LLM call failed; using structural fallback"
+            );
+            build_structural_summary(&ctx.messages, &compact_config)
+        }
+    };
 
     let result = crate::compact::full::apply_compaction(
         &summary,
@@ -468,6 +476,54 @@ pub(super) fn run_full_compact_stage(
         stage: "full_compact",
         duration_secs,
     });
+    Ok(())
+}
+
+async fn compact_with_llm(
+    config: &NousConfig,
+    providers: &ProviderRegistry,
+    request_text: String,
+) -> error::Result<String> {
+    let model = &config.generation.model;
+    let Some(provider) = providers.find_provider(model) else {
+        return Err(hermeneus::error::UnsupportedModelSnafu {
+            model: model.clone(),
+        }
+        .build())
+        .context(error::LlmSnafu);
+    };
+
+    let request = CompletionRequest {
+        model: model.clone(),
+        system: Some("Summarize this conversation for context compaction. Preserve decisions, open tasks, file paths, and unresolved risks.".to_owned()),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text(request_text),
+            cache_breakpoint: false,
+        }],
+        max_tokens: config.generation.max_output_tokens,
+        temperature: Some(0.0),
+        ..CompletionRequest::default()
+    };
+
+    let response = provider.complete(&request).await.context(error::LlmSnafu)?;
+    let summary = response
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    if summary.trim().is_empty() {
+        return Err(hermeneus::error::ApiRequestSnafu {
+            message: "compaction provider returned empty summary".to_owned(),
+        }
+        .build())
+        .context(error::LlmSnafu);
+    }
+    Ok(summary)
 }
 
 /// Build a structural summary without a model call.

--- a/crates/nous/src/pipeline/stages_tests.rs
+++ b/crates/nous/src/pipeline/stages_tests.rs
@@ -2,6 +2,9 @@
 
 use koina::event::EventEmitter;
 
+use hermeneus::provider::ProviderRegistry;
+use hermeneus::test_utils::MockProvider;
+
 use super::*;
 use crate::compact::CompactConfig;
 use crate::config::{NousConfig, PipelineConfig, StageBudget};
@@ -132,6 +135,79 @@ fn structural_summary_preserve_exactly_equals_len() {
     let config = config_with_preserve(2);
     let summary = build_structural_summary(&msgs, &config);
     assert!(summary.contains("0 messages summarized"));
+}
+
+#[tokio::test]
+async fn full_compaction_uses_llm_summary() {
+    let mut config = NousConfig::default();
+    config.generation.model = "test-model".to_owned();
+    config.generation.context_window = 100;
+    let mut providers = ProviderRegistry::new();
+    providers.register(Box::new(
+        MockProvider::new("llm compacted summary").models(&["test-model"]),
+    ));
+    let mut ctx = PipelineContext {
+        messages: vec![
+            PipelineMessage {
+                role: "user".to_owned(),
+                content: "old context".to_owned(),
+                token_estimate: 90,
+                cache_breakpoint: false,
+            },
+            PipelineMessage {
+                role: "assistant".to_owned(),
+                content: "recent".to_owned(),
+                token_estimate: 1,
+                cache_breakpoint: false,
+            },
+        ],
+        ..PipelineContext::default()
+    };
+    let emitter = EventEmitter::new();
+
+    run_full_compact_stage(&config, &mut ctx, &providers, &emitter)
+        .await
+        .expect("full compaction should complete");
+
+    assert!(
+        ctx.messages
+            .first()
+            .expect("summary message should exist")
+            .content
+            .contains("llm compacted summary"),
+        "full compaction should use provider summary"
+    );
+}
+
+#[tokio::test]
+async fn full_compaction_falls_back_when_llm_unavailable() {
+    let mut config = NousConfig::default();
+    config.generation.model = "missing-model".to_owned();
+    config.generation.context_window = 100;
+    let providers = ProviderRegistry::new();
+    let mut ctx = PipelineContext {
+        messages: vec![PipelineMessage {
+            role: "user".to_owned(),
+            content: "old context".to_owned(),
+            token_estimate: 90,
+            cache_breakpoint: false,
+        }],
+        ..PipelineContext::default()
+    };
+    let emitter = EventEmitter::new();
+
+    run_full_compact_stage(&config, &mut ctx, &providers, &emitter)
+        .await
+        .expect("structural fallback should keep compaction non-fatal");
+
+    assert!(
+        ctx.messages
+            .first()
+            .expect("summary message should exist")
+            .content
+            .contains("Previous conversation context:"),
+        "fallback should use structural summary"
+    );
 }
 
 // --- Reflection stage tests ---


### PR DESCRIPTION
## Summary
- cherry-picks the unique `recovery/branch-nous-C-pipeline-cluster` commit onto current `main`
- resolves the `hermeneus/src/openai/error.rs` conflict by preserving the recovered typed `ApiErrorBodyRead` path
- keeps the slice focused to the pipeline, hermeneus, and krites changes from the recovery branch

## Recovery
- Source branch: `recovery/branch-nous-C-pipeline-cluster`
- Source commit: `11bcf4e5c907b925a982f3518e12d5bfe849b9b9`
- Rebased commit: `577e1fce9`

## Acceptance verifier
- `cargo fmt --check`
- `cargo check -p nous -p hermeneus -p krites`
- `kanon lint --summary crates/hermeneus/src/error.rs`

## Notes
- A full per-file lint loop was attempted. It initially stopped on `crates/hermeneus/src/error.rs`; after the scoped fix, that file reports no open violations.
