### PR TITLE
chore(release-prep): fix llm-regen pin + bump CVE deps + repair fuzz target

### DIFF
--- a/.github/workflows/llm-regen.yml
+++ b/.github/workflows/llm-regen.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Set up uv
         if: steps.detect.outputs.full_regen == 'true' || steps.detect.outputs.changed_crates != ''
-        uses: astral-sh/setup-uv@6b9c6063bc60119d52da10785162238992151715 # v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:
           version: "latest"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5047,7 +5047,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
 ]
 
@@ -6317,7 +6317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -7205,9 +7205,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -7801,7 +7801,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -9404,7 +9404,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",

--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -3543,15 +3543,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3575,9 +3574,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -3739,7 +3738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3749,7 +3748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4252,9 +4251,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4683,9 +4682,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5087,7 +5086,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/fuzz/fuzz_targets/fuzz_knowledge_roundtrip.rs
+++ b/fuzz/fuzz_targets/fuzz_knowledge_roundtrip.rs
@@ -13,8 +13,9 @@ use libfuzzer_sys::fuzz_target;
 
 use mneme::id::FactId;
 use mneme::knowledge::{
-    EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal, FactType,
-    ForgetReason, far_future, format_timestamp, parse_timestamp,
+    EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactSensitivity, FactTemporal,
+    FactType, ForgetReason, MemoryScope, Visibility, far_future, format_timestamp,
+    parse_timestamp,
 };
 use mneme::knowledge_store::KnowledgeStore;
 
@@ -61,6 +62,9 @@ fuzz_target!(|data: &[u8]| {
     let Some(&b0) = data.get(0) else { return };
     let Some(&b1) = data.get(1) else { return };
     let Some(&b2) = data.get(2) else { return };
+    let Some(&b3) = data.get(3) else { return };
+    let Some(&b4) = data.get(4) else { return };
+    let Some(&b5) = data.get(5) else { return };
     let Some(content_bytes) = data.get(8..) else {
         return;
     };
@@ -107,6 +111,30 @@ fuzz_target!(|data: &[u8]| {
         _ => FactType::Observation,
     };
 
+    // Derive memory scope from b3: None or one of four variants.
+    let scope = match b3 % 5 {
+        0 => None,
+        1 => Some(MemoryScope::User),
+        2 => Some(MemoryScope::Feedback),
+        3 => Some(MemoryScope::Project),
+        _ => Some(MemoryScope::Reference),
+    };
+
+    // Derive sensitivity from b4.
+    let sensitivity = match b4 % 3 {
+        0 => FactSensitivity::Public,
+        1 => FactSensitivity::Internal,
+        _ => FactSensitivity::Confidential,
+    };
+
+    // Derive visibility from b5.
+    let visibility = match b5 % 4 {
+        0 => Visibility::Private,
+        1 => Visibility::Shared,
+        2 => Visibility::Restricted,
+        _ => Visibility::Published,
+    };
+
     let now = jiff::Timestamp::now();
     // WHY: FactId::new returns Result; skip iteration if ID is somehow invalid.
     let Ok(id) = FactId::new(fact_id) else { return };
@@ -115,6 +143,9 @@ fuzz_target!(|data: &[u8]| {
         nous_id: "fuzz-agent".to_owned(),
         fact_type: fact_type.as_str().to_owned(),
         content: content.to_string(),
+        scope,
+        sensitivity,
+        visibility,
         temporal: FactTemporal {
             valid_from: now,
             valid_to: far_future(),


### PR DESCRIPTION
Pre-release cleanup so main is green before cutting 0.27.0 (#3990).

## Three fixes bundled

### 1. `_llm Regeneration` workflow — bad SHA pin

`astral-sh/setup-uv` was pinned to a non-existent SHA (`6b9c606...`). Every push to main since the dependabot bump that introduced it has failed the `_llm Regeneration` workflow with `Unable to resolve action`. Repinned to v5 head (`e58605a`).

### 2. Security CVE bumps

Resolves 10 of 11 open dependabot security alerts:

| Crate | Old → New | Severity fixed |
|-------|-----------|---------------|
| openssl | 0.10.76 → 0.10.80 | 3 HIGH + 2 MEDIUM + 1 LOW |
| rustls-webpki | 0.103.12 → 0.103.13 | 1 HIGH (DoS via malformed CRL) |
| rand | 0.8.5 → 0.8.6 | 2 LOW (root + proskenion) |

Remaining: `rand 0.7.3` (LOW) is transitively locked through `dioxus-desktop > wry > kuchikiki > selectors` — would require dioxus major upgrade to break. Tracked separately.

### 3. Fuzz target compile fix

`fuzz_knowledge_roundtrip.rs` was missing `scope`, `sensitivity`, `visibility` fields added to `Fact` when the team-memory + sensitivity gating + visibility model landed (#3404, #3413). The fuzz workflow has failed 8 consecutive Saturdays with `error E0063: missing 'scope', 'sensitivity' and 'visibility'`. Added field derivation from fuzzer bytes (b3/b4/b5) so each variant is exercised.

## Verification

Local builds passed:
- `cargo check --workspace` (root)
- `cargo check --bin fuzz_knowledge_roundtrip` (fuzz subworkspace, with libfuzzer-sys C++ deps)

Both Cargo.lock changes via `cargo update --precise`.

## Blocks release of

#3990 (release-please 0.27.0) — once this lands main is green and the release can be cut.