### PR TITLE
fix(lint): resolve kanon rust-lint violations in 6 tiny crates to zero

### DIFF
--- a/crates/aletheia-classify/src/classifier.rs
+++ b/crates/aletheia-classify/src/classifier.rs
@@ -185,8 +185,7 @@ impl Classifier {
             "loading author classifier metadata"
         );
 
-        let metadata_content =
-            std::fs::read_to_string(&metadata_path) // kanon:ignore RUST/blocking-in-async WHY: startup-only; tokio is dev-dep only; bounded I/O
+        let metadata_content = std::fs::read_to_string(&metadata_path) // kanon:ignore RUST/blocking-in-async WHY: startup-only; tokio is dev-dep only; bounded I/O
             .context(ArtifactMissingSnafu {
                 path: &metadata_path,
             })?;

--- a/crates/aletheia-classify/src/classifier.rs
+++ b/crates/aletheia-classify/src/classifier.rs
@@ -42,7 +42,12 @@ impl AuthorClass {
     /// Return the integer index corresponding to this variant.
     #[must_use]
     pub fn index(self) -> usize {
-        self as usize
+        match self {
+            Self::User => 0,
+            Self::Subagent => 1,
+            Self::SystemScaffolding => 2,
+            Self::Template => 3,
+        }
     }
 
     /// Human-readable name for this class.
@@ -181,7 +186,8 @@ impl Classifier {
         );
 
         let metadata_content =
-            std::fs::read_to_string(&metadata_path).context(ArtifactMissingSnafu {
+            std::fs::read_to_string(&metadata_path) // kanon:ignore RUST/blocking-in-async WHY: startup-only; tokio is dev-dep only; bounded I/O
+            .context(ArtifactMissingSnafu {
                 path: &metadata_path,
             })?;
         let metadata: ArtifactMetadata =

--- a/crates/aletheia-classify/src/error.rs
+++ b/crates/aletheia-classify/src/error.rs
@@ -3,11 +3,11 @@ use std::path::PathBuf;
 /// Errors from author-classifier operations.
 #[derive(Debug, snafu::Snafu)]
 #[snafu(visibility(pub(crate)))]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "snafu error variant fields (source, path) are self-documenting via display format"
 )]
+#[non_exhaustive]
 pub enum ClassifyError {
     /// Failed to load classifier artifact from the filesystem.
     #[snafu(display("failed to load classifier artifact from {}: {source}", path.display()))]

--- a/crates/aletheia-lexica/src/lib.rs
+++ b/crates/aletheia-lexica/src/lib.rs
@@ -12,6 +12,8 @@ pub mod stopwords;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn modules_are_reachable() {
         assert!(!super::adjectives::UNFALSIFIABLE_ADJECTIVES.is_empty());

--- a/crates/aletheia-sessions-migrate/src/error.rs
+++ b/crates/aletheia-sessions-migrate/src/error.rs
@@ -13,11 +13,11 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Migrator error surface.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "snafu error variant fields (source, location, message) are self-documenting via display format"
 )]
+#[non_exhaustive]
 pub enum Error {
     #[snafu(display("opening SQLite source at {}: {source}", path.display()))]
     SqliteOpen {

--- a/crates/aletheia-sessions-migrate/src/source.rs
+++ b/crates/aletheia-sessions-migrate/src/source.rs
@@ -234,7 +234,7 @@ pub fn read_usage(conn: &Connection) -> Result<Vec<UsageRecord>> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DistillationRecord {
     /// Owning session.
-    pub session_id: String,
+    pub session_id: String, // kanon:ignore RUST/primitive-for-domain-id WHY: mirrors legacy SQLite schema byte-for-byte; newtype would break serde deserialization
     /// Message count before distillation.
     pub messages_before: i64,
     /// Message count after distillation.

--- a/crates/aletheia-sessions-migrate/src/verify.rs
+++ b/crates/aletheia-sessions-migrate/src/verify.rs
@@ -336,7 +336,7 @@ fn hex(bytes: &[u8]) -> String {
     use std::fmt::Write as _;
     let mut s = String::with_capacity(bytes.len() * 2);
     for b in bytes {
-        let _ = write!(&mut s, "{b:02x}");
+        write!(&mut s, "{b:02x}").expect("writing to String is infallible"); // kanon:ignore RUST/expect WHY: fmt::Write for String never returns Err
     }
     s
 }

--- a/crates/dianoia/src/reconciler.rs
+++ b/crates/dianoia/src/reconciler.rs
@@ -81,7 +81,7 @@ pub struct ConflictEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReconciliationResult {
     /// The project ID that was reconciled.
-    pub project_id: String,
+    pub project_id: String, // kanon:ignore RUST/primitive-for-domain-id WHY: serialized result DTO; eidos::ProjectId is not a dianoia dependency — refactor tracked separately
     /// Which direction the sync went.
     pub direction: ReconciliationDirection,
     /// Conflicts detected between the two sources.

--- a/crates/dianoia/src/research/mod.rs
+++ b/crates/dianoia/src/research/mod.rs
@@ -84,6 +84,7 @@ pub struct ResearchFinding {
 
 /// Configurable parameters for the research phase.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ResearchConfig {
     /// Timeout per researcher in seconds (default: 300).
     pub timeout_secs: u64,
@@ -215,7 +216,7 @@ fn format_markdown(findings: &[ResearchFinding]) -> String {
     let mut out = String::from("# Research Summary\n");
 
     for finding in findings {
-        let _ = write!(out, "\n## {}\n\n", finding.domain.heading());
+        write!(out, "\n## {}\n\n", finding.domain.heading()).expect("writing to String is infallible"); // kanon:ignore RUST/expect WHY: fmt::Write for String never returns Err
         match finding.status {
             FindingStatus::Complete => {
                 out.push_str(&finding.content);

--- a/crates/dianoia/src/research/mod.rs
+++ b/crates/dianoia/src/research/mod.rs
@@ -216,7 +216,8 @@ fn format_markdown(findings: &[ResearchFinding]) -> String {
     let mut out = String::from("# Research Summary\n");
 
     for finding in findings {
-        write!(out, "\n## {}\n\n", finding.domain.heading()).expect("writing to String is infallible"); // kanon:ignore RUST/expect WHY: fmt::Write for String never returns Err
+        write!(out, "\n## {}\n\n", finding.domain.heading())
+            .expect("writing to String is infallible"); // kanon:ignore RUST/expect WHY: fmt::Write for String never returns Err
         match finding.status {
             FindingStatus::Complete => {
                 out.push_str(&finding.content);

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -1,8 +1,8 @@
 //! Project lifecycle state machine.
 
-use serde::{Deserialize, Serialize};
 use crate::error::{self, GateBlockedSnafu, Result};
 use crate::gate::{GateResult, PhaseGate, evaluate_gate};
+use serde::{Deserialize, Serialize};
 
 /// Project lifecycle states.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -1,8 +1,6 @@
 //! Project lifecycle state machine.
 
 use serde::{Deserialize, Serialize};
-use snafu::ensure;
-
 use crate::error::{self, GateBlockedSnafu, Result};
 use crate::gate::{GateResult, PhaseGate, evaluate_gate};
 
@@ -130,14 +128,11 @@ impl ProjectState {
             ) => Ok(Self::Abandoned),
 
             _ => {
-                ensure!(
-                    false,
-                    error::InvalidTransitionSnafu {
-                        state: self,
-                        transition: t,
-                    }
-                );
-                unreachable!()
+                return error::InvalidTransitionSnafu {
+                    state: self,
+                    transition: t,
+                }
+                .fail();
             }
         };
 

--- a/crates/dianoia/src/stuck.rs
+++ b/crates/dianoia/src/stuck.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Callers should construct from the resolved taxis config rather than relying
 /// on `Default`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StuckConfig {
     /// How many identical consecutive errors trigger detection.
     pub repeated_error_threshold: u32,

--- a/crates/gnosis/src/error.rs
+++ b/crates/gnosis/src/error.rs
@@ -10,11 +10,11 @@ use snafu::Snafu;
 /// Errors produced by gnosis operations.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "snafu error variant fields are self-documenting via display format"
 )]
+#[non_exhaustive]
 pub enum GnosisError {
     /// `cargo metadata` failed to run or returned a non-zero exit.
     #[snafu(display("cargo metadata failed: {source}"))]

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -392,8 +392,8 @@ mod coexistence_tests {
         let ks = KnowledgeStore::open_mem()
             .expect("KnowledgeStore::open_mem should succeed with mneme-engine feature"); // kanon:ignore RUST/expect WHY: test assertion; infallible in-memory store
 
-        let ss = SessionStore::open_in_memory()
-            .expect("SessionStore::open_in_memory should succeed"); // kanon:ignore RUST/expect WHY: test assertion; infallible in-memory store
+        let ss =
+            SessionStore::open_in_memory().expect("SessionStore::open_in_memory should succeed"); // kanon:ignore RUST/expect WHY: test assertion; infallible in-memory store
 
         drop(ks);
         drop(ss);

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -390,10 +390,10 @@ mod coexistence_tests {
     #[test]
     fn engine_and_session_store_coexist() {
         let ks = KnowledgeStore::open_mem()
-            .expect("KnowledgeStore::open_mem should succeed with mneme-engine feature");
+            .expect("KnowledgeStore::open_mem should succeed with mneme-engine feature"); // kanon:ignore RUST/expect WHY: test assertion; infallible in-memory store
 
-        let ss =
-            SessionStore::open_in_memory().expect("SessionStore::open_in_memory should succeed");
+        let ss = SessionStore::open_in_memory()
+            .expect("SessionStore::open_in_memory should succeed"); // kanon:ignore RUST/expect WHY: test assertion; infallible in-memory store
 
         drop(ks);
         drop(ss);


### PR DESCRIPTION
## Wave 1 lint campaign — tiny crates

Brings 6 small crates to zero `kanon lint --rust` violations: `gnosis`, `aletheia-lexica`, `mneme`, `aletheia-classify`, `aletheia-sessions-migrate`, `dianoia`.

### Changes
- **non-exhaustive-enum**: reorder `#[non_exhaustive]` to immediately precede `pub enum` (kanon rule requires it as the last attribute before the enum keyword)
- **test-missing-use-super**: add `use super::*` to aletheia-lexica test module
- **expect in tests**: suppress with `kanon:ignore RUST/expect WHY:` on the same line (test assertions in in-memory infallible contexts)
- **as-cast**: replace `self as usize` in `AuthorClass::index()` with exhaustive match
- **blocking-in-async**: suppress startup-only `std::fs::read_to_string` with WHY (tokio is dev-dep only in aletheia-classify)
- **primitive-for-domain-id**: suppress migration-struct `session_id: String` with WHY (mirrors legacy SQLite schema; newtype would break serde)
- **no-silent-result-swallow** on `let _ = write!`: replace with `.expect("writing to String is infallible")` + `kanon:ignore RUST/expect WHY:`
- **config-deny-unknown-fields**: add `#[serde(deny_unknown_fields)]` to `ResearchConfig` and `StuckConfig` in dianoia
- **unreachable-in-match**: replace `ensure!(false,...) + unreachable!()` with direct `.fail()` return in dianoia state machine

All 6 crates: `kanon lint --rust` clean, `cargo check` passes.