### PR TITLE
feat(memory): tag observations with runtime project id

### DIFF
--- a/crates/aletheia/src/runtime/nous_config.rs
+++ b/crates/aletheia/src/runtime/nous_config.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use tracing::warn;
 
+use mneme::workspace::ProjectId;
 use nous::config::{NousConfig, PipelineConfig};
 use taxis::config::{AletheiaConfig, resolve_nous};
 use taxis::oikos::Oikos;
@@ -30,6 +32,22 @@ fn resolve_allowed_roots(
         }
     }
     roots
+}
+
+fn detect_project_id(workspace: &Path) -> Option<ProjectId> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let remote = String::from_utf8(output.stdout).ok()?;
+    ProjectId::from_git_remote(remote).ok()
 }
 
 pub(super) fn build_nous_runtime_config(
@@ -69,6 +87,8 @@ pub(super) fn build_nous_runtime_config(
         }
     }
 
+    let workspace = resolve_config_path(oikos, &resolved.workspace);
+    let project_id = detect_project_id(&workspace);
     let nous_config = NousConfig {
         id: resolved.id,
         name: resolved.name,
@@ -105,7 +125,7 @@ pub(super) fn build_nous_runtime_config(
         domains,
         private: resolved.private,
         episteme_cohort: resolved.episteme_cohort,
-        workspace: resolve_config_path(oikos, &resolved.workspace),
+        workspace,
         allowed_roots: resolve_allowed_roots(oikos, &resolved.workspace, &resolved.allowed_roots),
         server_tools: Vec::new(),
         cache_enabled: resolved.capabilities.cache_enabled,
@@ -123,6 +143,7 @@ pub(super) fn build_nous_runtime_config(
     (
         nous_config,
         PipelineConfig {
+            project_id,
             extraction: Some(extraction_cfg),
             training: config.training.clone(),
             ..PipelineConfig::default()

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -38,6 +38,10 @@
 pub use eidos::id;
 /// Knowledge graph domain types: facts, entities, relationships, embeddings (re-exported from `eidos`).
 pub use eidos::knowledge;
+/// Workspace/project identity primitives (re-exported from `eidos`).
+pub mod workspace {
+    pub use eidos::workspace::{ProjectId, ProjectIdError};
+}
 
 /// Bookkeeping provider contracts, DTOs, and pipeline adapters.
 pub mod bookkeeping {

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use hermeneus::complexity::ComplexityConfig;
 use mneme::knowledge::{EpistemicTier, MemoryScope};
+use mneme::workspace::ProjectId;
 use serde::{Deserialize, Serialize};
 use taxis::config::AgentBehaviorDefaults;
 
@@ -429,6 +430,9 @@ impl NousConfig {
 pub struct PipelineConfig {
     /// Token budget for history (remaining after bootstrap).
     pub history_budget_ratio: f64,
+    /// Git-remote-derived project partition for behavioral observations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
     /// Knowledge extraction configuration (None = disabled).
     #[serde(default)]
     pub extraction: Option<mneme::extract::ExtractionConfig>,
@@ -447,6 +451,7 @@ impl Default for PipelineConfig {
     fn default() -> Self {
         Self {
             history_budget_ratio: 0.6,
+            project_id: None,
             extraction: None,
             stage_budget: StageBudget::default(),
             training: crate::training::TrainingConfig::default(),

--- a/crates/nous/src/instinct.rs
+++ b/crates/nous/src/instinct.rs
@@ -7,6 +7,7 @@ use mneme::instinct::{
     DEFAULT_MAX_CONTEXT_SUMMARY_LEN, DEFAULT_MAX_PARAM_VALUE_LEN, ToolObservation, ToolOutcome,
     sanitize_parameters, truncate_context_summary,
 };
+use mneme::workspace::ProjectId;
 
 use crate::pipeline::ToolCall;
 
@@ -19,6 +20,7 @@ pub(crate) fn observation_from_tool_call(
     tool_call: &ToolCall,
     context_summary: &str,
     nous_id: &str,
+    project_id: Option<&ProjectId>,
 ) -> ToolObservation {
     let outcome = if tool_call.is_error {
         ToolOutcome::Failure {
@@ -44,7 +46,7 @@ pub(crate) fn observation_from_tool_call(
         outcome,
         context_summary: truncated_summary,
         nous_id: nous_id.to_owned(),
-        project_id: None,
+        project_id: project_id.cloned(),
         observed_at: jiff::Timestamp::now(),
     }
 }
@@ -60,10 +62,11 @@ pub(crate) fn record_observations(
     tool_calls: &[ToolCall],
     context_summary: &str,
     nous_id: &str,
+    project_id: Option<&ProjectId>,
 ) -> Vec<ToolObservation> {
     let observations: Vec<ToolObservation> = tool_calls
         .iter()
-        .map(|tc| observation_from_tool_call(tc, context_summary, nous_id))
+        .map(|tc| observation_from_tool_call(tc, context_summary, nous_id, project_id))
         .collect();
 
     if observations.is_empty() {
@@ -121,9 +124,10 @@ mod tests {
     #[test]
     fn observation_from_successful_tool_call() {
         let tc = make_tool_call("grep", false);
-        let obs = observation_from_tool_call(&tc, "searching code", "nous-1");
+        let obs = observation_from_tool_call(&tc, "searching code", "nous-1", None);
         assert_eq!(obs.tool_name, "grep");
         assert_eq!(obs.nous_id, "nous-1");
+        assert!(obs.project_id.is_none());
         assert!(obs.outcome.is_success());
         assert_eq!(obs.parameters["api_key"], "[REDACTED]");
         assert_eq!(obs.parameters["path"], "/src/main.rs");
@@ -132,12 +136,24 @@ mod tests {
     #[test]
     fn observation_from_failed_tool_call() {
         let tc = make_tool_call("exec", true);
-        let obs = observation_from_tool_call(&tc, "running command", "nous-2");
+        let obs = observation_from_tool_call(&tc, "running command", "nous-2", None);
         assert!(!obs.outcome.is_success());
         match &obs.outcome {
             ToolOutcome::Failure { error } => assert!(error.contains("tool failed")),
             _ => panic!("expected Failure outcome"),
         }
+    }
+
+    #[test]
+    fn observation_preserves_project_partition() {
+        let tc = make_tool_call("grep", false);
+        let project_id = ProjectId::from_git_remote("https://github.com/forkwright/aletheia.git")
+            .expect("valid remote");
+
+        let obs =
+            observation_from_tool_call(&tc, "searching project code", "nous-1", Some(&project_id));
+
+        assert_eq!(obs.project_id.as_ref(), Some(&project_id));
     }
 
     #[test]
@@ -147,13 +163,13 @@ mod tests {
             make_tool_call("read_file", false),
             make_tool_call("exec", true),
         ];
-        let observations = record_observations(&calls, "multi-tool turn", "nous-1");
+        let observations = record_observations(&calls, "multi-tool turn", "nous-1", None);
         assert_eq!(observations.len(), 3);
     }
 
     #[test]
     fn record_observations_empty_calls() {
-        let observations = record_observations(&[], "no tools used", "nous-1");
+        let observations = record_observations(&[], "no tools used", "nous-1", None);
         assert!(observations.is_empty());
     }
 }

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -1350,6 +1350,7 @@ pub(crate) async fn run_pipeline(
                 &result.tool_calls,
                 &input.content,
                 &config.id,
+                pipeline_config.project_id.as_ref(),
             );
             tracing::debug!(
                 observation_count = observations.len(),

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -202,6 +202,7 @@ impl SpawnService for SpawnServiceImpl {
         // are internal delegation, not user-facing conversation.
         let pipeline_config = PipelineConfig {
             history_budget_ratio: 0.6,
+            project_id: None,
             extraction: None,
             stage_budget: StageBudget::default(),
             training: crate::training::TrainingConfig::default(),


### PR DESCRIPTION
## Summary
- detect each configured nous workspace's git origin during runtime config assembly
- carry the derived project partition through pipeline config into instinct tool observations
- re-export workspace identity primitives from mneme for downstream runtime wiring

Refs #3975

## Verification
- cargo fmt --check --package mneme --package nous --package aletheia
- cargo test -p nous instinct --target-dir /tmp/codex-aletheia-tail5-project-id-target
- cargo check -p aletheia --target-dir /tmp/codex-aletheia-tail5-project-id-target
- git diff --check
- kanon lint . --rust --format tsv --summary --precision high --min-severity error --paths-from /tmp/codex-aletheia-tail5-project-id-paths.txt