### PR TITLE
fix(matrix): remove stale config dto surface

### DIFF
--- a/crates/pylon/src/handlers/config_dto.rs
+++ b/crates/pylon/src/handlers/config_dto.rs
@@ -62,8 +62,6 @@ pub struct GatewayConfig {
 pub struct ChannelsConfig {
     #[schema(value_type = Object)]
     pub signal: Option<Value>,
-    #[schema(value_type = Object)]
-    pub matrix: Option<Value>,
 }
 
 /// Schema for a single channel binding entry.


### PR DESCRIPTION
## Summary
- remove the stale `channels.matrix` field from the pylon config DTO/OpenAPI schema
- keep historical versioned example config untouched; active runtime/config remains Signal-only until Matrix Phase 3

## Gates
- Gate-Passed: cargo fmt --check --package pylon
- Gate-Passed: cargo test -p pylon --target-dir /tmp/codex-aletheia-provider-tail12-mm-target
- Gate-Passed: git diff --check

## Notes
- `cargo clippy -p pylon --all-targets --target-dir /tmp/codex-aletheia-provider-tail12-mm-target -- -D warnings` is blocked by unrelated existing episteme warnings in `crates/episteme/src/rl/reward.rs` and `crates/episteme/src/rl/state.rs`.

Refs #3981