### PR TITLE
chore(workflow): baseline current lint exceptions

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -8,3 +8,16 @@ MANIFEST/dep-count:Cargo.lock
 
 # WHY(#3169): XML namespace URI inside raw string literal, not a network endpoint
 SECURITY/insecure-transport:crates/poiesis/text/src/odt.rs
+
+# WHY(#3987): repo-level context intentionally points at operator-local files
+WORKFLOW/defers-to:CLAUDE.md
+
+# WHY(#3987): supplemental _llm references do not have embedded basanos schemas yet
+WORKFLOW/llm-schema-valid:_llm/api.toml
+WORKFLOW/llm-schema-valid:_llm/manifest.toml
+WORKFLOW/llm-schema-valid:_llm/observability.toml
+WORKFLOW/llm-schema-valid:_llm/recipes.toml
+WORKFLOW/llm-schema-valid:_llm/turn-pipeline.toml
+
+# WHY(#3987): proskenion is a standalone desktop manifest under this repo corpus
+WORKFLOW/llm-corpus-required:crates/theatron/proskenion/Cargo.toml


### PR DESCRIPTION
## Summary

- baseline the current workflow lint exceptions with path-specific `.kanon-lint-ignore` entries
- document why operator-local context references, supplemental `_llm` TOML files, and the standalone proskenion manifest are not actionable workflow failures today
- keep issue #3987 open for the broader writing/Rust/full-workspace lint cleanup

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`
- `kanon lint --summary --workflow`
- `kanon lint --summary .kanon-lint-ignore`

Kimi reviewer `0000019e52de76e6f214b1f7035fb21b`: APPROVE.
