### PR TITLE
chore(deps): remove stale RUSTSEC-2026-0097 advisory skip

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,10 +21,6 @@ reason = "paste unmaintained, transitive via tokenizers; no safe upgrade"
 id = "RUSTSEC-2025-0134"
 reason = "rustls-pemfile 2.x unmaintained — transitive via qdrant-client → tonic 0.12. Blocked until qdrant-client upgrades tonic to 0.13+"
 
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0097"
-reason = "rand 0.8 unsound only with custom logger using rand::rng() — not our usage. Transitive via qdrant-client → tonic 0.12 + spreadsheet-ods + phf. Blocked on upstream migrations to rand 0.9+"
-
 [licenses]
 # WHY: `version = 2` enables modern SPDX 3.x parsing so "AGPL-3.0-or-later" /
 # "LGPL-3.0-or-later" are accepted as bare license identifiers. Without this,


### PR DESCRIPTION
The advisory was resolved upstream. cargo-deny emits warning[advisory-not-detected] on every CI run. Removing the stale [[advisories.ignore]] entry eliminates persistent CI noise.