### PR TITLE
fix(proskenion): remove timeline scrubber placeholder

### DIFF
--- a/crates/theatron/proskenion/src/components/mod.rs
+++ b/crates/theatron/proskenion/src/components/mod.rs
@@ -35,8 +35,6 @@ pub(crate) mod theme_toggle;
 pub(crate) mod thinking;
 /// Reusable horizontal timeline with zoom, pan, and dependency arrows.
 pub(crate) mod timeline;
-/// Dual-handle timeline scrubber for selecting a date range.
-pub(crate) mod timeline_scrubber;
 // toast module extracted to skeue::ToastItem (chalkeion desktop UI integration).
 // See `skeue::toast`.
 pub(crate) mod toast_container;

--- a/crates/theatron/proskenion/src/components/timeline_scrubber.rs
+++ b/crates/theatron/proskenion/src/components/timeline_scrubber.rs
@@ -1,4 +1,0 @@
-//! Dual-handle timeline scrubber for selecting a date range.
-
-// NOTE: This component is currently unused but kept as a placeholder.
-// The original implementation has been removed to eliminate dead code warnings.


### PR DESCRIPTION
## Summary
- remove the empty `timeline_scrubber` component module
- drop the stale module declaration from `components/mod.rs`

Closes #3966

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --manifest-path crates/theatron/proskenion/Cargo.toml`
- `cargo test --manifest-path crates/theatron/proskenion/Cargo.toml`
- `RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion/src/components/mod.rs`
- `git diff --check`

## Note
An extra standalone `cargo clippy --manifest-path crates/theatron/proskenion/Cargo.toml --all-targets -- -D warnings` probe still fails on the pre-existing D5 proskenion lint baseline tracked by #3988; none of its findings are in the deleted placeholder file or changed module declaration.