### PR TITLE
docs(organon): refresh bookkeeper feature status

### DIFF
--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -31,8 +31,8 @@ receipt_verification = []
 # Energeia capability tools (dromeus, dokimasia, diorthosis, epitropos, parateresis,
 # mathesis, prographe, schedion, metron). Wires to real energeia subsystem.
 energeia = ["dep:energeia"]
-# Unimplemented prompt archival/worktree cleanup tool schemas. Default OFF so
-# agents do not see stub capabilities unless a deployment deliberately opts in.
+# Bookkeeper tools: `katharos` worktree cleanup is implemented; `tamias`
+# prompt archival remains deferred. Default OFF so deployments opt in explicitly.
 bookkeeper = []
 # Z3 SMT solver tool (z3_solver). Bundled so the default build doesn't pull libz3.
 z3 = ["dep:z3"]

--- a/crates/organon/src/builtins/mod.rs
+++ b/crates/organon/src/builtins/mod.rs
@@ -249,7 +249,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_energeia_registry_excludes_unimplemented_bookkeeper_tools() -> Result<()> {
+    fn default_energeia_registry_excludes_feature_gated_bookkeeper_tools() -> Result<()> {
         let mut registry = ToolRegistry::new();
         register_domain_tools(&mut registry, SandboxConfig::default(), None)?;
         let names: Vec<&str> = registry
@@ -264,7 +264,7 @@ mod tests {
         );
         assert!(
             !names.contains(&"tamias") && !names.contains(&"katharos"),
-            "unimplemented bookkeeper tools must not be exposed by default"
+            "feature-gated bookkeeper tools must not be exposed by default"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- refresh the `bookkeeper` feature description now that `katharos` worktree cleanup is implemented
- update the default registry test name/message to describe feature-gated bookkeeper tools instead of unimplemented tools

Refs #3973. This does not close the issue; energeia-owned worktree provisioning/recovery and any prompt policy decisions remain out of scope.

## Verification
- `cargo fmt --check --package organon`
- `cargo test -p organon builtins::tests::default_energeia_registry_excludes_feature_gated_bookkeeper_tools --features energeia --target-dir /tmp/codex-aletheia-tail5-3973-target`
- `kanon lint . --rust --format tsv --summary --precision high --min-severity error --paths-from /tmp/codex-aletheia-tail5-3973-paths.txt`
- `git diff --check`
