### PR TITLE
fix(symbolon): stabilize api key expiry boundary test

### DIFF
--- a/crates/symbolon/src/api_key.rs
+++ b/crates/symbolon/src/api_key.rs
@@ -89,7 +89,7 @@ pub(crate) fn validate(store: &AuthStore, raw_key: &str) -> Result<Claims> {
 
     if let Some(ref expires_at) = record.expires_at {
         let now = now_iso();
-        if *expires_at < now {
+        if is_expired(expires_at, &now) {
             return Err(error::ExpiredTokenSnafu.build());
         }
     }
@@ -146,6 +146,10 @@ fn now_iso() -> String {
         })
         .as_secs();
     time_from_unix(secs)
+}
+
+fn is_expired(expires_at: &str, now: &str) -> bool {
+    expires_at < now
 }
 
 fn time_from_unix(secs: u64) -> String {

--- a/crates/symbolon/src/api_key_tests.rs
+++ b/crates/symbolon/src/api_key_tests.rs
@@ -262,19 +262,10 @@ fn validate_accepts_unexpired_key() {
 /// would flip this case.
 #[test]
 fn validate_equal_to_now_is_not_rejected() {
-    // Build an ISO timestamp equal to right-now. Since now_iso() uses the same
-    // time_from_unix formatter, we match its exact second-truncation.
-    let now = time_from_unix(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-    );
-    let (result, _) = validate_with_stored_expiry(&now);
-    // Either Ok (strict <) or Err::ExpiredToken (<=) — assert Ok to pin strict <.
+    let now = "2026-05-22T00:00:00.000Z";
     assert!(
-        result.is_ok(),
-        "expires_at == now must not be considered expired (strict <). got {result:?}"
+        !super::is_expired(now, now),
+        "expires_at == now must not be considered expired (strict <)"
     );
 }
 


### PR DESCRIPTION
## Summary

- Stabilizes the API key expiry equality-boundary regression test by checking the pure strict-comparison helper.
- Keeps runtime expiry behavior unchanged: keys only expire when `expires_at < now`.

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --summary crates/symbolon/src/api_key.rs`
- `kanon lint --summary crates/symbolon/src/api_key_tests.rs`

## Reviewer

- Kimi reviewer: APPROVE (`0000019e51ce5613f214b1f7035fb1e3`)
