### PR TITLE
feat(agora): reintroduce Matrix channel provider

### DIFF
--- a/crates/agora/Cargo.toml
+++ b/crates/agora/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agora"
 version.workspace = true
-description = "Channel registry and provider implementations (Signal)"
+description = "Channel registry and provider implementations (Signal, Matrix)"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/agora/src/lib.rs
+++ b/crates/agora/src/lib.rs
@@ -3,12 +3,14 @@
 //!
 //! Agora (ἀγορά): "gathering place." The public square where messages flow
 //! between Aletheia and the outside world. Provides the channel abstraction
-//! and registry, with Signal (semeion) as the first provider.
+//! and registry, with Signal (semeion) and Matrix providers.
 
 /// Error types for channel operations and provider failures.
 pub(crate) mod error;
 /// Unified channel listener that merges inbound messages from all providers into a single stream.
 pub mod listener;
+/// Matrix channel provider backed by the Matrix Client-Server API.
+pub mod matrix;
 /// Prometheus metric definitions for channel messaging.
 pub mod metrics;
 /// Channel registry: the single source of truth for available channel providers.
@@ -23,6 +25,8 @@ pub mod types;
 #[cfg(test)]
 mod assertions {
     use super::listener::ChannelListener;
+    use super::matrix::MatrixProvider;
+    use super::matrix::client::MatrixClient;
     use super::registry::ChannelRegistry;
     use super::router::MessageRouter;
     use super::semeion::SignalProvider;
@@ -36,6 +40,8 @@ mod assertions {
         assert_send::<ChannelListener>();
         assert_send_sync::<InboundMessage>();
         assert_send_sync::<MessageRouter>();
+        assert_send_sync::<MatrixClient>();
+        assert_send_sync::<MatrixProvider>();
         assert_send_sync::<SignalClient>();
         assert_send_sync::<SignalProvider>();
     };

--- a/crates/agora/src/matrix/client.rs
+++ b/crates/agora/src/matrix/client.rs
@@ -1,0 +1,289 @@
+//! Matrix Client-Server API client.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use tracing::instrument;
+
+use koina::http::CONTENT_TYPE_JSON;
+
+use super::error::{self, Result};
+use super::{MatrixSyncResponse, encode_path_segment};
+
+/// Fallback default; runtime reads `MessagingConfig::rpc_timeout_secs`.
+pub(crate) const RPC_TIMEOUT: Duration = Duration::from_secs(10);
+/// Fallback default; runtime reads `MessagingConfig::receive_timeout_secs`.
+pub(crate) const SYNC_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Serialize)]
+struct SendMessageRequest<'a> {
+    msgtype: &'static str,
+    body: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "m.relates_to")]
+    relates_to: Option<ThreadRelation<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct ThreadRelation<'a> {
+    rel_type: &'static str,
+    event_id: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct MatrixErrorBody {
+    errcode: Option<String>,
+    error: Option<String>,
+}
+
+/// Async client for a single Matrix account.
+#[derive(Clone)]
+pub struct MatrixClient {
+    client: reqwest::Client,
+    homeserver: String,
+    access_token: String, // kanon:ignore RUST/plain-string-secret
+    sync_timeout: Duration,
+}
+
+impl MatrixClient {
+    /// Create a Matrix client with default timeouts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be constructed.
+    pub fn new(homeserver: &str, access_token: &str) -> Result<Self> {
+        Self::with_timeouts(homeserver, access_token, RPC_TIMEOUT, SYNC_TIMEOUT)
+    }
+
+    /// Create a Matrix client with explicit timeout configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be constructed.
+    pub fn with_timeouts(
+        homeserver: &str,
+        access_token: &str,
+        rpc_timeout: Duration,
+        sync_timeout: Duration,
+    ) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(rpc_timeout)
+            .build()
+            .context(error::HttpSnafu)?;
+
+        Ok(Self {
+            client,
+            homeserver: normalize_homeserver(homeserver),
+            access_token: access_token.to_owned(),
+            sync_timeout,
+        })
+    }
+
+    /// Send an `m.room.message` text event to a room or room alias.
+    #[instrument(skip(self, body), fields(room_id = %room_id))]
+    pub async fn send_text(
+        &self,
+        room_id: &str,
+        body: &str,
+        thread_id: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let txn_id = koina::uuid::uuid_v4();
+        let url = format!(
+            "{}/_matrix/client/v3/rooms/{}/send/m.room.message/{}",
+            self.homeserver,
+            encode_path_segment(room_id),
+            encode_path_segment(&txn_id)
+        );
+        let request = SendMessageRequest {
+            msgtype: "m.text",
+            body,
+            relates_to: thread_id.map(|event_id| ThreadRelation {
+                rel_type: "m.thread",
+                event_id,
+            }),
+        };
+
+        let response = self
+            .client
+            .put(url)
+            .bearer_auth(&self.access_token)
+            .header("content-type", CONTENT_TYPE_JSON)
+            .json(&request)
+            .send()
+            .await
+            .context(error::HttpSnafu)?;
+
+        json_response(response).await
+    }
+
+    /// Perform a Matrix `/sync` request.
+    #[instrument(skip(self, since))]
+    pub async fn sync(&self, since: Option<&str>) -> Result<MatrixSyncResponse> {
+        let mut query = vec![("timeout", self.sync_timeout.as_millis().to_string())];
+        if let Some(since_token) = since {
+            query.push(("since", since_token.to_owned()));
+        }
+
+        let url = format!("{}/_matrix/client/v3/sync", self.homeserver);
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(&self.access_token)
+            .query(&query)
+            .timeout(self.sync_timeout + Duration::from_secs(2))
+            .send()
+            .await
+            .context(error::HttpSnafu)?;
+
+        let value = json_response(response).await?;
+        serde_json::from_value(value).context(error::JsonSnafu)
+    }
+
+    /// Check whether the access token is accepted by the homeserver.
+    pub async fn health(&self) -> bool {
+        let url = format!("{}/_matrix/client/v3/account/whoami", self.homeserver);
+        let result = self
+            .client
+            .get(url)
+            .bearer_auth(&self.access_token)
+            .timeout(Duration::from_secs(2))
+            .send()
+            .await;
+        matches!(result, Ok(response) if response.status().is_success())
+    }
+}
+
+impl std::fmt::Debug for MatrixClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MatrixClient")
+            .field("homeserver", &self.homeserver)
+            .finish_non_exhaustive()
+    }
+}
+
+async fn json_response(response: reqwest::Response) -> Result<serde_json::Value> {
+    let status = response.status();
+    if status.is_success() {
+        return response.json().await.context(error::HttpSnafu);
+    }
+
+    let status_code = status.as_u16();
+    let body = response.text().await.context(error::HttpSnafu)?;
+    let message = serde_json::from_str::<MatrixErrorBody>(&body)
+        .ok()
+        .and_then(|error_body| match (error_body.errcode, error_body.error) {
+            (Some(code), Some(error)) => Some(format!("{code}: {error}")),
+            (None, Some(error)) => Some(error),
+            (Some(code), None) => Some(code),
+            (None, None) => None,
+        })
+        .unwrap_or(body);
+
+    error::ApiSnafu {
+        status: status_code,
+        message,
+    }
+    .fail()
+}
+
+fn normalize_homeserver(homeserver: &str) -> String {
+    homeserver.trim_end_matches('/').to_owned()
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use organon::testing::install_crypto_provider;
+    use wiremock::matchers::{body_json, header, method, path, path_regex, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn send_text_calls_room_send_endpoint() {
+        install_crypto_provider();
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path_regex(
+                r"^/_matrix/client/v3/rooms/%21room%3Aexample\.org/send/m\.room\.message/[A-Za-z0-9_-]+$",
+            ))
+            .and(header("authorization", "Bearer token-123"))
+            .and(body_json(serde_json::json!({
+                "msgtype": "m.text",
+                "body": "hello"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "event_id": "$event"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = MatrixClient::new(&server.uri(), "token-123").expect("client");
+        let result = client
+            .send_text("!room:example.org", "hello", None)
+            .await
+            .expect("send");
+        assert_eq!(
+            result.get("event_id").and_then(serde_json::Value::as_str),
+            Some("$event")
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_passes_since_token_and_timeout() {
+        install_crypto_provider();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/_matrix/client/v3/sync"))
+            .and(header("authorization", "Bearer token-123"))
+            .and(query_param("timeout", "50"))
+            .and(query_param("since", "s0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "next_batch": "s1",
+                "rooms": {
+                    "join": {
+                        "!room:example.org": {
+                            "timeline": {
+                                "events": []
+                            }
+                        }
+                    }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = MatrixClient::with_timeouts(
+            &server.uri(),
+            "token-123",
+            Duration::from_secs(1),
+            Duration::from_millis(50),
+        )
+        .expect("client");
+        let response = client.sync(Some("s0")).await.expect("sync");
+        assert_eq!(response.next_batch.as_deref(), Some("s1"));
+    }
+
+    #[tokio::test]
+    async fn api_error_surfaces_matrix_message() {
+        install_crypto_provider();
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "errcode": "M_FORBIDDEN",
+                "error": "no access"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = MatrixClient::new(&server.uri(), "token-123").expect("client");
+        let err = client
+            .send_text("!room:example.org", "hello", None)
+            .await
+            .expect_err("forbidden");
+        assert!(err.to_string().contains("M_FORBIDDEN: no access"));
+    }
+}

--- a/crates/agora/src/matrix/error.rs
+++ b/crates/agora/src/matrix/error.rs
@@ -1,0 +1,44 @@
+//! Matrix-specific error types.
+
+use snafu::Snafu;
+
+/// Result alias for Matrix client operations.
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+/// Matrix client and wire errors.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// HTTP transport or response decoding failed.
+    #[snafu(display("Matrix HTTP error: {source}"))]
+    Http {
+        /// Underlying reqwest error.
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        /// Source location captured by snafu.
+        location: snafu::Location,
+    },
+
+    /// JSON encoding or decoding failed.
+    #[snafu(display("Matrix JSON error: {source}"))]
+    Json {
+        /// Underlying serde JSON error.
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        /// Source location captured by snafu.
+        location: snafu::Location,
+    },
+
+    /// Matrix API returned an unsuccessful status.
+    #[snafu(display("Matrix API error {status}: {message}"))]
+    Api {
+        /// HTTP status code returned by the homeserver.
+        status: u16,
+        /// Matrix API error message.
+        message: String,
+        #[snafu(implicit)]
+        /// Source location captured by snafu.
+        location: snafu::Location,
+    },
+}

--- a/crates/agora/src/matrix/mod.rs
+++ b/crates/agora/src/matrix/mod.rs
@@ -1,0 +1,640 @@
+//! Matrix channel provider backed by the Matrix Client-Server API.
+
+/// Matrix Client-Server API client.
+pub mod client;
+/// Matrix-specific error types.
+pub mod error;
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, mpsc};
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, instrument};
+
+use crate::types::{
+    ChannelCapabilities, ChannelProvider, InboundMessage, ProbeResult,
+    SendParams as ChannelSendParams, SendResult,
+};
+
+/// Fallback default; runtime reads `MessagingConfig::poll_interval_ms`.
+pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+static MATRIX_CAPABILITIES: ChannelCapabilities = ChannelCapabilities {
+    threads: true,
+    reactions: false,
+    typing: false,
+    media: false,
+    streaming: false,
+    rich_formatting: false,
+    max_text_length: 65_536,
+};
+
+/// Joined-room section from Matrix `/sync`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MatrixSyncResponse {
+    /// Batch token to pass as `since` on the next sync.
+    pub next_batch: Option<String>,
+    /// Joined rooms returned by sync.
+    #[serde(default)]
+    pub rooms: MatrixRooms,
+}
+
+/// Matrix `/sync` rooms container.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MatrixRooms {
+    /// Joined rooms keyed by room ID.
+    #[serde(default)]
+    pub join: HashMap<String, MatrixJoinedRoom>,
+}
+
+/// Matrix joined-room sync payload.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MatrixJoinedRoom {
+    /// Timeline events returned for the room.
+    #[serde(default)]
+    pub timeline: MatrixTimeline,
+}
+
+/// Matrix room timeline payload.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MatrixTimeline {
+    /// Timeline events.
+    #[serde(default)]
+    pub events: Vec<MatrixEvent>,
+}
+
+/// Matrix event subset used by message extraction.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MatrixEvent {
+    /// Event type, e.g. `m.room.message`.
+    #[serde(rename = "type")]
+    pub event_type: String,
+    /// Matrix user ID of the sender.
+    pub sender: Option<String>,
+    /// Event ID.
+    pub event_id: Option<String>,
+    /// Server timestamp in milliseconds.
+    pub origin_server_ts: Option<u64>,
+    /// Event content.
+    #[serde(default)]
+    pub content: MatrixEventContent,
+    /// Raw unsigned metadata.
+    #[serde(default)]
+    pub unsigned: Option<serde_json::Value>,
+}
+
+/// Matrix room-message content subset.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MatrixEventContent {
+    /// Matrix message type, e.g. `m.text`.
+    pub msgtype: Option<String>,
+    /// Plain-text body.
+    pub body: Option<String>,
+    /// Additional content fields retained for attachments and raw diagnostics.
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Clone)]
+struct MatrixAccount {
+    client: client::MatrixClient,
+    user_id: Option<String>,
+    auto_start: bool,
+    since: Arc<Mutex<Option<String>>>,
+}
+
+/// Matrix channel provider implementing `ChannelProvider`.
+pub struct MatrixProvider {
+    accounts: HashMap<String, MatrixAccount>,
+    default_account: Option<String>,
+    circuit_breaker_threshold: u32,
+}
+
+impl MatrixProvider {
+    /// Create an empty Matrix provider.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            accounts: HashMap::new(),
+            default_account: None,
+            circuit_breaker_threshold: 5,
+        }
+    }
+
+    /// Create a Matrix provider from messaging config.
+    #[must_use]
+    pub fn from_config(config: &taxis::config::MessagingConfig) -> Self {
+        Self {
+            accounts: HashMap::new(),
+            default_account: None,
+            circuit_breaker_threshold: config.circuit_breaker_threshold,
+        }
+    }
+
+    /// Register a Matrix account.
+    pub fn add_account(
+        &mut self,
+        account_id: String,
+        client: client::MatrixClient,
+        user_id: Option<String>,
+        auto_start: bool,
+        initial_since: Option<String>,
+    ) {
+        if self.default_account.is_none() {
+            self.default_account = Some(account_id.clone());
+        }
+        self.accounts.insert(
+            account_id,
+            MatrixAccount {
+                client,
+                user_id,
+                auto_start,
+                since: Arc::new(Mutex::new(initial_since)),
+            },
+        );
+    }
+
+    /// Start Matrix `/sync` loops for accounts with `auto_start=true`.
+    #[instrument(skip(self, cancel))]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "CancellationToken is Arc-backed; pass-by-value is idiomatic"
+    )]
+    pub fn listen(
+        &self,
+        poll_interval: Option<Duration>,
+        cancel: CancellationToken,
+    ) -> (mpsc::Receiver<InboundMessage>, JoinSet<()>) {
+        let interval = poll_interval.unwrap_or(DEFAULT_POLL_INTERVAL);
+        let (tx, rx) = mpsc::channel(64);
+        let mut handles = JoinSet::new();
+
+        for (account_id, account) in &self.accounts {
+            if !account.auto_start {
+                tracing::info!(account = %account_id, "skipping Matrix sync loop (auto_start=false)");
+                continue;
+            }
+
+            let tx = tx.clone();
+            let token = cancel.clone();
+            let client = account.client.clone();
+            let since = Arc::clone(&account.since);
+            let user_id = account.user_id.clone();
+            let span = tracing::info_span!("matrix_sync", account = %account_id);
+
+            handles.spawn(
+                sync_loop(
+                    client,
+                    tx,
+                    interval,
+                    since,
+                    user_id,
+                    token,
+                    self.circuit_breaker_threshold,
+                )
+                .instrument(span),
+            );
+        }
+
+        (rx, handles)
+    }
+
+    fn resolve_account(&self, account_id: Option<&str>) -> Option<&MatrixAccount> {
+        let key = account_id.or(self.default_account.as_deref())?;
+        self.accounts.get(key)
+    }
+}
+
+impl Default for MatrixProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChannelProvider for MatrixProvider {
+    #[expect(
+        clippy::unnecessary_literal_bound,
+        reason = "trait signature requires &str"
+    )]
+    fn id(&self) -> &str {
+        "matrix"
+    }
+
+    #[expect(
+        clippy::unnecessary_literal_bound,
+        reason = "trait signature requires &str"
+    )]
+    fn name(&self) -> &str {
+        "Matrix"
+    }
+
+    fn capabilities(&self) -> &ChannelCapabilities {
+        &MATRIX_CAPABILITIES
+    }
+
+    fn send<'a>(
+        &'a self,
+        params: &'a ChannelSendParams,
+    ) -> Pin<Box<dyn Future<Output = SendResult> + Send + 'a>> {
+        Box::pin(async move {
+            if params
+                .attachments
+                .as_ref()
+                .is_some_and(|items| !items.is_empty())
+            {
+                return SendResult::err("Matrix media attachments are not supported");
+            }
+
+            let Some(account) = self.resolve_account(params.account_id.as_deref()) else {
+                return SendResult::err("no Matrix client available");
+            };
+
+            match account
+                .client
+                .send_text(&params.to, &params.text, params.thread_id.as_deref())
+                .await
+            {
+                Ok(_) => SendResult::ok(),
+                Err(e) => SendResult::err(e.to_string()),
+            }
+        })
+    }
+
+    fn listen(
+        &self,
+        poll_interval: Option<Duration>,
+        cancel: CancellationToken,
+    ) -> (mpsc::Receiver<InboundMessage>, JoinSet<()>) {
+        MatrixProvider::listen(self, poll_interval, cancel)
+    }
+
+    fn probe<'a>(&'a self) -> Pin<Box<dyn Future<Output = ProbeResult> + Send + 'a>> {
+        Box::pin(async move {
+            if self.accounts.is_empty() {
+                return ProbeResult {
+                    ok: false,
+                    latency_ms: None,
+                    error: Some("no Matrix clients configured".to_owned()),
+                    details: None,
+                };
+            }
+
+            let mut details = HashMap::new();
+            let mut any_ok = false;
+            for (account_id, account) in &self.accounts {
+                let ok = account.client.health().await;
+                any_ok |= ok;
+                details.insert(
+                    account_id.clone(),
+                    serde_json::json!({
+                        "reachable": ok,
+                        "auto_start": account.auto_start,
+                    }),
+                );
+            }
+
+            ProbeResult {
+                ok: any_ok,
+                latency_ms: None,
+                error: if any_ok {
+                    None
+                } else {
+                    Some("all Matrix accounts unreachable".to_owned())
+                },
+                details: Some(details),
+            }
+        })
+    }
+}
+
+impl std::fmt::Debug for MatrixProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MatrixProvider")
+            .field("accounts", &self.accounts.keys().collect::<Vec<_>>())
+            .field("default_account", &self.default_account)
+            .field("circuit_breaker_threshold", &self.circuit_breaker_threshold)
+            .finish()
+    }
+}
+
+async fn sync_loop(
+    client: client::MatrixClient,
+    tx: mpsc::Sender<InboundMessage>,
+    interval: Duration,
+    since: Arc<Mutex<Option<String>>>,
+    user_id: Option<String>,
+    cancel: CancellationToken,
+    circuit_breaker_threshold: u32,
+) {
+    tracing::info!("Matrix sync started");
+    let mut consecutive_failures = 0_u32;
+
+    loop {
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                tracing::info!("cancellation received, stopping Matrix sync");
+                return;
+            }
+            result = sync_once(&client, &tx, &since, user_id.as_deref()) => {
+                match result {
+                    Ok(()) => {
+                        consecutive_failures = 0;
+                        tokio::time::sleep(interval).await;
+                    }
+                    Err(e) => {
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        tracing::warn!(
+                            error = %e,
+                            consecutive_failures,
+                            "Matrix sync failed"
+                        );
+                        if consecutive_failures >= circuit_breaker_threshold {
+                            tracing::error!(
+                                consecutive_failures,
+                                "Matrix sync halted after repeated failures"
+                            );
+                            return;
+                        }
+                        tokio::time::sleep(interval).await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn sync_once(
+    client: &client::MatrixClient,
+    tx: &mpsc::Sender<InboundMessage>,
+    since: &Arc<Mutex<Option<String>>>,
+    own_user_id: Option<&str>,
+) -> error::Result<()> {
+    let since_token = { since.lock().await.clone() };
+    let response = client.sync(since_token.as_deref()).await?;
+
+    for (room_id, room) in &response.rooms.join {
+        for event in &room.timeline.events {
+            if let Some(message) = extract_message(room_id, event, own_user_id)
+                && tx.send(message).await.is_err()
+            {
+                tracing::info!("receiver dropped, stopping Matrix sync");
+                return Ok(());
+            }
+        }
+    }
+
+    if let Some(next_batch) = response.next_batch {
+        let mut guard = since.lock().await;
+        *guard = Some(next_batch);
+    }
+
+    Ok(())
+}
+
+fn extract_message(
+    room_id: &str,
+    event: &MatrixEvent,
+    own_user_id: Option<&str>,
+) -> Option<InboundMessage> {
+    if event.event_type != "m.room.message" {
+        return None;
+    }
+
+    let sender = event.sender.as_deref()?;
+    if own_user_id.is_some_and(|own| own == sender) {
+        return None;
+    }
+
+    let text = event.content.body.as_deref()?;
+    if text.is_empty() {
+        return None;
+    }
+
+    let attachments = event
+        .content
+        .extra
+        .get("url")
+        .and_then(serde_json::Value::as_str)
+        .map(|url| vec![url.to_owned()])
+        .unwrap_or_default();
+
+    Some(InboundMessage {
+        channel: "matrix".to_owned(),
+        sender: sender.to_owned(),
+        sender_name: None,
+        group_id: Some(room_id.to_owned()),
+        text: text.to_owned(),
+        timestamp: event.origin_server_ts.unwrap_or_else(|| {
+            tracing::warn!("Matrix event has no timestamp, defaulting to 0");
+            0
+        }),
+        attachments,
+        raw: serde_json::to_value(event).ok(),
+    })
+}
+
+pub(crate) fn encode_path_segment(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(char::from(byte));
+            }
+            _ => {
+                encoded.push('%');
+                encoded.push(hex_digit(byte >> 4));
+                encoded.push(hex_digit(byte & 0x0f));
+            }
+        }
+    }
+    encoded
+}
+
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => char::from(b'0' + nibble),
+        10..=15 => char::from(b'A' + (nibble - 10)),
+        _ => '?',
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use organon::testing::install_crypto_provider;
+    use wiremock::matchers::{header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[test]
+    fn encode_matrix_room_id_as_path_segment() {
+        assert_eq!(
+            encode_path_segment("!room:example.org"),
+            "%21room%3Aexample.org"
+        );
+        assert_eq!(
+            encode_path_segment("#alias:example.org"),
+            "%23alias%3Aexample.org"
+        );
+    }
+
+    #[test]
+    fn extract_matrix_room_message() {
+        let event: MatrixEvent = serde_json::from_value(serde_json::json!({
+            "type": "m.room.message",
+            "sender": "@alice:example.org",
+            "event_id": "$event",
+            "origin_server_ts": 100,
+            "content": {
+                "msgtype": "m.text",
+                "body": "hello"
+            }
+        }))
+        .expect("event");
+
+        let msg = extract_message("!room:example.org", &event, Some("@bot:example.org"))
+            .expect("message");
+        assert_eq!(msg.channel, "matrix");
+        assert_eq!(msg.sender, "@alice:example.org");
+        assert_eq!(msg.group_id.as_deref(), Some("!room:example.org"));
+        assert_eq!(msg.text, "hello");
+        assert_eq!(msg.timestamp, 100);
+    }
+
+    #[test]
+    fn extract_matrix_message_skips_own_sender() {
+        let event: MatrixEvent = serde_json::from_value(serde_json::json!({
+            "type": "m.room.message",
+            "sender": "@bot:example.org",
+            "origin_server_ts": 100,
+            "content": {
+                "msgtype": "m.text",
+                "body": "echo"
+            }
+        }))
+        .expect("event");
+
+        assert!(extract_message("!room:example.org", &event, Some("@bot:example.org")).is_none());
+    }
+
+    #[tokio::test]
+    async fn provider_send_uses_real_matrix_send() {
+        install_crypto_provider();
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(header("authorization", "Bearer token-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "event_id": "$event"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut provider = MatrixProvider::new();
+        let client = client::MatrixClient::new(&server.uri(), "token-123").expect("client");
+        provider.add_account(
+            "primary".to_owned(),
+            client,
+            Some("@bot:example.org".to_owned()),
+            true,
+            None,
+        );
+        let result = provider
+            .send(&ChannelSendParams {
+                to: "!room:example.org".to_owned(),
+                text: "hello".to_owned(),
+                account_id: None,
+                thread_id: None,
+                attachments: None,
+            })
+            .await;
+
+        assert!(result.sent, "send should succeed: {:?}", result.error);
+    }
+
+    #[tokio::test]
+    async fn provider_listen_maps_sync_events() {
+        install_crypto_provider();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/_matrix/client/v3/sync"))
+            .and(header("authorization", "Bearer token-123"))
+            .and(query_param("timeout", "50"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "next_batch": "s1",
+                "rooms": {
+                    "join": {
+                        "!room:example.org": {
+                            "timeline": {
+                                "events": [
+                                    {
+                                        "type": "m.room.message",
+                                        "sender": "@alice:example.org",
+                                        "event_id": "$event",
+                                        "origin_server_ts": 123,
+                                        "content": {
+                                            "msgtype": "m.text",
+                                            "body": "hello from Matrix"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut provider = MatrixProvider::from_config(&taxis::config::MessagingConfig {
+            receive_timeout_secs: 1,
+            circuit_breaker_threshold: 1,
+            ..taxis::config::MessagingConfig::default()
+        });
+        let client = client::MatrixClient::with_timeouts(
+            &server.uri(),
+            "token-123",
+            Duration::from_secs(1),
+            Duration::from_millis(50),
+        )
+        .expect("client");
+        provider.add_account(
+            "primary".to_owned(),
+            client,
+            Some("@bot:example.org".to_owned()),
+            true,
+            None,
+        );
+
+        let token = CancellationToken::new();
+        let (mut rx, mut handles) = provider.listen(Some(Duration::from_secs(60)), token.clone());
+        let msg = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timeout")
+            .expect("message");
+
+        assert_eq!(msg.channel, "matrix");
+        assert_eq!(msg.sender, "@alice:example.org");
+        assert_eq!(msg.group_id.as_deref(), Some("!room:example.org"));
+        assert_eq!(msg.text, "hello from Matrix");
+
+        token.cancel();
+        drop(rx);
+        while let Some(result) = tokio::time::timeout(Duration::from_secs(5), handles.join_next())
+            .await
+            .ok()
+            .flatten()
+        {
+            let _ = result;
+        }
+    }
+}

--- a/crates/agora/src/router.rs
+++ b/crates/agora/src/router.rs
@@ -124,12 +124,14 @@ fn expand_session_key(template: &str, msg: &InboundMessage) -> String {
 
 /// Determine reply target for outbound response.
 ///
-/// Group messages reply to the group. DMs reply to the sender.
+/// Group messages reply to the group. Signal keeps its `group:` send-target
+/// prefix; Matrix replies directly to the room ID.
 #[must_use]
 pub fn reply_target(msg: &InboundMessage) -> String {
-    match &msg.group_id {
-        Some(group) => format!("group:{group}"),
-        None => msg.sender.clone(),
+    match (msg.channel.as_str(), &msg.group_id) {
+        ("signal", Some(group)) => format!("group:{group}"),
+        (_, Some(group)) => group.clone(),
+        (_, None) => msg.sender.clone(),
     }
 }
 
@@ -298,6 +300,13 @@ mod tests {
     fn reply_target_group() {
         let msg = group_message("+1234567890", "group-abc");
         assert_eq!(reply_target(&msg), "group:group-abc");
+    }
+
+    #[test]
+    fn reply_target_matrix_room() {
+        let mut msg = group_message("@alice:example.org", "!room:example.org");
+        msg.channel = "matrix".to_owned();
+        assert_eq!(reply_target(&msg), "!room:example.org");
     }
 
     #[test]

--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -246,6 +246,11 @@ workspace = "{workspace}"
 # account = "+1XXXXXXXXXX"
 # http_host = "localhost"
 # http_port = 8080
+#
+# [channels.matrix.accounts.primary]
+# homeserver = "https://matrix.example.org"
+# access_token_env = "MATRIX_ACCESS_TOKEN"
+# user_id = "@bot:example.org"
 
 # --- Bindings (route messages to agents) ---
 # [[bindings]]

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -26,7 +26,9 @@ use organon::types::ToolServices;
 use pylon::state::AppState;
 use symbolon::auth::{AuthConfig, AuthFacade};
 use symbolon::jwt::{JwtConfig, JwtManager};
-use taxis::config::{AletheiaConfig, resolve_nous};
+use taxis::config::AletheiaConfig;
+#[cfg(feature = "recall")]
+use taxis::config::resolve_nous;
 use taxis::oikos::Oikos;
 use taxis::validate::{validate_section, validate_startup};
 
@@ -351,6 +353,11 @@ impl RuntimeBuilder {
         } else {
             None
         };
+        let matrix_provider = if self.tool_services {
+            build_matrix_provider(&self.config.channels.matrix, &self.config.messaging)
+        } else {
+            None
+        };
 
         // Tool services
         let (cross_nous, messenger, note_store, blackboard_store, planning) = if self.tool_services
@@ -636,6 +643,7 @@ impl RuntimeBuilder {
             &nous_manager,
             ready_rx,
             signal_provider.as_ref(),
+            matrix_provider.as_ref(),
             &shutdown_token,
         )?;
 
@@ -806,6 +814,6 @@ mod tool_adapters;
 #[cfg(feature = "recall")]
 use setup::open_knowledge_stores;
 use setup::{
-    LazyEmbeddingProvider, build_provider_registry, build_signal_provider, build_tool_registry,
-    start_inbound_dispatch,
+    LazyEmbeddingProvider, build_matrix_provider, build_provider_registry, build_signal_provider,
+    build_tool_registry, start_inbound_dispatch,
 };

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -7,6 +7,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use agora::listener::ChannelListener;
+use agora::matrix::MatrixProvider;
+use agora::matrix::client::MatrixClient;
 use agora::registry::ChannelRegistry;
 use agora::router::MessageRouter;
 use agora::semeion::SignalProvider;
@@ -601,14 +603,84 @@ pub(super) fn build_signal_provider(
     Some(Arc::new(provider))
 }
 
+pub(super) fn build_matrix_provider(
+    matrix_config: &taxis::config::MatrixConfig,
+    messaging_config: &taxis::config::MessagingConfig,
+) -> Option<Arc<MatrixProvider>> {
+    if !matrix_config.enabled {
+        info!("Matrix channel disabled");
+        return None;
+    }
+
+    if matrix_config.accounts.is_empty() {
+        tracing::debug!("Matrix enabled but no accounts configured");
+        return None;
+    }
+
+    let mut provider = MatrixProvider::from_config(messaging_config);
+    let rpc_timeout = std::time::Duration::from_secs(messaging_config.rpc_timeout_secs);
+    let receive_timeout = std::time::Duration::from_secs(messaging_config.receive_timeout_secs);
+
+    for (account_id, account_cfg) in &matrix_config.accounts {
+        if !account_cfg.enabled {
+            continue;
+        }
+        let access_token = match std::env::var(&account_cfg.access_token_env) {
+            Ok(token) if !token.is_empty() => token,
+            Ok(_) => {
+                warn!(
+                    account = %account_id,
+                    env = %account_cfg.access_token_env,
+                    "Matrix access token environment variable is empty"
+                );
+                continue;
+            }
+            Err(e) => {
+                warn!(
+                    account = %account_id,
+                    env = %account_cfg.access_token_env,
+                    error = %e,
+                    "Matrix access token environment variable is unavailable"
+                );
+                continue;
+            }
+        };
+
+        match MatrixClient::with_timeouts(
+            &account_cfg.homeserver,
+            &access_token,
+            rpc_timeout,
+            receive_timeout,
+        ) {
+            Ok(client) => {
+                provider.add_account(
+                    account_id.clone(),
+                    client,
+                    account_cfg.user_id.clone(),
+                    account_cfg.auto_start,
+                    account_cfg.initial_since.clone(),
+                );
+                info!(account = %account_id, auto_start = account_cfg.auto_start, "Matrix account added");
+            }
+            Err(e) => {
+                warn!(account = %account_id, error = %e, "failed to CREATE Matrix client");
+            }
+        }
+    }
+
+    Some(Arc::new(provider))
+}
+
 pub(super) fn start_inbound_dispatch(
     config: &AletheiaConfig,
     nous_manager: &Arc<NousManager>,
     ready_rx: tokio::sync::watch::Receiver<bool>,
     signal_provider: Option<&Arc<SignalProvider>>,
+    matrix_provider: Option<&Arc<MatrixProvider>>,
     shutdown_token: &CancellationToken,
 ) -> Result<(Arc<ChannelRegistry>, Option<tokio::task::JoinHandle<()>>)> {
     let mut channel_registry = ChannelRegistry::new();
+    let mut listen_providers: Vec<&dyn ChannelProvider> = Vec::new();
 
     if let Some(provider) = signal_provider {
         #[expect(
@@ -619,20 +691,34 @@ pub(super) fn start_inbound_dispatch(
             &mut channel_registry,
             Arc::clone(provider) as Arc<dyn ChannelProvider>,
         )?;
+        listen_providers.push(provider.as_ref());
+    }
+    if let Some(provider) = matrix_provider {
+        #[expect(
+            clippy::as_conversions,
+            reason = "coercion to dyn ChannelProvider trait object: required by registry API"
+        )]
+        register_channel_provider(
+            &mut channel_registry,
+            Arc::clone(provider) as Arc<dyn ChannelProvider>,
+        )?;
+        listen_providers.push(provider.as_ref());
     }
     let channel_registry = Arc::new(channel_registry);
 
-    let handle = if let Some(provider) = signal_provider {
+    let handle = if listen_providers.is_empty() {
+        None
+    } else {
         let poll_interval = Some(std::time::Duration::from_millis(
             config.messaging.poll_interval_ms,
         ));
-        let listener = ChannelListener::start_with_config(
-            provider.as_ref(),
+        let listener = ChannelListener::start_many_with_config(
+            listen_providers,
             poll_interval,
-            shutdown_token.child_token(),
+            &shutdown_token.child_token(),
             config.messaging.max_concurrent_handlers,
         );
-        info!("signal channel listener started");
+        info!("channel listeners started");
         let (rx, _poll_handles) = listener.into_receiver();
 
         let default_nous_id = config
@@ -651,8 +737,6 @@ pub(super) fn start_inbound_dispatch(
             Arc::clone(&channel_registry),
             ready_rx,
         ))
-    } else {
-        None
     };
 
     Ok((channel_registry, handle))

--- a/crates/pylon/src/handlers/config_dto.rs
+++ b/crates/pylon/src/handlers/config_dto.rs
@@ -62,6 +62,8 @@ pub struct GatewayConfig {
 pub struct ChannelsConfig {
     #[schema(value_type = Object)]
     pub signal: Option<Value>,
+    #[schema(value_type = Object)]
+    pub matrix: Option<Value>,
 }
 
 /// Schema for a single channel binding entry.

--- a/crates/taxis/src/config/config_tests/basics.rs
+++ b/crates/taxis/src/config/config_tests/basics.rs
@@ -103,6 +103,14 @@ fn defaults_are_sensible() {
         "signal accounts should be empty by default"
     );
     assert!(
+        !config.channels.matrix.enabled,
+        "matrix channel should be disabled by default"
+    );
+    assert!(
+        config.channels.matrix.accounts.is_empty(),
+        "matrix accounts should be empty by default"
+    );
+    assert!(
         config.bindings.is_empty(),
         "bindings should be empty by default"
     );
@@ -184,6 +192,10 @@ fn serde_roundtrip() {
     assert!(
         back.channels.signal.enabled,
         "signal channel enabled should survive serde roundtrip"
+    );
+    assert!(
+        !back.channels.matrix.enabled,
+        "matrix channel enabled flag should survive serde roundtrip"
     );
     assert_eq!(
         back.embedding.provider, "candle",

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -293,6 +293,8 @@ impl Default for EmbeddingSettings {
 pub struct ChannelsConfig { // kanon:ignore RUST/config-deny-unknown-fields
     /// Signal messenger transport configuration.
     pub signal: SignalConfig,
+    /// Matrix messenger transport configuration.
+    pub matrix: MatrixConfig,
 }
 
 /// Signal messenger channel configuration.
@@ -339,6 +341,51 @@ impl Default for SignalAccountConfig {
             http_host: "localhost".to_owned(),
             http_port: 8080,
             auto_start: true,
+        }
+    }
+}
+
+/// Matrix messenger channel configuration.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+#[rustfmt::skip]
+pub struct MatrixConfig { // kanon:ignore RUST/config-deny-unknown-fields
+    /// Whether the Matrix channel is active.
+    pub enabled: bool,
+    /// Named Matrix accounts keyed by account label.
+    pub accounts: HashMap<String, MatrixAccountConfig>,
+}
+
+/// Configuration for a single Matrix account.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+#[rustfmt::skip]
+pub struct MatrixAccountConfig { // kanon:ignore RUST/config-deny-unknown-fields
+    /// Whether this account is active.
+    pub enabled: bool,
+    /// Matrix homeserver base URL, e.g. `https://matrix.example.org`.
+    pub homeserver: String,
+    /// Environment variable that contains the Matrix access token.
+    pub access_token_env: String, // kanon:ignore RUST/plain-string-secret
+    /// Matrix user ID for this account. Used to ignore echoed self messages.
+    pub user_id: Option<String>,
+    /// Whether to auto-start the `/sync` receive loop on server boot.
+    pub auto_start: bool,
+    /// Optional initial `/sync` since token.
+    pub initial_since: Option<String>,
+}
+
+impl Default for MatrixAccountConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            homeserver: String::new(),
+            access_token_env: String::new(),
+            user_id: None,
+            auto_start: true,
+            initial_since: None,
         }
     }
 }

--- a/crates/taxis/src/config_tests.rs
+++ b/crates/taxis/src/config_tests.rs
@@ -98,6 +98,14 @@ fn defaults_are_sensible() {
         "signal accounts should be empty by default"
     );
     assert!(
+        !config.channels.matrix.enabled,
+        "matrix channel should be disabled by default"
+    );
+    assert!(
+        config.channels.matrix.accounts.is_empty(),
+        "matrix accounts should be empty by default"
+    );
+    assert!(
         config.bindings.is_empty(),
         "bindings should be empty by default"
     );
@@ -171,6 +179,10 @@ fn serde_roundtrip() {
     assert!(
         back.channels.signal.enabled,
         "signal channel enabled should survive serde roundtrip"
+    );
+    assert!(
+        !back.channels.matrix.enabled,
+        "matrix channel enabled flag should survive serde roundtrip"
     );
     assert_eq!(
         back.embedding.provider, "candle",

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -386,9 +386,37 @@ fn validate_channels(value: &Value, errors: &mut Vec<String>) {
             );
         }
     }
+
+    if let Some(matrix) = value.get("matrix")
+        && let Some(accounts) = matrix.get("accounts").and_then(Value::as_object)
+    {
+        for (account_id, account) in accounts {
+            if account.get("enabled").and_then(Value::as_bool) == Some(false) {
+                continue;
+            }
+            if account
+                .get("homeserver")
+                .and_then(Value::as_str)
+                .is_none_or(str::is_empty)
+            {
+                errors.push(format!(
+                    "channels.matrix.accounts.{account_id}.homeserver must not be empty"
+                ));
+            }
+            if account
+                .get("accessTokenEnv")
+                .and_then(Value::as_str)
+                .is_none_or(str::is_empty)
+            {
+                errors.push(format!(
+                    "channels.matrix.accounts.{account_id}.accessTokenEnv must not be empty"
+                ));
+            }
+        }
+    }
 }
 
-const KNOWN_CHANNEL_TYPES: &[&str] = &["signal", "slack", "discord", "webhook", "http"];
+const KNOWN_CHANNEL_TYPES: &[&str] = &["signal", "matrix", "slack", "discord", "webhook", "http"];
 
 fn validate_bindings(value: &Value, errors: &mut Vec<String>) {
     let Some(bindings) = value.as_array() else {

--- a/crates/taxis/src/validate_tests.rs
+++ b/crates/taxis/src/validate_tests.rs
@@ -355,11 +355,38 @@ fn accepts_valid_channels() {
             "accounts": {
                 "primary": { "httpPort": 8080 }
             }
+        },
+        "matrix": {
+            "accounts": {
+                "primary": {
+                    "homeserver": "https://matrix.example.org",
+                    "accessTokenEnv": "MATRIX_ACCESS_TOKEN"
+                }
+            }
         }
     });
     assert!(
         validate_section("channels", &section).is_ok(),
         "valid channel config should be accepted"
+    );
+}
+
+#[test]
+fn rejects_matrix_account_missing_token_env() {
+    let section = json!({
+        "matrix": {
+            "accounts": {
+                "primary": {
+                    "homeserver": "https://matrix.example.org",
+                    "accessTokenEnv": ""
+                }
+            }
+        }
+    });
+    let result = validate_section("channels", &section);
+    assert!(
+        result.is_err(),
+        "matrix account without accessTokenEnv should be rejected"
     );
 }
 
@@ -383,6 +410,17 @@ fn accepts_valid_bindings() {
     assert!(
         validate_section("bindings", &section).is_ok(),
         "valid binding config should be accepted"
+    );
+}
+
+#[test]
+fn accepts_matrix_binding() {
+    let section = json!([
+        { "channel": "matrix", "source": "!room:example.org", "nousId": "main" }
+    ]);
+    assert!(
+        validate_section("bindings", &section).is_ok(),
+        "matrix binding config should be accepted"
     );
 }
 


### PR DESCRIPTION
Closes #3981

Summary:
- Adds a Matrix Client-Server API channel provider with real text send and /sync receive mapping.
- Wires typed Matrix config into startup, ChannelRegistry registration, and merged channel listeners.
- Adds Matrix config validation and tests for send/listen behavior.

Verification:
- cargo test -p agora
- cargo test -p taxis matrix
- cargo clippy -p agora --tests -- -D warnings
- cargo clippy -p taxis --tests -- -D warnings
- cargo clippy -p aletheia --no-default-features --bin aletheia -- -D warnings

Gate-Passed: kanon 0.1.0