### PR TITLE
chore(repo): align aletheia with FLEET-REPO-SETUP

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md whitespace=-trailing-space,-blank-at-eol

--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -1,0 +1,47 @@
+name: Gate Attestation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate-attestation:
+    name: gate-attestation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify Gate-Passed trailer
+        run: |
+          commits=$(git log --format="%H" "origin/${{ github.base_ref }}..HEAD")
+          if [ -z "$commits" ]; then
+            echo "ERROR: No commits found in PR"
+            exit 1
+          fi
+
+          found=false
+          for sha in $commits; do
+            body=$(git log -1 --format="%b" "$sha")
+            if echo "$body" | grep -q "^Gate-Passed:"; then
+              version=$(echo "$body" | grep "^Gate-Passed:" | head -1)
+              echo "Found gate attestation: $version"
+              found=true
+              break
+            fi
+          done
+
+          if [ "$found" = false ]; then
+            echo "ERROR: No Gate-Passed trailer found in any PR commit."
+            echo "Run the local gate and commit with the trailer."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ One binary. No containers. No external databases. Beyond your LLM provider, ther
 Download the tarball from [releases](https://github.com/forkwright/aletheia/releases), extract, and run `init`:
 
 ```bash
-VERSION=v0.13.59
+VERSION=v0.27.0
 curl -L "https://github.com/forkwright/aletheia/releases/download/${VERSION}/aletheia-linux-x86_64-${VERSION}.tar.gz" \
   -o aletheia.tar.gz
 tar xzf aletheia.tar.gz


### PR DESCRIPTION
## Summary

Apply the fleet standard codified in [kanon `FLEET-REPO-SETUP.md`](https://github.com/forkwright/kanon/tree/main/crates/basanos/standards/FLEET-REPO-SETUP.md) (canary: harmonia#275). Aletheia is the reference template; this PR closes the remaining small deltas.

## In-tree changes

| Item | Before | After |
|------|--------|-------|
| `.gitattributes` | absent | adds `*.md whitespace=-trailing-space,-blank-at-eol` (D-055) |
| `.github/workflows/gate-attestation.yml` | absent | adds the standard gate-attestation check |
| `README.md` Quickstart `VERSION=` | `v0.13.59` (14 minors stale) | `v0.27.0` (current release per manifest) |

## Already spec-compliant (verified, no change)

- release-please workflow + config + manifest (at 0.27.0)
- CHANGELOG.md, llms.txt, AGENTS.md, STANDARDS.md (via standards/)
- Repo settings: squash-only, auto-merge, delete-on-merge already set
- No path/secret leaks, no AI attribution

## Requires operator manual action

1. **Branch protection on `main`.** Current state has `allow_force_pushes: true`. FLEET-REPO-SETUP §2 requires `allow_force_pushes: false`. Not auto-applied (lockout risk). Suggested patch:

   ```bash
   gh api repos/forkwright/aletheia/branches/main/protection -X PUT --input - <<'JSON'
   {
     "required_status_checks": {"strict": false, "contexts": ["gate-attestation"]},
     "enforce_admins": false,
     "required_pull_request_reviews": null,
     "restrictions": null,
     "required_linear_history": false,
     "allow_force_pushes": false,
     "allow_deletions": false
   }
   JSON
   ```

2. **Org-level toggle** — one-time, already done if other fleet repos use release-please.

## Out of scope (per audit, separate PR)

- `_llm/current_state.toml` staleness ("v0.22.0 in flight" / repo at 0.27.0).
- Fuzz workflow 4+ week red streak (cron-only verification window).
- `#[allow(dead_code)]` -> `#[expect(dead_code)]` in 4 code-side files.

## Related

- [kanon FLEET-REPO-SETUP.md](https://github.com/forkwright/kanon/tree/main/crates/basanos/standards/FLEET-REPO-SETUP.md)
- [harmonia#275](https://github.com/forkwright/harmonia/pull/275) — canary

Gate-Passed: kanon 0.1.0