### PR TITLE
chore(lint): baseline generated writing findings

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -21,3 +21,20 @@ WORKFLOW/llm-schema-valid:_llm/turn-pipeline.toml
 
 # WHY(#3987): proskenion is a standalone desktop manifest under this repo corpus
 WORKFLOW/llm-corpus-required:crates/theatron/proskenion/Cargo.toml
+
+# WHY(#3987): generated _llm crate summaries mirror extracted names and crate metadata
+WRITING/ai-trope:harness:_llm/L2-crate-summaries/integration-tests.md
+WRITING/definitional-opening:_llm/L2-crate-summaries/proskenion.md
+
+# WHY(#3987): generated _llm API indexes mirror extracted Rust doc comments; fix generator/policy before hand-editing snapshots
+WRITING/ai-trope:additionally:_llm/L3-api-index/*.md
+WRITING/ai-trope:comprehensive:_llm/L3-api-index/*.md
+WRITING/ai-trope:harness:_llm/L3-api-index/*.md
+WRITING/ai-trope:underscore:_llm/L3-api-index/*.md
+WRITING/double-space-after-period:_llm/L3-api-index/*.md
+WRITING/elegant-variation:_llm/L3-api-index/*.md
+WRITING/filler-phrase:_llm/L3-api-index/*.md
+WRITING/minimizer:_llm/L3-api-index/*.md
+WRITING/paragraph-length:_llm/L3-api-index/*.md
+WRITING/temporal-staleness:_llm/L3-api-index/*.md
+WRITING/weasel-word:_llm/L3-api-index/*.md


### PR DESCRIPTION
## Summary

- add reviewed, issue-linked writing lint suppressions for generated `_llm` crate-summary/API-index artifacts
- keep hand-authored docs and planning writing findings unsuppressed for follow-up work on #3987
- verify generated `_llm` writing findings are now zero, leaving 81 hand-authored findings visible

Refs #3987.

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --summary .kanon-lint-ignore`
- `git diff --check`

Additional measurement:

- `kanon lint --format json --writing`: 81 total remaining, 0 generated `_llm`, 81 hand-authored

## Reviewer

- Kimi reviewer dispatch `0000019e52f7c6b8f214b1f7035fb220`: APPROVE
