### PR TITLE
feat(mneme): partition recall by project

### DIFF
--- a/crates/aletheia-memory-mcp/src/tools.rs
+++ b/crates/aletheia-memory-mcp/src/tools.rs
@@ -681,6 +681,7 @@ impl MemoryServer {
                     fact_type: "annotation".to_owned(),
                     content,
                     scope: None,
+                    project_id: None,
                     sensitivity: mneme::knowledge::FactSensitivity::Public,
                     visibility: mneme::knowledge::Visibility::Private,
                     temporal: mneme::knowledge::FactTemporal {
@@ -867,6 +868,7 @@ impl MemoryServer {
                     fact_type: "supersession".to_owned(),
                     content: record_content,
                     scope: None,
+                    project_id: None,
                     sensitivity: mneme::knowledge::FactSensitivity::Public,
                     visibility: mneme::knowledge::Visibility::Private,
                     temporal: mneme::knowledge::FactTemporal {

--- a/crates/aletheia/src/bin/seed_psyche_facts.rs
+++ b/crates/aletheia/src/bin/seed_psyche_facts.rs
@@ -161,6 +161,7 @@ fn run(args: Args) -> anyhow::Result<()> {
             content: spec.content.clone(),
             fact_type: spec.fact_type.clone(),
             scope: Some(scope),
+            project_id: None,
             sensitivity,
             visibility: Visibility::Private,
             temporal: FactTemporal {

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -770,6 +770,7 @@ pub(crate) fn seed_skills(instance_root: Option<&PathBuf>, args: &SeedSkillsArgs
                 content: content_json.clone(),
                 fact_type: "skill".to_owned(),
                 scope: None,
+                project_id: None,
                 temporal: FactTemporal {
                     valid_from: now,
                     valid_to: mneme::knowledge::far_future(),

--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -194,6 +194,7 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
             let ts_now = jiff::Timestamp::now();
             let new_fact = Fact {
                 scope: None,
+                project_id: None,
                 id: mneme::id::FactId::new(new_id.as_str()).map_err(|e| {
                     MutateStoreSnafu {
                         message: e.to_string(),

--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -919,6 +919,7 @@ fn extracted_fact_to_fact(
         fact_type: classified_type.as_str().to_owned(),
         content,
         scope: Some(MemoryScope::Project),
+        project_id: None,
         temporal: FactTemporal {
             valid_from: now,
             valid_to: far_future(),

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -895,6 +895,7 @@ impl DiaporeiaServer {
                 fact_type: "knowledge".to_string(),
                 content: params.content.clone(),
                 scope: None,
+                project_id: None,
                 sensitivity,
                 visibility: mneme::knowledge::Visibility::Private,
                 temporal: FactTemporal {

--- a/crates/eidos/src/knowledge/entity.rs
+++ b/crates/eidos/src/knowledge/entity.rs
@@ -91,6 +91,12 @@ pub struct RecallResult {
     /// [`Fact::scope`]: super::fact::Fact::scope
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<super::scope::MemoryScope>,
+    /// Git-remote-derived project partition for the underlying fact.
+    ///
+    /// `None` means the result is global, non-fact, or predates project
+    /// partitioning.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<crate::workspace::ProjectId>,
     /// Visibility level for the underlying fact, carried from
     /// [`Fact::visibility`] so the recall pipeline can filter by visibility.
     /// Defaults to [`Visibility::Private`] for facts persisted before

--- a/crates/eidos/src/knowledge/fact.rs
+++ b/crates/eidos/src/knowledge/fact.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::id::FactId;
+use crate::workspace::ProjectId;
 
 use super::MemoryScope;
 
@@ -82,6 +83,12 @@ pub struct Fact {
     /// New facts should always populate this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<MemoryScope>,
+
+    /// Git-remote-derived project partition for project-scoped behavioral facts.
+    ///
+    /// `None` means the fact is global or predates project partitioning.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
 
     /// Data-sovereignty classification gating which provider deployment
     /// targets may receive this fact during recall (#3404, #3413).

--- a/crates/eidos/src/knowledge/knowledge_tests/entities_facts.rs
+++ b/crates/eidos/src/knowledge/knowledge_tests/entities_facts.rs
@@ -242,6 +242,7 @@ fn fact_with_supersession() {
         content: "outdated claim".to_owned(),
         fact_type: String::new(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-01-01"),
             valid_to: test_timestamp("2026-02-01"),
@@ -290,6 +291,7 @@ fn fact_with_session_source() {
         content: "extracted from conversation".to_owned(),
         fact_type: "relationship".to_owned(),
         scope: Some(MemoryScope::Project),
+        project_id: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-03-01"),
             valid_to: far_future(),

--- a/crates/eidos/src/knowledge/knowledge_tests/ids.rs
+++ b/crates/eidos/src/knowledge/knowledge_tests/ids.rs
@@ -95,6 +95,7 @@ fn fact_serde_roundtrip() {
         content: "The researcher published findings on memory consolidation".to_owned(),
         fact_type: String::new(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-02-01"),
             valid_to: far_future(),
@@ -263,6 +264,7 @@ fn recall_result_serde_roundtrip() {
         sensitivity: FactSensitivity::Public,
         graph_importance: 0.0,
         scope: None,
+        project_id: None,
         visibility: Visibility::Private,
     };
     let json = serde_json::to_string(&result).expect("RecallResult serialization is infallible");
@@ -286,6 +288,7 @@ fn fact_with_empty_content() {
         content: String::new(),
         fact_type: String::new(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-01-01"),
             valid_to: far_future(),
@@ -328,6 +331,7 @@ fn fact_with_unicode_content() {
         content: "The user writes \u{65E5}\u{672C}\u{8A9E} and emoji \u{1F980}".to_owned(),
         fact_type: String::new(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-01-01"),
             valid_to: far_future(),

--- a/crates/eidos/src/knowledge/knowledge_tests/scopes.rs
+++ b/crates/eidos/src/knowledge/knowledge_tests/scopes.rs
@@ -210,6 +210,7 @@ fn fact_scope_none_omitted_in_json() {
         content: "legacy fact without scope".to_owned(),
         fact_type: String::new(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-01-01"),
             valid_to: far_future(),
@@ -255,6 +256,7 @@ fn fact_scope_some_included_in_json() {
         content: "team project fact".to_owned(),
         fact_type: "project".to_owned(),
         scope: Some(MemoryScope::Project),
+        project_id: None,
         temporal: FactTemporal {
             valid_from: test_timestamp("2026-03-01"),
             valid_to: far_future(),
@@ -332,6 +334,7 @@ fn fact_scope_all_variants_roundtrip() {
             content: format!("fact in {scope} scope"),
             fact_type: String::new(),
             scope: Some(scope),
+            project_id: None,
             temporal: FactTemporal {
                 valid_from: test_timestamp("2026-01-01"),
                 valid_to: far_future(),

--- a/crates/eidos/src/knowledge/knowledge_tests/verification.rs
+++ b/crates/eidos/src/knowledge/knowledge_tests/verification.rs
@@ -15,6 +15,7 @@ fn make_test_fact(tier: EpistemicTier, recorded_at: jiff::Timestamp) -> Fact {
         content: "test fact".to_owned(),
         fact_type: "observation".to_owned(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: recorded_at,
             valid_to: far_future(),

--- a/crates/eidos/src/test_fixtures.rs
+++ b/crates/eidos/src/test_fixtures.rs
@@ -54,6 +54,7 @@ pub fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
         },
         sensitivity: FactSensitivity::Public,
         scope: None,
+        project_id: None,
         visibility: crate::knowledge::Visibility::Private,
     }
 }

--- a/crates/eidos/src/workspace.rs
+++ b/crates/eidos/src/workspace.rs
@@ -28,6 +28,20 @@ impl ProjectId {
         Ok(Self(id))
     }
 
+    /// Build a project ID from its stored SHA-256 lowercase hex form.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProjectIdError::InvalidHex`] when the value is not exactly
+    /// 64 ASCII hex characters.
+    pub fn from_sha256_hex(value: impl AsRef<str>) -> Result<Self, ProjectIdError> {
+        let trimmed = value.as_ref().trim();
+        if trimmed.len() != 64 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(ProjectIdError::InvalidHex);
+        }
+        Ok(Self(trimmed.to_ascii_lowercase()))
+    }
+
     /// The lowercase SHA-256 hex identifier.
     #[must_use]
     pub fn as_str(&self) -> &str {
@@ -53,12 +67,15 @@ impl AsRef<str> for ProjectId {
 pub enum ProjectIdError {
     /// The remote URL was empty after trimming whitespace.
     EmptyRemote,
+    /// The stored project ID was not a 64-character SHA-256 hex string.
+    InvalidHex,
 }
 
 impl fmt::Display for ProjectIdError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::EmptyRemote => f.write_str("git remote URL cannot be empty"),
+            Self::InvalidHex => f.write_str("project ID must be 64 hex characters"),
         }
     }
 }
@@ -123,6 +140,16 @@ mod tests {
 
         let json = serde_json::to_string(&id).expect("serialize");
         let back: ProjectId = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(id, back);
+    }
+
+    #[test]
+    fn project_id_constructs_from_stored_hex() {
+        let id = ProjectId::from_git_remote("https://github.com/forkwright/aletheia")
+            .expect("valid remote");
+        let back = ProjectId::from_sha256_hex(id.as_str().to_ascii_uppercase())
+            .expect("stored hex should parse");
 
         assert_eq!(id, back);
     }

--- a/crates/episteme/src/admission.rs
+++ b/crates/episteme/src/admission.rs
@@ -305,6 +305,7 @@ mod tests {
             fact_type: fact_type.to_owned(),
             content: content.to_owned(),
             scope: None,
+            project_id: None,
             temporal: FactTemporal {
                 valid_from: now,
                 valid_to: crate::knowledge::far_future(),

--- a/crates/episteme/src/consolidation/engine.rs
+++ b/crates/episteme/src/consolidation/engine.rs
@@ -297,6 +297,7 @@ impl KnowledgeStore {
                 content: consolidated.content.clone(),
                 fact_type: "observation".to_owned(),
                 scope: None,
+                project_id: None,
                 temporal: FactTemporal {
                     valid_from: now,
                     valid_to: far_future,

--- a/crates/episteme/src/extract/engine.rs
+++ b/crates/episteme/src/extract/engine.rs
@@ -614,6 +614,7 @@ Rules:
                 content,
                 fact_type: classified_type.as_str().to_owned(),
                 scope,
+                project_id: None,
                 temporal: FactTemporal {
                     valid_from: now,
                     valid_to: far_future(),

--- a/crates/episteme/src/extract/lesson.rs
+++ b/crates/episteme/src/extract/lesson.rs
@@ -508,6 +508,7 @@ pub(crate) fn persist_lesson(
             content,
             fact_type: classified_type.as_str().to_owned(),
             scope: None,
+            project_id: None,
             temporal: FactTemporal {
                 valid_from: now,
                 valid_to: far_future(),

--- a/crates/episteme/src/ingest.rs
+++ b/crates/episteme/src/ingest.rs
@@ -275,6 +275,7 @@ fn chunk_to_fact(
         content: chunk.content,
         fact_type: classified_type.as_str().to_owned(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: now,
             valid_to: far_future(),

--- a/crates/episteme/src/instinct.rs
+++ b/crates/episteme/src/instinct.rs
@@ -31,6 +31,12 @@ pub const DEFAULT_MIN_OBSERVATIONS: u32 = 5;
 /// Callers should prefer the value from `taxis::config::AgentBehaviorDefaults::knowledge_instinct_min_success_rate`.
 pub const DEFAULT_MIN_SUCCESS_RATE: f64 = 0.80;
 
+/// Default minimum distinct projects before project-scoped instincts promote to global.
+pub const DEFAULT_PROMOTION_MIN_PROJECTS: usize = 2;
+
+/// Default minimum per-project confidence before project-scoped instincts promote to global.
+pub const DEFAULT_PROMOTION_MIN_CONFIDENCE: f64 = 0.80;
+
 /// Patterns matching potential secret values in tool parameters.
 const SECRET_PATTERNS: &[&str] = &[
     "api_key",
@@ -509,6 +515,96 @@ pub(crate) fn aggregate_observations_by_project(
         min_success_rate,
         AggregationScope::ByProject,
     )
+}
+
+/// Promote convergent project-scoped patterns into global patterns.
+///
+/// A pattern promotes only when it is present in at least `min_projects`
+/// distinct project partitions and every contributing project pattern has a
+/// success rate at least `min_confidence`. Patterns without a `project_id` are
+/// already global and do not count toward cross-project evidence.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "promotion is an explicit opt-in step for project-scoped pattern callers"
+    )
+)]
+#[must_use]
+pub(crate) fn promote_cross_project_patterns(
+    patterns: &[BehavioralPattern],
+    min_projects: usize,
+    min_confidence: f64,
+) -> Vec<BehavioralPattern> {
+    use std::collections::{HashMap, HashSet};
+
+    #[derive(Default)]
+    struct PromotionAccum {
+        projects: HashSet<ProjectId>,
+        success_count: u32,
+        total_count: u32,
+        first_observed: Option<jiff::Timestamp>,
+        last_observed: Option<jiff::Timestamp>,
+    }
+
+    let mut groups: HashMap<(String, String), PromotionAccum> = HashMap::new();
+
+    for pattern in patterns
+        .iter()
+        .filter(|pattern| pattern.success_rate >= min_confidence)
+    {
+        let Some(project_id) = pattern.project_id.clone() else {
+            continue;
+        };
+
+        let accum = groups
+            .entry((pattern.tool_name.clone(), pattern.context_type.clone()))
+            .or_default();
+        accum.projects.insert(project_id);
+        accum.success_count = accum.success_count.saturating_add(pattern.success_count);
+        accum.total_count = accum.total_count.saturating_add(pattern.total_count);
+
+        match accum.first_observed {
+            Some(ref ts) if pattern.first_observed < *ts => {
+                accum.first_observed = Some(pattern.first_observed);
+            }
+            None => accum.first_observed = Some(pattern.first_observed),
+            _ => {}
+        }
+        match accum.last_observed {
+            Some(ref ts) if pattern.last_observed > *ts => {
+                accum.last_observed = Some(pattern.last_observed);
+            }
+            None => accum.last_observed = Some(pattern.last_observed),
+            _ => {}
+        }
+    }
+
+    groups
+        .into_iter()
+        .filter_map(|((tool_name, context_type), accum)| {
+            if accum.projects.len() < min_projects || accum.total_count == 0 {
+                return None;
+            }
+
+            let success_rate = f64::from(accum.success_count) / f64::from(accum.total_count);
+            let pattern = BehavioralPattern {
+                pattern: String::new(),
+                tool_name,
+                context_type,
+                project_id: None,
+                success_count: accum.success_count,
+                total_count: accum.total_count,
+                success_rate,
+                first_observed: accum.first_observed.unwrap_or_else(jiff::Timestamp::now),
+                last_observed: accum.last_observed.unwrap_or_else(jiff::Timestamp::now),
+            };
+            Some(BehavioralPattern {
+                pattern: pattern.to_fact_content(),
+                ..pattern
+            })
+        })
+        .collect()
 }
 
 fn aggregate_observations_scoped(

--- a/crates/episteme/src/instinct_tests/basic_behavior.rs
+++ b/crates/episteme/src/instinct_tests/basic_behavior.rs
@@ -676,3 +676,99 @@ fn project_scoped_aggregation_groups_none_project_id() {
         "pattern for None project_id should have None project_id"
     );
 }
+
+#[test]
+fn cross_project_promotion_requires_two_confident_projects() {
+    let project_alpha =
+        ProjectId::from_git_remote("https://github.com/acme/alpha.git").expect("valid remote");
+    let project_beta =
+        ProjectId::from_git_remote("https://github.com/acme/beta.git").expect("valid remote");
+
+    let mut observations = Vec::new();
+    for i in 0..20 {
+        let outcome = if i < 17 {
+            ToolOutcome::Success
+        } else {
+            ToolOutcome::Failure {
+                error: "synthetic timeout".to_owned(),
+            }
+        };
+        observations.push(make_observation_with_project(
+            "grep",
+            "code search",
+            outcome.clone(),
+            &format!("2026-03-{:02}T10:00:00Z", i + 1),
+            Some(project_alpha.clone()),
+        ));
+        observations.push(make_observation_with_project(
+            "grep",
+            "code search",
+            outcome,
+            &format!("2026-04-{:02}T10:00:00Z", i + 1),
+            Some(project_beta.clone()),
+        ));
+    }
+
+    let project_patterns = aggregate_observations_by_project(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
+    let promoted = promote_cross_project_patterns(
+        &project_patterns,
+        DEFAULT_PROMOTION_MIN_PROJECTS,
+        DEFAULT_PROMOTION_MIN_CONFIDENCE,
+    );
+
+    assert_eq!(
+        promoted.len(),
+        1,
+        "same pattern at 0.85 confidence in two projects should promote globally"
+    );
+    assert_eq!(
+        promoted[0].project_id, None,
+        "promoted pattern should be global"
+    );
+    assert_eq!(promoted[0].success_count, 34);
+    assert_eq!(promoted[0].total_count, 40);
+}
+
+#[test]
+fn cross_project_promotion_rejects_single_project_even_high_confidence() {
+    let project_alpha =
+        ProjectId::from_git_remote("https://github.com/acme/alpha.git").expect("valid remote");
+
+    let mut observations = Vec::new();
+    for i in 0..20 {
+        let outcome = if i < 19 {
+            ToolOutcome::Success
+        } else {
+            ToolOutcome::Failure {
+                error: "synthetic timeout".to_owned(),
+            }
+        };
+        observations.push(make_observation_with_project(
+            "grep",
+            "code search",
+            outcome,
+            &format!("2026-03-{:02}T10:00:00Z", i + 1),
+            Some(project_alpha.clone()),
+        ));
+    }
+
+    let project_patterns = aggregate_observations_by_project(
+        &observations,
+        DEFAULT_MIN_OBSERVATIONS,
+        DEFAULT_MIN_SUCCESS_RATE,
+    );
+    let promoted = promote_cross_project_patterns(
+        &project_patterns,
+        DEFAULT_PROMOTION_MIN_PROJECTS,
+        DEFAULT_PROMOTION_MIN_CONFIDENCE,
+    );
+
+    assert!(
+        promoted.is_empty(),
+        "one project at 0.95 confidence must remain project-scoped only"
+    );
+}

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -298,11 +298,11 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       scope, visibility},
+                       scope, project_id, visibility},
                 id = $id,
                 is_forgotten = true,
                 forgotten_at = $now,
@@ -310,7 +310,7 @@ impl KnowledgeStore {
             :put facts {id, valid_from => content, nous_id, confidence, tier,
                         valid_to, superseded_by, source_session_id, recorded_at,
                         access_count, last_accessed_at, stability_hours, fact_type,
-                        is_forgotten, forgotten_at, forget_reason, scope, visibility}
+                        is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
         ";
         let mut params = std::collections::BTreeMap::new();
         params.insert(
@@ -356,11 +356,11 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       scope, visibility},
+                       scope, project_id, visibility},
                 id = $id,
                 is_forgotten = false,
                 forgotten_at = null,
@@ -368,7 +368,7 @@ impl KnowledgeStore {
             :put facts {id, valid_from => content, nous_id, confidence, tier,
                         valid_to, superseded_by, source_session_id, recorded_at,
                         access_count, last_accessed_at, stability_hours, fact_type,
-                        is_forgotten, forgotten_at, forget_reason, scope, visibility}
+                        is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
         ";
         let mut params = std::collections::BTreeMap::new();
         params.insert(
@@ -612,11 +612,11 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       is_forgotten, forgotten_at, forget_reason, scope, visibility}
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
             :order -recorded_at
             :limit $limit
         ";
@@ -854,11 +854,11 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       is_forgotten, forgotten_at, forget_reason, scope, visibility},
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
                 nous_id == $nous_id,
                 fact_type == $fact_type,
                 is_forgotten == false

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -98,6 +98,13 @@ pub(super) fn fact_to_params(
         },
     );
     p.insert(
+        "project_id".to_owned(),
+        match &fact.project_id {
+            Some(id) => DataValue::Str(id.as_str().into()),
+            None => DataValue::Null,
+        },
+    );
+    p.insert(
         "visibility".to_owned(),
         DataValue::Str(fact.visibility.as_str().into()),
     );
@@ -363,8 +370,13 @@ pub(super) fn rows_to_facts(
             .and_then(|v| extract_optional_str(v).ok())
             .unwrap_or(None)
             .and_then(|s| s.parse::<crate::knowledge::MemoryScope>().ok());
-        let visibility = row
+        let project_id = row
             .get(18)
+            .and_then(|v| extract_optional_str(v).ok())
+            .unwrap_or(None)
+            .and_then(|s| eidos::workspace::ProjectId::from_sha256_hex(s).ok());
+        let visibility = row
+            .get(19)
             .and_then(|v| extract_str(v).ok())
             .unwrap_or_default()
             .parse::<crate::knowledge::Visibility>()
@@ -385,6 +397,7 @@ pub(super) fn rows_to_facts(
             content,
             fact_type,
             scope,
+            project_id,
             visibility,
             temporal: crate::knowledge::FactTemporal {
                 valid_from: crate::knowledge::parse_timestamp(&valid_from)
@@ -520,8 +533,13 @@ pub(super) fn rows_to_raw_facts(
             .and_then(|v| extract_optional_str(v).ok())
             .unwrap_or(None)
             .and_then(|s| s.parse::<crate::knowledge::MemoryScope>().ok());
-        let visibility = row
+        let project_id = row
             .get(18)
+            .and_then(|v| extract_optional_str(v).ok())
+            .unwrap_or(None)
+            .and_then(|s| eidos::workspace::ProjectId::from_sha256_hex(s).ok());
+        let visibility = row
+            .get(19)
             .and_then(|v| extract_str(v).ok())
             .unwrap_or_default()
             .parse::<crate::knowledge::Visibility>()
@@ -537,6 +555,7 @@ pub(super) fn rows_to_raw_facts(
             content,
             fact_type,
             scope,
+            project_id,
             visibility,
             temporal: crate::knowledge::FactTemporal {
                 valid_from: crate::knowledge::parse_timestamp(&valid_from)
@@ -608,6 +627,7 @@ pub(super) fn rows_to_facts_partial(
             content,
             fact_type: String::new(),
             scope: None,
+            project_id: None,
             visibility: crate::knowledge::Visibility::Private,
             temporal: crate::knowledge::FactTemporal {
                 valid_from: jiff::Timestamp::UNIX_EPOCH,
@@ -679,8 +699,13 @@ pub(super) fn rows_to_recall_results(
             .and_then(|v| extract_optional_str(v).ok())
             .unwrap_or(None)
             .and_then(|s| s.parse::<crate::knowledge::MemoryScope>().ok());
-        let visibility = row
+        let project_id = row
             .get(6)
+            .and_then(|v| extract_optional_str(v).ok())
+            .unwrap_or(None)
+            .and_then(|s| eidos::workspace::ProjectId::from_sha256_hex(s).ok());
+        let visibility = row
+            .get(7)
             .and_then(|v| extract_str(v).ok())
             .unwrap_or_default()
             .parse::<crate::knowledge::Visibility>()
@@ -696,6 +721,7 @@ pub(super) fn rows_to_recall_results(
             sensitivity: crate::knowledge::FactSensitivity::Public,
             graph_importance: 0.0,
             scope,
+            project_id,
             visibility,
         });
     }

--- a/crates/episteme/src/knowledge_store/migration.rs
+++ b/crates/episteme/src/knowledge_store/migration.rs
@@ -684,18 +684,18 @@ impl KnowledgeStore {
                   superseded_by, source_session_id, recorded_at,
                   access_count, last_accessed_at, stability_hours, fact_type,
                   is_forgotten, forgotten_at, forget_reason,
-                  scope, visibility] <- [[
+                  scope, project_id, visibility] <- [[
                     $id, $valid_from, $content, $nous_id, $confidence, $tier, $valid_to,
                     $superseded_by, $source_session_id, $recorded_at,
                     $access_count, $last_accessed_at, $stability_hours, $fact_type,
                     $is_forgotten, $forgotten_at, $forget_reason,
-                    null, 'private'
+                    null, null, 'private'
                 ]]
                 :put facts {id, valid_from => content, nous_id, confidence, tier,
                             valid_to, superseded_by, source_session_id, recorded_at,
                             access_count, last_accessed_at, stability_hours, fact_type,
                             is_forgotten, forgotten_at, forget_reason,
-                            scope, visibility}
+                            scope, project_id, visibility}
             ";
             let mut params = BTreeMap::new();
             for (i, name) in [
@@ -760,6 +760,153 @@ impl KnowledgeStore {
             })?;
 
         tracing::info!("knowledge schema migration v10 -> v11 complete");
+        Ok(())
+    }
+
+    /// Migrate v11 → v12: add `project_id` to `facts`.
+    ///
+    /// Existing rows are backfilled with `project_id = null`, which preserves
+    /// previous global recall semantics until runtime capture supplies a
+    /// git-remote-derived partition.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "migration is a single linear sequence"
+    )]
+    pub(super) fn migrate_v11_to_v12(&self) -> crate::error::Result<()> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::{DataValue, ScriptMutability};
+        tracing::info!("migrating knowledge schema v11 -> v12");
+
+        let all_facts = self
+            .db
+            .run(
+                r"?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+                    superseded_by, source_session_id, recorded_at,
+                    access_count, last_accessed_at, stability_hours, fact_type,
+                    is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+                    *facts{id, valid_from, content, nous_id, confidence, tier,
+                           valid_to, superseded_by, source_session_id, recorded_at,
+                           access_count, last_accessed_at, stability_hours, fact_type,
+                           is_forgotten, forgotten_at, forget_reason, scope, visibility}",
+                BTreeMap::new(),
+                ScriptMutability::Immutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v11->v12 read facts: {e}"),
+                }
+                .build()
+            })?;
+
+        let _ = self.db.run(
+            "::fts drop facts:content_fts",
+            BTreeMap::new(),
+            ScriptMutability::Mutable,
+        );
+
+        self.db
+            .run("::remove facts", BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v11->v12 remove facts: {e}"),
+                }
+                .build()
+            })?;
+
+        self.db
+            .run(KNOWLEDGE_DDL[0], BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v11->v12 recreate facts: {e}"),
+                }
+                .build()
+            })?;
+
+        for row in &all_facts.rows {
+            let script = r"
+                ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+                  superseded_by, source_session_id, recorded_at,
+                  access_count, last_accessed_at, stability_hours, fact_type,
+                  is_forgotten, forgotten_at, forget_reason,
+                  scope, project_id, visibility] <- [[
+                    $id, $valid_from, $content, $nous_id, $confidence, $tier, $valid_to,
+                    $superseded_by, $source_session_id, $recorded_at,
+                    $access_count, $last_accessed_at, $stability_hours, $fact_type,
+                    $is_forgotten, $forgotten_at, $forget_reason,
+                    $scope, null, $visibility
+                ]]
+                :put facts {id, valid_from => content, nous_id, confidence, tier,
+                            valid_to, superseded_by, source_session_id, recorded_at,
+                            access_count, last_accessed_at, stability_hours, fact_type,
+                            is_forgotten, forgotten_at, forget_reason,
+                            scope, project_id, visibility}
+            ";
+            let mut params = BTreeMap::new();
+            for (i, name) in [
+                "id",
+                "valid_from",
+                "content",
+                "nous_id",
+                "confidence",
+                "tier",
+                "valid_to",
+                "superseded_by",
+                "source_session_id",
+                "recorded_at",
+                "access_count",
+                "last_accessed_at",
+                "stability_hours",
+                "fact_type",
+                "is_forgotten",
+                "forgotten_at",
+                "forget_reason",
+                "scope",
+                "visibility",
+            ]
+            .iter()
+            .enumerate()
+            {
+                if let Some(val) = row.get(i) {
+                    params.insert((*name).to_owned(), val.clone());
+                }
+            }
+            self.db
+                .run(script, params, ScriptMutability::Mutable)
+                .map_err(|e| {
+                    crate::error::EngineQuerySnafu {
+                        message: format!("v11->v12 reinsert fact: {e}"),
+                    }
+                    .build()
+                })?;
+        }
+
+        self.db
+            .run(fts_ddl(), BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v11->v12 recreate FTS: {e}"),
+                }
+                .build()
+            })?;
+
+        let mut params = BTreeMap::new();
+        params.insert("key".to_owned(), DataValue::Str("schema".into()));
+        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
+        self.db
+            .run(
+                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
+                params,
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v11->v12 version write failed: {e}"),
+                }
+                .build()
+            })?;
+
+        tracing::info!("knowledge schema migration v11 -> v12 complete");
         Ok(())
     }
 }

--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -16,7 +16,8 @@
 //!         source_session_id: String?, recorded_at: String,
 //!         access_count: Int, last_accessed_at: String, stability_hours: Float,
 //!         fact_type: String, is_forgotten: Bool, forgotten_at: String?,
-//!         forget_reason: String? }
+//!         forget_reason: String?, scope: String?, project_id: String?,
+//!         visibility: String }
 //!
 //! entities { id: String => name: String, entity_type: String, aliases: String,
 //!            created_at: String, updated_at: String }
@@ -90,6 +91,7 @@ pub const KNOWLEDGE_DDL: &[&str] = &[
         forgotten_at: String?,
         forget_reason: String?,
         scope: String?,
+        project_id: String?,
         visibility: String default 'private'
     }",
     r":create entities {
@@ -494,7 +496,7 @@ pub struct KnowledgeStore {
 
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
-    const SCHEMA_VERSION: i64 = 11;
+    const SCHEMA_VERSION: i64 = 12;
 
     /// Open an in-memory knowledge store with default configuration.
     ///
@@ -726,6 +728,9 @@ impl KnowledgeStore {
             }
             if current_version < 11 {
                 self.migrate_v10_to_v11()?;
+            }
+            if current_version < 12 {
+                self.migrate_v11_to_v12()?;
             }
             return Ok(());
         }
@@ -1056,11 +1061,11 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       is_forgotten, forgotten_at, forget_reason, scope, visibility},
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
                 id = $id
         ";
         let mut params = BTreeMap::new();

--- a/crates/episteme/src/knowledge_store/search.rs
+++ b/crates/episteme/src/knowledge_store/search.rs
@@ -204,7 +204,7 @@ impl KnowledgeStore {
         Ok(())
     }
 
-    /// Hydrate recall results with `scope` and `visibility` from the `facts` relation.
+    /// Hydrate recall results with `scope`, `project_id`, and `visibility` from the `facts` relation.
     ///
     /// Semantic search returns from the `embeddings` relation, which does not
     /// carry these fields. This enrichment looks them up from `facts` for
@@ -213,8 +213,8 @@ impl KnowledgeStore {
     fn hydrate_recall_scope_visibility(&self, results: &mut [crate::knowledge::RecallResult]) {
         for result in results.iter_mut().filter(|r| r.source_type == "fact") {
             let script = r"
-                ?[scope, visibility] :=
-                    *facts{id: $fid, scope, visibility}
+                ?[scope, project_id, visibility] :=
+                    *facts{id: $fid, scope, project_id, visibility}
             ";
             let mut params = std::collections::BTreeMap::new();
             params.insert(
@@ -238,7 +238,14 @@ impl KnowledgeStore {
                         ),
                     }
                 }
-                if let Some(vis_str) = row.get(1).and_then(|v| v.get_str())
+                if let Some(project_id) = row
+                    .get(1)
+                    .and_then(|v| v.get_str())
+                    .and_then(|s| eidos::workspace::ProjectId::from_sha256_hex(s).ok())
+                {
+                    result.project_id = Some(project_id);
+                }
+                if let Some(vis_str) = row.get(2).and_then(|v| v.get_str())
                     && !vis_str.is_empty()
                 {
                     result.visibility = vis_str
@@ -345,6 +352,7 @@ impl KnowledgeStore {
                     sensitivity: crate::knowledge::FactSensitivity::Public,
                     graph_importance: 0.0,
                     scope: None,
+                    project_id: None,
                     visibility: crate::knowledge::Visibility::Private,
                 });
                 added += 1;
@@ -568,6 +576,7 @@ impl KnowledgeStore {
                     sensitivity: fact.sensitivity,
                     graph_importance: 0.0,
                     scope: fact.scope,
+                    project_id: fact.project_id,
                     visibility: fact.visibility,
                 });
                 break;

--- a/crates/episteme/src/knowledge_store/skills.rs
+++ b/crates/episteme/src/knowledge_store/skills.rs
@@ -58,11 +58,11 @@ impl KnowledgeStore {
         let script = r"?[id, content, confidence, tier, recorded_at, nous_id,
               valid_from, valid_to, superseded_by, source_session_id,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
             *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                    superseded_by, source_session_id, recorded_at,
                    access_count, last_accessed_at, stability_hours, fact_type,
-                   is_forgotten, forgotten_at, forget_reason, scope, visibility},
+                   is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
             nous_id = $nous_id,
             fact_type = 'skill',
             is_null(superseded_by),
@@ -101,12 +101,12 @@ impl KnowledgeStore {
             ?[id, content, confidence, tier, recorded_at, nous_id,
               valid_from, valid_to, superseded_by, source_session_id,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
                 candidates[id, _score],
                 *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                        superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       is_forgotten, forgotten_at, forget_reason, scope, visibility},
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
                 nous_id = $nous_id,
                 fact_type = 'skill',
                 is_null(superseded_by),
@@ -155,11 +155,11 @@ impl KnowledgeStore {
         let script = r"?[id, content, confidence, tier, recorded_at, nous_id,
               valid_from, valid_to, superseded_by, source_session_id,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
             *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                    superseded_by, source_session_id, recorded_at,
                    access_count, last_accessed_at, stability_hours, fact_type,
-                   is_forgotten, forgotten_at, forget_reason, scope, visibility},
+                   is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
             nous_id = $nous_id,
             fact_type = 'skill_pending',
             is_null(superseded_by),
@@ -216,6 +216,7 @@ impl KnowledgeStore {
             content: skill_json,
             fact_type: "skill".to_owned(),
             scope: None,
+            project_id: None,
             temporal: crate::knowledge::FactTemporal {
                 valid_from: now,
                 valid_to: jiff::Timestamp::from_second(i64::MAX / 2).unwrap_or(now),

--- a/crates/episteme/src/knowledge_store/tests/causal.rs
+++ b/crates/episteme/src/knowledge_store/tests/causal.rs
@@ -44,6 +44,7 @@ fn make_fact(id: &str, content: &str) -> Fact {
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }
 }
 

--- a/crates/episteme/src/knowledge_store/tests/ddl.rs
+++ b/crates/episteme/src/knowledge_store/tests/ddl.rs
@@ -154,6 +154,7 @@ fn hybrid_search_empty_seeds_returns_results() {
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
     store.insert_fact(&fact).expect("insert fact");
 
@@ -241,6 +242,7 @@ fn hybrid_search_graph_aggregation() {
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
     store.insert_fact(&f1).expect("insert f1");
     store
@@ -287,6 +289,7 @@ fn hybrid_search_graph_aggregation() {
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
     store.insert_fact(&f2).expect("insert f2");
     store
@@ -423,6 +426,7 @@ fn hybrid_search_two_signal_no_graph() {
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
     store.insert_fact(&fact).expect("insert fact");
 
@@ -519,6 +523,7 @@ fn hybrid_search_absent_signal_rank_is_negative_one() {
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
     store.insert_fact(&fact).expect("insert fact");
 

--- a/crates/episteme/src/knowledge_store/tests/derived_rules.rs
+++ b/crates/episteme/src/knowledge_store/tests/derived_rules.rs
@@ -68,6 +68,7 @@ fn make_fact_with_tier(
         sensitivity: FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
     store
         .insert_fact(&fact)
@@ -209,6 +210,7 @@ fn causal_chain_direct_edge_appears_in_derived_facts() {
         sensitivity: FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
 
     store
@@ -276,6 +278,7 @@ fn causal_chain_transitive_confidence_is_product() {
         sensitivity: FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
 
     store.insert_fact(&make("fa")).expect("fa");
@@ -344,6 +347,7 @@ fn causal_chain_low_confidence_pruned() {
         sensitivity: FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
 
     store.insert_fact(&make("g1")).expect("g1");
@@ -565,6 +569,7 @@ fn query_derived_facts_by_rule_prefix_filters_correctly() {
         sensitivity: FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
     store
         .insert_fact(&make("fact-dave", "dave does analysis"))

--- a/crates/episteme/src/knowledge_store/tests/facts/crud.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/crud.rs
@@ -94,6 +94,10 @@ fn insert_fact_with_scope_and_visibility_roundtrips() {
     let store = make_store();
     let mut fact = make_fact("f-scoped", "agent-a", "Scoped fact content");
     fact.scope = Some(crate::knowledge::MemoryScope::Project);
+    fact.project_id = Some(
+        eidos::workspace::ProjectId::from_git_remote("https://github.com/acme/alpha.git")
+            .expect("valid remote"),
+    );
     fact.visibility = crate::knowledge::Visibility::Shared;
     store.insert_fact(&fact).expect("insert fact");
 
@@ -110,6 +114,10 @@ fn insert_fact_with_scope_and_visibility_roundtrips() {
         results[0].visibility,
         crate::knowledge::Visibility::Shared,
         "visibility should roundtrip through storage"
+    );
+    assert_eq!(
+        results[0].project_id, fact.project_id,
+        "project_id should roundtrip through storage"
     );
 }
 

--- a/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/scripts.rs
@@ -364,6 +364,7 @@ fn concurrent_inserts() {
                     sensitivity: crate::knowledge::FactSensitivity::Public,
                     visibility: crate::knowledge::Visibility::Private,
                     scope: None,
+                    project_id: None,
                 };
                 s.insert_fact(&fact).expect("concurrent insert");
             })

--- a/crates/episteme/src/knowledge_store/tests/skills.rs
+++ b/crates/episteme/src/knowledge_store/tests/skills.rs
@@ -49,6 +49,7 @@ fn make_skill_fact(id: &str, nous_id: &str, skill_name: &str, domain_tags: &[&st
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }
 }
 

--- a/crates/episteme/src/knowledge_store/tests/temporal.rs
+++ b/crates/episteme/src/knowledge_store/tests/temporal.rs
@@ -48,6 +48,7 @@ fn make_temporal_fact(
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }
 }
 

--- a/crates/episteme/src/ops_facts.rs
+++ b/crates/episteme/src/ops_facts.rs
@@ -151,6 +151,7 @@ fn build_ops_fact(
             fact_type: String::from("operational"),
             content: content.to_owned(),
             scope: Some(MemoryScope::Project),
+            project_id: None,
             temporal: FactTemporal {
                 valid_from: now,
                 valid_to: far_future(),

--- a/crates/episteme/src/query/queries.rs
+++ b/crates/episteme/src/query/queries.rs
@@ -36,6 +36,7 @@ pub(crate) fn upsert_fact() -> String {
             ForgottenAt,
             ForgetReason,
             Scope,
+            ProjectId,
             Visibility,
         ])
         .done()
@@ -71,6 +72,7 @@ pub(crate) fn current_facts() -> String {
         .bind(ForgottenAt)
         .bind(ForgetReason)
         .bind(Scope)
+        .bind(ProjectId)
         .bind(Visibility)
         .filter("nous_id = $nous_id")
         .filter("valid_from <= $now")
@@ -109,6 +111,7 @@ pub(crate) fn full_current_facts() -> String {
             ForgottenAt,
             ForgetReason,
             Scope,
+            ProjectId,
             Visibility,
         ])
         .bind(Id)
@@ -129,6 +132,7 @@ pub(crate) fn full_current_facts() -> String {
         .bind(ForgottenAt)
         .bind(ForgetReason)
         .bind(Scope)
+        .bind(ProjectId)
         .bind(Visibility)
         .filter("nous_id = $nous_id")
         .filter("valid_from <= $now")
@@ -156,6 +160,7 @@ pub(crate) fn facts_at_time() -> String {
         .bind(ValidTo)
         .bind(IsForgotten)
         .bind(Scope)
+        .bind(ProjectId)
         .bind(Visibility)
         .filter("valid_from <= $time")
         .filter("valid_to > $time")
@@ -192,6 +197,7 @@ pub(crate) fn supersede_fact() -> String {
             ForgottenAt,
             ForgetReason,
             Scope,
+            ProjectId,
             Visibility,
         ])
         .row(&[
@@ -213,6 +219,7 @@ pub(crate) fn supersede_fact() -> String {
             "$old_forgotten_at",
             "$old_forget_reason",
             "$old_scope",
+            "$old_project_id",
             "$old_visibility",
         ])
         .row(&[
@@ -234,6 +241,7 @@ pub(crate) fn supersede_fact() -> String {
             "null",
             "null",
             "$scope",
+            "$project_id",
             "$visibility",
         ])
         .done()
@@ -298,9 +306,9 @@ pub(crate) const ENTITY_NEIGHBORHOOD: &str = r"
 pub(crate) const BM25_RECALL: &str = r"
     bm25[id, score] := ~facts:content_fts{id | query: $query_text, k: $k, score_kind: 'bm25', bind_score: score}
 
-    ?[id, content, source_type, source_id, dist, scope, visibility] :=
+    ?[id, content, source_type, source_id, dist, scope, project_id, visibility] :=
         bm25[id, bm25_score],
-        *facts{id, content, is_forgotten, superseded_by, scope, visibility},
+        *facts{id, content, is_forgotten, superseded_by, scope, project_id, visibility},
         is_forgotten == false,
         is_null(superseded_by),
         source_type = 'fact',
@@ -413,11 +421,11 @@ pub(crate) const TEMPORAL_FACTS_FILTERED: &str = r"
     ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
       superseded_by, source_session_id,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
         *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                superseded_by, source_session_id, recorded_at,
                access_count, last_accessed_at, stability_hours, fact_type,
-               is_forgotten, forgotten_at, forget_reason, scope, visibility},
+               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
         nous_id = $nous_id,
         is_forgotten == false,
         valid_from <= $at_time,
@@ -434,11 +442,11 @@ pub(crate) const TEMPORAL_DIFF_ADDED: &str = r"
     ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
       superseded_by, source_session_id,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
         *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                superseded_by, source_session_id, recorded_at,
                access_count, last_accessed_at, stability_hours, fact_type,
-               is_forgotten, forgotten_at, forget_reason, scope, visibility},
+               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
         nous_id = $nous_id,
         is_forgotten == false,
         valid_from > $from_time,
@@ -451,11 +459,11 @@ pub(crate) const TEMPORAL_DIFF_REMOVED: &str = r"
     ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
       superseded_by, source_session_id,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
         *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                superseded_by, source_session_id, recorded_at,
                access_count, last_accessed_at, stability_hours, fact_type,
-               is_forgotten, forgotten_at, forget_reason, scope, visibility},
+               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
         nous_id = $nous_id,
         is_forgotten == false,
         valid_to > $from_time,

--- a/crates/episteme/src/query/schema.rs
+++ b/crates/episteme/src/query/schema.rs
@@ -69,6 +69,7 @@ pub enum FactsField {
     ForgottenAt,
     ForgetReason,
     Scope,
+    ProjectId,
     Visibility,
 }
 

--- a/crates/episteme/src/query/schema/field_impl.rs
+++ b/crates/episteme/src/query/schema/field_impl.rs
@@ -26,6 +26,7 @@ impl Field for FactsField {
             Self::ForgottenAt => "forgotten_at",
             Self::ForgetReason => "forget_reason",
             Self::Scope => "scope",
+            Self::ProjectId => "project_id",
             Self::Visibility => "visibility",
         }
     }

--- a/crates/episteme/src/query/tests/builders.rs
+++ b/crates/episteme/src/query/tests/builders.rs
@@ -24,15 +24,15 @@ fn test_builder_matches_upsert_fact() {
     ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
       superseded_by, source_session_id, recorded_at,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, visibility] <- [[$id, $valid_from,
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] <- [[$id, $valid_from,
       $content, $nous_id, $confidence, $tier, $valid_to, $superseded_by,
       $source_session_id, $recorded_at,
       $access_count, $last_accessed_at, $stability_hours, $fact_type,
-      $is_forgotten, $forgotten_at, $forget_reason, $scope, $visibility]]
+      $is_forgotten, $forgotten_at, $forget_reason, $scope, $project_id, $visibility]]
     :put facts {id, valid_from => content, nous_id, confidence, tier,
                 valid_to, superseded_by, source_session_id, recorded_at,
                 access_count, last_accessed_at, stability_hours, fact_type,
-                is_forgotten, forgotten_at, forget_reason, scope, visibility}
+                is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
 ";
     let built = queries::upsert_fact();
     assert_eq!(
@@ -49,7 +49,7 @@ fn test_builder_matches_current_facts() {
         *facts{id, valid_from, content, nous_id, confidence, tier,
                valid_to, superseded_by, recorded_at,
                access_count, last_accessed_at, stability_hours, fact_type,
-               is_forgotten, forgotten_at, forget_reason, scope, visibility},
+               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
         nous_id = $nous_id,
         valid_from <= $now,
         valid_to > $now,
@@ -70,7 +70,7 @@ fn test_builder_matches_current_facts() {
 fn test_builder_matches_facts_at_time() {
     let original = r"
     ?[id, content, confidence, tier] :=
-        *facts{id, valid_from, content, confidence, tier, valid_to, is_forgotten, scope, visibility},
+        *facts{id, valid_from, content, confidence, tier, valid_to, is_forgotten, scope, project_id, visibility},
         valid_from <= $time,
         valid_to > $time,
         is_forgotten == false
@@ -89,20 +89,20 @@ fn test_builder_matches_supersede_fact() {
     ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
       superseded_by, source_session_id, recorded_at,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, visibility] <- [
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] <- [
         [$old_id, $old_valid_from, $old_content, $nous_id, $old_confidence,
          $old_tier, $now, $new_id, $old_source, $old_recorded,
          $old_access_count, $old_last_accessed_at, $old_stability_hours, $old_fact_type,
-         $old_is_forgotten, $old_forgotten_at, $old_forget_reason, $old_scope, $old_visibility],
+         $old_is_forgotten, $old_forgotten_at, $old_forget_reason, $old_scope, $old_project_id, $old_visibility],
         [$new_id, $now, $new_content, $nous_id, $new_confidence,
          $new_tier, "9999-12-31", null, $source_session_id, $now,
          0, "", $stability_hours, $fact_type,
-         false, null, null, $scope, $visibility]
+         false, null, null, $scope, $project_id, $visibility]
     ]
     :put facts {id, valid_from => content, nous_id, confidence, tier,
                 valid_to, superseded_by, source_session_id, recorded_at,
                 access_count, last_accessed_at, stability_hours, fact_type,
-                is_forgotten, forgotten_at, forget_reason, scope, visibility}
+                is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
 "#;
     let built = queries::supersede_fact();
     assert_eq!(
@@ -163,11 +163,11 @@ fn test_builder_matches_full_current_facts() {
     let original = r"
 ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to, superseded_by, source_session_id,
   access_count, last_accessed_at, stability_hours, fact_type,
-  is_forgotten, forgotten_at, forget_reason, scope, visibility] :=
+  is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
     *facts{id, valid_from, content, nous_id, confidence, tier,
            valid_to, superseded_by, source_session_id, recorded_at,
            access_count, last_accessed_at, stability_hours, fact_type,
-           is_forgotten, forgotten_at, forget_reason, scope, visibility},
+           is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
     nous_id = $nous_id,
     valid_from <= $now,
     valid_to > $now,

--- a/crates/episteme/src/recall/mod.rs
+++ b/crates/episteme/src/recall/mod.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::hash::BuildHasher;
 
 use eidos::meta::{ArtefactMeta, Stamped};
+use eidos::workspace::ProjectId;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
@@ -144,6 +145,10 @@ pub struct ScoredResult {
     /// `None` for results from non-fact sources or facts created before the
     /// team memory model was introduced.
     pub scope: Option<crate::knowledge::MemoryScope>,
+    /// Project partition for project-scoped recall.
+    ///
+    /// `None` means the result is global or predates project partitioning.
+    pub project_id: Option<ProjectId>,
 }
 
 impl Stamped for ScoredResult {
@@ -753,6 +758,38 @@ pub fn filter_by_visibility(candidates: Vec<ScoredResult>, min: Visibility) -> V
         .into_iter()
         .filter(|c| c.visibility >= min)
         .collect()
+}
+
+/// Project recall scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectRecallScope {
+    /// Return all projects and global results.
+    Global,
+    /// Return only this project plus global results.
+    Project(ProjectId),
+}
+
+/// Filter recall candidates by project partition.
+///
+/// Project-scoped reads retain global rows (`project_id = None`) so promoted
+/// cross-project facts remain visible. Facts tied to a different project are
+/// excluded unless the caller explicitly selects [`ProjectRecallScope::Global`].
+///
+/// # Complexity
+///
+/// O(C) where C is the number of candidates.
+#[must_use]
+pub fn filter_by_project_scope(
+    candidates: Vec<ScoredResult>,
+    scope: &ProjectRecallScope,
+) -> Vec<ScoredResult> {
+    match scope {
+        ProjectRecallScope::Global => candidates,
+        ProjectRecallScope::Project(project_id) => candidates
+            .into_iter()
+            .filter(|c| c.project_id.as_ref().is_none_or(|id| id == project_id))
+            .collect(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/episteme/src/recall/reranker.rs
+++ b/crates/episteme/src/recall/reranker.rs
@@ -211,7 +211,10 @@ impl HttpReranker {
 #[cfg(feature = "local-reranker")]
 #[derive(Debug, Clone)]
 pub struct CrossEncoderReranker {
-    #[expect(dead_code, reason = "groundwork stub: model_path stored for future ONNX wiring")]
+    #[expect(
+        dead_code,
+        reason = "groundwork stub: model_path stored for future ONNX wiring"
+    )]
     model_path: String,
 }
 
@@ -378,6 +381,7 @@ mod tests {
             sensitivity: FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         }
     }
 

--- a/crates/episteme/src/recall_tests/edge_cases.rs
+++ b/crates/episteme/src/recall_tests/edge_cases.rs
@@ -324,6 +324,7 @@ fn rank_preserves_equal_scores() {
             sensitivity: crate::knowledge::FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
         ScoredResult {
             content: "second".to_owned(),
@@ -335,6 +336,7 @@ fn rank_preserves_equal_scores() {
             sensitivity: crate::knowledge::FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
     ];
     let ranked = e.rank(candidates);
@@ -370,6 +372,7 @@ fn rank_large_input() {
                 sensitivity: crate::knowledge::FactSensitivity::Public,
                 visibility: crate::knowledge::Visibility::Private,
                 scope: None,
+                project_id: None,
             }
         })
         .collect();
@@ -692,6 +695,7 @@ fn integration_full_recall_with_decay() {
             sensitivity: crate::knowledge::FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
         ScoredResult {
             content: "old observation".to_owned(),
@@ -711,6 +715,7 @@ fn integration_full_recall_with_decay() {
             sensitivity: crate::knowledge::FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
     ];
 

--- a/crates/episteme/src/recall_tests/ranking.rs
+++ b/crates/episteme/src/recall_tests/ranking.rs
@@ -27,6 +27,7 @@ fn rank_sorts_by_score_descending() {
             sensitivity: crate::knowledge::FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
         ScoredResult {
             content: "high".to_owned(),
@@ -44,6 +45,7 @@ fn rank_sorts_by_score_descending() {
             sensitivity: crate::knowledge::FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
         ScoredResult {
             content: "mid".to_owned(),
@@ -59,6 +61,7 @@ fn rank_sorts_by_score_descending() {
             sensitivity: crate::knowledge::FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
     ];
 
@@ -233,6 +236,7 @@ fn rank_single_element() {
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }];
     let ranked = e.rank(single);
     assert_eq!(
@@ -399,6 +403,7 @@ fn verified_tier_scores_higher_than_inferred_in_ranking() {
             sensitivity: crate::knowledge::FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
         ScoredResult {
             content: "verified fact".to_owned(),
@@ -418,6 +423,7 @@ fn verified_tier_scores_higher_than_inferred_in_ranking() {
             sensitivity: crate::knowledge::FactSensitivity::Public,
             visibility: crate::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
     ];
 
@@ -501,6 +507,7 @@ fn rank_deterministic() {
                 sensitivity: crate::knowledge::FactSensitivity::Public,
                 visibility: crate::knowledge::Visibility::Private,
                 scope: None,
+                project_id: None,
             },
             ScoredResult {
                 content: "beta".to_owned(),
@@ -516,6 +523,7 @@ fn rank_deterministic() {
                 sensitivity: crate::knowledge::FactSensitivity::Public,
                 visibility: crate::knowledge::Visibility::Private,
                 scope: None,
+                project_id: None,
             },
         ]
     };

--- a/crates/episteme/src/recall_tests/side_query.rs
+++ b/crates/episteme/src/recall_tests/side_query.rs
@@ -115,6 +115,7 @@ fn make_scored_result(source_id: &str, score: f64) -> ScoredResult {
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }
 }
 

--- a/crates/episteme/src/recall_tests/stamped.rs
+++ b/crates/episteme/src/recall_tests/stamped.rs
@@ -23,6 +23,7 @@ fn sample_scored_result() -> ScoredResult {
         sensitivity: FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }
 }
 

--- a/crates/episteme/src/recall_tests/visibility.rs
+++ b/crates/episteme/src/recall_tests/visibility.rs
@@ -5,8 +5,8 @@
 )]
 
 use crate::knowledge::Visibility;
-use crate::recall::{FactorScores, ScoredResult};
-use crate::recall::{filter_by_cohort_visibility, filter_by_visibility};
+use crate::recall::{FactorScores, ProjectRecallScope, ScoredResult};
+use crate::recall::{filter_by_cohort_visibility, filter_by_project_scope, filter_by_visibility};
 
 fn make_scored_with_visibility(nous_id: &str, visibility: Visibility) -> ScoredResult {
     ScoredResult {
@@ -19,6 +19,14 @@ fn make_scored_with_visibility(nous_id: &str, visibility: Visibility) -> ScoredR
         sensitivity: crate::knowledge::FactSensitivity::Public,
         visibility,
         scope: None,
+        project_id: None,
+    }
+}
+
+fn make_scored_with_project(project_id: Option<eidos::workspace::ProjectId>) -> ScoredResult {
+    ScoredResult {
+        project_id,
+        ..make_scored_with_visibility("alice", Visibility::Private)
     }
 }
 
@@ -161,6 +169,64 @@ fn min_visibility_published_keeps_only_published() {
         "Published minimum should keep only Published"
     );
     assert_eq!(filtered[0].visibility, Visibility::Published);
+}
+
+#[test]
+fn project_scope_keeps_current_project_and_global_results() {
+    let project_alpha =
+        eidos::workspace::ProjectId::from_git_remote("https://github.com/acme/alpha.git")
+            .expect("valid remote");
+    let project_beta =
+        eidos::workspace::ProjectId::from_git_remote("https://github.com/acme/beta.git")
+            .expect("valid remote");
+
+    let candidates = vec![
+        make_scored_with_project(Some(project_alpha.clone())),
+        make_scored_with_project(Some(project_beta)),
+        make_scored_with_project(None),
+    ];
+
+    let filtered = filter_by_project_scope(
+        candidates,
+        &ProjectRecallScope::Project(project_alpha.clone()),
+    );
+
+    assert_eq!(
+        filtered.len(),
+        2,
+        "project-scoped recall should keep current project plus global facts"
+    );
+    assert!(
+        filtered.iter().all(|result| result
+            .project_id
+            .as_ref()
+            .is_none_or(|id| id == &project_alpha)),
+        "other project facts should be excluded"
+    );
+}
+
+#[test]
+fn global_project_scope_keeps_all_projects() {
+    let project_alpha =
+        eidos::workspace::ProjectId::from_git_remote("https://github.com/acme/alpha.git")
+            .expect("valid remote");
+    let project_beta =
+        eidos::workspace::ProjectId::from_git_remote("https://github.com/acme/beta.git")
+            .expect("valid remote");
+
+    let candidates = vec![
+        make_scored_with_project(Some(project_alpha)),
+        make_scored_with_project(Some(project_beta)),
+        make_scored_with_project(None),
+    ];
+
+    let filtered = filter_by_project_scope(candidates, &ProjectRecallScope::Global);
+
+    assert_eq!(
+        filtered.len(),
+        3,
+        "global recall should be an explicit all-project read"
+    );
 }
 
 #[test]

--- a/crates/episteme/src/succession.rs
+++ b/crates/episteme/src/succession.rs
@@ -444,6 +444,7 @@ mod tests {
                 sensitivity: crate::knowledge::FactSensitivity::Public,
                 visibility: crate::knowledge::Visibility::Private,
                 scope: None,
+                project_id: None,
             }
         }
 

--- a/crates/episteme/src/verification/tests.rs
+++ b/crates/episteme/src/verification/tests.rs
@@ -22,6 +22,7 @@ fn make_fact(id: &str, confidence: f64, tier: EpistemicTier, recorded_at: Timest
         fact_type: "preference".to_owned(),
         content: format!("test fact {id}"),
         scope: None,
+        project_id: None,
         sensitivity: FactSensitivity::Public,
         visibility: crate::knowledge::Visibility::Private,
         temporal: FactTemporal {
@@ -208,7 +209,7 @@ fn fresh_store_migrates_to_current_schema() {
 
     let store = KnowledgeStore::open_mem().expect("open_mem should succeed");
     let v = store.schema_version().expect("read schema version");
-    assert_eq!(v, 11, "fresh store should initialize at schema version 11");
+    assert_eq!(v, 12, "fresh store should initialize at schema version 12");
 
     // Probe the new relations exist by querying them (empty result is fine).
     let probe_pubs = store.run_query("?[id] := *published_facts{id}", BTreeMap::new());

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -239,14 +239,17 @@ pub mod extract {
 ///
 /// [`DEFAULT_MAX_CONTEXT_SUMMARY_LEN`](instinct::DEFAULT_MAX_CONTEXT_SUMMARY_LEN),
 /// [`DEFAULT_MAX_PARAM_VALUE_LEN`](instinct::DEFAULT_MAX_PARAM_VALUE_LEN),
+/// [`DEFAULT_PROMOTION_MIN_CONFIDENCE`](instinct::DEFAULT_PROMOTION_MIN_CONFIDENCE),
+/// [`DEFAULT_PROMOTION_MIN_PROJECTS`](instinct::DEFAULT_PROMOTION_MIN_PROJECTS),
 /// [`ToolObservation`](instinct::ToolObservation),
 /// [`ToolOutcome`](instinct::ToolOutcome),
 /// [`sanitize_parameters`](instinct::sanitize_parameters),
 /// [`truncate_context_summary`](instinct::truncate_context_summary)
 pub mod instinct {
     pub use episteme::instinct::{
-        DEFAULT_MAX_CONTEXT_SUMMARY_LEN, DEFAULT_MAX_PARAM_VALUE_LEN, ToolObservation, ToolOutcome,
-        sanitize_parameters, truncate_context_summary,
+        DEFAULT_MAX_CONTEXT_SUMMARY_LEN, DEFAULT_MAX_PARAM_VALUE_LEN,
+        DEFAULT_PROMOTION_MIN_CONFIDENCE, DEFAULT_PROMOTION_MIN_PROJECTS, ToolObservation,
+        ToolOutcome, sanitize_parameters, truncate_context_summary,
     };
 }
 
@@ -294,12 +297,13 @@ pub mod query_rewrite {
 ///
 /// [`FactorScores`](recall::FactorScores),
 /// [`RecallEngine`](recall::RecallEngine),
+/// [`ProjectRecallScope`](recall::ProjectRecallScope),
 /// [`RecallWeights`](recall::RecallWeights),
 /// [`ScoredResult`](recall::ScoredResult)
 pub mod recall {
     pub use episteme::recall::{
-        FactorScores, RecallEngine, RecallWeights, ScoredResult, filter_by_cohort_visibility,
-        filter_by_visibility,
+        FactorScores, ProjectRecallScope, RecallEngine, RecallWeights, ScoredResult,
+        filter_by_cohort_visibility, filter_by_project_scope, filter_by_visibility,
     };
 
     /// Optional reranker implementations and trait.

--- a/crates/nous/src/actor/background.rs
+++ b/crates/nous/src/actor/background.rs
@@ -806,6 +806,7 @@ async fn run_skill_extraction(
                             content,
                             fact_type: "skill_pending".to_owned(),
                             scope: None,
+                            project_id: None,
                             temporal: FactTemporal {
                                 valid_from: now,
                                 valid_to: jiff::Timestamp::from_second(i64::MAX / 2).unwrap_or(now),

--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -447,6 +447,7 @@ fn fact_from_content(
         fact_type: fact_type.clone(),
         content: content.to_owned(),
         scope: Some(MemoryScope::Project),
+        project_id: None,
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         visibility: Visibility::Private,
         temporal: FactTemporal {

--- a/crates/nous/src/pipeline/stages.rs
+++ b/crates/nous/src/pipeline/stages.rs
@@ -169,7 +169,7 @@ pub(super) async fn run_context_stage(
 )]
 pub(super) async fn run_recall_stage(
     config: &NousConfig,
-    _pipeline_config: &PipelineConfig,
+    pipeline_config: &PipelineConfig,
     ctx: &mut PipelineContext,
     content: &str,
     embedding_provider: Option<&dyn EmbeddingProvider>,
@@ -221,7 +221,8 @@ pub(super) async fn run_recall_stage(
                 "embeddings unavailable — using BM25-only recall"
             );
             let recall_stage = crate::recall::RecallStage::new(config.recall.clone())
-                .with_deployment_target(deployment_target);
+                .with_deployment_target(deployment_target)
+                .with_project_scope(project_recall_scope(pipeline_config));
             let result = recall_stage.run_bm25(content, &config.id, ts, budget);
             apply_recall_result(result, ctx, &span, config.recall.late_inject_anchor);
         } else {
@@ -234,7 +235,8 @@ pub(super) async fn run_recall_stage(
         }
     } else if let (Some(ep), Some(vs)) = (embedding_provider, vector_search) {
         let recall_stage = crate::recall::RecallStage::new(config.recall.clone())
-            .with_deployment_target(deployment_target);
+            .with_deployment_target(deployment_target)
+            .with_project_scope(project_recall_scope(pipeline_config));
         let recall_bridge = ProviderRecallBridge {
             providers,
             model: &config.generation.model,
@@ -266,6 +268,13 @@ pub(super) async fn run_recall_stage(
         duration_secs,
     });
     Ok(())
+}
+
+fn project_recall_scope(pipeline_config: &PipelineConfig) -> mneme::recall::ProjectRecallScope {
+    pipeline_config.project_id.clone().map_or(
+        mneme::recall::ProjectRecallScope::Global,
+        mneme::recall::ProjectRecallScope::Project,
+    )
 }
 
 /// History stage: load conversation history within token budget.

--- a/crates/nous/src/recall/mod.rs
+++ b/crates/nous/src/recall/mod.rs
@@ -113,6 +113,8 @@ pub struct RecallStage {
     late_inject_anchor: bool,
     /// Per-scope minimum result counts with slack-fill.
     scope_quotas: HashMap<MemoryScope, usize>,
+    /// Project partition filter applied before scoring thresholds and budgeting.
+    project_scope: mneme::recall::ProjectRecallScope,
     /// Optional URL for an HTTP cross-encoder reranker.
     reranker_url: Option<String>,
 }
@@ -148,6 +150,7 @@ impl RecallStage {
             pinned_facts,
             late_inject_anchor,
             scope_quotas,
+            project_scope: mneme::recall::ProjectRecallScope::Global,
             reranker_url,
         }
     }
@@ -196,6 +199,13 @@ impl RecallStage {
     #[must_use]
     pub fn with_scope_quotas(mut self, quotas: HashMap<MemoryScope, usize>) -> Self {
         self.scope_quotas = quotas;
+        self
+    }
+
+    /// Set project recall scope.
+    #[must_use]
+    pub fn with_project_scope(mut self, scope: mneme::recall::ProjectRecallScope) -> Self {
+        self.project_scope = scope;
         self
     }
 
@@ -553,6 +563,7 @@ impl RecallStage {
         // unchanged.
         let ranked =
             mneme::recall::filter_by_visibility(ranked, mneme::knowledge::Visibility::Private);
+        let ranked = mneme::recall::filter_by_project_scope(ranked, &self.project_scope);
         // TODO(#208) [deliberate-prudent]: wire `filter_by_cohort_visibility` once
         // `build_candidates` populates `nous_id` from the search layer instead of
         // `String::new()`.
@@ -752,6 +763,7 @@ impl RecallStage {
                 // per-fact classification rather than assuming `Public`.
                 sensitivity: r.sensitivity,
                 scope: r.scope,
+                project_id: r.project_id,
                 visibility: r.visibility,
             })
             .collect()

--- a/crates/nous/src/recall_tests/mod.rs
+++ b/crates/nous/src/recall_tests/mod.rs
@@ -75,6 +75,7 @@ fn make_knowledge_result(content: &str, distance: f64) -> KnowledgeRecallResult 
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         graph_importance: 0.0,
         scope: None,
+        project_id: None,
         visibility: mneme::knowledge::Visibility::Private,
     }
 }
@@ -92,6 +93,7 @@ fn make_knowledge_result_with_id(
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         graph_importance: 0.0,
         scope: None,
+        project_id: None,
         visibility: mneme::knowledge::Visibility::Private,
     }
 }
@@ -109,6 +111,7 @@ fn make_knowledge_result_with_scope(
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         graph_importance: 0.0,
         scope,
+        project_id: None,
         visibility: mneme::knowledge::Visibility::Private,
     }
 }
@@ -124,6 +127,7 @@ fn make_scored(content: &str, score: f64) -> ScoredResult {
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         visibility: mneme::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }
 }
 

--- a/crates/nous/src/recall_tests/recall_core.rs
+++ b/crates/nous/src/recall_tests/recall_core.rs
@@ -103,6 +103,7 @@ fn recall_formats_section_with_metadata() {
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         visibility: mneme::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
     let b = ScoredResult {
         content: "Project deadline is March 15".to_owned(),
@@ -122,6 +123,7 @@ fn recall_formats_section_with_metadata() {
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         visibility: mneme::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     };
     let refs: Vec<&ScoredResult> = vec![&a, &b];
     let section = format_section(&refs, true);

--- a/crates/nous/src/recall_tests/terminology_discovery.rs
+++ b/crates/nous/src/recall_tests/terminology_discovery.rs
@@ -18,6 +18,7 @@ fn terminology_discovery_finds_novel_terms() {
             sensitivity: mneme::knowledge::FactSensitivity::Public,
             visibility: mneme::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
         ScoredResult {
             content: "quantum computing leverages superposition states".to_owned(),
@@ -29,6 +30,7 @@ fn terminology_discovery_finds_novel_terms() {
             sensitivity: mneme::knowledge::FactSensitivity::Public,
             visibility: mneme::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         },
     ];
 
@@ -52,6 +54,7 @@ fn terminology_discovery_ignores_stopwords() {
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         visibility: mneme::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }];
 
     let terms = discover_terminology(&results, "test query");
@@ -79,6 +82,7 @@ fn terminology_discovery_skips_short_words() {
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         visibility: mneme::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }];
 
     let terms = discover_terminology(&results, "test");
@@ -101,6 +105,7 @@ fn gap_detection_finds_capitalized_phrases() {
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         visibility: mneme::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }];
 
     let gaps = detect_gaps(&results);
@@ -123,6 +128,7 @@ fn gap_detection_finds_quoted_strings() {
         sensitivity: mneme::knowledge::FactSensitivity::Public,
         visibility: mneme::knowledge::Visibility::Private,
         scope: None,
+        project_id: None,
     }];
 
     let gaps = detect_gaps(&results);
@@ -212,6 +218,7 @@ fn make_knowledge_result_sensitive(
         sensitivity,
         graph_importance: 0.0,
         scope: None,
+        project_id: None,
         visibility: mneme::knowledge::Visibility::Private,
     }
 }

--- a/crates/nous/src/self_audit/mod.rs
+++ b/crates/nous/src/self_audit/mod.rs
@@ -353,6 +353,7 @@ pub fn store_audit_report(
             fact_type: String::from("audit"),
             content,
             scope: None,
+            project_id: None,
             temporal: FactTemporal {
                 valid_from: now,
                 valid_to: far_future(),

--- a/crates/nous/src/skills.rs
+++ b/crates/nous/src/skills.rs
@@ -594,6 +594,7 @@ mod tests {
             sensitivity: mneme::knowledge::FactSensitivity::Public,
             visibility: mneme::knowledge::Visibility::Private,
             scope: None,
+            project_id: None,
         }
     }
 


### PR DESCRIPTION
Summary
- Add ProjectId parsing for stored SHA-256 hex values and persist project_id on facts and recall results.
- Carry project partitions through knowledge store recall hydration and apply project-scoped recall defaults from PipelineConfig.
- Add cross-project instinct promotion gate and synthetic project tests.

Verification
- cargo fmt --all --check
- cargo check --workspace --target-dir /tmp/kimi-t3-3975-target
- cargo test -p eidos -p episteme -p mneme -p nous --lib --target-dir /tmp/kimi-t3-3975-target
- git diff --check
- kanon lint . --rust --format tsv --summary --precision high --min-severity error --paths-from /tmp/kimi-t3-3975-paths.txt

Closes #3975

Gate-Passed: kanon 0.1.0