### PR TITLE
feat(recall): thread local reranker model path

### DIFF
--- a/crates/episteme/Cargo.toml
+++ b/crates/episteme/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 default = ["graph-algo", "reranker"]
 graph-algo = []
 reranker = ["dep:reqwest", "dep:rustls", "dep:tokio"]
+local-reranker = ["reranker"]
 gliner = ["dep:ort", "dep:tokio", "dep:tokenizers"]
 test-support = []
 # WHY: mneme-engine brings in the Datalog knowledge store via krites and the

--- a/crates/episteme/src/recall/reranker.rs
+++ b/crates/episteme/src/recall/reranker.rs
@@ -202,6 +202,60 @@ impl HttpReranker {
     }
 }
 
+/// In-process cross-encoder reranker backed by a local ONNX model.
+///
+/// This is a **groundwork stub**: the constructor validates that the model
+/// path exists, but [`Reranker::rerank`] always returns an error because
+/// full ONNX inference is not yet wired.  Gated behind the `local-reranker`
+/// feature.
+#[cfg(feature = "local-reranker")]
+#[derive(Debug, Clone)]
+pub struct CrossEncoderReranker {
+    #[expect(dead_code, reason = "groundwork stub: model_path stored for future ONNX wiring")]
+    model_path: String,
+}
+
+#[cfg(feature = "local-reranker")]
+impl CrossEncoderReranker {
+    /// Create a new local cross-encoder reranker pointing at `model_path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EpistemeError::RerankerFailed`] when `model_path` does not
+    /// exist on the filesystem.
+    pub fn new(model_path: impl Into<String>) -> Result<Self, EpistemeError> {
+        let path = model_path.into();
+        if !std::path::Path::new(&path).exists() {
+            return Err(RerankerFailedSnafu {
+                message: format!("local reranker model path does not exist: {path}"),
+            }
+            .build());
+        }
+        Ok(Self { model_path: path })
+    }
+}
+
+#[cfg(feature = "local-reranker")]
+impl Reranker for CrossEncoderReranker {
+    #[instrument(skip(self, candidates))]
+    fn rerank<'a>(&'a self, query: &'a str, candidates: Vec<RecallCandidate>) -> RerankFuture<'a> {
+        Box::pin(
+            async move {
+                let _ = (query, candidates);
+                Err(RerankerFailedSnafu {
+                    message: "local cross-encoder scoring not yet implemented".to_owned(),
+                }
+                .build())
+            }
+            .instrument(tracing::Span::current()),
+        )
+    }
+
+    fn name(&self) -> &'static str {
+        "cross-encoder-reranker"
+    }
+}
+
 impl Reranker for HttpReranker {
     #[instrument(skip(self, candidates))]
     fn rerank<'a>(
@@ -576,6 +630,44 @@ mod tests {
         assert!(
             msg.contains("test failure"),
             "error display should contain message: {msg}"
+        );
+    }
+
+    #[cfg(feature = "local-reranker")]
+    #[tokio::test]
+    async fn cross_encoder_reranker_new_fails_when_path_missing() {
+        let result = CrossEncoderReranker::new("/nonexistent/path/to/model");
+        assert!(
+            matches!(result, Err(EpistemeError::RerankerFailed { .. })),
+            "missing model path should yield RerankerFailed"
+        );
+    }
+
+    #[cfg(feature = "local-reranker")]
+    #[tokio::test]
+    async fn cross_encoder_reranker_new_succeeds_when_path_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().to_str().expect("utf8 path");
+        let reranker = CrossEncoderReranker::new(path).expect("valid path should succeed");
+        assert_eq!(reranker.name(), "cross-encoder-reranker");
+    }
+
+    #[cfg(feature = "local-reranker")]
+    #[tokio::test]
+    async fn cross_encoder_reranker_rerank_fails_clearly() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().to_str().expect("utf8 path");
+        let reranker = CrossEncoderReranker::new(path).expect("valid path");
+        let candidates = vec![make_candidate("foo bar baz", 0.5)];
+        let result = reranker.rerank("query", candidates).await;
+        assert!(
+            matches!(result, Err(EpistemeError::RerankerFailed { .. })),
+            "rerank should fail clearly when scoring is not implemented"
+        );
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("not yet implemented"),
+            "error message should explain scoring is not yet implemented: {msg}"
         );
     }
 }

