### PR TITLE
docs(matrix): remove stale config affordance

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -506,9 +506,10 @@ nous_id = "main"
 
 ## Matrix (Phase 3 deployment profile)
 
-Aletheia's public deployment profile treats the Matrix channel provider as
-scaffolding for the Phase 3 implementation against a
-self-hosted [conduwuit](https://conduwuit.puppyirl.gay/) homeserver.
+Aletheia's public deployment profile preserves homeserver deployment prep for
+the Phase 3 Matrix channel implementation against a self-hosted
+[conduwuit](https://conduwuit.puppyirl.gay/) homeserver. Aletheia does not
+currently expose a Matrix provider, config surface, or Cargo feature.
 
 ### Prerequisites
 

--- a/instance.example/config/aletheia.toml
+++ b/instance.example/config/aletheia.toml
@@ -77,22 +77,6 @@ workspace = "nous/main"
 # httpHost = "localhost"
 # httpPort = 8080
 
-# --- Matrix channel (feature-gated: build with `--features matrix`) ---
-# See docs/DEPLOYMENT.md "Matrix (optional)" and issue #3557.
-# Prefer TLS; fall back to http:// only on trusted loopback (e.g. a local
-# conduwuit running on 127.0.0.1) — never cross a network boundary in
-# plaintext because device access tokens are transported in each request.
-# [channels.matrix]
-# enabled = true
-# homeserverUrl = "https://matrix.example.com"
-# userId = "@agent:example.com"
-# deviceDisplayName = "menos-syn"
-# cryptoStorePath = "matrix-crypto"
-#
-# [[channels.matrix.accounts]]
-# nousId = "syn"
-# room = "!abcd1234:example.com"
-
 # --- Bindings (route messages to agents) ---
 # [[bindings]]
 # channel = "signal"


### PR DESCRIPTION
## Summary
- remove the commented `[channels.matrix]` example from the current instance template because no Matrix config surface or Cargo feature exists
- clarify the deployment guide Matrix section as homeserver prep for Phase 3, not an exposed Aletheia provider

Refs #3981.

## Verification
- `rg` for stale Matrix feature/config affordances in current docs and Cargo/config surfaces
- `kanon lint docs/DEPLOYMENT.md --writing --format tsv --summary --precision high --min-severity error`
- `kanon lint instance.example/config/aletheia.toml --workflow --format tsv --summary --precision high --min-severity error`
- `cargo test -p taxis --lib --target-dir /tmp/codex-aletheia-tail5-matrix-doc-target`
- `git diff --check`