### PR TITLE
docs(daemon): mark process watchdog unwired

### DIFF
--- a/crates/daemon/src/watchdog_tests.rs
+++ b/crates/daemon/src/watchdog_tests.rs
@@ -16,6 +16,8 @@ use tracing::Instrument;
 
 use super::*;
 
+const RUNBOOK: &str = include_str!("../../../docs/RUNBOOK.md");
+
 struct MockProcess {
     id: String,
     kill_called: AtomicBool,
@@ -74,6 +76,30 @@ fn watchdog_config_default_values() {
     assert_eq!(config.heartbeat_timeout, Duration::from_mins(1));
     assert_eq!(config.check_interval, Duration::from_secs(10));
     assert_eq!(config.max_restarts, 5);
+}
+
+#[test]
+fn runbook_separates_live_systemd_watchdog_from_unwired_process_watchdog() {
+    assert!(
+        RUNBOOK.contains("### Systemd watchdog heartbeat (live)"),
+        "runbook must document the live service-level watchdog"
+    );
+    assert!(
+        RUNBOOK.contains("### Daemon process watchdog (not wired)"),
+        "runbook must document that the per-process watchdog is not runtime-wired"
+    );
+    assert!(
+        RUNBOOK.contains("not wired into runtime startup yet"),
+        "runbook must not describe the process watchdog as an operational feature"
+    );
+    assert!(
+        RUNBOOK.contains("individual daemon tasks"),
+        "systemd watchdog docs must not imply per-process monitoring"
+    );
+    assert!(
+        RUNBOOK.contains("enabling them does not start a monitor"),
+        "reserved config fields must not be advertised as live toggles"
+    );
 }
 
 #[test]

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -24,7 +24,7 @@
 | Maintenance | `maintenance/` | Trace rotation, drift detection, DB monitoring, retention, knowledge maintenance, fact-extraction persistence |
 | Coordination | `coordination.rs` | Child agent spawning with concurrency limits |
 | Triggers | `triggers.rs` | Event-driven activation: file watchers, webhooks |
-| Watchdog | `watchdog.rs` | Process heartbeat monitoring with auto-recovery |
+| Watchdog | `watchdog.rs` | Tested process heartbeat monitor library; not wired into runtime startup yet |
 | State | `state.rs` | fjall persistence, workspace config, single-instance locking |
 
 ### What oikonomos does NOT do
@@ -37,7 +37,7 @@
 
 Oikonomos and dianoia are siblings, not parent/child:
 
-- **Oikonomos**: runs on a clock. Schedules tasks, fires on cron expressions, manages maintenance. Think cron + systemd watchdog.
+- **Oikonomos**: runs on a clock. Schedules tasks, fires on cron expressions, manages maintenance. Runtime liveness uses the systemd watchdog heartbeat; the per-process watchdog library is not started yet.
 - **Dianoia**: runs on intent. Orchestrates multi-step plans, allocates attention across projects, detects stuck states. Think project manager.
 
 They share no code. Oikonomos calls nous actors via `DaemonBridge`; dianoia will coordinate via the planning adapter. Both are leaf crates with no cross-dependency.
@@ -114,7 +114,8 @@ Active windows restrict execution to time ranges (e.g., `active_window: Some((8,
 - Consecutive failures trigger exponential backoff (1min → 5min → 15min)
 - 3 consecutive failures auto-disable the task
 - Catch-up mode: missed cron windows within 24h are executed on startup
-- Watchdog monitors heartbeat; auto-restarts unresponsive tasks
+- Systemd watchdog heartbeat covers whole-service liveness when the service unit enables `WatchdogSec`
+- The per-process watchdog library is tested but not yet started by runtime, so it does not auto-restart daemon tasks today
 
 ---
 

--- a/docs/HOT-RELOAD.md
+++ b/docs/HOT-RELOAD.md
@@ -153,10 +153,10 @@ Every `AletheiaConfig` field is classified as either **Hot** (safe to apply via 
 | `maintenance.diskSpace.checkIntervalSecs` | Hot | Interval read by background task |
 | `maintenance.retention.enabled` | Hot | Retention toggle checked by background task |
 | `maintenance.knowledgeMaintenanceEnabled` | Hot | Maintenance toggle checked by background task |
-| `maintenance.watchdog.enabled` | Hot | Watchdog toggle checked by monitor |
-| `maintenance.watchdog.heartbeatTimeoutSecs` | Hot | Timeout read by monitor |
-| `maintenance.watchdog.checkIntervalSecs` | Hot | Interval read by monitor |
-| `maintenance.watchdog.maxRestarts` | Hot | Max restarts read by monitor |
+| `maintenance.watchdog.enabled` | Reserved | Per-process watchdog monitor is not wired into runtime startup |
+| `maintenance.watchdog.heartbeatTimeoutSecs` | Reserved | Reserved for future per-process watchdog integration |
+| `maintenance.watchdog.checkIntervalSecs` | Reserved | Reserved for future per-process watchdog integration |
+| `maintenance.watchdog.maxRestarts` | Reserved | Reserved for future per-process watchdog integration |
 | `maintenance.cronTasks.evolution.enabled` | Hot | Task toggle checked by scheduler |
 | `maintenance.cronTasks.evolution.intervalSecs` | Hot | Interval read by scheduler |
 | `maintenance.cronTasks.reflection.enabled` | Hot | Task toggle checked by scheduler |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -443,82 +443,64 @@ RUST_LOG=aletheia_hermeneus=trace,aletheia=info aletheia   # LLM-only trace
 
 ## Watchdog
 
-The watchdog monitors registered processes via periodic heartbeats and restarts them automatically when they stop responding. It is defined in `crates/daemon/src/watchdog.rs` and configured under `[maintenance.watchdog]`.
+Aletheia distinguishes two watchdog mechanisms with different operational status.
 
-Watchdog is **disabled by default** (`enabled = false`).
+### Systemd watchdog heartbeat (live)
 
-### Configuration
+When Aletheia runs under a systemd unit with `Type=notify` and `WatchdogSec`,
+the runtime sends `READY=1`, periodic `WATCHDOG=1`, and `STOPPING=1`
+notifications through `sd_notify`. This is the live watchdog path.
+
+This mechanism monitors the whole Aletheia service. If the Tokio runtime stops
+sending heartbeats, systemd can restart the service. It does not monitor or
+restart individual daemon tasks, agents, or child processes.
+
+Check the live heartbeat with:
+
+```bash
+journalctl --user -u aletheia --since "1 hour ago" | grep "systemd watchdog"
+systemctl --user show aletheia -p WatchdogUSec -p Type
+```
+
+### Daemon process watchdog (not wired)
+
+`crates/daemon/src/watchdog.rs` contains a tested process-watchdog library for
+registered processes, per-process heartbeats, restart backoff, and states such
+as `Healthy`, `Hung`, `Restarting`, and `Abandoned`.
+
+That library is **not wired into runtime startup yet**. The daemon does not
+construct `Watchdog`, register the system runner or agent runners with it, or
+send per-process heartbeats. The `[maintenance.watchdog]` config fields are
+reserved for that future integration; enabling them does not start a monitor or
+produce per-process restart logs today.
+
+Do not expect these implementation-level log messages in production yet:
+
+| Future message | Current status |
+|----------------|----------------|
+| `watchdog: registered process` | Not emitted by runtime |
+| `watchdog: hung process detected - no heartbeat` | Not emitted by runtime |
+| `watchdog: restarting process` | Not emitted by runtime |
+| `watchdog: process restarted successfully` | Not emitted by runtime |
+| `watchdog: process recovered - heartbeat received` | Not emitted by runtime |
+| `watchdog: restart failed - applying backoff` | Not emitted by runtime |
+| `watchdog: max restarts exceeded - abandoning process` | Not emitted by runtime |
+
+Reserved config shape:
 
 ```toml
 [maintenance.watchdog]
-enabled = true
-heartbeat_timeout_secs = 60   # seconds without heartbeat before declaring a process hung
-check_interval_secs = 10      # sweep interval
-max_restarts = 5              # restart attempts before abandoning the process
+enabled = false
+heartbeat_timeout_secs = 60
+check_interval_secs = 10
+max_restarts = 5
 ```
 
-Changes to these values require a service restart (cold fields).
-
-### Process states
-
-| State | Meaning |
-|-------|---------|
-| `Healthy` | Heartbeats arriving within timeout |
-| `Hung` | Missed heartbeat deadline, restart pending |
-| `Restarting` | Kill and restart sequence in progress |
-| `Abandoned` | Exceeded `max_restarts`, no longer monitored |
-
-### Check status
-
-Watchdog emits structured logs at each state change. Filter them with:
+### Recovery guidance
 
 ```bash
-journalctl --user -u aletheia --since "1 hour ago" | grep watchdog
-```
-
-| Level | Message | Meaning |
-|-------|---------|---------|
-| INFO | `watchdog: registered process` | Process enrolled |
-| WARN | `watchdog: hung process detected - no heartbeat` | Timeout exceeded (includes `elapsed_secs`, `timeout_secs`) |
-| WARN | `watchdog: restarting process` | Restart initiated (includes `cause`, `attempt`) |
-| INFO | `watchdog: process restarted successfully` | Recovery succeeded |
-| INFO | `watchdog: process recovered - heartbeat received` | Process self-recovered before restart |
-| ERROR | `watchdog: restart failed - applying backoff` | Restart failed (includes `attempt`, `error`) |
-| ERROR | `watchdog: max restarts exceeded - abandoning process` | Process abandoned (includes `restart_count`, `max_restarts`) |
-
-### Restart backoff
-
-Failed restarts use exponential backoff: base 2 seconds, cap 300 seconds (5 minutes).
-
-| Attempt | Delay |
-|---------|-------|
-| 1 | 2 s |
-| 2 | 4 s |
-| 3 | 8 s |
-| 4 | 16 s |
-| 5 | 32 s |
-| 6+ | 64 s ... capped at 300 s |
-
-### Heartbeat timeout too short
-
-If processes are marked hung during heavy load, increase the timeout:
-
-```toml
-[maintenance.watchdog]
-heartbeat_timeout_secs = 120
-```
-
-Restart the service for this to take effect.
-
-### Process abandoned
-
-Once a process enters `Abandoned` state, the watchdog stops monitoring it entirely. Only a service restart resets watchdog state.
-
-```bash
-# Confirm in logs:
-journalctl --user -u aletheia --since "1 hour ago" | grep "max restarts exceeded"
-
-# Reset by restarting:
+# If the whole service is unhealthy, rely on systemd or restart it directly:
+systemctl --user status aletheia
 systemctl --user restart aletheia
 aletheia health
 ```


### PR DESCRIPTION
## Summary
- split the live systemd watchdog heartbeat from the not-yet-wired daemon process watchdog in the runbook
- mark `[maintenance.watchdog]` fields as reserved in hot-reload docs
- update daemon docs so they no longer imply per-process watchdog auto-restart is active
- add a daemon regression test that anchors the runbook boundary

Closes #3942.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p oikonomos watchdog`
- `git diff --check`
- `kanon lint --summary docs/RUNBOOK.md`
- `kanon lint --summary docs/DAEMON.md`
- `kanon lint --summary docs/HOT-RELOAD.md`
- `kanon lint --summary crates/daemon/src/watchdog_tests.rs`

## Review
- Kimi reviewer dispatch `0000019e52baa645f214b1f7035fb214`: APPROVE
