### PR TITLE
fix(hermeneus): normalize OpenAI cache token usage

### DIFF
--- a/crates/hermeneus/src/openai/wire/response.rs
+++ b/crates/hermeneus/src/openai/wire/response.rs
@@ -59,7 +59,14 @@ pub(crate) struct ChatUsage {
     pub prompt_tokens: u64,
     #[serde(default)]
     pub completion_tokens: u64,
-    // OpenAI does not expose cache-tier tokens; leave zero.
+    #[serde(default)]
+    pub prompt_tokens_details: Option<TokenDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct TokenDetails {
+    #[serde(default)]
+    pub cached_tokens: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -117,6 +124,8 @@ pub(crate) struct ResponsesUsage {
     pub input_tokens: u64,
     #[serde(default)]
     pub output_tokens: u64,
+    #[serde(default)]
+    pub input_tokens_details: Option<TokenDetails>,
 }
 
 impl ChatCompletionResponse {
@@ -167,11 +176,17 @@ impl ChatCompletionResponse {
         }
 
         let usage = usage
-            .map(|u| Usage {
-                input_tokens: u.prompt_tokens,
-                output_tokens: u.completion_tokens,
-                cache_read_tokens: 0,
-                cache_write_tokens: 0,
+            .map(|u| {
+                let cache_read_tokens = u
+                    .prompt_tokens_details
+                    .as_ref()
+                    .map_or(0, |details| details.cached_tokens);
+                Usage {
+                    input_tokens: u.prompt_tokens.saturating_sub(cache_read_tokens),
+                    output_tokens: u.completion_tokens,
+                    cache_read_tokens,
+                    cache_write_tokens: 0,
+                }
             })
             .unwrap_or_default();
 
@@ -267,11 +282,17 @@ impl ResponsesResponse {
         };
 
         let usage = usage
-            .map(|u| Usage {
-                input_tokens: u.input_tokens,
-                output_tokens: u.output_tokens,
-                cache_read_tokens: 0,
-                cache_write_tokens: 0,
+            .map(|u| {
+                let cache_read_tokens = u
+                    .input_tokens_details
+                    .as_ref()
+                    .map_or(0, |details| details.cached_tokens);
+                Usage {
+                    input_tokens: u.input_tokens.saturating_sub(cache_read_tokens),
+                    output_tokens: u.output_tokens,
+                    cache_read_tokens,
+                    cache_write_tokens: 0,
+                }
             })
             .unwrap_or_default();
 
@@ -415,6 +436,56 @@ mod tests {
         let resp = parsed.into_response().unwrap();
         assert_eq!(resp.usage.input_tokens, 0);
         assert_eq!(resp.usage.output_tokens, 0);
+    }
+
+    #[test]
+    fn chat_usage_extracts_cached_prompt_tokens() {
+        let body = r#"{
+            "id": "chatcmpl-cache",
+            "model": "qwen",
+            "choices": [{
+                "message": { "role": "assistant", "content": "cached" },
+                "finish_reason": "stop",
+                "index": 0
+            }],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 2,
+                "total_tokens": 11,
+                "prompt_tokens_details": { "cached_tokens": 7 }
+            }
+        }"#;
+        let parsed: ChatCompletionResponse = serde_json::from_str(body).unwrap();
+        let resp = parsed.into_response().unwrap();
+        assert_eq!(resp.usage.input_tokens, 2);
+        assert_eq!(resp.usage.output_tokens, 2);
+        assert_eq!(resp.usage.cache_read_tokens, 7);
+        assert_eq!(resp.usage.cache_write_tokens, 0);
+    }
+
+    #[test]
+    fn responses_usage_extracts_cached_input_tokens() {
+        let body = r#"{
+            "id": "resp-cache",
+            "model": "gpt-5",
+            "status": "completed",
+            "output": [{
+                "type": "message",
+                "content": [{ "type": "output_text", "text": "cached" }]
+            }],
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 3,
+                "total_tokens": 15,
+                "input_tokens_details": { "cached_tokens": 8 }
+            }
+        }"#;
+        let parsed: ResponsesResponse = serde_json::from_str(body).unwrap();
+        let resp = parsed.into_response().unwrap();
+        assert_eq!(resp.usage.input_tokens, 4);
+        assert_eq!(resp.usage.output_tokens, 3);
+        assert_eq!(resp.usage.cache_read_tokens, 8);
+        assert_eq!(resp.usage.cache_write_tokens, 0);
     }
 
     #[test]

--- a/crates/hermeneus/src/openai/wire/stream.rs
+++ b/crates/hermeneus/src/openai/wire/stream.rs
@@ -14,7 +14,7 @@ use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
 use crate::types::{CompletionResponse, ContentBlock, StopReason, Usage};
 
-use super::response::{ResponsesResponse, parse_arguments};
+use super::response::{ResponsesResponse, TokenDetails, parse_arguments};
 
 #[derive(Debug, Deserialize)]
 struct ChatStreamChunk {
@@ -66,6 +66,8 @@ struct ChatStreamUsage {
     prompt_tokens: u64,
     #[serde(default)]
     completion_tokens: u64,
+    #[serde(default)]
+    prompt_tokens_details: Option<TokenDetails>,
 }
 
 /// Accumulator for an OpenAI SSE stream.
@@ -127,8 +129,13 @@ impl OpenAiStreamAccumulator {
         }
 
         if let Some(usage) = chunk.usage {
-            self.usage.input_tokens = usage.prompt_tokens;
+            let cache_read_tokens = usage
+                .prompt_tokens_details
+                .as_ref()
+                .map_or(0, |details| details.cached_tokens);
+            self.usage.input_tokens = usage.prompt_tokens.saturating_sub(cache_read_tokens);
             self.usage.output_tokens = usage.completion_tokens;
+            self.usage.cache_read_tokens = cache_read_tokens;
         }
 
         for choice in chunk.choices {
@@ -479,8 +486,13 @@ impl ResponsesStreamAccumulator {
             self.model.clone_from(&response.model);
         }
         if let Some(usage) = &response.usage {
-            self.usage.input_tokens = usage.input_tokens;
+            let cache_read_tokens = usage
+                .input_tokens_details
+                .as_ref()
+                .map_or(0, |details| details.cached_tokens);
+            self.usage.input_tokens = usage.input_tokens.saturating_sub(cache_read_tokens);
             self.usage.output_tokens = usage.output_tokens;
+            self.usage.cache_read_tokens = cache_read_tokens;
         }
         self.start_message(on_event);
     }
@@ -647,6 +659,17 @@ mod tests {
         (events, resp)
     }
 
+    fn process_responses_events(chunks: &[&str]) -> (Vec<StreamEvent>, CompletionResponse) {
+        let mut acc = ResponsesStreamAccumulator::new();
+        let mut events = Vec::new();
+        for event_json in chunks {
+            let event: ResponsesStreamEvent = serde_json::from_str(event_json).unwrap();
+            acc.process_event(event, &mut |e| events.push(e)).unwrap();
+        }
+        let resp = acc.finish(&mut |e| events.push(e));
+        (events, resp)
+    }
+
     #[test]
     fn accumulates_text_deltas() {
         let (events, resp) = process_chunks(&[
@@ -692,9 +715,35 @@ mod tests {
     fn usage_propagates_when_present() {
         let (_, resp) = process_chunks(&[
             r#"{"id":"x","model":"m","choices":[{"index":0,"delta":{"content":"hi"}}]}"#,
-            r#"{"id":"x","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":1}}"#,
+            r#"{"id":"x","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":1,"prompt_tokens_details":{"cached_tokens":3}}}"#,
         ]);
-        assert_eq!(resp.usage.input_tokens, 4);
+        assert_eq!(resp.usage.input_tokens, 1);
         assert_eq!(resp.usage.output_tokens, 1);
+        assert_eq!(resp.usage.cache_read_tokens, 3);
+    }
+
+    #[test]
+    fn responses_stream_usage_extracts_cached_input_tokens() {
+        let (_, resp) = process_responses_events(&[r#"{
+            "type": "response.completed",
+            "response": {
+                "id": "resp-cache",
+                "model": "gpt-5",
+                "status": "completed",
+                "output": [{
+                    "type": "message",
+                    "content": [{ "type": "output_text", "text": "cached" }]
+                }],
+                "usage": {
+                    "input_tokens": 9,
+                    "output_tokens": 2,
+                    "total_tokens": 11,
+                    "input_tokens_details": { "cached_tokens": 6 }
+                }
+            }
+        }"#]);
+        assert_eq!(resp.usage.input_tokens, 3);
+        assert_eq!(resp.usage.output_tokens, 2);
+        assert_eq!(resp.usage.cache_read_tokens, 6);
     }
 }


### PR DESCRIPTION
## Summary

- parse OpenAI Chat Completions `prompt_tokens_details.cached_tokens` into canonical cache-read usage
- parse OpenAI Responses `input_tokens_details.cached_tokens` for blocking and streaming responses
- keep uncached input tokens separate from cache-read tokens so pricing and cache-hit metrics do not double-count

Closes #3971 for the OpenAI KPI normalization slice. Effort-cascade probing, Codex CLI usage extraction, rollup metrics, and MetricClaim/session-class work remain out of scope.

## Validation

- Gate-Passed: cargo fmt --check
- Gate-Passed: cargo test -p hermeneus openai::wire -- --nocapture

Note: running cargo in this workspace refreshed local `Cargo.lock` package versions from 0.26.1 to 0.27.0, but this PR intentionally leaves that generated release-version churn out of the commit.