### PR TITLE
docs(QUICKSTART): bump prebuilt-binary version pin to v0.27.0

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -52,7 +52,7 @@ aletheia --version
 Download the tarball from the [releases page](https://github.com/forkwright/aletheia/releases) instead of building from source:
 
 ```bash
-VERSION=v0.13.37
+VERSION=v0.27.0
 curl -L "https://github.com/forkwright/aletheia/releases/download/${VERSION}/aletheia-linux-x86_64-${VERSION}.tar.gz" \
   -o aletheia.tar.gz
 tar xzf aletheia.tar.gz


### PR DESCRIPTION
## Summary
- QUICKSTART "Alternative: prebuilt binary" pinned VERSION=v0.13.37 (14 minor releases stale).
- README's primary install block was bumped to v0.27.0 already; QUICKSTART was the missed second pin.
- One-line bump, docs-only.

## Test plan
- [ ] Quickstart curl URL resolves to a real release tarball.

Closes #4033