### PR TITLE
feat(memory): add project identity primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "agora",
  "anyhow",
@@ -177,11 +177,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.26.1"
+version = "0.27.0"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "jiff",
  "koina",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "futures",
  "jiff",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "jiff",
  "koina",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "eidos",
  "jiff",
@@ -2624,12 +2624,13 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "jiff",
  "koina",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "snafu",
  "tempfile",
  "tokio",
@@ -2671,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "aletheia-routing",
  "compact_str",
@@ -2787,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -3530,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "cargo_metadata",
  "fjall",
@@ -3547,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -3766,7 +3767,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -4406,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -4693,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "arboard",
  "clap",
@@ -4727,7 +4728,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "criterion",
  "fjall",
@@ -4872,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5352,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5456,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -5670,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -5891,7 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6004,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6453,7 +6454,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "jiff",
  "snafu",
@@ -6461,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -6473,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "docx-rs",
  "quick-xml 0.39.2",
@@ -6486,7 +6487,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -6502,7 +6503,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -6514,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6523,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -6535,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -6548,7 +6549,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -6561,7 +6562,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "krilla 0.7.0",
  "poiesis-core",
@@ -6571,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "comemo",
  "jiff",
@@ -6587,7 +6588,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6974,7 +6975,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -8391,7 +8392,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8738,7 +8739,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -8857,7 +8858,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -8969,14 +8970,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/eidos/Cargo.toml
+++ b/crates/eidos/Cargo.toml
@@ -22,6 +22,7 @@ jiff = { workspace = true, features = ["serde"] }
 koina = { path = "../koina" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/eidos/src/lib.rs
+++ b/crates/eidos/src/lib.rs
@@ -35,6 +35,8 @@ pub use meta::{ArtefactMeta, Provenance, ProvenanceProject, Stamped};
 pub mod test_fixtures;
 /// Training data capture types.
 pub mod training;
+/// Workspace and project identity primitives.
+pub mod workspace;
 
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]

--- a/crates/eidos/src/workspace.rs
+++ b/crates/eidos/src/workspace.rs
@@ -1,0 +1,129 @@
+//! Workspace and project identity primitives.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Stable project partition derived from a canonical remote URL.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ProjectId(String);
+
+impl ProjectId {
+    /// Build a project ID from a Git remote URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProjectIdError::EmptyRemote`] when the remote URL is empty
+    /// after trimming whitespace.
+    pub fn from_git_remote(remote_url: impl AsRef<str>) -> Result<Self, ProjectIdError> {
+        let normalized = normalize_remote_url(remote_url.as_ref())?;
+        let digest = Sha256::digest(normalized.as_bytes());
+        let mut id = String::with_capacity(64);
+        for byte in digest {
+            id.push(hex_digit(byte >> 4));
+            id.push(hex_digit(byte & 0x0f));
+        }
+        Ok(Self(id))
+    }
+
+    /// The lowercase SHA-256 hex identifier.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ProjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for ProjectId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Project ID derivation errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProjectIdError {
+    /// The remote URL was empty after trimming whitespace.
+    EmptyRemote,
+}
+
+impl fmt::Display for ProjectIdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyRemote => f.write_str("git remote URL cannot be empty"),
+        }
+    }
+}
+
+impl std::error::Error for ProjectIdError {}
+
+fn normalize_remote_url(remote_url: &str) -> Result<&str, ProjectIdError> {
+    let trimmed = remote_url.trim();
+    if trimmed.is_empty() {
+        return Err(ProjectIdError::EmptyRemote);
+    }
+    Ok(trimmed)
+}
+
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => char::from(b'0' + nibble),
+        10..=15 => char::from(b'a' + (nibble - 10)),
+        _ => '?',
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_id_is_stable_for_same_remote() {
+        let first = ProjectId::from_git_remote("https://github.com/forkwright/aletheia.git")
+            .expect("valid remote");
+        let second = ProjectId::from_git_remote(" https://github.com/forkwright/aletheia.git ")
+            .expect("valid remote");
+
+        assert_eq!(first, second);
+        assert_eq!(first.as_str().len(), 64);
+        assert!(first.as_str().chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn project_id_changes_by_remote() {
+        let aletheia = ProjectId::from_git_remote("https://github.com/forkwright/aletheia.git")
+            .expect("valid");
+        let kanon =
+            ProjectId::from_git_remote("https://github.com/forkwright/kanon.git").expect("valid");
+
+        assert_ne!(aletheia, kanon);
+    }
+
+    #[test]
+    fn empty_remote_is_rejected() {
+        assert!(matches!(
+            ProjectId::from_git_remote("   "),
+            Err(ProjectIdError::EmptyRemote)
+        ));
+    }
+
+    #[test]
+    fn project_id_serializes_as_string() {
+        let id = ProjectId::from_git_remote("https://github.com/forkwright/aletheia")
+            .expect("valid remote");
+
+        let json = serde_json::to_string(&id).expect("serialize");
+        let back: ProjectId = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(id, back);
+    }
+}

--- a/crates/episteme/src/instinct.rs
+++ b/crates/episteme/src/instinct.rs
@@ -9,6 +9,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use eidos::workspace::ProjectId;
+
 /// Default maximum length for parameter values before truncation.
 ///
 /// Callers should prefer the value from `taxis::config::KnowledgeConfig::instinct_max_param_value_len`.
@@ -59,6 +61,9 @@ pub struct ToolObservation {
     pub context_summary: String,
     /// Which nous made the observation.
     pub nous_id: String,
+    /// Optional git-remote-derived project partition for this observation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
     /// When the observation was recorded.
     pub observed_at: jiff::Timestamp,
 }

--- a/crates/episteme/src/instinct_tests/basic_behavior.rs
+++ b/crates/episteme/src/instinct_tests/basic_behavior.rs
@@ -23,6 +23,7 @@ fn make_observation(
         outcome,
         context_summary: context.to_owned(),
         nous_id: "test-nous".to_owned(),
+        project_id: None,
         observed_at: ts(timestamp),
     }
 }
