### PR TITLE
docs(_llm): refresh current_state.toml to v0.27.0

### DIFF
--- a/_llm/current_state.toml
+++ b/_llm/current_state.toml
@@ -5,32 +5,43 @@ generated = false
 source_docs = [
   "<canonical-state-doc>/STATE.md",
   "README.md",
+  "CHANGELOG.md",
 ]
 
 [state]
 summary = "Aletheia is the active self-hosted multi-agent runtime for persistent memory, tools, Signal, TUI, HTTP, and desktop surfaces."
-current_phase = "v0.22.0 in flight; architectural-review arc majority closed; theatron extraction accepted."
-updated = "2026-04-26"
+current_phase = "v0.27.0 released; energeia runtime hardening + proskenion shell stabilization; fleet-repo alignment (FLEET-REPO-SETUP) landed."
+updated = "2026-05-24"
 
 [[recent]]
-date = "2026-04-22"
-item = "Tier-aware model resolution, sovereignty regression fix, Z3 tool, rand migration, and dependabot clippy gate shipped."
+date = "2026-05-24"
+item = "0.27.0 release: energeia service-backed runtime tools, cli dispatch backend health probe, orchestrator session passthrough, proskenion component library, taxis strict provider example."
 
 [[recent]]
-date = "2026-04-20"
-item = "Production unwrap audit, sovereignty hardening, dispatch pipeline, graph recall, and _llm docs pipeline landed."
+date = "2026-05-22"
+item = "0.26.x: hermeneus OpenAI Responses provider, proskenion D2 contract coverage."
 
 [[open_threads]]
 name = "release-please"
-issue = 3774
-status = "v0.22.0 release PR open."
+issue = 3990
+status = "v0.27.0 released 2026-05-24; next release-please PR opens on next conventional commit."
 
 [[open_threads]]
 name = "empirical router silo"
-issue = 3738
-status = "Follow-up to complexity-router wire-in so interactive paths can consume success-rate feedback."
+issue = 3944
+status = "Empirical feedback routers implemented but runtime discards outcomes through NoOpRouter; awaiting wire-in."
 
 [[open_threads]]
-name = "theatron extraction"
-issue = 0
-status = "Accepted fleet refactor; aletheia-specific behavior must stay unchanged."
+name = "energeia approval-wait"
+issue = 3958
+status = "Reversibility approval metadata and UI approval events not wired to tool execution."
+
+[[open_threads]]
+name = "energeia cron scheduling"
+issue = 3940
+status = "Cron path fires logs instead of dispatch and registers bridge-less tasks."
+
+[[open_threads]]
+name = "energeia QA / steward loop"
+issue = 3941
+status = "QA and steward loop runs on empty diffs, placeholder results, and unwired learning capture."


### PR DESCRIPTION
## Summary
- Refreshes `_llm/current_state.toml` from claiming `v0.22.0 in flight` (updated 2026-04-26) to the actual repo state at v0.27.0 (released 2026-05-24).
- Updates open_threads to point at current valid open issues (#3940 cron, #3941 QA loop, #3944 router silo, #3958 approval-wait, #3990 release-please).
- Refreshes recent[] entries to cover the 0.26.x and 0.27.0 release content from CHANGELOG.

## Test plan
- [ ] CI green (docs-only, no Rust changes).
- [ ] Agents loading cold_start recipe see v0.27.0 phase + 2026-05-24 updated date.

Closes #4034