### PR TITLE
feat(hermeneus): carry structured output format

### DIFF
--- a/crates/hermeneus/src/openai/wire/request.rs
+++ b/crates/hermeneus/src/openai/wire/request.rs
@@ -19,7 +19,8 @@ use serde::Serialize;
 
 use crate::error::{self, Result};
 use crate::types::{
-    CompletionRequest, Content, ContentBlock, Message, Role, ToolChoice, ToolResultContent,
+    CompletionRequest, Content, ContentBlock, Message, OutputFormat, Role, ToolChoice,
+    ToolResultContent,
 };
 
 /// Top-level OpenAI Chat Completions request body.
@@ -40,6 +41,8 @@ pub(crate) struct ChatCompletionRequest<'a> {
     pub stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "response_format")]
+    pub output_format: Option<WireResponseFormat>,
 }
 
 /// Single chat message. `role` is `"system" | "user" | "assistant" | "tool"`.
@@ -102,6 +105,27 @@ pub(crate) struct ResponsesRequest<'a> {
     pub stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<&'a str>,
+}
+
+/// Wire representation of `response_format` for OpenAI Chat Completions.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+pub(crate) enum WireResponseFormat {
+    #[serde(rename = "json_schema")]
+    JsonSchema {
+        #[serde(rename = "json_schema")]
+        definition: WireJsonSchema,
+    },
+    #[serde(rename = "text")]
+    Text,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct WireJsonSchema {
+    pub name: String,
+    pub schema: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -187,6 +211,13 @@ impl<'a> ChatCompletionRequest<'a> {
             );
         }
 
+        if req.output_format.is_some() {
+            tracing::debug!(
+                "output_format set on request routed to OpenAI-compatible provider; \
+                 passing through response_format"
+            );
+        }
+
         let mut messages: Vec<ChatMessage> = Vec::with_capacity(req.messages.len() + 1);
 
         // Prepend system message. Anthropic carries `system` at the top level;
@@ -224,6 +255,7 @@ impl<'a> ChatCompletionRequest<'a> {
         let stop: Vec<&str> = req.stop_sequences.iter().map(String::as_str).collect();
 
         let user = req.metadata.as_ref().and_then(|m| m.user_id.as_deref());
+        let output_format = req.output_format.as_ref().map(translate_output_format);
 
         Ok(Self {
             model: &req.model,
@@ -235,6 +267,7 @@ impl<'a> ChatCompletionRequest<'a> {
             tool_choice,
             stream,
             user,
+            output_format,
         })
     }
 }
@@ -283,6 +316,13 @@ impl<'a> ResponsesRequest<'a> {
             tracing::debug!(
                 "citations config set on request routed to OpenAI Responses provider; \
                  ignored until Responses annotations are mapped"
+            );
+        }
+
+        if req.output_format.is_some() {
+            tracing::warn!(
+                "output_format set on request routed to OpenAI Responses provider; \
+                 dropping (Responses text.format not yet mapped in hermeneus)"
             );
         }
 
@@ -557,6 +597,23 @@ fn translate_responses_assistant_message(msg: &Message, out: &mut Vec<ResponsesI
             role: "assistant",
             content: text_parts.join("\n"),
         });
+    }
+}
+
+fn translate_output_format(format: &OutputFormat) -> WireResponseFormat {
+    match format {
+        OutputFormat::JsonSchema {
+            name,
+            schema,
+            strict,
+        } => WireResponseFormat::JsonSchema {
+            definition: WireJsonSchema {
+                name: name.clone(),
+                schema: schema.clone(),
+                strict: *strict,
+            },
+        },
+        OutputFormat::Text => WireResponseFormat::Text,
     }
 }
 

--- a/crates/hermeneus/src/openai/wire/request_tests.rs
+++ b/crates/hermeneus/src/openai/wire/request_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::types::{
-    CompletionRequest, Content, ContentBlock, Message, Role, ThinkingConfig, ToolDefinition,
-    ToolResultContent,
+    CompletionRequest, Content, ContentBlock, Message, OutputFormat, Role, ThinkingConfig,
+    ToolDefinition, ToolResultContent,
 };
 
 #[test]
