### PR TITLE
docs(daemon): mark trigger coordination as reserved

### DIFF
--- a/crates/daemon/src/coordination.rs
+++ b/crates/daemon/src/coordination.rs
@@ -1,17 +1,20 @@
-//! Team coordination: child agent spawning with concurrency limits.
+//! Reserved child-agent coordination boundary.
 //!
-//! WHY: Daemon-mode operations that exceed a single agent's scope (e.g.,
-//! multi-file refactors, parallel knowledge graph updates) need controlled
-//! child agent spawning with backpressure.
+//! WHY: daemon-mode operations that exceed a single agent's scope may need
+//! controlled child-agent spawning with backpressure. The current daemon
+//! runtime does not spawn, join, kill, or track child agents yet.
 
-/// Coordinator manages child agent lifecycle with concurrency limits.
+/// Reserved coordinator configuration for future child-agent lifecycle wiring.
+///
+/// Today this type only stores the configured child concurrency limit. It does
+/// not spawn child agents or track in-flight children.
 #[derive(Debug)]
 pub struct Coordinator {
     max_children: usize,
 }
 
 impl Coordinator {
-    /// Create a new coordinator with the given concurrency limit.
+    /// Create a reserved coordinator marker with the given concurrency limit.
     #[must_use]
     pub fn new(max_children: usize) -> Self {
         Self { max_children }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -7,12 +7,13 @@
 //! attention checks (prosoche), and maintenance cycles for each nous.
 //!
 //! Supports KAIROS-style autonomous daemon mode with jitter-aware scheduling,
-//! single-instance locking, child agent coordination, event-driven triggers,
-//! and systemd notify integration.
+//! single-instance locking, and systemd notify integration. Child-agent
+//! coordination and event-driven triggers are reserved API boundaries, not
+//! wired runtime capabilities yet.
 
 /// Bridge trait for daemon-to-nous communication without direct dependency coupling.
 pub mod bridge;
-/// Team coordination: child agent spawning with concurrency limits.
+/// Reserved child-agent coordination boundary.
 pub mod coordination;
 /// Periodic cron tasks: evolution, reflection, and graph cleanup.
 pub mod cron;
@@ -46,7 +47,7 @@ pub mod schedule;
 pub mod self_prompt;
 /// Task-state persistence (fjall), workspace config, and single-instance locking.
 pub mod state;
-/// Event-driven activation: file watchers and webhook receiver.
+/// Reserved external trigger boundary.
 pub mod triggers;
 /// Watchdog process monitor with heartbeat tracking and auto-recovery.
 pub mod watchdog;

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -40,7 +40,9 @@ pub struct DaemonConfig {
     #[serde(default)]
     pub enabled: bool,
 
-    /// Maximum concurrent child agents the daemon may spawn.
+    /// Reserved child-agent concurrency limit.
+    ///
+    /// The current runtime stores this value but does not spawn child agents.
     #[serde(default = "default_max_children")]
     pub max_children: usize,
 
@@ -52,11 +54,13 @@ pub struct DaemonConfig {
     #[serde(default)]
     pub allowed_tasks: Vec<String>,
 
-    /// Webhook listener port. `None` disables the webhook trigger.
+    /// Reserved webhook listener port. The current runtime does not start a
+    /// webhook listener.
     #[serde(default)]
     pub webhook_port: Option<u16>,
 
-    /// File watch paths (relative to workspace root). Empty disables file watching.
+    /// Reserved file watch paths (relative to workspace root). The current
+    /// runtime does not start file watchers.
     #[serde(default)]
     pub watch_paths: Vec<String>,
 
@@ -95,10 +99,10 @@ impl Default for DaemonConfig {
 /// Which trigger types are permitted in this workspace.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AllowedTriggers {
-    /// Allow file-watcher triggers.
+    /// Reserved file-watcher trigger opt-in.
     #[serde(default)]
     pub file_watch: bool,
-    /// Allow webhook triggers.
+    /// Reserved webhook trigger opt-in.
     #[serde(default)]
     pub webhook: bool,
 }

--- a/crates/daemon/src/triggers.rs
+++ b/crates/daemon/src/triggers.rs
@@ -1,17 +1,22 @@
-//! Event-driven activation: file watchers and webhook receiver.
+//! Reserved event-trigger boundary.
 //!
-//! WHY: KAIROS daemon needs to react to external events (file changes,
-//! webhook calls) in addition to cron-scheduled tasks. The trigger router
-//! multiplexes these event sources into the task runner.
+//! WHY: KAIROS eventually needs to react to external events (file changes,
+//! webhook calls) in addition to cron-scheduled tasks. The current runtime
+//! does not start file watchers, a webhook listener, or task queue dispatch
+//! from external events yet.
 
-/// Routes external events (file changes, webhooks) to registered task handlers.
+/// Reserved handle for future external trigger routing.
+///
+/// Today this type has no handler registry and does not dispatch file-watch or
+/// webhook events into the task runner. It remains as a stable API marker for
+/// the planned trigger subsystem.
 #[derive(Debug)]
 pub struct TriggerRouter {
     _private: (),
 }
 
 impl TriggerRouter {
-    /// Create a new trigger router.
+    /// Create an unwired trigger-router marker.
     #[must_use]
     pub fn new() -> Self {
         Self { _private: () }

--- a/crates/daemon/tests/public_api_misc.rs
+++ b/crates/daemon/tests/public_api_misc.rs
@@ -123,15 +123,17 @@ fn workspace_guard_acquires_releases_and_reacquires_cleanly() {
 fn coordinator_preserves_max_children_limit() {
     let coord = Coordinator::new(4);
     assert_eq!(coord.max_children(), 4);
-    // Coordinator is intentionally small — verify it survives zero capacity.
+    // Coordinator is a reserved boundary today: it preserves configuration but
+    // does not spawn or track children yet. Verify it survives zero capacity.
     let zero = Coordinator::new(0);
     assert_eq!(zero.max_children(), 0);
 }
 
 #[test]
 fn trigger_router_default_and_new_produce_equivalent_routers() {
-    // TriggerRouter currently has no observable state, so we verify only that
-    // both constructors succeed and the type is Debug-printable.
+    // TriggerRouter is a reserved boundary today with no observable event
+    // dispatch state. Verify both constructors succeed and the type remains
+    // Debug-printable while it is unwired.
     let via_new = TriggerRouter::new();
     let via_default = TriggerRouter::default();
     let new_debug = format!("{via_new:?}");

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -22,8 +22,8 @@
 | Scheduling | `schedule.rs` | Cron expressions (jiff-native parser), intervals, one-shots, jitter |
 | Prosoche | `prosoche.rs` | Periodic attention checks - agent surveys environment | 
 | Maintenance | `maintenance/` | Trace rotation, drift detection, DB monitoring, retention, knowledge maintenance, fact-extraction persistence |
-| Coordination | `coordination.rs` | Child agent spawning with concurrency limits |
-| Triggers | `triggers.rs` | Event-driven activation: file watchers, webhooks |
+| Coordination | `coordination.rs` | Reserved child-agent concurrency boundary; no spawn/join lifecycle is wired yet |
+| Triggers | `triggers.rs` | Reserved external trigger boundary; no file watcher or webhook dispatch is wired yet |
 | Watchdog | `watchdog.rs` | Tested process heartbeat monitor library; not wired into runtime startup yet |
 | State | `state.rs` | fjall persistence, workspace config, single-instance locking |
 
@@ -32,6 +32,8 @@
 - **Dispatch orchestration** - energeia handles prompt dispatch, session management, and QA
 - **Cross-project coordination** - dianoia (#2291) handles attention allocation across projects
 - **Planning** - dianoia handles plan lifecycle, phase gates, stuck detection
+- **External event triggers** - file-watcher and webhook config fields are reserved; the daemon does not listen for those events yet
+- **Child-agent lifecycle management** - `Coordinator` stores the intended concurrency limit, but it does not spawn, join, kill, or track children yet
 
 ### Relationship to dianoia
 
@@ -54,19 +56,19 @@ KAIROS mode composes the daemon subsystems into continuous autonomous operation:
                     │  (cron loop) │
                     └──────┬──────┘
                            │
-              ┌────────────┼────────────┐
-              ▼            ▼            ▼
-        ┌──────────┐ ┌──────────┐ ┌──────────┐
-        │ Prosoche │ │  Maint.  │ │ Triggers │
-        │ (attend) │ │ (rotate, │ │  (watch,  │
-        │          │ │  gc, ...)│ │  webhook) │
-        └────┬─────┘ └──────────┘ └─────┬────┘
-             │                          │
-             ▼                          ▼
-        ┌──────────┐           ┌──────────────┐
-        │  Daemon   │           │ Coordination │
-        │  Bridge   │           │ (child spawn)│
-        └────┬─────┘           └──────────────┘
+              ┌────────────┴────────────┐
+              ▼                         ▼
+        ┌──────────┐ ┌──────────┐
+        │ Prosoche │ │  Maint.  │
+        │ (attend) │ │ (rotate, │
+        │          │ │  gc, ...)│
+        └────┬─────┘ └──────────┘
+             │
+             ▼
+        ┌──────────┐
+        │  Daemon  │
+        │  Bridge  │
+        └────┬─────┘
              │
              ▼
         ┌──────────┐
@@ -74,6 +76,10 @@ KAIROS mode composes the daemon subsystems into continuous autonomous operation:
         │  Actor   │
         └──────────┘
 ```
+
+`TriggerRouter` and `Coordinator` remain reserved API boundaries outside the
+live diagram until external event dispatch and child-agent lifecycle tracking
+are implemented.
 
 ### Scheduling
 
@@ -122,5 +128,10 @@ Active windows restrict execution to time ranges (e.g., `active_window: Some((8,
 ## Status
 
 Oikonomos is implemented. KAIROS mode is scaffolded - the subsystems exist and are tested, and maintenance now includes persistent fact extraction plus drift/knowledge maintenance wiring. The full autonomous prosoche-to-decision-to-action loop remains the boundary for KAIROS completion. Integration with dianoia for cross-project attention is planned for Phase 05e.
+
+Event-driven triggers and child-agent coordination are also still scaffolded:
+their public types and config fields reserve the future boundary, but no
+runtime path starts file watchers, listens for webhooks, or manages child-agent
+lifecycles today.
 
 See [PROSOCHE.md](PROSOCHE.md) for the attention subsystem detail.


### PR DESCRIPTION
## Summary
- mark daemon TriggerRouter and Coordinator as reserved/unwired API boundaries
- remove trigger/coordination boxes from the live KAIROS runtime diagram
- clarify reserved daemon config fields and public API test comments

Closes #3946.

## Gates
- cargo fmt --all -- --check
- cargo check -p oikonomos
- cargo test -p oikonomos --test public_api_misc
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- git diff --check
- kanon lint --summary on touched files; only pre-existing baseline findings appeared on unchanged lines in state.rs/public_api_misc.rs
- Kimi reviewer 0000019e52c87e9bf214b1f7035fb216: APPROVE