### PR TITLE
fix(hermeneus): retry OpenAI streaming startup failures

### DIFF
--- a/crates/hermeneus/src/openai/client.rs
+++ b/crates/hermeneus/src/openai/client.rs
@@ -11,8 +11,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::{Client, Response};
 use tracing::{Instrument as _, info, info_span};
 
 use koina::secret::SecretString;
@@ -361,6 +361,26 @@ impl OpenAiProvider {
         request: &CompletionRequest,
         on_event: &mut (dyn FnMut(StreamEvent) + Send),
     ) -> Result<CompletionResponse> {
+        let span = info_span!("llm_call",
+            llm.provider = %self.config.name,
+            llm.model = %request.model,
+            llm.duration_ms = tracing::field::Empty,
+            llm.tokens_in = tracing::field::Empty,
+            llm.tokens_out = tracing::field::Empty,
+            llm.status = tracing::field::Empty,
+            llm.retries = tracing::field::Empty,
+            llm.stream = true,
+        );
+        self.execute_streaming_inner(request, on_event)
+            .instrument(span)
+            .await
+    }
+
+    async fn execute_streaming_inner(
+        &self,
+        request: &CompletionRequest,
+        on_event: &mut (dyn FnMut(StreamEvent) + Send),
+    ) -> Result<CompletionResponse> {
         if let Err(health) = self.health.check_available() {
             return Err(error::ApiRequestSnafu {
                 message: format!("provider circuit-breaker open: {health:?}"),
@@ -368,36 +388,92 @@ impl OpenAiProvider {
             .build());
         }
 
+        let start = Instant::now();
         let body = self.serialize_request(request, Some(true))?;
         let url = self.endpoint_url();
-        let headers = self.build_headers()?;
+        let mut last_error: Option<error::Error> = None;
 
-        let mut response = self
-            .client
-            .post(&url)
+        for attempt in 0..=self.config.max_retries {
+            if attempt > 0 {
+                tokio::time::sleep(backoff_delay(attempt)).await;
+            }
+
+            let mut response = match self.send_streaming_request(&url, &body).await {
+                Ok(r) => r,
+                Err(err) => {
+                    self.health.record_error(&err);
+                    if !err.is_retryable() {
+                        record_stream_failure(start, attempt, &self.config.name, request);
+                        return Err(err);
+                    }
+                    last_error = Some(err);
+                    continue;
+                }
+            };
+
+            let status = response.status().as_u16();
+            if !response.status().is_success() {
+                let err =
+                    map_error_response(response, &request.model, self.credential_source()).await;
+                self.health.record_error(&err);
+                if !err.is_retryable() {
+                    record_stream_http_failure(start, attempt, &self.config.name, request, status);
+                    return Err(err);
+                }
+                last_error = Some(err);
+                continue;
+            }
+
+            let resp = self.parse_streaming_response(&mut response, on_event).await;
+
+            match resp {
+                Ok(mut resp) => {
+                    self.health.record_success();
+                    record_stream_success(start, attempt, &self.config.name, request, &mut resp);
+                    return Ok(resp);
+                }
+                Err(err) => {
+                    self.health.record_error(&err);
+                    record_stream_failure(start, attempt, &self.config.name, request);
+                    return Err(err);
+                }
+            }
+        }
+
+        tracing::Span::current().record("llm.duration_ms", elapsed_millis_u64(start));
+        tracing::Span::current().record("llm.retries", self.config.max_retries);
+        tracing::Span::current().record("llm.status", "error");
+        crate::metrics::record_completion(&self.config.name, 0, 0, 0.0, false);
+        crate::metrics::record_latency(&request.model, "error", start.elapsed().as_secs_f64());
+        Err(last_error.unwrap_or_else(|| {
+            error::ApiRequestSnafu {
+                message: "streaming request failed after all retries".to_owned(),
+            }
+            .build()
+        }))
+    }
+
+    async fn send_streaming_request(&self, url: &str, body: &str) -> Result<Response> {
+        let headers = self.build_headers()?;
+        self.client
+            .post(url)
             .headers(headers)
-            .body(body)
+            .body(body.to_owned())
             .timeout(Duration::from_mins(10))
             .send()
             .await
-            .map_err(|e| map_request_error(&e))?;
+            .map_err(|e| map_request_error(&e))
+    }
 
-        if !response.status().is_success() {
-            return Err(
-                map_error_response(response, &request.model, self.credential_source()).await,
-            );
+    async fn parse_streaming_response(
+        &self,
+        response: &mut Response,
+        on_event: &mut (dyn FnMut(StreamEvent) + Send),
+    ) -> Result<CompletionResponse> {
+        match self.config.api_family {
+            OpenAiApiFamily::ChatCompletions => parse_chat_sse_response(response, on_event).await,
+            OpenAiApiFamily::Responses => parse_responses_sse_response(response, on_event).await,
         }
-
-        let resp = match self.config.api_family {
-            OpenAiApiFamily::ChatCompletions => {
-                parse_chat_sse_response(&mut response, on_event).await?
-            }
-            OpenAiApiFamily::Responses => {
-                parse_responses_sse_response(&mut response, on_event).await?
-            }
-        };
-        self.health.record_success();
-        Ok(resp)
     }
 
     fn endpoint_url(&self) -> String {
@@ -465,6 +541,68 @@ fn backoff_delay(attempt: u32) -> Duration {
     let cap_ms: u64 = 30_000;
     let delay = base_ms.saturating_mul(1_u64 << attempt.min(6));
     Duration::from_millis(delay.min(cap_ms))
+}
+
+fn elapsed_millis_u64(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn record_stream_failure(
+    start: Instant,
+    attempt: u32,
+    provider_name: &str,
+    request: &CompletionRequest,
+) {
+    tracing::Span::current().record("llm.duration_ms", elapsed_millis_u64(start));
+    tracing::Span::current().record("llm.retries", attempt);
+    tracing::Span::current().record("llm.status", "error");
+    crate::metrics::record_completion(provider_name, 0, 0, 0.0, false);
+    crate::metrics::record_latency(&request.model, "error", start.elapsed().as_secs_f64());
+}
+
+fn record_stream_http_failure(
+    start: Instant,
+    attempt: u32,
+    provider_name: &str,
+    request: &CompletionRequest,
+    status: u16,
+) {
+    tracing::Span::current().record("llm.duration_ms", elapsed_millis_u64(start));
+    tracing::Span::current().record("llm.retries", attempt);
+    tracing::Span::current().record(
+        "llm.status",
+        if status == 401 {
+            "auth_failed"
+        } else {
+            "error"
+        },
+    );
+    crate::metrics::record_completion(provider_name, 0, 0, 0.0, false);
+    crate::metrics::record_latency(&request.model, "error", start.elapsed().as_secs_f64());
+}
+
+fn record_stream_success(
+    start: Instant,
+    attempt: u32,
+    provider_name: &str,
+    request: &CompletionRequest,
+    response: &mut CompletionResponse,
+) {
+    let duration_ms = elapsed_millis_u64(start);
+    response.duration_ms = Some(duration_ms);
+    tracing::Span::current().record("llm.duration_ms", duration_ms);
+    tracing::Span::current().record("llm.tokens_in", response.usage.input_tokens);
+    tracing::Span::current().record("llm.tokens_out", response.usage.output_tokens);
+    tracing::Span::current().record("llm.status", "ok");
+    tracing::Span::current().record("llm.retries", attempt);
+    crate::metrics::record_completion(
+        provider_name,
+        response.usage.input_tokens,
+        response.usage.output_tokens,
+        0.0,
+        true,
+    );
+    crate::metrics::record_latency(&request.model, "ok", start.elapsed().as_secs_f64());
 }
 
 /// Leak a `Vec<String>` of model IDs to a `&'static [&'static str]` slice.

--- a/crates/hermeneus/src/openai/error.rs
+++ b/crates/hermeneus/src/openai/error.rs
@@ -97,8 +97,17 @@ pub(crate) async fn map_error_response(
 
 /// Map a reqwest transport error to a hermeneus error.
 pub(crate) fn map_request_error(err: &reqwest::Error) -> error::Error {
+    let prefix = if err.is_timeout() {
+        "timeout"
+    } else if err.is_connect() {
+        "connection error"
+    } else if err.is_request() {
+        "request error"
+    } else {
+        "transport error"
+    };
     error::ApiRequestSnafu {
-        message: err.to_string(),
+        message: format!("{prefix}: {err}"),
     }
     .build()
 }

--- a/crates/hermeneus/src/openai/tests.rs
+++ b/crates/hermeneus/src/openai/tests.rs
@@ -5,6 +5,10 @@
 //! wire module boundary (the per-module unit tests already cover JSON
 //! translation in isolation).
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use wiremock::matchers::{body_string_contains, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -370,6 +374,161 @@ async fn responses_streaming_text_round_trip() {
         events.iter().any(
             |e| matches!(e, crate::anthropic::StreamEvent::TextDelta { text } if text == "Hel")
         ),
+    );
+}
+
+#[tokio::test]
+async fn streaming_retries_retryable_http_error_before_sse() {
+    let server = MockServer::start().await;
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_responder = Arc::clone(&attempts);
+    let sse = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"output_index\":0,\"content_index\":0,\"delta\":\"Ok\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-retry\",\"model\":\"gpt-5\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Ok\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":1,\"total_tokens\":4}}}\n\n"
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .and(body_string_contains("\"stream\":true"))
+        .respond_with(move |_request: &wiremock::Request| {
+            if attempts_for_responder.fetch_add(1, Ordering::SeqCst) == 0 {
+                ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                    "error": { "message": "temporary overload" }
+                }))
+            } else {
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse)
+            }
+        })
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let provider = OpenAiProvider::new(OpenAiProviderConfig {
+        name: "test-openai-responses".to_owned(),
+        base_url: format!("{}/v1", server.uri()),
+        models: vec!["gpt-5".to_owned()],
+        max_retries: 1,
+        api_family: OpenAiApiFamily::Responses,
+        ..OpenAiProviderConfig::default()
+    })
+    .expect("mock responses provider construct");
+
+    let mut events = Vec::new();
+    let resp = provider
+        .complete_streaming(&basic_request("gpt-5"), &mut |event| events.push(event))
+        .await
+        .expect("streaming completion retries and succeeds");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(resp.id, "resp-retry");
+    assert_eq!(resp.usage.input_tokens, 3);
+    assert!(events.iter().any(
+        |event| matches!(event, crate::anthropic::StreamEvent::TextDelta { text } if text == "Ok")
+    ));
+}
+
+#[tokio::test]
+async fn streaming_retries_request_send_failure_before_sse() {
+    let reserved = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve test port");
+    let addr = reserved.local_addr().expect("read reserved port");
+    drop(reserved);
+
+    let listener_attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = Arc::clone(&listener_attempts);
+    let server = tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .expect("bind retry target");
+        let (mut socket, _peer_addr) = listener.accept().await.expect("accept retry request");
+        attempts_for_server.fetch_add(1, Ordering::SeqCst);
+
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        loop {
+            let read = socket.read(&mut chunk).await.expect("read request");
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&chunk[..read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let body = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"output_index\":0,\"content_index\":0,\"delta\":\"Ok\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-send-retry\",\"model\":\"gpt-5\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Ok\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":1,\"total_tokens\":4}}}\n\n"
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write sse response");
+    });
+
+    let provider = OpenAiProvider::new(OpenAiProviderConfig {
+        name: "test-openai-responses".to_owned(),
+        base_url: format!("http://{addr}/v1"),
+        models: vec!["gpt-5".to_owned()],
+        max_retries: 1,
+        api_family: OpenAiApiFamily::Responses,
+        ..OpenAiProviderConfig::default()
+    })
+    .expect("mock responses provider construct");
+
+    let mut events = Vec::new();
+    let resp = provider
+        .complete_streaming(&basic_request("gpt-5"), &mut |event| events.push(event))
+        .await
+        .expect("streaming completion retries after send failure");
+
+    server.await.expect("server task completes");
+    assert_eq!(listener_attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(resp.id, "resp-send-retry");
+    assert!(events.iter().any(
+        |event| matches!(event, crate::anthropic::StreamEvent::TextDelta { text } if text == "Ok")
+    ));
+}
+
+#[tokio::test]
+async fn streaming_does_not_retry_non_retryable_http_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "error": { "message": "bad stream request" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = OpenAiProvider::new(OpenAiProviderConfig {
+        name: "test-openai-responses".to_owned(),
+        base_url: format!("{}/v1", server.uri()),
+        models: vec!["gpt-5".to_owned()],
+        max_retries: 2,
+        api_family: OpenAiApiFamily::Responses,
+        ..OpenAiProviderConfig::default()
+    })
+    .expect("mock responses provider construct");
+
+    let mut events = Vec::new();
+    let err = provider
+        .complete_streaming(&basic_request("gpt-5"), &mut |event| events.push(event))
+        .await
+        .expect_err("bad request should fail without retry");
+
+    assert!(events.is_empty());
+    assert!(
+        matches!(err, crate::error::Error::ApiError { status: 400, .. }),
+        "expected ApiError 400, got {err:?}"
     );
 }
 


### PR DESCRIPTION
## Summary\n- retry OpenAI streaming startup failures before SSE parsing begins\n- preserve terminal SSE parsing once a stream starts\n- classify OpenAI transport connection errors as retryable and cover request-send, retryable HTTP, and non-retryable HTTP paths\n\n## Gates\n- cargo fmt --all -- --check\n- cargo check --workspace\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace\n- kanon lint --rust --summary crates/hermeneus/src/openai/client.rs\n- kanon lint --rust --summary crates/hermeneus/src/openai/error.rs\n- kanon lint --rust --summary crates/hermeneus/src/openai/tests.rs\n- git diff --check\n\nCloses #3982