### PR TITLE
feat(episteme): add memory policy RL readiness

### DIFF
--- a/crates/aletheia/src/commands/benchmark.rs
+++ b/crates/aletheia/src/commands/benchmark.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use clap::{Args, Subcommand};
 use owo_colors::OwoColorize;
+use serde::Serialize;
 use snafu::prelude::*;
 
 use dokimion::benchmarks::{
@@ -57,6 +58,9 @@ pub(crate) struct RunArgs {
     /// Write the full JSON report to a file for reproducibility and publishing
     #[arg(long)]
     pub output: Option<PathBuf>,
+    /// Write a compact baseline summary for training reward loaders
+    #[arg(long)]
+    pub baseline_out: Option<PathBuf>,
     /// Query the knowledge store after ingestion and compute Recall@k / NDCG@k
     #[arg(long)]
     pub retrieval_k: Option<usize>,
@@ -146,6 +150,16 @@ async fn run_benchmark(benchmark: &dyn MemoryBenchmark, args: &RunArgs) -> Resul
         println!("Report written to {}", path.display());
     }
 
+    if let Some(ref path) = args.baseline_out {
+        let summary = BenchmarkBaselineSummary::from_report(&report);
+        let json = serde_json::to_string_pretty(&summary)
+            .whatever_context("failed to serialize baseline summary")?;
+        tokio::fs::write(path, json)
+            .await
+            .whatever_context("failed to write baseline summary file")?;
+        println!("Baseline summary written to {}", path.display());
+    }
+
     if args.json {
         print_report_json(&report).whatever_context("failed to serialize report")?;
     } else {
@@ -153,6 +167,28 @@ async fn run_benchmark(benchmark: &dyn MemoryBenchmark, args: &RunArgs) -> Resul
     }
 
     Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct BenchmarkBaselineSummary {
+    benchmark: String,
+    total_questions: usize,
+    exact_match_rate: f64,
+    mean_f1: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    judge_accuracy: Option<f64>,
+}
+
+impl BenchmarkBaselineSummary {
+    fn from_report(report: &BenchmarkReport) -> Self {
+        Self {
+            benchmark: report.benchmark.clone(),
+            total_questions: report.total,
+            exact_match_rate: report.exact_match_rate(),
+            mean_f1: report.mean_f1(),
+            judge_accuracy: report.judge_accuracy(),
+        }
+    }
 }
 
 async fn collect_metadata(

--- a/crates/episteme/src/lib.rs
+++ b/crates/episteme/src/lib.rs
@@ -68,6 +68,8 @@ pub mod query;
 pub mod query_rewrite;
 /// 6-factor recall scoring engine for knowledge retrieval ranking.
 pub mod recall;
+/// Reinforcement-learning readiness types for future memory-policy training.
+pub mod rl;
 /// Steward rule proposal generation from observed tool-usage patterns.
 pub mod rule_proposals;
 /// Side-query memory relevance selector with LRU caching and already-surfaced tracking.

--- a/crates/episteme/src/rl/actions.rs
+++ b/crates/episteme/src/rl/actions.rs
@@ -1,0 +1,44 @@
+//! Memory-policy action placeholders for the Phase 06b training scaffold.
+
+use serde::{Deserialize, Serialize};
+
+/// A candidate memory-policy action.
+///
+/// The variants mirror the planned policy vocabulary without encoding the
+/// still-missing Phase 05c parameter inventory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Action {
+    /// Keep a memory item regardless of ordinary decay pressure.
+    Pin {
+        /// Stable memory identifier chosen by the caller.
+        memory_id: String,
+    },
+    /// Remove a memory item from active recall.
+    Evict {
+        /// Stable memory identifier chosen by the caller.
+        memory_id: String,
+    },
+    /// Merge two memory items into a single survivor.
+    Merge {
+        /// Identifier of the item being merged away.
+        source_id: String,
+        /// Identifier of the item that remains after the merge.
+        target_id: String,
+    },
+    /// Compact a scoped set of memory items into a denser representation.
+    Compact {
+        /// Caller-defined scope such as a session, project, or topic key.
+        scope: String,
+    },
+    /// Lower recall priority without removing the memory item.
+    Demote {
+        /// Stable memory identifier chosen by the caller.
+        memory_id: String,
+    },
+    /// Leave the memory item unchanged for this step.
+    Retain {
+        /// Stable memory identifier chosen by the caller.
+        memory_id: String,
+    },
+}

--- a/crates/episteme/src/rl/mod.rs
+++ b/crates/episteme/src/rl/mod.rs
@@ -1,0 +1,16 @@
+//! Reinforcement-learning readiness types for memory policy experiments.
+//!
+//! This module intentionally defines only stable boundary types. The concrete
+//! environment is deferred until the in-tree memory-policy constants have been
+//! inventoried into a durable state schema.
+
+/// Memory policy action space placeholders.
+pub mod actions;
+/// Reward functions and benchmark outcome loading.
+pub mod reward;
+/// Memory policy state representation.
+pub mod state;
+
+pub use actions::Action;
+pub use reward::{LongMemEvalReward, MemoryOutcome, RewardFn};
+pub use state::{MemoryState, MemoryTransition};

--- a/crates/episteme/src/rl/reward.rs
+++ b/crates/episteme/src/rl/reward.rs
@@ -1,0 +1,130 @@
+//! Reward helpers for memory-policy training experiments.
+
+use std::fs;
+use std::io::{self, ErrorKind};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Benchmark outcome consumed by reward functions.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct MemoryOutcome {
+    /// Exact-match rate in the inclusive range 0.0..=1.0.
+    pub exact_match_rate: f64,
+    /// Mean F1 score in the inclusive range 0.0..=1.0 when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mean_f1: Option<f64>,
+}
+
+/// Computes scalar reward from a benchmark outcome.
+pub trait RewardFn {
+    /// Return the scalar reward for an observed benchmark outcome.
+    fn reward(&self, outcome: &MemoryOutcome) -> f64;
+}
+
+/// Reward function that scores improvement over a LongMemEval baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct LongMemEvalReward {
+    /// Baseline exact-match rate to improve on.
+    pub baseline_exact_match_rate: f64,
+}
+
+impl LongMemEvalReward {
+    /// Build a reward from a compact baseline summary or full benchmark report.
+    pub fn from_json_file(path: impl AsRef<Path>) -> io::Result<Self> {
+        let text = fs::read_to_string(path)?;
+        let value: serde_json::Value = serde_json::from_str(&text)
+            .map_err(|error| io::Error::new(ErrorKind::InvalidData, error))?;
+        let exact_match_rate = extract_exact_match_rate(&value).ok_or_else(|| {
+            io::Error::new(
+                ErrorKind::InvalidData,
+                "baseline JSON must contain exact_match_rate or scored questions",
+            )
+        })?;
+        Ok(Self {
+            baseline_exact_match_rate: exact_match_rate,
+        })
+    }
+}
+
+impl RewardFn for LongMemEvalReward {
+    fn reward(&self, outcome: &MemoryOutcome) -> f64 {
+        outcome.exact_match_rate - self.baseline_exact_match_rate
+    }
+}
+
+fn extract_exact_match_rate(value: &serde_json::Value) -> Option<f64> {
+    value
+        .get("exact_match_rate")
+        .and_then(serde_json::Value::as_f64)
+        .or_else(|| exact_match_rate_from_questions(value))
+}
+
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "benchmark question counts are small enough for exact f64 conversion"
+)]
+#[expect(
+    clippy::as_conversions,
+    reason = "usize to f64 for bounded benchmark counts"
+)]
+fn exact_match_rate_from_questions(value: &serde_json::Value) -> Option<f64> {
+    let questions = value.get("questions")?.as_array()?;
+    if questions.is_empty() {
+        return Some(0.0);
+    }
+
+    let hits = questions
+        .iter()
+        .filter(|question| {
+            question
+                .get("score")
+                .and_then(|score| score.get("exact_match"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false)
+        })
+        .count();
+
+    Some(hits as f64 / questions.len() as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LongMemEvalReward, MemoryOutcome, RewardFn, extract_exact_match_rate};
+
+    #[test]
+    fn loads_compact_baseline_summary() {
+        let value = serde_json::json!({
+            "benchmark": "LongMemEval",
+            "exact_match_rate": 0.42
+        });
+
+        assert_eq!(extract_exact_match_rate(&value), Some(0.42));
+    }
+
+    #[test]
+    fn computes_exact_match_from_full_report() {
+        let value = serde_json::json!({
+            "questions": [
+                { "score": { "exact_match": true } },
+                { "score": { "exact_match": false } },
+                { "score": { "exact_match": true } }
+            ]
+        });
+
+        assert_eq!(extract_exact_match_rate(&value), Some(2.0 / 3.0));
+    }
+
+    #[test]
+    fn reward_is_delta_over_baseline() {
+        let reward = LongMemEvalReward {
+            baseline_exact_match_rate: 0.35,
+        };
+        let outcome = MemoryOutcome {
+            exact_match_rate: 0.50,
+            mean_f1: None,
+        };
+
+        assert!((reward.reward(&outcome) - 0.15).abs() < f64::EPSILON);
+    }
+}

--- a/crates/episteme/src/rl/state.rs
+++ b/crates/episteme/src/rl/state.rs
@@ -1,0 +1,48 @@
+//! State boundary types for memory-policy training experiments.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::Action;
+
+/// Feature-bag state for a memory-policy decision point.
+///
+/// The concrete 66-constant schema referenced by the Phase 06b issue is not
+/// present in this repository. A named feature map keeps the scaffold useful
+/// for reward-loader and harness work without freezing placeholder constants.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct MemoryState {
+    /// Stable identifier for the memory item or policy decision point.
+    pub subject_id: String,
+    /// Named numeric features available to the policy.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub features: BTreeMap<String, f64>,
+}
+
+impl MemoryState {
+    /// Create an empty state for a subject.
+    pub fn new(subject_id: impl Into<String>) -> Self {
+        Self {
+            subject_id: subject_id.into(),
+            features: BTreeMap::new(),
+        }
+    }
+
+    /// Add or replace a named numeric feature.
+    pub fn with_feature(mut self, name: impl Into<String>, value: f64) -> Self {
+        self.features.insert(name.into(), value);
+        self
+    }
+}
+
+/// A single memory-policy transition emitted by a future training environment.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryTransition {
+    /// State before the action.
+    pub previous: MemoryState,
+    /// Action chosen by the policy.
+    pub action: Action,
+    /// State after the action.
+    pub next: MemoryState,
+}


### PR DESCRIPTION
## Summary
- add `episteme::rl` boundary types for memory-policy actions, feature-bag state, transitions, and LongMemEval reward deltas
- add `aletheia benchmark --baseline-out` to write a compact machine-readable baseline summary alongside the existing full report path
- keep the environment/FFI training loop out of scope until the memory-policy constant inventory and inbound reader endpoint exist

Refs #3979

## Gates
- `cargo fmt --all -- --check`
- `cargo test -p episteme rl::`
- `cargo test -p aletheia benchmark`