### PR TITLE
fix(proskenion): clean truncation lint

### DIFF
--- a/crates/theatron/proskenion/src/services/file_watcher.rs
+++ b/crates/theatron/proskenion/src/services/file_watcher.rs
@@ -106,7 +106,6 @@ impl FileChangeTracker {
             _ => None,
         }
     }
-
 }
 
 impl Default for FileChangeTracker {
@@ -153,8 +152,17 @@ pub(crate) fn truncate_path(path: &str, max_len: usize) -> String {
     if path.len() <= max_len {
         return path.to_string();
     }
+    if max_len <= 3 {
+        return ".".repeat(max_len);
+    }
     // NOTE: Show the tail of the path (most informative part).
-    let suffix = &path[path.len() - (max_len - 3)..];
+    let suffix_max_len = max_len - 3;
+    let suffix_start = path
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .find(|idx| path.len() - idx <= suffix_max_len)
+        .unwrap_or(path.len());
+    let suffix = path.get(suffix_start..).unwrap_or("");
     format!("...{suffix}")
 }
 
@@ -264,6 +272,21 @@ mod tests {
         assert!(truncated.starts_with("..."));
         assert!(truncated.len() <= 20);
         assert!(truncated.ends_with("file.rs"));
+    }
+
+    #[test]
+    fn truncate_path_respects_unicode_boundaries() {
+        let truncated = truncate_path("src/διαδρομή/deep/file.rs", 18);
+        assert!(truncated.starts_with("..."));
+        assert!(truncated.len() <= 18);
+        assert!(truncated.ends_with("file.rs"));
+    }
+
+    #[test]
+    fn truncate_path_handles_tiny_limits() {
+        assert_eq!(truncate_path("src/main.rs", 0), "");
+        assert_eq!(truncate_path("src/main.rs", 2), "..");
+        assert_eq!(truncate_path("src/main.rs", 3), "...");
     }
 
     #[test]

--- a/crates/theatron/proskenion/src/services/notification_dispatch.rs
+++ b/crates/theatron/proskenion/src/services/notification_dispatch.rs
@@ -349,7 +349,10 @@ impl NotificationDispatch {
     // -- Send -----------------------------------------------------------------
 
     /// Apply DND, rate limit, then dispatch the notification.
-    #[expect(clippy::too_many_arguments, reason = "all parameters are contextual state")]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "all parameters are contextual state"
+    )]
     fn send(
         &mut self,
         category: NotificationCategory,
@@ -424,7 +427,7 @@ fn severity_for(category: NotificationCategory) -> ToastSeverity {
 /// Truncate `s` to at most `max_chars` Unicode scalar values.
 fn truncate_chars(s: &str, max_chars: usize) -> &str {
     match s.char_indices().nth(max_chars) {
-        Some((byte_idx, _)) => &s[..byte_idx],
+        Some((byte_idx, _)) => s.get(..byte_idx).unwrap_or(s),
         None => s,
     }
 }
@@ -500,7 +503,10 @@ mod tests {
             &mut no_fallback,
         );
 
-        assert!(history.is_empty(), "completion should be suppressed when focused");
+        assert!(
+            history.is_empty(),
+            "completion should be suppressed when focused"
+        );
     }
 
     // -- Focus rules ----------------------------------------------------------
@@ -570,9 +576,11 @@ mod tests {
 
         // Only the first notification should reach history.
         assert_eq!(history.len(), 1);
-        assert!(dispatch
-            .pending_groups
-            .contains_key(&NotificationCategory::AgentCompletion));
+        assert!(
+            dispatch
+                .pending_groups
+                .contains_key(&NotificationCategory::AgentCompletion)
+        );
     }
 
     // -- Preferences ----------------------------------------------------------
@@ -622,7 +630,10 @@ mod tests {
             &mut no_fallback,
         );
 
-        assert!(history.is_empty(), "DND should suppress completion notification");
+        assert!(
+            history.is_empty(),
+            "DND should suppress completion notification"
+        );
     }
 
     // -- Helpers --------------------------------------------------------------


### PR DESCRIPTION
## Summary

- makes file-change toast path truncation Unicode-boundary-safe and handles tiny limits explicitly
- replaces notification text truncation string slicing with checked `str::get` access
- adds regression coverage for Unicode path truncation and tiny path limits
- reduces the #3988 Proskenion lint tail from 136 to 133 open findings

## Issue

Refs #3988. This is a focused service truncation slice after #4055.

## Verification

- `rustfmt --check crates/theatron/proskenion/src/services/file_watcher.rs crates/theatron/proskenion/src/services/notification_dispatch.rs`
- `git diff --check`
- `timeout 300s env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion` -> `Total: 133 violation(s), 87 suppressed`

Blocked locally:

- `cargo test --manifest-path crates/theatron/proskenion/Cargo.toml truncate_path --lib` is blocked on this host by missing GTK/WebKit pkg-config libraries, including `gobject-2.0`, `glib-2.0`, `gio-2.0`, `gdk-3.0`, `cairo`, `pango`, `javascriptcoregtk-4.1`, `gdk-pixbuf-2.0`, `libsoup-3.0`, and `atk`.