### PR TITLE
fix(routing): wire empirical feedback router injection at runtime startup

### DIFF
--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -283,8 +283,14 @@ impl RuntimeBuilder {
         };
 
         // Tool registry
+        let after_action_log_dir = self.oikos.logs().join("after-actions");
         let mut tool_registry = if self.credentials {
-            build_tool_registry(&self.config, &self.oikos, &shutdown_token)?
+            build_tool_registry(
+                &self.config,
+                &self.oikos,
+                &shutdown_token,
+                Some(after_action_log_dir.clone()),
+            )?
         } else {
             ToolRegistry::new()
         };

--- a/crates/aletheia/src/runtime/setup/setup_energeia_tests.rs
+++ b/crates/aletheia/src/runtime/setup/setup_energeia_tests.rs
@@ -45,7 +45,7 @@ async fn energeia_feature_registers_service_backed_runtime_tools() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let oikos = Oikos::from_root(tmp.path());
     let config = AletheiaConfig::default();
-    let registry = build_tool_registry(&config, &oikos, &CancellationToken::new())
+    let registry = build_tool_registry(&config, &oikos, &CancellationToken::new(), None)
         .expect("tool registry with energeia services");
     let names: HashSet<String> = registry
         .definitions()

--- a/crates/aletheia/src/runtime/setup/tool_registry.rs
+++ b/crates/aletheia/src/runtime/setup/tool_registry.rs
@@ -45,6 +45,7 @@ pub(in crate::runtime) fn build_tool_registry(
     config: &AletheiaConfig,
     oikos: &Oikos,
     shutdown_token: &CancellationToken,
+    after_action_log_dir: Option<std::path::PathBuf>,
 ) -> Result<ToolRegistry> {
     let mut registry = ToolRegistry::new();
     let sandbox_settings = &config.sandbox;
@@ -74,6 +75,7 @@ pub(in crate::runtime) fn build_tool_registry(
         config,
         oikos,
         shutdown_token.child_token(),
+        after_action_log_dir,
     )?;
     info!(count = registry.definitions().len(), "tools registered");
     Ok(registry)
@@ -85,10 +87,11 @@ fn register_builtin_tools(
     config: &AletheiaConfig,
     oikos: &Oikos,
     cancel_token: CancellationToken,
+    after_action_log_dir: Option<std::path::PathBuf>,
 ) -> Result<()> {
     #[cfg(feature = "energeia")]
     {
-        let services = build_energeia_services(config, oikos, cancel_token)?;
+        let services = build_energeia_services(config, oikos, cancel_token, after_action_log_dir)?;
         builtins::register_all_with_sandbox_and_energeia_services(
             registry,
             sandbox,
@@ -99,7 +102,7 @@ fn register_builtin_tools(
 
     #[cfg(not(feature = "energeia"))]
     {
-        let _ = (config, oikos, cancel_token);
+        let _ = (config, oikos, cancel_token, after_action_log_dir);
         builtins::register_all_with_sandbox(registry, sandbox)
             .whatever_context("failed to register builtin tools")
     }
@@ -110,6 +113,7 @@ fn build_energeia_services(
     config: &AletheiaConfig,
     oikos: &Oikos,
     cancel_token: CancellationToken,
+    after_action_log_dir: Option<std::path::PathBuf>,
 ) -> Result<Arc<organon::builtins::energeia::EnergeiaServices>> {
     let store_path = oikos.data().join("energeia.fjall");
     if let Some(parent) = store_path.parent() {
@@ -138,7 +142,8 @@ fn build_energeia_services(
             energeia::orchestrator::OrchestratorConfig::new(),
         )
         .with_store(Arc::clone(&store))
-        .with_cancel_token(cancel_token),
+        .with_cancel_token(cancel_token)
+        .with_after_action_log_dir(after_action_log_dir),
     );
 
     Ok(Arc::new(

--- a/crates/energeia/src/orchestrator/mod.rs
+++ b/crates/energeia/src/orchestrator/mod.rs
@@ -3,6 +3,7 @@
 // stages (preparation → execution → post_processing). The orchestrator owns
 // the public API surface and the store attachment.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio_util::sync::CancellationToken;
@@ -40,6 +41,7 @@ pub struct Orchestrator {
     store: Option<Arc<crate::store::EnergeiaStore>>,
     config: OrchestratorConfig,
     cancel: CancellationToken,
+    after_action_log_dir: Option<PathBuf>,
 }
 
 impl Orchestrator {
@@ -58,6 +60,7 @@ impl Orchestrator {
             store: None,
             config,
             cancel: CancellationToken::new(),
+            after_action_log_dir: None,
         }
     }
 
@@ -86,6 +89,16 @@ impl Orchestrator {
     #[must_use]
     pub fn with_store(mut self, store: Arc<crate::store::EnergeiaStore>) -> Self {
         self.store = Some(store);
+        self
+    }
+
+    /// Attach the directory for after-action JSONL logs.
+    ///
+    /// When set, the post-processing stage writes dispatch outcomes as JSONL
+    /// records to this directory so they can be read by `AfterActionStore`.
+    #[must_use]
+    pub fn with_after_action_log_dir(mut self, dir: Option<PathBuf>) -> Self {
+        self.after_action_log_dir = dir;
         self
     }
 
@@ -126,7 +139,8 @@ impl Orchestrator {
             self.store.clone(),
         )
         .with_cancel_token(self.cancel.clone())
-        .with_diff_provider(self.diff_provider.clone());
+        .with_diff_provider(self.diff_provider.clone())
+        .with_after_action_log_dir(self.after_action_log_dir.clone());
 
         let pipeline = DispatchPipeline::default();
         pipeline

--- a/crates/energeia/src/pipeline/context.rs
+++ b/crates/energeia/src/pipeline/context.rs
@@ -178,6 +178,13 @@ impl PipelineContext {
         self
     }
 
+    /// Set the directory for after-action JSONL logs.
+    #[must_use]
+    pub(crate) fn with_after_action_log_dir(mut self, dir: Option<PathBuf>) -> Self {
+        self.after_action_log_dir = dir;
+        self
+    }
+
     /// Attach a diff provider for PR diff fetching during QA.
     #[must_use]
     pub(crate) fn with_diff_provider(mut self, provider: Option<Arc<dyn DiffProvider>>) -> Self {

--- a/crates/energeia/src/routing/affinity.rs
+++ b/crates/energeia/src/routing/affinity.rs
@@ -177,10 +177,7 @@ impl AffinityRouter {
     /// * `store` — shared after-action store (same instance as the inner empirical router)
     /// * `window` — rolling window for stat queries (should match empirical window)
     /// * `affinity_threshold` — minimum affinity gap to override empirical selection
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "binary wiring constructs AffinityRouter")
-    )]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(
         inner: PersonaRouter,
         store: Arc<AfterActionStore>,
@@ -202,10 +199,7 @@ impl AffinityRouter {
     /// the empirical winner by at least `affinity_threshold`.
     ///
     /// When `persona_hint` is `Some`, it is forwarded to the inner persona router.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "binary wiring calls route_with_affinity")
-    )]
+    #[cfg_attr(not(test), allow(dead_code))]
     #[instrument(skip(self), fields(
         affinity_threshold = self.affinity_threshold,
     ))]

--- a/crates/energeia/src/routing/empirical.rs
+++ b/crates/energeia/src/routing/empirical.rs
@@ -53,10 +53,7 @@ impl EmpiricalRouter {
     /// * `min_samples` — minimum records before empirical choice is made (default 5)
     /// * `window` — rolling window for record weighting (default 7 days)
     /// * `confidence_threshold` — minimum gap (winner − static) to override (default 0.1)
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "binary wiring constructs EmpiricalRouter")
-    )]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(
         store: Arc<AfterActionStore>,
         fallback: StaticRouter,
@@ -166,10 +163,7 @@ impl EmpiricalRouter {
     /// Return the success rate for a specific (provider, category) pair.
     ///
     /// Returns `None` when the cache has no records for this pair.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "observability API for binary wiring")
-    )]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn success_rate(
         &self,
         provider: &ProviderId,

--- a/crates/energeia/src/routing/mod.rs
+++ b/crates/energeia/src/routing/mod.rs
@@ -63,10 +63,7 @@ pub(crate) struct StaticRouter {
 
 impl StaticRouter {
     /// Create a static router with the given default provider.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "binary wiring constructs StaticRouter")
-    )]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(default_provider: ProviderId) -> Self {
         Self { default_provider }
     }
@@ -102,13 +99,7 @@ pub(crate) enum RoutingMode {
 /// Operator-facing routing configuration for the dispatch engine.
 ///
 /// Placed under `[dispatch.routing]` in the instance `taxis` config.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "binary wiring constructs DispatchRoutingConfig (follow-up #3455)"
-    )
-)]
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
 pub(crate) struct DispatchRoutingConfig {

--- a/crates/energeia/src/routing/persona.rs
+++ b/crates/energeia/src/routing/persona.rs
@@ -167,13 +167,7 @@ pub(crate) struct PersonaRouter {
 
 impl PersonaRouter {
     /// Create a new persona router wrapping the given empirical router.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "binary wiring constructs PersonaRouter (follow-up wiring)"
-        )
-    )]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(inner: EmpiricalRouter) -> Self {
         Self { inner }
     }

--- a/crates/nous/src/actor/spawn.rs
+++ b/crates/nous/src/actor/spawn.rs
@@ -130,6 +130,8 @@ pub struct DaemonSpawnParams {
     pub tool_services: Option<Arc<organon::types::ToolServices>>,
     /// Additional bootstrap sections for the child agent.
     pub extra_bootstrap: Vec<BootstrapSection>,
+    /// Optional empirical router (shared with parent).
+    pub empirical_router: Option<Arc<dyn aletheia_routing::Router>>,
 }
 
 /// Spawn a child agent for daemon coordination.
@@ -170,7 +172,7 @@ pub fn spawn_for_daemon(
         cancel,
         taxis::config::NousBehaviorConfig::default(),
         None, // WHY: daemon child agents share the parent's audit log via binary crate wiring
-        None, // WHY: daemon child agents use the NoOpRouter; binary crate wires empirical router
+        params.empirical_router,
     )
 }
 

--- a/crates/nous/src/actor/tests/lifecycle_and_panic.rs
+++ b/crates/nous/src/actor/tests/lifecycle_and_panic.rs
@@ -390,3 +390,47 @@ async fn status_includes_uptime() {
     handle.shutdown().await.expect("shutdown");
     join.await.expect("join");
 }
+
+// ── empirical router: after-action recording ────────────────────────────────
+
+use aletheia_routing::types::{ProviderId, TaskCategory};
+use aletheia_routing::{AfterActionStore, RecordingRouter};
+use std::time::Duration;
+
+#[tokio::test]
+async fn turn_records_after_action_outcome_in_empirical_store() {
+    let store = Arc::new(AfterActionStore::in_memory());
+    let router: Arc<dyn aletheia_routing::Router> =
+        Arc::new(RecordingRouter::new(Arc::clone(&store), "test-model"));
+
+    let (handle, join, _dir) = spawn_test_actor_with_router(Some(router));
+
+    let result = handle
+        .send_turn("main", "Build a feature")
+        .await
+        .expect("turn");
+    assert_eq!(result.content, "Hello from actor!");
+
+    handle.shutdown().await.expect("shutdown");
+    join.await.expect("join");
+
+    let provider = ProviderId::new("test-model");
+    for _ in 0..20 {
+        if let Some(stats) = store
+            .rolling_stats(
+                &provider,
+                &TaskCategory::Feature,
+                Duration::from_secs(7 * 24 * 60 * 60),
+            )
+            .await
+        {
+            assert_eq!(stats.successes, 1);
+            assert_eq!(stats.failures, 0);
+            assert_eq!(stats.total, 1);
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    panic!("completed interactive turn did not record after-action outcome");
+}

--- a/crates/nous/src/actor/tests/mod.rs
+++ b/crates/nous/src/actor/tests/mod.rs
@@ -306,6 +306,38 @@ fn spawn_test_actor_with_cross() -> (
     (handle, join, cross_tx, dir)
 }
 
+fn spawn_test_actor_with_router(
+    router: Option<Arc<dyn aletheia_routing::Router>>,
+) -> (NousHandle, tokio::task::JoinHandle<()>, tempfile::TempDir) {
+    let (dir, oikos) = test_oikos();
+    let providers = test_providers();
+    let tools = Arc::new(ToolRegistry::new());
+    let config = test_config();
+    let pipeline_config = PipelineConfig::default();
+
+    let (handle, join, _active_turn, _turn_started_at_ms) = spawn(
+        config,
+        pipeline_config,
+        providers,
+        tools,
+        oikos,
+        None,
+        None,
+        None,
+        #[cfg(feature = "knowledge-store")]
+        None,
+        None,
+        Vec::new(),
+        None,
+        None,
+        CancellationToken::new(),
+        taxis::config::NousBehaviorConfig::default(),
+        None, // audit_log
+        router,
+    );
+    (handle, join, dir)
+}
+
 fn spawn_panicking_actor_with_cross() -> (
     NousHandle,
     tokio::task::JoinHandle<()>,


### PR DESCRIPTION
Closes #3944

- Pass after-action log directory into the energeia orchestrator so dispatch
  outcomes are written to the same JSONL directory used by AfterActionStore.
- Fix spawn_for_daemon to accept and forward the empirical router instead of
  hard-coding None.
- Remove false dead-code suppressions in energeia routing that claimed binary
  wiring exists; replace with honest allow(dead_code).
- Add actor test proving a completed interactive turn records an outcome in
  the empirical store and later routing can read it.