### PR TITLE
fix(proskenion): clean state indexing lint

### DIFF
--- a/crates/theatron/proskenion/src/state/credentials.rs
+++ b/crates/theatron/proskenion/src/state/credentials.rs
@@ -124,9 +124,9 @@ impl CredentialStore {
 /// Returns `"...XXXX"` where XXXX is the last 4 chars of `key`.
 /// Returns `"...????"` if `key` is shorter than 4 characters.
 pub(crate) fn mask_key(key: &str) -> String {
-    let chars: Vec<char> = key.chars().collect();
-    if chars.len() >= 4 {
-        let tail: String = chars[chars.len() - 4..].iter().collect();
+    let tail_chars: Vec<char> = key.chars().rev().take(4).collect();
+    if tail_chars.len() == 4 {
+        let tail: String = tail_chars.into_iter().rev().collect();
         format!("...{tail}")
     } else {
         "...????".to_string()
@@ -231,5 +231,10 @@ mod tests {
     #[test]
     fn mask_key_empty_returns_placeholder() {
         assert_eq!(mask_key(""), "...????");
+    }
+
+    #[test]
+    fn mask_key_handles_unicode_char_boundaries() {
+        assert_eq!(mask_key("sk-αβγδ"), "...αβγδ");
     }
 }

--- a/crates/theatron/proskenion/src/state/memory.rs
+++ b/crates/theatron/proskenion/src/state/memory.rs
@@ -500,7 +500,8 @@ impl EntityNavigationHistory {
         if self.stack.is_empty() {
             &[]
         } else {
-            &self.stack[..=self.cursor]
+            let end = self.cursor.saturating_add(1).min(self.stack.len());
+            self.stack.get(..end).unwrap_or(&[])
         }
     }
 


### PR DESCRIPTION
## Summary

- masks credential keys without collecting then slicing the character buffer
- adds Unicode-boundary coverage for credential masking
- uses checked slice access for entity navigation breadcrumbs
- reduces the #3988 Proskenion lint tail from 133 to 130 open findings

## Issue

Refs #3988. This is a focused state indexing slice after #4056.

## Verification

- `rustfmt --check crates/theatron/proskenion/src/state/credentials.rs crates/theatron/proskenion/src/state/memory.rs`
- `kanon lint --summary crates/theatron/proskenion/src/state/credentials.rs` -> `No open violations.`
- `git diff --check`
- `timeout 300s env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion` -> `Total: 130 violation(s), 87 suppressed`

Blocked locally:

- `cargo test --manifest-path crates/theatron/proskenion/Cargo.toml mask_key --lib` is blocked on this host by missing GTK/WebKit pkg-config libraries.