### PR TITLE
fix(routing): preserve interactive after-action outcomes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ name = "aletheia"
 version = "0.27.0"
 dependencies = [
  "agora",
+ "aletheia-routing",
  "anyhow",
  "assert_cmd",
  "axum 0.8.9",

--- a/crates/aletheia-routing/src/lib.rs
+++ b/crates/aletheia-routing/src/lib.rs
@@ -94,3 +94,97 @@ impl Router for NoOpRouter {
         Ok(())
     }
 }
+
+/// A static router that records after-action outcomes into a shared store.
+///
+/// This is the interactive-runtime counterpart to the richer dispatch
+/// empirical routers: it does not change provider selection, but it prevents
+/// completed turns from being discarded when the binary has not enabled an
+/// empirical selection policy.
+pub struct RecordingRouter {
+    /// Shared empirical outcome store.
+    store: Arc<AfterActionStore>,
+    /// Static provider/model returned for route calls.
+    provider: Arc<str>,
+}
+
+impl RecordingRouter {
+    /// Create a router that records outcomes while preserving static routing.
+    #[must_use]
+    pub fn new(store: Arc<AfterActionStore>, provider: impl Into<Arc<str>>) -> Self {
+        Self {
+            store,
+            provider: provider.into(),
+        }
+    }
+}
+
+impl Router for RecordingRouter {
+    fn route<'a>(&'a self, _features: &'a RequestFeatures) -> BoxFuture<'a, RoutingDecision> {
+        let provider = self.provider.clone();
+        Box::pin(async move { RoutingDecision::new(provider, None) })
+    }
+
+    fn after_action(
+        &self,
+        _decision: &RoutingDecision,
+        outcome: &TurnOutcome,
+    ) -> Result<(), RouterError> {
+        let store = Arc::clone(&self.store);
+        let outcome = outcome.clone();
+        tokio::spawn(async move {
+            store.record_outcome(&outcome).await;
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::types::{ProviderId, TaskCategory};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn recording_router_preserves_static_route() {
+        let store = Arc::new(AfterActionStore::in_memory());
+        let router = RecordingRouter::new(store, "claude-sonnet");
+        let decision = router
+            .route(&RequestFeatures::new(Vec::new(), None, None))
+            .await;
+
+        assert_eq!(decision.provider.as_ref(), "claude-sonnet");
+        assert_eq!(decision.confidence, None);
+    }
+
+    #[tokio::test]
+    async fn recording_router_records_after_action_into_store() {
+        let store = Arc::new(AfterActionStore::in_memory());
+        let router = RecordingRouter::new(Arc::clone(&store), "claude-sonnet");
+        let provider = ProviderId::new("claude-sonnet");
+        let outcome = TurnOutcome::new(provider.clone(), TaskCategory::Feature, true, true);
+        let decision = RoutingDecision::new("claude-sonnet", None);
+
+        assert!(router.after_action(&decision, &outcome).is_ok());
+
+        for _ in 0..10 {
+            if let Some(stats) = store
+                .rolling_stats(
+                    &provider,
+                    &TaskCategory::Feature,
+                    Duration::from_secs(7 * 24 * 60 * 60),
+                )
+                .await
+            {
+                assert_eq!(stats.successes, 1);
+                assert_eq!(stats.total, 1);
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        panic!("recording router did not write outcome");
+    }
+}

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -55,6 +55,7 @@ test-full = ["test-core", "mneme/test-full", "online-tests"]
 diaporeia = { path = "../diaporeia", optional = true }
 rmcp = { version = "=1.5.0", optional = true, features = ["client"] }
 dianoia = { path = "../dianoia" }
+aletheia-routing = { path = "../aletheia-routing" }
 energeia = { path = "../energeia", optional = true }
 oikonomos = { path = "../daemon" }
 koina = { path = "../koina", features = ["fjall"] }

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -1,6 +1,7 @@
 //! `aletheia maintenance`: instance maintenance task management.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use clap::Subcommand;
 use snafu::prelude::*;
@@ -212,7 +213,9 @@ pub(crate) fn build_config(
     prompt_audit: &taxis::config::PromptAuditSettings,
 ) -> MaintenanceConfig {
     MaintenanceConfig {
-        after_action_store: None,
+        after_action_store: Some(Arc::new(aletheia_routing::AfterActionStore::new(
+            oikos.logs().join("after-actions"),
+        ))),
         trace_rotation: TraceRotationConfig {
             enabled: settings.trace_rotation.enabled,
             trace_dir: oikos.traces(),

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -12,6 +12,7 @@ use tokio_util::task::TaskTracker;
 use tracing::{Instrument, error, info, warn};
 
 use agora::types::ChannelProvider;
+use aletheia_routing::{AfterActionStore, RecordingRouter};
 use hermeneus::provider::ProviderRegistry;
 use koina::secret::SecretString;
 use koina::system::{Environment, RealSystem};
@@ -476,6 +477,19 @@ impl RuntimeBuilder {
             audit_log_dir,
             self.config.prompt_audit.enabled,
         ));
+        let after_action_store = Arc::new(AfterActionStore::new(
+            self.oikos.logs().join("after-actions"),
+        ));
+        let empirical_router: Arc<dyn aletheia_routing::Router> = Arc::new(RecordingRouter::new(
+            Arc::clone(&after_action_store),
+            self.config
+                .agents
+                .defaults
+                .model_defaults
+                .model
+                .primary
+                .as_str(),
+        ));
 
         let spawn_impl = if self.tool_services {
             #[cfg(feature = "recall")]
@@ -494,7 +508,7 @@ impl RuntimeBuilder {
                     knowledge_store: child_knowledge_store,
                     router: Some(Arc::clone(&cross_router)),
                     audit_log: Some(Arc::clone(&audit_log)),
-                    empirical_router: None,
+                    empirical_router: Some(Arc::clone(&empirical_router)),
                 }),
             ))
         } else {
@@ -542,7 +556,8 @@ impl RuntimeBuilder {
             Some(tool_services),
             self.config.nous_behavior.clone(),
         )
-        .with_audit_log(Arc::clone(&audit_log));
+        .with_audit_log(Arc::clone(&audit_log))
+        .with_empirical_router(Arc::clone(&empirical_router));
 
         // Spawn nous actors
         {
@@ -565,6 +580,7 @@ impl RuntimeBuilder {
             &self.config.maintenance,
             &self.config.prompt_audit,
         );
+        maintenance_config.after_action_store = Some(Arc::clone(&after_action_store));
         maintenance_config.backup_metrics = Some(Arc::new(RuntimeBackupMetricsRecorder));
         let task_state_root = self.oikos.data().join("daemon-task-state");
 


### PR DESCRIPTION
## Summary
- add a shared `RecordingRouter` that preserves static provider selection while writing `TurnOutcome` records into `AfterActionStore`
- wire runtime-created nous actors and spawned sub-agents to the shared recording router
- configure maintenance to refresh the same after-action store directory used for routing evidence

Refs #3944.

## Verification
- `cargo fmt --check --package aletheia-routing --package aletheia`
- `cargo test -p aletheia-routing`
- `cargo check -p aletheia --target-dir /tmp/codex-aletheia-tail5-routing-target`
- `cargo clippy -p aletheia-routing --target-dir /tmp/codex-aletheia-tail5-routing-target -- -D warnings`
- `cargo clippy -p aletheia --no-deps --target-dir /tmp/codex-aletheia-tail5-routing-target -- -D warnings`
- `kanon lint crates/aletheia-routing/src/lib.rs --rust --format tsv --summary --precision high --min-severity error`
- `kanon lint crates/aletheia/src/runtime/mod.rs --rust --format tsv --summary --precision high --min-severity error`
- `kanon lint crates/aletheia/src/commands/maintenance.rs --rust --format tsv --summary --precision high --min-severity error`
- `git diff --check`