### PR TITLE
fix(taxis): ship strict provider example config

### DIFF
--- a/crates/taxis/tests/public_api_loader.rs
+++ b/crates/taxis/tests/public_api_loader.rs
@@ -8,7 +8,7 @@
 
 mod common;
 
-use taxis::config::AletheiaConfig;
+use taxis::config::{AletheiaConfig, DeploymentTarget, ProviderKind};
 use taxis::loader::{load_config, write_config};
 use taxis::oikos::Oikos;
 use taxis::reload::{prepare_reload, restart_prefixes};
@@ -25,6 +25,12 @@ fn seed_instance(jail: &EnvJail) -> &std::path::Path {
     std::fs::create_dir_all(root.join("data")).expect("create data dir");
     std::fs::create_dir_all(root.join("nous")).expect("create nous dir");
     root
+}
+
+fn is_gguf_model_id(model: &str) -> bool {
+    std::path::Path::new(model)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("gguf"))
 }
 
 // ─── TOML loading: cascade (defaults → file → env) ──────────────────────
@@ -97,6 +103,46 @@ fn load_config_parses_camel_case_keys() {
     let config = load_config(&oikos).unwrap();
     assert_eq!(config.embedding.provider, "mock");
     assert_eq!(config.embedding.dimension, 512);
+}
+
+#[test]
+fn instance_example_provider_entries_load_strictly() {
+    let jail = EnvJail::new();
+    let root = seed_instance(&jail);
+    write_toml(
+        root,
+        include_str!("../../../instance.example/config/aletheia.toml"),
+    );
+
+    let oikos = Oikos::from_root(root);
+    let config = load_config(&oikos).expect("example config should load");
+
+    let anthropic = config
+        .providers
+        .iter()
+        .find(|provider| provider.name == "anthropic-cloud")
+        .expect("anthropic provider should be declared");
+    assert_eq!(anthropic.kind, ProviderKind::Anthropic);
+    assert_eq!(anthropic.deployment_target, DeploymentTarget::Cloud);
+
+    for name in ["menos-chat", "menos-code", "menos-inference", "menos-vlm"] {
+        let provider = config
+            .providers
+            .iter()
+            .find(|provider| provider.name == name)
+            .unwrap_or_else(|| panic!("{name} provider should be declared"));
+
+        assert_eq!(provider.kind, ProviderKind::OpenAiCompatible);
+        assert_eq!(provider.deployment_target, DeploymentTarget::LocalHosted);
+        assert!(
+            provider.models.iter().any(|model| is_gguf_model_id(model)),
+            "{name} should include the llama-server model id"
+        );
+        assert!(
+            provider.models.iter().any(|model| !is_gguf_model_id(model)),
+            "{name} should keep a short routing alias"
+        );
+    }
 }
 
 #[test]

--- a/instance.example/config/aletheia.toml
+++ b/instance.example/config/aletheia.toml
@@ -165,6 +165,61 @@ workspace = "nous/main"
 #   extended            — reserved for the 1-hour cache (currently behaves
 #                         the same as `ephemeral`).
 
+# --- LLM providers ---
+# Declarative providers used by the runtime registry. Local OpenAI-compatible
+# servers list both the operator-facing alias and the exact model id returned
+# by /v1/models so either form routes to the same endpoint.
+[[providers]]
+name = "anthropic-cloud"
+providerType = "anthropic"
+deploymentTarget = "cloud"
+apiKeyEnv = "ANTHROPIC_API_KEY"
+models = [
+  "claude-sonnet-4-6",
+  "claude-opus-4-6",
+  "claude-haiku-4-5",
+]
+
+[[providers]]
+name = "menos-chat"
+providerType = "openai-compatible"
+baseUrl = "http://127.0.0.1:8088/v1"
+deploymentTarget = "localhosted"
+models = [
+  "qwen3.5-27b",
+  "Qwen3.5-27B-Instruct-Q4_K_M.gguf",
+]
+
+[[providers]]
+name = "menos-code"
+providerType = "openai-compatible"
+baseUrl = "http://127.0.0.1:8089/v1"
+deploymentTarget = "localhosted"
+models = [
+  "qwen3-coder-30b-a3b",
+  "Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+]
+
+[[providers]]
+name = "menos-inference"
+providerType = "openai-compatible"
+baseUrl = "http://127.0.0.1:8090/v1"
+deploymentTarget = "localhosted"
+models = [
+  "qwen3-4b",
+  "Qwen3-4B-Instruct-Q4_K_M.gguf",
+]
+
+[[providers]]
+name = "menos-vlm"
+providerType = "openai-compatible"
+baseUrl = "http://127.0.0.1:8091/v1"
+deploymentTarget = "localhosted"
+models = [
+  "qwen3-vl-8b",
+  "Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
+]
+
 # --- Cost tracking ---
 # [pricing."claude-sonnet-4-6"]
 # inputCostPerMtok = 3.0


### PR DESCRIPTION
## Summary
- adds canonical `[[providers]]` entries to `instance.example/config/aletheia.toml` for `anthropic-cloud` and the four local menos OpenAI-compatible providers
- uses `providerType = "openai-compatible"` and `deploymentTarget = "localhosted"` for local providers
- includes both short aliases and `.gguf` model IDs, and covers the example TOML through the taxis loader

Closes #3937.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --summary crates/taxis/tests/public_api_loader.rs`
- `kanon lint --summary instance.example/config/aletheia.toml`
- `git diff --check`

Note: `cargo run -p aletheia --bin aletheia -- -r instance.example check-config` gets past config load/provider deserialization, then fails on pre-existing example startup checks: missing `instance.example/nous/main` and placeholder JWT signing key.