### PR TITLE
docs(eidos): align FactStore filename transform docs

### DIFF
--- a/crates/eidos/src/knowledge/architecture_fact.rs
+++ b/crates/eidos/src/knowledge/architecture_fact.rs
@@ -11,8 +11,8 @@
 //! [`FactStore`] uses flat JSON files under a configurable directory
 //! (default: `~/aletheia/instance/facts/`).  Each fact is serialised to
 //! `<dir>/<id>.json` where `<id>` is the dot-separated fact identifier
-//! with `/` replaced by `__` to produce a safe filename.  No external
-//! database is required — the directory is created on first write.
+//! with path separators replaced by `-` to produce a safe filename.  No
+//! external database is required — the directory is created on first write.
 //!
 //! # Design constraints
 //!


### PR DESCRIPTION
## Summary
- Update FactStore documentation to describe the actual filename transform: path separators become `-`, dots are preserved, and the store remains flat JSON files with no external database.

## Gates
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --summary crates/eidos/src/knowledge/architecture_fact.rs`

## Review
- Kimi reviewer dispatch `0000019e50e6f7638525be8fe2c0d69f`: APPROVE
- Reviewer ran `git diff --check origin/main...HEAD`, reviewed the touched file diff, and ran targeted `kanon lint` with no violations.

Closes #3959