### PR TITLE
fix(ci): repair YAML syntax in llm-regen workflow PR body

### DIFF
--- a/.github/workflows/llm-regen.yml
+++ b/.github/workflows/llm-regen.yml
@@ -175,11 +175,10 @@ jobs:
 
           # WHY: --auto-merge queues the PR for squash-merge once required
           # status checks pass. The branch is deleted automatically on merge.
+          PR_BODY="Automated regeneration of _llm/ L3 API index.\n\nGate-Passed: kanon 0.1.0"
           gh pr create \
             --title "chore(_llm): regenerate L3 API index" \
-            --body "Automated regeneration of `_llm/` L3 API index.
-
-Gate-Passed: kanon 0.1.0" \
+            --body "$PR_BODY" \
             --base main \
             --head "$BRANCH" || true
 


### PR DESCRIPTION
The multi-line `--body` string in `gh pr create` contained a blank line at zero indentation inside the `run: |` block scalar, which broke the YAML parser. GitHub Actions rejected the workflow with "This run likely failed because of a workflow file issue" — the error is silent and the workflow never runs.

Fix: extract the PR body into a `PR_BODY` variable before the `gh pr create` call. Also removes the backtick shell substitution around `_llm/` in the body string.

Gate-Passed: kanon 0.1.0