### PR TITLE
test(sessions): localize migrator lint suppressions

### DIFF
--- a/crates/aletheia-sessions-migrate/src/main.rs
+++ b/crates/aletheia-sessions-migrate/src/main.rs
@@ -37,7 +37,7 @@ After verification, the operator swaps the live aletheia data dir at their own p
 // would surface to operators as literal characters.
 #[expect(
     clippy::struct_excessive_bools,
-    reason = "orthogonal CLI mode flags; idiomatic clap shape (#[arg(long)] per flag)"
+    reason = "orthogonal CLI mode flags; idiomatic clap shape"
 )]
 #[expect(
     clippy::doc_markdown,

--- a/crates/aletheia-sessions-migrate/tests/common/mod.rs
+++ b/crates/aletheia-sessions-migrate/tests/common/mod.rs
@@ -1,13 +1,8 @@
-//! Shared test scaffolding: build a SQLite v32 fixture from scratch.
+//! Shared test scaffolding: build a `SQLite` v32 fixture from scratch.
 
-#![allow(
+#![expect(
     clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::indexing_slicing,
-    clippy::doc_markdown,
-    clippy::too_many_lines,
-    clippy::too_many_arguments,
-    dead_code
+    reason = "integration test fixtures use direct setup assertions"
 )]
 // per-test binary uses only a subset of these helpers
 
@@ -109,13 +104,15 @@ CREATE TABLE blackboard (
 );
 ";
 
-/// Create an empty v32 SQLite DB file at `path`.
+/// Create an empty v32 `SQLite` DB file at `path`.
+#[allow(dead_code, reason = "shared fixture helper used by a subset of tests")]
 pub fn build_empty_v32(path: &Path) {
     let conn = Connection::open(path).expect("open writable SQLite");
     conn.execute_batch(SCHEMA_SQL).expect("apply v32 DDL");
 }
 
 /// Insert one session row.
+#[allow(dead_code, reason = "shared fixture helper used by a subset of tests")]
 pub fn insert_session(
     conn: &Connection,
     id: &str,
@@ -135,6 +132,7 @@ pub fn insert_session(
 }
 
 /// Insert one message row.
+#[allow(dead_code, reason = "shared fixture helper used by a subset of tests")]
 pub fn insert_message(
     conn: &Connection,
     session_id: &str,
@@ -154,6 +152,7 @@ pub fn insert_message(
 }
 
 /// Insert one distillation row.
+#[allow(dead_code, reason = "shared fixture helper used by a subset of tests")]
 pub fn insert_distillation(
     conn: &Connection,
     session_id: &str,
@@ -172,7 +171,8 @@ pub fn insert_distillation(
     .expect("insert distillation");
 }
 
-/// Insert one agent_note row.
+/// Insert one `agent_note` row.
+#[allow(dead_code, reason = "shared fixture helper used by a subset of tests")]
 pub fn insert_note(
     conn: &Connection,
     session_id: &str,
@@ -189,6 +189,7 @@ pub fn insert_note(
 }
 
 /// Insert one usage row.
+#[allow(dead_code, reason = "shared fixture helper used by a subset of tests")]
 pub fn insert_usage(
     conn: &Connection,
     session_id: &str,

--- a/crates/aletheia-sessions-migrate/tests/idempotency.rs
+++ b/crates/aletheia-sessions-migrate/tests/idempotency.rs
@@ -3,12 +3,9 @@
 //! run errors loudly. With `--force`, the second run replays the same
 //! data on top of the existing keys (overwrite semantics).
 
-#![allow(
+#![expect(
     clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::indexing_slicing,
-    clippy::doc_markdown,
-    clippy::too_many_lines
+    reason = "integration tests use direct assertions over fixture setup"
 )]
 
 mod common;

--- a/crates/aletheia-sessions-migrate/tests/legacy_extras.rs
+++ b/crates/aletheia-sessions-migrate/tests/legacy_extras.rs
@@ -3,12 +3,10 @@
 //! The migrator routes them to the `migration_legacy` partition; the
 //! data is recoverable post-migration.
 
-#![allow(
+#![expect(
     clippy::expect_used,
-    clippy::unwrap_used,
     clippy::indexing_slicing,
-    clippy::doc_markdown,
-    clippy::too_many_lines
+    reason = "integration tests use direct assertions over fixture setup"
 )]
 
 mod common;

--- a/crates/aletheia-sessions-migrate/tests/orphan_recovery.rs
+++ b/crates/aletheia-sessions-migrate/tests/orphan_recovery.rs
@@ -1,13 +1,10 @@
 //! Orphan messages (whose parent session row was already deleted in
-//! the legacy SQLite DB) must be preserved under a synthesised
+//! the legacy `SQLite` DB) must be preserved under a synthesised
 //! `orphan-recovery` session, not silently dropped.
 
-#![allow(
+#![expect(
     clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::indexing_slicing,
-    clippy::doc_markdown,
-    clippy::too_many_lines
+    reason = "integration tests use direct assertions over fixture setup"
 )]
 
 mod common;

