### PR TITLE
fix(hermeneus): classify seat-bridged providers as cloud

### DIFF
--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info};
 
 use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
-use crate::provider::LlmProvider;
+use crate::provider::{DeploymentTarget, LlmProvider};
 use crate::types::{CompletionRequest, CompletionResponse, Content, ContentBlock, Role};
 
 use super::parse;
@@ -276,6 +276,10 @@ impl LlmProvider for CcProvider {
         "cc"
     }
 
+    fn deployment_target(&self) -> DeploymentTarget {
+        DeploymentTarget::Cloud
+    }
+
     fn supports_streaming(&self) -> bool {
         true
     }
@@ -393,5 +397,15 @@ mod tests {
         assert!(SUPPORTED_MODELS.contains(&"claude-sonnet-4-20250514"));
         assert!(SUPPORTED_MODELS.contains(&"claude-opus-4-20250514"));
         assert!(!SUPPORTED_MODELS.contains(&"gpt-4"));
+    }
+
+    #[test]
+    fn cc_provider_reports_cloud_deployment_target() {
+        let provider = CcProvider {
+            cc_binary: PathBuf::from("claude"),
+            default_model: "claude-opus-4-6".to_owned(),
+            timeout: Duration::from_secs(1),
+        };
+        assert_eq!(provider.deployment_target(), DeploymentTarget::Cloud);
     }
 }

--- a/crates/hermeneus/src/codex/provider.rs
+++ b/crates/hermeneus/src/codex/provider.rs
@@ -13,7 +13,7 @@ use koina::system::{Environment, RealSystem};
 use tracing::{debug, info};
 
 use crate::error::{self, Result};
-use crate::provider::LlmProvider;
+use crate::provider::{DeploymentTarget, LlmProvider};
 use crate::types::{CompletionRequest, CompletionResponse, Content, ContentBlock, Role};
 
 use super::{parse, process};
@@ -203,6 +203,10 @@ impl LlmProvider for CodexProvider {
     fn name(&self) -> &'static str {
         "codex"
     }
+
+    fn deployment_target(&self) -> DeploymentTarget {
+        DeploymentTarget::Cloud
+    }
 }
 
 fn find_codex_binary() -> Result<PathBuf> {
@@ -304,5 +308,15 @@ mod tests {
         assert!(provider.supports_model("codex/gpt-5-codex"));
         assert!(provider.supports_model("gpt-5-codex"));
         assert!(!provider.supports_model("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn codex_provider_reports_cloud_deployment_target() {
+        let provider = CodexProvider {
+            codex_binary: PathBuf::from("codex"),
+            default_model: "codex/gpt-5-codex".to_owned(),
+            timeout: Duration::from_secs(1),
+        };
+        assert_eq!(provider.deployment_target(), DeploymentTarget::Cloud);
     }
 }

--- a/crates/hermeneus/src/complexity/mod.rs
+++ b/crates/hermeneus/src/complexity/mod.rs
@@ -475,8 +475,7 @@ fn select_model_for_tier(tier: ModelTier, config: &ComplexityConfig) -> String {
     match tier {
         // Until a Tier-1 handler registry exists, no-LLM decisions fall back to
         // the fast model while preserving the tier in telemetry and tests.
-        ModelTier::NoLlm => config.haiku_model.clone(),
-        ModelTier::Haiku => config.haiku_model.clone(),
+        ModelTier::NoLlm | ModelTier::Haiku => config.haiku_model.clone(),
         ModelTier::Sonnet => config.sonnet_model.clone(),
         ModelTier::Opus => config.opus_model.clone(),
     }


### PR DESCRIPTION
## Summary
- Explicitly classify Codex and Claude Code subprocess providers as `DeploymentTarget::Cloud`.
- Add provider-level tests so seat-bridged OAuth providers cannot silently drift to a less restrictive trust boundary.
- Merge the equivalent `NoLlm`/`Haiku` model-selection arms while preserving the current fast-model fallback until Tier-1 handlers exist.

Refs #3980.
Refs #3970.

## Gates
- `cargo fmt --check --package hermeneus`
- `cargo test -p hermeneus --features codex-provider,cc-provider --target-dir /tmp/codex-aletheia-runtime-tail3-mm-target`
- `cargo clippy -p hermeneus --features codex-provider,cc-provider --target-dir /tmp/codex-aletheia-runtime-tail3-mm-target --all-targets -- -D warnings`
- `git diff --check`

## Notes
The larger first-class `provider_type = "codex_oauth"` config surface remains open for #3980; this PR only makes the existing seat-bridged provider boundary explicit.