### PR TITLE
fix(proskenion): clean planning fetch lint

### DIFF
--- a/crates/theatron/proskenion/src/views/planning/dashboard.rs
+++ b/crates/theatron/proskenion/src/views/planning/dashboard.rs
@@ -242,8 +242,9 @@ fn render_project_card(project: &Project) -> Element {
     let phase_text = project
         .current_phase
         .as_ref()
-        .map(|p| format!("{} (Phase {} of {})", p.name, p.number, p.total))
-        .unwrap_or_default();
+        .map_or_else(String::new, |p| {
+            format!("{} (Phase {} of {})", p.name, p.number, p.total)
+        });
 
     let activity_text = project.last_activity.as_deref().unwrap_or("—");
 
@@ -253,8 +254,9 @@ fn render_project_card(project: &Project) -> Element {
         project.active_agents.join(", ")
     };
 
-    let progress_fill =
-        format!("width: {pct}%; height: 100%; background: var(--status-success); border-radius: var(--radius-sm);");
+    let progress_fill = format!(
+        "width: {pct}%; height: 100%; background: var(--status-success); border-radius: var(--radius-sm);"
+    );
 
     rsx! {
         div { style: "{CARD_TITLE}", "{project.name}" }

--- a/crates/theatron/proskenion/src/views/planning/requirements.rs
+++ b/crates/theatron/proskenion/src/views/planning/requirements.rs
@@ -227,10 +227,18 @@ pub(crate) fn RequirementsView(project_id: String) -> Element {
 
             // WHY: Proposals endpoint may not exist yet; treat 404 as empty.
             let proposals = match props_result {
-                Ok(resp) if resp.status().is_success() => resp
-                    .json::<Vec<CategoryProposal>>()
-                    .await
-                    .unwrap_or_default(),
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<Vec<CategoryProposal>>().await {
+                        Ok(proposals) => proposals,
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err,
+                                "failed to parse planning category proposals"
+                            );
+                            Vec::new()
+                        }
+                    }
+                }
                 _ => Vec::new(),
             };
 

--- a/crates/theatron/proskenion/src/views/planning/verification.rs
+++ b/crates/theatron/proskenion/src/views/planning/verification.rs
@@ -214,7 +214,9 @@ pub(crate) fn VerificationView(project_id: String) -> Element {
                         store.write().push_full(
                             ToastSeverity::Error,
                             "Re-verify failed".to_owned(),
-                            Some(format!("Could not reach the verification refresh endpoint: {e}")),
+                            Some(format!(
+                                "Could not reach the verification refresh endpoint: {e}"
+                            )),
                             None,
                         );
                     }
@@ -283,8 +285,7 @@ pub(crate) fn VerificationView(project_id: String) -> Element {
                     let reqs: Vec<RequirementVerification> = store
                         .result
                         .as_ref()
-                        .map(|r| r.requirements.clone())
-                        .unwrap_or_default();
+                        .map_or_else(Vec::new, |r| r.requirements.clone());
 
                     rsx! {
                         div {


### PR DESCRIPTION
## Summary
- replace planning dashboard and verification display defaults with explicit empty fallbacks
- log malformed optional planning category proposals before preserving the empty fallback
- reduce the #3988 Proskenion lint tail from 88 to 85 open findings

Refs #3988

## Verification
- `rustfmt --edition 2024 --check crates/theatron/proskenion/src/views/planning/dashboard.rs crates/theatron/proskenion/src/views/planning/requirements.rs crates/theatron/proskenion/src/views/planning/verification.rs`
- `timeout 120s env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion/src/views/planning/dashboard.rs` -> `No violations found.`
- `timeout 120s env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion/src/views/planning/requirements.rs` -> `No violations found.`
- `timeout 120s env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion/src/views/planning/verification.rs` -> `No violations found.`
- `timeout 300s env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion` -> `Total: 85 violation(s), 87 suppressed`
- `git diff --check`

Blocked local compile gate:
- `timeout 180s cargo check --manifest-path crates/theatron/proskenion/Cargo.toml --target-dir /tmp/codex-aletheia-proskenion-tail19-mm-target` is blocked on this host by missing pkg-config system libraries: `glib-2.0`, `gdk-3.0`, `gio-2.0`, `gobject-2.0`, `gdk-pixbuf-2.0`, `cairo`, `pango`, `atk`, `libsoup-3.0`, and `javascriptcoregtk-4.1`.