@@ -35,6 +36,7 @@ fn observation_stores_correct_fields() {
         outcome: ToolOutcome::Success,
         context_summary: "searching for TODOs in code".to_owned(),
         nous_id: "nous-1".to_owned(),
+        project_id: None,
         observed_at: ts("2026-03-01T12:00:00Z"),
     };
     assert_eq!(
@@ -431,6 +433,7 @@ fn observation_serde_roundtrip() {
         outcome: ToolOutcome::Success,
         context_summary: "reading test file".to_owned(),
         nous_id: "nous-1".to_owned(),
+        project_id: None,
         observed_at: ts("2026-03-01T12:00:00Z"),
     };
     let json = serde_json::to_string(&obs).expect("serialize");
@@ -472,6 +475,7 @@ fn observations_different_context_categories_aggregate_separately() {
             outcome: ToolOutcome::Success,
             context_summary: "searching code files".to_owned(),
             nous_id: "nous-alice".to_owned(),
+            project_id: None,
             observed_at: ts(&format!("2026-03-{:02}T10:00:00Z", i + 1)),
         });
     }
@@ -482,6 +486,7 @@ fn observations_different_context_categories_aggregate_separately() {
             outcome: ToolOutcome::Success,
             context_summary: "web search and research documentation".to_owned(),
             nous_id: "nous-alice".to_owned(),
+            project_id: None,
             observed_at: ts(&format!("2026-03-{:02}T12:00:00Z", i + 1)),
         });
     }

--- a/crates/episteme/src/instinct_tests/requirements.rs
+++ b/crates/episteme/src/instinct_tests/requirements.rs
@@ -23,6 +23,7 @@ fn make_observation(
         outcome,
         context_summary: context.to_owned(),
         nous_id: "test-nous".to_owned(),
+        project_id: None,
         observed_at: ts(timestamp),
     }
 }
@@ -46,6 +47,7 @@ fn aggregation_with_empty_parameters_does_not_panic() {
             outcome: ToolOutcome::Success,
             context_summary: "reading code file".to_owned(),
             nous_id: "nous-1".to_owned(),
+            project_id: None,
             observed_at: ts(&format!("2026-03-{:02}T10:00:00Z", i + 1)),
         })
         .collect();
@@ -280,6 +282,7 @@ fn different_nous_observations_aggregate_together_without_filter() {
             outcome: ToolOutcome::Success,
             context_summary: "code search".to_owned(),
             nous_id: "nous-alice".to_owned(),
+            project_id: None,
             observed_at: ts(&format!("2026-03-{:02}T10:00:00Z", i + 1)),
         })
         .collect();
