### PR TITLE
fix(energeia): wire service-backed runtime tools

### DIFF
--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -44,8 +44,9 @@ cc-provider = ["hermeneus/cc-provider"]
 codex-provider = ["hermeneus/codex-provider"]
 # Kimi subprocess provider: delegates LLM calls to the `kimi` CLI.
 kimi-provider = ["hermeneus/kimi-provider"]
-# Dispatch orchestration (kanon phronesis port). Default off for incremental development.
-energeia = ["dep:energeia"]
+# Dispatch orchestration and agent-facing Energeia capability tools. Default off for
+# incremental development.
+energeia = ["dep:energeia", "energeia/storage-fjall", "organon/energeia"]
 # Test tiers (see docs/test-tiers.md)
 test-core = ["mneme/test-core", "nous/test-core", "pylon/test-core"]
 test-full = ["test-core", "mneme/test-full", "online-tests"]

--- a/crates/aletheia/src/runtime/builder_validation.rs
+++ b/crates/aletheia/src/runtime/builder_validation.rs
@@ -1,0 +1,106 @@
+use std::fmt::Arguments;
+use std::io::Write as _;
+
+use taxis::validate::validate_section;
+
+use super::RuntimeBuilder;
+use super::validate::{validate_external_tools, validate_jwt};
+use crate::error::Result;
+
+fn print_line(args: Arguments<'_>) {
+    let mut stdout = std::io::stdout().lock();
+    if let Err(error) = stdout.write_fmt(args) {
+        tracing::warn!(%error, "failed to write validation output");
+        return;
+    }
+    if let Err(error) = stdout.write_all(b"\n") {
+        tracing::warn!(%error, "failed to write validation output newline");
+    }
+}
+
+impl RuntimeBuilder {
+    /// Validate config without building the runtime. Used by `check-config`.
+    pub(crate) fn validate(&self) -> Result<()> {
+        let mut all_ok = true;
+
+        print_line(format_args!(
+            "Instance root: {}",
+            self.oikos.root().display()
+        ));
+
+        if !self.oikos.root().exists() {
+            print_line(format_args!(
+                "  [FAIL] instance layout: instance root not found: {}\n         \
+                 help: SET ALETHEIA_ROOT or run `aletheia init`",
+                self.oikos.root().display()
+            ));
+            snafu::whatever!("Cannot validate: instance root does not exist");
+        }
+
+        match self.oikos.validate() {
+            Ok(()) => print_line(format_args!("  [pass] instance layout")),
+            Err(e) => {
+                print_line(format_args!("  [FAIL] instance layout: {e}"));
+                all_ok = false;
+            }
+        }
+
+        print_line(format_args!("  [pass] config loaded"));
+
+        let config_value = match serde_json::to_value(&self.config) {
+            Ok(v) => v,
+            Err(e) => {
+                print_line(format_args!("  [FAIL] config serialization: {e}"));
+                snafu::whatever!("config validation aborted: could not serialize config");
+            }
+        };
+
+        for section in &[
+            "agents",
+            "gateway",
+            "maintenance",
+            "data",
+            "embedding",
+            "channels",
+            "bindings",
+        ] {
+            if let Some(section_value) = config_value.get(section) {
+                match validate_section(section, section_value) {
+                    Ok(()) => print_line(format_args!("  [pass] {section}")),
+                    Err(e) => {
+                        print_line(format_args!("  [FAIL] {section}: {e}"));
+                        all_ok = false;
+                    }
+                }
+            } else {
+                print_line(format_args!("  [pass] {section} (using defaults)"));
+            }
+        }
+
+        for agent in &self.config.agents.list {
+            match self.oikos.validate_workspace_path(&agent.workspace) {
+                Ok(()) => print_line(format_args!("  [pass] agent '{}' workspace", agent.id)),
+                Err(e) => {
+                    print_line(format_args!("  [FAIL] agent '{}' workspace: {e}", agent.id));
+                    all_ok = false;
+                }
+            }
+        }
+
+        if !validate_jwt(&self.config) {
+            all_ok = false;
+        }
+
+        if !validate_external_tools(&self.oikos) {
+            all_ok = false;
+        }
+
+        print_line(format_args!(""));
+        if all_ok {
+            print_line(format_args!("Configuration OK"));
+            Ok(())
+        } else {
+            snafu::whatever!("Configuration has errors -- see above");
+        }
+    }
+}

