### PR TITLE
fix(energeia): pass orchestrator additional dirs to sessions

### DIFF
--- a/crates/energeia/src/orchestrator/config.rs
+++ b/crates/energeia/src/orchestrator/config.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// Controls concurrency limits, budget defaults, and timeouts that apply to
 /// the entire dispatch run rather than individual sessions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(from = "OrchestratorConfigRaw")]
+#[serde(deny_unknown_fields, from = "OrchestratorConfigRaw")]
 #[non_exhaustive]
 pub struct OrchestratorConfig {
     /// Maximum number of sessions executing concurrently within a group.
@@ -45,10 +45,13 @@ pub struct OrchestratorConfig {
     pub standards: Vec<String>,
     /// Optional scope context appended to the dynamic suffix.
     pub scope: Option<String>,
+    /// Additional directories the agent sessions may access.
+    pub additional_dirs: Vec<PathBuf>,
 }
 
 /// Raw deserialization type for [`OrchestratorConfig`].
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct OrchestratorConfigRaw {
     max_concurrent: u32,
     default_budget_usd: Option<f64>,
@@ -66,6 +69,8 @@ struct OrchestratorConfigRaw {
     standards: Vec<String>,
     #[serde(default)]
     scope: Option<String>,
+    #[serde(default)]
+    additional_dirs: Vec<PathBuf>,
 }
 
 impl From<OrchestratorConfigRaw> for OrchestratorConfig {
@@ -81,6 +86,7 @@ impl From<OrchestratorConfigRaw> for OrchestratorConfig {
             standards_dir: raw.standards_dir,
             standards: raw.standards,
             scope: raw.scope,
+            additional_dirs: raw.additional_dirs,
         }
     }
 }
@@ -98,6 +104,7 @@ impl Default for OrchestratorConfig {
             standards_dir: None,
             standards: Vec::new(),
             scope: None,
+            additional_dirs: Vec::new(),
         }
     }
 }
@@ -178,6 +185,13 @@ impl OrchestratorConfig {
         self.scope = Some(scope.into());
         self
     }
+
+    /// Add an additional directory to expose to every dispatched agent session.
+    #[must_use]
+    pub fn add_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.additional_dirs.push(dir.into());
+        self
+    }
 }
 
 /// Serde helper for `Option<Duration>` as milliseconds.
@@ -222,6 +236,7 @@ mod tests {
         assert!(config.max_duration.is_none());
         assert_eq!(config.session_idle_timeout, Some(Duration::from_mins(10)));
         assert_eq!(config.max_corrective_retries, 0);
+        assert!(config.additional_dirs.is_empty());
     }
 
     #[test]
@@ -232,7 +247,8 @@ mod tests {
             .default_budget_turns(500)
             .max_duration(Duration::from_hours(1))
             .session_idle_timeout(Duration::from_mins(5))
-            .max_corrective_retries(2);
+            .max_corrective_retries(2)
+            .add_dir("/tmp/shared");
 
         assert_eq!(config.max_concurrent, 8);
         assert_eq!(config.default_budget_usd, Some(25.0));
@@ -240,6 +256,7 @@ mod tests {
         assert_eq!(config.max_duration, Some(Duration::from_hours(1)));
         assert_eq!(config.session_idle_timeout, Some(Duration::from_mins(5)));
         assert_eq!(config.max_corrective_retries, 2);
+        assert_eq!(config.additional_dirs, vec![PathBuf::from("/tmp/shared")]);
     }
 
     #[test]
@@ -255,6 +272,21 @@ mod tests {
         assert_eq!(back.max_concurrent, 6);
         assert_eq!(back.default_budget_usd, Some(10.0));
         assert_eq!(back.max_duration, Some(Duration::from_mins(30)));
+    }
+
+    #[test]
+    fn roundtrip_additional_dirs() {
+        let config = OrchestratorConfig::new()
+            .add_dir("/workspace")
+            .add_dir("/shared");
+
+        let json = serde_json::to_string(&config).expect("serialize");
+        let back: OrchestratorConfig = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(
+            back.additional_dirs,
+            vec![PathBuf::from("/workspace"), PathBuf::from("/shared")]
+        );
     }
 
     #[test]

--- a/crates/energeia/src/pipeline/preparation.rs
+++ b/crates/energeia/src/pipeline/preparation.rs
@@ -121,6 +121,9 @@ impl PipelineStage for PreparationStage {
         ctx.resume_policy = crate::resume::ResumePolicy::default();
         let mut engine_config = EngineConfig::new(crate::engine::AgentOptions::new())
             .idle_timeout_opt(cfg.session_idle_timeout);
+        for dir in &cfg.additional_dirs {
+            engine_config = engine_config.add_dir(dir.clone());
+        }
         if let Some(max_turns) = ctx.spec.max_turns {
             engine_config = engine_config.max_turns(max_turns);
         }
@@ -206,7 +209,10 @@ mod tests {
         }
     }
 
-    fn make_context_with_prompts(prompts: Vec<PromptSpec>) -> PipelineContext {
+    fn make_context_with_config(
+        prompts: Vec<PromptSpec>,
+        config: OrchestratorConfig,
+    ) -> PipelineContext {
         let engine = Arc::new(MockEngine::new(vec![]));
         let qa = Arc::new(AlwaysPassQa);
         let spec = DispatchSpec::new(
@@ -218,10 +224,14 @@ mod tests {
             prompts,
             engine,
             qa,
-            OrchestratorConfig::default(),
+            config,
             #[cfg(feature = "storage-fjall")]
             None,
         )
+    }
+
+    fn make_context_with_prompts(prompts: Vec<PromptSpec>) -> PipelineContext {
+        make_context_with_config(prompts, OrchestratorConfig::default())
     }
 
     #[tokio::test]
@@ -288,6 +298,37 @@ mod tests {
 
         assert_eq!(ctx.max_concurrent, 2);
         assert_eq!(ctx.engine_config().options.max_turns, Some(7));
+    }
+
+    #[tokio::test]
+    async fn preparation_passes_configured_additional_dirs_to_engine() {
+        let prompts = vec![PromptSpec {
+            number: 1,
+            description: "first".to_owned(),
+            depends_on: vec![],
+            acceptance_criteria: vec![],
+            blast_radius: vec![],
+            body: "do first".to_owned(),
+            prompt_components: None,
+        }];
+        let config = OrchestratorConfig::default()
+            .add_dir("/workspace/shared")
+            .add_dir("/workspace/fixtures");
+        let mut ctx = make_context_with_config(prompts, config);
+
+        let stage = PreparationStage;
+        stage
+            .run(&mut ctx)
+            .await
+            .expect("preparation should succeed");
+
+        assert_eq!(
+            ctx.engine_config().additional_dirs,
+            vec![
+                std::path::PathBuf::from("/workspace/shared"),
+                std::path::PathBuf::from("/workspace/fixtures"),
+            ]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- adds `OrchestratorConfig::additional_dirs` with a builder and strict serde round-trip coverage
- passes configured additional directories into `EngineConfig` during preparation so spawned sessions receive them
- adds a preparation-stage regression test for the config-to-session path

## Gates

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --rust --summary crates/energeia/src/orchestrator/config.rs`
- `kanon lint --rust --summary crates/energeia/src/pipeline/preparation.rs`

## Notes

Addresses the `additional_dirs` slice of #3955. The issue should remain open for the remaining health-probe policy work.
