### PR TITLE
fix(organon): clarify dokimasia qa scope

### DIFF
--- a/crates/organon/src/builtins/energeia/qa.rs
+++ b/crates/organon/src/builtins/energeia/qa.rs
@@ -26,8 +26,9 @@ use super::shared::{opt_str, opt_u64, require_str, to_json_text};
 pub(super) fn dokimasia_def() -> ToolDef {
     ToolDef {
         name: ToolName::from_static("dokimasia"),
-        description: "Run a QA evaluation of a pull request against the originating prompt spec. \
-            Returns a verdict (pass/partial/fail), per-criterion results, and mechanical issues."
+        description: "Run mechanical QA checks against a caller-provided pull-request diff. \
+            Semantic acceptance-criteria evaluation requires orchestrator-side prompt and LLM \
+            wiring; empty diffs return no-work rather than a pass verdict."
             .to_owned(),
         extended_description: None,
         input_schema: InputSchema {

--- a/crates/organon/tests/energeia_tools.rs
+++ b/crates/organon/tests/energeia_tools.rs
@@ -352,6 +352,38 @@ fn dokimasia_schema_does_not_require_reserved_project() {
     );
 }
 
+#[test]
+fn dokimasia_description_advertises_mechanical_only_qa() {
+    let mut registry = ToolRegistry::new();
+    register(&mut registry, None).expect("register");
+    let definitions = registry.definitions();
+    let dokimasia = definitions
+        .iter()
+        .find(|def| def.name.as_str() == "dokimasia")
+        .expect("dokimasia definition registered");
+
+    assert!(
+        dokimasia.description.contains("mechanical QA checks"),
+        "dokimasia should not advertise semantic QA without prompt and LLM wiring"
+    );
+    assert!(
+        dokimasia
+            .description
+            .contains("caller-provided pull-request diff"),
+        "dokimasia should document that callers must supply the diff"
+    );
+    assert!(
+        dokimasia
+            .description
+            .contains("Semantic acceptance-criteria evaluation requires"),
+        "dokimasia should document the semantic QA limitation"
+    );
+    assert!(
+        dokimasia.description.contains("empty diffs return no-work"),
+        "dokimasia should document its empty-diff behavior"
+    );
+}
+
 #[tokio::test]
 async fn dokimasia_runs_without_project() {
     let (_tmp, services) = setup();


### PR DESCRIPTION
## Summary
- clarify `dokimasia` as mechanical-only QA over a caller-provided pull-request diff
- document that semantic acceptance-criteria evaluation needs orchestrator-side prompt and LLM wiring
- add a regression test so the public tool description cannot drift back to promising full semantic QA

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --summary` on touched files
- reviewer gate: APPROVE (fallback multi-agent reviewer; kanon kimi MCP tools unavailable in this session)

Closes #3961