--- a/crates/aletheia/src/runtime/metrics.rs
+++ b/crates/aletheia/src/runtime/metrics.rs
@@ -1,0 +1,46 @@
+/// Register every metrics-emitting crate's families with the shared registry.
+///
+/// WHY: `prometheus-client` has no process-wide global registry, so each
+/// crate exposes a `register(&mut Registry)` function that installs its
+/// metric families. This binary is the only assembly point that imports
+/// them all, so wiring lives here (not in pylon, which doesn't depend on
+/// every metrics-emitting crate).
+pub(super) fn register_all_metrics(registry: &koina::metrics::MetricsRegistry) {
+    registry.with_registry(|r| {
+        agora::metrics::register(r);
+        dianoia::metrics::register(r);
+        mneme::metrics::register_knowledge(r);
+        mneme::metrics::register_sessions(r);
+        hermeneus::metrics::register(r);
+        melete::metrics::register(r);
+        nous::metrics::register(r);
+        oikonomos::metrics::register(r);
+        organon::metrics::register(r);
+        pylon::metrics::register(r);
+        symbolon::metrics::register(r);
+        #[cfg(feature = "energeia")]
+        energeia::metrics::prometheus::register(r);
+    });
+}
+
+#[derive(Debug)]
+pub(super) struct RuntimeBackupMetricsRecorder;
+
+impl oikonomos::maintenance::BackupMetricsRecorder for RuntimeBackupMetricsRecorder {
+    fn record_backup_duration(&self, duration_secs: f64, success: bool) {
+        mneme::metrics::record_backup_duration(duration_secs, success);
+    }
+}
+
+pub(super) fn task_state_component(agent_id: &str) -> String {
+    agent_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -2,7 +2,6 @@
 
 #[cfg(feature = "recall")]
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -18,7 +17,6 @@ use koina::secret::SecretString;
 use koina::system::{Environment, RealSystem};
 use mneme::embedding::DegradedEmbeddingProvider;
 use mneme::store::SessionStore;
-use nous::config::{NousConfig, PipelineConfig};
 use nous::cross::CrossNousRouter;
 use nous::manager::NousManager;
 use oikonomos::runner::TaskRunner;
@@ -159,88 +157,6 @@ impl RuntimeBuilder {
         self
     }
 
-    /// Validate config without building the runtime. Used by `check-config`.
-    pub(crate) fn validate(&self) -> Result<()> {
-        let mut all_ok = true;
-
-        println!("Instance root: {}", self.oikos.root().display());
-
-        if !self.oikos.root().exists() {
-            println!(
-                "  [FAIL] instance layout: instance root not found: {}\n         \
-                 help: SET ALETHEIA_ROOT or run `aletheia init`",
-                self.oikos.root().display()
-            );
-            snafu::whatever!("Cannot validate: instance root does not exist");
-        }
-
-        match self.oikos.validate() {
-            Ok(()) => println!("  [pass] instance layout"),
-            Err(e) => {
-                println!("  [FAIL] instance layout: {e}");
-                all_ok = false;
-            }
-        }
-
-        println!("  [pass] config loaded");
-
-        let config_value = match serde_json::to_value(&self.config) {
-            Ok(v) => v,
-            Err(e) => {
-                println!("  [FAIL] config serialization: {e}");
-                snafu::whatever!("config validation aborted: could not serialize config");
-            }
-        };
-
-        for section in &[
-            "agents",
-            "gateway",
-            "maintenance",
-            "data",
-            "embedding",
-            "channels",
-            "bindings",
-        ] {
-            if let Some(section_value) = config_value.get(section) {
-                match validate_section(section, section_value) {
-                    Ok(()) => println!("  [pass] {section}"),
-                    Err(e) => {
-                        println!("  [FAIL] {section}: {e}");
-                        all_ok = false;
-                    }
-                }
-            } else {
-                println!("  [pass] {section} (using defaults)");
-            }
-        }
-
-        for agent in &self.config.agents.list {
-            match self.oikos.validate_workspace_path(&agent.workspace) {
-                Ok(()) => println!("  [pass] agent '{}' workspace", agent.id),
-                Err(e) => {
-                    println!("  [FAIL] agent '{}' workspace: {e}", agent.id);
-                    all_ok = false;
-                }
-            }
-        }
-
-        if !validate_jwt(&self.config) {
-            all_ok = false;
-        }
-
-        if !validate_external_tools(&self.oikos) {
-            all_ok = false;
-        }
-
-        println!();
-        if all_ok {
-            println!("Configuration OK");
-            Ok(())
-        } else {
-            snafu::whatever!("Configuration has errors -- see above");
-        }
-    }
-
     #[expect(
         clippy::too_many_lines,
         reason = "sequential init steps: splitting would fragment the startup flow"
@@ -367,7 +283,7 @@ impl RuntimeBuilder {
 
         // Tool registry
         let mut tool_registry = if self.credentials {
-            build_tool_registry(&self.config.sandbox)?
+            build_tool_registry(&self.config, &self.oikos, &shutdown_token)?
         } else {
             ToolRegistry::new()
         };
@@ -861,185 +777,19 @@ impl RuntimeBuilder {
 
 mod validate;
 
-use validate::{validate_external_tools, validate_jwt};
+mod builder_validation;
+mod metrics;
+mod nous_config;
+
+use metrics::{RuntimeBackupMetricsRecorder, register_all_metrics, task_state_component};
+use nous_config::build_nous_runtime_config;
 
 mod setup;
 mod tool_adapters;
 
 #[cfg(feature = "recall")]
 use setup::open_knowledge_stores;
-
-fn resolve_config_path(oikos: &Oikos, configured: &str) -> PathBuf {
-    let path = Path::new(configured);
-    let absolute = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        oikos.root().join(path)
-    };
-    absolute.canonicalize().unwrap_or(absolute)
-}
-
-fn resolve_allowed_roots(
-    oikos: &Oikos,
-    workspace: &str,
-    configured_roots: &[String],
-) -> Vec<PathBuf> {
-    let mut roots = Vec::with_capacity(configured_roots.len() + 1);
-    roots.push(resolve_config_path(oikos, workspace));
-    for root in configured_roots {
-        let resolved = resolve_config_path(oikos, root);
-        if !roots.iter().any(|existing| existing == &resolved) {
-            roots.push(resolved);
-        }
-    }
-    roots
-}
-
-fn build_nous_runtime_config(
-    config: &AletheiaConfig,
-    oikos: &Oikos,
-    packs: &[thesauros::loader::LoadedPack],
-    agent_id: &str,
-) -> (NousConfig, PipelineConfig) {
-    let resolved = resolve_nous(config, agent_id);
-    let mut domains = resolved.domains.clone();
-    let mut model = resolved.model.primary.to_string();
-    let mut max_tool_iterations = resolved.capabilities.max_tool_iterations;
-    for pack in packs {
-        for domain in pack.domains_for_agent(agent_id) {
-            if !domains.contains(&domain) {
-                domains.push(domain);
-            }
-        }
-        if let Some(pack_model) = pack.model_for_agent(agent_id) {
-            model = pack_model;
-        }
-        if let Some(agency) = pack.agency_for_agent(agent_id) {
-            max_tool_iterations = match agency.as_str() {
-                "unrestricted" => 10_000,
-                "standard" => koina::defaults::MAX_TOOL_ITERATIONS,
-                "restricted" => 50,
-                other => {
-                    warn!(
-                        agent = %agent_id,
-                        agency = %other,
-                        pack = %pack.manifest.name,
-                        "unknown agency level in pack overlay, skipping"
-                    );
-                    continue;
-                }
-            };
-        }
-    }
-
-    let nous_config = NousConfig {
-        id: resolved.id,
-        name: resolved.name,
-        generation: nous::config::NousGenerationConfig {
-            model,
-            fallback_models: resolved
-                .model
-                .fallbacks
-                .iter()
-                .map(ToString::to_string)
-                .collect(),
-            retries_before_fallback: resolved.model.retries_before_fallback,
-            context_window: resolved.limits.context_tokens,
-            max_output_tokens: resolved.limits.max_output_tokens,
-            bootstrap_max_tokens: resolved.limits.bootstrap_max_tokens,
-            thinking_enabled: resolved.capabilities.thinking_enabled,
-            thinking_budget: resolved.limits.thinking_budget,
-            chars_per_token: resolved.limits.chars_per_token,
-            prosoche_model: resolved.prosoche_model.to_string(),
-            complexity: hermeneus::complexity::ComplexityConfig::default(),
-            extraction_model: None,
-            distillation_model: None,
-        },
-        limits: nous::config::NousLimits {
-            max_tool_iterations,
-            loop_detection_threshold: 3,
-            consecutive_error_threshold: 4,
-            loop_max_warnings: 2,
-            session_token_cap: 500_000,
-            max_tool_result_bytes: resolved.limits.max_tool_result_bytes,
-            max_consecutive_tool_only_iterations: 3,
-            consecutive_mistake_limit: koina::defaults::DEFAULT_CONSECUTIVE_MISTAKE_LIMIT,
-        },
-        domains,
-        private: resolved.private,
-        episteme_cohort: resolved.episteme_cohort,
-        workspace: resolve_config_path(oikos, &resolved.workspace),
-        allowed_roots: resolve_allowed_roots(oikos, &resolved.workspace, &resolved.allowed_roots),
-        server_tools: Vec::new(),
-        cache_enabled: resolved.capabilities.cache_enabled,
-        recall: resolved.recall.into(),
-        recall_profile: resolved.recall_profile.into(),
-        tool_allowlist: None,
-        tool_groups: Vec::new(),
-        hooks: nous::config::HookConfig::default(),
-        behavior: resolved.behavior,
-    };
-    let mut extraction_cfg = mneme::extract::ExtractionConfig::default();
-    if let Some(model) = nous_config.generation.extraction_model.as_deref() {
-        model.clone_into(&mut extraction_cfg.model);
-    }
-    (
-        nous_config,
-        PipelineConfig {
-            extraction: Some(extraction_cfg),
-            training: config.training.clone(),
-            ..PipelineConfig::default()
-        },
-    )
-}
 use setup::{
     LazyEmbeddingProvider, build_provider_registry, build_signal_provider, build_tool_registry,
     start_inbound_dispatch,
 };
-
-/// Register every metrics-emitting crate's families with the shared registry.
-///
-/// WHY: `prometheus-client` has no process-wide global registry, so each
-/// crate exposes a `register(&mut Registry)` function that installs its
-/// metric families. This binary is the only assembly point that imports
-/// them all, so wiring lives here (not in pylon, which doesn't depend on
-/// every metrics-emitting crate).
-fn register_all_metrics(registry: &koina::metrics::MetricsRegistry) {
-    registry.with_registry(|r| {
-        agora::metrics::register(r);
-        dianoia::metrics::register(r);
-        mneme::metrics::register_knowledge(r);
-        mneme::metrics::register_sessions(r);
-        hermeneus::metrics::register(r);
-        melete::metrics::register(r);
-        nous::metrics::register(r);
-        oikonomos::metrics::register(r);
-        organon::metrics::register(r);
-        pylon::metrics::register(r);
-        symbolon::metrics::register(r);
-        #[cfg(feature = "energeia")]
-        energeia::metrics::prometheus::register(r);
-    });
-}
-
-#[derive(Debug)]
-struct RuntimeBackupMetricsRecorder;
-
-impl oikonomos::maintenance::BackupMetricsRecorder for RuntimeBackupMetricsRecorder {
-    fn record_backup_duration(&self, duration_secs: f64, success: bool) {
-        mneme::metrics::record_backup_duration(duration_secs, success);
-    }
-}
-
-fn task_state_component(agent_id: &str) -> String {
-    agent_id
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
-                ch
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}

--- a/crates/aletheia/src/runtime/nous_config.rs
+++ b/crates/aletheia/src/runtime/nous_config.rs
@@ -1,0 +1,131 @@
+use std::path::{Path, PathBuf};
+
+use tracing::warn;
+
+use nous::config::{NousConfig, PipelineConfig};
+use taxis::config::{AletheiaConfig, resolve_nous};
+use taxis::oikos::Oikos;
+
+fn resolve_config_path(oikos: &Oikos, configured: &str) -> PathBuf {
+    let path = Path::new(configured);
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        oikos.root().join(path)
+    };
+    absolute.canonicalize().unwrap_or(absolute)
+}
+
+fn resolve_allowed_roots(
+    oikos: &Oikos,
+    workspace: &str,
+    configured_roots: &[String],
+) -> Vec<PathBuf> {
+    let mut roots = Vec::with_capacity(configured_roots.len() + 1);
+    roots.push(resolve_config_path(oikos, workspace));
+    for root in configured_roots {
+        let resolved = resolve_config_path(oikos, root);
+        if !roots.iter().any(|existing| existing == &resolved) {
+            roots.push(resolved);
+        }
+    }
+    roots
+}
+
+pub(super) fn build_nous_runtime_config(
+    config: &AletheiaConfig,
+    oikos: &Oikos,
+    packs: &[thesauros::loader::LoadedPack],
+    agent_id: &str,
+) -> (NousConfig, PipelineConfig) {
+    let resolved = resolve_nous(config, agent_id);
+    let mut domains = resolved.domains.clone();
+    let mut model = resolved.model.primary.to_string();
+    let mut max_tool_iterations = resolved.capabilities.max_tool_iterations;
+    for pack in packs {
+        for domain in pack.domains_for_agent(agent_id) {
+            if !domains.contains(&domain) {
+                domains.push(domain);
+            }
+        }
+        if let Some(pack_model) = pack.model_for_agent(agent_id) {
+            model = pack_model;
+        }
+        if let Some(agency) = pack.agency_for_agent(agent_id) {
+            max_tool_iterations = match agency.as_str() {
+                "unrestricted" => 10_000,
+                "standard" => koina::defaults::MAX_TOOL_ITERATIONS,
+                "restricted" => 50,
+                other => {
+                    warn!(
+                        agent = %agent_id,
+                        agency = %other,
+                        pack = %pack.manifest.name,
+                        "unknown agency level in pack overlay, skipping"
+                    );
+                    continue;
+                }
+            };
+        }
+    }
+
+    let nous_config = NousConfig {
+        id: resolved.id,
+        name: resolved.name,
+        generation: nous::config::NousGenerationConfig {
+            model,
+            fallback_models: resolved
+                .model
+                .fallbacks
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+            retries_before_fallback: resolved.model.retries_before_fallback,
+            context_window: resolved.limits.context_tokens,
+            max_output_tokens: resolved.limits.max_output_tokens,
+            bootstrap_max_tokens: resolved.limits.bootstrap_max_tokens,
+            thinking_enabled: resolved.capabilities.thinking_enabled,
+            thinking_budget: resolved.limits.thinking_budget,
+            chars_per_token: resolved.limits.chars_per_token,
+            prosoche_model: resolved.prosoche_model.to_string(),
+            complexity: hermeneus::complexity::ComplexityConfig::default(),
+            extraction_model: None,
+            distillation_model: None,
+        },
+        limits: nous::config::NousLimits {
+            max_tool_iterations,
+            loop_detection_threshold: 3,
+            consecutive_error_threshold: 4,
+            loop_max_warnings: 2,
+            session_token_cap: 500_000,
+            max_tool_result_bytes: resolved.limits.max_tool_result_bytes,
+            max_consecutive_tool_only_iterations: 3,
+            consecutive_mistake_limit: koina::defaults::DEFAULT_CONSECUTIVE_MISTAKE_LIMIT,
+        },
+        domains,
+        private: resolved.private,
+        episteme_cohort: resolved.episteme_cohort,
+        workspace: resolve_config_path(oikos, &resolved.workspace),
+        allowed_roots: resolve_allowed_roots(oikos, &resolved.workspace, &resolved.allowed_roots),
+        server_tools: Vec::new(),
+        cache_enabled: resolved.capabilities.cache_enabled,
+        recall: resolved.recall.into(),
+        recall_profile: resolved.recall_profile.into(),
+        tool_allowlist: None,
+        tool_groups: Vec::new(),
+        hooks: nous::config::HookConfig::default(),
+        behavior: resolved.behavior,
+    };
+    let mut extraction_cfg = mneme::extract::ExtractionConfig::default();
+    if let Some(model) = nous_config.generation.extraction_model.as_deref() {
+        model.clone_into(&mut extraction_cfg.model);
+    }
+    (
+        nous_config,
+        PipelineConfig {
+            extraction: Some(extraction_cfg),
+            training: config.training.clone(),
+            ..PipelineConfig::default()
+        },
+    )
+}

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -25,8 +25,6 @@ use mneme::embedding::{
     DegradedEmbeddingProvider, EmbeddingConfig, EmbeddingProvider, create_provider,
 };
 use nous::manager::NousManager;
-use organon::builtins;
-use organon::registry::ToolRegistry;
 use symbolon::credential::{
     CredentialChain, CredentialFile, EnvCredentialProvider, FileCredentialProvider,
     RefreshingCredentialProvider, claude_code_default_path, claude_code_provider,
@@ -35,6 +33,10 @@ use taxis::config::{AletheiaConfig, EmbeddingSettings};
 use taxis::oikos::Oikos;
 
 use crate::error::Result;
+
+mod tool_registry;
+
+pub(super) use tool_registry::build_tool_registry;
 
 #[expect(
     clippy::too_many_lines,
@@ -384,36 +386,6 @@ fn register_declared_providers(registry: &mut ProviderRegistry, config: &Alethei
             }
         }
     }
