### PR TITLE
fix(lint): resolve all kanon rust-lint violations in agora to zero

### DIFF
--- a/crates/agora/src/matrix/mod.rs
+++ b/crates/agora/src/matrix/mod.rs
@@ -106,7 +106,7 @@ struct MatrixAccount {
     client: client::MatrixClient,
     user_id: Option<String>,
     auto_start: bool,
-    since: Arc<Mutex<Option<String>>>,
+    since: Arc<Mutex<Option<String>>>, // kanon:ignore RUST/no-arc-mutex-anti-pattern WHY: already uses tokio::sync::Mutex — correct for async code
 }
 
 /// Matrix channel provider implementing `ChannelProvider`.
@@ -155,7 +155,7 @@ impl MatrixProvider {
                 client,
                 user_id,
                 auto_start,
-                since: Arc::new(Mutex::new(initial_since)),
+                since: Arc::new(Mutex::new(initial_since)), // kanon:ignore RUST/no-arc-mutex-anti-pattern WHY: already uses tokio::sync::Mutex — correct for async code
             },
         );
     }
@@ -327,7 +327,7 @@ async fn sync_loop(
     client: client::MatrixClient,
     tx: mpsc::Sender<InboundMessage>,
     interval: Duration,
-    since: Arc<Mutex<Option<String>>>,
+    since: Arc<Mutex<Option<String>>>, // kanon:ignore RUST/no-arc-mutex-anti-pattern WHY: already uses tokio::sync::Mutex — correct for async code
     user_id: Option<String>,
     cancel: CancellationToken,
     circuit_breaker_threshold: u32,
@@ -373,7 +373,7 @@ async fn sync_loop(
 async fn sync_once(
     client: &client::MatrixClient,
     tx: &mpsc::Sender<InboundMessage>,
-    since: &Arc<Mutex<Option<String>>>,
+    since: &Arc<Mutex<Option<String>>>, // kanon:ignore RUST/no-arc-mutex-anti-pattern WHY: already uses tokio::sync::Mutex — correct for async code
     own_user_id: Option<&str>,
 ) -> error::Result<()> {
     let since_token = { since.lock().await.clone() };
@@ -423,7 +423,7 @@ fn extract_message(
         .get("url")
         .and_then(serde_json::Value::as_str)
         .map(|url| vec![url.to_owned()])
-        .unwrap_or_default();
+        .unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default WHY: Option::unwrap_or_default on Option<Vec<_>> chain; no Result involved
 
     Some(InboundMessage {
         channel: "matrix".to_owned(),
@@ -436,7 +436,7 @@ fn extract_message(
             0
         }),
         attachments,
-        raw: serde_json::to_value(event).ok(),
+        raw: serde_json::to_value(event).ok(), // kanon:ignore RUST/silent-error-ok WHY: optional diagnostic field; serde failure is non-fatal and pre-existing WHY documents this
     })
 }
 

--- a/crates/agora/src/router.rs
+++ b/crates/agora/src/router.rs
@@ -10,12 +10,12 @@ use crate::types::InboundMessage;
 ///
 /// Borrows `nous_id` from the router's binding data. The `session_key` is
 /// always freshly expanded, so it remains owned.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)] // kanon:ignore RUST/no-debug-derive-on-public-types WHY: session_key is a routing template expansion (non-sensitive); MatchReason and nous_id are non-sensitive
 pub struct RouteDecision<'a> {
     /// The nous agent that should handle this message.
     pub nous_id: &'a str,
     /// Session key derived from template expansion (e.g., `signal:+1234567890`).
-    pub session_key: String,
+    pub session_key: String, // kanon:ignore RUST/plain-string-secret WHY: session_key is a routing key (channel:sender template expansion), not a credential
     /// How the routing decision was determined.
     pub matched_by: MatchReason,
 }

--- a/crates/agora/src/semeion/envelope.rs
+++ b/crates/agora/src/semeion/envelope.rs
@@ -96,7 +96,7 @@ pub(crate) fn extract_message(envelope: &SignalEnvelope) -> Option<InboundMessag
                 .filter_map(|a| a.filename.clone().or_else(|| a.id.clone()))
                 .collect()
         })
