### PR TITLE
docs(memory-mcp): align write contract metadata

### DIFF
--- a/_llm/L1-workspace.md
+++ b/_llm/L1-workspace.md
@@ -9,7 +9,7 @@ Aletheia is a single-binary Rust agent runtime with 44 workspace crates plus the
 | `aletheia` | `crates/aletheia` | Aletheia cognitive agent runtime. |
 | `aletheia-classify` | `crates/aletheia-classify` | aletheia-classify crate in the Aletheia workspace. |
 | `aletheia-lexica` | `crates/aletheia-lexica` | Static lexicon and data constants for Aletheia. |
-| `aletheia-memory-mcp` | `crates/aletheia-memory-mcp` | Standalone stdio MCP server exposing Aletheia's memory and knowledge graph (read-only) to external agents. |
+| `aletheia-memory-mcp` | `crates/aletheia-memory-mcp` | Standalone stdio MCP server exposing Aletheia's memory and token-gated write tools to external agents. |
 | `aletheia-routing` | `crates/aletheia-routing` | Shared routing trait and empirical success-rate storage for dispatch and interactive paths. |
 | `diaporeia` | `crates/diaporeia` | MCP server interface - the passage through for external AI agents. |
 | `dianoia` | `crates/dianoia` | Planning and project orchestration - multi-phase state machine with workspace persistence. |
@@ -54,12 +54,19 @@ Aletheia is a single-binary Rust agent runtime with 44 workspace crates plus the
 ## Layer grouping
 
 **Foundations.** Core data, errors, classification, and static facts: `koina`, `eidos`, `dianoia`, `aletheia-lexica`.
+
 **Storage and knowledge.** Sessions, Datalog, recall, ingestion, and memory facade: `graphe`, `krites`, `episteme`, `mneme`, `gnosis`.
+
 **LLM, tools, and runtime.** Providers, tools, distillation, domain packs, and the agent actor pipeline: `hermeneus`, `organon`, `melete`, `thesauros`, `nous`.
+
 **Auth, gateway, MCP, and channels.** HTTP, auth/RBAC, external MCP, Signal/channel routing: `symbolon`, `pylon`, `diaporeia`, `agora`, `aletheia-memory-mcp`.
+
 **Dispatch, daemon, and routing.** Background maintenance, empirical routing, and dispatch orchestration: `oikonomos`, `aletheia-routing`, `energeia`.
+
 **CLI and operators.** Binary wiring, migrations, evals, and integration canaries: `aletheia`, `aletheia-sessions-migrate`, `dokimion`, `integration-tests`.
+
 **Poiesis document stack.** Report model, renderers, diff/inspect/intake/scaffold helpers: `poiesis-core`, `poiesis-text`, `poiesis-sheet`, `poiesis-slides`, `poiesis-lint`, `poiesis-verify`, `poiesis-typst`, `poiesis-intake`, `poiesis-doc`, `poiesis-diff`, `poiesis-inspect`, `poiesis-scaffold`.
+
 **Presentation.** Shared UI client, TUI, facade, and excluded desktop shell: `skene`, `koilon`, `theatron`, `proskenion`.
 
 ## Dependency direction

--- a/_llm/L2-crate-summaries/aletheia-memory-mcp.md
+++ b/_llm/L2-crate-summaries/aletheia-memory-mcp.md
@@ -1,6 +1,6 @@
 # aletheia-memory-mcp
 
-**Purpose:** Standalone stdio MCP server exposing Aletheia's memory and knowledge graph (read-only) to external agents.
+**Purpose:** Standalone stdio MCP server exposing Aletheia's memory and token-gated write tools to external agents.
 
 ## Key types
 
@@ -24,4 +24,4 @@
 
 ## Recent changes
 
-The standalone MCP surface uses the nous_* namespace and clearly separates Aletheia local nous memory from kanon mnemosyne.
+The standalone MCP surface uses the nous_* namespace, hides write tools unless a per-process capability token is configured, and clearly separates Aletheia local nous memory from kanon mnemosyne.

--- a/crates/aletheia-memory-mcp/Cargo.toml
+++ b/crates/aletheia-memory-mcp/Cargo.toml
@@ -1,14 +1,11 @@
 [package]
 name = "aletheia-memory-mcp"
 version.workspace = true
-description = "Standalone stdio MCP server exposing Aletheia's memory and knowledge graph (read-only) to external agents"
+description = "Standalone stdio MCP server exposing Aletheia's memory and token-gated write tools to external agents"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-
-[lints]
-workspace = true
 
 [[bin]]
 name = "aletheia-memory-mcp"
@@ -60,3 +57,6 @@ rmcp = { version = "=1.5.0", features = [
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 jiff = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary

- update the memory MCP package and _llm summaries so the crate is no longer described as read-only
- state the current contract as memory access plus token-gated write tools
- split the L1 layer grouping into separate paragraphs so the touched _llm file lints cleanly

Closes #3939

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p aletheia-memory-mcp`
- `git diff --check`
- `kanon lint --summary crates/aletheia-memory-mcp/Cargo.toml`
- `kanon lint --summary _llm/L1-workspace.md`
- `kanon lint --summary _llm/L2-crate-summaries/aletheia-memory-mcp.md`

Kimi reviewer `0000019e52d2c28bf214b1f7035fb219`: APPROVE.
