### PR TITLE
fix(organon): separate dispatch turn limits

### DIFF
--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -695,7 +695,8 @@ impl RuntimeBuilder {
                             c.dispatch_spec.prompt_numbers.clone(),
                             c.dispatch_spec.dag_ref.clone(),
                             c.dispatch_spec.max_parallel,
-                        ),
+                        )
+                        .with_max_turns(c.dispatch_spec.max_turns),
                     )
                     .with_whatever_context(|_| format!("invalid cron task '{}'", c.name))?;
                     tasks.push(task);

--- a/crates/energeia/src/metrics/cost.rs
+++ b/crates/energeia/src/metrics/cost.rs
@@ -350,6 +350,7 @@ mod tests {
             project: "acme".to_owned(),
             dag_ref: None,
             max_parallel: Some(2),
+            max_turns: None,
         }
     }
 
@@ -417,6 +418,7 @@ mod tests {
                     prompt_numbers: vec![1],
                     dag_ref: None,
                     max_parallel: None,
+                    max_turns: None,
                 },
             )
             .unwrap();
@@ -428,6 +430,7 @@ mod tests {
                     prompt_numbers: vec![1],
                     dag_ref: None,
                     max_parallel: None,
+                    max_turns: None,
                 },
             )
             .unwrap();

--- a/crates/energeia/src/metrics/status.rs
+++ b/crates/energeia/src/metrics/status.rs
@@ -247,6 +247,7 @@ mod tests {
             project: project.to_owned(),
             dag_ref: None,
             max_parallel: None,
+            max_turns: None,
         }
     }
 

--- a/crates/energeia/src/orchestrator/orchestrator_tests.rs
+++ b/crates/energeia/src/orchestrator/orchestrator_tests.rs
@@ -119,6 +119,7 @@ fn sample_dispatch_spec(prompt_numbers: Vec<u32>) -> DispatchSpec {
         project: ".".to_owned(),
         dag_ref: None,
         max_parallel: None,
+        max_turns: None,
     }
 }
 

--- a/crates/energeia/src/pipeline/preparation.rs
+++ b/crates/energeia/src/pipeline/preparation.rs
@@ -119,10 +119,12 @@ impl PipelineStage for PreparationStage {
         ctx.cost_ledger = Some(Arc::new(CostLedger::new()));
 
         ctx.resume_policy = crate::resume::ResumePolicy::default();
-        ctx.engine_config = Some(
-            EngineConfig::new(crate::engine::AgentOptions::new())
-                .idle_timeout_opt(cfg.session_idle_timeout),
-        );
+        let mut engine_config = EngineConfig::new(crate::engine::AgentOptions::new())
+            .idle_timeout_opt(cfg.session_idle_timeout);
+        if let Some(max_turns) = ctx.spec.max_turns {
+            engine_config = engine_config.max_turns(max_turns);
+        }
+        ctx.engine_config = Some(engine_config);
 
         ctx.max_concurrent = usize::try_from(
             ctx.spec
@@ -261,6 +263,31 @@ mod tests {
         assert!(ctx.budget.is_some());
         assert!(ctx.cost_ledger.is_some());
         assert!(ctx.engine_config.is_some());
+    }
+
+    #[tokio::test]
+    async fn preparation_keeps_parallelism_and_turn_limit_separate() {
+        let prompts = vec![PromptSpec {
+            number: 1,
+            description: "first".to_owned(),
+            depends_on: vec![],
+            acceptance_criteria: vec![],
+            blast_radius: vec![],
+            body: "do first".to_owned(),
+            prompt_components: None,
+        }];
+        let mut ctx = make_context_with_prompts(prompts);
+        ctx.spec.max_parallel = Some(2);
+        ctx.spec.max_turns = Some(7);
+
+        let stage = PreparationStage;
+        stage
+            .run(&mut ctx)
+            .await
+            .expect("preparation should succeed");
+
+        assert_eq!(ctx.max_concurrent, 2);
+        assert_eq!(ctx.engine_config().options.max_turns, Some(7));
     }
 
     #[tokio::test]

--- a/crates/energeia/src/store/fjall_store_tests.rs
+++ b/crates/energeia/src/store/fjall_store_tests.rs
@@ -22,6 +22,7 @@ fn sample_dispatch_spec() -> DispatchSpec {
         project: "acme".to_owned(),
         dag_ref: None,
         max_parallel: Some(2),
+        max_turns: None,
     }
 }
 

--- a/crates/energeia/src/types.rs
+++ b/crates/energeia/src/types.rs
@@ -27,6 +27,8 @@ pub struct DispatchSpec {
     pub dag_ref: Option<String>,
     /// Maximum parallelism (simultaneous sessions). `None` means unlimited.
     pub max_parallel: Option<u32>,
+    /// Maximum turns per initial session. `None` delegates to engine defaults.
+    pub max_turns: Option<u32>,
 }
 
 /// Raw deserialization type for [`DispatchSpec`].
@@ -36,6 +38,8 @@ struct DispatchSpecRaw {
     project: String,
     dag_ref: Option<String>,
     max_parallel: Option<u32>,
+    #[serde(default)]
+    max_turns: Option<u32>,
 }
 
 impl From<DispatchSpecRaw> for DispatchSpec {
@@ -45,6 +49,7 @@ impl From<DispatchSpecRaw> for DispatchSpec {
             project: raw.project,
             dag_ref: raw.dag_ref,
             max_parallel: raw.max_parallel,
+            max_turns: raw.max_turns,
         }
     }
 }
