### PR TITLE
fix(organon): make energeia tool limits explicit

### DIFF
--- a/crates/organon/src/builtins/energeia/mod.rs
+++ b/crates/organon/src/builtins/energeia/mod.rs
@@ -1,14 +1,14 @@
 //! Energeia capability tool implementations.
 //!
-//! Wires the 9 energeia agent tools to real subsystem calls:
+//! Wires the 9 energeia agent tools to the currently available subsystem calls:
 //! - dromeus → Orchestrator::dispatch / dry_run
-//! - dokimasia → qa::run_qa
+//! - dokimasia → qa::run_qa mechanical checks on caller-provided diffs
 //! - diorthosis → qa::corrective::generate_corrective
-//! - epitropos → steward::service::run_once
+//! - epitropos → steward::service::run_once placeholder classification
 //! - parateresis → EnergeiaStore observation pipeline
 //! - mathesis → EnergeiaStore::query_lessons / add_lesson
-//! - prographe → prompt template rendering
-//! - schedion → PromptDag + compute_frontier
+//! - prographe → prompt template rendering, not queue allocation or file writes
+//! - schedion → empty PromptDag + compute_frontier until a prompt path is supplied
 //! - metron → MetricsService health / cost / velocity
 
 mod dispatch;
@@ -28,14 +28,15 @@ use crate::registry::ToolRegistry;
 
 // ── registration ───────────────────────────────────────────────────────────
 
-/// Register all 9 energeia tools with real implementations.
+/// Register all 9 energeia tools.
 ///
 /// When `services` is `Some`, tools that need the orchestrator or store call
 /// through to the real energeia subsystem. When `None`, those tools return a
 /// structured error indicating the missing dependency — they do not panic.
 ///
-/// Tools that are pure computation (schedion, prographe, diorthosis,
-/// dokimasia, epitropos) work regardless of whether services are provided.
+/// Tools that are bounded local computations (`schedion`, `prographe`,
+/// `diorthosis`, `dokimasia`, `epitropos`) work regardless of whether services
+/// are provided, but their public definitions describe the current limitations.
 ///
 /// # Errors
 ///

