### PR TITLE
docs(lint): clean hand-authored writing findings

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,6 +1,6 @@
-# Configuration Security Defaults
+# Configuration security defaults
 
-## Gateway Auth And Bind
+## Gateway auth and bind
 
 `gateway.auth.mode = "none"` is only supported with a loopback bind such as
 `gateway.bind = "localhost"` or `127.0.0.1`.

--- a/crates/aletheia-memory-mcp/README.md
+++ b/crates/aletheia-memory-mcp/README.md
@@ -4,40 +4,40 @@ Standalone stdio MCP server exposing Aletheia's nous local knowledge store to ex
 
 ## Tools
 
-### Read Tools (Always Available)
+### Read tools (always available)
 
-- `nous_search` — BM25 text search across active facts in the Aletheia nous local knowledge store
-- `nous_neighbors` — one-hop graph traversal from a fact's entities; neighbor rows include `src_id`, `dst_id`, `name`, `entity_type`, `relation`, and `weight`
-- `nous_list_topics` — enumerate fact-type buckets with counts
-- `nous_stats` — knowledge graph health metrics (fact count, schema version, last updated)
+- `nous_search` - BM25 text search across active facts in the Aletheia nous local knowledge store
+- `nous_neighbors` - one-hop graph traversal from a fact's entities; neighbor rows include `src_id`, `dst_id`, `name`, `entity_type`, `relation`, and `weight`
+- `nous_list_topics` - enumerate fact-type buckets with counts
+- `nous_stats` - knowledge graph health metrics (fact count, schema version, last updated)
 
-### Write Tools (Capability Token Gated)
+### Write tools (capability-token gated)
 
-- `nous_annotate` — create an annotation on an existing fact and link it back to the target fact
-- `nous_supersede` — mark one fact as superseded by another
-- `nous_forget` — soft-delete a fact (mark as forgotten)
+- `nous_annotate` - create an annotation on an existing fact and link it back to the target fact
+- `nous_supersede` - mark one fact as superseded by another
+- `nous_forget` - soft-delete a fact (mark as forgotten)
 
 ## Configuration
 
-### Environment Variables
+### Environment variables
 
-- `ALETHEIA_ROOT` — instance root directory (default: `./instance`). The knowledge store is opened at `<root>/data/knowledge.fjall`.
-- `ALETHEIA_MEMORY_MCP_STORE` — override the store path directly.
-- `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` — capability token for write tools. If unset, write tools are not registered.
-- `RUST_LOG` — tracing filter (default: `info`). Logs go to stderr; stdout is JSON-RPC only.
+- `ALETHEIA_ROOT` - instance root directory (default: `./instance`). The knowledge store is opened at `<root>/data/knowledge.fjall`.
+- `ALETHEIA_MEMORY_MCP_STORE` - override the store path directly.
+- `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` - capability token for write tools. If unset, write tools are not registered.
+- `RUST_LOG` - tracing filter (default: `info`). Logs go to stderr; stdout is JSON-RPC only.
 
-## Write Tool Authentication
+## Write tool authentication
 
 Write tools are protected by a **per-process capability token** passed via environment variable at server startup.
 
-### How It Works
+### How it works
 
 1. **Server Startup**: The spawning process (aletheia daemon or operator) generates a random token and sets it in the child's environment as `ALETHEIA_MEMORY_MCP_WRITE_TOKEN`. If this variable is unset, write tools are not registered or listed by MCP discovery.
 2. **Token Validation**: Each write tool call includes a `write_token` field in its input. The server compares it against the configured token using constant-time comparison (via `subtle::ConstantTimeEq`).
 3. **Authorization**: If tokens match, the write proceeds. If they don't match, the call returns an "unauthorized" error.
 4. **Audit Logging**: Successful writes are logged at INFO level to stderr with the tool name and affected fact IDs.
 
-### Token Generation
+### Token generation
 
 Operators should generate tokens cryptographically:
 
@@ -47,14 +47,14 @@ openssl rand -hex 32
 
 This produces a 64-character hexadecimal string suitable for use as `ALETHEIA_MEMORY_MCP_WRITE_TOKEN`.
 
-### Example: Spawning with Write Access
+### Example: spawning with write access
 
 ```bash
 export ALETHEIA_MEMORY_MCP_WRITE_TOKEN=$(openssl rand -hex 32)
 aletheia-memory-mcp  # server inherits the token
 ```
 
-### Example: MCP Client Call
+### Example: MCP client call
 
 ```json
 {
@@ -68,20 +68,20 @@ aletheia-memory-mcp  # server inherits the token
 }
 ```
 
-## Security Notes
+## Security notes
 
 - **Capability Token**: This is a shared secret, not user authentication. Any process with access to the server's environment can invoke writes if it knows the token.
 - **No Encryption**: The token is passed in-process via environment variable and in-protocol via MCP calls. It's not encrypted on the wire; use this server only over local IPC or secure channels (SSH, TLS).
 - **Constant-Time Comparison**: Token comparison uses `subtle::ConstantTimeEq` to prevent timing-based token leakage.
 