@@ -60,6 +65,7 @@ impl DispatchSpec {
             project,
             dag_ref: None,
             max_parallel: None,
+            max_turns: None,
         }
     }
 
@@ -76,7 +82,15 @@ impl DispatchSpec {
             project,
             dag_ref,
             max_parallel,
+            max_turns: None,
         }
+    }
+
+    /// Set the per-session turn limit.
+    #[must_use]
+    pub fn with_max_turns(mut self, max_turns: Option<u32>) -> Self {
+        self.max_turns = max_turns;
+        self
     }
 }
 
@@ -399,11 +413,13 @@ mod tests {
             project: "test-project".to_owned(),
             dag_ref: None,
             max_parallel: Some(2),
+            max_turns: Some(7),
         };
         let json = serde_json::to_string(&spec).unwrap();
         let deserialized: DispatchSpec = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.prompt_numbers, vec![1, 2, 3]);
         assert_eq!(deserialized.max_parallel, Some(2));
+        assert_eq!(deserialized.max_turns, Some(7));
     }
 
     #[test]

--- a/crates/energeia/tests/public_api_types_and_config.rs
+++ b/crates/energeia/tests/public_api_types_and_config.rs
@@ -24,6 +24,7 @@ fn dispatch_spec_serde_roundtrip_basic() {
     assert_eq!(deserialized.project, "my-project");
     assert!(deserialized.dag_ref.is_none());
     assert!(deserialized.max_parallel.is_none());
+    assert!(deserialized.max_turns.is_none());
 }
 
 #[test]
@@ -33,7 +34,8 @@ fn dispatch_spec_serde_with_dag_ref() {
         "prompt_numbers": [10, 20, 30],
         "project": "test-proj",
         "dag_ref": "dag.yaml",
-        "max_parallel": 8
+        "max_parallel": 8,
+        "max_turns": 12
     }"#;
     let spec: DispatchSpec = serde_json::from_str(json).expect("deserialize");
 
@@ -41,6 +43,7 @@ fn dispatch_spec_serde_with_dag_ref() {
     assert_eq!(spec.project, "test-proj");
     assert_eq!(spec.dag_ref, Some("dag.yaml".to_owned()));
     assert_eq!(spec.max_parallel, Some(8));
+    assert_eq!(spec.max_turns, Some(12));
 }
 
 #[test]
@@ -52,6 +55,7 @@ prompt_numbers:
 project: yaml-test
 dag_ref: prompts/dag.yaml
 max_parallel: 4
+max_turns: 9
 ";
     let spec: DispatchSpec = serde_yaml::from_str(yaml).expect("deserialize from yaml");
 
@@ -59,6 +63,7 @@ max_parallel: 4
     assert_eq!(spec.project, "yaml-test");
     assert_eq!(spec.dag_ref, Some("prompts/dag.yaml".to_owned()));
     assert_eq!(spec.max_parallel, Some(4));
+    assert_eq!(spec.max_turns, Some(9));
 }
 
 // ============================================================================