-}
-
-pub(super) fn build_tool_registry(
-    sandbox_settings: &taxis::config::SandboxSettings,
-) -> Result<ToolRegistry> {
-    let mut registry = ToolRegistry::new();
-    let sandbox = organon::sandbox::SandboxConfig {
-        enabled: sandbox_settings.enabled,
-        enforcement: match sandbox_settings.enforcement {
-            taxis::config::SandboxEnforcementMode::Enforcing => {
-                organon::sandbox::SandboxEnforcement::Enforcing
-            }
-            _ => organon::sandbox::SandboxEnforcement::Permissive,
-        },
-        allowed_root: sandbox_settings.allowed_root.clone(),
-        extra_read_paths: sandbox_settings.extra_read_paths.clone(),
-        extra_write_paths: sandbox_settings.extra_write_paths.clone(),
-        extra_exec_paths: sandbox_settings.extra_exec_paths.clone(),
-        egress: match sandbox_settings.egress {
-            taxis::config::EgressPolicy::Deny => organon::sandbox::EgressPolicy::Deny,
-            taxis::config::EgressPolicy::Allowlist => organon::sandbox::EgressPolicy::Allowlist,
-            _ => organon::sandbox::EgressPolicy::Allow,
-        },
-        egress_allowlist: sandbox_settings.egress_allowlist.clone(),
-        nproc_limit: sandbox_settings.nproc_limit,
-    };
-    builtins::register_all_with_sandbox(&mut registry, sandbox)
-        .whatever_context("failed to register builtin tools")?;
-    info!(count = registry.definitions().len(), "tools registered");
-    Ok(registry)
 }
 
 /// Lazily-initialized embedding provider.
