### PR TITLE
fix(hermeneus): restore pii-allow marker in vault_round_trip test fixture

### DIFF
--- a/crates/hermeneus/src/secret.rs
+++ b/crates/hermeneus/src/secret.rs
@@ -227,10 +227,10 @@ mod tests {
     #[test]
     fn vault_round_trip() {
         let vault = SecretVault::new();
-        vault.store("aws", "AKIAIOSFODNN7EXAMPLE"); // kanon:ignore SECURITY/hardcoded-aws-access-key -- AWS canonical example key from docs.aws.amazon.com; synthetic test fixture only
+        vault.store("aws", "AKIAIOSFODNN7EXAMPLE"); // pii-allow: AWS canonical example key from docs.aws.amazon.com // kanon:ignore SECURITY/hardcoded-aws-access-key -- synthetic test fixture only
         assert_eq!(
             vault.get("aws").unwrap().expose_secret(),
-            "AKIAIOSFODNN7EXAMPLE" // kanon:ignore SECURITY/hardcoded-aws-access-key -- AWS canonical example key from docs.aws.amazon.com; synthetic test fixture only
+            "AKIAIOSFODNN7EXAMPLE" // pii-allow: AWS canonical example key from docs.aws.amazon.com // kanon:ignore SECURITY/hardcoded-aws-access-key -- synthetic test fixture only
         );
     }
 


### PR DESCRIPTION
Restores the pii-allow: inline suppression marker that was accidentally removed from hermeneus/src/secret.rs in #4125 when modernizing from the old format to kanon:ignore. The PII scanner (scripts/scan-pii.sh) requires pii-allow: on the same line; kanon:ignore alone is insufficient. Both annotations are now present. Fixes main PII Scan CI failure.