--- a/crates/episteme/src/rl/reward.rs
+++ b/crates/episteme/src/rl/reward.rs
@@ -22,7 +22,7 @@ pub trait RewardFn {
     fn reward(&self, outcome: &MemoryOutcome) -> f64;
 }
 
-/// Reward function that scores improvement over a LongMemEval baseline.
+/// Reward function that scores improvement over a `LongMemEval` baseline.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct LongMemEvalReward {
     /// Baseline exact-match rate to improve on.

--- a/crates/episteme/src/rl/state.rs
+++ b/crates/episteme/src/rl/state.rs
@@ -30,6 +30,7 @@ impl MemoryState {
     }
 
     /// Add or replace a named numeric feature.
+    #[must_use]
     pub fn with_feature(mut self, name: impl Into<String>, value: f64) -> Self {
         self.features.insert(name.into(), value);
         self

--- a/crates/nous/src/recall/scoring.rs
+++ b/crates/nous/src/recall/scoring.rs
@@ -86,6 +86,9 @@ pub struct RecallConfig {
     /// URL for an HTTP cross-encoder reranker.
     #[serde(default)]
     pub reranker_url: Option<String>,
+    /// Filesystem path to a local ONNX cross-encoder model for in-process reranking.
+    #[serde(default)]
+    pub reranker_model_path: Option<String>,
     /// Characters per token for recall budget estimation.
     ///
     /// Wired from `agents.defaults.chars_per_token` at startup.
@@ -113,6 +116,7 @@ impl Default for RecallConfig {
             late_inject_anchor: false,
             scope_quotas: HashMap::new(),
             reranker_url: None,
+            reranker_model_path: None,
             chars_per_token: default_chars_per_token(),
         }
     }
@@ -140,6 +144,7 @@ impl From<taxis::config::RecallSettings> for RecallConfig {
             late_inject_anchor: s.late_inject_anchor,
             scope_quotas: s.scope_quotas,
             reranker_url: s.reranker_url,
+            reranker_model_path: s.reranker_model_path,
             // NOTE: chars_per_token is forwarded separately from AgentDefaults
             //       via NousConfig; the From conversion cannot carry it since
             //       RecallSettings does not own that field.

--- a/crates/nous/src/recall_tests/recall_core.rs
+++ b/crates/nous/src/recall_tests/recall_core.rs
@@ -299,6 +299,10 @@ fn recall_config_defaults() {
         config.reranker_url.is_none(),
         "default reranker_url should be None"
     );
+    assert!(
+        config.reranker_model_path.is_none(),
+        "default reranker_model_path should be None"
+    );
 }
 
 #[test]
@@ -318,6 +322,7 @@ fn recall_from_settings_propagation() {
             m
         },
         reranker_url: Some("http://localhost:9999/rerank".to_owned()),
+        reranker_model_path: Some("/models/cross-encoder".to_owned()),
         ..taxis::config::RecallSettings::default()
     };
     let config = RecallConfig::from(settings);
@@ -333,6 +338,30 @@ fn recall_from_settings_propagation() {
     assert_eq!(
         config.reranker_url,
         Some("http://localhost:9999/rerank".to_owned())
+    );
+    assert_eq!(
+        config.reranker_model_path,
+        Some("/models/cross-encoder".to_owned())
+    );
+}
+
+#[test]
+fn recall_url_behavior_unchanged_when_model_path_present() {
+    let settings = taxis::config::RecallSettings {
+        reranker_url: Some("http://localhost:9999/rerank".to_owned()),
+        reranker_model_path: Some("/models/cross-encoder".to_owned()),
+        ..taxis::config::RecallSettings::default()
+    };
+    let config = RecallConfig::from(settings);
+    assert_eq!(
+        config.reranker_url,
+        Some("http://localhost:9999/rerank".to_owned()),
+        "reranker_url should still propagate when model path is also set"
+    );
+    assert_eq!(
+        config.reranker_model_path,
+        Some("/models/cross-encoder".to_owned()),
+        "reranker_model_path should propagate alongside url"
     );
 }
 

