### PR TITLE
fix(energeia): expose dispatch cancellation token

### DIFF
--- a/crates/energeia/src/backend/backend_impl.rs
+++ b/crates/energeia/src/backend/backend_impl.rs
@@ -4,6 +4,8 @@
 use std::future::Future;
 #[cfg(feature = "storage-fjall")]
 use std::pin::Pin;
+#[cfg(feature = "storage-fjall")]
+use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "storage-fjall")]
 use crate::backend::DispatchBackend;
@@ -48,6 +50,15 @@ impl EnergeiaBackend {
             steward_config,
             metrics,
         }
+    }
+
+    /// Attach an external cancellation token to the underlying orchestrator.
+    ///
+    /// Time: O(1). Space: O(1).
+    #[must_use]
+    pub fn with_cancel_token(mut self, cancel: CancellationToken) -> Self {
+        self.orchestrator = self.orchestrator.with_cancel_token(cancel);
+        self
     }
 }
 

--- a/crates/energeia/src/orchestrator/mod.rs
+++ b/crates/energeia/src/orchestrator/mod.rs
@@ -5,6 +5,8 @@
 
 use std::sync::Arc;
 
+use tokio_util::sync::CancellationToken;
+
 use crate::engine::DispatchEngine;
 use crate::error::{self, Result};
 use crate::pipeline::DispatchPipeline;
@@ -36,6 +38,7 @@ pub struct Orchestrator {
     #[cfg(feature = "storage-fjall")]
     store: Option<Arc<crate::store::EnergeiaStore>>,
     config: OrchestratorConfig,
+    cancel: CancellationToken,
 }
 
 impl Orchestrator {
@@ -52,7 +55,21 @@ impl Orchestrator {
             #[cfg(feature = "storage-fjall")]
             store: None,
             config,
+            cancel: CancellationToken::new(),
         }
+    }
+
+    /// Attach an external cancellation token for dispatches started by this orchestrator.
+    ///
+    /// Control planes use this to abort a running dispatch without killing the
+    /// process. Group execution clones the token into session managers, which
+    /// abort live session handles before returning an aborted outcome.
+    ///
+    /// Time: O(1). Space: O(1).
+    #[must_use]
+    pub fn with_cancel_token(mut self, cancel: CancellationToken) -> Self {
+        self.cancel = cancel;
+        self
     }
 
     /// Attach a state persistence store.
@@ -98,7 +115,8 @@ impl Orchestrator {
             self.config.clone(),
             #[cfg(feature = "storage-fjall")]
             self.store.clone(),
-        );
+        )
+        .with_cancel_token(self.cancel.clone());
 
         let pipeline = DispatchPipeline::default();
         pipeline

--- a/crates/energeia/src/orchestrator/orchestrator_tests.rs
+++ b/crates/energeia/src/orchestrator/orchestrator_tests.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 
 use jiff::Timestamp;
+use tokio_util::sync::CancellationToken;
 
 use crate::dag::PromptDag;
 use crate::engine::{SessionEvent, SessionResult};
@@ -262,6 +263,30 @@ async fn dispatch_budget_exceeded_aborts() {
         .find(|o| o.prompt_number == 2)
         .unwrap();
     assert_eq!(o2.status, SessionStatus::Skipped);
+}
+
+#[tokio::test]
+async fn dispatch_respects_external_cancel_token() {
+    let engine = Arc::new(MockEngine::new(vec![]));
+    let qa = Arc::new(MockQaGate::passing());
+    let config = OrchestratorConfig::new()
+        .max_concurrent(4)
+        .default_budget_usd(10.0);
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let orchestrator = Orchestrator::new(engine, qa, config).with_cancel_token(cancel);
+    let prompts = vec![sample_prompt_spec(1, vec![]), sample_prompt_spec(2, vec![])];
+    let spec = sample_dispatch_spec(vec![1, 2]);
+
+    let result = orchestrator.dispatch(spec, &prompts).await.unwrap();
+
+    assert!(result.aborted);
+    assert_eq!(result.outcomes.len(), 2);
+    assert!(result.outcomes.iter().all(|outcome| {
+        outcome.status == SessionStatus::Skipped
+            && outcome.error.as_deref() == Some("dispatch aborted")
+    }));
 }
 
 #[tokio::test]

--- a/crates/energeia/src/pipeline/context.rs
+++ b/crates/energeia/src/pipeline/context.rs
@@ -163,6 +163,13 @@ impl PipelineContext {
         }
     }
 
+    /// Replace the default internal cancellation token with a caller-owned token.
+    #[must_use]
+    pub(crate) fn with_cancel_token(mut self, cancel: CancellationToken) -> Self {
+        self.cancel = cancel;
+        self
+    }
+
     /// Convenience accessor — returns the frontier (panics if preparation has not run).
     ///
     /// Only used from execution stage where preparation is guaranteed to have run.


### PR DESCRIPTION
## Summary
- Adds an `Orchestrator::with_cancel_token` hook and wires that token into each dispatch `PipelineContext`.
- Adds `EnergeiaBackend::with_cancel_token` so callers using the backend facade can cancel dispatches.
- Covers the behavior with a pre-cancelled-token test that verifies dispatch aborts and pending outcomes are skipped.

Closes #3954.

## Gates
- `cargo fmt --all -- --check`
- `kanon lint --rust --summary crates/energeia/src/backend/backend_impl.rs`
- `kanon lint --rust --summary crates/energeia/src/orchestrator/mod.rs`
- `kanon lint --rust --summary crates/energeia/src/pipeline/context.rs`
- `kanon lint --rust --summary crates/energeia/src/orchestrator/orchestrator_tests.rs`
- `cargo test -p energeia orchestrator -- --nocapture`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Reviewer
- Kimi reviewer dispatch `0000019e5347403af214b1f7035fb22c`: APPROVE, no blocking findings.