@@ -289,6 +292,7 @@ fn different_nous_observations_aggregate_together_without_filter() {
         outcome: ToolOutcome::Success,
         context_summary: "code search".to_owned(),
         nous_id: "nous-bob".to_owned(),
+        project_id: None,
         observed_at: ts(&format!("2026-03-{:02}T11:00:00Z", i + 1)),
     }));
     let all = aggregate_observations(
@@ -325,6 +329,7 @@ fn two_tools_identical_parameters_produce_separate_patterns() {
             outcome: ToolOutcome::Success,
             context_summary: "code search".to_owned(),
             nous_id: "nous-1".to_owned(),
+            project_id: None,
             observed_at: ts(&format!("2026-03-{:02}T10:00:00Z", i + 1)),
         });
         observations.push(ToolObservation {
@@ -333,6 +338,7 @@ fn two_tools_identical_parameters_produce_separate_patterns() {
             outcome: ToolOutcome::Success,
             context_summary: "code search".to_owned(),
             nous_id: "nous-1".to_owned(),
+            project_id: None,
             observed_at: ts(&format!("2026-03-{:02}T11:00:00Z", i + 1)),
         });
     }
@@ -495,6 +501,7 @@ mod proptests {
                     outcome: ToolOutcome::Success,
                     context_summary: "code search".to_owned(),
                     nous_id: "nous-1".to_owned(),
+                    project_id: None,
                     observed_at: jiff::Timestamp::UNIX_EPOCH,
                 })
                 .collect();

--- a/crates/episteme/src/rule_proposals.rs
+++ b/crates/episteme/src/rule_proposals.rs
@@ -344,6 +344,7 @@ mod tests {
                 outcome: outcome.clone(),
                 context_summary: "code review".to_owned(),
                 nous_id: "test-nous".to_owned(),
+                project_id: None,
                 observed_at: jiff::Timestamp::now(),
             })
             .collect()

--- a/crates/nous/src/instinct.rs
+++ b/crates/nous/src/instinct.rs
@@ -44,6 +44,7 @@ pub(crate) fn observation_from_tool_call(
         outcome,
         context_summary: truncated_summary,
         nous_id: nous_id.to_owned(),
+        project_id: None,
         observed_at: jiff::Timestamp::now(),
     }
 }


### PR DESCRIPTION
## Summary
- add an eidos `ProjectId` primitive derived from a SHA-256 hash of a trimmed Git remote URL
- add optional `project_id` telemetry to `ToolObservation`, defaulting/skipping absent values for compatibility
- keep observation capture behavior unchanged: runtime observations currently record `project_id: None`
- refresh `Cargo.lock` for the new eidos `sha2` dependency

Refs #3975

## Scope Boundary
This is the primitive-only slice. It does not implement durable git-remote storage partitioning, project-scoped recall defaults, registry path management, migrations, or the cross-project promotion gate. Those remain design-blocked by the scope taxonomy and registry/migration decisions already called out on #3975.

## Verification
- `cargo fmt --check --package eidos --package episteme --package nous`
- `env RUST_LOG=error NO_COLOR=1 kanon lint . --rust --format json --summary --precision high --min-severity error --paths-from <touched-paths>`
- `cargo check -p eidos -p episteme -p nous --target-dir /tmp/codex-aletheia-tail5-project-target`
- `cargo test -p eidos workspace --target-dir /tmp/codex-aletheia-tail5-project-target`
- `cargo test -p episteme observation_serde_roundtrip --target-dir /tmp/codex-aletheia-tail5-project-target`
- `cargo test -p episteme different_nous_observations_aggregate_together_without_filter --target-dir /tmp/codex-aletheia-tail5-project-target`
- `cargo test -p nous instinct::tests::observation_from_successful_tool_call --target-dir /tmp/codex-aletheia-tail5-project-target`
- `git diff --check`

## Notes
- `cargo clippy -p eidos -p episteme -p nous -- -D warnings` is not used as a gate because current main has unrelated pre-existing `episteme::rl` warnings: `doc_markdown` in `rl/reward.rs` and `return_self_not_must_use` in `rl/state.rs`.
