### PR TITLE
fix(proskenion): clean config prefs lint

### DIFF
--- a/crates/theatron/proskenion/src/services/config.rs
+++ b/crates/theatron/proskenion/src/services/config.rs
@@ -217,9 +217,13 @@ pub(crate) fn load_notification_prefs() -> NotificationPreferences {
         Ok(c) => c,
         Err(_) => return NotificationPreferences::default(),
     };
-    toml::from_str::<DesktopConfig>(&content)
-        .map(|c| c.notifications)
-        .unwrap_or_default()
+    match toml::from_str::<DesktopConfig>(&content) {
+        Ok(config) => config.notifications,
+        Err(err) => {
+            tracing::warn!("failed to parse notification preferences, using defaults: {err}");
+            NotificationPreferences::default()
+        }
+    }
 }
 
 /// Save notification preferences to the config file.
@@ -444,7 +448,10 @@ server_url = "http://custom:9000"
         assert_eq!(loaded.connection.server_url, "http://test-host:9000");
         assert_eq!(loaded.connection.connect_timeout_secs, 60);
         assert!(!loaded.connection.auto_reconnect);
-        assert_eq!(loaded.connection.auth_token.as_deref(), Some("session-token"));
+        assert_eq!(
+            loaded.connection.auth_token.as_deref(),
+            Some("session-token")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- log malformed notification preference config before preserving the default fallback
- remove the final `RUST/no-result-unwrap-or-default` finding from the current Proskenion scan
- reduce the #3988 Proskenion lint tail from 81 to 80 open findings

Refs #3988

## Verification
- `rustfmt --edition 2024 --check crates/theatron/proskenion/src/services/config.rs`
- `timeout 120s env RUST_LOG=error NO_COLOR=1 kanon lint --format json crates/theatron/proskenion/src/services/config.rs | jq -r '.[] | select(.rule=="RUST/no-result-unwrap-or-default")'` -> no output
- `timeout 120s env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion/src/services/config.rs` -> `Total: 2 violation(s)` for existing `RUST/config-deny-unknown-fields` and `TESTING/tautological-test`
- `timeout 300s env RUST_LOG=error NO_COLOR=1 kanon lint --summary crates/theatron/proskenion` -> `Total: 80 violation(s), 87 suppressed`
- `git diff --check`

Notes:
- `DesktopConfig` schema strictness and the remaining config test lint are intentionally left for a compatibility-aware config slice.
