### PR TITLE
chore(aletheia-routing): reduce kanon lint baseline

### DIFF
--- a/crates/aletheia-routing/Cargo.toml
+++ b/crates/aletheia-routing/Cargo.toml
@@ -7,9 +7,6 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
-[lints]
-workspace = true
-
 [features]
 # Test tiers (see docs/test-tiers.md)
 test-core = []
@@ -27,3 +24,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/aletheia-routing/src/lib.rs
+++ b/crates/aletheia-routing/src/lib.rs
@@ -30,6 +30,8 @@ pub use types::{RequestFeatures, RouterError, RoutingDecision, TurnOutcome};
 
 use std::sync::Arc;
 
+use tracing::Instrument;
+
 /// Re-export `BoxFuture` for use in `Router` implementations.
 ///
 /// WHY: `async fn` in traits is not dyn-compatible in Rust (the vtable cannot
@@ -132,9 +134,12 @@ impl Router for RecordingRouter {
     ) -> Result<(), RouterError> {
         let store = Arc::clone(&self.store);
         let outcome = outcome.clone();
-        tokio::spawn(async move {
-            store.record_outcome(&outcome).await;
-        });
+        tokio::spawn(
+            async move {
+                store.record_outcome(&outcome).await;
+            }
+            .instrument(tracing::Span::current()),
+        );
         Ok(())
     }
 }

--- a/crates/aletheia-routing/src/store.rs
+++ b/crates/aletheia-routing/src/store.rs
@@ -38,6 +38,7 @@ const DEFAULT_REFRESH_WINDOW: Duration = Duration::from_secs(7 * SECS_PER_DAY);
 /// Errors produced by [`AfterActionStore`] operations.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum AfterActionStoreError {
     /// Could not read a JSONL log directory.
     #[snafu(display("I/O error reading after-action log '{}': {source}", path.display()))]
@@ -411,7 +412,7 @@ fn merge_stats(target: &mut RollingStats, source: &RollingStats) {
 ///
 /// Returns [`TaskCategory::Feature`] for unrecognised strings so that new
 /// categories added in future PRs degrade gracefully on old store data.
-pub fn parse_category(s: &str) -> TaskCategory {
+pub(crate) fn parse_category(s: &str) -> TaskCategory {
     match s {
         "refactor" => TaskCategory::Refactor,
         "bug" => TaskCategory::Bug,

--- a/crates/aletheia-routing/src/types.rs
+++ b/crates/aletheia-routing/src/types.rs
@@ -70,7 +70,9 @@ impl TaskCategory {
                 "chore" | "dependency" | "dependencies" | "deps" | "ci" | "lint" => {
                     is_chore = true;
                 }
-                _ => {}
+                _ => {
+                    // other tokens are ignored — only keyword hits affect categorisation
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Fix a focused slice of default `kanon lint` baseline in `aletheia-routing`.

**Before:** 8 lint findings  
**After:** 3 lint findings (the remaining 2 `trait-impl-colocation` + 1 `no-blocking-io-in-async` require larger architectural changes and are out of scope for this slice).

### Changes

- `Cargo.toml`: reorder sections so `[features]` → `[dependencies]` → `[dev-dependencies]` → `[lints]` (fixes `TOML/cargo-section-order`).
- `src/lib.rs`: add `tracing::Instrument` import and `.instrument(tracing::Span::current())` on the `tokio::spawn` in `RecordingRouter::after_action` (fixes `RUST/spawn-no-instrument`).
- `src/store.rs`: add `#[non_exhaustive]` to `AfterActionStoreError` (fixes `RUST/non-exhaustive-enum`); narrow `parse_category` visibility to `pub(crate)` — confirmed no sibling-crate consumers (fixes `RUST/pub-visibility`).
- `src/types.rs`: add explanatory comment to the intentionally-empty wildcard match arm in `TaskCategory::from_prompt` (fixes `RUST/empty-match-arm`).

### Verification

```bash
$ cargo fmt -p aletheia-routing
$ cargo check -p aletheia-routing   # clean
$ cargo clippy -p aletheia-routing  # clean
$ cargo test -p aletheia-routing    # 14 passed
$ kanon lint crates/aletheia-routing # 5 fixed, 3 remaining (architectural/performance)
$ git diff --check                  # clean
```

Refs #3987