-## Admission Control
+## Admission control
 
 Write tools respect the knowledge store's `DefaultAdmissionPolicy` before persisting facts. If a policy rejects a write, the call fails with an admission error.
 
-## Exit Codes
+## Exit codes
 
-- `0` — clean shutdown (peer closed connection)
-- `1` — startup or transport error (details on stderr)
+- `0` - clean shutdown (peer closed connection)
+- `1` - startup or transport error (details on stderr)
 
 ## Development
 

--- a/crates/aletheia/CLAUDE.md
+++ b/crates/aletheia/CLAUDE.md
@@ -1,3 +1,9 @@
+---
+scope: "crates/aletheia/"
+defers_to: ["../../CLAUDE.md"]
+tightens: ["binary adapter, command, and startup wiring guidance"]
+---
+
 # aletheia
 
 ## At a glance
@@ -38,7 +44,7 @@ Binary entrypoint: CLI, server startup, service wiring, and adapter glue. 8.9K l
 ## Recent substrate notes
 
 - CLI scaffold commands now include export-agent, seed-skills persistence, consolidate wiring, and dry-run guards.
-- Binary wiring is responsible for connecting `AuthFacade`, provider registry, working-checkpoint services, and maintenance stores.
+- Binary wiring connects `AuthFacade`, provider registry, working-checkpoint services, and maintenance stores.
 
 ## Common tasks
 

--- a/crates/episteme/README.md
+++ b/crates/episteme/README.md
@@ -9,7 +9,7 @@ of the knowledge graph.
 
 Enable the `openai-embed` feature and set `provider = "openai-compat"` in the
 embedding configuration. This offloads embedding inference to any endpoint that