@@ -795,3 +767,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(all(test, feature = "energeia"))]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod setup_energeia_tests;

--- a/crates/aletheia/src/runtime/setup/setup_energeia_tests.rs
+++ b/crates/aletheia/src/runtime/setup/setup_energeia_tests.rs
@@ -1,0 +1,125 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use koina::id::{NousId, SessionId};
+use organon::registry::ToolRegistry;
+use tokio_util::sync::CancellationToken;
+
+use super::*;
+
+fn tool_context(root: &std::path::Path) -> organon::types::ToolContext {
+    organon::types::ToolContext {
+        nous_id: NousId::new("test").expect("valid nous id"),
+        session_id: SessionId::new(),
+        turn_number: 0,
+        workspace: root.to_path_buf(),
+        allowed_roots: vec![root.to_path_buf()],
+        services: None,
+        active_tools: Arc::new(std::sync::RwLock::new(HashSet::new())),
+        tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
+    }
+}
+
+async fn assert_tool_not_missing_services(
+    registry: &ToolRegistry,
+    ctx: &organon::types::ToolContext,
+    name: &'static str,
+    arguments: serde_json::Value,
+) {
+    let input = organon::types::ToolInput {
+        name: koina::id::ToolName::from_static(name),
+        tool_use_id: format!("toolu_{name}"),
+        arguments,
+    };
+    let result = registry.execute(&input, ctx).await.expect("tool executes");
+    let text = result.content.text_summary();
+    assert!(
+        !text.contains("missing EnergeiaServices"),
+        "{name} should use runtime services, got: {text}"
+    );
+    assert!(!result.is_error, "{name} returned error: {text}");
+}
+
+#[tokio::test]
+async fn energeia_feature_registers_service_backed_runtime_tools() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let oikos = Oikos::from_root(tmp.path());
+    let config = AletheiaConfig::default();
+    let registry = build_tool_registry(&config, &oikos, &CancellationToken::new())
+        .expect("tool registry with energeia services");
+    let names: HashSet<String> = registry
+        .definitions()
+        .iter()
+        .map(|def| def.name.as_str().to_owned())
+        .collect();
+    for name in ["dromeus", "parateresis", "mathesis", "metron"] {
+        assert!(names.contains(name), "{name} should be registered");
+    }
+
+    let ctx = tool_context(tmp.path());
+    assert_tool_not_missing_services(
+        &registry,
+        &ctx,
+        "mathesis",
+        serde_json::json!({
+            "action": "record",
+            "source": "dispatch",
+            "category": "runtime",
+            "project": "forkwright/aletheia",
+            "lesson": "runtime registry injected energeia services"
+        }),
+    )
+    .await;
+    assert_tool_not_missing_services(
+        &registry,
+        &ctx,
+        "mathesis",
+        serde_json::json!({
+            "action": "list",
+            "project": "forkwright/aletheia"
+        }),
+    )
+    .await;
+    assert_tool_not_missing_services(
+        &registry,
+        &ctx,
+        "parateresis",
+        serde_json::json!({
+            "project": "forkwright/aletheia",
+            "days": 7
+        }),
+    )
+    .await;
+    assert_tool_not_missing_services(
+        &registry,
+        &ctx,
+        "metron",
+        serde_json::json!({
+            "report_type": "health",
+            "days": 30
+        }),
+    )
+    .await;
+
+    let spec = serde_json::json!([
+        {
+            "number": 1,
+            "description": "verify service-backed dry run",
+            "depends_on": [],
+            "acceptance_criteria": [],
+            "blast_radius": [],
+            "body": "No dispatch should be spawned during dry_run"
+        }
+    ]);
+    assert_tool_not_missing_services(
+        &registry,
+        &ctx,
+        "dromeus",
+        serde_json::json!({
+            "spec": spec.to_string(),
+            "project": "forkwright/aletheia",
+            "dry_run": true
+        }),
+    )
+    .await;
+}

