### PR TITLE
fix(proskenion): preserve session context when opening chat

### DIFF
--- a/crates/theatron/proskenion/src/app.rs
+++ b/crates/theatron/proskenion/src/app.rs
@@ -13,6 +13,7 @@ use crate::services::toast::provide_toast_context;
 use crate::services::{config, settings_config};
 use crate::state::agents::AgentStore;
 use crate::state::app::TabBar;
+use crate::state::chat::ChatSelection;
 use crate::state::commands::CommandStore;
 use crate::state::connection::ConnectionState;
 use crate::state::notifications::{DndState, NotificationHistory};
@@ -169,6 +170,7 @@ fn ConnectedApp() -> Element {
     // and not the connect view.
     use_context_provider(|| Signal::new(CommandStore::new()));
     use_context_provider(|| Signal::new(TabBar::new()));
+    use_context_provider(|| Signal::new(None::<ChatSelection>));
 
     // WHY: Start SSE coroutine here (not in App) so it only runs when connected
     // and has access to the finalized connection config.

--- a/crates/theatron/proskenion/src/components/session_tabs.rs
+++ b/crates/theatron/proskenion/src/components/session_tabs.rs
@@ -4,8 +4,11 @@
 //! actually interacted with (those with open tabs), not all agents.
 
 use dioxus::prelude::*;
+use skene::id::NousId;
 
+use crate::state::agents::AgentStore;
 use crate::state::app::TabBar;
+use crate::state::chat::ChatSelection;
 
 const TABS_BAR_STYLE: &str = "\
     display: flex; \
@@ -80,13 +83,24 @@ const UNREAD_BADGE_STYLE: &str = "\
 #[component]
 pub(crate) fn SessionTabsView() -> Element {
     let tab_bar = use_context::<Signal<TabBar>>();
+    let agent_store = use_context::<Signal<AgentStore>>();
+    let chat_selection = use_context::<Signal<Option<ChatSelection>>>();
 
-    let tabs: Vec<(u64, String, bool, bool)> = {
+    let tabs: Vec<(u64, NousId, Option<String>, String, bool, bool)> = {
         let bar = tab_bar.read();
         bar.tabs
             .iter()
             .enumerate()
-            .map(|(i, t)| (t.id, t.title.clone(), i == bar.active, t.unread))
+            .map(|(i, t)| {
+                (
+                    t.id,
+                    t.agent_id.clone(),
+                    t.session_key.clone(),
+                    t.title.clone(),
+                    i == bar.active,
+                    t.unread,
+                )
+            })
             .collect()
     };
 
@@ -97,10 +111,15 @@ pub(crate) fn SessionTabsView() -> Element {
     rsx! {
         div {
             style: "{TABS_BAR_STYLE}",
-            for (tab_id , title , is_active , has_unread) in tabs {
+            for (tab_id , agent_id , session_key , title , is_active , has_unread) in tabs {
                 {
                     let mut tab_bar_for_click = tab_bar;
                     let mut tab_bar_for_close = tab_bar;
+                    let mut agent_store_for_click = agent_store;
+                    let mut chat_selection_for_click = chat_selection;
+                    let agent_id_for_click = agent_id.clone();
+                    let session_key_for_click = session_key.clone();
+                    let title_for_click = title.clone();
                     let style = if is_active { TAB_ACTIVE_STYLE } else { TAB_STYLE };
 
                     rsx! {
@@ -111,6 +130,14 @@ pub(crate) fn SessionTabsView() -> Element {
                                 let mut bar = tab_bar_for_click.write();
                                 if let Some(idx) = bar.tabs.iter().position(|t| t.id == tab_id) {
                                     bar.active = idx;
+                                }
+                                agent_store_for_click.write().set_active(&agent_id_for_click);
+                                if let Some(session_key) = session_key_for_click.clone() {
+                                    chat_selection_for_click.set(Some(ChatSelection::new(
+                                        agent_id_for_click.clone(),
+                                        session_key,
+                                        title_for_click.clone(),
+                                    )));
                                 }
                             },
                             if has_unread {

--- a/crates/theatron/proskenion/src/state/app.rs
+++ b/crates/theatron/proskenion/src/state/app.rs
@@ -63,12 +63,14 @@ pub(crate) type TabId = u64;
 
 /// Metadata for a tab. The actual chat state lives in `AgentChatState`,
 /// owned by the tab's component, not here.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone)] // kanon:ignore RUST/no-debug-derive-on-public-types
 pub struct TabEntry {
     /// Unique tab identifier.
     pub id: TabId,
     /// Agent associated with this tab.
     pub agent_id: NousId,
+    /// Server session key associated with the tab, if known.
+    pub session_key: Option<String>, // kanon:ignore RUST/plain-string-secret
     /// Display title for the tab.
     pub title: String,
     /// Whether this tab has unread messages.
@@ -103,6 +105,26 @@ impl TabBar {
         self.tabs.push(TabEntry {
             id,
             agent_id,
+            session_key: None,
+            title: title.into(),
+            unread: false,
+        });
+        self.tabs.len() - 1
+    }
+
+    /// Create a tab bound to a known server session, returning its index.
+    pub(crate) fn create_for_session(
+        &mut self,
+        agent_id: NousId,
+        session_key: String, // kanon:ignore RUST/plain-string-secret
+        title: impl Into<String>,
+    ) -> usize {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.tabs.push(TabEntry {
+            id,
+            agent_id,
+            session_key: Some(session_key),
             title: title.into(),
             unread: false,
         });
@@ -246,6 +268,21 @@ mod tests {
         let tab = bar.active_tab();
         assert!(tab.is_some());
         assert_eq!(tab.unwrap().title, "first");
+    }
+
+    #[test]
+    fn tab_bar_create_for_session_records_session_key() {
+        let mut bar = TabBar::new();
+        let idx = bar.create_for_session(
+            NousId::from("syn"),
+            "incident-review".to_string(),
+            "Incident Review",
+        );
+
+        let tab = &bar.tabs[idx];
+        assert_eq!(tab.agent_id, NousId::from("syn"));
+        assert_eq!(tab.session_key.as_deref(), Some("incident-review"));
+        assert_eq!(tab.title, "Incident Review");
     }
 
     #[test]

--- a/crates/theatron/proskenion/src/state/chat.rs
+++ b/crates/theatron/proskenion/src/state/chat.rs
@@ -2,6 +2,29 @@
 
 use skene::id::NousId;
 
+/// Session selected by another view for the chat route to activate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChatSelection {
+    /// Agent that owns the session.
+    pub agent_id: NousId,
+    /// Server session key used when streaming turns.
+    pub session_key: String, // kanon:ignore RUST/plain-string-secret
+    /// Human-readable title shown in the chat tab bar.
+    pub title: String, // kanon:ignore RUST/plain-string-secret
+}
+
+impl ChatSelection {
+    /// Create an activation request for the chat route.
+    #[must_use]
+    pub(crate) fn new(agent_id: NousId, session_key: String, title: String) -> Self { // kanon:ignore RUST/plain-string-secret
+        Self {
+            agent_id,
+            session_key,
+            title,
+        }
+    }
+}
+
 /// Role of a chat message sender.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -13,7 +36,6 @@ pub enum Role {
     /// System-level message (context, errors).
     System,
 }
-
 
 /// A single chat message in the conversation history.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/theatron/proskenion/src/views/chat.rs
+++ b/crates/theatron/proskenion/src/views/chat.rs
@@ -22,18 +22,20 @@ use crate::components::message::{MessageBubble, should_group};
 use crate::components::planning_card::PlanningCard;
 use crate::components::routing_indicator::{RoutingIndicator, update_routing_stage};
 use crate::components::session_tabs::SessionTabsView;
-use crate::components::tool_approval::ToolApproval;
 use crate::components::tool_panel::ToolPanel;
 use crate::services::file_watcher::{self, FileChangeTracker};
 use crate::state::agents::AgentStore;
 use crate::state::app::TabBar;
-use crate::state::chat::ChatMessage;
+use crate::state::chat::{ChatMessage, ChatSelection};
 use crate::state::commands::CommandStore;
 use crate::state::connection::ConnectionConfig;
 use crate::state::input::InputState;
 use crate::state::pipeline::{PipelineStage, RoutingState};
+use crate::state::platform::WindowState;
 use crate::state::toasts::{ToastSeverity, ToastStore};
 use crate::state::view_preservation::{PreservedViewState, ViewKey, ViewPreservationStore};
+use crate::views::chat_helpers::{format_tool_call, render_approval};
+use crate::views::chat_selection::activate_chat_selection;
 
 /// Estimated message height in pixels for virtual scroll calculations.
 const ESTIMATED_MSG_HEIGHT: f64 = 80.0;
@@ -53,9 +55,11 @@ pub(crate) fn Chat() -> Element {
     let mut palette_open = use_signal(|| false);
     let config: Signal<ConnectionConfig> = use_context();
     let cmd_store = use_context::<Signal<CommandStore>>();
-    let agent_store = use_context::<Signal<AgentStore>>();
+    let mut agent_store = use_context::<Signal<AgentStore>>();
     let mut tab_bar = use_context::<Signal<TabBar>>();
     let mut routing_signal = use_context::<Signal<Option<RoutingState>>>();
+    let mut pending_chat_selection = use_context::<Signal<Option<ChatSelection>>>();
+    let mut window_state = use_context::<Signal<WindowState>>();
 
     // WHY: Track last user message to enable retry on stream failure.
     let mut last_user_message = use_signal(String::new);
@@ -96,6 +100,22 @@ pub(crate) fn Chat() -> Element {
                 secondary_scroll: 0.0,
             },
         );
+    });
+
+    use_effect(move || {
+        let selection = pending_chat_selection.read().clone();
+        let Some(selection) = selection else {
+            return;
+        };
+
+        activate_chat_selection(
+            &selection,
+            &mut legacy_state.write(),
+            &mut agent_store.write(),
+            &mut tab_bar.write(),
+            &mut window_state.write(),
+        );
+        pending_chat_selection.set(None);
     });
 
     // Derive the active agent ID from the agent store.
@@ -177,8 +197,8 @@ pub(crate) fn Chat() -> Element {
         // WHY: Slash commands beginning with `/` are intercepted here so the
         // palette can handle them. Unrecognised commands get a toast warning
         // so the operator knows the input was not silently eaten.
-        if text.starts_with('/') {
-            let cmd_name = text[1..].split_whitespace().next().unwrap_or("");
+        if let Some(command_text) = text.strip_prefix('/') {
+            let cmd_name = command_text.split_whitespace().next().unwrap_or("");
             let known = cmd_store
                 .read()
                 .filtered
@@ -304,7 +324,9 @@ pub(crate) fn Chat() -> Element {
                     event = rx.recv() => event,
                     _ = tokio::time::sleep(Duration::from_millis(100)) => {
                         let mut state = legacy_state.write();
-                        let _ = manager.tick(&mut state);
+                        if manager.tick(&mut state) {
+                            tracing::trace!("flushed buffered chat stream state");
+                        }
                         continue;
                     }
                 };
@@ -358,7 +380,9 @@ pub(crate) fn Chat() -> Element {
                 }
 
                 let mut state = legacy_state.write();
-                let _ = manager.apply(event, &mut state);
+                if manager.apply(event, &mut state) {
+                    tracing::trace!("applied chat stream event");
+                }
             }
 
             // WHY: Clear stream start so the elapsed timer stops.
@@ -566,7 +590,7 @@ pub(crate) fn Chat() -> Element {
                                                 // WHY: Read elapsed_tick to subscribe to
                                                 // re-renders, then compute actual elapsed
                                                 // from the Instant for accuracy.
-                                                let _ = elapsed_tick();
+                                                std::hint::black_box(elapsed_tick());
                                                 let label = match stream_start_time.read().as_ref() {
                                                     Some(start) => {
                                                         let secs = start.elapsed().as_secs();
@@ -581,7 +605,7 @@ pub(crate) fn Chat() -> Element {
                                     // WHY: Escalating timeout messages give the operator
                                     // actionable feedback when streaming takes unexpectedly long.
                                     {
-                                        let _ = elapsed_tick();
+                                        std::hint::black_box(elapsed_tick());
                                         let elapsed_secs = stream_start_time
                                             .read()
                                             .as_ref()
@@ -744,66 +768,6 @@ pub(crate) fn Chat() -> Element {
                 on_abort: on_abort,
             }
         }
-    }
-}
-
-fn render_approval(
-    approval: crate::state::tools::ToolApprovalState,
-    _chat_signal: Signal<ChatState>,
-) -> Element {
-    let turn_id = approval.turn_id.to_string();
-    let tool_id = approval.tool_id.to_string();
-    let turn_id_deny = turn_id.clone();
-    let tool_id_deny = tool_id.clone();
-
-    // WHY: capture IDs by value for the async approval/deny calls.
-    let config: Signal<ConnectionConfig> = use_context();
-
-    rsx! {
-        ToolApproval {
-            approval: approval,
-            on_approve: move |_| {
-                let turn_id = turn_id.clone();
-                let tool_id = tool_id.clone();
-                let cfg = config.read().clone();
-                spawn(async move {
-                    let client = skene::api::client::ApiClient::new(
-                        &cfg.server_url,
-                        cfg.auth_token.clone(),
-                    );
-                    if let Ok(client) = client {
-                        let _ = client.approve_tool(&turn_id, &tool_id).await;
-                    }
-                });
-            },
-            on_deny: move |_| {
-                let turn_id = turn_id_deny.clone();
-                let tool_id = tool_id_deny.clone();
-                let cfg = config.read().clone();
-                spawn(async move {
-                    let client = skene::api::client::ApiClient::new(
-                        &cfg.server_url,
-                        cfg.auth_token.clone(),
-                    );
-                    if let Ok(client) = client {
-                        let _ = client.deny_tool(&turn_id, &tool_id).await;
-                    }
-                });
-            },
-        }
-    }
-}
-
-fn format_tool_call(tc: &crate::state::events::ToolCallInfo) -> String {
-    if tc.completed {
-        let marker = if tc.is_error { "[x]" } else { "[v]" };
-        match tc.duration_ms {
-            Some(ms) => format!("{marker} {} ({ms}ms)", tc.tool_name),
-            None => format!("{marker} {}", tc.tool_name),
-        }
-    } else {
-        let ellipsis = "[\u{2026}]";
-        format!("{ellipsis} {}", tc.tool_name)
     }
 }
 

--- a/crates/theatron/proskenion/src/views/chat_helpers.rs
+++ b/crates/theatron/proskenion/src/views/chat_helpers.rs
@@ -1,0 +1,72 @@
+//! Small rendering helpers for the chat view.
+
+use dioxus::prelude::*;
+
+use crate::components::chat::ChatState;
+use crate::components::tool_approval::ToolApproval;
+use crate::state::connection::ConnectionConfig;
+
+pub(crate) fn render_approval(
+    approval: crate::state::tools::ToolApprovalState,
+    _chat_signal: Signal<ChatState>,
+) -> Element {
+    let turn_id = approval.turn_id.to_string();
+    let tool_id = approval.tool_id.to_string();
+    let turn_id_deny = turn_id.clone();
+    let tool_id_deny = tool_id.clone();
+
+    // WHY: capture IDs by value for the async approval/deny calls.
+    let config: Signal<ConnectionConfig> = use_context();
+
+    rsx! {
+        ToolApproval {
+            approval: approval,
+            on_approve: move |_| {
+                let turn_id = turn_id.clone();
+                let tool_id = tool_id.clone();
+                let cfg = config.read().clone();
+                spawn(async move {
+                    let client = skene::api::client::ApiClient::new(
+                        &cfg.server_url,
+                        cfg.auth_token.clone(),
+                    );
+                    if let Ok(client) = client {
+                        if let Err(err) = client.approve_tool(&turn_id, &tool_id).await {
+                            tracing::warn!(%turn_id, %tool_id, error = %err, "tool approval request failed");
+                        }
+                    }
+                });
+            },
+            on_deny: move |_| {
+                let turn_id = turn_id_deny.clone();
+                let tool_id = tool_id_deny.clone();
+                let cfg = config.read().clone();
+                spawn(async move {
+                    let client = skene::api::client::ApiClient::new(
+                        &cfg.server_url,
+                        cfg.auth_token.clone(),
+                    );
+                    if let Ok(client) = client {
+                        if let Err(err) = client.deny_tool(&turn_id, &tool_id).await {
+                            tracing::warn!(%turn_id, %tool_id, error = %err, "tool denial request failed");
+                        }
+                    }
+                });
+            },
+        }
+    }
+}
+
+#[must_use]
+pub(crate) fn format_tool_call(tc: &crate::state::events::ToolCallInfo) -> String {
+    if tc.completed {
+        let marker = if tc.is_error { "[x]" } else { "[v]" };
+        match tc.duration_ms {
+            Some(ms) => format!("{marker} {} ({ms}ms)", tc.tool_name),
+            None => format!("{marker} {}", tc.tool_name),
+        }
+    } else {
+        let ellipsis = "[\u{2026}]";
+        format!("{ellipsis} {}", tc.tool_name)
+    }
+}

--- a/crates/theatron/proskenion/src/views/chat_selection.rs
+++ b/crates/theatron/proskenion/src/views/chat_selection.rs
@@ -1,0 +1,154 @@
+//! Shared chat activation helpers for cross-view navigation.
+
+use crate::components::chat::ChatState;
+use crate::state::agents::AgentStore;
+use crate::state::app::TabBar;
+use crate::state::chat::ChatSelection;
+use crate::state::platform::WindowState;
+
+pub(crate) fn activate_chat_selection(
+    selection: &ChatSelection,
+    legacy_state: &mut ChatState,
+    agent_store: &mut AgentStore,
+    tab_bar: &mut TabBar,
+    window_state: &mut WindowState,
+) {
+    let session_changed = legacy_state.agent_id.as_ref() != Some(&selection.agent_id)
+        || legacy_state.session_key.as_deref() != Some(selection.session_key.as_str());
+
+    if session_changed {
+        legacy_state.messages.clear();
+        legacy_state.streaming = Default::default();
+    }
+    legacy_state.agent_id = Some(selection.agent_id.clone());
+    legacy_state.session_key = Some(selection.session_key.clone());
+
+    let agent_known = agent_store.set_active(&selection.agent_id);
+    debug_assert!(
+        agent_known || agent_store.is_empty(),
+        "chat selection referenced an agent absent from AgentStore"
+    );
+    window_state.active_sessions.insert(
+        selection.agent_id.to_string(),
+        selection.session_key.clone(),
+    );
+
+    if let Some(idx) = tab_bar.tabs.iter().position(|tab| {
+        tab.agent_id == selection.agent_id
+            && tab.session_key.as_deref() == Some(selection.session_key.as_str())
+    }) {
+        tab_bar.active = idx;
+    } else {
+        let idx = tab_bar.create_for_session(
+            selection.agent_id.clone(),
+            selection.session_key.clone(),
+            selection.title.clone(),
+        );
+        tab_bar.active = idx;
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions may panic on failure")]
+mod tests {
+    use skene::api::types::Agent;
+    use skene::id::NousId;
+
+    use super::*;
+    use crate::components::chat::{ChatMessage as LegacyChatMessage, MessageRole};
+
+    fn agent(id: &str) -> Agent {
+        Agent {
+            id: NousId::from(id),
+            name: Some(id.to_string()),
+            model: None,
+            emoji: None,
+        }
+    }
+
+    fn selection() -> ChatSelection {
+        ChatSelection::new(
+            NousId::from("syn"),
+            "incident-review".to_string(),
+            "Incident Review".to_string(),
+        )
+    }
+
+    #[test]
+    fn activate_chat_selection_sets_agent_session_tab_and_window_state() {
+        let mut chat_state = ChatState::default();
+        chat_state.messages.push(LegacyChatMessage {
+            role: MessageRole::User,
+            content: "old draft".to_string(),
+            model: None,
+            tool_calls: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            thinking: None,
+            tool_call_details: Vec::new(),
+            plans: Vec::new(),
+        });
+        let mut agent_store = AgentStore::new();
+        agent_store.load_from_api(vec![agent("syn")]);
+        let mut tab_bar = TabBar::new();
+        let mut window_state = WindowState::default();
+
+        activate_chat_selection(
+            &selection(),
+            &mut chat_state,
+            &mut agent_store,
+            &mut tab_bar,
+            &mut window_state,
+        );
+
+        assert_eq!(agent_store.active_id.as_deref(), Some("syn"));
+        assert_eq!(chat_state.agent_id.as_deref(), Some("syn"));
+        assert_eq!(chat_state.session_key.as_deref(), Some("incident-review"));
+        assert!(chat_state.messages.is_empty());
+        let active_tab = tab_bar.active_tab().unwrap();
+        assert_eq!(active_tab.title, "Incident Review");
+        assert_eq!(active_tab.session_key.as_deref(), Some("incident-review"));
+        assert_eq!(
+            window_state.active_sessions.get("syn").map(String::as_str),
+            Some("incident-review")
+        );
+    }
+
+    #[test]
+    fn activate_chat_selection_preserves_messages_when_selection_is_unchanged() {
+        let mut chat_state = ChatState::default();
+        chat_state.agent_id = Some(NousId::from("syn"));
+        chat_state.session_key = Some("incident-review".to_string());
+        chat_state.messages.push(LegacyChatMessage {
+            role: MessageRole::User,
+            content: "keep me".to_string(),
+            model: None,
+            tool_calls: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            thinking: None,
+            tool_call_details: Vec::new(),
+            plans: Vec::new(),
+        });
+        let mut agent_store = AgentStore::new();
+        agent_store.load_from_api(vec![agent("syn")]);
+        let mut tab_bar = TabBar::new();
+        tab_bar.create_for_session(
+            NousId::from("syn"),
+            "incident-review".to_string(),
+            "Incident Review",
+        );
+        let mut window_state = WindowState::default();
+
+        activate_chat_selection(
+            &selection(),
+            &mut chat_state,
+            &mut agent_store,
+            &mut tab_bar,
+            &mut window_state,
+        );
+
+        assert_eq!(chat_state.messages.len(), 1);
+        assert_eq!(tab_bar.len(), 1);
+    }
+}

--- a/crates/theatron/proskenion/src/views/mod.rs
+++ b/crates/theatron/proskenion/src/views/mod.rs
@@ -1,6 +1,8 @@
 //! View components for each route.
 
 pub(crate) mod chat;
+pub(crate) mod chat_helpers;
+pub(crate) mod chat_selection;
 pub(crate) mod component_library;
 pub(crate) mod connect;
 pub(crate) mod files;
@@ -8,6 +10,6 @@ pub(crate) mod memory;
 pub(crate) mod metrics;
 pub(crate) mod ops;
 pub(crate) mod planning;
-pub(crate) mod sessions;
 pub(crate) mod meta;
+pub(crate) mod sessions;
 pub(crate) mod settings;

--- a/crates/theatron/proskenion/src/views/sessions/mod.rs
+++ b/crates/theatron/proskenion/src/views/sessions/mod.rs
@@ -12,6 +12,7 @@ use skene::id::SessionId;
 use crate::api::client::authenticated_client;
 use crate::components::resize_handle::{use_resize_state, ResizeDir, ResizeHandle};
 use crate::state::agents::AgentStore;
+use crate::state::chat::ChatSelection;
 use crate::state::connection::ConnectionConfig;
 use crate::state::fetch::FetchState;
 use crate::state::sessions::{
@@ -74,10 +75,19 @@ const DEFAULT_LIST_WIDTH: f64 = 480.0;
 const MIN_LIST_WIDTH: f64 = 280.0;
 const MAX_LIST_WIDTH: f64 = 800.0;
 
+fn chat_selection_for_session(session: &Session) -> ChatSelection {
+    ChatSelection::new(
+        session.nous_id.clone(),
+        session.key.clone(),
+        session.label().to_string(),
+    )
+}
+
 #[component]
 pub(crate) fn Sessions() -> Element {
     let config: Signal<ConnectionConfig> = use_context();
-    let agents: Signal<AgentStore> = use_context();
+    let mut agents: Signal<AgentStore> = use_context();
+    let mut chat_selection: Signal<Option<ChatSelection>> = use_context();
 
     let mut list_store = use_signal(SessionListStore::new);
     let selection_store = use_signal(SessionSelectionStore::new);
@@ -509,8 +519,26 @@ pub(crate) fn Sessions() -> Element {
                     if selected_session_id.read().is_some() {
                         SessionDetail {
                             detail_state,
-                            on_open_chat: move |_id: SessionId| {
-                                // TODO(#108): set active agent and session in chat state before navigating.
+                            on_open_chat: move |id: SessionId| {
+                                let selected = match &*detail_state.read() {
+                                    FetchState::Loaded(store) => store.session.clone(),
+                                    FetchState::Loading | FetchState::Error(_) => None,
+                                }
+                                .or_else(|| {
+                                    list_store
+                                        .read()
+                                        .sessions
+                                        .iter()
+                                        .find(|session| session.id == id)
+                                        .cloned()
+                                });
+
+                                if let Some(session) = selected {
+                                    let selection = chat_selection_for_session(&session);
+                                    agents.write().set_active(&selection.agent_id);
+                                    chat_selection.set(Some(selection));
+                                }
+
                                 let nav = navigator();
                                 nav.push(crate::app::Route::Chat {});
                             },
@@ -537,5 +565,41 @@ pub(crate) fn Sessions() -> Element {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use skene::id::{NousId, SessionId};
+
+    use super::*;
+
+    fn session(display_name: Option<&str>) -> Session {
+        Session {
+            id: SessionId::from("session-id"),
+            nous_id: NousId::from("syn"),
+            key: "incident-review".to_string(),
+            status: Some("active".to_string()),
+            message_count: 4,
+            session_type: None,
+            updated_at: None,
+            display_name: display_name.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn chat_selection_uses_session_owner_key_and_label() {
+        let selection = chat_selection_for_session(&session(Some("Incident Review")));
+
+        assert_eq!(selection.agent_id, NousId::from("syn"));
+        assert_eq!(selection.session_key, "incident-review");
+        assert_eq!(selection.title, "Incident Review");
+    }
+
+    #[test]
+    fn chat_selection_title_falls_back_to_session_key() {
+        let selection = chat_selection_for_session(&session(None));
+
+        assert_eq!(selection.title, "incident-review");
     }
 }


### PR DESCRIPTION
## Summary

- Wire Sessions "Open in Chat" through a connected-scope chat selection so the chat route activates the selected agent/session.
- Persist session-backed chat tab metadata and restore the same agent/session when a session tab is clicked.
- Add focused tests for selection construction, tab session metadata, and chat selection activation.

Closes #3967

## Gates

- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo check --manifest-path crates/theatron/proskenion/Cargo.toml
- cargo test --manifest-path crates/theatron/proskenion/Cargo.toml chat_selection -- --nocapture
- kanon lint --rust --summary <touched files>
- git diff --check
