### PR TITLE
fix(nous): preserve local complexity routing boundary

### DIFF
--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -77,7 +77,7 @@ pub async fn execute(
         || tools.definitions_for_groups(&config.tool_groups).len(),
         Vec::len,
     );
-    let turn_model = resolve_turn_model(ctx, config, tool_count);
+    let turn_model = resolve_turn_model(ctx, config, providers, tool_count);
 
     let mut messages = build_messages(&ctx.messages);
     let mut all_tool_calls: Vec<ToolCall> = Vec::new();
@@ -483,7 +483,7 @@ pub async fn execute_streaming(
         || tools.definitions_for_groups(&config.tool_groups).len(),
         Vec::len,
     );
-    let turn_model = resolve_turn_model(ctx, config, tool_count);
+    let turn_model = resolve_turn_model(ctx, config, providers, tool_count);
 
     let Some(streaming_provider) = providers.find_streaming_provider(&turn_model) else {
         // NOTE: fall back to non-streaming execute if no streaming provider is registered

--- a/crates/nous/src/execute/resolve.rs
+++ b/crates/nous/src/execute/resolve.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 
 use hermeneus::complexity::{ComplexityInput, route_model};
 use hermeneus::health::ProviderHealth;
-use hermeneus::provider::{LlmProvider, ProviderRegistry};
+use hermeneus::provider::{DeploymentTarget, LlmProvider, ProviderRegistry};
 use hermeneus::types::{ContentBlock, ServerToolDefinition};
 use koina::id::ToolName;
 use organon::types::ToolContext;
@@ -35,6 +35,7 @@ pub(super) struct ResponseExtract {
 pub(super) fn resolve_turn_model(
     ctx: &PipelineContext,
     config: &NousConfig,
+    providers: &ProviderRegistry,
     tool_count: usize,
 ) -> String {
     if !config.generation.complexity.enabled {
@@ -61,6 +62,34 @@ pub(super) fn resolve_turn_model(
     };
 
     let decision = route_model(&input, &config.generation.complexity);
+    let deployment_target = providers
+        .find_provider(&config.generation.model)
+        .map_or(DeploymentTarget::Cloud, LlmProvider::deployment_target);
+    let configured_local = matches!(
+        deployment_target,
+        DeploymentTarget::LocalHosted | DeploymentTarget::Embedded
+    );
+    let routed_deployment_target = providers
+        .find_provider(&decision.model)
+        .map(LlmProvider::deployment_target);
+    let routed_local = matches!(
+        routed_deployment_target,
+        Some(DeploymentTarget::LocalHosted | DeploymentTarget::Embedded)
+    );
+    if configured_local && !routed_local && decision.model != config.generation.model {
+        debug!(
+            configured_model = config.generation.model,
+            routed_model = decision.model,
+            deployment_target = deployment_target.as_str(),
+            routed_deployment_target = routed_deployment_target
+                .map_or("unregistered", DeploymentTarget::as_str),
+            complexity_score = decision.complexity.score,
+            complexity_tier = %decision.complexity.tier,
+            "complexity routing preserved local deployment target"
+        );
+        return config.generation.model.clone();
+    }
+
     decision.model
 }
 

--- a/crates/nous/src/execute/tests/core.rs
+++ b/crates/nous/src/execute/tests/core.rs
@@ -7,7 +7,7 @@ use super::*;
 use std::sync::{Arc, Mutex};
 
 use hermeneus::error as llm_error;
-use hermeneus::provider::LlmProvider;
+use hermeneus::provider::{DeploymentTarget, LlmProvider};
 
 struct FallbackSequenceProvider {
     responses: Mutex<Vec<hermeneus::error::Result<CompletionResponse>>>,
@@ -17,6 +17,11 @@ struct FallbackSequenceProvider {
 }
 
 struct ArcProvider(Arc<FallbackSequenceProvider>);
+
+struct DeploymentTargetProvider {
+    inner: MockProvider,
+    target: DeploymentTarget,
+}
 
 impl FallbackSequenceProvider {
     fn new(
@@ -34,6 +39,12 @@ impl FallbackSequenceProvider {
 
     fn called_models(&self) -> Vec<String> {
         self.models.lock().expect("models lock").clone()
+    }
+}
+
+impl DeploymentTargetProvider {
+    fn new(inner: MockProvider, target: DeploymentTarget) -> Self {
+        Self { inner, target }
     }
 }
 
@@ -57,6 +68,28 @@ impl LlmProvider for FallbackSequenceProvider {
 
     fn name(&self) -> &str {
         self.provider_name
+    }
+}
+
+impl LlmProvider for DeploymentTargetProvider {
+    fn complete<'a>(
+        &'a self,
+        request: &'a hermeneus::types::CompletionRequest,
+    ) -> Pin<Box<dyn Future<Output = hermeneus::error::Result<CompletionResponse>> + Send + 'a>>
+    {
+        self.inner.complete(request)
+    }
+
+    fn supported_models(&self) -> &[&str] {
+        self.inner.supported_models()
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn deployment_target(&self) -> DeploymentTarget {
+        self.target
     }
 }
 
@@ -854,5 +887,94 @@ async fn test_routing_enabled_selects_tier_model() {
     .expect("execute should resolve opus-tier via complexity routing");
 
     assert_eq!(result.content, "opus answer");
+    assert_eq!(result.usage.llm_calls, 1);
+}
+
+#[tokio::test]
+async fn test_routing_enabled_preserves_local_deployment_target() {
+    // WHY: a locally configured turn model must not be replaced by a cloud
+    // tier model just because the complexity score is high. Provider
+    // resolution only registers the local model, so this fails if the
+    // sovereignty guard is bypassed.
+    let mut providers = ProviderRegistry::new();
+    providers.register(Box::new(DeploymentTargetProvider::new(
+        MockProvider::with_responses(vec![make_text_response("local answer")])
+            .models(&["local-tier"]),
+        DeploymentTarget::Embedded,
+    )));
+
+    let tools = ToolRegistry::new();
+
+    let mut config = test_config();
+    config.generation.model = "local-tier".to_owned();
+    config.generation.complexity = hermeneus::complexity::ComplexityConfig {
+        enabled: true,
+        haiku_model: "haiku-cloud".to_owned(),
+        sonnet_model: "sonnet-cloud".to_owned(),
+        opus_model: "opus-cloud".to_owned(),
+        ..hermeneus::complexity::ComplexityConfig::default()
+    };
+
+    let mut ctx = test_pipeline_ctx();
+    ctx.messages[0].content = "think hard about this architecture decision".to_owned();
+
+    let result = execute(
+        &ctx,
+        &test_session(),
+        &config,
+        &providers,
+        &tools,
+        &test_tool_ctx(),
+        None,
+    )
+    .await
+    .expect("execute should preserve the embedded provider's local model");
+
+    assert_eq!(result.content, "local answer");
+    assert_eq!(result.usage.llm_calls, 1);
+}
+
+#[tokio::test]
+async fn test_routing_enabled_allows_local_tier_model() {
+    let mut providers = ProviderRegistry::new();
+    providers.register(Box::new(DeploymentTargetProvider::new(
+        MockProvider::with_responses(vec![make_text_response("configured local")])
+            .models(&["local-tier"]),
+        DeploymentTarget::Embedded,
+    )));
+    providers.register(Box::new(DeploymentTargetProvider::new(
+        MockProvider::with_responses(vec![make_text_response("local opus answer")])
+            .models(&["local-opus"]),
+        DeploymentTarget::Embedded,
+    )));
+
+    let tools = ToolRegistry::new();
+
+    let mut config = test_config();
+    config.generation.model = "local-tier".to_owned();
+    config.generation.complexity = hermeneus::complexity::ComplexityConfig {
+        enabled: true,
+        haiku_model: "local-tier".to_owned(),
+        sonnet_model: "local-sonnet".to_owned(),
+        opus_model: "local-opus".to_owned(),
+        ..hermeneus::complexity::ComplexityConfig::default()
+    };
+
+    let mut ctx = test_pipeline_ctx();
+    ctx.messages[0].content = "think hard about this architecture decision".to_owned();
+
+    let result = execute(
+        &ctx,
+        &test_session(),
+        &config,
+        &providers,
+        &tools,
+        &test_tool_ctx(),
+        None,
+    )
+    .await
+    .expect("execute should allow local tier model routing");
+
+    assert_eq!(result.content, "local opus answer");
     assert_eq!(result.usage.llm_calls, 1);
 }


### PR DESCRIPTION
## Summary
- keep complexity routing from substituting a cloud or unregistered tier model when the configured turn model is backed by a local/embedded provider
- still allow tier routing when the selected tier model is also local/embedded
- add execute-loop regression tests for blocked cloud substitution and allowed local tier substitution

Refs #3970. This intentionally does not close the issue; Tier-1 handler execution, MetricClaim emission, and standards verification remain follow-ups.

## Verification
- `cargo fmt --check --package nous`
- `cargo check -p nous --target-dir /tmp/codex-aletheia-tail5-3970-target`
- `cargo test -p nous test_routing_enabled_ --target-dir /tmp/codex-aletheia-tail5-3970-target`
- `kanon lint . --rust --format tsv --summary --precision high --min-severity error --paths-from /tmp/codex-aletheia-tail5-3970-paths.txt`
- `cargo clippy -p nous --no-deps --target-dir /tmp/codex-aletheia-tail5-3970-target -- -D warnings`
- `git diff --check`

Note: broader `cargo clippy -p nous --target-dir /tmp/codex-aletheia-tail5-3970-target -- -D warnings` hit pre-existing episteme warnings in `crates/episteme/src/rl/reward.rs` and `crates/episteme/src/rl/state.rs`; the `--no-deps` nous clippy gate passed.