--- a/crates/organon/src/builtins/energeia/dispatch.rs
+++ b/crates/organon/src/builtins/energeia/dispatch.rs
@@ -69,6 +69,16 @@ pub(super) fn dromeus_def() -> ToolDef {
                     },
                 ),
                 (
+                    "max_turns".to_owned(),
+                    PropertyDef {
+                        property_type: PropertyType::Integer,
+                        description: "Maximum turns per session (default: engine default)"
+                            .to_owned(),
+                        enum_values: None,
+                        default: None,
+                    },
+                ),
+                (
                     "dry_run".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::Boolean,
@@ -143,6 +153,8 @@ impl ToolExecutor for DromeusExecutor {
                 energeia::types::DispatchSpec::new(project.to_owned(), prompt_numbers);
             dispatch_spec.max_parallel =
                 opt_u64(args, "max_parallel").and_then(|v| u32::try_from(v).ok());
+            dispatch_spec.max_turns =
+                opt_u64(args, "max_turns").and_then(|v| u32::try_from(v).ok());
 
             match orchestrator.dispatch(dispatch_spec, &prompts).await {
                 Ok(result) => Ok(to_json_text(&result)),

--- a/crates/organon/src/builtins/energeia/qa.rs
+++ b/crates/organon/src/builtins/energeia/qa.rs
@@ -19,7 +19,7 @@ use crate::types::{
     ToolGroupId, ToolInput, ToolResult, ToolTag,
 };
 
-use super::shared::{opt_u64, require_str, to_json_text};
+use super::shared::{opt_str, opt_u64, require_str, to_json_text};
 
 // ── dokimasia (δοκιμασία — examination) ────────────────────────────────────
 
@@ -54,7 +54,9 @@ pub(super) fn dokimasia_def() -> ToolDef {
                     "project".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::String,
-                        description: "GitHub project slug (owner/repo)".to_owned(),
+                        description: "Optional GitHub project slug (owner/repo), reserved for \
+                            future QA result persistence"
+                            .to_owned(),
                         enum_values: None,
                         default: None,
                     },
@@ -73,7 +75,6 @@ pub(super) fn dokimasia_def() -> ToolDef {
             required: vec![
                 "prompt_number".to_owned(),
                 "pr_number".to_owned(),
-                "project".to_owned(),
                 "diff".to_owned(),
             ],
         },
@@ -104,12 +105,9 @@ impl ToolExecutor for DokimasiaExecutor {
                 Some(n) => n,
                 None => return Ok(ToolResult::error("missing required field 'pr_number'")),
             };
-            let _project = match require_str(args, "project") {
-                Ok(s) => s,
-                Err(e) => return Ok(e),
-            };
-            if _project.trim().is_empty() {
-                return Ok(ToolResult::error("missing required field 'project'"));
+            let project = opt_str(args, "project");
+            if project.is_some_and(|p| p.trim().is_empty()) {
+                return Ok(ToolResult::error("field 'project' must not be empty"));
             }
             let diff = match require_str(args, "diff") {
                 Ok(s) => s,
@@ -119,7 +117,7 @@ impl ToolExecutor for DokimasiaExecutor {
                 let output = serde_json::json!({
                     "status": "no_work",
                     "reason": "no diff to QA",
-                    "project": _project,
+                    "project": project,
                     "prompt_number": prompt_number,
                     "pr_number": pr_number,
                 });

--- a/crates/organon/tests/energeia_tools.rs
+++ b/crates/organon/tests/energeia_tools.rs
@@ -307,3 +307,66 @@ async fn dokimasia_empty_diff_returns_no_work() {
         "empty diff must not produce vacuous Pass: {text}"
     );
 }
+
+#[test]
+fn dromeus_schema_exposes_parallel_and_turn_limits() {
+    let mut registry = ToolRegistry::new();
+    register(&mut registry, None).expect("register");
+    let definitions = registry.definitions();
+    let dromeus = definitions
+        .iter()
+        .find(|def| def.name.as_str() == "dromeus")
+        .expect("dromeus definition registered");
+
+    assert!(
+        dromeus.input_schema.properties.contains_key("max_parallel"),
+        "dromeus should expose concurrency separately"
+    );
+    assert!(
+        dromeus.input_schema.properties.contains_key("max_turns"),
+        "dromeus should expose per-session turn budget separately"
+    );
+}
+
+#[test]
+fn dokimasia_schema_does_not_require_reserved_project() {
+    let mut registry = ToolRegistry::new();
+    register(&mut registry, None).expect("register");
+    let definitions = registry.definitions();
+    let dokimasia = definitions
+        .iter()
+        .find(|def| def.name.as_str() == "dokimasia")
+        .expect("dokimasia definition registered");
+
+    assert!(
+        dokimasia.input_schema.properties.contains_key("project"),
+        "dokimasia should still document the reserved project field"
+    );
+    assert!(
+        !dokimasia
+            .input_schema
+            .required
+            .iter()
+            .any(|field| field == "project"),
+        "dokimasia should not require a reserved field it cannot persist"
+    );
+}
+
+#[tokio::test]
+async fn dokimasia_runs_without_project() {
+    let (_tmp, services) = setup();
+    let ctx = make_ctx();
+    let mut registry = ToolRegistry::new();
+    register(&mut registry, Some(services)).expect("register");
+
+    let input = make_input(
+        "dokimasia",
+        serde_json::json!({
+            "prompt_number": 1,
+            "pr_number": 42,
+            "diff": "diff --git a/src/lib.rs b/src/lib.rs\n+fn added() {}\n"
+        }),
+    );
+    let result = registry.execute(&input, &ctx).await.unwrap();
+    assert_non_error(&result, "dokimasia without project");
+}

--- a/crates/taxis/src/config/behavior/dispatch.rs
+++ b/crates/taxis/src/config/behavior/dispatch.rs
@@ -41,4 +41,7 @@ pub struct DispatchSpecConfig {
     /// Maximum parallelism.
     #[serde(default)]
     pub max_parallel: Option<u32>,
+    /// Maximum turns per initial session.
+    #[serde(default)]
+    pub max_turns: Option<u32>,
 }


### PR DESCRIPTION
## Summary
- add distinct dispatch `max_turns` wiring from organon dromeus through energeia preparation
- keep `max_parallel` as concurrency only and preserve `DispatchSpec::with_options` compatibility with `with_max_turns`
- make dokimasia `project` optional/reserved instead of required-then-dropped

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (clean rerun; an unrelated architecture_fact test flaked once and passed exact rerun)
- `kanon lint` changed-line scan on touched files: no findings on changed lines; full diff-aware invocation timed out silently and file-wide lint reports pre-existing findings in `runtime/mod.rs`
- reviewer gate: APPROVE (fallback multi-agent reviewer; kanon kimi MCP tools unavailable in this session)

Closes #3950
