### PR TITLE
docs(krites): clarify dokimion evaluation boundary

### DIFF
--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -1,7 +1,11 @@
 //! aletheia-krites: embedded Datalog engine with HNSW and graph support
 //!
-//! Krites (Κριτής): Datalog engine. Evaluates Datalog queries against a graph store
-//! with HNSW vector search and graph algorithms.
+//! Krites (Κριτής): Datalog engine. It judges Datalog query satisfaction against
+//! rules and facts in a graph store, with HNSW vector search and graph
+//! algorithms.
+//!
+//! This crate does not evaluate agent behavior. Behavioral and cognitive
+//! evaluation lives in `dokimion` (`crates/eval`).
 // SAFETY: warn-level satisfies the ARCHITECTURE/no-deny-missing-docs lint.
 // deny-level is impractical for krites internal modules.
 #![warn(missing_docs)]

--- a/crates/krites/tests/naming_boundary.rs
+++ b/crates/krites/tests/naming_boundary.rs
@@ -1,0 +1,48 @@
+const KRITES_LIB: &str = include_str!("../src/lib.rs");
+const ARCHITECTURE: &str = include_str!("../../../docs/ARCHITECTURE.md");
+const LEXICON: &str = include_str!("../../../docs/lexicon.md");
+const GLOSSARY: &str = include_str!("../../../docs/glossary.md");
+
+#[test]
+fn krites_docs_name_datalog_boundary() {
+    assert!(
+        KRITES_LIB.contains("Datalog query satisfaction"),
+        "krites crate docs must describe Datalog satisfaction, not generic judging"
+    );
+    assert!(
+        KRITES_LIB.contains("does not evaluate agent behavior"),
+        "krites crate docs must cross-reference dokimion for agent evaluation"
+    );
+}
+
+#[test]
+fn architecture_docs_separate_krites_from_dokimion() {
+    assert!(
+        ARCHITECTURE.contains("`krites` is the embedded Datalog and graph query engine"),
+        "architecture docs must name the krites query-engine boundary"
+    );
+    assert!(
+        ARCHITECTURE.contains("`dokimion` is the behavioral and cognitive evaluation runner"),
+        "architecture docs must name the dokimion evaluation boundary"
+    );
+}
+
+#[test]
+fn lexicon_and_glossary_separate_query_engine_from_evaluation() {
+    assert!(
+        LEXICON.contains("judges Datalog query satisfaction, not agent behavior"),
+        "lexicon must qualify the krites judge metaphor"
+    );
+    assert!(
+        LEXICON.contains("Behavioral and cognitive evaluation framework"),
+        "lexicon must make dokimion discoverable as the evaluation crate"
+    );
+    assert!(
+        GLOSSARY.contains("not agent behavior"),
+        "glossary must qualify the krites judge metaphor"
+    );
+    assert!(
+        GLOSSARY.contains("agent evaluation lives in `dokimion`"),
+        "glossary must cross-reference dokimion from krites"
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -147,7 +147,7 @@ generated inventory is `_llm/L1-workspace.md`.
 | `eidos` | `crates/eidos` | Shared knowledge types: Fact, Entity, Relationship, EpistemicTier, Visibility, MemoryScope | nothing (leaf) |
 | `graphe` | `crates/graphe` | fjall session/message store, retention, archive support | eidos, koina |
 | `episteme` | `crates/episteme` | Knowledge pipeline: extraction, trace ingest, query rewrite, recall, consolidation, embedding provider | eidos, koina, graphe, krites (opt) |
-| `krites` | `crates/krites` | Embedded Datalog engine with HNSW and graph support | eidos |
+| `krites` | `crates/krites` | Embedded Datalog and graph query engine with HNSW support | eidos |
 | `mneme` | `crates/mneme` | Thin facade re-exporting eidos, graphe, episteme, krites | eidos, graphe, episteme, krites |
 | `hermeneus` | `crates/hermeneus` | LLM provider registry, fallback chains, token redaction, provider trait, loop guard | koina, taxis |
 | `organon` | `crates/organon` | Tool registry, tool definitions, tags, HMAC receipts, 49 built-in tools, sandbox | koina, hermeneus |
@@ -223,7 +223,7 @@ on the same host (`embedded`) or an operator-trusted local endpoint
 
 | Crate | Directory | Domain | Depends On |
 |-------|-----------|--------|------------|
-| `dokimion` | `crates/eval` | Behavioral eval framework (HTTP scenario runner) | koina |
+| `dokimion` | `crates/eval` | Behavioral and cognitive eval framework (HTTP scenario runner) | koina |
 | `integration-tests` | `crates/integration-tests` | Cross-crate integration test suite | dokimion, koina, taxis, mneme, hermeneus, nous, organon, pylon, symbolon, thesauros |
 
 Additional workspace crates include `aletheia-classify`, `aletheia-lexica`,
@@ -337,6 +337,11 @@ When adding a component, prefer extending an existing edge (dependency or trait 
 - **symbolon depends only on koina** (plus external crates: reqwest, fjall, hmac/sha2/aes-gcm, argon2).
 - **mneme is a thin facade.** It re-exports from eidos (types), graphe (session store), episteme (knowledge pipeline), and krites (Datalog engine). No logic of its own.
 - **krites contains the Datalog+HNSW engine**, gated behind the `mneme-engine` feature.
+- **Boundary: `krites` is the embedded Datalog and graph query engine.** It decides
+  whether rules and facts satisfy a query; it does not judge agent behavior.
+- **Boundary: `dokimion` is the behavioral and cognitive evaluation runner.** It
+  runs scenarios, benchmarks, and agent-behavior checks against live Aletheia
+  instances.
 - **EmbeddingProvider lives in episteme**, not mneme.
 - **Trait boundaries are extension points.** `EmbeddingProvider`, `ChannelProvider`, `LlmProvider` - implement the trait, swap the provider.
 - **daemon depends only on koina** - lightweight scheduling, not a high-layer crate. No other application crate imports it.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,7 +1,6 @@
 # Glossary
 
-Project-specific terms used across the Aletheia codebase. For the naming philosophy and
-Greek construction system, see [gnomon.md](gnomon.md). For the full crate registry with
+Project-specific terms used across the Aletheia codebase. For the full crate registry with
 layer-by-layer analysis, see [lexicon.md](lexicon.md).
 
 Each entry lists the Greek word and pronunciation, etymology, and technical meaning in this
@@ -170,11 +169,13 @@ workspace uses without it belonging to any single layer.
 
 **κριτής** (*kri-tís*)
 
-**Etymology.** From *κρίνω* (to separate, to judge, to decide). The judge: one who
-distinguishes, evaluates, and renders a verdict.
+**Etymology.** From *κρίνω* (to separate, to judge, to decide). In this project the
+"judge" metaphor is scoped to logical inference: separating which Datalog conclusions
+follow from rules and facts, not agent behavior.
 
-**In this codebase.** The embedded Datalog query engine evaluates
-logical rules and facts, deciding what follows from what the system knows.
+**In this codebase.** The embedded Datalog query engine evaluates logical rules and
+facts, deciding what follows from what the system knows. Behavioral and cognitive
+agent evaluation lives in `dokimion`.
 
 **Crate.** `krites` (low layer) - Datalog engine.
 
@@ -392,6 +393,5 @@ Pylon guards the boundary      Outside world reaches Nous only through Pylon
 
 ## Further reading
 
-- [gnomon.md](gnomon.md) - Naming philosophy, construction system, layer test (L1–L4)
 - [lexicon.md](lexicon.md) - Full crate registry with L1–L4 analysis for each name
 - [ARCHITECTURE.md](ARCHITECTURE.md) - Crate workspace, module map, dependency graph

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -1,7 +1,7 @@
 # Aletheia: lexicon
 
 *Living registry. Updated as crates are added or renamed.*
-*For the naming methodology and construction system, see [gnomon.md](gnomon.md).*
+*The naming methodology and construction system are recorded in this registry.*
 
 ---
 
@@ -35,7 +35,7 @@
 | **Hermeneus** | ἑρμηνεύς | "provider" | Hermes' art of carrying meaning across worlds. Anthropic client, model routing, credential management. The translation layer between nous and LLM backends. |
 | **Mneme** | μνήμη | "memory" | Memory as active faculty, the Muse's gift, not passive storage. Facade re-exporting eidos, krites, graphe, episteme. |
 | **Eidos** | εἶδος | "types" | The visible form: what makes a Fact a Fact, a Session a Session. Shared memory types, IDs, error definitions. |
-| **Krites** | κριτής | "engine" | The judge: evaluates queries, decides what follows from rules and facts. Embedded Datalog engine. |
+| **Krites** | κριτής | "engine" | The query judge: judges Datalog query satisfaction, not agent behavior. Embedded Datalog and graph engine. Behavioral/cognitive evaluation lives in Dokimion. |
 | **Graphe** | γραφή | "session" | The inscription: messages written, turns recorded, history preserved. fjall session persistence. |
 | **Episteme** | ἐπιστήμη | "knowledge" | Systematic knowledge: extraction, recall, scoring, dedup, succession. Transforms raw experience into understanding. |
 | **Organon** | ὄργανον | "tools" | Aristotle's name for the instruments of thought, that by which the mind extends itself. Tool registry, definitions, built-in tool set. |
@@ -50,7 +50,7 @@
 | **Nous** | νοῦς | "agent" | Direct apprehension, the highest mode of knowing, distinct from discursive thought. The agent pipeline: bootstrap, recall, execute, finalize. |
 | **Dianoia** | διάνοια | "planning" | Discursive reasoning, Plato's divided line: thinking *through* problems step by step. Multi-phase planning orchestrator, project context tracking. |
 | **Thesauros** | θησαυρός | "packs" | The storehouse, a treasury of accumulated knowledge held ready for use. Domain pack loader: knowledge, tools, config overlays. |
-| **Dokimion** | δοκίμιον | "eval" | The test, the proof, that which demonstrates whether something is genuine. Behavioral evaluation framework, HTTP scenario runner. |
+| **Dokimion** | δοκίμιον | "eval" | The test, the proof, that which demonstrates whether something is genuine. Behavioral and cognitive evaluation framework, HTTP scenario runner. |
 
 ### High layer
 


### PR DESCRIPTION
## Summary
- qualify Krites as the embedded Datalog/graph query engine, not an agent behavior evaluator
- document Dokimion as the behavioral and cognitive evaluation runner in architecture and naming docs
- add a boundary regression test covering crate docs and canonical docs

## Gates
- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- kanon lint --summary crates/krites/src/lib.rs
- kanon lint --summary crates/krites/tests/naming_boundary.rs
- kanon lint --summary docs/ARCHITECTURE.md
- kanon lint --summary docs/lexicon.md
- kanon lint --summary docs/glossary.md
- git diff --check

Note: replacement for closed PR #4012; diff is unchanged, commit trailer corrected per AGENTS.md.

Closes #3960