### PR TITLE
feat(organon): implement katharos worktree cleanup

### DIFF
--- a/crates/organon/src/builtins/bookkeeper.rs
+++ b/crates/organon/src/builtins/bookkeeper.rs
@@ -1,27 +1,33 @@
 //! Bookkeeper tools for prompt archival and worktree cleanup.
 //!
 //! - `tamias` (ταμίας — steward/treasurer): placeholder for prompt archival
-//! - `katharos` (καθαρός — clean): placeholder for worktree cleanup
+//! - `katharos` (καθαρός — clean): conservative stale worktree cleanup
 
 use std::future::Future;
+use std::io::Read as _;
 use std::pin::Pin;
+use std::process::{Command, Stdio}; // kanon:ignore RUST/no-direct-process-command
+use std::time::{Duration, Instant, SystemTime};
 
 use indexmap::IndexMap;
 
 use koina::id::ToolName;
 
 use crate::error::Result;
+use crate::process_guard::ProcessGuard;
 use crate::registry::{ToolExecutor, ToolRegistry};
 use crate::types::{
     InputSchema, PropertyDef, PropertyType, Reversibility, ToolCategory, ToolContext, ToolDef,
     ToolGroupId, ToolInput, ToolResult, ToolTag,
 };
 
-/// Stub executor for bookkeeper tools.
+const GIT_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_GIT_OUTPUT: usize = 256 * 1024;
+
+/// Stub executor for deferred bookkeeper tools.
 ///
-/// WHY: Real implementations require integration with the dispatch store
-/// and git subprocess calls. Stubs are registered now so that tool schemas
-/// are available to agents; implementations land in a follow-up.
+/// WHY: `tamias` still requires integration with the dispatch store. The
+/// schema is registered now so deployments can trial the future tool surface.
 struct BookkeeperStub {
     tool_name: &'static str,
 }
@@ -39,6 +45,18 @@ impl ToolExecutor for BookkeeperStub {
                 "bookkeeper: {name} is not yet implemented"
             )))
         })
+    }
+}
+
+struct KatharosExecutor;
+
+impl ToolExecutor for KatharosExecutor {
+    fn execute<'a>(
+        &'a self,
+        input: &'a ToolInput,
+        ctx: &'a ToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
+        Box::pin(async move { execute_katharos(input, ctx) })
     }
 }
 
