### PR TITLE
fix(daemon): skip bridge-dependent cron tasks without bridge

### DIFF
--- a/crates/daemon/src/runner/registration.rs
+++ b/crates/daemon/src/runner/registration.rs
@@ -158,7 +158,9 @@ impl TaskRunner {
     /// All cron tasks are disabled by default. Each is registered only if
     /// its `enabled` flag is SET in the configuration.
     fn register_cron_tasks(&mut self, config: &crate::cron::CronConfig) {
-        if config.evolution.enabled {
+        let has_bridge = self.bridge.is_some();
+
+        if config.evolution.enabled && has_bridge {
             self.register_builtin(
                 "cron-evolution",
                 "Evolution: config variant search",
@@ -166,15 +168,25 @@ impl TaskRunner {
                 BuiltinTask::EvolutionSearch,
                 false,
             );
+        } else if config.evolution.enabled {
+            tracing::warn!(
+                task = "cron-evolution",
+                "skipping bridge-dependent cron task because no daemon bridge is configured"
+            );
         }
 
-        if config.reflection.enabled {
+        if config.reflection.enabled && has_bridge {
             self.register_builtin(
                 "cron-reflection",
                 "Reflection: self-evaluation",
                 Schedule::Interval(config.reflection.interval),
                 BuiltinTask::SelfReflection,
                 false,
+            );
+        } else if config.reflection.enabled {
+            tracing::warn!(
+                task = "cron-reflection",
+                "skipping bridge-dependent cron task because no daemon bridge is configured"
             );
         }
 

--- a/crates/daemon/src/runner_tests/lifecycle_and_builders.rs
+++ b/crates/daemon/src/runner_tests/lifecycle_and_builders.rs
@@ -191,6 +191,45 @@ fn routing_store_refresh_registers_when_store_is_attached() {
 }
 
 #[test]
+fn bridge_dependent_cron_tasks_skip_without_bridge() {
+    let token = CancellationToken::new();
+    let mut config = MaintenanceConfig::default();
+    config.cron.evolution.enabled = true;
+    config.cron.reflection.enabled = true;
+
+    let mut runner = TaskRunner::new("system", token).with_maintenance(config);
+    runner.register_maintenance_tasks();
+
+    let ids: Vec<String> = runner
+        .status()
+        .into_iter()
+        .map(|status| status.id)
+        .collect();
+    assert!(!ids.iter().any(|id| id == "cron-evolution"));
+    assert!(!ids.iter().any(|id| id == "cron-reflection"));
+}
+
+#[test]
+fn bridge_dependent_cron_tasks_register_with_bridge() {
+    let token = CancellationToken::new();
+    let bridge: Arc<dyn DaemonBridge> = Arc::new(crate::bridge::NoopBridge);
+    let mut config = MaintenanceConfig::default();
+    config.cron.evolution.enabled = true;
+    config.cron.reflection.enabled = true;
+
+    let mut runner = TaskRunner::with_bridge("test-nous", token, bridge).with_maintenance(config);
+    runner.register_maintenance_tasks();
+
+    let ids: Vec<String> = runner
+        .status()
+        .into_iter()
+        .map(|status| status.id)
+        .collect();
+    assert!(ids.iter().any(|id| id == "cron-evolution"));
+    assert!(ids.iter().any(|id| id == "cron-reflection"));
+}
+
+#[test]
 fn register_maintenance_tasks_skips_without_config() {
     let token = CancellationToken::new();
     let mut runner = TaskRunner::new("system", token);


### PR DESCRIPTION
## Summary

- skip evolution/reflection cron task registration when the daemon runner has no bridge
- keep graph cleanup gated on the knowledge executor as before
- add regression tests for both skip-without-bridge and register-with-bridge behavior

Part of #3940.

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p oikonomos bridge_dependent_cron_tasks -- --nocapture`
- `kanon lint --rust --summary crates/daemon/src/runner/registration.rs`
- `kanon lint --rust --summary crates/daemon/src/runner_tests/lifecycle_and_builders.rs`

## Reviewer

Kimi reviewer dispatch `0000019e535b5d6df214b1f7035fb22f`: APPROVE, no blocking findings.