@@ -255,4 +255,79 @@ fn tool_arguments_serialized_as_json_string() {
     let tc = &wire.messages[0].tool_calls[0];
     let parsed: serde_json::Value = serde_json::from_str(&tc.function.arguments).unwrap();
     assert_eq!(parsed["x"], 1);
+}
+
+#[test]
+fn output_format_json_schema_maps_to_response_format() {
+    let req = CompletionRequest {
+        model: "gpt-4o".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("Give me JSON".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        output_format: Some(OutputFormat::JsonSchema {
+            name: "answer".to_owned(),
+            schema: serde_json::json!({
+                "type": "object",
+                "properties": { "answer": { "type": "string" } }
+            }),
+            strict: Some(true),
+        }),
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    assert!(
+        wire.output_format.is_some(),
+        "output_format should be translated"
+    );
+    let json = serde_json::to_value(&wire).unwrap();
+    assert_eq!(json["response_format"]["type"], "json_schema");
+    assert_eq!(json["response_format"]["json_schema"]["name"], "answer");
+    assert_eq!(json["response_format"]["json_schema"]["strict"], true);
+    assert_eq!(
+        json["response_format"]["json_schema"]["schema"]["type"],
+        "object"
+    );
+}
+
+#[test]
+fn output_format_none_omits_response_format() {
+    let req = CompletionRequest {
+        model: "gpt-4o".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("hi".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        output_format: None,
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    assert!(wire.output_format.is_none());
+    let json = serde_json::to_string(&wire).unwrap();
+    assert!(
+        !json.contains("response_format"),
+        "serialized request must not contain response_format when output_format is None"
+    );
+}
+
+#[test]
+fn output_format_text_maps_to_response_format_text() {
+    let req = CompletionRequest {
+        model: "gpt-4o".to_owned(),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::Text("hi".to_owned()),
+            cache_breakpoint: false,
+        }],
+        max_tokens: 128,
+        output_format: Some(OutputFormat::Text),
+        ..Default::default()
+    };
+    let wire = ChatCompletionRequest::from_request(&req, None).unwrap();
+    let json = serde_json::to_value(&wire).unwrap();
+    assert_eq!(json["response_format"]["type"], "text");
 }

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -484,6 +484,25 @@ pub struct CitationConfig {
     pub enabled: bool,
 }
 
+/// Structured output format for LLM responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OutputFormat {
+    /// Constrain output to a JSON Schema.
+    JsonSchema {
+        /// Descriptive name for the schema.
+        name: String,
+        /// The JSON Schema definition.
+        schema: serde_json::Value,
+        /// Whether to enforce strict schema adherence.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        strict: Option<bool>,
+    },
+    /// Plain text output.
+    Text,
+}
+
 /// A source citation in a response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -555,6 +574,9 @@ pub struct CompletionRequest {
     pub metadata: Option<RequestMetadata>,
     /// Enable citation tracking in responses.
     pub citations: Option<CitationConfig>,
+    /// Structured output format (e.g. JSON Schema).
+    /// When `None`, providers default to plain text.
+    pub output_format: Option<OutputFormat>,
 }
 
 impl Default for CompletionRequest {
@@ -575,6 +597,7 @@ impl Default for CompletionRequest {
             tool_choice: None,
             metadata: None,
             citations: None,
+            output_format: None,
         }
     }
 }

--- a/crates/hermeneus/src/types_tests/request_response.rs
+++ b/crates/hermeneus/src/types_tests/request_response.rs
@@ -5,6 +5,8 @@
 )]
 use super::*;
 
+use crate::types::OutputFormat;
+
 #[test]
 fn citation_char_location_serde() {
     let citation = Citation::CharLocation {
@@ -222,4 +224,62 @@ fn completion_request_default() {
         req.citations.is_none(),
         "default CompletionRequest citations should be None"
     );
+    assert!(
+        req.output_format.is_none(),
+        "default CompletionRequest output_format should be None"
+    );
+}
+
+#[test]
+fn output_format_json_schema_serde_roundtrip() {
+    let format = OutputFormat::JsonSchema {
+        name: "test_schema".to_owned(),
+        schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "answer": { "type": "string" }
+            }
+        }),
+        strict: Some(true),
+    };
+    let json =
+        serde_json::to_string(&format).expect("OutputFormat::JsonSchema should serialize to JSON");
+    assert!(
+        json.contains("json_schema"),
+        "serialized JSON should contain type tag"
+    );
+    assert!(
+        json.contains("test_schema"),
+        "serialized JSON should contain schema name"
+    );
+    let back: OutputFormat =
+        serde_json::from_str(&json).expect("OutputFormat::JsonSchema should deserialize from JSON");
+    match back {
+        OutputFormat::JsonSchema {
+            name,
+            schema,
+            strict,
+        } => {
+            assert_eq!(name, "test_schema", "schema name should round-trip");
+            assert_eq!(schema["type"], "object", "schema body should round-trip");
+            assert_eq!(strict, Some(true), "strict flag should round-trip");
+        }
+        other => panic!("expected JsonSchema, got {other:?}"),
+    }
+}
+
+#[test]
+fn output_format_text_serde_roundtrip() {
+    let format = OutputFormat::Text;
+    let json = serde_json::to_string(&format).expect("OutputFormat::Text should serialize to JSON");
+    assert!(
+        json.contains("text"),
+        "serialized JSON should contain type tag 'text'"
+    );
+    let back: OutputFormat =
+        serde_json::from_str(&json).expect("OutputFormat::Text should deserialize from JSON");
+    match back {
+        OutputFormat::Text => {}
+        other => panic!("expected Text, got {other:?}"),
+    }
 }


### PR DESCRIPTION
Add optional `output_format` field to `CompletionRequest` with `OutputFormat::JsonSchema` and `Text` variants. Wire it through OpenAI Chat Completions as `response_format`; warn and drop for OpenAI Responses API (different shape) and silently ignore for Anthropic, Kimi, and Codex providers.

Refs #3972
Gate-Passed: kanon 0.1.0