### PR TITLE
chore(proskenion): review lint false positives

### DIFF
--- a/crates/theatron/proskenion/Cargo.toml
+++ b/crates/theatron/proskenion/Cargo.toml
@@ -1,3 +1,4 @@
+# kanon:ignore WORKFLOW/llm-corpus-required -- proskenion is a standalone workspace linted under the parent repo corpus (#3988)
 # WHY: Explicit [workspace] prevents cargo from walking up to the root
 # workspace and failing with "not in workspace" when building standalone.
 [workspace]

--- a/crates/theatron/proskenion/src/services/settings_config.rs
+++ b/crates/theatron/proskenion/src/services/settings_config.rs
@@ -155,7 +155,7 @@ struct SerializedCombo {
     alt: bool,
     #[serde(default)]
     shift: bool,
-    key: String,
+    key: String, // kanon:ignore RUST/plain-string-secret -- keyboard key name, not credential material (#3988)
 }
 
 impl From<&KeyCombo> for SerializedCombo {

--- a/crates/theatron/proskenion/src/state/credentials.rs
+++ b/crates/theatron/proskenion/src/state/credentials.rs
@@ -59,7 +59,7 @@ pub(crate) struct CredentialEntry {
     pub(crate) provider: String,
     pub(crate) role: CredentialRole,
     /// Display form of the key: last 4 chars prefixed with "...".
-    pub(crate) masked_key: String,
+    pub(crate) masked_key: String, // kanon:ignore RUST/plain-string-secret -- masked display suffix only, never the raw credential (#3988)
     pub(crate) status: ValidationStatus,
     pub(crate) last_validated: Option<String>,
     pub(crate) requests_today: u64,
@@ -117,7 +117,6 @@ impl CredentialStore {
             .any(|e| e.provider == provider && e.role == CredentialRole::Backup);
         has_primary && has_backup
     }
-
 }
 
 /// Masks a credential key to show only the last 4 characters.

--- a/crates/theatron/proskenion/src/state/memory.rs
+++ b/crates/theatron/proskenion/src/state/memory.rs
@@ -223,7 +223,7 @@ fn default_entity_type() -> EntityType {
 /// A key-value property on an entity.
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub(crate) struct EntityProperty {
-    pub key: String,
+    pub key: String, // kanon:ignore RUST/plain-string-secret -- metadata property name, not credential material (#3988)
     pub value: String,
 }
 

--- a/crates/theatron/proskenion/src/state/ops.rs
+++ b/crates/theatron/proskenion/src/state/ops.rs
@@ -252,7 +252,7 @@ pub(crate) struct ToolToggle {
 /// A system-wide feature flag.
 #[derive(Debug, Clone)]
 pub(crate) struct FeatureFlag {
-    pub key: String,
+    pub key: String, // kanon:ignore RUST/plain-string-secret -- feature flag identifier, not credential material (#3988)
     pub description: String,
     pub enabled: bool,
     pub pending: bool,

--- a/crates/theatron/proskenion/src/state/settings.rs
+++ b/crates/theatron/proskenion/src/state/settings.rs
@@ -21,12 +21,7 @@ pub(crate) struct ServerConfigStore {
 
 impl ServerConfigStore {
     /// Add a new server; returns the assigned id.
-    pub(crate) fn add(
-        &mut self,
-        name: String,
-        url: String,
-        auth_token: Option<String>,
-    ) -> String {
+    pub(crate) fn add(&mut self, name: String, url: String, auth_token: Option<String>) -> String {
         let id = gen_server_id();
         self.servers.push(ServerEntry {
             id: id.clone(),
@@ -166,7 +161,7 @@ pub(crate) struct KeyCombo {
     pub(crate) ctrl: bool,
     pub(crate) alt: bool,
     pub(crate) shift: bool,
-    pub(crate) key: String,
+    pub(crate) key: String, // kanon:ignore RUST/plain-string-secret -- keyboard key name, not credential material (#3988)
 }
 
 impl KeyCombo {
@@ -481,7 +476,11 @@ mod tests {
     #[test]
     fn server_store_add_increases_count() {
         let mut store = ServerConfigStore::default();
-        store.add("Local".to_string(), "http://localhost:3000".to_string(), None);
+        store.add(
+            "Local".to_string(),
+            "http://localhost:3000".to_string(),
+            None,
+        );
         assert_eq!(store.servers.len(), 1);
     }
 
@@ -603,5 +602,4 @@ mod tests {
         };
         assert_eq!(combo.display(), "Ctrl+Shift+K");
     }
-
 }

--- a/crates/theatron/proskenion/src/views/ops/credentials.rs
+++ b/crates/theatron/proskenion/src/views/ops/credentials.rs
@@ -30,7 +30,7 @@ struct CredentialApiEntry {
     role: String,
     /// Key value from API. Must be masked before use if it is not already masked.
     #[serde(default)]
-    masked_key: String,
+    masked_key: String, // kanon:ignore RUST/plain-string-secret -- API payload is masked before it enters UI state (#3988)
     #[serde(default)]
     status: String,
     #[serde(default)]

--- a/crates/theatron/proskenion/src/views/ops/toggles.rs
+++ b/crates/theatron/proskenion/src/views/ops/toggles.rs
@@ -314,7 +314,7 @@ fn ToolToggleRow(
 
 #[component]
 fn FeatureFlagRow(
-    flag_key: String,
+    flag_key: String, // kanon:ignore RUST/plain-string-secret -- feature flag identifier, not credential material (#3988)
     description: String,
     enabled: bool,
     pending: bool,
@@ -431,10 +431,7 @@ fn toggle_switch(
 
 // WHY: Signal::set requires &mut self, which is unavailable inside Fn closures.
 // Passing Signal by value to a function with `mut` parameter sidesteps this.
-fn request_confirm(
-    mut sig: Signal<Option<skene::id::NousId>>,
-    id: skene::id::NousId,
-) {
+fn request_confirm(mut sig: Signal<Option<skene::id::NousId>>, id: skene::id::NousId) {
     sig.set(Some(id));
 }
 
@@ -501,7 +498,7 @@ fn fire_tool_toggle(
 fn fire_feature_toggle(
     mut store: Signal<ToggleStore>,
     config: Signal<ConnectionConfig>,
-    key: String,
+    key: String, // kanon:ignore RUST/plain-string-secret -- feature flag identifier, not credential material (#3988)
 ) {
     let prev = store.write().flip_feature(&key);
     let Some(prev_val) = prev else { return };


### PR DESCRIPTION
## Summary
- Adds a reviewed `WORKFLOW/llm-corpus-required` suppression at `crates/theatron/proskenion/Cargo.toml:1` for the standalone proskenion workspace lint-root command shape.
- Adds issue-specific `RUST/plain-string-secret` review reasons for eight false-positive identifier/display fields in `settings_config.rs`, `state/{credentials,memory,ops,settings}.rs`, and `views/ops/{credentials,toggles}.rs`.
- Current measurement: targeted buckets went from 10 open findings (`2 WORKFLOW/llm-corpus-required` + `8 RUST/plain-string-secret`) to 0; `kanon lint --summary crates/theatron/proskenion` dropped from `Total: 159 violation(s), 77 suppressed` to `Total: 149 violation(s), 87 suppressed`.

## Verification
- `rustfmt --check crates/theatron/proskenion/src/services/settings_config.rs crates/theatron/proskenion/src/state/credentials.rs crates/theatron/proskenion/src/state/memory.rs crates/theatron/proskenion/src/state/ops.rs crates/theatron/proskenion/src/state/settings.rs crates/theatron/proskenion/src/views/ops/credentials.rs crates/theatron/proskenion/src/views/ops/toggles.rs`
- `git diff --check`
- `env RUST_LOG=error NO_COLOR=1 kanon lint --format json crates/theatron/proskenion | jq -r '.[] | select(.rule=="RUST/plain-string-secret" or .rule=="WORKFLOW/llm-corpus-required") | "\(.rule)\t\(.file):\(.line)\t\(.text)"'` produced no output.
- `env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion` still exits 1 for the remaining baseline, with `Total: 149 violation(s), 87 suppressed`; the removed buckets are absent from the summary.
- Attempted: `cargo test --manifest-path crates/theatron/proskenion/Cargo.toml --target-dir /tmp/codex-aletheia-proskenion-target`; blocked by missing system pkg-config libraries `gobject-2.0`, `gdk-3.0`, `glib-2.0`, and `gio-2.0`.

## Issue
Refs #3988; this is the first focused cleanup slice and does not close the full D5 lint-zero audit because 149 residual proskenion findings remain.