### PR TITLE
fix(lint): add serde(deny_unknown_fields) to 39 taxis config structs

### DIFF
--- a/crates/taxis/src/config/behavior/api.rs
+++ b/crates/taxis/src/config/behavior/api.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct ApiLimitsConfig {
     /// Maximum characters in a session name. Default: 255.
     /// Mirrors `pylon::handlers::sessions::MAX_SESSION_NAME_LEN`.

--- a/crates/taxis/src/config/behavior/daemon.rs
+++ b/crates/taxis/src/config/behavior/daemon.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct DaemonBehaviorConfig {
     /// Base duration in seconds for watchdog restart backoff. Default: 2.
     /// Mirrors `daemon::watchdog::BACKOFF_BASE`.

--- a/crates/taxis/src/config/behavior/dispatch.rs
+++ b/crates/taxis/src/config/behavior/dispatch.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct DispatchConfig {
     /// Recurring cron-dispatched tasks.
     pub cron_tasks: Vec<CronTaskConfig>,

--- a/crates/taxis/src/config/behavior/jwt.rs
+++ b/crates/taxis/src/config/behavior/jwt.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct JwtSettings {
     /// Clock skew tolerance in seconds applied when checking the `exp`
     /// claim. A token whose `exp` lies up to this many seconds in the past

--- a/crates/taxis/src/config/behavior/messaging.rs
+++ b/crates/taxis/src/config/behavior/messaging.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct MessagingConfig {
     /// How often Semeion polls for new channel messages in milliseconds. Default: 2000.
     /// Mirrors `agora::semeion::DEFAULT_POLL_INTERVAL`.

--- a/crates/taxis/src/config/behavior/nous.rs
+++ b/crates/taxis/src/config/behavior/nous.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct NousBehaviorConfig {
     /// Panics within the window that trigger degraded mode. Default: 5.
     /// Mirrors `nous::actor::DEGRADED_PANIC_THRESHOLD`.

--- a/crates/taxis/src/config/behavior/timeouts.rs
+++ b/crates/taxis/src/config/behavior/timeouts.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct TimeoutsConfig {
     /// Maximum wall-clock seconds for a single LLM API call (Anthropic or CC provider).
     ///
@@ -33,6 +34,7 @@ impl Default for TimeoutsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct CapacityConfig {
     /// Maximum bytes returned by a single tool call before the output is
     /// truncated with an indicator showing the original size.
@@ -58,6 +60,7 @@ impl Default for CapacityConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct RetrySettings {
     /// Maximum number of retry attempts after an initial transient failure.
     ///

--- a/crates/taxis/src/config/behavior/tools.rs
+++ b/crates/taxis/src/config/behavior/tools.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct ToolLimitsConfig {
     /// Maximum character length for glob patterns. Default: 1000.
     /// Mirrors `organon::builtins::filesystem::MAX_PATTERN_LENGTH`.

--- a/crates/taxis/src/config/behavior/tuning.rs
+++ b/crates/taxis/src/config/behavior/tuning.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct TuningConfig {
     /// Global kill switch for self-tuning. Default: false.
     ///

--- a/crates/taxis/src/config/gateway.rs
+++ b/crates/taxis/src/config/gateway.rs
@@ -8,6 +8,7 @@ use koina::secret::SecretString;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct GatewayConfig {
     /// TCP port the gateway listens on.
     pub port: u16,
@@ -49,6 +50,7 @@ impl Default for GatewayConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct GatewayAuthConfig {
     /// Auth mode: `"token"` (bearer token), `"none"` (disabled), `"jwt"` (explicit JWT).
     pub mode: String,
@@ -76,6 +78,7 @@ impl Default for GatewayAuthConfig {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct TlsConfig {
     /// Whether TLS termination is active.
     pub enabled: bool,
@@ -89,6 +92,7 @@ pub struct TlsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct CorsConfig {
     /// Allowed origins. Empty or `["*"]` means permissive (dev mode).
     pub allowed_origins: Vec<String>,
@@ -109,6 +113,7 @@ impl Default for CorsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct BodyLimitConfig {
     /// Maximum request body size in bytes.
     pub max_bytes: usize,
@@ -126,6 +131,7 @@ impl Default for BodyLimitConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct CsrfConfig {
     /// Whether CSRF header checking is active.
     pub enabled: bool,
@@ -152,6 +158,7 @@ impl Default for CsrfConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct RateLimitConfig {
     /// Whether rate limiting is active.
     pub enabled: bool,
@@ -178,6 +185,7 @@ impl Default for RateLimitConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct PerUserRateLimitConfig {
     /// Whether per-user rate limiting is active.
     pub enabled: bool,

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -10,6 +10,7 @@ use super::{EgressPolicy, SandboxEnforcementMode};
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct MaintenanceSettings {
     /// Trace log file rotation and compression.
     pub trace_rotation: TraceRotationSettings,
@@ -36,6 +37,7 @@ pub struct MaintenanceSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct TraceRotationSettings {
     /// Whether automatic trace rotation runs.
     pub enabled: bool,
@@ -65,6 +67,7 @@ impl Default for TraceRotationSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct DriftDetectionSettings {
     /// Whether drift detection runs during maintenance.
     pub enabled: bool,
@@ -113,6 +116,7 @@ impl Default for DriftDetectionSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct DbMonitoringSettings {
     /// Whether database size monitoring runs.
     pub enabled: bool,
@@ -140,6 +144,7 @@ impl Default for DbMonitoringSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct DiskSpaceSettings {
     /// Whether disk space monitoring is active.
     pub enabled: bool,
@@ -167,6 +172,7 @@ impl Default for DiskSpaceSettings {
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 #[derive(Default)]
+#[serde(deny_unknown_fields)]
 pub struct RetentionSettings {
     /// Whether automatic retention enforcement (session cleanup) runs.
     pub enabled: bool,
@@ -176,6 +182,7 @@ pub struct RetentionSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct SandboxSettings {
     /// Whether sandbox restrictions are applied to tool execution.
     pub enabled: bool,
@@ -236,6 +243,7 @@ impl Default for SandboxSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct CredentialConfig {
     /// Credential source strategy: `"auto"`, `"api-key"`, or `"claude-code"`.
     pub source: String,
@@ -267,6 +275,7 @@ impl Default for CredentialConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct CircuitBreakerSettings {
     /// Number of failures within the window to trip the circuit.
     pub failure_threshold: u32,
@@ -300,6 +309,7 @@ impl Default for CircuitBreakerSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct LoggingSettings {
     /// Directory where daily log files are written.
     ///
@@ -340,6 +350,7 @@ impl Default for LoggingSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct RedactionSettings {
     /// Primary switch for the redaction layer. Default: `true`.
     pub enabled: bool,
@@ -383,6 +394,7 @@ impl Default for RedactionSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct WatchdogSettings {
     /// Whether the watchdog monitor is enabled.
     pub enabled: bool,
@@ -409,6 +421,7 @@ impl Default for WatchdogSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct BackupSettings {
     /// Whether automatic fjall backups are enabled.
     pub enabled: bool,
@@ -435,6 +448,7 @@ impl Default for BackupSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct CronTaskSettings {
     /// Evolution: periodic configuration variant search.
     pub evolution: CronTaskEntry,
@@ -491,6 +505,7 @@ impl Default for CronTaskEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct PromptAuditSettings {
     /// Whether outbound requests are recorded. Default: `true`.
     ///
@@ -524,6 +539,7 @@ impl Default for PromptAuditSettings {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct McpConfig {
     /// Per-session rate limiting for MCP tool calls.
     pub rate_limit: McpRateLimitConfig,
@@ -541,6 +557,7 @@ pub struct McpConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct KnowledgeGraphMcpConfig {
     /// Whether the knowledge graph MCP tools are enabled.
     ///
@@ -576,6 +593,7 @@ impl Default for KnowledgeGraphMcpConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct RepomixMcpConfig {
     /// Whether the repomix MCP tools are enabled.
     ///
@@ -610,6 +628,7 @@ impl Default for RepomixMcpConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct McpRateLimitConfig {
     /// Whether MCP rate limiting is active.
     pub enabled: bool,

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct ObservabilitySettings {
     /// Install the episteme trace-ingest subscriber layer and flush ops facts
     /// into the knowledge store. Default: true.


### PR DESCRIPTION
## Wave 1 lint campaign — taxis config-deny-unknown-fields

Clears `RUST/config-deny-unknown-fields` for all 39 violating config structs in the `taxis` crate (39 → 0).

### What changed
Added `#[serde(deny_unknown_fields)]` to all config structs in:
- `src/config/behavior/` (api, daemon, dispatch, jwt, messaging, nous, timeouts ×3, tools, tuning)
- `src/config/gateway.rs` (GatewayConfig, GatewayAuthConfig, TlsConfig, CorsConfig, BodyLimitConfig, CsrfConfig, RateLimitConfig, PerUserRateLimitConfig)
- `src/config/maintenance.rs` (21 structs: MaintenanceSettings, TraceRotationSettings, DriftDetectionSettings, DbMonitoringSettings, DiskSpaceSettings, RetentionSettings, SandboxSettings, CredentialConfig, CircuitBreakerSettings, LoggingSettings, RedactionSettings, WatchdogSettings, BackupSettings, CronTaskSettings, PromptAuditSettings, McpConfig, KnowledgeGraphMcpConfig, RepomixMcpConfig, McpRateLimitConfig)
- `src/config/mod.rs` (ObservabilitySettings)

`AletheiaConfig` (root) keeps its existing `kanon:ignore` — it intentionally uses `#[serde(default)]` for partial config loading.

`deny_unknown_fields` + `default` are compatible in serde for structs.

`cargo check` passes; `kanon lint --rust crates/taxis/` config-deny-unknown-fields: 0.