### PR TITLE
fix(lint): resolve kanon rust-lint violation in dianoia to zero

### DIFF
--- a/crates/dianoia/src/state.rs
+++ b/crates/dianoia/src/state.rs
@@ -1,8 +1,9 @@
 //! Project lifecycle state machine.
 
+use serde::{Deserialize, Serialize};
+
 use crate::error::{self, GateBlockedSnafu, Result};
 use crate::gate::{GateResult, PhaseGate, evaluate_gate};
-use serde::{Deserialize, Serialize};
 
 /// Project lifecycle states.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Fixes 1 `[RUST/import-order]` violation in `crates/dianoia/src/state.rs`
- Corrects import group ordering to std → external → crate

## Test plan
- [x] `kanon lint --rust` shows zero violations for `crates/dianoia/`
- [x] `kanon gate` light GREEN