### PR TITLE
fix(proskenion): tag credentials TODO debt quadrant

### DIFF
--- a/crates/theatron/proskenion/src/views/ops/credentials.rs
+++ b/crates/theatron/proskenion/src/views/ops/credentials.rs
@@ -1,6 +1,6 @@
 //! Credential management panel: display, validate, rotate, add, and remove credentials.
 //!
-//! TODO(#107): move CredentialApiEntry and related request types to skene
+//! TODO(#107)[deliberate-prudent]: move CredentialApiEntry and related request types to skene
 //! when /api/system/credentials is implemented in pylon.
 
 use dioxus::prelude::*;


### PR DESCRIPTION
## Summary
- adds the required deliberate-prudent quadrant metadata to the proskenion credentials TODO tracked by #107
- removes the remaining high-severity TODO marker finding from the current proskenion lint scan

Refs #3988

## Verification
- `rustfmt --check crates/theatron/proskenion/src/views/ops/credentials.rs`
- `kanon lint --summary crates/theatron/proskenion/src/views/ops/credentials.rs`
- `timeout 180s env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion` reports `Total: 129 violation(s), 87 suppressed`, down from 130/87
- `scripts/check-proskenion-pins.py`
- `git diff --check`

Blocked locally:
- `cargo check --manifest-path crates/theatron/proskenion/Cargo.toml --target-dir /tmp/codex-aletheia-hygiene-tail11-proskenion-target` is blocked on this host by missing pkg-config system libraries: `cairo` and `glib-2.0`.