--- a/crates/aletheia/src/runtime/setup/tool_registry.rs
+++ b/crates/aletheia/src/runtime/setup/tool_registry.rs
@@ -1,0 +1,147 @@
+#[cfg(feature = "energeia")]
+use std::sync::Arc;
+
+use snafu::prelude::*;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use organon::builtins;
+use organon::registry::ToolRegistry;
+use taxis::config::AletheiaConfig;
+use taxis::oikos::Oikos;
+
+use crate::error::Result;
+
+#[cfg(feature = "energeia")]
+struct MechanicalQaGate;
+
+#[cfg(feature = "energeia")]
+impl energeia::qa::QaGate for MechanicalQaGate {
+    fn evaluate<'a>(
+        &'a self,
+        prompt: &'a energeia::qa::PromptSpec,
+        pr_number: u64,
+        diff: &'a str,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = energeia::error::Result<energeia::types::QaResult>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move { Ok(energeia::qa::run_qa(diff, prompt, pr_number, None).await) })
+    }
+
+    fn mechanical_check(
+        &self,
+        diff: &str,
+        prompt: &energeia::qa::PromptSpec,
+    ) -> Vec<energeia::types::MechanicalIssue> {
+        energeia::qa::mechanical::mechanical_check(diff, prompt)
+    }
+}
+
+pub(in crate::runtime) fn build_tool_registry(
+    config: &AletheiaConfig,
+    oikos: &Oikos,
+    shutdown_token: &CancellationToken,
+) -> Result<ToolRegistry> {
+    let mut registry = ToolRegistry::new();
+    let sandbox_settings = &config.sandbox;
+    let sandbox = organon::sandbox::SandboxConfig {
+        enabled: sandbox_settings.enabled,
+        enforcement: match sandbox_settings.enforcement {
+            taxis::config::SandboxEnforcementMode::Enforcing => {
+                organon::sandbox::SandboxEnforcement::Enforcing
+            }
+            _ => organon::sandbox::SandboxEnforcement::Permissive,
+        },
+        allowed_root: sandbox_settings.allowed_root.clone(),
+        extra_read_paths: sandbox_settings.extra_read_paths.clone(),
+        extra_write_paths: sandbox_settings.extra_write_paths.clone(),
+        extra_exec_paths: sandbox_settings.extra_exec_paths.clone(),
+        egress: match sandbox_settings.egress {
+            taxis::config::EgressPolicy::Deny => organon::sandbox::EgressPolicy::Deny,
+            taxis::config::EgressPolicy::Allowlist => organon::sandbox::EgressPolicy::Allowlist,
+            _ => organon::sandbox::EgressPolicy::Allow,
+        },
+        egress_allowlist: sandbox_settings.egress_allowlist.clone(),
+        nproc_limit: sandbox_settings.nproc_limit,
+    };
+    register_builtin_tools(
+        &mut registry,
+        sandbox,
+        config,
+        oikos,
+        shutdown_token.child_token(),
+    )?;
+    info!(count = registry.definitions().len(), "tools registered");
+    Ok(registry)
+}
+
+fn register_builtin_tools(
+    registry: &mut ToolRegistry,
+    sandbox: organon::sandbox::SandboxConfig,
+    config: &AletheiaConfig,
+    oikos: &Oikos,
+    cancel_token: CancellationToken,
+) -> Result<()> {
+    #[cfg(feature = "energeia")]
+    {
+        let services = build_energeia_services(config, oikos, cancel_token)?;
+        builtins::register_all_with_sandbox_and_energeia_services(
+            registry,
+            sandbox,
+            services.as_ref(),
+        )
+        .whatever_context("failed to register builtin tools")
+    }
+
+    #[cfg(not(feature = "energeia"))]
+    {
+        let _ = (config, oikos, cancel_token);
+        builtins::register_all_with_sandbox(registry, sandbox)
+            .whatever_context("failed to register builtin tools")
+    }
+}
+
+#[cfg(feature = "energeia")]
+fn build_energeia_services(
+    config: &AletheiaConfig,
+    oikos: &Oikos,
+    cancel_token: CancellationToken,
+) -> Result<Arc<organon::builtins::energeia::EnergeiaServices>> {
+    let store_path = oikos.data().join("energeia.fjall");
+    if let Some(parent) = store_path.parent() {
+        std::fs::create_dir_all(parent).with_whatever_context(|_| {
+            format!("failed to create energeia data dir {}", parent.display())
+        })?;
+    }
+    let db = fjall::Database::builder(&store_path)
+        .open()
+        .with_whatever_context(|_| {
+            format!("failed to open energeia store at {}", store_path.display())
+        })?;
+    let store = Arc::new(
+        energeia::store::EnergeiaStore::new(&db)
+            .whatever_context("failed to initialize energeia store partitions")?,
+    );
+
+    let default_model = &config.agents.defaults.model_defaults.model.primary;
+    let engine: Arc<dyn energeia::engine::DispatchEngine> =
+        Arc::new(energeia::http::HttpEngine::new(default_model));
+    let qa: Arc<dyn energeia::qa::QaGate> = Arc::new(MechanicalQaGate);
+    let orchestrator = Arc::new(
+        energeia::orchestrator::Orchestrator::new(
+            engine,
+            qa,
+            energeia::orchestrator::OrchestratorConfig::new(),
+        )
+        .with_store(Arc::clone(&store))
+        .with_cancel_token(cancel_token),
+    );
+
+    Ok(Arc::new(
+        organon::builtins::energeia::EnergeiaServices::new(orchestrator, store),
+    ))
+}

