### PR TITLE
fix(daemon): disable logging-only dispatch cron

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5896,7 +5896,6 @@ dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
  "eidos",
- "energeia",
  "episteme",
  "fjall",
  "flate2",

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -45,7 +45,7 @@ codex-provider = ["hermeneus/codex-provider"]
 # Kimi subprocess provider: delegates LLM calls to the `kimi` CLI.
 kimi-provider = ["hermeneus/kimi-provider"]
 # Dispatch orchestration (kanon phronesis port). Default off for incremental development.
-energeia = ["dep:energeia", "oikonomos/dispatch-cron"]
+energeia = ["dep:energeia"]
 # Test tiers (see docs/test-tiers.md)
 test-core = ["mneme/test-core", "nous/test-core", "pylon/test-core"]
 test-full = ["test-core", "mneme/test-full", "online-tests"]

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -675,34 +675,11 @@ impl RuntimeBuilder {
                 daemon_runner = daemon_runner.with_knowledge_maintenance(km_executor);
             }
 
-            #[cfg(feature = "energeia")]
             if !self.config.dispatch.cron_tasks.is_empty() {
-                let db_path = self.oikos.data().join("cron-locks");
-                let db = koina::fjall::FjallDb::open(&db_path, &["cron_locks"])
-                    .with_whatever_context(|_| "failed to open cron lock store")?;
-                let lock_store = Arc::new(
-                    energeia::cron::CronLockStore::open(Arc::new(db.db))
-                        .with_whatever_context(|_| "failed to open cron lock partition")?,
+                warn!(
+                    cron_tasks = self.config.dispatch.cron_tasks.len(),
+                    "dispatch cron tasks configured but not started; recurring energeia dispatch is disabled until the daemon can execute real dispatch actions"
                 );
-                let mut tasks = Vec::with_capacity(self.config.dispatch.cron_tasks.len());
-                for c in &self.config.dispatch.cron_tasks {
-                    let task = energeia::cron::CronTask::new(
-                        &c.name,
-                        &c.schedule,
-                        std::time::Duration::from_secs(c.jitter_secs),
-                        energeia::types::DispatchSpec::with_options(
-                            c.dispatch_spec.project.clone(),
-                            c.dispatch_spec.prompt_numbers.clone(),
-                            c.dispatch_spec.dag_ref.clone(),
-                            c.dispatch_spec.max_parallel,
-                        )
-                        .with_max_turns(c.dispatch_spec.max_turns),
-                    )
-                    .with_whatever_context(|_| format!("invalid cron task '{}'", c.name))?;
-                    tasks.push(task);
-                }
-                let scheduler = Arc::new(energeia::cron::CronScheduler::new(tasks, lock_store));
-                daemon_runner = daemon_runner.with_cron_scheduler(scheduler);
             }
 
             daemon_runner.register_maintenance_tasks();

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -7,15 +7,11 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
-[lints]
-workspace = true
-
 [features]
 default = []
 # WHY: gates anomaly detection (prosoche memory consistency checks) on the
 # heavy CozoDB-backed KnowledgeStore from episteme. Not all daemon users need it.
 knowledge-store = ["episteme/mneme-engine"]
-dispatch-cron = ["energeia/storage-fjall", "dep:energeia"]
 test-core = []
 test-full = []
 
@@ -23,7 +19,6 @@ test-full = []
 aletheia-routing = { path = "../aletheia-routing" }
 eidos = { path = "../eidos" }
 episteme = { path = "../episteme", default-features = false }
-energeia = { path = "../energeia", optional = true }
 koina = { path = "../koina", features = ["fjall"] }
 taxis = { path = "../taxis" }
 # WHY: axum for webhook trigger listener
@@ -51,6 +46,11 @@ toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-episteme = { path = "../episteme", default-features = false, features = ["storage-fjall"] }
+episteme = { path = "../episteme", default-features = false, features = [
+    "storage-fjall",
+] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/daemon/src/runner/lifecycle.rs
+++ b/crates/daemon/src/runner/lifecycle.rs
@@ -37,29 +37,6 @@ impl TaskRunner {
         let mut watchdog_tick =
             tokio::time::interval(watchdog_interval.unwrap_or(Duration::from_secs(30)));
 
-        #[cfg(feature = "dispatch-cron")]
-        let _cron_handle = self.cron_scheduler.clone().map(|scheduler| {
-            let cancel = self.shutdown.child_token();
-            tokio::spawn(
-                async move {
-                    let _ = scheduler
-                        .run(cancel, |task| {
-                            let name = task.name.clone();
-                            let project = task.dispatch_spec.project.clone();
-                            async move {
-                                tracing::info!(
-                                    task = %name,
-                                    project = %project,
-                                    "cron dispatch task fired"
-                                );
-                            }
-                        })
-                        .await;
-                }
-                .instrument(tracing::info_span!("daemon.cron_scheduler")),
-            )
-        });
-
         loop {
             tokio::select! {
                 // SAFETY: cancel-safe. `interval.tick()` is cancel-safe; dropping it

--- a/crates/daemon/src/runner/mod.rs
+++ b/crates/daemon/src/runner/mod.rs
@@ -62,9 +62,6 @@ pub struct TaskRunner {
     self_prompt_limiter: crate::self_prompt::SelfPromptLimiter,
     /// Self-prompt configuration (enabled, rate limits).
     self_prompt_config: crate::self_prompt::SelfPromptConfig,
-    /// Optional cron scheduler for recurring dispatch tasks.
-    #[cfg(feature = "dispatch-cron")]
-    cron_scheduler: Option<Arc<energeia::cron::CronScheduler>>,
 }
 
 /// Tracks a task that is currently executing.
@@ -113,8 +110,6 @@ impl TaskRunner {
             daemon_behavior: DaemonBehaviorConfig::default(),
             self_prompt_limiter: crate::self_prompt::SelfPromptLimiter::new(1),
             self_prompt_config: crate::self_prompt::SelfPromptConfig::default(),
-            #[cfg(feature = "dispatch-cron")]
-            cron_scheduler: None,
         }
     }
 
@@ -138,17 +133,7 @@ impl TaskRunner {
             daemon_behavior: DaemonBehaviorConfig::default(),
             self_prompt_limiter: crate::self_prompt::SelfPromptLimiter::new(1),
             self_prompt_config: crate::self_prompt::SelfPromptConfig::default(),
-            #[cfg(feature = "dispatch-cron")]
-            cron_scheduler: None,
         }
-    }
-
-    /// Attach a cron scheduler for recurring dispatch tasks.
-    #[cfg(feature = "dispatch-cron")]
-    #[must_use]
-    pub fn with_cron_scheduler(mut self, scheduler: Arc<energeia::cron::CronScheduler>) -> Self {
-        self.cron_scheduler = Some(scheduler);
-        self
     }
 
     /// Attach maintenance configuration.

--- a/docs/FEATURE-FLAGS.md
+++ b/docs/FEATURE-FLAGS.md
@@ -22,7 +22,6 @@ Every feature flag defined in the workspace, how flags interact across crates, a
 | **aletheia** | `test-core` | no | - | `mneme/test-core`, `nous/test-core`, `pylon/test-core` |
 | **aletheia** | `test-full` | no | - | `test-core`, `mneme/test-full` |
 | **daemon** (oikonomos) | `default` | **yes** | *(empty)* | - |
-| **daemon** | `dispatch-cron` | no | Dispatch cron integration | `energeia/storage-fjall`, `dep:energeia` |
 | **daemon** | `knowledge-store` | no | Prosoche memory consistency checks | `episteme/mneme-engine` |
 | **daemon** | `test-core` | no | - | - |
 | **daemon** | `test-full` | no | - | - |


### PR DESCRIPTION
## Summary

- remove the daemon `dispatch-cron` feature and the `with_cron_scheduler` runtime hook that only logged fired tasks
- stop `aletheia/energeia` from enabling the removed daemon feature
- warn when dispatch cron tasks are configured so operators do not mistake ignored recurring dispatch config for executed work
- update feature docs and lockfile dependency edge

Closes #3945.

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --rust --summary --precision high crates/aletheia/src/runtime/mod.rs`
- `kanon lint --rust --summary --precision high crates/daemon/src/runner/mod.rs`
- `kanon lint --rust --summary --precision high crates/daemon/src/runner/lifecycle.rs`
- `kanon lint --summary crates/aletheia/Cargo.toml`
- `kanon lint --summary crates/daemon/Cargo.toml`
- `kanon lint --summary docs/FEATURE-FLAGS.md`

Note: `kanon lint --summary Cargo.lock` still reports the existing workspace `MANIFEST/dep-count` baseline; this change removes one dependency edge from `oikonomos`.

## Reviewer

Kimi reviewer dispatch `0000019e5353a3bdf214b1f7035fb22e`: APPROVE, no blocking findings.