--- a/crates/taxis/src/config/agents.rs
+++ b/crates/taxis/src/config/agents.rs
@@ -113,6 +113,13 @@ pub struct RecallSettings {
     /// not enabled, the pipeline falls back to baseline ranking.
     #[serde(default)]
     pub reranker_url: Option<String>,
+    /// Filesystem path to a local ONNX cross-encoder model for in-process reranking.
+    ///
+    /// When set alongside `reranker_url`, the URL takes precedence.  This path
+    /// is only consulted when `reranker_url` is `None` and the
+    /// `local-reranker` feature is enabled.  Default: `None`.
+    #[serde(default)]
+    pub reranker_model_path: Option<String>,
 }
 
 /// Named recall behavior profile for a nous agent.
@@ -144,6 +151,7 @@ impl Default for RecallSettings {
             late_inject_anchor: false,
             scope_quotas: HashMap::new(),
             reranker_url: None,
+            reranker_model_path: None,
         }
     }
 }

--- a/crates/taxis/src/config/config_tests/basics.rs
+++ b/crates/taxis/src/config/config_tests/basics.rs
@@ -479,6 +479,27 @@ fn pricing_defaults_empty() {
 }
 
 #[test]
+fn recall_settings_serde_roundtrip() {
+    let mut config = AletheiaConfig::default();
+    config.agents.defaults.recall.reranker_url = Some("http://localhost:9999/rerank".to_owned());
+    config.agents.defaults.recall.reranker_model_path = Some("/models/cross-encoder".to_owned());
+
+    let json = serde_json::to_string(&config).expect("serialize");
+    let back: AletheiaConfig = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(
+        back.agents.defaults.recall.reranker_url,
+        Some("http://localhost:9999/rerank".to_owned()),
+        "reranker_url should survive serde roundtrip"
+    );
+    assert_eq!(
+        back.agents.defaults.recall.reranker_model_path,
+        Some("/models/cross-encoder".to_owned()),
+        "reranker_model_path should survive serde roundtrip"
+    );
+}
+
+#[test]
 fn pricing_from_json() {
     let json = r#"{
         "pricing": {

--- a/crates/taxis/src/config_tests.rs
+++ b/crates/taxis/src/config_tests.rs
@@ -469,6 +469,10 @@ fn pricing_defaults_empty() {
         config.agents.defaults.recall.reranker_url.is_none(),
         "default reranker_url should be None"
     );
+    assert!(
+        config.agents.defaults.recall.reranker_model_path.is_none(),
+        "default reranker_model_path should be None"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Groundwork for in-process local cross-encoder reranking (#3977).

**What this PR does:**
- Adds `reranker_model_path` to `taxis::config::RecallSettings` (default `None`).
- Threads the new field through `nous::recall::RecallConfig` via `From<taxis::config::RecallSettings>`.
- Introduces `episteme::recall::reranker::CrossEncoderReranker` behind the `local-reranker` feature gate.
  - Constructor validates that the model path exists.
  - `rerank` fails clearly with `RerankerFailed` because ONNX scoring is not yet wired.
- Preserves existing `reranker_url` behavior; no pipeline wiring changes.

**Tests added:**
- Config roundtrip (JSON) for `reranker_model_path` in taxis.
- Default `None` assertions for both `reranker_url` and `reranker_model_path`.
- Propagation test from taxis settings → nous config.
- URL-behavior-unchanged test when model path is also present.
- Feature-gated episteme tests: constructor fails on missing path, succeeds on existing path, and `rerank` returns a clear "not yet implemented" error.

Refs #3977