### PR TITLE
feat(provider): accept codex oauth config type

### DIFF
--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -280,10 +280,10 @@ fn configured_openai_api_family(
 /// registry (#3424, #3414).
 ///
 /// Dispatches on `ProviderKind` to pick between Anthropic, OpenAI-compatible
-/// HTTP, and the CC subprocess adapter. Anthropic entries in the declarative
-/// list are skipped — the top-level credential chain already owns the
-/// Anthropic provider so we do not double-register. Empty list (the default)
-/// is a no-op, preserving legacy single-provider behavior.
+/// HTTP, and subprocess adapters. Anthropic and subprocess entries in the
+/// declarative list are skipped when their legacy registration path already
+/// owns the provider so we do not double-register. Empty list (the default) is
+/// a no-op, preserving legacy single-provider behavior.
 fn register_declared_providers(registry: &mut ProviderRegistry, config: &AletheiaConfig) {
     use taxis::config::ProviderKind;
 
@@ -373,6 +373,17 @@ fn register_declared_providers(registry: &mut ProviderRegistry, config: &Alethei
                 tracing::debug!(
                     provider = %entry.name,
                     "declarative ClaudeCode entry skipped — provider already registered via credential chain"
+                );
+            }
+            ProviderKind::CodexOauth => {
+                // WHY: codex-provider registration is feature-gated above and
+                // owns binary discovery / CLI OAuth inheritance when enabled.
+                // Accepting the typed config shape here makes the provider
+                // declarable without changing startup behavior or introducing
+                // duplicate routing.
+                tracing::debug!(
+                    provider = %entry.name,
+                    "declarative Codex OAuth entry accepted; registration remains controlled by codex-provider feature path"
                 );
             }
             // WHY: ProviderKind is #[non_exhaustive] so future additions

--- a/crates/taxis/src/config/behavior/provider.rs
+++ b/crates/taxis/src/config/behavior/provider.rs
@@ -119,8 +119,8 @@ pub enum DeploymentTarget {
 /// Which concrete provider implementation to instantiate at startup.
 ///
 /// Matches on this in `crates/aletheia/src/runtime/setup.rs` to pick between
-/// the Anthropic HTTP client, OpenAI-compatible HTTP client, or the CC
-/// subprocess adapter.
+/// the Anthropic HTTP client, OpenAI-compatible HTTP client, or a subprocess
+/// adapter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
@@ -138,6 +138,10 @@ pub enum ProviderKind {
     /// Claude Code subprocess adapter (delegates to the `claude` CLI).
     /// Requires the `cc-provider` feature flag on hermeneus.
     ClaudeCode,
+    /// Codex CLI subprocess adapter (delegates to the `codex` CLI).
+    /// Requires the `codex-provider` feature flag on hermeneus.
+    #[serde(rename = "codex_oauth", alias = "codex-oauth")]
+    CodexOauth,
 }
 
 /// `OpenAI` HTTP API family for `OpenAI` and OpenAI-compatible providers.
@@ -170,7 +174,7 @@ pub struct LlmProviderConfig {
     /// HTTP base URL override. Required for OpenAI-compatible providers
     /// (e.g., `http://127.0.0.1:8088/v1` for local llama.cpp). Optional for
     /// Anthropic (defaults to `https://api.anthropic.com`). Ignored for
-    /// the Claude Code subprocess adapter.
+    /// subprocess adapters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
     /// Environment variable name holding the API key. Read at startup via
@@ -180,7 +184,8 @@ pub struct LlmProviderConfig {
     pub api_key_env: Option<String>,
     /// `OpenAI` API family to use. If omitted, `providerType = "openai"`
     /// defaults to `responses`, while `openai-compatible` defaults to
-    /// `chat-completions` for local/proxy compatibility.
+    /// `chat-completions` for local/proxy compatibility. Ignored for
+    /// subprocess adapters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_family: Option<OpenAiApiFamily>,
     /// Where this provider's traffic terminates. Drives the

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -732,7 +732,7 @@ fn validate_providers(value: &Value, errors: &mut Vec<String>) {
         match entry.get("providerType").and_then(Value::as_str) {
             None | Some("") => {
                 errors.push(format!(
-                    "providers[{i}].providerType must be one of: anthropic, openai, open-ai-compatible, openai-compatible, claude-code"
+                    "providers[{i}].providerType must be one of: anthropic, openai, open-ai-compatible, openai-compatible, claude-code, codex_oauth, codex-oauth"
                 ));
             }
             Some(kind) => {
@@ -743,9 +743,11 @@ fn validate_providers(value: &Value, errors: &mut Vec<String>) {
                         | "open-ai-compatible"
                         | "openai-compatible"
                         | "claude-code"
+                        | "codex_oauth"
+                        | "codex-oauth"
                 ) {
                     errors.push(format!(
-                        "providers[{i}].providerType '{kind}' is not recognized (expected one of: anthropic, openai, open-ai-compatible, openai-compatible, claude-code)"
+                        "providers[{i}].providerType '{kind}' is not recognized (expected one of: anthropic, openai, open-ai-compatible, openai-compatible, claude-code, codex_oauth, codex-oauth)"
                     ));
                 }
                 // OpenAI-compatible requires baseUrl.

--- a/crates/taxis/src/validate_tests.rs
+++ b/crates/taxis/src/validate_tests.rs
@@ -171,6 +171,12 @@ fn accepts_provider_type_and_deployment_aliases() {
             "baseUrl": "http://127.0.0.1:5009/v1",
             "deploymentTarget": "localhosted",
             "models": ["qwen3-vl"]
+        },
+        {
+            "name": "codex-seat",
+            "providerType": "codex_oauth",
+            "deploymentTarget": "cloud",
+            "models": ["codex/gpt-5-codex"]
         }
     ]);
 
@@ -196,6 +202,12 @@ fn provider_aliases_deserialize_to_typed_config() {
                 "baseUrl": "http://127.0.0.1:5001/v1",
                 "deploymentTarget": "local_hosted",
                 "models": ["anubis-70b"]
+            },
+            {
+                "name": "codex-seat",
+                "providerType": "codex-oauth",
+                "deploymentTarget": "cloud",
+                "models": ["codex/gpt-5-codex"]
             }
         ]
     }"#;
@@ -206,7 +218,7 @@ fn provider_aliases_deserialize_to_typed_config() {
         "provider aliases should parse: {config_result:?}"
     );
     let config = config_result.unwrap_or_default();
-    assert_eq!(config.providers.len(), 2);
+    assert_eq!(config.providers.len(), 3);
     assert_eq!(
         config.providers[0].kind,
         crate::config::ProviderKind::OpenAi
@@ -218,6 +230,14 @@ fn provider_aliases_deserialize_to_typed_config() {
     assert_eq!(
         config.providers[1].deployment_target,
         crate::config::DeploymentTarget::LocalHosted
+    );
+    assert_eq!(
+        config.providers[2].kind,
+        crate::config::ProviderKind::CodexOauth
+    );
+    assert_eq!(
+        config.providers[2].deployment_target,
+        crate::config::DeploymentTarget::Cloud
     );
 }
 


### PR DESCRIPTION
## Summary
- add `ProviderKind::CodexOauth` with `codex_oauth` / `codex-oauth` serde support
- teach strict provider validation to accept the codex OAuth provider type
- add a runtime registration arm that accepts declarative Codex OAuth entries without changing the existing feature-gated subprocess registration path

## Gates
- Gate-Passed: cargo fmt --check --package taxis --package aletheia
- Gate-Passed: cargo test -p taxis --target-dir /tmp/codex-aletheia-provider-tail12-mm-target
- Gate-Passed: cargo check -p aletheia --target-dir /tmp/codex-aletheia-provider-tail12-mm-target
- Gate-Passed: cargo clippy -p taxis --all-targets --target-dir /tmp/codex-aletheia-provider-tail12-mm-target -- -D warnings
- Gate-Passed: git diff --check

Refs #3980