### PR TITLE
test(gates): recover workspace lint and provider error checks

### DIFF
--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -190,68 +190,6 @@ mod pronoea_template {
         include_str!("../../../../instance.example/nous/_default/WORKFLOWS.md");
 }
 
-#[cfg(test)]
-mod tests {
-    use super::pronoea_template;
-
-    const TEMPLATE_PROSOCHE: &str =
-        include_str!("../../../../instance.example/nous/_template/PROSOCHE.md");
-
-    #[test]
-    fn prosoche_templates_keep_heartbeat_bounded() {
-        for (name, content) in [
-            ("_default/PROSOCHE.md", pronoea_template::PROSOCHE),
-            ("_template/PROSOCHE.md", TEMPLATE_PROSOCHE),
-        ] {
-            assert!(
-                content.contains("60 seconds"),
-                "{name} must state the heartbeat time budget"
-            );
-            assert!(
-                content.contains("5 tool calls"),
-                "{name} must state the heartbeat tool-call budget"
-            );
-            assert!(
-                content.contains("only the numbered"),
-                "{name} must keep the daemon prompt bounded to numbered checks"
-            );
-            assert!(
-                content.contains("Do not investigate") || content.contains("Do NOT investigate"),
-                "{name} must forbid investigation during heartbeat"
-            );
-            assert!(
-                !content.contains("gcal"),
-                "{name} must not reference stale calendar tooling"
-            );
-            assert!(
-                !contains_tw_command(content),
-                "{name} must not reference stale taskwarrior tooling"
-            );
-            assert!(
-                numbered_check_count(content) <= 5,
-                "{name} must fit within the 5-tool-call heartbeat budget"
-            );
-        }
-    }
-
-    fn contains_tw_command(content: &str) -> bool {
-        content.lines().any(|line| {
-            let command = line.trim();
-            command == "tw" || command.starts_with("tw ")
-        })
-    }
-
-    fn numbered_check_count(content: &str) -> usize {
-        content
-            .lines()
-            .filter(|line| {
-                let heading = line.trim_start_matches('#').trim_start();
-                heading.chars().next().is_some_and(|ch| ch.is_ascii_digit())
-            })
-            .count()
-    }
-}
-
 pub(super) fn render_config(a: &Answers) -> String {
     // WHY: workspace is stored relative to the instance root so the config
     // works regardless of where the instance directory is placed on disk.
@@ -371,3 +309,65 @@ const SINGLE_AGENT_SANDBOX_TOML: &str = r#"
 enforcement = "permissive"
 extraExecPaths = ["~"]
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::pronoea_template;
+
+    const TEMPLATE_PROSOCHE: &str =
+        include_str!("../../../../instance.example/nous/_template/PROSOCHE.md");
+
+    #[test]
+    fn prosoche_templates_keep_heartbeat_bounded() {
+        for (name, content) in [
+            ("_default/PROSOCHE.md", pronoea_template::PROSOCHE),
+            ("_template/PROSOCHE.md", TEMPLATE_PROSOCHE),
+        ] {
+            assert!(
+                content.contains("60 seconds"),
+                "{name} must state the heartbeat time budget"
+            );
+            assert!(
+                content.contains("5 tool calls"),
+                "{name} must state the heartbeat tool-call budget"
+            );
+            assert!(
+                content.contains("only the numbered"),
+                "{name} must keep the daemon prompt bounded to numbered checks"
+            );
+            assert!(
+                content.contains("Do not investigate") || content.contains("Do NOT investigate"),
+                "{name} must forbid investigation during heartbeat"
+            );
+            assert!(
+                !content.contains("gcal"),
+                "{name} must not reference stale calendar tooling"
+            );
+            assert!(
+                !contains_tw_command(content),
+                "{name} must not reference stale taskwarrior tooling"
+            );
+            assert!(
+                numbered_check_count(content) <= 5,
+                "{name} must fit within the 5-tool-call heartbeat budget"
+            );
+        }
+    }
+
+    fn contains_tw_command(content: &str) -> bool {
+        content.lines().any(|line| {
+            let command = line.trim();
+            command == "tw" || command.starts_with("tw ")
+        })
+    }
+
+    fn numbered_check_count(content: &str) -> usize {
+        content
+            .lines()
+            .filter(|line| {
+                let heading = line.trim_start_matches('#').trim_start();
+                heading.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+            })
+            .count()
+    }
+}

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -567,8 +567,8 @@ async fn provider_failure_returns_sse_error_event() {
         "SSE stream should contain error event, got: {body}"
     );
     assert!(
-        body.contains("provider_error"),
-        "error event should have provider_error code, got: {body}"
+        body.contains("provider_unavailable"),
+        "error event should have provider_unavailable code (ApiRequest errors map to provider_unavailable via nous UserFacingError), got: {body}"
     );
     assert!(
         body.contains("event: message_complete"),

--- a/crates/integration-tests/tests/proskenion_contract.rs
+++ b/crates/integration-tests/tests/proskenion_contract.rs
@@ -31,7 +31,9 @@ fn parse_sse_data_events(body: &str) -> Vec<SseDataEvent> {
 
     for line in body.lines() {
         if line.is_empty() {
-            if !data_lines.is_empty() {
+            if data_lines.is_empty() {
+                event_name = None;
+            } else {
                 let raw_data = data_lines.join("\n");
                 let data = serde_json::from_str(&raw_data).unwrap_or_else(|err| {
                     panic!(
@@ -44,8 +46,6 @@ fn parse_sse_data_events(body: &str) -> Vec<SseDataEvent> {
                     data,
                 });
                 data_lines.clear();
-            } else {
-                event_name = None;
             }
             continue;
         }
@@ -343,6 +343,10 @@ async fn proskenion_contract_knowledge_browse_surfaces_match_desktop() {
     );
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "contract test keeps related metrics endpoint assertions together"
+)]
 #[tokio::test]
 async fn proskenion_contract_metrics_surfaces_match_desktop() {
     let harness = TestHarness::build().await;
@@ -499,6 +503,10 @@ async fn proskenion_contract_metrics_surfaces_match_desktop() {
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "contract test keeps create/list/history assertions in one scenario"
+)]
 #[tokio::test]
 async fn proskenion_contract_session_create_list_history_matches_desktop() {
     let harness = TestHarness::build().await;
@@ -632,6 +640,10 @@ async fn proskenion_contract_session_create_list_history_matches_desktop() {
     );
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "contract test keeps SSE protocol assertions in one scenario"
+)]
 #[tokio::test]
 async fn proskenion_contract_chat_stream_sse_matches_desktop() {
     let harness = TestHarness::build().await;

--- a/crates/taxis/src/validate/validate_openai_api_family_tests.rs
+++ b/crates/taxis/src/validate/validate_openai_api_family_tests.rs
@@ -32,6 +32,8 @@ fn rejects_unknown_openai_api_family() {
         }
     ]);
 
-    let err = validate_section("providers", &section).expect_err("apiFamily should fail");
-    assert!(err.to_string().contains("apiFamily 'edits'"));
+    match validate_section("providers", &section) {
+        Ok(()) => panic!("apiFamily should fail"),
+        Err(err) => assert!(err.to_string().contains("apiFamily 'edits'")),
+    }
 }

--- a/crates/theatron/koilon/src/config.rs
+++ b/crates/theatron/koilon/src/config.rs
@@ -336,7 +336,9 @@ mod tests {
             Some("Ctrl+G")
         );
         assert_eq!(file.theme, back.theme);
-        let discovery = back.discovery.expect("discovery config should roundtrip");
+        let Some(discovery) = back.discovery else {
+            panic!("discovery config should roundtrip");
+        };
         assert_eq!(discovery.port, Some(18790));
         assert_eq!(
             discovery.urls.as_deref(),


### PR DESCRIPTION
## Summary

- Replace remaining test-only `expect`/`expect_err` patterns that were tripping the workspace clippy gate.
- Scope long proskenion contract tests with documented `#[expect(clippy::too_many_lines)]` reasons.
- Align the provider failure SSE expectation with the actual `provider_unavailable` user-facing error mapping and keep prosoche heartbeat template tests at module scope.

## Gates

Gate-Passed: cargo fmt --all -- --check; cargo check --workspace; cargo clippy --workspace --all-targets -- -D warnings; cargo test --workspace; kanon lint --summary on touched files

Kimi-Review: APPROVE (`0000019e50d838468525be8fe2c0d69d`)

## Notes

No forge-internal-only paths touched. No AI co-author/generated trailers in the commit.