@@ -105,8 +123,7 @@ fn tamias_def() -> ToolDef {
 fn katharos_def() -> ToolDef {
     ToolDef {
         name: ToolName::from_static("katharos"),
-        description: "Placeholder for future dispatch cleanup; currently returns not implemented."
-            .to_owned(),
+        description: "Clean stale linked git worktrees for the current project.".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
             properties: IndexMap::from([
@@ -114,7 +131,8 @@ fn katharos_def() -> ToolDef {
                     "project".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::String,
-                        description: "Project slug for the future cleanup operation".to_owned(),
+                        description: "Project slug; must match the current repository directory"
+                            .to_owned(),
                         enum_values: None,
                         default: None,
                     },
@@ -123,7 +141,8 @@ fn katharos_def() -> ToolDef {
                     "max_age_hours".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::Integer,
-                        description: "Future max-age cleanup threshold (default: 48)".to_owned(),
+                        description: "Minimum worktree age in hours before cleanup (default: 48)"
+                            .to_owned(),
                         enum_values: None,
                         default: Some(serde_json::json!(48)),
                     },
@@ -132,7 +151,9 @@ fn katharos_def() -> ToolDef {
                     "dry_run".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::Boolean,
-                        description: "Future dry-run flag (default: false)".to_owned(),
+                        description:
+                            "Report candidate removals without deleting worktrees (default: false)"
+                                .to_owned(),
                         enum_values: None,
                         default: Some(serde_json::json!(false)),
                     },
@@ -143,9 +164,280 @@ fn katharos_def() -> ToolDef {
         category: ToolCategory::System,
         reversibility: Reversibility::Irreversible,
         auto_activate: false,
-        groups: vec![ToolGroupId::Read, ToolGroupId::Verify],
+        groups: vec![
+            ToolGroupId::Read,
+            ToolGroupId::Edit,
+            ToolGroupId::Command,
+            ToolGroupId::Verify,
+        ],
         tags: vec![ToolTag::Edit, ToolTag::Execute],
     }
+}
+
+#[derive(Debug)]
+struct WorktreeEntry {
+    path: std::path::PathBuf,
+    prunable: bool,
+}
+
+#[derive(Debug)]
+enum CleanupAction {
+    Removed(std::path::PathBuf),
+    Pruned(std::path::PathBuf),
+    WouldRemove(std::path::PathBuf),
+    SkippedDirty(std::path::PathBuf),
+    SkippedYoung(std::path::PathBuf),
+    SkippedOutsideAllowedRoot(std::path::PathBuf),
+}
+
+fn execute_katharos(input: &ToolInput, ctx: &ToolContext) -> Result<ToolResult> {
+    let project = super::workspace::extract_str(&input.arguments, "project", &input.name)?;
+    let max_age_hours =
+        super::workspace::extract_opt_u64(&input.arguments, "max_age_hours").unwrap_or(48);
+    let dry_run = super::workspace::extract_opt_bool(&input.arguments, "dry_run").unwrap_or(false);
+
+    if !project_matches_workspace(project, ctx) {
+        return Ok(ToolResult::error(format!(
+            "katharos project mismatch: requested {project:?}, current workspace is {:?}",
+            ctx.workspace.file_name().and_then(std::ffi::OsStr::to_str)
+        )));
+    }
+
+    let worktrees = match list_worktrees(&ctx.workspace) {
+        Ok(entries) => entries,
+        Err(message) => return Ok(ToolResult::error(message)),
+    };
+
+    let cutoff = SystemTime::now()
+        .checked_sub(Duration::from_secs(max_age_hours.saturating_mul(60 * 60)))
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let active_workspace = canonicalize_or_clone(&ctx.workspace);
+    let mut actions = Vec::new();
+
+    for entry in worktrees {
+        let worktree_path = canonicalize_or_clone(&entry.path);
+        if worktree_path == active_workspace {
+            continue;
+        }
+
+        if !is_under_allowed_root(&worktree_path, &ctx.allowed_roots) {
+            actions.push(CleanupAction::SkippedOutsideAllowedRoot(entry.path));
+            continue;
+        }
+
+        if !entry.prunable && !is_old_enough(&worktree_path, cutoff) {
+            actions.push(CleanupAction::SkippedYoung(entry.path));
+            continue;
+        }
+
+        if !entry.prunable && !worktree_is_clean(&worktree_path) {
+            actions.push(CleanupAction::SkippedDirty(entry.path));
+            continue;
+        }
+
+        if dry_run {
+            actions.push(CleanupAction::WouldRemove(entry.path));
+            continue;
+        }
+
+        if entry.prunable {
+            actions.push(CleanupAction::Pruned(entry.path));
+            continue;
+        }
+
+        match remove_worktree(&ctx.workspace, &entry.path) {
+            Ok(()) => actions.push(CleanupAction::Removed(entry.path)),
+            Err(message) => return Ok(ToolResult::error(message)),
+        }
+    }
+
+    if !dry_run
+        && actions
+            .iter()
+            .any(|action| matches!(action, CleanupAction::Pruned(_)))
+    {
+        match run_git(&ctx.workspace, &["worktree", "prune", "--expire", "now"]) {
+            Ok(_) => {}
+            Err(message) => return Ok(ToolResult::error(message)),
+        }
+    }
+
+    Ok(ToolResult::text(format_cleanup_actions(&actions, dry_run)))
+}
+
+fn project_matches_workspace(project: &str, ctx: &ToolContext) -> bool {
+    ctx.workspace
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .is_some_and(|name| name == project)
+}
+
+fn list_worktrees(repo: &std::path::Path) -> std::result::Result<Vec<WorktreeEntry>, String> {
+    let output = run_git(repo, &["worktree", "list", "--porcelain"])?;
+    let mut entries = Vec::new();
+    let mut current: Option<WorktreeEntry> = None;
+
+    for line in output.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            if let Some(entry) = current.take() {
+                entries.push(entry);
+            }
+            current = Some(WorktreeEntry {
+                path: std::path::PathBuf::from(path),
+                prunable: false,
+            });
+        } else if line.starts_with("prunable ")
+            && let Some(entry) = current.as_mut()
+        {
+            entry.prunable = true;
+        }
+    }
+
+    if let Some(entry) = current {
+        entries.push(entry);
+    }
+
+    Ok(entries)
+}
+
+fn is_old_enough(path: &std::path::Path, cutoff: SystemTime) -> bool {
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .is_ok_and(|modified| modified <= cutoff)
+}
+
+fn worktree_is_clean(path: &std::path::Path) -> bool {
+    run_git(path, &["status", "--porcelain"])
+        .map(|output| output.trim().is_empty())
+        .unwrap_or(false)
+}
+
+fn remove_worktree(
+    repo: &std::path::Path,
+    path: &std::path::Path,
+) -> std::result::Result<(), String> {
+    run_git(repo, &["worktree", "remove", path_to_git_arg(path)?]).map(|_| ())
+}
+
+fn path_to_git_arg(path: &std::path::Path) -> std::result::Result<&str, String> {
+    path.to_str()
+        .ok_or_else(|| format!("worktree path is not UTF-8: {}", path.display()))
+}
+
+fn run_git(repo: &std::path::Path, args: &[&str]) -> std::result::Result<String, String> {
+    let child = Command::new("git") // kanon:ignore RUST/no-direct-process-command
+        .args(args)
+        .current_dir(repo)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|source| format!("failed to spawn git: {source}"))?;
+    let mut guard = ProcessGuard::new(child);
+
+    let deadline = Instant::now() + GIT_TIMEOUT;
+    let status = loop {
+        match guard.get_mut().try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("git {} timed out after 30s", args.join(" ")));
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(source) => return Err(format!("git wait failed: {source}")),
+        }
+    };
+
+    let mut stdout = String::new();
+    if let Some(ref mut pipe) = guard.get_mut().stdout {
+        pipe.read_to_string(&mut stdout)
+            .map_err(|source| format!("failed to read git stdout: {source}"))?;
+    }
+
+    let mut stderr = String::new();
+    if let Some(ref mut pipe) = guard.get_mut().stderr {
+        pipe.read_to_string(&mut stderr)
+            .map_err(|source| format!("failed to read git stderr: {source}"))?;
+    }
+
+    #[expect(
+        clippy::zombie_processes,
+        reason = "process already reaped via try_wait in poll loop above"
+    )]
+    let _child = guard.detach();
+
+    if stdout.len() > MAX_GIT_OUTPUT {
+        let mut end = MAX_GIT_OUTPUT;
+        while end > 0 && !stdout.is_char_boundary(end) {
+            end -= 1;
+        }
+        stdout.truncate(end);
+        stdout.push_str("\n[output truncated]");
+    }
+
+    if status.success() {
+        Ok(stdout)
+    } else {
+        Err(format!(
+            "git {} failed with status {}: {}",
+            args.join(" "),
+            status.code().unwrap_or(-1),
+            stderr.trim()
+        ))
+    }
+}
+
+fn canonicalize_or_clone(path: &std::path::Path) -> std::path::PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn is_under_allowed_root(path: &std::path::Path, roots: &[std::path::PathBuf]) -> bool {
+    roots
+        .iter()
+        .map(|root| canonicalize_or_clone(root))
+        .any(|root| path.starts_with(root))
+}
+
+fn format_cleanup_actions(actions: &[CleanupAction], dry_run: bool) -> String {
+    if actions.is_empty() {
+        return if dry_run {
+            "katharos dry run: no stale worktrees found".to_owned()
+        } else {
+            "katharos: no stale worktrees removed".to_owned()
+        };
+    }
+
+    let mut lines = Vec::with_capacity(actions.len() + 1);
+    lines.push(if dry_run {
+        "katharos dry run:".to_owned()
+    } else {
+        "katharos cleanup:".to_owned()
+    });
+
+    for action in actions {
+        match action {
+            CleanupAction::Removed(path) => {
+                lines.push(format!("removed {}", path.display()));
+            }
+            CleanupAction::Pruned(path) => {
+                lines.push(format!("pruned {}", path.display()));
+            }
+            CleanupAction::WouldRemove(path) => {
+                lines.push(format!("would remove {}", path.display()));
+            }
+            CleanupAction::SkippedDirty(path) => {
+                lines.push(format!("skipped dirty {}", path.display()));
+            }
+            CleanupAction::SkippedYoung(path) => {
+                lines.push(format!("skipped not old enough {}", path.display()));
+            }
+            CleanupAction::SkippedOutsideAllowedRoot(path) => {
+                lines.push(format!("skipped outside allowed roots {}", path.display()));
+            }
+        }
+    }
+
+    lines.join("\n")
 }
 
 // -- registration ----------------------------------------------------------
