### PR TITLE
docs(decisions): backfill aletheia ADRs 001-003 (D-020 canary)

### DIFF
--- a/projects/aletheia/decisions/ADR-001-energeia-orchestrator-shape.md
+++ b/projects/aletheia/decisions/ADR-001-energeia-orchestrator-shape.md
@@ -1,0 +1,91 @@
+<!-- Operator-review-pending: agent-drafted under DIRECTIVE v20; T0 metis review required before status moves Proposed → Accepted -->
+# ADR-001: energeia orchestrator shape
+
+## Status
+
+Proposed
+
+## Context
+
+Energeia is the aletheia dispatch crate: it plans work, executes prompt groups, monitors session outcomes, accounts for budget, and reports quality results. The most important boundary is not a vendor API client; it is the `DispatchEngine` trait that lets orchestration logic treat every provider-backed run as a spawned session with events, completion, and abort semantics.
+
+The current codebase has two execution shapes behind that boundary. One shape wraps a generic `hermeneus::provider::LlmProvider`, allowing the provider layer to adapt concrete transports such as Claude Code, Codex, or Kimi. The other shape, despite names like `HttpEngine` and `AgentSdkEngine`, is explicit that the production transport is currently a local Claude CLI subprocess rather than a direct native HTTP/SSE or Agent SDK client. That naming history matters because it captures the architectural pressure: callers should not care whether a provider is reached through a local OAuth'd CLI, a provider SDK, or a direct HTTP token, but the operationally stable path today is the local CLI.
+
+The CLI pattern is visible in energeia itself:
+
+```text
+crates/energeia/src/engine.rs:27
+pub trait DispatchEngine: Send + Sync {
+```
+
+```text
+crates/energeia/src/http/client.rs:3
+//! Named `HttpEngine` because the trait targets the Anthropic Agent SDK HTTP/SSE
+//! API. The current implementation uses the Claude CLI subprocess as a transport
+//! (matching phronesis's approach) because the Agent SDK HTTP endpoints are not
+//! yet publicly documented. The [`DispatchEngine`] trait boundary insulates
+//! callers from this implementation detail.
+```
+
+```text
+crates/energeia/src/agent_sdk.rs:71
+/// Experimental Claude CLI dispatch engine.
+///
+/// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+/// permissions, and MCP configuration fields while the native SDK path remains
+/// unwired.
+```
+
+The wider provider layer uses the same local process model for concrete providers. Claude Code, Codex, and Kimi are invoked through provider-specific binaries, with stdout/stderr captured and authentication state delegated to the installed CLI:
+
+```text
+crates/hermeneus/src/cc/process.rs:134
+let mut cmd = Command::new(cc_binary);
+```
+
+```text
+crates/hermeneus/src/codex/process.rs:78
+let mut cmd = Command::new(codex_binary);
+```
+
+```text
+crates/hermeneus/src/kimi/process.rs:75
+fn build_kimi_command(kimi_binary: &Path, cwd: &Path, model: &str) -> Command {
+```
+
+This leaves a decision to record. Energeia could become the place where provider API tokens, token refresh, SDK quirks, HTTP retry policy, and provider streaming protocols are all implemented directly. Or it can remain an orchestrator that starts local provider sessions, lets each provider CLI use its own OAuth store and policy model, and receives normalized session events/results through internal traits.
+
+## Decision
+
+**Energeia keeps the dispatch model centered on spawned local provider sessions, with provider-specific CLI or provider adapters behind `DispatchEngine`, rather than making energeia the owner of direct provider API-token clients.**
+
+The preferred production path is the OAuth'd local-CLI pattern when a provider CLI exists and already owns login, token refresh, permission prompts, and workspace-level behavior. Energeia may wrap that path directly, as with the Claude subprocess engines, or indirectly through `HermeneusEngine` and a `LlmProvider`. In both cases, orchestration code sees the same session-oriented interface: `spawn_session`, `resume_session`, event streaming, wait, abort, budget accounting, and cancellation.
+
+This decision does not forbid future direct SDK or HTTP integrations. It says the integration must stay behind the execution boundary and must not pull provider credentials, provider-specific retry state, or vendor protocol details into the orchestrator core. Direct HTTP/SSE is acceptable when it is mature enough to be just another `DispatchEngine` or `LlmProvider` implementation.
+
+The operational rule is: energeia owns dispatch lifecycle; provider adapters own provider transport. The CLI subprocess is a transport choice, not an orchestration concept. That is why the code can support `AgentSdkEngine`, `HttpEngine`, and `HermeneusEngine` without changing DAG execution, session management, QA, or budget behavior.
+
+## Consequences
+
+**Positive:**
+
+- **Credential handling stays out of the orchestrator.** OAuth tokens and local auth state remain in provider tooling where login, refresh, revocation, and account selection already exist. Energeia only injects a configured token when the bridge explicitly supports it, and avoids making API secrets a central dispatch concern.
+- **Provider diversity is cheaper.** Claude Code, Codex, Kimi, and future CLIs can be adapted at the process/provider edge while preserving the shared dispatch lifecycle. The orchestration code remains focused on concurrency, cancellation, budgets, health, and outcomes.
+- **The boundary supports replacement.** If a native SDK becomes the better transport, the replacement can land behind `DispatchEngine` or `LlmProvider` without changing the DAG, session manager, or backend control plane.
+- **Local behavior matches operator workflows.** Provider CLIs already encode local workspace access, account state, permission modes, and provider-specific flags. Reusing them reduces duplicated policy code inside aletheia.
+
+**Negative:**
+
+- **Subprocesses add failure modes.** CLI binaries can be missing, busy, slow to start, or change output format. The code already carries process lifecycle handling, stdout/stderr capture, timeouts, and retries, and those concerns remain part of provider operations.
+- **CLI semantics are provider-specific.** Flags such as permission bypasses, stream formats, model names, and working-directory handling differ by provider. Normalization happens in adapters, so each adapter needs focused tests when a provider CLI changes.
+- **Streaming fidelity is bounded by CLI output.** Direct SDKs may expose richer structured streaming or usage metadata than a CLI can report. The local-CLI pattern trades some protocol precision for operational stability and credential simplicity.
+- **The naming can confuse new readers.** `HttpEngine` and `AgentSdkEngine` describe intended or historical boundaries while currently spawning CLIs. Documentation and ADR references must keep that distinction visible until native transports exist.
+
+## References
+
+- [forkwright/aletheia#4039](https://github.com/forkwright/aletheia/issues/4039) - ADR canary issue requesting ADR-001.
+- `crates/energeia/src/engine.rs:27` - `DispatchEngine` session execution boundary.
+- `crates/energeia/src/http/client.rs:3` - local Claude CLI transport rationale behind `HttpEngine`.
+- `crates/energeia/src/agent_sdk.rs:71` - OAuth-enabled Claude CLI bridge rationale.
+- `crates/hermeneus/src/cc/process.rs:134`, `crates/hermeneus/src/codex/process.rs:78`, `crates/hermeneus/src/kimi/process.rs:75` - concrete provider subprocess adapters.
+- Michael Nygard, "Documenting Architecture Decisions" - lightweight decision record practice used by this ADR.

--- a/projects/aletheia/decisions/ADR-002-graphe-vs-mneme-session-memory-split.md
+++ b/projects/aletheia/decisions/ADR-002-graphe-vs-mneme-session-memory-split.md
@@ -1,0 +1,119 @@
+<!-- Operator-review-pending: agent-drafted under DIRECTIVE v20; T0 metis review required before status moves Proposed → Accepted -->
+# ADR-002: graphe vs mneme session memory split
+
+## Status
+
+Proposed
+
+## Context
+
+Aletheia separates session persistence from the wider memory facade. `graphe` is the low-level session record crate. It owns sessions, messages, usage records, notes, blackboard rows, fjall storage, and the portability schema for exported session history. `mneme` is a curated facade that re-exports selected session, knowledge, embedding, recall, ingestion, and Datalog-engine surfaces from decomposed sub-crates.
+
+The split is explicit in crate-level documentation:
+
+```text
+crates/graphe/src/lib.rs:2
+//! aletheia-graphe: session persistence layer
+//!
+//! Graphe (Γραφή): "writing, record." Manages sessions, messages, and usage
+//! tracking via a fjall LSM-tree store (pure Rust, zero C dependencies).
+```
+
+```text
+crates/mneme/src/lib.rs:4
+//! Mneme (Μνήμη): "memory." Curated facade that re-exports from the extracted
+//! sub-crates: graphe (session persistence), episteme (knowledge pipeline),
+//! eidos (types), and krites (Datalog engine).
+```
+
+`graphe` also documents the concrete session store data model. Its key schema is session-native: session ids, logical session keys, message sequences, usage records, distillations, notes, blackboard entries, and counters. It is not a general semantic memory graph:
+
+```text
+crates/graphe/src/store/fjall_store.rs:9
+//! | Partition       | Key pattern                                            | Value                    |
+//! |-----------------|--------------------------------------------------------|--------------------------|
+//! | `sessions`      | `{session_id}`                                         | JSON `Session`           |
+//! | `messages`      | `{session_id}:{seq_padded_20}`                         | JSON `Message`           |
+//! | `usage`         | `{session_id}:{turn_seq_padded_20}`                    | JSON `UsageRecord`       |
+```
+
+The domain types are likewise session history types:
+
+```text
+crates/graphe/src/types.rs:145
+/// A session record persisted in the store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+```
+
+```text
+crates/graphe/src/types.rs:196
+/// A single message within a session's conversation history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+```
+
+`mneme` crosses that boundary by re-exporting selected graphe types through a stable import path:
+
+```text
+crates/mneme/src/lib.rs:109
+/// Session store — fjall LSM-tree backend.
+///
+/// # Facade surface
+///
+/// [`SessionStore`](store::SessionStore)
+pub mod store {
+    pub use graphe::store::SessionStore;
+}
+```
+
+```text
+crates/mneme/src/lib.rs:132
+pub mod types {
+    pub use graphe::types::{
+        AgentNote, BlackboardRow, Message, Role, Session, SessionMetrics, SessionOrigin,
+        SessionStatus, SessionType, UsageRecord,
+```
+
+The facade also states why it exists: downstream crates import `mneme::` instead of knowing every decomposed storage and memory crate. That is a stability contract, not permission to put all memory behavior in one crate:
+
+```text
+crates/mneme/src/lib.rs:17
+//! 1. **API stability**: downstream application crates import from `mneme`
+//!    instead of from `eidos`/`graphe`/`episteme`/`krites` directly.
+```
+
+## Decision
+
+**Keep `graphe` as the session graph and persistence crate, and keep `mneme` as the curated memory facade that re-exports `graphe` session surfaces plus knowledge-memory surfaces from the other memory sub-crates.**
+
+What crosses from `graphe` to `mneme` is the stable public session API needed by application crates: `SessionStore`, session/message/usage/note/blackboard types, graphe error types, session metrics registration, and portability DTOs. These exports let pylon, nous, daemon, and other consumers import `mneme::store::SessionStore` and `mneme::types::Session` without binding themselves to the internal crate layout.
+
+What does not cross is graphe's storage implementation detail. Fjall partitions, key formats, counters, write locks, backend modules, and distillation-row internals remain in `graphe`. Likewise, semantic knowledge behavior, embeddings, recall ranking, ingestion, trace ingest, verification, and the optional Datalog/graph engine remain in the episteme/krites side of the memory system and are surfaced through `mneme` only as explicitly curated modules.
+
+The boundary is therefore asymmetric. `graphe` can compile as a focused session persistence crate. `mneme` depends on `graphe` and re-exports selected session types, but should not accumulate its own persistence logic. The existing alarm threshold in `mneme` is part of the decision: if the facade starts gaining logic instead of re-exporting stable surfaces, the logic belongs in a sub-crate.
+
+## Consequences
+
+**Positive:**
+
+- **Session storage remains focused.** Graphe can optimize fjall schemas, sequence scans, session lifecycle states, and portability without carrying knowledge-ingestion or recall concerns.
+- **Downstream imports stay stable.** Consumers can use `mneme::` for session and memory concepts while the internal decomposition changes. That reduces churn when storage or knowledge internals move.
+- **Feature gates stay centralized.** Optional engine behavior such as Datalog/graph support can be gated once in mneme rather than duplicated across every application crate.
+- **The distinction clarifies data ownership.** Session history is not the same as semantic memory. Messages, usage records, and session lifecycle belong to graphe; facts, entities, relationships, embeddings, and recall belong to the memory pipeline exposed through mneme.
+
+**Negative:**
+
+- **There are two names to learn.** New contributors must understand that graphe is the implementation crate for session records while mneme is the import facade and broader memory surface.
+- **Facade drift is a risk.** A convenience facade can become a dumping ground. The documented line-count alarm and "re-export only" discipline must be preserved.
+- **Some internal users may reach around the facade.** Low-level crates can import graphe directly when they truly own session persistence details, but application crates should generally use mneme. That distinction requires review attention.
+- **Portability spans both concepts.** Graphe's `AgentFile` includes sessions and optional memory/knowledge data, so export/import code must avoid treating portability DTOs as permission to merge storage responsibilities.
+
+## References
+
+- [forkwright/aletheia#4039](https://github.com/forkwright/aletheia/issues/4039) - ADR canary issue requesting ADR-002.
+- `crates/graphe/src/lib.rs:2` - graphe crate purpose as session persistence.
+- `crates/graphe/src/store/fjall_store.rs:9` - fjall key schema for session/message/usage records.
+- `crates/mneme/src/lib.rs:4` and `crates/mneme/src/lib.rs:17` - mneme facade scope and API stability rationale.
+- `crates/mneme/src/lib.rs:109` and `crates/mneme/src/lib.rs:132` - curated re-exports of graphe session store and session types.
+- Michael Nygard, "Documenting Architecture Decisions" - lightweight decision record practice used by this ADR.

--- a/projects/aletheia/decisions/ADR-003-pylon-middleware-ordering.md
+++ b/projects/aletheia/decisions/ADR-003-pylon-middleware-ordering.md
@@ -1,0 +1,148 @@
+<!-- Operator-review-pending: agent-drafted under DIRECTIVE v20; T0 metis review required before status moves Proposed → Accepted -->
+# ADR-003: pylon middleware ordering
+
+## Status
+
+Proposed
+
+## Context
+
+Pylon is aletheia's Axum HTTP gateway. It combines versioned routes, session and knowledge handlers, SSE streams, OpenAPI, metrics, auth extraction, rate limiting, request ids, tracing, compression, error shaping, CORS, and security headers. Middleware order is architectural because it decides which requests consume quota, which failures receive request ids, what spans observe, and which responses carry security and rate-limit headers.
+
+The canary issue summarizes the policy as auth, rate-limit, trace, handler. The implementation is more precise: pylon's global Axum stack is documented outermost-first as security headers, CORS, request id, trace, compression, metrics, error enrichment, body limit, CSRF, per-IP rate limit, per-user rate limit, then JWT claims and handler execution. Knowledge routes also have a route-layer bearer-auth wrapper. The ADR therefore records the effective code contract and its gotchas rather than implying a single `tower::ServiceBuilder` sequence.
+
+The router file states that route and middleware assembly stays together because order is part of correctness:
+
+```text
+crates/pylon/src/router.rs:42
+// NOTE(#940): 130+ lines: route and middleware layer assembly where ordering matters.
+// Extraction would obscure the middleware stack ordering that is critical for correctness.
+```
+
+The handler reference describes the current global stack:
+
+```text
+crates/pylon/docs/handlers.md:12
+Every request traverses the following stack, outermost first. Later sections note any
+per-handler exceptions.
+```
+
+Extra routes are merged before global layers so the same protections apply to external routers:
+
+```text
+crates/pylon/src/router.rs:170
+// WHY: Extra routes are merged BEFORE middleware layers so they benefit from
+// the same global protections (rate limiting, CSRF, compression, tracing,
+// metrics, error enrichment) as pylon's own routes (#3226).
+```
+
+The route tree applies subtree auth for knowledge routes and handler-level auth for protected session and API handlers. The reusable auth middleware validates bearer tokens and stores claims so handlers do not re-validate:
+
+```text
+crates/pylon/src/router.rs:91
+.route_layer(axum::middleware::from_fn_with_state(
+    Arc::clone(&state),
+    require_bearer_auth,
+));
+```
+
+```text
+crates/pylon/src/middleware/mod.rs:27
+/// Middleware that validates bearer auth for an entire router subtree.
+///
+/// The validated claims are cached in request extensions so handlers that also
+/// extract [`Claims`] do not re-validate the same token.
+```
+
+Handlers that require authorization also extract claims directly:
+
+```text
+crates/pylon/src/handlers/sessions/mod.rs:50
+pub async fn create(
+    State(state): State<SessionsState>,
+    claims: Claims,
+    Json(body): Json<CreateSessionRequest>,
+```
+
+Rate limiting is applied globally after route construction and before the later response-shaping/observability layers in the builder. The per-user limiter is installed before the per-IP limiter in code, and Axum/Tower layering means later layers wrap earlier layers on the request path. The important policy is that rate limiting happens before expensive handlers and before handler-level business side effects:
+
+```text
+crates/pylon/src/router.rs:177
+if security.rate_limit.per_user.enabled {
+    let user_limiter = Arc::new(UserRateLimiter::new(security.rate_limit.per_user.clone()));
+    spawn_stale_cleanup(Arc::clone(&user_limiter), shutdown.clone());
+    router = router
+        .layer(axum::middleware::from_fn(per_user_rate_limit))
+```
+
+```text
+crates/pylon/src/router.rs:185
+if security.rate_limit.enabled {
+    let limiter = Arc::new(
+        RateLimiter::new(security.rate_limit.requests_per_minute)
+            .with_trust_proxy(security.rate_limit.trust_proxy),
+    );
+    router = router
+        .layer(axum::middleware::from_fn(rate_limit))
+```
+
+The rate-limit middleware itself short-circuits with `429` before running the next service:
+
+```text
+crates/pylon/src/middleware/rate_limiter.rs:170
+let client = extract_client_key(&request, limiter.trust_proxy);
+if let Some(retry_after_secs) = limiter.check(&client) {
+```
+
+Tracing and request-id propagation are deliberately adjacent. Request IDs must be injected before the trace layer observes the request so the span includes the correlation id:
+
+```text
+crates/pylon/src/router.rs:228
+router = router.layer(
+    TraceLayer::new_for_http()
+        .make_span_with(|request: &axum::http::Request<_>| {
+```
+
+```text
+crates/pylon/src/router.rs:256
+// WARNING: Must be before trace layer so the span includes the ID.
+router = router.layer(axum::middleware::from_fn(inject_request_id));
+```
+
+## Decision
+
+**Pylon preserves the documented Axum middleware order: outer security/CORS/request-id/trace/response layers, then body/CSRF/rate-limit guards, then bearer claims and handler execution, with route-layer auth allowed for protected subtrees such as knowledge routes.**
+
+In practical Axum terms, this is not a single `ServiceBuilder` list; it is a route tree plus route-layer auth, handler claim extractors, conditional rate-limit layers, request-id injection, trace spans, and outer response decorators. The decision is about the policy order that must be preserved when editing `build_router_with`:
+
+1. Request ids and trace spans wrap the guarded work so both successful handlers and middleware-generated failures are observable.
+2. Body limits, CSRF, and rate limiting must short-circuit before expensive handlers and side effects. Per-user and per-IP checks remain in middleware, and successful responses should receive quota headers.
+3. Bearer authentication must happen before protected handler work. Most protected routes use the `Claims` extractor in the handler signature; selected subtrees can use `require_bearer_auth` as a route layer.
+4. Handlers should run only after the applicable quota, request identity, trace context, and auth decisions are in place.
+
+Outer layers have their own invariants. Security headers must wrap every response. CORS must apply broadly. Error enrichment must see uncompressed bodies and should add request ids to error envelopes. Compression and ETag behavior must not hide error bodies from the enrichment layer. These concerns are intentionally documented in the router comments because a visually harmless reorder can change client-visible behavior.
+
+## Consequences
+
+**Positive:**
+
+- **Protected work is guarded.** Unauthorized protected routes fail through the auth extractor or auth route layer before handler logic performs session, knowledge, or config mutations.
+- **Quota enforcement is central.** Global and per-user rate limiting do not have to be repeated in handlers, and `429` responses can be emitted consistently with retry and rate-limit headers.
+- **Traceability is consistent.** Request ids are available to spans and error envelopes, including failures emitted by CSRF and rate-limit middleware, making logs, client errors, and metrics easier to correlate.
+- **External routes inherit the same policy.** Routers merged through `extra` are wrapped by the same global protections instead of becoming an unprotected side entrance.
+
+**Negative:**
+
+- **Axum layer order is non-obvious.** The order in code is not the same as the intuitive request path, because later layers wrap earlier services. Future edits need tests or careful review.
+- **Auth has two mechanisms and usually sits inside rate limiting.** Route-layer auth and handler-level `Claims` extraction both exist. That is intentional, but reviewers must verify each protected route uses one of them and applies role/scope checks where needed.
+- **Rate limiting before verified claims limits identity precision.** The per-user limiter hashes the bearer token rather than relying on fully verified `Claims`, because claims are normally extracted deeper in handlers. This avoids trusting unsigned payloads, but it means quota keys are token-derived rather than subject-derived at that layer.
+- **Response decorators depend on placement.** Moving compression, error enrichment, request ids, or security headers can silently drop request ids from errors, compress bodies before they are normalized, or omit headers from short-circuit responses.
+
+## References
+
+- [forkwright/aletheia#4039](https://github.com/forkwright/aletheia/issues/4039) - ADR canary issue requesting ADR-003.
+- `crates/pylon/src/router.rs:42` and `crates/pylon/docs/handlers.md:12` - router construction and documented outermost-first stack.
+- `crates/pylon/src/router.rs:170`, `crates/pylon/src/router.rs:177`, `crates/pylon/src/router.rs:185`, `crates/pylon/src/router.rs:228`, `crates/pylon/src/router.rs:256` - route merge, rate-limit, trace, and request-id layer anchors.
+- `crates/pylon/src/middleware/mod.rs:27` and `crates/pylon/src/extract.rs:29` - bearer auth route layer and handler claim extraction.
+- `crates/pylon/src/middleware/rate_limiter.rs:170` and `crates/pylon/src/middleware/user_rate_limiter.rs:406` - rate-limit short-circuit policy and per-IP ceiling.
+- Michael Nygard, "Documenting Architecture Decisions" - lightweight decision record practice used by this ADR.


### PR DESCRIPTION
- Add ADR-001 for energeia local-CLI dispatch and orchestrator boundaries.
- Add ADR-002 for the graphe session persistence and mneme memory facade split.
- Add ADR-003 for pylon middleware ordering and gotchas.

Each ADR is marked Operator-review-pending and remains Proposed until operator review.

Closes forkwright/aletheia#4039

Gate-Passed: docs-only