### PR TITLE
fix(nous): preserve missing tool result state in loop guard

### DIFF
--- a/crates/nous/src/actor/tests/internal_state.rs
+++ b/crates/nous/src/actor/tests/internal_state.rs
@@ -301,6 +301,32 @@ fn apply_loop_guard_detects_doom_loop() {
 }
 
 #[test]
+fn apply_loop_guard_preserves_missing_vs_empty_tool_result() {
+    let (mut actor, _tx, _dir) = make_test_actor(PipelineConfig::default());
+    actor.sessions.insert(
+        "s".to_owned(),
+        SessionState::new("ses-1".to_owned(), "s".to_owned(), &test_config()),
+    );
+    actor.sessions.get_mut("s").unwrap().loop_guard =
+        hermeneus::loop_detector::LoopGuard::with_limits(3, 10, 10);
+
+    let sequence = [
+        make_tool_call_with_result("read_file", false, None),
+        make_tool_call_with_result("read_file", false, Some("")),
+        make_tool_call_with_result("read_file", false, None),
+    ];
+
+    for call in sequence {
+        let mut result = Ok(make_turn_result(50, vec![call]));
+        actor.apply_loop_guard("s", &mut result);
+        assert!(
+            !actor.sessions["s"].brake_tripped,
+            "missing and empty results must remain distinct for loop detection"
+        );
+    }
+}
+
+#[test]
 fn apply_loop_guard_detects_ping_pong() {
     let (mut actor, _tx, _dir) = make_test_actor(PipelineConfig::default());
     actor.sessions.insert(

--- a/crates/nous/src/actor/tests/mod.rs
+++ b/crates/nous/src/actor/tests/mod.rs
@@ -11,9 +11,6 @@ use super::*;
 use crate::cross::{CrossNousEnvelope, CrossNousMessage};
 use crate::handle::NousHandle;
 
-// Split from `actor/tests.rs` (1392 lines) to satisfy `RUST/file-too-long`.
-// Each submodule groups tests by subject; shared helpers live here.
-
 mod cross_nous;
 mod internal_state;
 mod lifecycle_and_panic;
@@ -253,11 +250,19 @@ fn make_turn_result(
 }
 
 fn make_tool_call(name: &str, is_error: bool) -> crate::pipeline::ToolCall {
+    make_tool_call_with_result(name, is_error, None)
+}
+
+fn make_tool_call_with_result(
+    name: &str,
+    is_error: bool,
+    result: Option<&str>,
+) -> crate::pipeline::ToolCall {
     crate::pipeline::ToolCall {
         id: "tc-1".to_owned(),
         name: name.to_owned(),
         input: serde_json::Value::Null,
-        result: None,
+        result: result.map(str::to_owned),
         is_error,
         duration_ms: 10,
         receipt: None,

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -216,7 +216,7 @@ impl NousActor {
                 (
                     tc.name.clone(),
                     tc.input.to_string(),
-                    tc.result.clone().unwrap_or_default(),
+                    loop_guard_result_signature(tc.result.as_deref()),
                 )
             })
             .collect();
@@ -765,5 +765,12 @@ impl NousActor {
             );
             self.channel.status = NousLifecycle::Degraded;
         }
+    }
+}
+
+fn loop_guard_result_signature(result: Option<&str>) -> String {
+    match result {
+        Some(result) => format!("present:{result}"),
+        None => "missing".to_owned(),
     }
 }


### PR DESCRIPTION
## Summary
- distinguish missing tool-call results from present empty strings before loop-guard hashing
- add a regression test covering None vs Some("") tool results
- remove a stale test-module comment that triggered existing lint in a touched file

Closes #3936

## Gates
- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/nous/src/actor/tests/mod.rs
- RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/nous/src/actor/tests/internal_state.rs
- RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/nous/src/actor/turn.rs: baseline-only findings on unchanged lines 35 and 620