### PR TITLE
fix(episteme): partition instinct aggregation by project

### DIFF
--- a/crates/episteme/src/instinct.rs
+++ b/crates/episteme/src/instinct.rs
@@ -140,6 +140,9 @@ pub(crate) struct BehavioralPattern {
     pub tool_name: String,
     /// Simplified context category (code, research, system, memory, communication, other).
     pub context_type: String,
+    /// Project partition this pattern belongs to, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
     /// Number of successful observations.
     pub success_count: u32,
     /// Total number of observations.
@@ -445,6 +448,15 @@ pub fn truncate_context_summary(summary: &str, max_context_summary_len: usize) -
     }
 }
 
+/// Scope for observation aggregation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AggregationScope {
+    /// Group observations globally by `(tool_name, context_category)`.
+    Global,
+    /// Group observations by `(project_id, tool_name, context_category)`.
+    ByProject,
+}
+
 /// Aggregate raw observations into behavioral patterns.
 ///
 /// Groups by (`tool_name`, `context_category`), computes success rates, and
@@ -465,6 +477,46 @@ pub(crate) fn aggregate_observations(
     min_observations: u32,
     min_success_rate: f64,
 ) -> Vec<BehavioralPattern> {
+    aggregate_observations_scoped(
+        observations,
+        min_observations,
+        min_success_rate,
+        AggregationScope::Global,
+    )
+}
+
+/// Aggregate raw observations into behavioral patterns, scoped by project.
+///
+/// Groups by (`project_id`, `tool_name`, `context_category`), computes success
+/// rates, and returns patterns that meet the minimum thresholds. Observations
+/// from different projects never mix into the same pattern.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "behavioral analysis internal; exercised by crate tests"
+    )
+)]
+#[must_use]
+pub(crate) fn aggregate_observations_by_project(
+    observations: &[ToolObservation],
+    min_observations: u32,
+    min_success_rate: f64,
+) -> Vec<BehavioralPattern> {
+    aggregate_observations_scoped(
+        observations,
+        min_observations,
+        min_success_rate,
+        AggregationScope::ByProject,
+    )
+}
+
+fn aggregate_observations_scoped(
+    observations: &[ToolObservation],
+    min_observations: u32,
+    min_success_rate: f64,
+    scope: AggregationScope,
+) -> Vec<BehavioralPattern> {
     use std::collections::HashMap;
 
     #[derive(Default)]
@@ -475,11 +527,20 @@ pub(crate) fn aggregate_observations(
         last_observed: Option<jiff::Timestamp>,
     }
 
-    let mut groups: HashMap<(String, String), Accum> = HashMap::new();
+    let mut groups: HashMap<(Option<ProjectId>, String, String), Accum> = HashMap::new();
 
     for obs in observations {
         let category = ContextCategory::classify(&obs.tool_name, &obs.context_summary);
-        let key = (obs.tool_name.clone(), category.as_str().to_owned());
+        let project_id = if scope == AggregationScope::ByProject {
+            obs.project_id.clone()
+        } else {
+            None
+        };
+        let key = (
+            project_id,
+            obs.tool_name.clone(),
+            category.as_str().to_owned(),
+        );
         let accum = groups.entry(key).or_default();
 
         accum.total_count += 1;
@@ -514,7 +575,7 @@ pub(crate) fn aggregate_observations(
 
     groups
         .into_iter()
-        .filter_map(|((tool_name, context_type), accum)| {
+        .filter_map(|((project_id, tool_name, context_type), accum)| {
             let success_rate = if accum.total_count > 0 {
                 f64::from(accum.success_count) / f64::from(accum.total_count)
             } else {
@@ -525,6 +586,7 @@ pub(crate) fn aggregate_observations(
                 pattern: String::new(), // filled below
                 tool_name,
                 context_type,
+                project_id,
                 success_count: accum.success_count,
                 total_count: accum.total_count,
                 success_rate,

--- a/crates/episteme/src/instinct_tests/basic_behavior.rs
+++ b/crates/episteme/src/instinct_tests/basic_behavior.rs
@@ -6,6 +6,7 @@
 )]
 use super::super::*;
 use crate::knowledge::parse_timestamp;
+use eidos::workspace::ProjectId;
 
 fn ts(s: &str) -> jiff::Timestamp {
     parse_timestamp(s).expect("valid test timestamp")
@@ -160,6 +161,7 @@ fn pattern_generates_correct_fact_content() {
         pattern: String::new(),
         tool_name: "grep".to_owned(),
         context_type: "code".to_owned(),
+        project_id: None,
         success_count: 8,
         total_count: 10,
         success_rate: 0.8,
@@ -343,6 +345,7 @@ fn pattern_meets_thresholds_at_boundary() {
         pattern: String::new(),
         tool_name: "grep".to_owned(),
         context_type: "code".to_owned(),
+        project_id: None,
         success_count: 5,
         total_count: 6,
         success_rate: 5.0 / 6.0,
@@ -361,6 +364,7 @@ fn pattern_does_not_meet_thresholds_below() {
         pattern: String::new(),
         tool_name: "grep".to_owned(),
         context_type: "code".to_owned(),
+        project_id: None,
         success_count: 4,
         total_count: 5,
         success_rate: 0.8,
@@ -513,5 +517,162 @@ fn observations_different_context_categories_aggregate_separately() {
     assert!(
         ctx_types.contains("research"),
         "expected a research context pattern"
+    );
+}
+
+fn make_observation_with_project(
+    tool_name: &str,
+    context: &str,
+    outcome: ToolOutcome,
+    timestamp: &str,
+    project_id: Option<ProjectId>,
+) -> ToolObservation {
+    ToolObservation {
+        tool_name: tool_name.to_owned(),
+        parameters: serde_json::json!({}),
+        outcome,
+        context_summary: context.to_owned(),
+        nous_id: "test-nous".to_owned(),
+        project_id,
+        observed_at: ts(timestamp),
+    }
+}
+
+#[test]
+fn project_scoped_aggregation_separates_projects() {
+    let project_alpha =
+        ProjectId::from_git_remote("https://github.com/acme/alpha.git").expect("valid remote");
+    let project_beta =
+        ProjectId::from_git_remote("https://github.com/acme/beta.git").expect("valid remote");
+
+    let mut observations = Vec::new();
+    for i in 0..5 {
+        observations.push(make_observation_with_project(
+            "grep",
+            "code search",
+            ToolOutcome::Success,
+            &format!("2026-03-{:02}T10:00:00Z", i + 1),
+            Some(project_alpha.clone()),
+        ));
+        observations.push(make_observation_with_project(
+            "grep",
+            "code search",
+            ToolOutcome::Success,
+            &format!("2026-03-{:02}T11:00:00Z", i + 1),
+            Some(project_beta.clone()),
+        ));
+    }
+
+    let patterns = aggregate_observations_by_project(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
+    assert_eq!(
+        patterns.len(),
+        2,
+        "two projects with same tool/context should produce two separate patterns"
+    );
+
+    let alpha_patterns: Vec<_> = patterns
+        .iter()
+        .filter(|p| p.project_id == Some(project_alpha.clone()))
+        .collect();
+    let beta_patterns: Vec<_> = patterns
+        .iter()
+        .filter(|p| p.project_id == Some(project_beta.clone()))
+        .collect();
+
+    assert_eq!(
+        alpha_patterns.len(),
+        1,
+        "alpha should have exactly one pattern"
+    );
+    assert_eq!(
+        beta_patterns.len(),
+        1,
+        "beta should have exactly one pattern"
+    );
+    assert_eq!(
+        alpha_patterns[0].success_count, 5,
+        "alpha pattern should have 5 successes"
+    );
+    assert_eq!(
+        beta_patterns[0].success_count, 5,
+        "beta pattern should have 5 successes"
+    );
+}
+
+#[test]
+fn global_aggregation_still_combines_projects() {
+    let project_alpha =
+        ProjectId::from_git_remote("https://github.com/acme/alpha.git").expect("valid remote");
+    let project_beta =
+        ProjectId::from_git_remote("https://github.com/acme/beta.git").expect("valid remote");
+
+    let mut observations = Vec::new();
+    for i in 0..5 {
+        observations.push(make_observation_with_project(
+            "grep",
+            "code search",
+            ToolOutcome::Success,
+            &format!("2026-03-{:02}T10:00:00Z", i + 1),
+            Some(project_alpha.clone()),
+        ));
+        observations.push(make_observation_with_project(
+            "grep",
+            "code search",
+            ToolOutcome::Success,
+            &format!("2026-03-{:02}T11:00:00Z", i + 1),
+            Some(project_beta.clone()),
+        ));
+    }
+
+    let patterns = aggregate_observations(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
+    assert_eq!(
+        patterns.len(),
+        1,
+        "global aggregation should still combine cross-project observations"
+    );
+    assert_eq!(
+        patterns[0].total_count, 10,
+        "combined pattern should have 10 total observations"
+    );
+    assert_eq!(
+        patterns[0].project_id, None,
+        "global aggregation should not set project_id"
+    );
+}
+
+#[test]
+fn project_scoped_aggregation_groups_none_project_id() {
+    let mut observations = Vec::new();
+    for i in 0..5 {
+        observations.push(make_observation_with_project(
+            "grep",
+            "code search",
+            ToolOutcome::Success,
+            &format!("2026-03-{:02}T10:00:00Z", i + 1),
+            None,
+        ));
+    }
+
+    let patterns = aggregate_observations_by_project(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
+    assert_eq!(
+        patterns.len(),
+        1,
+        "None project_id observations should still aggregate into one pattern"
+    );
+    assert_eq!(
+        patterns[0].project_id, None,
+        "pattern for None project_id should have None project_id"
     );
 }


### PR DESCRIPTION
Make behavioral observation aggregation project-aware enough to avoid mixing project-specific patterns by default.

- Add `AggregationScope` enum (`Global`, `ByProject`).
- Add `aggregate_observations_by_project` that groups by `(project_id, tool_name, context_category)`.
- Keep existing `aggregate_observations` unchanged for backward compatibility (delegates to shared `aggregate_observations_scoped` with `Global`).
- Add `project_id` field to `BehavioralPattern`.
- Tests demonstrate two synthetic projects with identical tool/context produce separate patterns under `ByProject`, while `Global` still combines them.

Refs #3975