### PR TITLE
fix(proskenion): clean standards lint tail

### DIFF
--- a/crates/theatron/proskenion/src/state/planning.rs
+++ b/crates/theatron/proskenion/src/state/planning.rs
@@ -359,7 +359,10 @@ impl RoadmapStore {
 #[must_use]
 pub(crate) fn days_between(start: &str, end: &str) -> u32 {
     match (date_to_days(start), date_to_days(end)) {
-        #[expect(clippy::as_conversions, reason = "day difference verified positive and small")]
+        #[expect(
+            clippy::as_conversions,
+            reason = "day difference verified positive and small"
+        )]
         (Some(s), Some(e)) if e > s => (e - s) as u32,
         (Some(_), Some(_)) => 1,
         _ => 30,
@@ -398,7 +401,7 @@ pub(crate) fn status_label(status: ProjectStatus) -> &'static str {
     }
 }
 
-/// Phase status color.
+/// CSS background color for phase status badges.
 #[must_use]
 pub(crate) fn phase_status_color(status: PhaseStatus) -> &'static str {
     match status {

--- a/crates/theatron/proskenion/src/state/platform.rs
+++ b/crates/theatron/proskenion/src/state/platform.rs
@@ -55,8 +55,6 @@ pub struct TrayState {
     pub window_visible: bool,
 }
 
-
-
 /// Registration status for a global hotkey.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -84,16 +82,12 @@ pub enum HotkeyAction {
     AbortStreaming,
 }
 
-
-
 /// Reactive state for global hotkey registration.
 #[derive(Debug, Clone, Default)]
 pub struct HotkeyState {
     /// Registration status for each hotkey action.
     pub registrations: Vec<(HotkeyAction, HotkeyRegistration)>,
 }
-
-
 
 /// Persisted window geometry and UI state.
 ///
@@ -166,8 +160,6 @@ impl Default for WindowState {
         }
     }
 }
-
-
 
 /// Reactive state for the quick input overlay.
 #[derive(Debug, Clone, Default)]

--- a/crates/theatron/proskenion/src/state/tools.rs
+++ b/crates/theatron/proskenion/src/state/tools.rs
@@ -20,8 +20,6 @@ pub enum ToolStatus {
     Error,
 }
 
-
-
 impl ToolStatus {
     /// Whether this status represents a terminal (completed) state.
     #[cfg_attr(not(test), expect(dead_code, reason = "used in tests"))]
@@ -185,7 +183,6 @@ impl PlanCardState {
     pub(crate) fn is_finished(&self) -> bool {
         matches!(self.status, PlanStatus::Complete { .. })
     }
-
 }
 
 #[cfg(test)]

--- a/crates/theatron/proskenion/src/views/metrics/tool_duration.rs
+++ b/crates/theatron/proskenion/src/views/metrics/tool_duration.rs
@@ -5,9 +5,7 @@ use dioxus::prelude::*;
 use crate::components::chart::{
     LineChart, LinePoint, LineSeries, PercentileBarChart, PercentileEntry, SERIES_COLORS,
 };
-use crate::state::tool_metrics::{
-    TimeSeriesBucket, ToolStat, tools_by_duration,
-};
+use crate::state::tool_metrics::{tools_by_duration, TimeSeriesBucket, ToolStat};
 
 // -- Component ----------------------------------------------------------------
 
@@ -84,10 +82,13 @@ pub(crate) fn DurationTrendView(
                         label: bucket.date.clone(),
                         value: if bucket_count > 0 {
                             {
-                            #[expect(clippy::as_conversions, reason = "u64 ms to f64 for chart point")]
-                            let v = tool.p50_ms as f64;
-                            v
-                        }
+                                #[expect(
+                                    clippy::as_conversions,
+                                    reason = "u64 ms to f64 for chart point"
+                                )]
+                                let v = tool.p50_ms as f64;
+                                v
+                            }
                         } else {
                             0.0
                         },
@@ -106,5 +107,3 @@ pub(crate) fn DurationTrendView(
         LineChart { series, height: 150 }
     }
 }
-
-


### PR DESCRIPTION
## Summary
- remove Proskenion standards-only blank-line lint findings
- clarify the phase status color doc comment flagged as tautological
- keep the slice behavior-neutral and outside the credential TODO work from #4071

Refs #3988

## Verification
- rustfmt --edition 2021 --check crates/theatron/proskenion/src/state/platform.rs crates/theatron/proskenion/src/state/tools.rs crates/theatron/proskenion/src/views/metrics/tool_duration.rs crates/theatron/proskenion/src/state/planning.rs
- timeout 180s env RUST_LOG=error NO_COLOR=1 kanon lint --format json crates/theatron/proskenion | jq -r '.[] | select(.rule|startswith("STANDARDS/"))'
- timeout 180s env RUST_LOG=error NO_COLOR=1 kanon lint --format json --summary crates/theatron/proskenion
- git diff --check