### PR TITLE
docs(gnosis): align fjall cache boundary

### DIFF
--- a/crates/aletheia-sessions-migrate/Cargo.toml
+++ b/crates/aletheia-sessions-migrate/Cargo.toml
@@ -12,14 +12,10 @@ publish = false
 name = "aletheia-sessions-migrate"
 path = "src/main.rs"
 
-# WHY: rusqlite is pinned to 0.31 to match the only other workspace user
-# (`gnosis`). Cargo's `links = "sqlite3"` constraint forbids two
-# different versions of `libsqlite3-sys` in the same dep graph; the
-# alternative would be a major-version bump in gnosis, which is out of
-# scope for this migrator. PR #3446 removed rusqlite from graphe / symbolon /
-# daemon — gnosis is the remaining holder, so we align to its version.
-# `bundled` vendors libsqlite3-sys so the build is deterministic and
-# does not require a system libsqlite3.
+# WHY: this one-shot legacy migrator is the remaining SQLite reader. The
+# production stores are fjall-backed, including gnosis. `bundled` vendors
+# libsqlite3-sys so the build is deterministic and does not require a system
+# libsqlite3 while old 0.15.x session databases can still be imported.
 [dependencies]
 graphe = { path = "../graphe" }
 eidos = { path = "../eidos" }

--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -1,7 +1,7 @@
 //! `aletheia backup`: database backup management.
 //!
 //! Operates on the fjall knowledge store. Session/auth storage also uses fjall;
-//! `rusqlite` remains only for gnosis and legacy migration tooling.
+//! `rusqlite` remains only in the legacy one-shot sessions migrator.
 
 use std::path::{Path, PathBuf};
 
@@ -204,8 +204,15 @@ fn validate_kv(partition: &str, key: &[u8], value: &[u8]) -> std::result::Result
         "revoked_tokens" => validate_utf8(value),
         // Known partitions with opaque/internal encoding, plus unknown partitions:
         // all verified by successful read (iteration implicitly verifies checksums).
-        _ => Ok(()),
+        other => validate_opaque_or_unknown_partition(other),
     }
+}
+
+fn validate_opaque_or_unknown_partition(partition: &str) -> std::result::Result<(), String> {
+    if partition.is_empty() {
+        return Err("partition name must not be empty".into());
+    }
+    Ok(())
 }
 
 fn validate_sessions(key: &[u8], value: &[u8]) -> std::result::Result<(), String> {

--- a/crates/organon/src/builtins/code_graph_query.rs
+++ b/crates/organon/src/builtins/code_graph_query.rs
@@ -30,8 +30,8 @@
 //!
 //! # Cache
 //!
-//! The index lives at `~/.cache/aletheia/gnosis.sqlite` by default.
-//! Override with `GNOSIS_CACHE_PATH`.  Delete the file to force a full rebuild.
+//! The index lives at `~/.cache/aletheia/gnosis.fjall` by default.
+//! Override with `GNOSIS_CACHE_PATH`.  Delete the directory to force a full rebuild.
 //!
 //! # Workspace path
 //!
@@ -352,7 +352,7 @@ fn code_graph_query_def() -> ToolDef {
             "Results carry EpistemicTier::Inferred confidence — machine-derived from AST. \
              Every row has a 'source' field ('gnosis@<schema_version>') for provenance. \
              Index is built from cargo metadata + syn AST walk. Run op=rebuild before \
-             querying if the index is stale. Cache: ~/.cache/aletheia/gnosis.sqlite \
+             querying if the index is stale. Cache: ~/.cache/aletheia/gnosis.fjall \
              (override: GNOSIS_CACHE_PATH). Workspace: GNOSIS_WORKSPACE_ROOT or cwd."
                 .to_owned(),
         ),
@@ -415,5 +415,16 @@ mod tests {
         ] {
             assert!(vals.contains(&(*op).to_owned()), "missing op: {op}");
         }
+    }
+
+    #[test]
+    fn tool_def_documents_fjall_cache_path() {
+        let def = code_graph_query_def();
+        let desc = def
+            .extended_description
+            .as_deref()
+            .expect("extended description");
+        assert!(desc.contains("gnosis.fjall"));
+        assert!(!desc.contains("gnosis.sqlite"));
     }
 }


### PR DESCRIPTION
## Summary

- align stale gnosis references with the current fjall-backed index and `gnosis.fjall` cache path
- clarify that `rusqlite` remains only for the legacy one-shot sessions migrator
- replace backup verification's silent wildcard success with an explicit opaque/unknown partition validator

Closes #3964.

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`
- `kanon lint --summary crates/aletheia/src/commands/backup.rs`
- `kanon lint --summary crates/aletheia-sessions-migrate/Cargo.toml`
- `kanon lint --summary crates/organon/src/builtins/code_graph_query.rs`

## Reviewer

- Kimi reviewer dispatch `0000019e52eff3aef214b1f7035fb21e`: APPROVE
