### PR TITLE
fix(taxis,episteme,krites,aletheia,gnosis): recover misc truth cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "agora",
  "anyhow",
@@ -177,11 +177,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.26.0"
+version = "0.26.1"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "jiff",
  "koina",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "futures",
  "jiff",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "jiff",
  "koina",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "eidos",
  "jiff",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "jiff",
  "koina",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "aletheia-routing",
  "compact_str",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -3530,12 +3530,12 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "cargo_metadata",
+ "fjall",
  "parking_lot",
  "proc-macro2",
- "rusqlite",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "criterion",
  "eidos",
@@ -3766,7 +3766,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "criterion",
  "jiff",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -4657,8 +4657,8 @@ dependencies = [
 
 [[package]]
 name = "keryx"
-version = "1.2.0"
-source = "git+https://github.com/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
+version = "1.3.0"
+source = "git+https://github.com/forkwright/theatron.git?tag=v1.3.0#2f73ff19667f88d5780e9b3d4b935ebfb07516ba"
 dependencies = [
  "bytes",
  "dioxus",
@@ -4693,7 +4693,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "arboard",
  "clap",
@@ -4727,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "criterion",
  "fjall",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5352,7 +5352,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "eidos",
  "episteme",
@@ -5670,7 +5670,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6139,8 +6139,8 @@ dependencies = [
 
 [[package]]
 name = "parodos"
-version = "1.2.0"
-source = "git+https://github.com/forkwright/theatron.git?tag=v1.2.0#6225613827dcc21a0b7b1c1585f9ff8199affae9"
+version = "1.3.0"
+source = "git+https://github.com/forkwright/theatron.git?tag=v1.3.0#2f73ff19667f88d5780e9b3d4b935ebfb07516ba"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -6454,7 +6454,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "jiff",
  "snafu",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "docx-rs",
  "quick-xml 0.39.2",
@@ -6487,7 +6487,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -6503,7 +6503,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -6515,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -6549,7 +6549,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -6562,7 +6562,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "krilla 0.7.0",
  "poiesis-core",
@@ -6572,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "comemo",
  "jiff",
@@ -6588,7 +6588,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6975,7 +6975,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -8392,7 +8392,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8739,7 +8739,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -8858,7 +8858,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -8970,14 +8970,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/eidos/src/knowledge/architecture_fact.rs
+++ b/crates/eidos/src/knowledge/architecture_fact.rs
@@ -173,7 +173,7 @@ impl ArchitectureFact {
 /// Flat-JSON-file backed store for [`ArchitectureFact`]s.
 ///
 /// One file per fact: `<dir>/<safe_id>.json` where `<safe_id>` is the fact's
-/// `id` with `.` and `/` replaced by `__` and `-` respectively.
+/// `id` with `/` and `\` replaced by `-`. Dots are preserved.
 ///
 /// The store is created lazily: the directory is created on first [`put`].
 ///

--- a/crates/episteme/src/embedding.rs
+++ b/crates/episteme/src/embedding.rs
@@ -13,11 +13,11 @@ use tracing::instrument;
 
 /// Errors from embedding operations.
 #[derive(Debug, Snafu)]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "snafu error variant fields (message, location) are self-documenting via display format"
 )]
+#[non_exhaustive]
 pub enum EmbeddingError {
     /// The embedding model failed to initialize.
     #[snafu(display("embedding model init failed: {message}"))]
@@ -50,6 +50,7 @@ pub(crate) type EmbeddingResult<T> = std::result::Result<T, EmbeddingError>;
 ///
 /// Implementations must be `Send + Sync` for use across async boundaries.
 pub trait EmbeddingProvider: Send + Sync {
+    // kanon:ignore ARCHITECTURE/trait-impl-colocation
     /// Embed a single text chunk. Returns a vector of floats.
     ///
     /// # Complexity
@@ -365,7 +366,8 @@ mod candle_provider {
         }
     }
 
-    impl EmbeddingProvider for CandelProvider {
+    impl EmbeddingProvider for CandelProvider // kanon:ignore ARCHITECTURE/trait-impl-colocation
+    {
         #[instrument(skip(self, text))]
         fn embed(&self, text: &str) -> EmbeddingResult<Vec<f32>> {
             let mut results = self.forward_embed(&[text])?;
@@ -533,6 +535,36 @@ pub fn create_provider(config: &EmbeddingConfig) -> EmbeddingResult<Box<dyn Embe
             };
             Ok(Box::new(OpenAiEmbeddingProvider::new(&cfg)?))
         }
+        #[cfg(feature = "openai-embed")]
+        "voyage" => {
+            let model = config
+                .model
+                .clone()
+                .unwrap_or_else(|| "voyage-3-lite".to_owned());
+            let dim = config.dimension.unwrap_or(1024);
+            let api_key = config.api_key.clone().or_else(|| {
+                std::env::var("VOYAGE_API_KEY")
+                    .ok()
+                    .filter(|key| !key.is_empty())
+                    .map(koina::secret::SecretString::from)
+            });
+            let cfg = OpenAiCompatConfig {
+                base_url: config
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.voyageai.com/v1".to_owned()),
+                api_key,
+                model,
+                dimension: dim,
+            };
+            Ok(Box::new(OpenAiEmbeddingProvider::new(&cfg)?))
+        }
+        #[cfg(not(feature = "openai-embed"))]
+        "voyage" => InitFailedSnafu {
+            message: "openai-embed feature not enabled — build with --features openai-embed"
+                .to_owned(),
+        }
+        .fail(),
         #[cfg(not(feature = "openai-embed"))]
         "openai-compat" => InitFailedSnafu {
             message: "openai-embed feature not enabled — build with --features openai-embed"

--- a/crates/gnosis/Cargo.toml
+++ b/crates/gnosis/Cargo.toml
@@ -17,7 +17,7 @@ cargo_metadata = "0.18"
 parking_lot = "0.12"
 proc-macro2 = { version = "1", features = ["span-locations"] }
 syn = { version = "2", features = ["full", "extra-traits", "visit"] }
-rusqlite = { version = "0.31", features = ["bundled"] }
+fjall = { version = "3", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/gnosis/README.md
+++ b/crates/gnosis/README.md
@@ -28,7 +28,7 @@ architecture_fact (existing)          code_graph_query (this crate)
 ─────────────────────────────         ─────────────────────────────────
 ops: get/put/list/search              ops: rdeps/impl/reexports/deps
 tier: Verified (human-curated)        tier: Inferred (machine-derived)
-storage: flat JSON per-fact           storage: SQLite index
+storage: flat JSON per-fact           storage: fjall index
 use: "what does the design say?"      use: "what does the code actually do?"
 ```
 
@@ -38,11 +38,11 @@ architectural fact.
 
 ## Cache location
 
-Default: `~/.cache/aletheia/gnosis.sqlite`
+Default: `~/.cache/aletheia/gnosis.fjall`
 
 Override with `GNOSIS_CACHE_PATH` environment variable.
 
-**Delete the file to force a full rebuild** (next rebuild will re-parse all files).
+**Delete the directory to force a full rebuild** (next rebuild will re-parse all files).
 
 ## Rebuild trigger
 
@@ -56,10 +56,10 @@ Override with `GNOSIS_CACHE_PATH` environment variable.
 
 ## Cache eviction
 
-Delete the SQLite file:
+Delete the fjall directory:
 
 ```bash
-rm ~/.cache/aletheia/gnosis.sqlite
+rm -rf ~/.cache/aletheia/gnosis.fjall
 ```
 
 The next rebuild will re-parse all workspace source files.
@@ -91,12 +91,12 @@ The next rebuild will re-parse all workspace source files.
 
 ## Architecture
 
-- **`CodeGraph`** - public API handle; wraps a `Mutex<rusqlite::Connection>`.
+- **`CodeGraph`** - public API handle; wraps a `Mutex<schema::Store>`.
 - **`crates/gnosis/src/index.rs`** - walks workspace via `cargo metadata`, parses each
-  `*.rs` with `syn::visit`, and populates the SQLite index. Incremental rebuilds use the SHA-256 digest stored in `file_hashes`.
-- **`crates/gnosis/src/query.rs`** - query impls against the SQLite tables.
-- **`crates/gnosis/src/schema.rs`** - DDL for `symbols`, `symbol_refs`, `crate_edges`,
-  `file_hashes` tables.
+  `*.rs` with `syn::visit`, and populates the fjall index. Incremental rebuilds use the SHA-256 digest stored in `file_hashes`.
+- **`crates/gnosis/src/query.rs`** - query impls against the fjall keyspaces.
+- **`crates/gnosis/src/schema.rs`** - keyspace and record definitions for `symbols`, `symbol_refs`, `crate_edges`,
+  `file_hashes`, and `meta`.
 - **`crates/organon/src/builtins/code_graph_query.rs`** - MCP tool executor.
 
 ## Limitations (v1)

--- a/crates/gnosis/src/error.rs
+++ b/crates/gnosis/src/error.rs
@@ -31,9 +31,17 @@ pub enum GnosisError {
     #[snafu(display("failed to parse {}: {source}", path.display()))]
     Parse { path: PathBuf, source: syn::Error },
 
-    /// A `SQLite` operation failed.
-    #[snafu(display("sqlite error: {source}"))]
-    Sqlite { source: rusqlite::Error },
+    /// A fjall operation failed.
+    #[snafu(display("fjall error: {source}"))]
+    Fjall { source: fjall::Error },
+
+    /// Stored index data could not be encoded or decoded.
+    #[snafu(display("index serialization error: {source}"))]
+    Codec { source: serde_json::Error },
+
+    /// Stored index data is malformed.
+    #[snafu(display("corrupt index data: {message}"))]
+    Corrupt { message: String },
 
     /// The index cache directory could not be created.
     #[snafu(display("failed to create cache directory {}: {source}", dir.display()))]
@@ -47,17 +55,6 @@ pub enum GnosisError {
     RemoveCacheFile {
         path: PathBuf,
         source: std::io::Error,
-    },
-
-    /// A query was passed an unsupported operation string.
-    #[snafu(display("unknown query operation: '{op}'"))]
-    UnknownOp { op: String },
-
-    /// A required argument was missing from a query.
-    #[snafu(display("missing required argument '{arg}' for query '{query}'"))]
-    MissingArg {
-        arg: &'static str,
-        query: &'static str,
     },
 }
 

--- a/crates/gnosis/src/index.rs
+++ b/crates/gnosis/src/index.rs
@@ -1,7 +1,7 @@
 //! Workspace index builder.
 //!
 //! Walks a Cargo workspace via `cargo metadata`, then parses each `*.rs`
-//! file with `syn`, populating the `SQLite` schema with symbol definitions and
+//! file with `syn`, populating the fjall index with symbol definitions and
 //! cross-reference edges.
 //!
 //! # Incremental rebuild
@@ -9,7 +9,7 @@
 //! Each file's SHA-256 hash is stored in `file_hashes`.  On the next
 //! `rebuild()` call only files whose on-disk hash differs from the stored
 //! value are re-parsed.  To force a full rebuild, delete the cache file
-//! (typically `~/.cache/aletheia/gnosis.sqlite`).
+//! (typically `~/.cache/aletheia/gnosis.fjall`).
 //!
 //! # What is indexed
 //!
@@ -40,11 +40,11 @@ use sha2::{Digest, Sha256};
 
 use cargo_metadata::MetadataCommand;
 use proc_macro2::Span;
-use rusqlite::{Connection, params};
 use snafu::ResultExt;
 use syn::visit::Visit;
 
-use crate::error::{CargoMetadataSnafu, ParseSnafu, ReadSourceSnafu, Result, SqliteSnafu};
+use crate::error::{CargoMetadataSnafu, ParseSnafu, ReadSourceSnafu, Result};
+use crate::schema::Store;
 
 // ── SHA-256 helper ───────────────────────────────────────────────────────────
 
@@ -69,55 +69,61 @@ fn file_hash(data: &[u8]) -> String {
 
 /// Context passed to the `syn::visit` walker.
 struct IndexVisitor<'a> {
-    conn: &'a Connection,
+    store: &'a Store,
     crate_name: &'a str,
     /// Dot-separated module path within the crate, e.g. `"types::message"`.
     module_path: String,
     file_path: &'a str,
+    last_symbol_id: Option<u64>,
 }
 
 impl<'a> IndexVisitor<'a> {
-    fn new(
-        conn: &'a Connection,
-        crate_name: &'a str,
-        file_path: &'a str,
-        module_path: String,
-    ) -> Self {
+    fn new(store: &'a Store, crate_name: &'a str, file_path: &'a str, module_path: String) -> Self {
         Self {
-            conn,
+            store,
             crate_name,
             module_path,
             file_path,
-        }
-    }
-
-    fn insert_symbol(&self, name: &str, kind: &str, line: u32) {
-        // Non-fatal: log and continue on DB errors during indexing.
-        if let Err(e) = self.conn.execute(
-            "INSERT INTO symbols (crate_name, module_path, symbol_name, symbol_kind, file_path, line_start)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![self.crate_name, self.module_path, name, kind, self.file_path, line],
-        ) {
-            tracing::warn!(
-                crate_name = self.crate_name,
-                symbol = name,
-                kind,
-                error = %e,
-                "gnosis: failed to insert symbol"
-            );
+            last_symbol_id: None,
         }
     }
 
     fn last_symbol_id(&self) -> Option<i64> {
-        self.conn.last_insert_rowid().into()
+        self.last_symbol_id.and_then(|id| i64::try_from(id).ok())
+    }
+
+    fn record_symbol(&mut self, name: &str, kind: &str, line: u32) {
+        match self.store.insert_symbol(
+            self.crate_name,
+            &self.module_path,
+            name,
+            kind,
+            self.file_path,
+            i64::from(line),
+        ) {
+            Ok(id) => self.last_symbol_id = Some(id),
+            Err(e) => {
+                self.last_symbol_id = None;
+                tracing::warn!(
+                    crate_name = self.crate_name,
+                    symbol = name,
+                    kind,
+                    error = %e,
+                    "gnosis: failed to insert symbol"
+                );
+            }
+        }
     }
 
     fn insert_ref(&self, from_id: i64, to_crate: &str, to_module: &str, to_sym: &str, kind: &str) {
-        if let Err(e) = self.conn.execute(
-            "INSERT INTO symbol_refs (from_symbol, to_crate, to_module, to_symbol, ref_kind)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![from_id, to_crate, to_module, to_sym, kind],
-        ) {
+        let Ok(from_id) = u64::try_from(from_id) else {
+            tracing::warn!(from_id, "gnosis: invalid negative symbol id");
+            return;
+        };
+        if let Err(e) = self
+            .store
+            .insert_ref(from_id, to_crate, to_module, to_sym, kind)
+        {
             tracing::warn!(
                 from_id,
                 to_symbol = to_sym,
@@ -176,7 +182,7 @@ fn decompose_path(path: &syn::Path) -> (String, String, String) {
 
 /// Extract the line number from a `proc_macro2::Span`.
 ///
-/// Line numbers are `usize` in `proc_macro2` but stored as `u32` in `SQLite`.
+/// Line numbers are `usize` in `proc_macro2` but stored as `u32` in fjall.
 /// Real source files never exceed `u32::MAX` lines so the truncation is safe;
 /// we use `try_from` and fall back to 0 for defence.
 fn span_line(span: Span) -> u32 {
@@ -189,21 +195,21 @@ impl<'ast> Visit<'ast> for IndexVisitor<'_> {
     fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
         let name = node.sig.ident.to_string();
         let line = span_line(node.sig.ident.span());
-        self.insert_symbol(&name, "fn", line);
+        self.record_symbol(&name, "fn", line);
         syn::visit::visit_item_fn(self, node);
     }
 
     fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
         let name = node.sig.ident.to_string();
         let line = span_line(node.sig.ident.span());
-        self.insert_symbol(&name, "fn", line);
+        self.record_symbol(&name, "fn", line);
         syn::visit::visit_impl_item_fn(self, node);
     }
 
     fn visit_trait_item_fn(&mut self, node: &'ast syn::TraitItemFn) {
         let name = node.sig.ident.to_string();
         let line = span_line(node.sig.ident.span());
-        self.insert_symbol(&name, "fn", line);
+        self.record_symbol(&name, "fn", line);
         syn::visit::visit_trait_item_fn(self, node);
     }
 
@@ -212,7 +218,7 @@ impl<'ast> Visit<'ast> for IndexVisitor<'_> {
     fn visit_item_struct(&mut self, node: &'ast syn::ItemStruct) {
         let name = node.ident.to_string();
         let line = span_line(node.ident.span());
-        self.insert_symbol(&name, "struct", line);
+        self.record_symbol(&name, "struct", line);
         syn::visit::visit_item_struct(self, node);
     }
 
@@ -221,7 +227,7 @@ impl<'ast> Visit<'ast> for IndexVisitor<'_> {
     fn visit_item_enum(&mut self, node: &'ast syn::ItemEnum) {
         let name = node.ident.to_string();
         let line = span_line(node.ident.span());
-        self.insert_symbol(&name, "enum", line);
+        self.record_symbol(&name, "enum", line);
         syn::visit::visit_item_enum(self, node);
     }
 
@@ -230,7 +236,7 @@ impl<'ast> Visit<'ast> for IndexVisitor<'_> {
     fn visit_item_trait(&mut self, node: &'ast syn::ItemTrait) {
         let name = node.ident.to_string();
         let line = span_line(node.ident.span());
-        self.insert_symbol(&name, "trait", line);
+        self.record_symbol(&name, "trait", line);
         syn::visit::visit_item_trait(self, node);
     }
 
@@ -239,7 +245,7 @@ impl<'ast> Visit<'ast> for IndexVisitor<'_> {
     fn visit_item_type(&mut self, node: &'ast syn::ItemType) {
         let name = node.ident.to_string();
         let line = span_line(node.ident.span());
-        self.insert_symbol(&name, "type", line);
+        self.record_symbol(&name, "type", line);
         syn::visit::visit_item_type(self, node);
     }
 
@@ -248,7 +254,7 @@ impl<'ast> Visit<'ast> for IndexVisitor<'_> {
     fn visit_item_const(&mut self, node: &'ast syn::ItemConst) {
         let name = node.ident.to_string();
         let line = span_line(node.ident.span());
-        self.insert_symbol(&name, "const", line);
+        self.record_symbol(&name, "const", line);
         syn::visit::visit_item_const(self, node);
     }
 
@@ -265,7 +271,7 @@ impl<'ast> Visit<'ast> for IndexVisitor<'_> {
                     .map_or_else(Span::call_site, |s| s.ident.span()),
             );
             let (trait_crate, trait_module, trait_sym) = decompose_path(trait_path);
-            self.insert_symbol(&type_name, "impl", line);
+            self.record_symbol(&type_name, "impl", line);
             if let Some(sym_id) = self.last_symbol_id() {
                 self.insert_ref(sym_id, &trait_crate, &trait_module, &trait_sym, "impl");
             }
@@ -326,7 +332,7 @@ fn extract_reexports(
         syn::UseTree::Name(n) => {
             let sym = n.ident.to_string();
             let line = span_line(n.ident.span());
-            visitor.insert_symbol(&sym, "reexport", line);
+            visitor.record_symbol(&sym, "reexport", line);
             if let Some(id) = visitor.last_symbol_id() {
                 prefix.push(sym.clone());
                 let (to_crate, to_module, to_sym) = decompose_segments(prefix);
@@ -337,7 +343,7 @@ fn extract_reexports(
         syn::UseTree::Rename(r) => {
             let alias = r.rename.to_string();
             let line = span_line(r.rename.span());
-            visitor.insert_symbol(&alias, "reexport", line);
+            visitor.record_symbol(&alias, "reexport", line);
             if let Some(id) = visitor.last_symbol_id() {
                 let original = r.ident.to_string();
                 prefix.push(original);
@@ -400,13 +406,8 @@ fn module_path_from_file_path(src_dir: &Path, file_path: &Path) -> String {
 ///
 /// Errors during parsing are logged at WARN and skipped — they do not abort
 /// the overall index build.
-#[tracing::instrument(skip(conn), fields(crate_name, file = file_path))]
-fn index_file(
-    conn: &Connection,
-    crate_name: &str,
-    file_path: &str,
-    module_path: &str,
-) -> Result<()> {
+#[tracing::instrument(skip(store), fields(crate_name, file = file_path))]
+fn index_file(store: &Store, crate_name: &str, file_path: &str, module_path: &str) -> Result<()> {
     let content = std::fs::read_to_string(file_path).with_context(|_| ReadSourceSnafu {
         path: PathBuf::from(file_path),
     })?;
@@ -415,25 +416,17 @@ fn index_file(
         path: PathBuf::from(file_path),
     })?;
 
-    // Delete any existing symbols from this file before re-inserting.
-    conn.execute(
-        "DELETE FROM symbols WHERE file_path = ?1",
-        params![file_path],
-    )
-    .context(SqliteSnafu)?;
+    store.delete_symbols_for_file(file_path)?;
 
-    let mut visitor = IndexVisitor::new(conn, crate_name, file_path, module_path.to_owned());
+    let mut visitor = IndexVisitor::new(store, crate_name, file_path, module_path.to_owned());
     visitor.visit_file(&file);
 
     Ok(())
 }
 
 /// Populate `crate_edges` from `cargo metadata` dependency graph.
-fn populate_crate_edges(
-    conn: &Connection,
-    metadata: &cargo_metadata::Metadata,
-) -> rusqlite::Result<()> {
-    conn.execute("DELETE FROM crate_edges", [])?;
+fn populate_crate_edges(store: &Store, metadata: &cargo_metadata::Metadata) -> Result<()> {
+    store.clear_crate_edges()?;
 
     let workspace_ids: HashMap<_, _> = metadata
         .workspace_members
@@ -454,10 +447,7 @@ fn populate_crate_edges(
         let from_name = pkg.name.as_str();
         for dep in &pkg.dependencies {
             if workspace_ids.values().any(|n| n == dep.name.as_str()) {
-                conn.execute(
-                    "INSERT OR IGNORE INTO crate_edges (from_crate, to_crate) VALUES (?1, ?2)",
-                    params![from_name, dep.name.as_str()],
-                )?;
+                store.insert_crate_edge(from_name, dep.name.as_str())?;
             }
         }
     }
@@ -478,8 +468,8 @@ fn populate_crate_edges(
 ///
 /// Time: O(P + F + B), where P is workspace packages, F is source files, and B
 /// is bytes read from changed files. Space: O(F) for the present-file set.
-#[tracing::instrument(skip(conn))]
-pub(crate) fn rebuild(conn: &Connection, workspace_root: &Path) -> Result<()> {
+#[tracing::instrument(skip(store))]
+pub(crate) fn rebuild(store: &Store, workspace_root: &Path) -> Result<()> {
     tracing::info!(workspace = %workspace_root.display(), "gnosis: starting index rebuild");
 
     // ── 1. cargo metadata ────────────────────────────────────────────────────
@@ -496,7 +486,7 @@ pub(crate) fn rebuild(conn: &Connection, workspace_root: &Path) -> Result<()> {
         .context(CargoMetadataSnafu)?;
 
     // ── 2. Populate crate_edges ───────────────────────────────────────────────
-    populate_crate_edges(conn, &metadata_full).context(SqliteSnafu)?;
+    populate_crate_edges(store, &metadata_full)?;
 
     // ── 3. Walk workspace source files ───────────────────────────────────────
     let mut total_files = 0usize;
@@ -536,18 +526,7 @@ pub(crate) fn rebuild(conn: &Connection, workspace_root: &Path) -> Result<()> {
             let hash = file_hash(&content);
 
             // Check stored hash.
-            let stored_hash: Option<String> = match conn.query_row(
-                "SELECT sha256 FROM file_hashes WHERE file_path = ?1",
-                params![path_str],
-                |row| row.get(0),
-            ) {
-                Ok(h) => Some(h),
-                Err(rusqlite::Error::QueryReturnedNoRows) => None,
-                Err(e) => {
-                    tracing::warn!(file = %path_str, error = %e, "gnosis: failed to read stored hash");
-                    None
-                }
-            };
+            let stored_hash = store.file_hash(path_str)?;
 
             if stored_hash.as_deref() == Some(hash.as_str()) {
                 skipped += 1;
@@ -557,24 +536,21 @@ pub(crate) fn rebuild(conn: &Connection, workspace_root: &Path) -> Result<()> {
 
             // Parse and index.
             let module_path = module_path_from_file_path(&src_dir, &file_path);
-            if let Err(e) = index_file(conn, crate_name, path_str, &module_path) {
+            if let Err(e) = index_file(store, crate_name, path_str, &module_path) {
                 tracing::warn!(file = %path_str, error = %e, "gnosis: parse error, skipping file");
                 all_present_paths.push(present_path);
                 continue;
             }
 
             // Update hash.
-            conn.execute(
-                "INSERT OR REPLACE INTO file_hashes (file_path, sha256) VALUES (?1, ?2)",
-                params![path_str, hash],
-            )
-            .context(SqliteSnafu)?;
+            store.set_file_hash(path_str, &hash)?;
             all_present_paths.push(present_path);
         }
     }
 
     // ── 4. Prune deleted files ────────────────────────────────────────────────
-    prune_deleted_files(conn, &all_present_paths)?;
+    prune_deleted_files(store, &all_present_paths)?;
+    store.persist()?;
 
     tracing::info!(
         total_files,
@@ -587,32 +563,20 @@ pub(crate) fn rebuild(conn: &Connection, workspace_root: &Path) -> Result<()> {
 }
 
 /// Remove symbols and `file_hashes` for source files no longer on disk.
-fn prune_deleted_files(conn: &Connection, present: &[String]) -> Result<()> {
-    conn.execute(
-        "CREATE TEMP TABLE IF NOT EXISTS present_files (path TEXT PRIMARY KEY)",
-        [],
-    )
-    .context(SqliteSnafu)?;
-    conn.execute("DELETE FROM present_files", [])
-        .context(SqliteSnafu)?;
-    {
-        let mut stmt = conn
-            .prepare("INSERT OR IGNORE INTO present_files (path) VALUES (?1)")
-            .context(SqliteSnafu)?;
-        for path in present {
-            stmt.execute([path]).context(SqliteSnafu)?;
+fn prune_deleted_files(store: &Store, present: &[String]) -> Result<()> {
+    let present_set: std::collections::BTreeSet<&str> =
+        present.iter().map(String::as_str).collect();
+    let file_paths: Vec<String> = store
+        .symbols()?
+        .into_iter()
+        .map(|symbol| symbol.file_path)
+        .collect();
+    for file_path in file_paths {
+        if !present_set.contains(file_path.as_str()) {
+            store.delete_symbols_for_file(&file_path)?;
         }
     }
-    conn.execute(
-        "DELETE FROM symbols WHERE NOT EXISTS (SELECT 1 FROM present_files WHERE path = file_path)",
-        [],
-    )
-    .context(SqliteSnafu)?;
-    conn.execute(
-        "DELETE FROM file_hashes WHERE NOT EXISTS (SELECT 1 FROM present_files WHERE path = file_path)",
-        [],
-    )
-    .context(SqliteSnafu)?;
+    store.prune_file_hashes_not_in(present)?;
     Ok(())
 }
 

--- a/crates/gnosis/src/index_tests.rs
+++ b/crates/gnosis/src/index_tests.rs
@@ -1,10 +1,10 @@
 use super::*;
-use crate::schema;
+use crate::schema::Store;
 
-fn open_test_db() -> Connection {
-    let conn = Connection::open_in_memory().expect("in-memory db");
-    schema::init(&conn).expect("schema init");
-    conn
+fn open_test_store() -> (Store, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(dir.path()).expect("open fjall store");
+    (store, dir)
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn file_hash_differs_for_different_content() {
 
 #[test]
 fn index_simple_fn() {
-    let conn = open_test_db();
+    let (store, _dir) = open_test_store();
     let src = r"
             pub fn greet(name: &str) -> String {
                 format!('Hello, {name}!')
@@ -50,21 +50,20 @@ fn index_simple_fn() {
     std::fs::write(tmp.path(), src.replace('\'', "\"")).expect("write");
     let path_str = tmp.path().to_string_lossy().into_owned();
 
-    index_file(&conn, "test_crate", &path_str, "").expect("index");
+    index_file(&store, "test_crate", &path_str, "").expect("index");
 
-    let count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbols WHERE symbol_name = 'greet' AND symbol_kind = 'fn'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query");
+    let count = store
+        .symbols()
+        .expect("query")
+        .into_iter()
+        .filter(|symbol| symbol.symbol_name == "greet" && symbol.symbol_kind == "fn")
+        .count();
     assert_eq!(count, 1, "expected 1 'greet' fn symbol");
 }
 
 #[test]
 fn index_struct_and_impl_trait() {
-    let conn = open_test_db();
+    let (store, _dir) = open_test_store();
     let src = r"
             pub struct Foo;
             pub trait Bar {}
@@ -74,122 +73,120 @@ fn index_struct_and_impl_trait() {
     std::fs::write(tmp.path(), src).expect("write");
     let path_str = tmp.path().to_string_lossy().into_owned();
 
-    index_file(&conn, "my_crate", &path_str, "").expect("index");
+    index_file(&store, "my_crate", &path_str, "").expect("index");
 
-    let struct_count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbols WHERE symbol_name = 'Foo' AND symbol_kind = 'struct'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query struct");
+    let symbols = store.symbols().expect("query symbols");
+    let struct_count = symbols
+        .iter()
+        .filter(|symbol| symbol.symbol_name == "Foo" && symbol.symbol_kind == "struct")
+        .count();
     assert_eq!(struct_count, 1, "expected Foo struct");
 
-    let impl_count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbols WHERE symbol_kind = 'impl'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query impl");
+    let impl_count = symbols
+        .iter()
+        .filter(|symbol| symbol.symbol_kind == "impl")
+        .count();
     assert_eq!(impl_count, 1, "expected 1 impl block");
 }
 
 #[test]
 fn reindex_clears_old_symbols() {
-    let conn = open_test_db();
+    let (store, _dir) = open_test_store();
     let tmp = tempfile::NamedTempFile::new().expect("tempfile");
     let path_str = tmp.path().to_string_lossy().into_owned();
 
     std::fs::write(tmp.path(), "pub fn alpha() {}").expect("write v1");
-    index_file(&conn, "krate", &path_str, "").expect("index v1");
+    index_file(&store, "krate", &path_str, "").expect("index v1");
 
-    let c1: i64 = conn
-        .query_row("SELECT COUNT(*) FROM symbols", [], |r| r.get(0))
-        .expect("count v1");
+    let c1 = store.symbols().expect("count v1").len();
     assert_eq!(c1, 1);
 
     // Overwrite with different content.
     std::fs::write(tmp.path(), "pub fn beta() {} pub fn gamma() {}").expect("write v2");
-    index_file(&conn, "krate", &path_str, "").expect("index v2");
+    index_file(&store, "krate", &path_str, "").expect("index v2");
 
-    let c2: i64 = conn
-        .query_row("SELECT COUNT(*) FROM symbols", [], |r| r.get(0))
-        .expect("count v2");
+    let symbols = store.symbols().expect("count v2");
+    let c2 = symbols.len();
     assert_eq!(c2, 2, "old symbols must be cleared on re-index");
 
     // Verify alpha is gone.
-    let alpha: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbols WHERE symbol_name = 'alpha'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("count alpha");
+    let alpha = symbols
+        .iter()
+        .filter(|symbol| symbol.symbol_name == "alpha")
+        .count();
     assert_eq!(alpha, 0, "alpha should have been removed");
 }
 
 #[test]
 fn pub_use_produces_reexport_symbol() {
-    let conn = open_test_db();
+    let (store, _dir) = open_test_store();
     let src = "pub use other_crate::SomeType;";
     let tmp = tempfile::NamedTempFile::new().expect("tempfile");
     std::fs::write(tmp.path(), src).expect("write");
     let path_str = tmp.path().to_string_lossy().into_owned();
 
-    index_file(&conn, "re_crate", &path_str, "").expect("index");
+    index_file(&store, "re_crate", &path_str, "").expect("index");
 
-    let count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbols WHERE symbol_kind = 'reexport'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query");
+    let count = store
+        .symbols()
+        .expect("query")
+        .into_iter()
+        .filter(|symbol| symbol.symbol_kind == "reexport")
+        .count();
     assert_eq!(count, 1, "expected 1 reexport symbol for 'pub use'");
 }
 
 #[test]
 fn pub_use_reexport_populates_to_crate() {
-    let conn = open_test_db();
+    let (store, _dir) = open_test_store();
     let src = r"pub use hermeneus::types::Message;";
     let tmp = tempfile::NamedTempFile::new().expect("tempfile");
     std::fs::write(tmp.path(), src).expect("write");
     let path_str = tmp.path().to_string_lossy().into_owned();
 
-    index_file(&conn, "re_crate", &path_str, "").expect("index");
+    index_file(&store, "re_crate", &path_str, "").expect("index");
 
-    let to_crate: String = conn
-        .query_row(
-            "SELECT to_crate FROM symbol_refs
-                 JOIN symbols ON symbols.id = symbol_refs.from_symbol
-                 WHERE symbols.symbol_kind = 'reexport'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query");
+    let reexport_ids: Vec<_> = store
+        .symbols()
+        .expect("symbols")
+        .into_iter()
+        .filter(|symbol| symbol.symbol_kind == "reexport")
+        .map(|symbol| symbol.id)
+        .collect();
+    let to_crate = store
+        .refs()
+        .expect("refs")
+        .into_iter()
+        .find(|reference| reexport_ids.contains(&reference.from_symbol))
+        .expect("reexport ref")
+        .to_crate;
     assert_eq!(to_crate, "hermeneus", "reexport must record origin crate");
 }
 
 #[test]
 fn pub_use_rename_populates_to_crate() {
-    let conn = open_test_db();
+    let (store, _dir) = open_test_store();
     let src = r"pub use hermeneus::types::Message as Msg;";
     let tmp = tempfile::NamedTempFile::new().expect("tempfile");
     std::fs::write(tmp.path(), src).expect("write");
     let path_str = tmp.path().to_string_lossy().into_owned();
 
-    index_file(&conn, "re_crate", &path_str, "").expect("index");
+    index_file(&store, "re_crate", &path_str, "").expect("index");
 
-    let to_crate: String = conn
-        .query_row(
-            "SELECT to_crate FROM symbol_refs
-                 JOIN symbols ON symbols.id = symbol_refs.from_symbol
-                 WHERE symbols.symbol_name = 'Msg'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query");
+    let msg_id = store
+        .symbols()
+        .expect("symbols")
+        .into_iter()
+        .find(|symbol| symbol.symbol_name == "Msg")
+        .expect("Msg symbol")
+        .id;
+    let to_crate = store
+        .refs()
+        .expect("refs")
+        .into_iter()
+        .find(|reference| reference.from_symbol == msg_id)
+        .expect("Msg ref")
+        .to_crate;
     assert_eq!(
         to_crate, "hermeneus",
         "rename reexport must record origin crate"
@@ -198,7 +195,7 @@ fn pub_use_rename_populates_to_crate() {
 
 #[test]
 fn indexed_rdeps_cover_impl_and_reexport_edges_only() {
-    let conn = open_test_db();
+    let (store, _dir) = open_test_store();
     let src = r"
         pub struct Local;
         impl hermeneus::types::Message for Local {}
@@ -208,31 +205,29 @@ fn indexed_rdeps_cover_impl_and_reexport_edges_only() {
     std::fs::write(tmp.path(), src).expect("write");
     let path_str = tmp.path().to_string_lossy().into_owned();
 
-    index_file(&conn, "re_crate", &path_str, "").expect("index");
+    index_file(&store, "re_crate", &path_str, "").expect("index");
 
-    let impl_count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbol_refs
-                 WHERE to_crate = 'hermeneus' AND to_symbol = 'Message' AND ref_kind = 'impl'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query impl refs");
-    let reexport_count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbol_refs
-                 WHERE to_crate = 'hermeneus' AND to_symbol = 'Message' AND ref_kind = 'reexport'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query reexport refs");
-    let other_count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbol_refs WHERE ref_kind NOT IN ('impl', 'reexport')",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query other refs");
+    let refs = store.refs().expect("refs");
+    let impl_count = refs
+        .iter()
+        .filter(|reference| {
+            reference.to_crate == "hermeneus"
+                && reference.to_symbol == "Message"
+                && reference.ref_kind == "impl"
+        })
+        .count();
+    let reexport_count = refs
+        .iter()
+        .filter(|reference| {
+            reference.to_crate == "hermeneus"
+                && reference.to_symbol == "Message"
+                && reference.ref_kind == "reexport"
+        })
+        .count();
+    let other_count = refs
+        .iter()
+        .filter(|reference| reference.ref_kind != "impl" && reference.ref_kind != "reexport")
+        .count();
 
     assert_eq!(impl_count, 1, "expected one impl edge");
     assert_eq!(reexport_count, 1, "expected one reexport edge");
@@ -244,7 +239,7 @@ fn indexed_rdeps_cover_impl_and_reexport_edges_only() {
 
 #[test]
 fn module_path_for_file_module() {
-    let conn = open_test_db();
+    let (store, _dir) = open_test_store();
     let tmp = tempfile::tempdir().expect("tempdir");
     let src_dir = tmp.path().join("src");
     std::fs::create_dir_all(&src_dir).expect("create src");
@@ -257,22 +252,20 @@ fn module_path_for_file_module() {
     let module_path = module_path_from_file_path(&src_dir, &bar_rs);
     assert_eq!(module_path, "foo::bar");
 
-    index_file(&conn, "test_crate", &path_str, &module_path).expect("index");
+    index_file(&store, "test_crate", &path_str, &module_path).expect("index");
 
-    let count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbols
-                 WHERE symbol_name = 'inside_bar' AND module_path = 'foo::bar'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query");
+    let count = store
+        .symbols()
+        .expect("query")
+        .into_iter()
+        .filter(|symbol| symbol.symbol_name == "inside_bar" && symbol.module_path == "foo::bar")
+        .count();
     assert_eq!(count, 1, "expected symbol inside foo::bar file module");
 }
 
 #[test]
 fn rebuild_prunes_deleted_files() {
-    let conn = open_test_db();
+    let (store, _dir) = open_test_store();
     let tmp = tempfile::tempdir().expect("tempdir");
     let ws = tmp.path();
 
@@ -305,15 +298,15 @@ edition = "2021"
     std::fs::write(&lib_rs, "pub mod foo;\npub fn keep() {}").expect("write lib.rs");
     std::fs::write(&foo_rs, "pub fn vanish() {}").expect("write foo.rs");
 
-    rebuild(&conn, ws).expect("first rebuild");
+    rebuild(&store, ws).expect("first rebuild");
 
-    let count_before: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbols WHERE file_path = ?1",
-            [&foo_rs.to_string_lossy()],
-            |r| r.get(0),
-        )
-        .expect("count foo symbols before");
+    let foo_path = foo_rs.to_string_lossy();
+    let count_before = store
+        .symbols()
+        .expect("count foo symbols before")
+        .into_iter()
+        .filter(|symbol| symbol.file_path == foo_path)
+        .count();
     assert_eq!(
         count_before, 1,
         "foo.rs symbol should exist before deletion"
@@ -323,23 +316,19 @@ edition = "2021"
     std::fs::remove_file(&foo_rs).expect("remove foo.rs");
     std::fs::write(&lib_rs, "pub fn keep() {}").expect("rewrite lib.rs");
 
-    rebuild(&conn, ws).expect("second rebuild");
+    rebuild(&store, ws).expect("second rebuild");
 
-    let count_after: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM symbols WHERE file_path = ?1",
-            [&foo_rs.to_string_lossy()],
-            |r| r.get(0),
-        )
-        .expect("count foo symbols after");
+    let count_after = store
+        .symbols()
+        .expect("count foo symbols after")
+        .into_iter()
+        .filter(|symbol| symbol.file_path == foo_path)
+        .count();
     assert_eq!(count_after, 0, "symbols for deleted file must be pruned");
 
-    let hash_after: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM file_hashes WHERE file_path = ?1",
-            [&foo_rs.to_string_lossy()],
-            |r| r.get(0),
-        )
-        .expect("count foo hash after");
-    assert_eq!(hash_after, 0, "file_hash for deleted file must be pruned");
+    let hash_after = store.file_hash(&foo_path).expect("count foo hash after");
+    assert!(
+        hash_after.is_none(),
+        "file_hash for deleted file must be pruned"
+    );
 }

--- a/crates/gnosis/src/lib.rs
+++ b/crates/gnosis/src/lib.rs
@@ -1,7 +1,7 @@
 //! # gnosis — machine-derived code-graph index
 //!
 //! `gnosis` (γνῶσις: "knowledge") provides symbol-level cross-crate queries
-//! over an aletheia workspace via a lightweight `SQLite` index built from
+//! over an aletheia workspace via a lightweight `fjall` index built from
 //! `cargo metadata` and `syn` AST walks.
 //!
 //! ## What it does
@@ -30,8 +30,8 @@
 //!
 //! ## Cache location
 //!
-//! Default: `~/.cache/aletheia/gnosis.sqlite`.  Override with
-//! `GNOSIS_CACHE_PATH` env var.  Delete the file to force a full rebuild.
+//! Default: `~/.cache/aletheia/gnosis.fjall`.  Override with
+//! `GNOSIS_CACHE_PATH` env var.  Delete the directory to force a full rebuild.
 //!
 //! ## Rebuild trigger
 //!
@@ -52,25 +52,23 @@ mod index;
 use std::path::{Path, PathBuf};
 
 use parking_lot::Mutex;
-use rusqlite::Connection;
 use snafu::ResultExt;
 
-use crate::error::{CreateCacheDirSnafu, RemoveCacheFileSnafu, Result, SqliteSnafu};
+use crate::error::{CreateCacheDirSnafu, Result};
 use crate::query::QueryRow;
-use crate::schema::SCHEMA_VERSION;
+use crate::schema::Store;
 
 // ── CodeGraph ─────────────────────────────────────────────────────────────────
 
-/// A handle to the gnosis `SQLite` index.
+/// A handle to the gnosis fjall index.
 ///
 /// # Thread safety
 ///
-/// `Connection` is `!Send`; we wrap it in `Mutex` so `CodeGraph` can be
-/// stored in `Arc` and shared across async tasks.  All methods lock the
-/// mutex for the duration of the call.
+/// The fjall keyspace handles are thread-safe. We keep them behind a mutex so
+/// query and rebuild operations see a consistent sequence of mutations.
 pub struct CodeGraph {
-    /// Mutex-protected `SQLite` connection.
-    conn: Mutex<Connection>,
+    /// Mutex-protected fjall store.
+    store: Mutex<Store>,
     /// Workspace root (for rebuild).
     workspace_root: PathBuf,
     /// Gnosis schema version this instance was opened with.
@@ -91,15 +89,15 @@ impl std::fmt::Debug for CodeGraph {
 impl CodeGraph {
     /// Open (or create) a gnosis index at `db_path` for `workspace_root`.
     ///
-    /// If the file does not exist it is created and the schema is initialised.
-    /// If the file exists but has an incompatible `user_version`, it is
-    /// truncated and re-initialised (data loss is acceptable — the index is
-    /// fully rebuildable).
+    /// If the directory does not exist it is created and the schema is
+    /// initialised. If the directory exists but carries an incompatible schema
+    /// version, the index keyspaces are cleared and re-initialised (data loss
+    /// is acceptable — the index is fully rebuildable).
     ///
     /// # Errors
     ///
     /// Returns [`error::GnosisError`] if the cache directory cannot be created,
-    /// the database cannot be opened, or schema initialisation fails.
+    /// the fjall database cannot be opened, or schema initialisation fails.
     #[tracing::instrument]
     pub fn open(db_path: &Path, workspace_root: &Path) -> Result<Self> {
         // Ensure the cache directory exists.
@@ -111,52 +109,20 @@ impl CodeGraph {
             })?;
         }
 
-        let conn = Connection::open(db_path).context(SqliteSnafu)?;
-
-        // Check schema version.
-        let stored_ver: u32 = conn
-            .query_row("PRAGMA user_version", [], |r| r.get(0))
-            .context(SqliteSnafu)?;
-
-        if stored_ver != 0 && stored_ver != SCHEMA_VERSION {
-            tracing::warn!(
-                stored_ver,
-                expected = SCHEMA_VERSION,
-                db_path = %db_path.display(),
-                "gnosis: schema version mismatch — dropping and reinitialising index"
-            );
-            // Drop all tables by closing and re-opening (truncate).
-            drop(conn);
-            std::fs::remove_file(db_path).with_context(|_| RemoveCacheFileSnafu {
-                path: db_path.to_owned(),
-            })?;
-            let conn = Connection::open(db_path).context(SqliteSnafu)?;
-            schema::init(&conn)?;
-            conn.execute_batch(&format!("PRAGMA user_version = {SCHEMA_VERSION}"))
-                .context(SqliteSnafu)?;
-            return Ok(Self {
-                conn: Mutex::new(conn),
-                workspace_root: workspace_root.to_owned(),
-                schema_version: SCHEMA_VERSION,
-                producer: format!("gnosis@{SCHEMA_VERSION}"),
-            });
-        }
-
-        schema::init(&conn)?;
-        conn.execute_batch(&format!("PRAGMA user_version = {SCHEMA_VERSION}"))
-            .context(SqliteSnafu)?;
+        let store = Store::open(db_path)?;
+        let schema_version = store.schema_version()?;
 
         Ok(Self {
-            conn: Mutex::new(conn),
+            store: Mutex::new(store),
             workspace_root: workspace_root.to_owned(),
-            schema_version: SCHEMA_VERSION,
-            producer: format!("gnosis@{SCHEMA_VERSION}"),
+            schema_version,
+            producer: format!("gnosis@{schema_version}"),
         })
     }
 
     /// Open a gnosis index at the default cache path for `workspace_root`.
     ///
-    /// Default path: `~/.cache/aletheia/gnosis.sqlite` (or
+    /// Default path: `~/.cache/aletheia/gnosis.fjall` (or
     /// `GNOSIS_CACHE_PATH` env override).
     ///
     /// # Errors
@@ -167,10 +133,10 @@ impl CodeGraph {
         Self::open(&path, workspace_root)
     }
 
-    /// The default `SQLite` cache path.
+    /// The default fjall cache path.
     ///
     /// Respects `GNOSIS_CACHE_PATH` env var; falls back to
-    /// `~/.cache/aletheia/gnosis.sqlite`.
+    /// `~/.cache/aletheia/gnosis.fjall`.
     #[must_use]
     pub fn default_cache_path() -> PathBuf {
         if let Ok(p) = std::env::var("GNOSIS_CACHE_PATH")
@@ -179,7 +145,7 @@ impl CodeGraph {
             return PathBuf::from(p);
         }
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
-        PathBuf::from(home).join(".cache/aletheia/gnosis.sqlite")
+        PathBuf::from(home).join(".cache/aletheia/gnosis.fjall")
     }
 
     /// Schema version this index was opened with.
@@ -205,11 +171,11 @@ impl CodeGraph {
     /// # Errors
     ///
     /// Returns [`error::GnosisError`] if `cargo metadata` fails, a source file
-    /// cannot be read, or a `SQLite` operation fails.
+    /// cannot be read, or a fjall operation fails.
     #[tracing::instrument(skip(self))]
     pub fn rebuild(&self) -> Result<()> {
-        let conn = self.conn.lock();
-        index::rebuild(&conn, &self.workspace_root)
+        let store = self.store.lock();
+        index::rebuild(&store, &self.workspace_root)
     }
 
     // ── Queries ───────────────────────────────────────────────────────────────
@@ -220,59 +186,59 @@ impl CodeGraph {
     ///
     /// # Errors
     ///
-    /// Returns [`error::GnosisError`] on `SQLite` failure.
+    /// Returns [`error::GnosisError`] on fjall failure.
     #[tracing::instrument(skip(self))]
     pub fn symbol_rdeps(
         &self,
         symbol_name: &str,
         target_crate: Option<&str>,
     ) -> Result<Vec<QueryRow>> {
-        let conn = self.conn.lock();
-        query::symbol_rdeps(&conn, symbol_name, target_crate)
+        let store = self.store.lock();
+        query::symbol_rdeps(&store, symbol_name, target_crate)
     }
 
     /// Which types implement `trait_name`?
     ///
     /// # Errors
     ///
-    /// Returns [`error::GnosisError`] on `SQLite` failure.
+    /// Returns [`error::GnosisError`] on fjall failure.
     #[tracing::instrument(skip(self))]
     pub fn impl_search(&self, trait_name: &str) -> Result<Vec<QueryRow>> {
-        let conn = self.conn.lock();
-        query::impl_search(&conn, trait_name)
+        let store = self.store.lock();
+        query::impl_search(&store, trait_name)
     }
 
     /// Which crates re-export `symbol_name` via `pub use`?
     ///
     /// # Errors
     ///
-    /// Returns [`error::GnosisError`] on `SQLite` failure.
+    /// Returns [`error::GnosisError`] on fjall failure.
     #[tracing::instrument(skip(self))]
     pub fn reexport_chain(&self, symbol_name: &str) -> Result<Vec<QueryRow>> {
-        let conn = self.conn.lock();
-        query::reexport_chain(&conn, symbol_name)
+        let store = self.store.lock();
+        query::reexport_chain(&store, symbol_name)
     }
 
     /// What workspace crates does `crate_name` directly depend on?
     ///
     /// # Errors
     ///
-    /// Returns [`error::GnosisError`] on `SQLite` failure.
+    /// Returns [`error::GnosisError`] on fjall failure.
     #[tracing::instrument(skip(self))]
     pub fn crate_deps(&self, crate_name: &str) -> Result<Vec<QueryRow>> {
-        let conn = self.conn.lock();
-        query::crate_deps(&conn, crate_name)
+        let store = self.store.lock();
+        query::crate_deps(&store, crate_name)
     }
 
     /// What workspace crates directly depend on `crate_name`?
     ///
     /// # Errors
     ///
-    /// Returns [`error::GnosisError`] on `SQLite` failure.
+    /// Returns [`error::GnosisError`] on fjall failure.
     #[tracing::instrument(skip(self))]
     pub fn crate_rdeps(&self, crate_name: &str) -> Result<Vec<QueryRow>> {
-        let conn = self.conn.lock();
-        query::crate_rdeps(&conn, crate_name)
+        let store = self.store.lock();
+        query::crate_rdeps(&store, crate_name)
     }
 
     /// List all symbols in `crate_name`, optionally filtered by `kind`.
@@ -282,11 +248,11 @@ impl CodeGraph {
     ///
     /// # Errors
     ///
-    /// Returns [`error::GnosisError`] on `SQLite` failure.
+    /// Returns [`error::GnosisError`] on fjall failure.
     #[tracing::instrument(skip(self))]
     pub fn symbols_in(&self, crate_name: &str, kind: Option<&str>) -> Result<Vec<QueryRow>> {
-        let conn = self.conn.lock();
-        query::symbols_in(&conn, crate_name, kind)
+        let store = self.store.lock();
+        query::symbols_in(&store, crate_name, kind)
     }
 }
 
@@ -299,7 +265,7 @@ mod tests {
 
     fn open_tmp_graph() -> (CodeGraph, tempfile::TempDir) {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let db_path = tmp.path().join("gnosis.sqlite");
+        let db_path = tmp.path().join("gnosis.fjall");
         let graph = CodeGraph::open(&db_path, tmp.path()).expect("open");
         (graph, tmp)
     }
@@ -307,19 +273,22 @@ mod tests {
     #[test]
     fn open_creates_db_and_schema() {
         let (_graph, tmp) = open_tmp_graph();
-        assert!(tmp.path().join("gnosis.sqlite").exists());
+        assert!(tmp.path().join("gnosis.fjall").exists());
     }
 
     #[test]
     fn schema_version_matches_constant() {
         let (graph, _tmp) = open_tmp_graph();
-        assert_eq!(graph.schema_version(), SCHEMA_VERSION);
+        assert_eq!(graph.schema_version(), crate::schema::SCHEMA_VERSION);
     }
 
     #[test]
     fn producer_string_matches_schema_version() {
         let (graph, _tmp) = open_tmp_graph();
-        assert_eq!(graph.producer(), format!("gnosis@{SCHEMA_VERSION}"));
+        assert_eq!(
+            graph.producer(),
+            format!("gnosis@{}", crate::schema::SCHEMA_VERSION)
+        );
     }
 
     #[test]
@@ -327,10 +296,10 @@ mod tests {
         // SAFETY: test-only env mutation.
         #[expect(unsafe_code, reason = "test env mutation")]
         unsafe {
-            std::env::set_var("GNOSIS_CACHE_PATH", "/tmp/test-gnosis-override.sqlite");
+            std::env::set_var("GNOSIS_CACHE_PATH", "/tmp/test-gnosis-override.fjall");
         }
         let path = CodeGraph::default_cache_path();
-        assert_eq!(path, PathBuf::from("/tmp/test-gnosis-override.sqlite"));
+        assert_eq!(path, PathBuf::from("/tmp/test-gnosis-override.fjall"));
         #[expect(unsafe_code, reason = "test env mutation")]
         unsafe {
             std::env::remove_var("GNOSIS_CACHE_PATH");

--- a/crates/gnosis/src/query.rs
+++ b/crates/gnosis/src/query.rs
@@ -1,34 +1,32 @@
-//! Query implementations against the gnosis `SQLite` index.
+//! Query implementations against the gnosis fjall index.
 //!
-//! All queries are synchronous — the index is a local `SQLite` file and queries
-//! complete in milliseconds.  The public API returns `Vec<QueryRow>`, a common
-//! result type that serialises cleanly to JSON for MCP tool output.
+//! All queries are synchronous and scan small local keyspaces. The public API
+//! returns `Vec<QueryRow>`, a common result type that serialises cleanly to
+//! JSON for MCP tool output.
 //!
 //! # Available queries
 //!
 //! | Query            | Answers                                                        |
 //! |------------------|----------------------------------------------------------------|
-//! | `symbol_rdeps`   | Which symbols implement or re-export a target symbol?    |
-//! | `impl_search`    | Which types implement a given trait?                            |
-//! | `reexport_chain` | Which crates re-export a given symbol name?                     |
-//! | `crate_deps`     | What crates does a given crate directly depend on?              |
-//! | `crate_rdeps`    | What crates directly depend on a given crate?                   |
-//! | `symbols_in`     | List all symbols in a given crate (optionally filtered by kind). |
+//! | `symbol_rdeps`   | Which symbols implement or re-export a target symbol?          |
+//! | `impl_search`    | Which types implement a given trait?                           |
+//! | `reexport_chain` | Which crates re-export a given symbol name?                    |
+//! | `crate_deps`     | What crates does a given crate directly depend on?             |
+//! | `crate_rdeps`    | What crates directly depend on a given crate?                  |
+//! | `symbols_in`     | List all symbols in a given crate, optionally filtered by kind. |
 //!
 //! # Epistemic tier
 //!
 //! Results are machine-derived from the AST and carry `EpistemicTier::Inferred`
-//! confidence.  They reflect the source as of the last `CodeGraph::rebuild()`
-//! call, not necessarily the current on-disk state.  The `source` field of
+//! confidence. They reflect the source as of the last `CodeGraph::rebuild()`
+//! call, not necessarily the current on-disk state. The `source` field of
 //! every `QueryRow` records the gnosis schema version so callers can detect
 //! staleness.
 
-use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
-use snafu::ResultExt;
 
-use crate::error::{Result, SqliteSnafu};
-use crate::schema::SCHEMA_VERSION;
+use crate::error::Result;
+use crate::schema::{SCHEMA_VERSION, Store, SymbolRecord};
 
 /// A single row in a query result.
 ///
@@ -46,7 +44,7 @@ pub struct QueryRow {
     /// Symbol name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_name: Option<String>,
-    /// Symbol kind (`fn`, `struct`, `enum`, `trait`, `impl`, `reexport`, …).
+    /// Symbol kind (`fn`, `struct`, `enum`, `trait`, `impl`, `reexport`, ...).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_kind: Option<String>,
     /// Absolute path to the source file.
@@ -90,57 +88,42 @@ impl QueryRow {
 ///
 /// - `symbol_name` — the symbol to look up (e.g. `"Message"`).
 /// - `target_crate` — if `Some`, only return refs where `to_crate` matches.
-#[tracing::instrument(skip(conn))]
+#[tracing::instrument(skip(store))]
 pub(crate) fn symbol_rdeps(
-    conn: &Connection,
+    store: &Store,
     symbol_name: &str,
     target_crate: Option<&str>,
 ) -> Result<Vec<QueryRow>> {
-    let sql = if target_crate.is_some() {
-        "SELECT s.crate_name, s.module_path, s.symbol_name, s.symbol_kind,
-                s.file_path, s.line_start, r.ref_kind
-         FROM symbol_refs r
-         JOIN symbols s ON s.id = r.from_symbol
-         WHERE r.to_symbol = ?1 AND r.to_crate = ?2
-           AND r.ref_kind IN ('impl', 'reexport')
-         ORDER BY s.crate_name, s.module_path, s.symbol_name"
-    } else {
-        "SELECT s.crate_name, s.module_path, s.symbol_name, s.symbol_kind,
-                s.file_path, s.line_start, r.ref_kind
-         FROM symbol_refs r
-         JOIN symbols s ON s.id = r.from_symbol
-         WHERE r.to_symbol = ?1
-           AND r.ref_kind IN ('impl', 'reexport')
-         ORDER BY s.crate_name, s.module_path, s.symbol_name"
-    };
-
-    let mut stmt = conn.prepare(sql).context(SqliteSnafu)?;
-
-    let rows = if let Some(tc) = target_crate {
-        stmt.query_map(params![symbol_name, tc], map_symbol_ref_row)
-            .context(SqliteSnafu)?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .context(SqliteSnafu)?
-    } else {
-        stmt.query_map(params![symbol_name], map_symbol_ref_row)
-            .context(SqliteSnafu)?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .context(SqliteSnafu)?
-    };
-
+    let mut rows = Vec::new();
+    for reference in store.refs()? {
+        if reference.to_symbol != symbol_name {
+            continue;
+        }
+        if target_crate.is_some_and(|crate_name| reference.to_crate != crate_name) {
+            continue;
+        }
+        if reference.ref_kind != "impl" && reference.ref_kind != "reexport" {
+            continue;
+        }
+        if let Some(symbol) = store.symbol(reference.from_symbol)? {
+            let mut row = row_from_symbol(&symbol);
+            row.ref_kind = Some(reference.ref_kind);
+            rows.push(row);
+        }
+    }
+    rows.sort_by(|left, right| {
+        (
+            left.crate_name.as_deref(),
+            left.module_path.as_deref(),
+            left.symbol_name.as_deref(),
+        )
+            .cmp(&(
+                right.crate_name.as_deref(),
+                right.module_path.as_deref(),
+                right.symbol_name.as_deref(),
+            ))
+    });
     Ok(rows)
-}
-
-fn map_symbol_ref_row(row: &rusqlite::Row<'_>) -> std::result::Result<QueryRow, rusqlite::Error> {
-    let mut r = QueryRow::new(SCHEMA_VERSION);
-    r.crate_name = Some(row.get(0)?);
-    r.module_path = Some(row.get(1)?);
-    r.symbol_name = Some(row.get(2)?);
-    r.symbol_kind = Some(row.get(3)?);
-    r.file_path = Some(row.get(4)?);
-    r.line_start = Some(row.get(5)?);
-    r.ref_kind = Some(row.get(6)?);
-    Ok(r)
 }
 
 // ── Query: impl_search ────────────────────────────────────────────────────────
@@ -153,31 +136,24 @@ fn map_symbol_ref_row(row: &rusqlite::Row<'_>) -> std::result::Result<QueryRow, 
 ///
 /// - `trait_name` — the trait name to search for (e.g. `"Stamped"`).
 ///   Matched against `to_symbol` in `symbol_refs` where `ref_kind = 'impl'`.
-#[tracing::instrument(skip(conn))]
-pub(crate) fn impl_search(conn: &Connection, trait_name: &str) -> Result<Vec<QueryRow>> {
-    let sql = "SELECT s.crate_name, s.module_path, s.symbol_name, s.file_path, s.line_start
-               FROM symbol_refs r
-               JOIN symbols s ON s.id = r.from_symbol
-               WHERE r.ref_kind = 'impl' AND r.to_symbol = ?1
-               ORDER BY s.crate_name, s.symbol_name";
-
-    let mut stmt = conn.prepare(sql).context(SqliteSnafu)?;
-    let rows = stmt
-        .query_map(params![trait_name], |row| {
-            let mut r = QueryRow::new(SCHEMA_VERSION);
-            r.crate_name = Some(row.get(0)?);
-            r.module_path = Some(row.get(1)?);
-            r.symbol_name = Some(row.get(2)?);
-            r.symbol_kind = Some("impl".to_owned());
-            r.file_path = Some(row.get(3)?);
-            r.line_start = Some(row.get(4)?);
-            r.ref_kind = Some("impl".to_owned());
-            Ok(r)
-        })
-        .context(SqliteSnafu)?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .context(SqliteSnafu)?;
-
+#[tracing::instrument(skip(store))]
+pub(crate) fn impl_search(store: &Store, trait_name: &str) -> Result<Vec<QueryRow>> {
+    let mut rows = Vec::new();
+    for reference in store.refs()? {
+        if reference.ref_kind == "impl"
+            && reference.to_symbol == trait_name
+            && let Some(symbol) = store.symbol(reference.from_symbol)?
+        {
+            let mut row = row_from_symbol(&symbol);
+            row.symbol_kind = Some("impl".to_owned());
+            row.ref_kind = Some("impl".to_owned());
+            rows.push(row);
+        }
+    }
+    rows.sort_by(|left, right| {
+        (left.crate_name.as_deref(), left.symbol_name.as_deref())
+            .cmp(&(right.crate_name.as_deref(), right.symbol_name.as_deref()))
+    });
     Ok(rows)
 }
 
@@ -190,118 +166,95 @@ pub(crate) fn impl_search(conn: &Connection, trait_name: &str) -> Result<Vec<Que
 /// # Arguments
 ///
 /// - `symbol_name` — the symbol name to look up (e.g. `"Message"`).
-#[tracing::instrument(skip(conn))]
-pub(crate) fn reexport_chain(conn: &Connection, symbol_name: &str) -> Result<Vec<QueryRow>> {
-    let sql = "SELECT s.crate_name, s.module_path, s.file_path, s.line_start
-               FROM symbols s
-               WHERE s.symbol_name = ?1 AND s.symbol_kind = 'reexport'
-               ORDER BY s.crate_name, s.module_path";
-
-    let mut stmt = conn.prepare(sql).context(SqliteSnafu)?;
-    let rows = stmt
-        .query_map(params![symbol_name], |row| {
-            let mut r = QueryRow::new(SCHEMA_VERSION);
-            r.crate_name = Some(row.get(0)?);
-            r.module_path = Some(row.get(1)?);
-            r.symbol_name = Some(symbol_name.to_owned());
-            r.symbol_kind = Some("reexport".to_owned());
-            r.file_path = Some(row.get(2)?);
-            r.line_start = Some(row.get(3)?);
-            r.ref_kind = Some("reexport".to_owned());
-            Ok(r)
+#[tracing::instrument(skip(store))]
+pub(crate) fn reexport_chain(store: &Store, symbol_name: &str) -> Result<Vec<QueryRow>> {
+    let mut rows: Vec<QueryRow> = store
+        .symbols()?
+        .into_iter()
+        .filter(|symbol| symbol.symbol_name == symbol_name && symbol.symbol_kind == "reexport")
+        .map(|symbol| {
+            let mut row = row_from_symbol(&symbol);
+            row.ref_kind = Some("reexport".to_owned());
+            row
         })
-        .context(SqliteSnafu)?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .context(SqliteSnafu)?;
-
+        .collect();
+    rows.sort_by(|left, right| {
+        (left.crate_name.as_deref(), left.module_path.as_deref())
+            .cmp(&(right.crate_name.as_deref(), right.module_path.as_deref()))
+    });
     Ok(rows)
 }
 
 // ── Query: crate_deps ─────────────────────────────────────────────────────────
 
 /// Return the direct workspace dependencies of `crate_name`.
-#[tracing::instrument(skip(conn))]
-pub(crate) fn crate_deps(conn: &Connection, crate_name: &str) -> Result<Vec<QueryRow>> {
-    let sql = "SELECT to_crate FROM crate_edges WHERE from_crate = ?1 ORDER BY to_crate";
-    let mut stmt = conn.prepare(sql).context(SqliteSnafu)?;
-    let rows = stmt
-        .query_map(params![crate_name], |row| {
-            let mut r = QueryRow::new(SCHEMA_VERSION);
-            r.crate_name = row.get(0)?;
-            Ok(r)
+#[tracing::instrument(skip(store))]
+pub(crate) fn crate_deps(store: &Store, crate_name: &str) -> Result<Vec<QueryRow>> {
+    let mut rows: Vec<QueryRow> = store
+        .crate_edges()?
+        .into_iter()
+        .filter(|(from_crate, _to_crate)| from_crate == crate_name)
+        .map(|(_from_crate, to_crate)| {
+            let mut row = QueryRow::new(SCHEMA_VERSION);
+            row.crate_name = Some(to_crate);
+            row
         })
-        .context(SqliteSnafu)?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .context(SqliteSnafu)?;
+        .collect();
+    rows.sort_by(|left, right| left.crate_name.cmp(&right.crate_name));
     Ok(rows)
 }
 
 // ── Query: crate_rdeps ────────────────────────────────────────────────────────
 
 /// Return the workspace crates that directly depend on `crate_name`.
-#[tracing::instrument(skip(conn))]
-pub(crate) fn crate_rdeps(conn: &Connection, crate_name: &str) -> Result<Vec<QueryRow>> {
-    let sql = "SELECT from_crate FROM crate_edges WHERE to_crate = ?1 ORDER BY from_crate";
-    let mut stmt = conn.prepare(sql).context(SqliteSnafu)?;
-    let rows = stmt
-        .query_map(params![crate_name], |row| {
-            let mut r = QueryRow::new(SCHEMA_VERSION);
-            r.crate_name = row.get(0)?;
-            Ok(r)
+#[tracing::instrument(skip(store))]
+pub(crate) fn crate_rdeps(store: &Store, crate_name: &str) -> Result<Vec<QueryRow>> {
+    let mut rows: Vec<QueryRow> = store
+        .crate_edges()?
+        .into_iter()
+        .filter(|(_from_crate, to_crate)| to_crate == crate_name)
+        .map(|(from_crate, _to_crate)| {
+            let mut row = QueryRow::new(SCHEMA_VERSION);
+            row.crate_name = Some(from_crate);
+            row
         })
-        .context(SqliteSnafu)?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .context(SqliteSnafu)?;
+        .collect();
+    rows.sort_by(|left, right| left.crate_name.cmp(&right.crate_name));
     Ok(rows)
 }
 
 // ── Query: symbols_in ─────────────────────────────────────────────────────────
 
 /// List all symbols in `crate_name`, optionally filtered to `kind`.
-#[tracing::instrument(skip(conn))]
+#[tracing::instrument(skip(store))]
 pub(crate) fn symbols_in(
-    conn: &Connection,
+    store: &Store,
     crate_name: &str,
     kind: Option<&str>,
 ) -> Result<Vec<QueryRow>> {
-    let sql = if kind.is_some() {
-        "SELECT crate_name, module_path, symbol_name, symbol_kind, file_path, line_start
-         FROM symbols
-         WHERE crate_name = ?1 AND symbol_kind = ?2
-         ORDER BY module_path, symbol_name"
-    } else {
-        "SELECT crate_name, module_path, symbol_name, symbol_kind, file_path, line_start
-         FROM symbols
-         WHERE crate_name = ?1
-         ORDER BY module_path, symbol_name"
-    };
-
-    let mut stmt = conn.prepare(sql).context(SqliteSnafu)?;
-
-    let rows = if let Some(k) = kind {
-        stmt.query_map(params![crate_name, k], map_symbol_row)
-            .context(SqliteSnafu)?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .context(SqliteSnafu)?
-    } else {
-        stmt.query_map(params![crate_name], map_symbol_row)
-            .context(SqliteSnafu)?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .context(SqliteSnafu)?
-    };
-
+    let mut rows: Vec<QueryRow> = store
+        .symbols()?
+        .into_iter()
+        .filter(|symbol| symbol.crate_name == crate_name)
+        .filter(|symbol| kind.is_none_or(|wanted| symbol.symbol_kind == wanted))
+        .map(|symbol| row_from_symbol(&symbol))
+        .collect();
+    rows.sort_by(|left, right| {
+        (left.module_path.as_deref(), left.symbol_name.as_deref())
+            .cmp(&(right.module_path.as_deref(), right.symbol_name.as_deref()))
+    });
     Ok(rows)
 }
 
-fn map_symbol_row(row: &rusqlite::Row<'_>) -> std::result::Result<QueryRow, rusqlite::Error> {
-    let mut r = QueryRow::new(SCHEMA_VERSION);
-    r.crate_name = Some(row.get(0)?);
-    r.module_path = Some(row.get(1)?);
-    r.symbol_name = Some(row.get(2)?);
-    r.symbol_kind = Some(row.get(3)?);
-    r.file_path = Some(row.get(4)?);
-    r.line_start = Some(row.get(5)?);
-    Ok(r)
+fn row_from_symbol(symbol: &SymbolRecord) -> QueryRow {
+    let mut row = QueryRow::new(SCHEMA_VERSION);
+    row.crate_name = Some(symbol.crate_name.clone());
+    row.module_path = Some(symbol.module_path.clone());
+    row.symbol_name = Some(symbol.symbol_name.clone());
+    row.symbol_kind = Some(symbol.symbol_kind.clone());
+    row.file_path = Some(symbol.file_path.clone());
+    row.line_start = Some(symbol.line_start);
+    row
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -309,74 +262,60 @@ fn map_symbol_row(row: &rusqlite::Row<'_>) -> std::result::Result<QueryRow, rusq
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
-    use rusqlite::Connection;
-
     use super::*;
-    use crate::schema;
 
-    fn open_db() -> Connection {
-        let conn = Connection::open_in_memory().expect("in-memory db");
-        schema::init(&conn).expect("schema init");
-        conn
+    fn open_store() -> (Store, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path()).expect("open fjall store");
+        (store, dir)
     }
 
     fn insert_symbol(
-        conn: &Connection,
+        store: &Store,
         crate_name: &str,
         module: &str,
         name: &str,
         kind: &str,
         file: &str,
         line: i64,
-    ) -> i64 {
-        conn.execute(
-            "INSERT INTO symbols (crate_name, module_path, symbol_name, symbol_kind, file_path, line_start)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![crate_name, module, name, kind, file, line],
-        )
-        .expect("insert symbol");
-        conn.last_insert_rowid()
+    ) -> u64 {
+        store
+            .insert_symbol(crate_name, module, name, kind, file, line)
+            .expect("insert symbol")
     }
 
     fn insert_ref(
-        conn: &Connection,
-        from_id: i64,
+        store: &Store,
+        from_id: u64,
         to_crate: &str,
         to_module: &str,
         to_sym: &str,
         kind: &str,
     ) {
-        conn.execute(
-            "INSERT INTO symbol_refs (from_symbol, to_crate, to_module, to_symbol, ref_kind)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![from_id, to_crate, to_module, to_sym, kind],
-        )
-        .expect("insert ref");
+        store
+            .insert_ref(from_id, to_crate, to_module, to_sym, kind)
+            .expect("insert ref");
     }
 
-    fn insert_edge(conn: &Connection, from: &str, to: &str) {
-        conn.execute(
-            "INSERT OR IGNORE INTO crate_edges (from_crate, to_crate) VALUES (?1, ?2)",
-            params![from, to],
-        )
-        .expect("insert edge");
+    fn insert_edge(store: &Store, from: &str, to: &str) {
+        store
+            .insert_crate_edge(from, to)
+            .expect("insert crate edge");
     }
-
-    // ── symbol_rdeps ─────────────────────────────────────────────────────────
 
     #[test]
     fn symbol_rdeps_empty_when_no_refs() {
-        let conn = open_db();
-        let rows = symbol_rdeps(&conn, "Message", None).expect("query");
+        let (store, _tmp) = open_store();
+        let rows = symbol_rdeps(&store, "Message", None).expect("query");
         assert!(rows.is_empty());
     }
 
     #[test]
     #[expect(clippy::indexing_slicing, reason = "test assertion: len checked above")]
     fn symbol_rdeps_finds_single_caller() {
-        let conn = open_db();
+        let (store, _tmp) = open_store();
         let sym_id = insert_symbol(
-            &conn,
+            &store,
             "nous",
             "execute",
             "dispatch",
@@ -384,9 +323,9 @@ mod tests {
             "nous/src/execute.rs",
             10,
         );
-        insert_ref(&conn, sym_id, "hermeneus", "types", "Message", "impl");
+        insert_ref(&store, sym_id, "hermeneus", "types", "Message", "impl");
 
-        let rows = symbol_rdeps(&conn, "Message", None).expect("query");
+        let rows = symbol_rdeps(&store, "Message", None).expect("query");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].symbol_name.as_deref(), Some("dispatch"));
         assert_eq!(rows[0].crate_name.as_deref(), Some("nous"));
@@ -395,16 +334,16 @@ mod tests {
     #[test]
     #[expect(clippy::indexing_slicing, reason = "test assertion: len checked above")]
     fn symbol_rdeps_filters_by_target_crate() {
-        let conn = open_db();
-        let id1 = insert_symbol(&conn, "nous", "", "fn_a", "fn", "a.rs", 1);
-        insert_ref(&conn, id1, "hermeneus", "types", "Message", "reexport");
-        let id2 = insert_symbol(&conn, "melete", "", "fn_b", "fn", "b.rs", 2);
-        insert_ref(&conn, id2, "other", "", "Message", "impl");
+        let (store, _tmp) = open_store();
+        let id1 = insert_symbol(&store, "nous", "", "fn_a", "fn", "a.rs", 1);
+        insert_ref(&store, id1, "hermeneus", "types", "Message", "reexport");
+        let id2 = insert_symbol(&store, "melete", "", "fn_b", "fn", "b.rs", 2);
+        insert_ref(&store, id2, "other", "", "Message", "impl");
 
-        let all = symbol_rdeps(&conn, "Message", None).expect("query all");
+        let all = symbol_rdeps(&store, "Message", None).expect("query all");
         assert_eq!(all.len(), 2);
 
-        let filtered = symbol_rdeps(&conn, "Message", Some("hermeneus")).expect("query filtered");
+        let filtered = symbol_rdeps(&store, "Message", Some("hermeneus")).expect("query filtered");
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].crate_name.as_deref(), Some("nous"));
     }
@@ -412,33 +351,33 @@ mod tests {
     #[test]
     #[expect(clippy::indexing_slicing, reason = "test assertion: len checked above")]
     fn symbol_rdeps_includes_reexports_with_target_crate_filter() {
-        let conn = open_db();
+        let (store, _tmp) = open_store();
         let id1 = insert_symbol(
-            &conn, "organon", "prelude", "Message", "reexport", "a.rs", 1,
+            &store, "organon", "prelude", "Message", "reexport", "a.rs", 1,
         );
-        insert_ref(&conn, id1, "hermeneus", "types", "Message", "reexport");
+        insert_ref(&store, id1, "hermeneus", "types", "Message", "reexport");
 
-        let all = symbol_rdeps(&conn, "Message", None).expect("query all");
+        let all = symbol_rdeps(&store, "Message", None).expect("query all");
         assert_eq!(all.len(), 1);
 
-        let filtered = symbol_rdeps(&conn, "Message", Some("hermeneus")).expect("query filtered");
+        let filtered = symbol_rdeps(&store, "Message", Some("hermeneus")).expect("query filtered");
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].symbol_name.as_deref(), Some("Message"));
         assert_eq!(filtered[0].ref_kind.as_deref(), Some("reexport"));
 
-        let none = symbol_rdeps(&conn, "Message", Some("other")).expect("query other");
+        let none = symbol_rdeps(&store, "Message", Some("other")).expect("query other");
         assert!(none.is_empty());
     }
 
     #[test]
     fn symbol_rdeps_excludes_unindexed_edge_kinds() {
-        let conn = open_db();
-        let id1 = insert_symbol(&conn, "nous", "", "fn_a", "fn", "a.rs", 1);
-        insert_ref(&conn, id1, "hermeneus", "types", "Message", "type_use");
-        let id2 = insert_symbol(&conn, "melete", "", "fn_b", "fn", "b.rs", 2);
-        insert_ref(&conn, id2, "hermeneus", "types", "Message", "call");
+        let (store, _tmp) = open_store();
+        let id1 = insert_symbol(&store, "nous", "", "fn_a", "fn", "a.rs", 1);
+        insert_ref(&store, id1, "hermeneus", "types", "Message", "type_use");
+        let id2 = insert_symbol(&store, "melete", "", "fn_b", "fn", "b.rs", 2);
+        insert_ref(&store, id2, "hermeneus", "types", "Message", "call");
 
-        let rows = symbol_rdeps(&conn, "Message", None).expect("query all");
+        let rows = symbol_rdeps(&store, "Message", None).expect("query all");
         assert!(
             rows.is_empty(),
             "symbol_rdeps v1 must expose only indexed impl and reexport edges"
@@ -448,20 +387,20 @@ mod tests {
     #[test]
     #[expect(clippy::indexing_slicing, reason = "test assertion: len checked above")]
     fn symbol_rdeps_target_crate_filter_excludes_type_use_edges() {
-        let conn = open_db();
-        let type_use_id = insert_symbol(&conn, "nous", "", "fn_type_use", "fn", "a.rs", 1);
+        let (store, _tmp) = open_store();
+        let type_use_id = insert_symbol(&store, "nous", "", "fn_type_use", "fn", "a.rs", 1);
         insert_ref(
-            &conn,
+            &store,
             type_use_id,
             "hermeneus",
             "types",
             "Message",
             "type_use",
         );
-        let impl_id = insert_symbol(&conn, "melete", "", "Response", "impl", "b.rs", 2);
-        insert_ref(&conn, impl_id, "hermeneus", "types", "Message", "impl");
+        let impl_id = insert_symbol(&store, "melete", "", "Response", "impl", "b.rs", 2);
+        insert_ref(&store, impl_id, "hermeneus", "types", "Message", "impl");
 
-        let rows = symbol_rdeps(&conn, "Message", Some("hermeneus")).expect("query filtered");
+        let rows = symbol_rdeps(&store, "Message", Some("hermeneus")).expect("query filtered");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].symbol_name.as_deref(), Some("Response"));
         assert_eq!(rows[0].ref_kind.as_deref(), Some("impl"));
@@ -471,9 +410,9 @@ mod tests {
 
     #[test]
     fn impl_search_finds_implementing_types() {
-        let conn = open_db();
+        let (store, _tmp) = open_store();
         let id1 = insert_symbol(
-            &conn,
+            &store,
             "eidos",
             "types",
             "Response",
@@ -481,9 +420,9 @@ mod tests {
             "eidos/src/types.rs",
             42,
         );
-        insert_ref(&conn, id1, "", "", "Stamped", "impl");
+        insert_ref(&store, id1, "", "", "Stamped", "impl");
         let id2 = insert_symbol(
-            &conn,
+            &store,
             "nous",
             "agent",
             "AgentCtx",
@@ -491,9 +430,9 @@ mod tests {
             "nous/src/agent.rs",
             7,
         );
-        insert_ref(&conn, id2, "", "", "Stamped", "impl");
+        insert_ref(&store, id2, "", "", "Stamped", "impl");
 
-        let rows = impl_search(&conn, "Stamped").expect("query");
+        let rows = impl_search(&store, "Stamped").expect("query");
         assert_eq!(rows.len(), 2);
         let names: Vec<_> = rows
             .iter()
@@ -505,18 +444,16 @@ mod tests {
 
     #[test]
     fn impl_search_empty_for_unknown_trait() {
-        let conn = open_db();
-        let rows = impl_search(&conn, "NoSuchTrait").expect("query");
+        let (store, _tmp) = open_store();
+        let rows = impl_search(&store, "NoSuchTrait").expect("query");
         assert!(rows.is_empty());
     }
 
-    // ── reexport_chain ───────────────────────────────────────────────────────
-
     #[test]
     fn reexport_chain_finds_pub_use_sites() {
-        let conn = open_db();
+        let (store, _tmp) = open_store();
         insert_symbol(
-            &conn,
+            &store,
             "organon",
             "prelude",
             "Message",
@@ -525,7 +462,7 @@ mod tests {
             5,
         );
         insert_symbol(
-            &conn,
+            &store,
             "nous",
             "prelude",
             "Message",
@@ -534,16 +471,15 @@ mod tests {
             3,
         );
 
-        let rows = reexport_chain(&conn, "Message").expect("query");
+        let rows = reexport_chain(&store, "Message").expect("query");
         assert_eq!(rows.len(), 2);
     }
 
     #[test]
     fn reexport_chain_ignores_non_reexport_symbols() {
-        let conn = open_db();
-        // A struct named "Message" should NOT appear in reexport results.
+        let (store, _tmp) = open_store();
         insert_symbol(
-            &conn,
+            &store,
             "eidos",
             "types",
             "Message",
@@ -552,23 +488,21 @@ mod tests {
             1,
         );
 
-        let rows = reexport_chain(&conn, "Message").expect("query");
+        let rows = reexport_chain(&store, "Message").expect("query");
         assert!(
             rows.is_empty(),
             "struct should not appear in reexport_chain"
         );
     }
 
-    // ── crate_deps / crate_rdeps ─────────────────────────────────────────────
-
     #[test]
     fn crate_deps_returns_direct_deps() {
-        let conn = open_db();
-        insert_edge(&conn, "nous", "eidos");
-        insert_edge(&conn, "nous", "hermeneus");
-        insert_edge(&conn, "melete", "nous");
+        let (store, _tmp) = open_store();
+        insert_edge(&store, "nous", "eidos");
+        insert_edge(&store, "nous", "hermeneus");
+        insert_edge(&store, "melete", "nous");
 
-        let deps = crate_deps(&conn, "nous").expect("deps");
+        let deps = crate_deps(&store, "nous").expect("deps");
         let names: Vec<_> = deps
             .iter()
             .filter_map(|r| r.crate_name.as_deref())
@@ -583,11 +517,11 @@ mod tests {
 
     #[test]
     fn crate_rdeps_returns_dependents() {
-        let conn = open_db();
-        insert_edge(&conn, "nous", "eidos");
-        insert_edge(&conn, "hermeneus", "eidos");
+        let (store, _tmp) = open_store();
+        insert_edge(&store, "nous", "eidos");
+        insert_edge(&store, "hermeneus", "eidos");
 
-        let rdeps = crate_rdeps(&conn, "eidos").expect("rdeps");
+        let rdeps = crate_rdeps(&store, "eidos").expect("rdeps");
         let names: Vec<_> = rdeps
             .iter()
             .filter_map(|r| r.crate_name.as_deref())
@@ -596,32 +530,28 @@ mod tests {
         assert!(names.contains(&"hermeneus"));
     }
 
-    // ── symbols_in ───────────────────────────────────────────────────────────
-
     #[test]
     fn symbols_in_returns_all_for_crate() {
-        let conn = open_db();
-        insert_symbol(&conn, "eidos", "types", "Foo", "struct", "f.rs", 1);
-        insert_symbol(&conn, "eidos", "types", "bar", "fn", "f.rs", 5);
-        insert_symbol(&conn, "nous", "", "baz", "fn", "g.rs", 1);
+        let (store, _tmp) = open_store();
+        insert_symbol(&store, "eidos", "types", "Foo", "struct", "f.rs", 1);
+        insert_symbol(&store, "eidos", "types", "bar", "fn", "f.rs", 5);
+        insert_symbol(&store, "nous", "", "baz", "fn", "g.rs", 1);
 
-        let rows = symbols_in(&conn, "eidos", None).expect("query");
+        let rows = symbols_in(&store, "eidos", None).expect("query");
         assert_eq!(rows.len(), 2);
     }
 
     #[test]
     #[expect(clippy::indexing_slicing, reason = "test assertion: len checked above")]
     fn symbols_in_filters_by_kind() {
-        let conn = open_db();
-        insert_symbol(&conn, "eidos", "types", "Foo", "struct", "f.rs", 1);
-        insert_symbol(&conn, "eidos", "types", "bar", "fn", "f.rs", 5);
+        let (store, _tmp) = open_store();
+        insert_symbol(&store, "eidos", "types", "Foo", "struct", "f.rs", 1);
+        insert_symbol(&store, "eidos", "types", "bar", "fn", "f.rs", 5);
 
-        let fns = symbols_in(&conn, "eidos", Some("fn")).expect("query fns");
+        let fns = symbols_in(&store, "eidos", Some("fn")).expect("query fns");
         assert_eq!(fns.len(), 1);
         assert_eq!(fns[0].symbol_name.as_deref(), Some("bar"));
     }
-
-    // ── QueryRow source field ─────────────────────────────────────────────────
 
     #[test]
     fn query_row_source_carries_schema_version() {

--- a/crates/gnosis/src/schema.rs
+++ b/crates/gnosis/src/schema.rs
@@ -1,89 +1,377 @@
-//! `SQLite` schema for the gnosis code-graph index.
+//! fjall schema for the gnosis code-graph index.
 //!
-//! # Tables
+//! # Keyspaces
 //!
-//! - `symbols` — one row per public-ish definition (fn, struct, enum, trait,
-//!   type alias, const) with crate + module path, name, kind, file, and line.
+//! - `symbols` — one JSON row per public-ish definition.
 //! - `symbol_refs` — directed edges from one symbol site to a named target
 //!   (`impl`, `reexport` in v1; call-site and type-use edges are deferred to v2).
 //! - `crate_edges` — workspace-level crate dependency edges, loaded from
 //!   `cargo metadata` and used for `crate_deps` queries.
 //! - `file_hashes` — SHA-256 of each indexed file for incremental rebuilds.
-//!   Re-parses only files whose hash has changed since the last index run.
+//! - `meta` — schema version and monotonic ID counters.
 //!
 //! # Schema version
 //!
-//! Stored in `PRAGMA user_version`.  Currently `1`.  Bump when the schema
-//! changes in a backward-incompatible way; `CodeGraph::open` detects a
-//! mismatch and triggers a full rebuild.
-//!
-//! # Thread safety
-//!
-//! `rusqlite::Connection` is `!Send + !Sync`.  `CodeGraph` wraps it in a
-//! `Mutex<Connection>` so it can be shared across async tasks.  All queries
-//! lock the mutex for the duration of the call.
+//! Stored under `meta/schema_version`. Currently `1`. Bump when the on-disk
+//! shape changes in a backward-incompatible way; `CodeGraph::open` clears the
+//! index when it finds a mismatch.
 
-use rusqlite::Connection;
+use std::path::Path;
+
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use snafu::ResultExt;
 
-use crate::error::{Result, SqliteSnafu};
+use crate::error::{CodecSnafu, CorruptSnafu, FjallSnafu, Result};
 
-/// Schema version embedded in `SQLite` `user_version`.
+/// Schema version embedded in fjall metadata.
 pub(crate) const SCHEMA_VERSION: u32 = 1;
 
-/// Initialise all tables and indexes on a fresh or opened connection.
-///
-/// Idempotent: uses `CREATE TABLE IF NOT EXISTS` throughout.
-#[tracing::instrument(skip(conn))]
-pub(crate) fn init(conn: &Connection) -> Result<()> {
-    conn.execute_batch(SCHEMA_SQL).context(SqliteSnafu)?;
-    Ok(())
+const META_SCHEMA_VERSION: &[u8] = b"schema_version";
+const META_NEXT_SYMBOL_ID: &[u8] = b"next_symbol_id";
+const META_NEXT_REF_ID: &[u8] = b"next_ref_id";
+
+/// Persisted symbol row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SymbolRecord {
+    /// Monotonic row ID.
+    pub id: u64,
+    /// Crate that contains the symbol.
+    pub crate_name: String,
+    /// Module path within the crate.
+    pub module_path: String,
+    /// Symbol name.
+    pub symbol_name: String,
+    /// Symbol kind (`fn`, `struct`, `impl`, `reexport`, ...).
+    pub symbol_kind: String,
+    /// Absolute source path.
+    pub file_path: String,
+    /// 1-based source line.
+    pub line_start: i64,
 }
 
-/// Full schema DDL for the gnosis index.
-const SCHEMA_SQL: &str = r"
-PRAGMA journal_mode = WAL;
-PRAGMA synchronous  = NORMAL;
-PRAGMA foreign_keys = ON;
+/// Persisted symbol reference row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SymbolRefRecord {
+    /// Monotonic row ID.
+    pub id: u64,
+    /// Source symbol ID.
+    pub from_symbol: u64,
+    /// Target crate.
+    pub to_crate: String,
+    /// Target module path.
+    pub to_module: String,
+    /// Target symbol.
+    pub to_symbol: String,
+    /// Reference kind (`impl`, `reexport`).
+    pub ref_kind: String,
+}
 
-CREATE TABLE IF NOT EXISTS symbols (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    crate_name  TEXT NOT NULL,
-    module_path TEXT NOT NULL,
-    symbol_name TEXT NOT NULL,
-    symbol_kind TEXT NOT NULL,
-    file_path   TEXT NOT NULL,
-    line_start  INTEGER NOT NULL DEFAULT 0
-);
+/// fjall-backed gnosis store.
+pub(crate) struct Store {
+    db: Database,
+    symbols: Keyspace,
+    refs: Keyspace,
+    crate_edges: Keyspace,
+    file_hashes: Keyspace,
+    meta: Keyspace,
+}
 
-CREATE INDEX IF NOT EXISTS idx_sym_crate  ON symbols(crate_name);
-CREATE INDEX IF NOT EXISTS idx_sym_name   ON symbols(symbol_name);
-CREATE INDEX IF NOT EXISTS idx_sym_kind   ON symbols(symbol_kind);
+impl Store {
+    /// Open or create the gnosis store.
+    pub(crate) fn open(path: &Path) -> Result<Self> {
+        let db = Database::builder(path).open().context(FjallSnafu)?;
+        let store = Self {
+            symbols: db
+                .keyspace("symbols", KeyspaceCreateOptions::default)
+                .context(FjallSnafu)?,
+            refs: db
+                .keyspace("symbol_refs", KeyspaceCreateOptions::default)
+                .context(FjallSnafu)?,
+            crate_edges: db
+                .keyspace("crate_edges", KeyspaceCreateOptions::default)
+                .context(FjallSnafu)?,
+            file_hashes: db
+                .keyspace("file_hashes", KeyspaceCreateOptions::default)
+                .context(FjallSnafu)?,
+            meta: db
+                .keyspace("meta", KeyspaceCreateOptions::default)
+                .context(FjallSnafu)?,
+            db,
+        };
+        store.ensure_schema()?;
+        Ok(store)
+    }
 
-CREATE TABLE IF NOT EXISTS symbol_refs (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    from_symbol INTEGER REFERENCES symbols(id) ON DELETE CASCADE,
-    to_crate    TEXT NOT NULL,
-    to_module   TEXT NOT NULL,
-    to_symbol   TEXT NOT NULL,
-    ref_kind    TEXT NOT NULL
-);
+    fn ensure_schema(&self) -> Result<()> {
+        let stored = self.meta_u32(META_SCHEMA_VERSION)?;
+        if stored.is_some_and(|version| version != SCHEMA_VERSION) {
+            self.clear_all()?;
+        }
+        self.put_meta_u32(META_SCHEMA_VERSION, SCHEMA_VERSION)?;
+        if self.meta_u64(META_NEXT_SYMBOL_ID)?.is_none() {
+            self.put_meta_u64(META_NEXT_SYMBOL_ID, 1)?;
+        }
+        if self.meta_u64(META_NEXT_REF_ID)?.is_none() {
+            self.put_meta_u64(META_NEXT_REF_ID, 1)?;
+        }
+        self.persist()
+    }
 
-CREATE INDEX IF NOT EXISTS idx_ref_to ON symbol_refs(to_symbol, to_crate);
-CREATE INDEX IF NOT EXISTS idx_ref_from ON symbol_refs(from_symbol);
+    fn clear_all(&self) -> Result<()> {
+        self.symbols.clear().context(FjallSnafu)?;
+        self.refs.clear().context(FjallSnafu)?;
+        self.crate_edges.clear().context(FjallSnafu)?;
+        self.file_hashes.clear().context(FjallSnafu)?;
+        self.meta.clear().context(FjallSnafu)?;
+        Ok(())
+    }
 
-CREATE TABLE IF NOT EXISTS crate_edges (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    from_crate  TEXT NOT NULL,
-    to_crate    TEXT NOT NULL,
-    UNIQUE(from_crate, to_crate)
-);
+    /// Persist pending writes.
+    pub(crate) fn persist(&self) -> Result<()> {
+        self.db.persist(PersistMode::SyncAll).context(FjallSnafu)
+    }
 
-CREATE INDEX IF NOT EXISTS idx_edge_from ON crate_edges(from_crate);
-CREATE INDEX IF NOT EXISTS idx_edge_to   ON crate_edges(to_crate);
+    /// Current stored schema version.
+    pub(crate) fn schema_version(&self) -> Result<u32> {
+        self.meta_u32(META_SCHEMA_VERSION)?.ok_or_else(|| {
+            CorruptSnafu {
+                message: "missing gnosis schema version".to_owned(),
+            }
+            .build()
+        })
+    }
 
-CREATE TABLE IF NOT EXISTS file_hashes (
-    file_path TEXT PRIMARY KEY,
-    sha256    TEXT NOT NULL
-);
-";
+    /// Insert a symbol and return its ID.
+    pub(crate) fn insert_symbol(
+        &self,
+        crate_name: &str,
+        module_path: &str,
+        symbol_name: &str,
+        symbol_kind: &str,
+        file_path: &str,
+        line_start: i64,
+    ) -> Result<u64> {
+        let id = self.next_id(META_NEXT_SYMBOL_ID)?;
+        let record = SymbolRecord {
+            id,
+            crate_name: crate_name.to_owned(),
+            module_path: module_path.to_owned(),
+            symbol_name: symbol_name.to_owned(),
+            symbol_kind: symbol_kind.to_owned(),
+            file_path: file_path.to_owned(),
+            line_start,
+        };
+        self.symbols
+            .insert(id_key(id), encode(&record)?)
+            .context(FjallSnafu)?;
+        Ok(id)
+    }
+
+    /// Insert a symbol reference.
+    pub(crate) fn insert_ref(
+        &self,
+        from_symbol: u64,
+        to_crate: &str,
+        to_module: &str,
+        to_symbol: &str,
+        ref_kind: &str,
+    ) -> Result<()> {
+        let id = self.next_id(META_NEXT_REF_ID)?;
+        let record = SymbolRefRecord {
+            id,
+            from_symbol,
+            to_crate: to_crate.to_owned(),
+            to_module: to_module.to_owned(),
+            to_symbol: to_symbol.to_owned(),
+            ref_kind: ref_kind.to_owned(),
+        };
+        self.refs
+            .insert(id_key(id), encode(&record)?)
+            .context(FjallSnafu)
+    }
+
+    /// Delete symbols for a source file and any refs from those symbols.
+    pub(crate) fn delete_symbols_for_file(&self, file_path: &str) -> Result<()> {
+        let deleted_ids: Vec<u64> = self
+            .symbols()?
+            .into_iter()
+            .filter(|symbol| symbol.file_path == file_path)
+            .map(|symbol| symbol.id)
+            .collect();
+        for id in &deleted_ids {
+            self.symbols.remove(id_key(*id)).context(FjallSnafu)?;
+        }
+        for reference in self.refs()? {
+            if deleted_ids.contains(&reference.from_symbol) {
+                self.refs.remove(id_key(reference.id)).context(FjallSnafu)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Insert a workspace crate edge.
+    pub(crate) fn insert_crate_edge(&self, from_crate: &str, to_crate: &str) -> Result<()> {
+        self.crate_edges
+            .insert(edge_key(from_crate, to_crate), b"1".as_slice())
+            .context(FjallSnafu)
+    }
+
+    /// Clear all crate edges.
+    pub(crate) fn clear_crate_edges(&self) -> Result<()> {
+        self.crate_edges.clear().context(FjallSnafu)
+    }
+
+    /// Return all crate edges.
+    pub(crate) fn crate_edges(&self) -> Result<Vec<(String, String)>> {
+        self.crate_edges
+            .iter()
+            .map(|entry| {
+                let (key, _value) = entry.into_inner().context(FjallSnafu)?;
+                decode_edge_key(key.as_ref())
+            })
+            .collect()
+    }
+
+    /// Return all symbol rows.
+    pub(crate) fn symbols(&self) -> Result<Vec<SymbolRecord>> {
+        collect_json(&self.symbols)
+    }
+
+    /// Return a symbol by ID.
+    pub(crate) fn symbol(&self, id: u64) -> Result<Option<SymbolRecord>> {
+        self.symbols
+            .get(id_key(id))
+            .context(FjallSnafu)?
+            .map(|bytes| decode(bytes.as_ref()))
+            .transpose()
+    }
+
+    /// Return all reference rows.
+    pub(crate) fn refs(&self) -> Result<Vec<SymbolRefRecord>> {
+        collect_json(&self.refs)
+    }
+
+    /// Return the stored hash for a file.
+    pub(crate) fn file_hash(&self, file_path: &str) -> Result<Option<String>> {
+        let hash = self
+            .file_hashes
+            .get(file_path.as_bytes())
+            .context(FjallSnafu)?
+            .map(|bytes| String::from_utf8_lossy(bytes.as_ref()).into_owned());
+        Ok(hash)
+    }
+
+    /// Store the hash for a file.
+    pub(crate) fn set_file_hash(&self, file_path: &str, hash: &str) -> Result<()> {
+        self.file_hashes
+            .insert(file_path.as_bytes(), hash.as_bytes())
+            .context(FjallSnafu)
+    }
+
+    /// Prune hashes for files no longer present.
+    pub(crate) fn prune_file_hashes_not_in(&self, present: &[String]) -> Result<()> {
+        let present: std::collections::BTreeSet<&str> =
+            present.iter().map(String::as_str).collect();
+        let paths: Vec<String> = self
+            .file_hashes
+            .iter()
+            .map(|entry| {
+                let (key, _value) = entry.into_inner().context(FjallSnafu)?;
+                Ok(String::from_utf8_lossy(key.as_ref()).into_owned())
+            })
+            .collect::<Result<_>>()?;
+        for path in paths {
+            if !present.contains(path.as_str()) {
+                self.file_hashes
+                    .remove(path.as_bytes())
+                    .context(FjallSnafu)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn next_id(&self, key: &[u8]) -> Result<u64> {
+        let id = self.meta_u64(key)?.unwrap_or(1);
+        self.put_meta_u64(key, id.saturating_add(1))?;
+        Ok(id)
+    }
+
+    fn meta_u32(&self, key: &[u8]) -> Result<Option<u32>> {
+        self.meta
+            .get(key)
+            .context(FjallSnafu)?
+            .map(|bytes| decode(bytes.as_ref()))
+            .transpose()
+    }
+
+    fn meta_u64(&self, key: &[u8]) -> Result<Option<u64>> {
+        self.meta
+            .get(key)
+            .context(FjallSnafu)?
+            .map(|bytes| decode(bytes.as_ref()))
+            .transpose()
+    }
+
+    fn put_meta_u32(&self, key: &[u8], value: u32) -> Result<()> {
+        self.meta.insert(key, encode(&value)?).context(FjallSnafu)
+    }
+
+    fn put_meta_u64(&self, key: &[u8], value: u64) -> Result<()> {
+        self.meta.insert(key, encode(&value)?).context(FjallSnafu)
+    }
+}
+
+fn collect_json<T: DeserializeOwned>(keyspace: &Keyspace) -> Result<Vec<T>> {
+    keyspace
+        .iter()
+        .map(|entry| {
+            let (_key, value) = entry.into_inner().context(FjallSnafu)?;
+            decode(value.as_ref())
+        })
+        .collect()
+}
+
+fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    serde_json::to_vec(value).context(CodecSnafu)
+}
+
+fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
+    serde_json::from_slice(bytes).context(CodecSnafu)
+}
+
+fn id_key(id: u64) -> [u8; 8] {
+    id.to_be_bytes()
+}
+
+fn edge_key(from_crate: &str, to_crate: &str) -> Vec<u8> {
+    let mut key = Vec::with_capacity(from_crate.len() + to_crate.len() + 1);
+    key.extend_from_slice(from_crate.as_bytes());
+    key.push(0);
+    key.extend_from_slice(to_crate.as_bytes());
+    key
+}
+
+fn decode_edge_key(key: &[u8]) -> Result<(String, String)> {
+    let Some(pos) = key.iter().position(|b| *b == 0) else {
+        return CorruptSnafu {
+            message: "malformed crate edge key".to_owned(),
+        }
+        .fail();
+    };
+    let Some(from_bytes) = key.get(..pos) else {
+        return CorruptSnafu {
+            message: "malformed crate edge prefix".to_owned(),
+        }
+        .fail();
+    };
+    let Some(to_bytes) = key.get(pos.saturating_add(1)..) else {
+        return CorruptSnafu {
+            message: "malformed crate edge suffix".to_owned(),
+        }
+        .fail();
+    };
+    let from = String::from_utf8_lossy(from_bytes).into_owned();
+    let to = String::from_utf8_lossy(to_bytes).into_owned();
+    Ok((from, to))
+}

--- a/crates/gnosis/tests/integration.rs
+++ b/crates/gnosis/tests/integration.rs
@@ -50,7 +50,7 @@ mod workspace_integration {
     fn symbol_rdeps_finds_many_callers() {
         let root = workspace_root();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let db_path = tmp.path().join("gnosis_integration.sqlite");
+        let db_path = tmp.path().join("gnosis_integration.fjall");
 
         let graph = CodeGraph::open(&db_path, &root).expect("open graph");
         graph.rebuild().expect("rebuild");
@@ -86,7 +86,7 @@ mod workspace_integration {
     fn impl_search_finds_stamped_impls() {
         let root = workspace_root();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let db_path = tmp.path().join("gnosis_stamped.sqlite");
+        let db_path = tmp.path().join("gnosis_stamped.fjall");
 
         let graph = CodeGraph::open(&db_path, &root).expect("open graph");
         graph.rebuild().expect("rebuild");
@@ -105,7 +105,7 @@ mod workspace_integration {
     fn crate_rdeps_eidos_returns_many() {
         let root = workspace_root();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let db_path = tmp.path().join("gnosis_eidos.sqlite");
+        let db_path = tmp.path().join("gnosis_eidos.fjall");
 
         let graph = CodeGraph::open(&db_path, &root).expect("open graph");
         graph.rebuild().expect("rebuild");

--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -1,6 +1,6 @@
 //! aletheia-krites: embedded Datalog engine with HNSW and graph support
 //!
-//! Krites (Κριτής): "judge." Evaluates Datalog queries against a graph store
+//! Krites (Κριτής): Datalog engine. Evaluates Datalog queries against a graph store
 //! with HNSW vector search and graph algorithms.
 // SAFETY: warn-level satisfies the ARCHITECTURE/no-deny-missing-docs lint.
 // deny-level is impractical for krites internal modules.

--- a/crates/taxis/src/config/behavior/timeouts.rs
+++ b/crates/taxis/src/config/behavior/timeouts.rs
@@ -26,10 +26,10 @@ impl Default for TimeoutsConfig {
     }
 }
 
-/// Deployment-tunable capacity limits for tool output and context windows.
+/// Deployment-tunable capacity limits for tool output.
 ///
-/// Controls memory and token budgets that depend on the host's hardware and
-/// the LLM provider's context limits. Defaults match `koina::defaults`.
+/// Controls memory budgets that depend on the host's hardware. Defaults match
+/// `koina::defaults`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
@@ -40,21 +40,12 @@ pub struct CapacityConfig {
     /// Applies to all built-in tools (filesystem, workspace, shell). Set to
     /// `0` to disable truncation. Valid range: 0–10 MiB. Default: 51200 (50 KiB).
     pub max_tool_output_bytes: usize,
-    /// Context window token limit applied to Opus-class models when the
-    /// global `contextTokens` is still at its default value (200k).
-    ///
-    /// Opus models support a 1M token context window; this automatic upgrade
-    /// preserves that capability without requiring manual per-agent overrides.
-    /// Set to the same value as `contextTokens` to disable the auto-upgrade.
-    /// Valid range: 200000–2000000. Default: 1000000.
-    pub opus_context_tokens: u32,
 }
 
 impl Default for CapacityConfig {
     fn default() -> Self {
         Self {
             max_tool_output_bytes: koina::defaults::MAX_OUTPUT_BYTES,
-            opus_context_tokens: koina::defaults::OPUS_CONTEXT_TOKENS,
         }
     }
 }

--- a/crates/taxis/src/config/config_tests/deployment_wave1.rs
+++ b/crates/taxis/src/config/config_tests/deployment_wave1.rs
@@ -32,15 +32,6 @@ fn capacity_defaults_match_koina_consts() {
         config.capacity.max_tool_output_bytes, 51_200,
         "default max_tool_output_bytes must be 51200 (50 KiB)"
     );
-    assert_eq!(
-        config.capacity.opus_context_tokens,
-        koina::defaults::OPUS_CONTEXT_TOKENS,
-        "default opus_context_tokens must equal koina::defaults::OPUS_CONTEXT_TOKENS"
-    );
-    assert_eq!(
-        config.capacity.opus_context_tokens, 1_000_000,
-        "default opus_context_tokens must be 1 000 000"
-    );
 }
 
 #[test]
@@ -80,15 +71,11 @@ fn timeouts_override_from_json() {
 
 #[test]
 fn capacity_override_from_json() {
-    let json = r#"{"capacity": {"maxToolOutputBytes": 102400, "opusContextTokens": 500000}}"#;
+    let json = r#"{"capacity": {"maxToolOutputBytes": 102400}}"#;
     let config: AletheiaConfig = serde_json::from_str(json).expect("parse capacity override");
     assert_eq!(
         config.capacity.max_tool_output_bytes, 102_400,
         "max_tool_output_bytes override from json should take effect"
-    );
-    assert_eq!(
-        config.capacity.opus_context_tokens, 500_000,
-        "opus_context_tokens override from json should take effect"
     );
 }
 
@@ -115,7 +102,6 @@ fn new_sections_survive_serde_roundtrip() {
     let mut config = AletheiaConfig::default();
     config.timeouts.llm_call_secs = 120;
     config.capacity.max_tool_output_bytes = 8192;
-    config.capacity.opus_context_tokens = 500_000;
     config.retry.max_attempts = 1;
     config.retry.backoff_base_ms = 500;
     config.retry.backoff_max_ms = 5_000;
@@ -130,10 +116,6 @@ fn new_sections_survive_serde_roundtrip() {
     assert_eq!(
         back.capacity.max_tool_output_bytes, 8192,
         "max_tool_output_bytes should survive serde roundtrip"
-    );
-    assert_eq!(
-        back.capacity.opus_context_tokens, 500_000,
-        "opus_context_tokens should survive serde roundtrip"
     );
     assert_eq!(
         back.retry.max_attempts, 1,

--- a/crates/taxis/src/registry.rs
+++ b/crates/taxis/src/registry.rs
@@ -862,19 +862,6 @@ fn build_registry() -> Vec<ParameterSpec> {
             evidence_required: "Tool output size distribution",
             direction_hint: TuningDirection::Higher,
         },
-        ParameterSpec {
-            key: "capacity.opusContextTokens",
-            section: "capacity",
-            tier: ParameterTier::Deployment,
-            default: ParameterValue::Int(1_000_000),
-            bounds: Some((200_000.0, 2_000_000.0)),
-            hot_reloadable: false,
-            description: "Context window token limit applied to Opus-class models",
-            affects: "model_context_window",
-            outcome_signal: "context_utilization_rate",
-            evidence_required: "Context utilization and quality at different window sizes",
-            direction_hint: TuningDirection::Higher,
-        },
         // ===================================================================
         // Nous behavior
         // ===================================================================

--- a/crates/taxis/src/reload.rs
+++ b/crates/taxis/src/reload.rs
@@ -28,7 +28,6 @@ const RESTART_PREFIXES: &[&str] = &[
     // WHY: idempotency capacity sets the LRU cache size at server startup.
     "apiLimits.idempotencyCapacity",
     // WHY: model context limits are loaded into provider/model routing state.
-    "capacity.opusContextTokens",
 ];
 
 /// Returns true if changing the given dotted field path requires a restart.

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -467,17 +467,6 @@ fn validate_capacity(value: &Value, errors: &mut Vec<String>) {
             "capacity.maxToolOutputBytes must not exceed {MAX_TOOL_OUTPUT_BYTES} bytes (10 MiB)"
         ));
     }
-
-    // WHY: opus_context_tokens must be at least 200k (the standard default) and
-    // no more than 2M to prevent nonsensical configurations.
-    if let Some(val) = value.get("opusContextTokens").and_then(Value::as_u64) {
-        if val < 200_000 {
-            errors.push("capacity.opusContextTokens must be at least 200 000 tokens".to_owned());
-        }
-        if val > 2_000_000 {
-            errors.push("capacity.opusContextTokens must not exceed 2 000 000 tokens".to_owned());
-        }
-    }
 }
 
 fn validate_retry(value: &Value, errors: &mut Vec<String>) {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -307,7 +307,7 @@ Embedding provider for the recall pipeline (vector search over knowledge).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `provider` | string | `"mock"` | Provider type: `"mock"`, `"candle"` |
+| `provider` | string | `"mock"` | Provider type: `"mock"`, `"candle"`, `"openai-compat"`, `"voyage"` |
 | `model` | string | -- | Provider-specific model name |
 | `dimension` | usize | `384` | Output vector dimension (must match HNSW index) |
 


### PR DESCRIPTION
## Summary
- cherry-picks the unique `recovery/branch-misc-D-truth-gnosis-cluster` commit onto current `main`
- resolves the `gnosis/src/query.rs` conflict by preserving the upstream `symbol_rdeps` test and adapting it to the fjall store helper API
- refreshes the lockfile against the current 0.26.1/v1.3.0 main-line dependency state

## Recovery
- Source branch: `recovery/branch-misc-D-truth-gnosis-cluster`
- Source commit: `ecff032444a1d56e0383642a4090228eb6ec1a11`
- Rebased commit: `b9a315b60`

## Acceptance verifier
- `cargo fmt --check`
- `cargo check -p gnosis -p taxis -p episteme -p krites -p eidos`
- `kanon lint --summary crates/episteme/src/embedding.rs`

## Notes
- A full per-file lint loop was attempted. It initially stopped on `crates/episteme/src/embedding.rs`; after the scoped fix, that file reports no open violations and one reviewed suppression for the intentional built-in provider colocation.
