### PR TITLE
fix(organon): stop advertising unimplemented tool capabilities

### DIFF
--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -31,6 +31,9 @@ receipt_verification = []
 # Energeia capability tools (dromeus, dokimasia, diorthosis, epitropos, parateresis,
 # mathesis, prographe, schedion, metron). Wires to real energeia subsystem.
 energeia = ["dep:energeia"]
+# Unimplemented prompt archival/worktree cleanup tool schemas. Default OFF so
+# agents do not see stub capabilities unless a deployment deliberately opts in.
+bookkeeper = []
 # Z3 SMT solver tool (z3_solver). Bundled so the default build doesn't pull libz3.
 z3 = ["dep:z3"]
 # Gates MockToolExecutor, ToolExecutorSpec, and other test helpers. No test code in release binaries.

--- a/crates/organon/src/builtins/energeia/observation.rs
+++ b/crates/organon/src/builtins/energeia/observation.rs
@@ -1,6 +1,6 @@
 //! Observation and learning tools (parateresis + mathesis).
 //!
-//! - parateresis (παρατήρησις — observation): collect observations from merged PRs
+//! - parateresis (παρατήρησις — observation): query stored observations
 //! - mathesis (μάθησις — learning): query/record lessons learned
 
 use std::future::Future;
@@ -28,7 +28,7 @@ pub(super) fn parateresis_def() -> ToolDef {
     ToolDef {
         name: ToolName::from_static("parateresis"),
         description:
-            "Record an observation scan request and return stored observations for a project."
+            "Record an observation query request and return stored observations for a project."
                 .to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -37,7 +37,7 @@ pub(super) fn parateresis_def() -> ToolDef {
                     "project".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::String,
-                        description: "GitHub project slug (owner/repo)".to_owned(),
+                        description: "Project slug for stored observations (owner/repo)".to_owned(),
                         enum_values: None,
                         default: None,
                     },
@@ -46,7 +46,8 @@ pub(super) fn parateresis_def() -> ToolDef {
                     "days".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::Integer,
-                        description: "How many days of merged PRs to scan (default: 7)".to_owned(),
+                        description: "How many days of stored observations to return (default: 7)"
+                            .to_owned(),
                         enum_values: None,
                         default: Some(serde_json::json!(7)),
                     },
@@ -88,19 +89,19 @@ impl ToolExecutor for ParateresisExecutor {
                 .and_then(|d| u32::try_from(d).ok())
                 .unwrap_or(7);
 
-            // Record an observation for this collection pass and return existing ones.
+            // Record an observation for this query pass and return existing ones.
             // WHY: The observation pipeline captures patterns from merged PRs as
             // ObservationRecord entries. This tool queries existing observations and
-            // records a new sentinel observation for the scan run.
-            let scan_observation = NewObservation {
+            // records a new sentinel observation for the query run.
+            let query_observation = NewObservation {
                 project: project.to_owned(),
                 source: "parateresis".to_owned(),
-                content: format!("observation scan requested for last {days} days"),
-                observation_type: "scan".to_owned(),
+                content: format!("observation query requested for last {days} days"),
+                observation_type: "query".to_owned(),
                 session_id: None,
             };
-            if let Err(e) = store.add_observation(&scan_observation) {
-                tracing::warn!(error = %e, "parateresis: failed to record scan observation");
+            if let Err(e) = store.add_observation(&query_observation) {
+                tracing::warn!(error = %e, "parateresis: failed to record query observation");
             }
 
             match store.query_observations(Some(project), Some(days), 100) {

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -5,7 +5,7 @@ pub mod agent;
 /// Architecture-fact query/write tool (architecture_fact).
 pub mod architecture_fact;
 /// Bookkeeper tools (prompt archival and worktree cleanup).
-#[cfg(feature = "energeia")]
+#[cfg(feature = "bookkeeper")]
 pub mod bookkeeper;
 /// Machine-derived code-graph symbol-level queries (code_graph_query).
 pub mod code_graph_query;
@@ -192,7 +192,7 @@ pub(crate) fn register_domain_tools(
     // have services configured should use energeia::register(registry, Some(services)).
     // Tools requiring services return structured errors rather than panicking.
     energeia::register(registry, None)?;
-    #[cfg(feature = "energeia")]
+    #[cfg(feature = "bookkeeper")]
     bookkeeper::register(registry)?;
     poiesis::register(registry)?;
     intake_report::register(registry)?;
@@ -207,4 +207,30 @@ pub(crate) fn register_domain_tools(
     diff_report::register(registry)?;
     inspect_report::register(registry)?;
     Ok(())
+}
+
+#[cfg(all(test, feature = "energeia", not(feature = "bookkeeper")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_energeia_registry_excludes_unimplemented_bookkeeper_tools() -> Result<()> {
+        let mut registry = ToolRegistry::new();
+        register_domain_tools(&mut registry, SandboxConfig::default())?;
+        let names: Vec<&str> = registry
+            .definitions()
+            .iter()
+            .map(|def| def.name.as_str())
+            .collect();
+
+        assert!(
+            names.contains(&"parateresis"),
+            "implemented energeia tools should still register"
+        );
+        assert!(
+            !names.contains(&"tamias") && !names.contains(&"katharos"),
+            "unimplemented bookkeeper tools must not be exposed by default"
+        );
+        Ok(())
+    }
 }

--- a/crates/organon/tests/energeia_tools.rs
+++ b/crates/organon/tests/energeia_tools.rs
@@ -384,6 +384,39 @@ fn dokimasia_description_advertises_mechanical_only_qa() {
     );
 }
 
+#[test]
+fn parateresis_schema_advertises_store_query_only() {
+    let mut registry = ToolRegistry::new();
+    register(&mut registry, None).expect("register");
+    let definitions = registry.definitions();
+    let parateresis = definitions
+        .iter()
+        .find(|def| def.name.as_str() == "parateresis")
+        .expect("parateresis definition registered");
+
+    assert!(
+        parateresis
+            .description
+            .contains("return stored observations"),
+        "parateresis should describe local observation-store behavior"
+    );
+    assert!(
+        !parateresis.description.contains("pull requests")
+            && !parateresis.description.contains("tracking issues"),
+        "parateresis must not advertise external PR or issue creation work"
+    );
+    let days_description = &parateresis
+        .input_schema
+        .properties
+        .get("days")
+        .expect("days property documented")
+        .description;
+    assert!(
+        days_description.contains("stored observations"),
+        "days should describe the store-query window, got: {days_description}"
+    );
+}
+
 #[tokio::test]
 async fn dokimasia_runs_without_project() {
     let (_tmp, services) = setup();


### PR DESCRIPTION
## Summary

- gate unimplemented `tamias`/`katharos` bookkeeper schemas behind an explicit off-by-default `bookkeeper` feature
- keep implemented Energeia tools in the default `energeia` registry while asserting bookkeeper stubs are absent
- narrow `parateresis` schema/descriptions to stored observation query behavior

Closes #3951

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --summary crates/organon/Cargo.toml`
- `kanon lint --summary crates/organon/src/builtins/mod.rs`
- `kanon lint --summary crates/organon/src/builtins/energeia/observation.rs`
- `kanon lint --summary crates/organon/tests/energeia_tools.rs`

Additional feature checks:

- `cargo test -p organon --features energeia default_energeia_registry_excludes_unimplemented_bookkeeper_tools -- --nocapture`
- `cargo test -p organon --features 'energeia bookkeeper' builtins::bookkeeper`

## Reviewer

- Kimi reviewer: APPROVE (`0000019e51e08832f214b1f7035fb1e7`)