--- a/crates/organon/src/builtins/energeia/planning.rs
+++ b/crates/organon/src/builtins/energeia/planning.rs
@@ -25,9 +25,9 @@ use super::shared::{opt_str, opt_u64, require_str, to_json_text};
 pub(super) fn prographe_def() -> ToolDef {
     ToolDef {
         name: ToolName::from_static("prographe"),
-        description: "Render a prompt spec from a GitHub issue or description. \
-            Assigns the next available prompt number, writes the spec file, \
-            and returns the generated content."
+        description: "Render a prompt spec template from a GitHub issue number or \
+            description. This tool does not allocate queue numbers or write files; \
+            it returns YAML with number 0 for the caller to save."
             .to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -36,7 +36,8 @@ pub(super) fn prographe_def() -> ToolDef {
                     "from_issue".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::Integer,
-                        description: "GitHub issue number to base the prompt spec on".to_owned(),
+                        description: "GitHub issue number used only to seed template text"
+                            .to_owned(),
                         enum_values: None,
                         default: None,
                     },
@@ -45,7 +46,9 @@ pub(super) fn prographe_def() -> ToolDef {
                     "project".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::String,
-                        description: "GitHub project slug (owner/repo)".to_owned(),
+                        description: "GitHub project slug echoed in the result; no project files \
+                            are read or written"
+                            .to_owned(),
                         enum_values: None,
                         default: None,
                     },
@@ -137,6 +140,9 @@ impl ToolExecutor for ProographeExecutor {
                 "project": project,
                 "spec": spec_yaml,
                 "criteria_count": criteria.len(),
+                "prompt_number_assigned": false,
+                "files_written": [],
+                "note": "Template only: number 0 is a placeholder and no files were written.",
             });
 
             Ok(to_json_text(&output))
@@ -149,8 +155,9 @@ impl ToolExecutor for ProographeExecutor {
 pub(super) fn schedion_def() -> ToolDef {
     ToolDef {
         name: ToolName::from_static("schedion"),
-        description: "Visualize the prompt dependency DAG for a project and compute the \
-            execution frontier: which prompt specs are ready to dispatch now."
+        description: "Compute the execution frontier for an empty prompt dependency DAG. \
+            The tool does not load prompt specs from a project path yet, so callers should \
+            use the CLI dispatch pipeline for file-backed DAGs."
             .to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -158,7 +165,9 @@ pub(super) fn schedion_def() -> ToolDef {
                 "project".to_owned(),
                 PropertyDef {
                     property_type: PropertyType::String,
-                    description: "GitHub project slug (owner/repo)".to_owned(),
+                    description: "GitHub project slug echoed in the result; no prompt files are \
+                        loaded from it"
+                        .to_owned(),
                     enum_values: None,
                     default: None,
                 },
@@ -201,6 +210,7 @@ impl ToolExecutor for SchedionExecutor {
                 "node_count": 0,
                 "frontier_group_count": frontier.len(),
                 "frontier": frontier,
+                "loaded_prompt_specs": false,
                 "note": "No prompt spec files found via tool call. \
                     Use the CLI dispatch pipeline to load prompts from the filesystem.",
             });

--- a/crates/organon/src/builtins/energeia/steward.rs
+++ b/crates/organon/src/builtins/energeia/steward.rs
@@ -1,7 +1,9 @@
 //! Steward tool (epitropos — ἐπίτροπος, steward).
 //!
-//! CI steward: monitors pull requests, auto-merges passing PRs, and queues
-//! failing PRs for repair.
+//! CI steward tool surface.
+//!
+//! The current tool executor runs one placeholder steward classification pass.
+//! It does not start the polling loop, merge PRs, or queue repair work.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -25,8 +27,9 @@ use super::shared::{opt_bool, require_str, to_json_text};
 pub(super) fn epitropos_def() -> ToolDef {
     ToolDef {
         name: ToolName::from_static("epitropos"),
-        description: "CI steward: monitor pull requests, auto-merge passing PRs, \
-            queue failing PRs for repair. Runs as a polling loop unless `once` is set."
+        description: "Run one placeholder CI steward classification pass. The tool \
+            does not poll, merge PRs, or queue repair work until the steward backend \
+            is wired."
             .to_owned(),
         extended_description: None,
         input_schema: InputSchema {
@@ -44,8 +47,8 @@ pub(super) fn epitropos_def() -> ToolDef {
                     "once".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::Boolean,
-                        description: "Run a single classification pass instead of a polling loop \
-                            (default: false)"
+                        description: "Accepted for compatibility; this tool always runs one \
+                            classification pass and never starts a polling loop"
                             .to_owned(),
                         enum_values: None,
                         default: Some(serde_json::json!(false)),
@@ -55,8 +58,8 @@ pub(super) fn epitropos_def() -> ToolDef {
                     "dry_run".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::Boolean,
-                        description: "Classify PRs without merging or queuing repairs \
-                            (default: false)"
+                        description: "Accepted for compatibility; the placeholder pass has no \
+                            merge or repair side effects"
                             .to_owned(),
                         enum_values: None,
                         default: Some(serde_json::json!(false)),
@@ -103,12 +106,17 @@ impl ToolExecutor for EpitroposExecutor {
             let output = serde_json::json!({
                 "project": project,
                 "dry_run": dry_run,
+                "mode": "single_placeholder_pass",
+                "polling_loop_started": false,
+                "merge_side_effects_enabled": false,
+                "repair_queue_side_effects_enabled": false,
                 "classified_count": result.classified.len(),
                 "merged_count": result.merged.len(),
                 "needs_fix_count": result.needs_fix.len(),
                 "blocked_count": result.blocked.len(),
                 "main_ci_status": format!("{:?}", result.main_ci_status),
                 "main_fix_attempted": result.main_fix_attempted,
+                "note": "run_once currently returns placeholder classification data.",
             });
 
             Ok(to_json_text(&output))

--- a/crates/organon/tests/energeia_tools.rs
+++ b/crates/organon/tests/energeia_tools.rs
@@ -19,7 +19,7 @@ use tempfile::TempDir;
 
 use organon::builtins::energeia::{EnergeiaServices, register};
 use organon::registry::ToolRegistry;
-use organon::types::{ToolContext, ToolInput, ToolResult};
+use organon::types::{ToolContext, ToolDef, ToolInput, ToolResult};
 
 // ── Mock QA gate ─────────────────────────────────────────────────────────────
 
@@ -113,6 +113,21 @@ fn assert_non_error(result: &ToolResult, tool: &str) {
         "{tool}: expected non-error result, got error: {:?}",
         result.content
     );
+}
+
+fn definition_for(name: &str) -> ToolDef {
+    let mut registry = ToolRegistry::new();
+    register(&mut registry, None).expect("register");
+    registry
+        .definitions()
+        .into_iter()
+        .find(|def| def.name.as_str() == name)
+        .unwrap_or_else(|| panic!("{name} definition registered"))
+        .clone()
+}
+
+fn result_json(result: &ToolResult) -> serde_json::Value {
+    serde_json::from_str(&result.content.text_summary()).expect("tool result is JSON text")
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -382,6 +397,125 @@ fn dokimasia_description_advertises_mechanical_only_qa() {
         dokimasia.description.contains("empty diffs return no-work"),
         "dokimasia should document its empty-diff behavior"
     );
+}
+
+#[test]
+fn placeholder_tool_descriptions_match_current_side_effect_limits() {
+    let prographe = definition_for("prographe");
+    assert!(
+        prographe.description.contains("prompt spec template"),
+        "prographe should advertise template rendering, got: {}",
+        prographe.description
+    );
+    assert!(
+        prographe
+            .description
+            .contains("does not allocate queue numbers")
+            && prographe.description.contains("write files"),
+        "prographe must not claim queue allocation or file writes"
+    );
+    assert!(
+        prographe
+            .input_schema
+            .properties
+            .get("project")
+            .expect("project property documented")
+            .description
+            .contains("no project files are read or written"),
+        "prographe project field should document that it is not a file root"
+    );
+
+    let schedion = definition_for("schedion");
+    assert!(
+        schedion.description.contains("empty prompt dependency DAG"),
+        "schedion should document its empty-DAG behavior"
+    );
+    assert!(
+        schedion.description.contains("does not load prompt specs"),
+        "schedion must not advertise file-backed DAG loading"
+    );
+
+    let epitropos = definition_for("epitropos");
+    assert!(
+        epitropos
+            .description
+            .contains("placeholder CI steward classification pass"),
+        "epitropos should advertise placeholder single-pass classification"
+    );
+    assert!(
+        epitropos.description.contains("does not poll")
+            && epitropos.description.contains("merge PRs")
+            && epitropos.description.contains("queue repair work"),
+        "epitropos must not advertise polling, merge, or repair side effects"
+    );
+    assert!(
+        epitropos
+            .input_schema
+            .properties
+            .get("once")
+            .expect("once property documented")
+            .description
+            .contains("always runs one classification pass"),
+        "epitropos once field should match run_once semantics"
+    );
+}
+
+#[tokio::test]
+async fn placeholder_tool_outputs_report_current_side_effect_limits() {
+    let ctx = make_ctx();
+    let mut registry = ToolRegistry::new();
+    register(&mut registry, None).expect("register");
+
+    let input = make_input(
+        "prographe",
+        serde_json::json!({
+            "project": "acme/test",
+            "description": "Add health endpoint"
+        }),
+    );
+    let result = registry.execute(&input, &ctx).await.unwrap();
+    assert_non_error(&result, "prographe");
+    let output = result_json(&result);
+    assert_eq!(output["prompt_number_assigned"], false);
+    assert_eq!(output["files_written"], serde_json::json!([]));
+    assert!(
+        output["spec"]
+            .as_str()
+            .expect("spec is text")
+            .contains("number: 0"),
+        "prographe should return an unallocated template spec"
+    );
+
+    let input = make_input("schedion", serde_json::json!({"project": "acme/test"}));
+    let result = registry.execute(&input, &ctx).await.unwrap();
+    assert_non_error(&result, "schedion");
+    let output = result_json(&result);
+    assert_eq!(output["node_count"], 0);
+    assert_eq!(output["loaded_prompt_specs"], false);
+    assert!(
+        output["note"]
+            .as_str()
+            .expect("note is text")
+            .contains("No prompt spec files found"),
+        "schedion should explain the empty DAG"
+    );
+
+    let input = make_input(
+        "epitropos",
+        serde_json::json!({
+            "project": "acme/test",
+            "once": false,
+            "dry_run": false
+        }),
+    );
+    let result = registry.execute(&input, &ctx).await.unwrap();
+    assert_non_error(&result, "epitropos");
+    let output = result_json(&result);
+    assert_eq!(output["mode"], "single_placeholder_pass");
+    assert_eq!(output["polling_loop_started"], false);
+    assert_eq!(output["merge_side_effects_enabled"], false);
+    assert_eq!(output["repair_queue_side_effects_enabled"], false);
+    assert_eq!(output["classified_count"], 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make energeia `prographe`, `schedion`, and `epitropos` descriptions match their current template/placeholder behavior
- return explicit no-side-effect metadata for template-only prompt rendering, empty-DAG frontier computation, and steward `run_once`
- add tool-level regression tests for public descriptions and output metadata

Closes #3943.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p organon --features energeia --test energeia_tools`
- `git diff --check`
- `kanon lint --summary crates/organon/src/builtins/energeia/mod.rs`
- `kanon lint --summary crates/organon/src/builtins/energeia/planning.rs`
- `kanon lint --summary crates/organon/src/builtins/energeia/steward.rs`
- `kanon lint --summary crates/organon/tests/energeia_tools.rs`

## Review
- Kimi reviewer dispatch `0000019e52b3ad9bf214b1f7035fb212`: APPROVE