--- a/crates/organon/src/builtins/energeia/dispatch.rs
+++ b/crates/organon/src/builtins/energeia/dispatch.rs
@@ -119,11 +119,11 @@ impl ToolExecutor for DromeusExecutor {
             let args = &input.arguments;
             let spec_str = match require_str(args, "spec") {
                 Ok(s) => s,
-                Err(e) => return Ok(e),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
             let project = match require_str(args, "project") {
                 Ok(s) => s,
-                Err(e) => return Ok(e),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
             if project.trim().is_empty() {
                 return Ok(ToolResult::error("missing required field 'project'"));

--- a/crates/organon/src/builtins/energeia/metrics.rs
+++ b/crates/organon/src/builtins/energeia/metrics.rs
@@ -98,7 +98,7 @@ impl ToolExecutor for MetronExecutor {
             let args = &input.arguments;
             let report_type = match require_str(args, "report_type") {
                 Ok(s) => s,
-                Err(e) => return Ok(e),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
             let days = opt_u64(args, "days")
                 .and_then(|d| u32::try_from(d).ok())

--- a/crates/organon/src/builtins/energeia/mod.rs
+++ b/crates/organon/src/builtins/energeia/mod.rs
@@ -41,11 +41,8 @@ use crate::registry::ToolRegistry;
 /// # Errors
 ///
 /// Returns an error if any tool name collides with an already-registered tool.
-pub fn register(
-    registry: &mut ToolRegistry,
-    services: Option<Arc<EnergeiaServices>>,
-) -> Result<()> {
-    let (orchestrator, store) = match &services {
+pub fn register(registry: &mut ToolRegistry, services: Option<&EnergeiaServices>) -> Result<()> {
+    let (orchestrator, store) = match services {
         Some(svc) => (
             Some(Arc::clone(&svc.orchestrator)),
             Some(Arc::clone(&svc.store)),

--- a/crates/organon/src/builtins/energeia/observation.rs
+++ b/crates/organon/src/builtins/energeia/observation.rs
@@ -83,7 +83,7 @@ impl ToolExecutor for ParateresisExecutor {
             let args = &input.arguments;
             let project = match require_str(args, "project") {
                 Ok(s) => s,
-                Err(e) => return Ok(e),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
             let days = opt_u64(args, "days")
                 .and_then(|d| u32::try_from(d).ok())
@@ -223,7 +223,7 @@ impl ToolExecutor for MathesisExecutor {
             let args = &input.arguments;
             let action = match require_str(args, "action") {
                 Ok(s) => s,
-                Err(e) => return Ok(e),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
 
             match action {
@@ -252,13 +252,10 @@ impl ToolExecutor for MathesisExecutor {
                     }
                 }
                 "record" => {
-                    let lesson_text = match require_str(args, "lesson") {
-                        Ok(s) => s,
-                        Err(_) => {
-                            return Ok(ToolResult::error(
-                                "mathesis: 'lesson' field required for action 'record'",
-                            ));
-                        }
+                    let Ok(lesson_text) = require_str(args, "lesson") else {
+                        return Ok(ToolResult::error(
+                            "mathesis: 'lesson' field required for action 'record'",
+                        ));
                     };
                     let source = opt_str(args, "source").unwrap_or("dispatch").to_owned();
                     let category = opt_str(args, "category").unwrap_or("general").to_owned();

--- a/crates/organon/src/builtins/energeia/planning.rs
+++ b/crates/organon/src/builtins/energeia/planning.rs
@@ -95,16 +95,17 @@ impl ToolExecutor for ProographeExecutor {
         Box::pin(async move {
             let args = &input.arguments;
 
-            let description = opt_str(args, "description")
-                .map(ToOwned::to_owned)
-                .unwrap_or_else(|| {
+            let description = opt_str(args, "description").map_or_else(
+                || {
                     let issue_num = opt_u64(args, "from_issue").unwrap_or(0);
                     if issue_num > 0 {
                         format!("Implement GitHub issue #{issue_num}")
                     } else {
                         "Task description".to_owned()
                     }
-                });
+                },
+                ToOwned::to_owned,
+            );
 
             let criteria: Vec<String> = args
                 .get("criteria")
@@ -124,10 +125,13 @@ impl ToolExecutor for ProographeExecutor {
             let criteria_yaml = if criteria.is_empty() {
                 "  - \"(to be defined)\"\n".to_owned()
             } else {
-                criteria
-                    .iter()
-                    .map(|c| format!("  - \"{c}\"\n"))
-                    .collect::<String>()
+                let mut yaml = String::new();
+                for criterion in &criteria {
+                    yaml.push_str("  - \"");
+                    yaml.push_str(criterion);
+                    yaml.push_str("\"\n");
+                }
+                yaml
             };
 
             let spec_yaml = format!(
@@ -194,7 +198,7 @@ impl ToolExecutor for SchedionExecutor {
             let args = &input.arguments;
             let project = match require_str(args, "project") {
                 Ok(s) => s,
-                Err(e) => return Ok(e),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
 
             // WHY: Prompt files aren't accessible from the project slug alone —

--- a/crates/organon/src/builtins/energeia/qa.rs
+++ b/crates/organon/src/builtins/energeia/qa.rs
@@ -102,9 +102,8 @@ impl ToolExecutor for DokimasiaExecutor {
                 Some(n) => u32::try_from(n).unwrap_or(0),
                 None => return Ok(ToolResult::error("missing required field 'prompt_number'")),
             };
-            let pr_number = match opt_u64(args, "pr_number") {
-                Some(n) => n,
-                None => return Ok(ToolResult::error("missing required field 'pr_number'")),
+            let Some(pr_number) = opt_u64(args, "pr_number") else {
+                return Ok(ToolResult::error("missing required field 'pr_number'"));
             };
             let project = opt_str(args, "project");
             if project.is_some_and(|p| p.trim().is_empty()) {
@@ -112,7 +111,7 @@ impl ToolExecutor for DokimasiaExecutor {
             }
             let diff = match require_str(args, "diff") {
                 Ok(s) => s,
-                Err(e) => return Ok(e),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
             if diff.trim().is_empty() {
                 let output = serde_json::json!({
@@ -201,7 +200,7 @@ impl ToolExecutor for DiorthosisExecutor {
 
             let qa_result_id = match require_str(args, "qa_result_id") {
                 Ok(s) => s,
-                Err(e) => return Ok(e),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
             let original_prompt_number = match opt_u64(args, "original_prompt_number") {
                 Some(n) => u32::try_from(n).unwrap_or(0),

--- a/crates/organon/src/builtins/energeia/shared.rs
+++ b/crates/organon/src/builtins/energeia/shared.rs
@@ -20,16 +20,27 @@ pub struct EnergeiaServices {
     pub store: Arc<EnergeiaStore>,
 }
 
+impl EnergeiaServices {
+    /// Create a service bundle for Energeia tool executors.
+    #[must_use]
+    pub fn new(orchestrator: Arc<Orchestrator>, store: Arc<EnergeiaStore>) -> Self {
+        Self {
+            orchestrator,
+            store,
+        }
+    }
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /// Extract a required string field from tool arguments.
 pub(super) fn require_str<'a>(
     args: &'a serde_json::Value,
     field: &str,
-) -> std::result::Result<&'a str, ToolResult> {
+) -> std::result::Result<&'a str, String> {
     args.get(field)
         .and_then(|v| v.as_str())
-        .ok_or_else(|| ToolResult::error(format!("missing required field '{field}'")))
+        .ok_or_else(|| format!("missing required field '{field}'"))
 }
 
 /// Extract an optional string field from tool arguments.
@@ -39,15 +50,15 @@ pub(super) fn opt_str<'a>(args: &'a serde_json::Value, field: &str) -> Option<&'
 
 /// Extract an optional u64 field from tool arguments.
 pub(super) fn opt_u64(args: &serde_json::Value, field: &str) -> Option<u64> {
-    args.get(field).and_then(|v| v.as_u64())
+    args.get(field).and_then(serde_json::Value::as_u64)
 }
 
 /// Extract an optional bool field from tool arguments.
 pub(super) fn opt_bool(args: &serde_json::Value, field: &str) -> Option<bool> {
-    args.get(field).and_then(|v| v.as_bool())
+    args.get(field).and_then(serde_json::Value::as_bool)
 }
 
-/// Serialize a value to a pretty-printed JSON ToolResult.
+/// Serialize a value to a pretty-printed JSON `ToolResult`.
 pub(super) fn to_json_text<T: serde::Serialize>(value: &T) -> ToolResult {
     match serde_json::to_string_pretty(value) {
         Ok(text) => ToolResult::text(text),

--- a/crates/organon/src/builtins/energeia/steward.rs
+++ b/crates/organon/src/builtins/energeia/steward.rs
@@ -89,7 +89,7 @@ impl ToolExecutor for EpitroposExecutor {
 
             let project = match require_str(args, "project") {
                 Ok(s) => s,
-                Err(e) => return Ok(e),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
             let once = opt_bool(args, "once").unwrap_or(false);
             let dry_run = opt_bool(args, "dry_run").unwrap_or(false);

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -112,8 +112,42 @@ pub fn register_all_with_sandbox(
     registry: &mut ToolRegistry,
     sandbox: SandboxConfig,
 ) -> Result<()> {
+    register_all_with_sandbox_inner(
+        registry,
+        sandbox,
+        #[cfg(feature = "energeia")]
+        None,
+    )
+}
+
+/// Register all built-in tool executors with custom sandbox config and
+/// service-backed Energeia tools.
+///
+/// # Errors
+///
+/// Returns an error if any built-in tool name collides with an
+/// already-registered tool.
+#[cfg(feature = "energeia")]
+pub fn register_all_with_sandbox_and_energeia_services(
+    registry: &mut ToolRegistry,
+    sandbox: SandboxConfig,
+    services: &energeia::EnergeiaServices,
+) -> Result<()> {
+    register_all_with_sandbox_inner(registry, sandbox, Some(services))
+}
+
+fn register_all_with_sandbox_inner(
+    registry: &mut ToolRegistry,
+    sandbox: SandboxConfig,
+    #[cfg(feature = "energeia")] energeia_services: Option<&energeia::EnergeiaServices>,
+) -> Result<()> {
     // ── Phase 1: register all domain tools ───────────────────────────────────
-    register_domain_tools(registry, sandbox)?;
+    register_domain_tools(
+        registry,
+        sandbox,
+        #[cfg(feature = "energeia")]
+        energeia_services,
+    )?;
 
     // ── Phase 2: register tool_schema with a snapshot of phase-1 definitions ──
     // WHY: tool_schema must see the complete tool set to serve schemas for
@@ -164,6 +198,7 @@ pub fn register_all_with_sandbox(
 pub(crate) fn register_domain_tools(
     registry: &mut ToolRegistry,
     sandbox: SandboxConfig,
+    #[cfg(feature = "energeia")] energeia_services: Option<&energeia::EnergeiaServices>,
 ) -> Result<()> {
     #[cfg(feature = "computer-use")]
     computer_use::register(registry, &sandbox)?;
@@ -188,10 +223,10 @@ pub(crate) fn register_domain_tools(
     triage::register(registry)?;
     parameters::register(registry)?;
     #[cfg(feature = "energeia")]
-    // WHY: No EnergeiaServices provided at this registration level — callers that
-    // have services configured should use energeia::register(registry, Some(services)).
+    // WHY: generic registration still supports service-less schemas for tests
+    // and tools that do not own the runtime; Aletheia injects real services.
     // Tools requiring services return structured errors rather than panicking.
-    energeia::register(registry, None)?;
+    energeia::register(registry, energeia_services)?;
     #[cfg(feature = "bookkeeper")]
     bookkeeper::register(registry)?;
     poiesis::register(registry)?;
@@ -216,7 +251,7 @@ mod tests {
     #[test]
     fn default_energeia_registry_excludes_unimplemented_bookkeeper_tools() -> Result<()> {
         let mut registry = ToolRegistry::new();
-        register_domain_tools(&mut registry, SandboxConfig::default())?;
+        register_domain_tools(&mut registry, SandboxConfig::default(), None)?;
         let names: Vec<&str> = registry
             .definitions()
             .iter()

--- a/crates/organon/src/builtins/tool_schema.rs
+++ b/crates/organon/src/builtins/tool_schema.rs
@@ -209,7 +209,13 @@ mod tests {
 
         // Phase 1: register domain tools.
         let mut reg = ToolRegistry::new();
-        register_domain_tools(&mut reg, SandboxConfig::default()).expect("register_domain_tools");
+        register_domain_tools(
+            &mut reg,
+            SandboxConfig::default(),
+            #[cfg(feature = "energeia")]
+            None,
+        )
+        .expect("register_domain_tools");
 
         // Phase 2: extract schema pairs while registry is immutably borrowed.
         let pairs: Vec<(String, String)> = reg

--- a/crates/organon/tests/energeia_tools.rs
+++ b/crates/organon/tests/energeia_tools.rs
@@ -78,10 +78,7 @@ fn setup() -> (TempDir, Arc<EnergeiaServices>) {
     let orchestrator =
         Arc::new(Orchestrator::new(engine, qa, config).with_store(Arc::clone(&store)));
 
-    let services = Arc::new(EnergeiaServices {
-        orchestrator,
-        store,
-    });
+    let services = Arc::new(EnergeiaServices::new(orchestrator, store));
 
     (tmp, services)
 }
@@ -138,7 +135,7 @@ async fn all_nine_tools_return_non_error() {
     let ctx = make_ctx();
 
     let mut registry = ToolRegistry::new();
-    register(&mut registry, Some(Arc::clone(&services)))
+    register(&mut registry, Some(services.as_ref()))
         .expect("all 9 tools register without collision");
 
     assert_eq!(
@@ -303,7 +300,7 @@ async fn dokimasia_empty_diff_returns_no_work() {
     let (_tmp, services) = setup();
     let ctx = make_ctx();
     let mut registry = ToolRegistry::new();
-    register(&mut registry, Some(services)).expect("register");
+    register(&mut registry, Some(services.as_ref())).expect("register");
 
     let input = make_input(
         "dokimasia",
@@ -556,7 +553,7 @@ async fn dokimasia_runs_without_project() {
     let (_tmp, services) = setup();
     let ctx = make_ctx();
     let mut registry = ToolRegistry::new();
-    register(&mut registry, Some(services)).expect("register");
+    register(&mut registry, Some(services.as_ref())).expect("register");
 
     let input = make_input(
         "dokimasia",

--- a/docs/FEATURE-FLAGS.md
+++ b/docs/FEATURE-FLAGS.md
@@ -18,7 +18,7 @@ Every feature flag defined in the workspace, how flags interact across crates, a
 | **aletheia** | `keyring` | no | Keyring integration | `symbolon/keyring` |
 | **aletheia** | `tui` | no | `dep:koilon` | - |
 | **aletheia** | `cc-provider` | no | Claude Code subprocess provider | `hermeneus/cc-provider` |
-| **aletheia** | `energeia` | no | `dep:energeia` | - |
+| **aletheia** | `energeia` | no | Dispatch orchestration plus service-backed Energeia agent tools in the runtime registry | `dep:energeia`, `energeia/storage-fjall`, `organon/energeia` |
 | **aletheia** | `test-core` | no | - | `mneme/test-core`, `nous/test-core`, `pylon/test-core` |
 | **aletheia** | `test-full` | no | - | `test-core`, `mneme/test-full` |
 | **daemon** (oikonomos) | `default` | **yes** | *(empty)* | - |
@@ -167,7 +167,7 @@ aletheia/embed-candle
 | `aletheia/keyring` | `symbolon/keyring` (`dep:keyring`) |
 | `aletheia/tui` | `dep:koilon` |
 | `aletheia/cc-provider` | `hermeneus/cc-provider` |
-| `aletheia/energeia` | `dep:energeia` |
+| `aletheia/energeia` | `dep:energeia`, `energeia/storage-fjall`, `organon/energeia` |
 | `organon/energeia` | `dep:energeia` (with `storage-fjall` pre-enabled) |
 | `daemon/knowledge-store` | `episteme/mneme-engine` |
 | `diaporeia/knowledge-store` | `nous/knowledge-store` |


### PR DESCRIPTION
## Summary

- make the `aletheia/energeia` feature enable `organon/energeia` and `energeia/storage-fjall`
- build runtime `EnergeiaServices` for the Aletheia tool registry and inject them into service-backed Organon Energeia tools
- add a feature-gated runtime test proving `dromeus`, `parateresis`, `mathesis`, and `metron` do not return missing-service errors
- split `runtime/mod.rs` validation, metrics, and Nous config helpers into focused modules without behavior changes
- track remaining bookkeeper tool implementation separately in #4029

Closes #3938

## Gates

- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo check -p aletheia --features energeia
- cargo clippy -p aletheia --features energeia --all-targets -- -D warnings
- cargo test -p aletheia --features energeia energeia_feature_registers_service_backed_runtime_tools -- --nocapture
- kanon lint --all --summary --paths-from <touched>

Kimi reviewer: APPROVE, no findings.