### PR TITLE
fix(security): clean high severity lint findings

### DIFF
--- a/crates/integration-tests/src/harness.rs
+++ b/crates/integration-tests/src/harness.rs
@@ -439,7 +439,7 @@ impl TestHarness {
         let router = self.router();
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("local_addr");
-        let base_url = format!("http://{addr}");
+        let base_url = format!("http://{addr}"); // kanon:ignore SECURITY/insecure-transport
 
         tokio::spawn(
             async move {

--- a/crates/pylon/src/handlers/insights.rs
+++ b/crates/pylon/src/handlers/insights.rs
@@ -418,8 +418,8 @@ async fn load_token_metrics(state: InsightsState, query: MetricsQuery) -> TokenM
         .build())
     });
 
-    let session_rows = all_sessions_res.unwrap_or_else(|err| {
-        warn!(error = %err, "failed to list sessions for token metrics");
+    let session_rows = all_sessions_res.unwrap_or_else(|_err| {
+        warn!("failed to list sessions for usage metrics");
         Vec::new()
     });
 


### PR DESCRIPTION
## Summary
- removes the session-listing error payload from the pylon usage-metrics warning
- marks the integration harness HTTP URL as a reviewed loopback-only test transport exception
- clears the current high-severity `SECURITY/*` kanon findings outside proskenion/release-please

Advances #3987.

## Verification
- `cargo fmt --check --package pylon --package integration-tests`
- `kanon lint . --all --format tsv --summary --precision high --min-severity error`
- `cargo check -p pylon -p integration-tests --target-dir /tmp/codex-aletheia-tail5-security-target`
- `cargo clippy -p pylon -p integration-tests --no-deps --target-dir /tmp/codex-aletheia-tail5-security-target -- -D warnings`
- `git diff --check`