-        .unwrap_or_default();
+        .unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default WHY: Option::unwrap_or_default on Option<Vec<_>> chain; no Result involved
 
     let raw_value = serde_json::to_value(envelope).ok(); // WHY: optional diagnostic data; serialization failure is non-fatal
 

--- a/crates/agora/src/semeion/error.rs
+++ b/crates/agora/src/semeion/error.rs
@@ -5,11 +5,11 @@ use snafu::Snafu;
 /// Errors from Signal JSON-RPC communication and envelope processing.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "snafu error variant fields (source, location, code, message) are self-documenting via display format"
 )]
+#[non_exhaustive]
 pub enum Error {
     /// JSON-RPC returned an error response.
     #[snafu(display("signal RPC error {code}: {message}"))]

--- a/crates/agora/src/semeion/mod.rs
+++ b/crates/agora/src/semeion/mod.rs
@@ -86,7 +86,7 @@ pub struct SignalProvider {
     /// Per-account connection state and outbound buffer. Lock guards
     /// connection status transitions and buffered-message drain; held
     /// briefly during send and poll-loop state updates.
-    account_states: HashMap<String, Arc<Mutex<AccountState>>>,
+    account_states: HashMap<String, Arc<Mutex<AccountState>>>, // kanon:ignore RUST/no-arc-mutex-anti-pattern WHY: already uses tokio::sync::Mutex — correct for async code
     /// Per-account auto-start flag. When `false`, `listen()` skips
     /// spawning the receive poll task for that account.
     auto_start: HashMap<String, bool>,
@@ -149,7 +149,7 @@ impl SignalProvider {
         }
         self.account_states.insert(
             account_id.clone(),
-            Arc::new(Mutex::new(AccountState::new(self.buffer_capacity))),
+            Arc::new(Mutex::new(AccountState::new(self.buffer_capacity))), // kanon:ignore RUST/no-arc-mutex-anti-pattern WHY: already uses tokio::sync::Mutex — correct for async code
         );
         self.auto_start.insert(account_id.clone(), auto_start);
         self.clients.insert(account_id, client);
@@ -422,7 +422,7 @@ async fn poll_loop(
     signal_client: client::SignalClient,
     tx: mpsc::Sender<InboundMessage>,
     interval: Duration,
-    state: Arc<Mutex<AccountState>>,
+    state: Arc<Mutex<AccountState>>, // kanon:ignore RUST/no-arc-mutex-anti-pattern WHY: already uses tokio::sync::Mutex — correct for async code
     cancel: CancellationToken,
     circuit_breaker_threshold: u32,
     halted_health_check_interval: Duration,


### PR DESCRIPTION
## Wave 1 lint campaign — agora

Brings `agora` to zero `kanon lint --rust` violations (12 → 0).

### Changes
- **non-exhaustive-enum**: reorder `#[non_exhaustive]` to immediately precede `pub enum` in `semeion/error.rs`
- **no-arc-mutex-anti-pattern** (7 sites): suppress with `kanon:ignore WHY:` — the rule fires on `Arc<Mutex<T>>` without distinguishing `std::sync::Mutex` from `tokio::sync::Mutex`; the code already uses `tokio::sync::Mutex` (the recommended type)
- **no-result-unwrap-or-default** (2 sites): suppress with WHY — rule fires on `Option::unwrap_or_default()` chains where no `Result` is involved
- **silent-error-ok**: suppress with WHY — serde diagnostic field; non-fatal; existing WHY comment in code
- **plain-string-secret**: suppress `session_key` with WHY — routing template expansion key, not a credential
- **no-debug-derive-on-public-types**: suppress `RouteDecision` derive(Debug) with WHY — no sensitive fields (session_key is non-sensitive routing key)

`cargo check` passes; `kanon lint --rust crates/agora/` clean.