@@ -162,12 +454,7 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
             tool_name: "tamias",
         }),
     )?;
-    registry.register(
-        katharos_def(),
-        Box::new(BookkeeperStub {
-            tool_name: "katharos",
-        }),
-    )?;
+    registry.register(katharos_def(), Box::new(KatharosExecutor))?;
     Ok(())
 }
 
@@ -175,6 +462,73 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
 mod tests {
     use super::*;
     use crate::registry::ToolRegistry;
+
+    fn result_text(result: &ToolResult) -> String {
+        match &result.content {
+            crate::types::ToolResultContent::Text(text) => text.clone(),
+            _ => panic!("expected text content"),
+        }
+    }
+
+    fn run_test_git(repo: &std::path::Path, args: &[&str]) -> String {
+        run_git(repo, args).unwrap_or_else(|message| panic!("git command failed: {message}"))
+    }
+
+    fn write_test_file(path: &std::path::Path, content: &str) {
+        std::fs::write(path, content)
+            .unwrap_or_else(|source| panic!("failed to write {}: {source}", path.display()));
+    }
+
+    fn remove_test_dir(path: &std::path::Path) {
+        std::fs::remove_dir_all(path)
+            .unwrap_or_else(|source| panic!("failed to remove {}: {source}", path.display()));
+    }
+
+    fn test_context(
+        workspace: std::path::PathBuf,
+        allowed_roots: Vec<std::path::PathBuf>,
+    ) -> ToolContext {
+        use std::collections::HashSet;
+        use std::sync::{Arc, RwLock};
+
+        use koina::id::{NousId, SessionId};
+
+        ToolContext {
+            nous_id: NousId::new("test").expect("valid nous id"),
+            session_id: SessionId::new(),
+            turn_number: 0,
+            workspace,
+            allowed_roots,
+            services: None,
+            active_tools: Arc::new(RwLock::new(HashSet::new())),
+            tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
+        }
+    }
+
+    fn init_repo(root: &std::path::Path) -> std::path::PathBuf {
+        let repo = root.join("aletheia");
+        std::fs::create_dir(&repo)
+            .unwrap_or_else(|source| panic!("failed to create {}: {source}", repo.display()));
+        run_test_git(&repo, &["init"]);
+        run_test_git(&repo, &["config", "user.email", "test@example.com"]);
+        run_test_git(&repo, &["config", "user.name", "Aletheia Test"]);
+        write_test_file(&repo.join("README.md"), "test\n");
+        run_test_git(&repo, &["add", "README.md"]);
+        run_test_git(&repo, &["commit", "-m", "initial"]);
+        repo
+    }
+
+    fn katharos_input(dry_run: bool) -> ToolInput {
+        ToolInput {
+            name: ToolName::from_static("katharos"),
+            tool_use_id: "toolu_katharos".to_owned(),
+            arguments: serde_json::json!({
+                "project": "aletheia",
+                "max_age_hours": 48,
+                "dry_run": dry_run,
+            }),
+        }
+    }
 
     #[test]
     fn bookkeeper_tools_register_without_collision() {
@@ -200,6 +554,15 @@ mod tests {
     }
 
     #[test]
+    fn katharos_uses_mutating_groups() {
+        let groups = katharos_def().groups;
+        assert!(groups.contains(&ToolGroupId::Read));
+        assert!(groups.contains(&ToolGroupId::Edit));
+        assert!(groups.contains(&ToolGroupId::Command));
+        assert!(groups.contains(&ToolGroupId::Verify));
+    }
+
+    #[test]
     fn tamias_is_partially_reversible() {
         assert_eq!(
             tamias_def().reversibility,
@@ -215,21 +578,10 @@ mod tests {
 
     #[tokio::test]
     async fn stubs_return_not_implemented() {
-        use std::collections::HashSet;
-        use std::sync::{Arc, RwLock};
-
-        use koina::id::{NousId, SessionId};
-
-        let ctx = ToolContext {
-            nous_id: NousId::new("test").expect("valid nous id"),
-            session_id: SessionId::new(),
-            turn_number: 0,
-            workspace: std::path::PathBuf::from("/tmp"),
-            allowed_roots: vec![std::path::PathBuf::from("/tmp")],
-            services: None,
-            active_tools: Arc::new(RwLock::new(HashSet::new())),
-            tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
-        };
+        let ctx = test_context(
+            std::path::PathBuf::from("/tmp"),
+            vec![std::path::PathBuf::from("/tmp")],
+        );
 
         let stub = BookkeeperStub {
             tool_name: "tamias",
@@ -245,13 +597,134 @@ mod tests {
             .await
             .expect("stub execute returns Ok");
         assert!(result.is_error, "stub must return an error result");
-        let text = match &result.content {
-            crate::types::ToolResultContent::Text(t) => t.clone(),
-            _ => panic!("expected text content"),
-        };
+        let text = result_text(&result);
         assert!(
             text.contains("not yet implemented"),
             "error message must mention 'not yet implemented', got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn katharos_dry_run_reports_prunable_worktree_without_pruning() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = init_repo(temp.path());
+        let old_worktree = temp.path().join("old-worktree");
+        let old_worktree_arg = old_worktree
+            .to_str()
+            .expect("temp paths should be UTF-8 for git");
+
+        run_test_git(&repo, &["worktree", "add", old_worktree_arg, "-b", "old"]);
+        remove_test_dir(&old_worktree);
+
+        let ctx = test_context(repo.clone(), vec![temp.path().to_path_buf()]);
+        let result = KatharosExecutor
+            .execute(&katharos_input(true), &ctx)
+            .await
+            .expect("katharos dry-run succeeds");
+
+        assert!(!result.is_error, "dry-run should not error");
+        let text = result_text(&result);
+        assert!(
+            text.contains("would remove") && text.contains("old-worktree"),
+            "dry-run should report prunable worktree, got: {text}"
+        );
+        let worktrees = run_test_git(&repo, &["worktree", "list", "--porcelain"]);
+        assert!(
+            worktrees.contains("old-worktree"),
+            "dry-run must not prune stale metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn katharos_prunes_stale_worktree_metadata() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = init_repo(temp.path());
+        let old_worktree = temp.path().join("old-worktree");
+        let old_worktree_arg = old_worktree
+            .to_str()
+            .expect("temp paths should be UTF-8 for git");
+
+        run_test_git(&repo, &["worktree", "add", old_worktree_arg, "-b", "old"]);
+        remove_test_dir(&old_worktree);
+
+        let ctx = test_context(repo.clone(), vec![temp.path().to_path_buf()]);
+        let result = KatharosExecutor
+            .execute(&katharos_input(false), &ctx)
+            .await
+            .expect("katharos cleanup succeeds");
+
+        assert!(!result.is_error, "cleanup should not error");
+        let text = result_text(&result);
+        assert!(
+            text.contains("pruned") && text.contains("old-worktree"),
+            "cleanup should report pruned metadata, got: {text}"
+        );
+        let worktrees = run_test_git(&repo, &["worktree", "list", "--porcelain"]);
+        assert!(
+            !worktrees.contains("old-worktree"),
+            "cleanup should prune stale metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn katharos_rejects_project_mismatch() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = init_repo(temp.path());
+        let ctx = test_context(repo, vec![temp.path().to_path_buf()]);
+        let input = ToolInput {
+            name: ToolName::from_static("katharos"),
+            tool_use_id: "toolu_katharos".to_owned(),
+            arguments: serde_json::json!({
+                "project": "other",
+                "dry_run": true,
+            }),
+        };
+
+        let result = KatharosExecutor
+            .execute(&input, &ctx)
+            .await
+            .expect("project mismatch returns tool result");
+
+        assert!(result.is_error, "project mismatch must be an error");
+        let text = result_text(&result);
+        assert!(
+            text.contains("project mismatch"),
+            "error should explain mismatch, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn katharos_skips_worktrees_outside_allowed_roots() {
+        let repo_temp = tempfile::tempdir().expect("repo tempdir");
+        let outside_temp = tempfile::tempdir().expect("outside tempdir");
+        let repo = init_repo(repo_temp.path());
+        let outside_worktree = outside_temp.path().join("old-worktree");
+        let outside_worktree_arg = outside_worktree
+            .to_str()
+            .expect("temp paths should be UTF-8 for git");
+
+        run_test_git(
+            &repo,
+            &["worktree", "add", outside_worktree_arg, "-b", "old"],
+        );
+        remove_test_dir(&outside_worktree);
+
+        let ctx = test_context(repo.clone(), vec![repo_temp.path().to_path_buf()]);
+        let result = KatharosExecutor
+            .execute(&katharos_input(false), &ctx)
+            .await
+            .expect("outside root skip succeeds");
+
+        assert!(!result.is_error, "outside root skip should not error");
+        let text = result_text(&result);
+        assert!(
+            text.contains("skipped outside allowed roots"),
+            "cleanup should report outside-root skip, got: {text}"
+        );
+        let worktrees = run_test_git(&repo, &["worktree", "list", "--porcelain"]);
+        assert!(
+            worktrees.contains("old-worktree"),
+            "outside-root stale metadata should remain for a wider allowed root"
         );
     }
 }


### PR DESCRIPTION
## Summary
- replaces the `katharos` bookkeeper stub with a conservative git worktree cleanup executor
- supports dry-run reporting, stale metadata pruning, project matching, allowed-root containment, and dirty/young worktree skips
- keeps `tamias` as the remaining deferred bookkeeper stub

Advances #3973. This intentionally does not claim the energeia IsolationResolver or per-prompt worktree policy portions of the issue.

## Verification
- `cargo fmt --check --package organon`
- `cargo test -p organon --features bookkeeper bookkeeper --target-dir /tmp/codex-aletheia-tail5-organon-target`
- `cargo clippy -p organon --features bookkeeper --target-dir /tmp/codex-aletheia-tail5-organon-target -- -D warnings`
- `kanon lint crates/organon/src/builtins/bookkeeper.rs --rust --format json --summary`
- `git diff --check`