-implements the OpenAI `/v1/embeddings` surface — OpenAI, Voyage, Cohere (with a
+implements the OpenAI `/v1/embeddings` surface - OpenAI, Voyage, Cohere (with a
 shim), or a local **llama-server**.
 
 ```toml

--- a/crates/organon/CLAUDE.md
+++ b/crates/organon/CLAUDE.md
@@ -1,3 +1,9 @@
+---
+scope: "crates/organon/"
+defers_to: ["../../CLAUDE.md"]
+tightens: ["tool registration, schema, tag, and sandbox guidance"]
+---
+
 # organon
 
 ## At a glance
@@ -76,12 +82,12 @@ Tool registry, executors, and sandbox. 16K lines. 49 built-in tools.
 
 ## Query axes
 
-There are two ways to query the registry for tools:
+Query the registry for tools in two ways:
 
 | Axis | Method | Semantics | When to use |
 |------|--------|-----------|-------------|
 | **Category** | `definitions_for_category` | Structural / navigational. Groups tools by domain (Workspace, Memory, Planning, etc.). | Browsing the tool surface by domain. |
-| **Tags** | `definitions_for_tags` | Operational / semantic. Returns tools whose tags intersect the query set (union semantics). | "What tools help me look things up?" — cuts across categories. |
+| **Tags** | `definitions_for_tags` | Operational / semantic. Returns tools whose tags intersect the query set (union semantics). | "What tools help me look things up?" - cuts across categories. |
 
 Tags are explicit, typed, and declared at registration time. Empty tag list returns an empty Vec (not "all tools").
 

--- a/crates/organon/README.md
+++ b/crates/organon/README.md
@@ -8,10 +8,10 @@ Organon (ὄργανον): "instrument." The formal instruments through which ag
 
 `organon` is the single source of truth for what tools an aletheia agent can use. It provides:
 
-- **`ToolRegistry`** — the runtime registry; tools are registered at startup and looked up by name during execution.
-- **`ToolDef`** / **`InputSchema`** — rich metadata for each tool (name, description, JSON Schema, reversibility, category).
-- **Built-in executors** — implementations for all platform tools (filesystem, workspace, memory, planning, communication, research, agent coordination, and more).
-- **`to_hermeneus_tools`** / **`to_hermeneus_tools_filtered`** — serialization to the `hermeneus::types::ToolDefinition` wire format for LLM requests.
+- **`ToolRegistry`** - the runtime registry; tools are registered at startup and looked up by name during execution.
+- **`ToolDef`** / **`InputSchema`** - rich metadata for each tool (name, description, JSON Schema, reversibility, category).
+- **Built-in executors** - implementations for all platform tools (filesystem, workspace, memory, planning, communication, research, agent coordination, and more).
+- **`to_hermeneus_tools`** / **`to_hermeneus_tools_filtered`** - serialization to the `hermeneus::types::ToolDefinition` wire format for LLM requests.
 
 ## Feature flags
 
@@ -28,7 +28,7 @@ Organon (ὄργανον): "instrument." The formal instruments through which ag
 
 ### Problem
 
-By default, every LLM request includes the full JSON Schema for every registered tool in the `tools` array. With 49+ built-in tools this is a substantial static token cost paid before the first user message — even for tools the agent never uses.
+By default, every LLM request includes the full JSON Schema for every registered tool in the `tools` array. With 49+ built-in tools this is a substantial static token cost paid before the first user message - even for tools the agent never uses.
 
 ### Solution
 
@@ -76,7 +76,7 @@ Always registered (regardless of the feature flag). Agents call it when they nee
 // Request
 { "tool_name": "plan_create" }
 
-// Response — full input_schema JSON object
+// Response - full input_schema JSON object
 {
   "type": "object",
   "properties": {
@@ -89,7 +89,7 @@ Always registered (regardless of the feature flag). Agents call it when they nee
 
 ### Enabling the flag
 
-The flag is **default OFF** in v1. Operators flip it per-deployment after the flag has soaked in a test environment. To enable in a Cargo workspace:
+Operators keep the flag **default OFF** in v1 and flip it per deployment after the flag has soaked in a test environment. To enable in a Cargo workspace:
 
 ```toml
 # Cargo.toml (workspace or crate)
@@ -115,12 +115,12 @@ Tests assert a **≥50% byte-size reduction** across the full builtin set when `
 
 ## Registration lifecycle
 
-All built-in tools are registered via `register_all` or `register_all_with_sandbox`. Registration is two-phase:
+`register_all` or `register_all_with_sandbox` registers every built-in tool in two phases:
 
 1. **Phase 1**: all domain tools are registered.
 2. **Phase 2**: `tool_schema` is registered last, capturing a serialized snapshot of every schema from phase 1.
 
-The two-phase split avoids a self-referential ownership cycle: the registry owns the `tool_schema` executor, which needs schema data from the registry. The snapshot (a `Vec<(name, json)>`) breaks the cycle — the executor is self-contained and holds no back-reference to the registry.
+The two-phase split avoids a self-referential ownership cycle: the registry owns the `tool_schema` executor, which needs schema data from the registry. The snapshot (a `Vec<(name, json)>`) breaks the cycle - the executor is self-contained and holds no back-reference to the registry.
 
 ## Standards
 

--- a/crates/theatron/proskenion/CLAUDE.md
+++ b/crates/theatron/proskenion/CLAUDE.md
@@ -1,3 +1,9 @@
+---
+scope: "crates/theatron/proskenion/"
+defers_to: ["../../../CLAUDE.md"]
+tightens: ["desktop UI route, state, service, and component guidance"]
+---
+
 # proskenion
 
 ## At a glance
@@ -21,17 +27,17 @@ Dioxus desktop application for Aletheia: chat, planning, memory, metrics, ops, a
 | Type | Path | Purpose |
 |------|------|---------|
 | `AppState` | `state/app.rs` | Top-level state: agents, sessions, tab bar, overlays, connection |
-| `EventState` | `state/events.rs` | SSE connection state, streaming state, tool calls in progress |
+| `EventState` | `state/events.rs` | SSE connection state, streaming state, calls in progress |
 | `PylonClient` | `services/connection.rs` | Gateway API client wrapper with auth and reconnection |
 | `AgentStore` | `state/agents.rs` | Agent roster with status tracking and selection |
 | `ToastStore` | `state/toasts.rs` | Notification toast queue with severity and auto-dismiss |
 | `CommandStore` | `state/commands.rs` | Command palette entries and execution |
 | `InputState` | `state/input.rs` | Chat input field state with submission tracking |
-| `PerMessageStreamState` | `state/streaming.rs` | Per-message streaming accumulator (text, thinking, tool calls) |
-| `ToolCallState` | `state/tools.rs` | Active tool call tracking with approval state |
+| `PerMessageStreamState` | `state/streaming.rs` | Per-message streaming accumulator (text, thinking, calls) |
+| `ToolCallState` | `state/tools.rs` | Active call tracking with approval state |
 | `PlanCardState` | `state/tools.rs` | Plan visualization with step status tracking |
 | `WindowState` | `state/platform.rs` | Window geometry persistence across sessions |
-| `TrayState` | `state/platform.rs` | System tray icon and menu state |
+| `TrayState` | `state/platform.rs` | Tray icon and menu state |
 | `HotkeyState` | `state/platform.rs` | Global hotkey registration and actions |
 
 ## Views

--- a/docs/GROUNDS.md
+++ b/docs/GROUNDS.md
@@ -69,7 +69,7 @@ An abstraction with only one creation path is a mesh with a single root. If that
 
 ### Missing grounds
 
-- **Planning API creation surface** - pylon now serves verification results over HTTP, but project and plan creation still route through the planning tool service rather than HTTP handlers.
+- **Planning API creation surface** - pylon serves verification results over HTTP. Project and plan creation route through the planning tool service instead of HTTP handlers.
 
 ---
 

--- a/docs/NETWORK.md
+++ b/docs/NETWORK.md
@@ -9,7 +9,7 @@ Every network connection Aletheia makes, documented for transparency.
 
 ## Outbound connections
 
-Sorted by criticality (highest data-sovereignty impact first).
+Sorted by criticality (highest sovereignty impact first).
 
 | Endpoint | Protocol | Direction | Carries | Triggered by | Source reference |
 |----------|----------|-----------|---------|--------------|------------------|
@@ -20,8 +20,8 @@ Sorted by criticality (highest data-sovereignty impact first).
 | Configurable OAuth provider (PKCE / device code) | HTTPS | Outbound | Authorization codes, device codes, access tokens | `aletheia credential login` (PKCE) or `aletheia credential device-code` | `crates/symbolon/src/credential/pkce.rs:361` (authorization URL build); `crates/symbolon/src/credential/pkce.rs:612` (code→token exchange); `crates/symbolon/src/credential/device_code.rs:220` (device authorization POST); `crates/symbolon/src/credential/device_code.rs:285` (token polling POST) |
 | HuggingFace Hub (`hf-hub` internal endpoint) | HTTPS (via `ureq`) | Outbound | Model files: `config.json`, `tokenizer.json`, `model.safetensors` | First initialization of the `candle` embedding provider | `crates/episteme/src/embedding.rs:165` (hub API init); `crates/episteme/src/embedding.rs:173` (`config.json` download); `crates/episteme/src/embedding.rs:179` (`tokenizer.json` download); `crates/episteme/src/embedding.rs:185` (`model.safetensors` download) |
 | `api.github.com` | HTTPS | Outbound | Public issue metadata (title, state, labels, milestone) | Agent uses `issue_scan` or `issue_triage` built-in tool | `crates/organon/src/builtins/triage/mod.rs:359` (URL template); `crates/organon/src/builtins/triage/mod.rs:369` (HTTP GET) |
-| Arbitrary URLs (`web_fetch` tool) | HTTPS/HTTP | Outbound | Arbitrary web page content (HTML, markdown, etc.) | Agent uses `web_fetch` built-in tool | `crates/organon/src/builtins/research.rs:118` (protocol guard); `crates/organon/src/builtins/research.rs:156` (HTTP GET execution) |
-| Operator-configured external tool endpoints | HTTPS/HTTP (config-driven) | Outbound | JSON tool payload (`tool`, `kind`, `arguments`) | Agent invokes an external tool registered in `aletheia.toml` | `crates/aletheia/src/external_tools.rs:30` (config types); `crates/aletheia/src/external_tools.rs:330` (HTTP POST executor) |
+| Arbitrary URLs (`web_fetch` tool) | HTTPS/HTTP | Outbound | Arbitrary web page body (HTML, markdown, etc.) | Agent uses `web_fetch` built-in tool | `crates/organon/src/builtins/research.rs:118` (protocol guard); `crates/organon/src/builtins/research.rs:156` (HTTP GET execution) |
+| Operator-configured external tool endpoints | HTTPS/HTTP (config-driven) | Outbound | JSON tool body (`tool`, `kind`, `arguments`) | Agent invokes an external tool registered in `aletheia.toml` | `crates/aletheia/src/external_tools.rs:30` (config types); `crates/aletheia/src/external_tools.rs:330` (HTTP POST executor) |
 | Qdrant (migration only) | HTTPS/gRPC (configurable, default `localhost:6333`) | Outbound | Vector memory records (scroll points, payloads) | One-time `aletheia agent-io migrate-memory` CLI command | `crates/aletheia/src/migrate_memory.rs:68` (client build); `crates/aletheia/src/commands/agent_io.rs:106` (CLI `--qdrant-url` arg) |
 | signal-cli daemon (`localhost:8080` by default) | HTTP (JSON-RPC) | Outbound | Signal message text, recipient IDs, JSON-RPC envelopes | Sending or receiving Signal messages when Signal channel is enabled | `crates/taxis/src/config/mod.rs:268` (default host); `crates/agora/src/semeion/client.rs:88` (URL construction); `crates/agora/src/semeion/client.rs:144` (`send` RPC); `crates/agora/src/semeion/mod.rs:170` (receive poll loop) |
 | Tailscale local status query | stdio (`tailscale status --json`) | Outbound (local-only) | Local Tailscale IPv4 address | Pylon server startup (discovery file write) | `crates/pylon/src/discovery.rs:125` (subprocess spawn) |

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -54,8 +54,8 @@ Check `git log --oneline` or [GitHub releases](https://github.com/forkwright/ale
 
 ## Store migration
 
-The current session store is fjall-backed. The pre-fjall SQLite session backend
-is historical; use the one-shot migration tool if you still have a legacy
+Sessions now use a fjall-backed store. The pre-fjall SQLite session backend is
+historical; use the one-shot migration tool if you still have a legacy
 `sessions.db` file.
 
 The embedded Datalog engine (knowledge store) manages its own schema versioning internally.

--- a/planning/research/identity-continuity.md
+++ b/planning/research/identity-continuity.md
@@ -2,24 +2,24 @@
 
 ## Question
 
-Aletheia's recall and extraction pipelines are tuned for general task agents whose self-presentation drifts gracefully and whose memory is shared across the fleet by default. For nouses where consistent self-presentation across long sessions matters more than encyclopedic factual accuracy — and where the workspace is operator-private rather than shared infrastructure — we need a coordinated set of primitives that compose cleanly with the existing stack. What mechanics are required, where do they land in the codebase, and how do they relate to R716 (cross-agent knowledge sharing)?
+Aletheia's recall and extraction pipelines are tuned for broad task agents whose self-presentation drifts across long sessions and whose memory is shared across the fleet by default. For nouses where consistent self-presentation matters over encyclopedic factual accuracy - and where the workspace is operator-private instead of shared infrastructure - we need a coordinated set of primitives that compose cleanly with the existing stack. What mechanics are required, where do they land in the codebase, and how do they relate to R716 (cross-agent knowledge sharing)?
 
 ## Findings
 
-### Background — empirical motivation
+### Background - empirical motivation
 
 The architectural intuition that this work formalizes has empirical backing:
 
-- **Knowledge vs reasoning are separable in network architecture** (arXiv:2507.18178, July 2025) — knowledge retrieval localizes in lower layers; reasoning operates in higher layers. Models stripped of knowledge-pretraining pressure perform better on calibration and reasoning at fixed parameter budgets.
-- **Knowledge is capacity-hungry, reasoning is data-hungry** (ACL 2025 / arXiv 2503.10061) — at fixed VRAM, more capacity goes to knowledge compression than to reasoning depth.
-- **Persona drift is mechanistically real** (arXiv:2402.10962 + Lu et al. Jan 2026) — 20-40% identity-axis drift documented past turn 8-15 in 27B-70B class models. Late-position re-injection compensates for the attention-decay cause.
-- **Reflection cycles crystallize observation into self-knowledge** (Park et al. 2023, "Generative Agents") — periodic reflection over recent observations produces higher-order insights that stabilize agent identity across long arcs.
+- **Knowledge vs reasoning are separable in network architecture** (arXiv:2507.18178, July 2025) - knowledge retrieval localizes in lower layers; reasoning operates in higher layers. Models stripped of knowledge-pretraining pressure perform better on calibration and reasoning at fixed parameter budgets.
+- **Knowledge is capacity-hungry, reasoning is data-hungry** (ACL 2025 / arXiv 2503.10061) - at fixed VRAM, more capacity goes to knowledge compression than to reasoning depth.
+- **Persona drift is mechanistically real** (arXiv:2402.10962 + Lu et al. Jan 2026) - 20-40% identity-axis drift documented past turn 8-15 in 27B-70B class models. Late-position re-injection compensates for the attention-decay cause.
+- **Reflection cycles crystallize observation into self-knowledge** (Park et al. 2023, "Generative Agents") - periodic reflection over recent observations produces higher-order insights that stabilize agent identity across long arcs.
 
 The mechanics in this design address those mechanistic causes.
 
 ### Relationship to R716 (knowledge-sharing)
 
-R716 designed a four-phase rollout for cross-agent knowledge sharing: visibility (Phase 1), subscription (Phase 2), verification (Phase 3), federated recall (Phase 4). This work absorbs **R716 Phase 1** (visibility as a fact property: `Private | Shared | Restricted | Published`) into the same lock-step crate move, because the visibility model is required for the private-workspace fence to work cleanly. **R716 Phase 3** (multi-agent verification + tier promotion) is tracked as a separate follow-up — load-bearing for fleet-wide knowledge confidence but not required for the private-nous use case. **R716 Phase 2 + Phase 4** are deferred; no consumer demand.
+R716 designed a four-phase rollout for cross-agent knowledge sharing: visibility (Phase 1), subscription (Phase 2), verification (Phase 3), federated recall (Phase 4). This work absorbs **R716 Phase 1** (visibility as a fact property: `Private | Shared | Restricted | Published`) into the same lock-step crate move, because the visibility model is required for the private-workspace fence to work cleanly. **R716 Phase 3** (multi-agent verification + tier promotion) is tracked as a separate follow-up - load-bearing for fleet-wide knowledge confidence but not required for the private-nous use case. **R716 Phase 2 + Phase 4** are deferred; no consumer demand.
 
 ### Mechanics
 
@@ -50,7 +50,7 @@ Three new fields on `ExtractionConfig` (episteme):
 
 #### 3. Reflection cycle (new pipeline stage)
 
-A new `run_reflection_stage` async fn in `nous::pipeline::stages`, inserted after `run_finalize_stage` and before the training-capture block. Reads recent session facts from the per-nous knowledge store; promotes raw `FactType::Observation` records to a higher tier (existing `EpistemicTier::Verified` or a new `Reflected` variant — `EpistemicTier` is `#[non_exhaustive]`, so adding a variant is additive and safe). Config-gated by `reflection_enabled: bool` on `NousConfig` or `PipelineConfig`. New `StageBudget::reflection_secs: u32` for time-boxing.
+A new `run_reflection_stage` async fn in `nous::pipeline::stages`, inserted after `run_finalize_stage` and before the training-capture block. Reads recent session facts from the per-nous knowledge store; promotes raw `FactType::Observation` records to a higher tier (existing `EpistemicTier::Verified` or a new `Reflected` variant - `EpistemicTier` is `#[non_exhaustive]`, so adding a variant is additive and safe). Config-gated by `reflection_enabled: bool` on `NousConfig` or `PipelineConfig`. New `StageBudget::reflection_secs: u32` for time-boxing.
 
 This is the canonical tier-promotion path beyond the multi-agent verification mechanism that R716 Phase 3 will add.
 
@@ -88,11 +88,11 @@ pub enum AddressMask {
 }
 ```
 
-`CrossNousRouter` gains `address_mask: HashMap<String, AddressMask>`; `send` and `ask` check the mask before delivering to the target inbox. Outbound is unaffected — a private nous can still send messages out (e.g. delegate research) without becoming addressable. Rejection returns `AddressRejectedSnafu` (or extends `NousNotFoundSnafu`).
+`CrossNousRouter` gains `address_mask: HashMap<String, AddressMask>`; `send` and `ask` check the mask before delivering to the target inbox. Outbound is unaffected - a private nous can still send messages out (e.g. delegate research) without becoming addressable. Rejection returns `AddressRejectedSnafu` (or extends `NousNotFoundSnafu`).
 
 #### 6. Per-nous episteme keyspace
 
-`KnowledgeStore::open_fjall` already takes a path; the API stays stable, but the call sites that currently open a single shared store under `oikos.knowledge_db()` must scope by cohort:
+`KnowledgeStore::open_fjall` takes a path; the API stays stable, but the call sites that open a single shared store under `oikos.knowledge_db()` must scope by cohort:
 
 - Default cohort `"shared"` preserves existing behaviour.
 - Cohort override → `oikos.knowledge_db().join(cohort)`.
@@ -109,10 +109,10 @@ Two design options:
 
 Either way, the flag drives:
 
-- `BootstrapAssembler::resolve_workspace_files` — skip cross-nous discovery sources when `private == true`.
-- `NousManager::list` — filter private nouses from public status output.
-- `diaporeia::tools::nous_list` — filter from non-operator callers.
-- `pylon::handlers::nous::list_nous` — filter at the HTTP API.
+- `BootstrapAssembler::resolve_workspace_files` - skip cross-nous discovery sources when `private == true`.
+- `NousManager::list` - filter private nouses from public status output.
+- `diaporeia::tools::nous_list` - filter from non-operator callers.
+- `pylon::handlers::nous::list_nous` - filter at the HTTP API.
 
 Recommendation: **Option A** for first land (smaller surface), with the option to migrate to a per-nous manifest later if the workspace flag proliferates.
 
@@ -129,16 +129,16 @@ Three orthogonal axes already exist or land here:
 
 These axes do not interact at scoring; they layer in different filter passes. `Visibility` is consumed by recall to filter out other nouses' private facts; `FactSensitivity` is consumed earlier for sovereignty-tier filtering.
 
-Schema migration: CozoDB does not support `ALTER`, so adding `visibility` to the `facts` relation requires a Datalog rebuild via the existing migration ladder (`init_schema`, currently at `SCHEMA_VERSION = 9`). A v10 migration rebuilds `facts` with the new column and backfills existing rows to `Private`.
+Schema migration: CozoDB does not support `ALTER`, so adding `visibility` to the `facts` relation requires a Datalog rebuild via the existing migration ladder (`init_schema`, `SCHEMA_VERSION = 9` in this design snapshot). A v10 migration rebuilds `facts` with the new column and backfills existing rows to `Private`.
 
 ### Cross-crate lock-step
 
 The four crates must move together; partial merges break compilation because the config structs deserialize from a single TOML source:
 
-- `eidos` — add `Visibility` enum; additive `EpistemicTier::Reflected` if used.
-- `episteme` — propagate `visibility` into `ScoredResult`; add `HttpReranker`; extend `ExtractionConfig`.
-- `nous` — consume new `episteme` types in `RecallStage`, `PipelineConfig`, `NousConfig`; add reflection stage; add address mask; per-nous keyspace.
-- `taxis` — extend `RecallSettings`, `NousDefinition`, `ResolvedNousConfig`.
+- `eidos` - add `Visibility` enum; additive `EpistemicTier::Reflected` if used.
+- `episteme` - propagate `visibility` into `ScoredResult`; add `HttpReranker`; extend `ExtractionConfig`.
+- `nous` - consume new `episteme` types in `RecallStage`, `PipelineConfig`, `NousConfig`; add reflection stage; add address mask; per-nous keyspace.
+- `taxis` - extend `RecallSettings`, `NousDefinition`, `ResolvedNousConfig`.
 
 ## Recommendations
 
@@ -160,39 +160,39 @@ The four crates must move together; partial merges break compilation because the
 
 - **`extract_refined` line 575 hardcoded tier.** This is the existing default; the new `default_tier` config replaces it. Tests in `episteme::extract::tests::config_parsing` need updates.
 
-- **R716 partial absorption.** R716's `published_facts` and `provenance` relations are **not** added by this work. Adding them later (under R716 Phase 3) does not break what this work lands; it adds rows to a new relation rather than mutating the existing one.
+- **R716 partial absorption.** This work excludes R716's `published_facts` and `provenance` relations. R716 Phase 3 preserves this work by adding rows to a new relation instead of mutating the existing one.
 
 - **Stages ordering for reflection.** The reflection stage runs after `run_finalize_stage` (which persists the user-visible turn) but before training-capture. If reflection writes new facts to the knowledge store, training capture sees them; if it writes only to a separate reflection sink, training capture does not. Decide explicitly and test.
 
 - **`#[non_exhaustive]` on `EpistemicTier` is a contract.** Downstream pattern matches must use `_ => ...` arms. A new `Reflected` variant for the reflection cycle is safe; downstream consumers compile without change because they already handle the `_` case (or fail their own lints).
 
-- **`AddressMask` enforcement is inbound-only.** A private nous can still ask others to do work on its behalf. The receiving nous's outbound logs are a side channel — the operator is the trust boundary, but if a private nous delegates to a less-private nous, the receiving nous's extracted facts about the request are themselves private-leakage surface. Document the asymmetry; no enforcement at this layer.
+- **`AddressMask` enforcement is inbound-only.** A private nous can still ask others to do work on its behalf. The receiving nous's outbound logs are a side channel - the operator is the trust boundary, but if a private nous delegates to a less-private nous, the receiving nous's extracted facts about the request are themselves private-leakage surface. Document the asymmetry; no enforcement at this layer.
 
 - **CozoDB v10 migration is one-way.** Backups of `data/knowledge.fjall/` should be taken before the migration runs in production. The existing migration ladder writes a backup; ensure the v10 migration preserves that pattern.
 
 ## References
 
-- `crates/eidos/src/knowledge/fact.rs` — `Fact`, `EpistemicTier`, `FactProvenance`, `FactSensitivity`, `FactAccess`, `MemoryScope`
-- `crates/episteme/src/recall/mod.rs` — `RecallEngine`, `score_epistemic_tier`, `RecallWeights`
-- `crates/episteme/src/recall/reranker.rs` — `Reranker` trait, `NaiveReranker`
-- `crates/episteme/src/extract/engine.rs` — `extract_refined`, `persist`, prompt construction
-- `crates/episteme/src/extract/types.rs` — `ExtractionConfig`
-- `crates/episteme/src/knowledge_store/mod.rs` — `KnowledgeStore`, `open_fjall`, `init_schema`, migration ladder
-- `crates/nous/src/recall/scoring.rs` — `RecallConfig`
-- `crates/nous/src/recall/mod.rs` — `RecallStage`, `finalize_results`, `filter_by_sensitivity`
-- `crates/nous/src/pipeline/mod.rs` — pipeline stage ordering
-- `crates/nous/src/pipeline/stages.rs` — `run_recall_stage`, `apply_recall_result`, `run_finalize_stage`
-- `crates/nous/src/cross/router.rs` — `CrossNousRouter`, `send`, `ask`
-- `crates/nous/src/bootstrap/mod.rs` — `BootstrapAssembler`, `resolve_workspace_files`
-- `crates/nous/src/manager.rs` — `NousManager`, actor spawn path
-- `crates/nous/src/config.rs` — `NousConfig`, `PipelineConfig`, `StageBudget`
-- `crates/taxis/src/config/agents.rs` — `RecallSettings`, `NousDefinition`
-- `crates/taxis/src/config/resolved.rs` — `ResolvedNousConfig`, `resolve_nous`
-- `crates/diaporeia/src/tools/mod.rs` — `nous_list`
-- `crates/pylon/src/handlers/nous.rs` — HTTP `list_nous`
-- `crates/aletheia/src/runtime/setup.rs` — `open_knowledge_store`
-- R716 (`knowledge-sharing.md`) — visibility model, provenance schema, verification protocol (Phase 3 deferred)
-- R717 (`active-forgetting.md`) — FSRS decay; tier-aware stability multipliers
-- arXiv:2402.10962 — Persona drift mechanism
-- Park et al. 2023 — Generative Agents reflection cycle pattern
-- arXiv:2507.18178, arXiv:2503.10061 — Cognition-vs-knowledge separability empirical findings
+- `crates/eidos/src/knowledge/fact.rs` - `Fact`, `EpistemicTier`, `FactProvenance`, `FactSensitivity`, `FactAccess`, `MemoryScope`
+- `crates/episteme/src/recall/mod.rs` - `RecallEngine`, `score_epistemic_tier`, `RecallWeights`
+- `crates/episteme/src/recall/reranker.rs` - `Reranker` trait, `NaiveReranker`
+- `crates/episteme/src/extract/engine.rs` - `extract_refined`, `persist`, prompt construction
+- `crates/episteme/src/extract/types.rs` - `ExtractionConfig`
+- `crates/episteme/src/knowledge_store/mod.rs` - `KnowledgeStore`, `open_fjall`, `init_schema`, migration ladder
+- `crates/nous/src/recall/scoring.rs` - `RecallConfig`
+- `crates/nous/src/recall/mod.rs` - `RecallStage`, `finalize_results`, `filter_by_sensitivity`
+- `crates/nous/src/pipeline/mod.rs` - pipeline stage ordering
+- `crates/nous/src/pipeline/stages.rs` - `run_recall_stage`, `apply_recall_result`, `run_finalize_stage`
+- `crates/nous/src/cross/router.rs` - `CrossNousRouter`, `send`, `ask`
+- `crates/nous/src/bootstrap/mod.rs` - `BootstrapAssembler`, `resolve_workspace_files`
+- `crates/nous/src/manager.rs` - `NousManager`, actor spawn path
+- `crates/nous/src/config.rs` - `NousConfig`, `PipelineConfig`, `StageBudget`
+- `crates/taxis/src/config/agents.rs` - `RecallSettings`, `NousDefinition`
+- `crates/taxis/src/config/resolved.rs` - `ResolvedNousConfig`, `resolve_nous`
+- `crates/diaporeia/src/tools/mod.rs` - `nous_list`
+- `crates/pylon/src/handlers/nous.rs` - HTTP `list_nous`
+- `crates/aletheia/src/runtime/setup.rs` - `open_knowledge_store`
+- R716 (`knowledge-sharing.md`) - visibility model, provenance schema, verification protocol (Phase 3 deferred)
+- R717 (`active-forgetting.md`) - FSRS decay; tier-aware stability multipliers
+- arXiv:2402.10962 - Persona drift mechanism
+- Park et al. 2023 - Generative Agents reflection cycle pattern
+- arXiv:2507.18178, arXiv:2503.10061 - Cognition-vs-knowledge separability empirical findings

--- a/planning/research/observability-trace.md
+++ b/planning/research/observability-trace.md
@@ -172,7 +172,7 @@ The `TraceRotator` (`crates/daemon/src/maintenance/trace_rotation.rs`) runs as a
 
 Log retention (separate from trace rotation) prunes daily log files in `logs/` after `retention_days`.
 
-### 9. debugging workflow
+### 9. debugging trace
 
 To trace a user-visible error back to its cause:
 

--- a/planning/research/vision-support.md
+++ b/planning/research/vision-support.md
@@ -402,7 +402,7 @@ Phases 1 and 3 can be done in parallel. Phase 4 and 5 can be done in parallel af
 
 1. **Token budget explosion.** A single image costs 54-3,280 tokens. Multiple images in conversation history can exhaust the context window. The budget calculator must account for image tokens, and distillation must handle (or drop) image messages.
 
-2. **Base64 payload size.** A 5 MB image becomes ~6.7 MB base64-encoded. With multiple images in a request, the HTTP payload grows large. Consider streaming uploads or chunked encoding if this becomes a bottleneck.
+2. **Base64 request size.** A 5 MB image becomes ~6.7 MB base64-encoded. With multiple images in a request, the HTTP body grows large. Consider streaming uploads or chunked encoding if this becomes a bottleneck.
 
 3. **SQLite BLOB performance.** SQLite handles BLOBs well up to ~1 MB. Above that, performance degrades. The preprocessing step (resize to 1568x1568) keeps most images under 1 MB after compression, but this must be enforced.
 
@@ -410,7 +410,7 @@ Phases 1 and 3 can be done in parallel. Phase 4 and 5 can be done in parallel af
 
 5. **History reconstruction.** When loading conversation history, image attachments must be reconstructed into `Content::Blocks` for the API request. If images are dropped (distilled), the history must gracefully handle missing attachments without breaking the message format.
 
-6. **Cache invalidation.** The TUI image cache keys on `(PathBuf, width)`. In-memory image data from base64 needs a different cache key (message ID + attachment sequence, or content hash).
+6. **Cache invalidation.** The TUI image cache keys on `(PathBuf, width)`. In-memory image bytes from base64 need a different cache key (message ID + attachment sequence, or content hash).
 
 ---
 


### PR DESCRIPTION
## Summary

- clean the remaining hand-authored writing findings across docs and crate-local context files
- add valid preambles to touched crate-local `CLAUDE.md` files so direct file lint stays clean
- leave generated `_llm` artifacts untouched; those were handled by the reviewed baseline in #4020

Refs #3987.

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --summary --writing`
- `kanon lint --summary --workflow`
- `kanon lint --summary <each touched file>`
- `git diff --check`

## Reviewer

- Kimi reviewer dispatch `0000019e5300c598f214b1f7035fb221`: APPROVE

## Remaining #3987 work

- full Rust lint summary behavior
- full-workspace `kanon lint --summary` timeout/green gate