--- a/crates/aletheia-sessions-migrate/tests/round_trip_integrity.rs
+++ b/crates/aletheia-sessions-migrate/tests/round_trip_integrity.rs
@@ -1,12 +1,10 @@
 //! Test 2 from the deliverable: N sessions × M messages, migrate, then
 //! iterate via `SessionStore` and confirm content is bit-identical.
 
-#![allow(
+#![expect(
     clippy::expect_used,
     clippy::unwrap_used,
-    clippy::indexing_slicing,
-    clippy::doc_markdown,
-    clippy::too_many_lines
+    reason = "integration tests use direct assertions over fixture setup"
 )]
 
 mod common;
@@ -21,6 +19,10 @@ const N_SESSIONS: usize = 7;
 const M_MESSAGES: usize = 23;
 
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "round-trip fixture asserts full migration"
+)]
 fn round_trip_n_sessions_m_messages() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let src = tmp.path().join("source.db");

--- a/crates/aletheia-sessions-migrate/tests/schema_mismatch.rs
+++ b/crates/aletheia-sessions-migrate/tests/schema_mismatch.rs
@@ -1,13 +1,11 @@
-//! Test 4 from the deliverable: hand the migrator a SQLite file with
+//! Test 4 from the deliverable: hand the migrator a `SQLite` file with
 //! mismatched schema, assert it errors with a specific message
 //! identifying what's wrong.
 
-#![allow(
+#![expect(
     clippy::expect_used,
     clippy::unwrap_used,
-    clippy::indexing_slicing,
-    clippy::doc_markdown,
-    clippy::too_many_lines
+    reason = "integration tests use direct assertions over fixture setup"
 )]
 
 mod common;

--- a/crates/aletheia-sessions-migrate/tests/tiny_synthetic.rs
+++ b/crates/aletheia-sessions-migrate/tests/tiny_synthetic.rs
@@ -3,12 +3,10 @@
 //! directory must be openable via graphe's `SessionStore` and every row
 //! must be queryable through the public API.
 
-#![allow(
+#![expect(
     clippy::expect_used,
-    clippy::unwrap_used,
     clippy::indexing_slicing,
-    clippy::doc_markdown,
-    clippy::too_many_lines
+    reason = "integration tests use direct assertions over fixture setup"
 )]
 
 mod common;


### PR DESCRIPTION
## Summary
- replace crate-level integration-test clippy allow lists with narrower expectations/allowances
- clean the sessions migrator CLI suppression reason that kanon flags as tautological
- keep #3987 open; this only clears the remaining high-severity aletheia-sessions-migrate lint cluster

Refs #3987

## Verification
- cargo fmt --check --package aletheia-sessions-migrate
- timeout 180s env RUST_LOG=error NO_COLOR=1 kanon lint crates/aletheia-sessions-migrate --rust --format json --summary --precision high --min-severity error
- cargo clippy -p aletheia-sessions-migrate --all-targets --target-dir /tmp/codex-aletheia-tail5-sessions-target -- -D warnings
- cargo test -p aletheia-sessions-migrate --target-dir /tmp/codex-aletheia-tail5-sessions-target
- git diff --check