### PR TITLE
fix(lint): make `kanon gate --full` pass on main

### DIFF
--- a/crates/agora/src/matrix/mod.rs
+++ b/crates/agora/src/matrix/mod.rs
@@ -616,7 +616,7 @@ mod tests {
         );
 
         let token = CancellationToken::new();
-        let (mut rx, mut handles) = provider.listen(Some(Duration::from_secs(60)), token.clone());
+        let (mut rx, mut handles) = provider.listen(Some(Duration::from_mins(1)), token.clone());
         let msg = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
             .expect("timeout")

--- a/crates/aletheia-lexica/src/lib.rs
+++ b/crates/aletheia-lexica/src/lib.rs
@@ -12,7 +12,6 @@ pub mod stopwords;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
 
     #[test]
     fn modules_are_reachable() {

--- a/crates/aletheia-memory-mcp/src/tools.rs
+++ b/crates/aletheia-memory-mcp/src/tools.rs
@@ -200,11 +200,11 @@ fn forget_fact_with_current_schema(
         ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
           superseded_by, source_session_id, recorded_at,
           access_count, last_accessed_at, stability_hours, fact_type,
-          scope, visibility, is_forgotten, forgotten_at, forget_reason] :=
+          scope, project_id, visibility, is_forgotten, forgotten_at, forget_reason] :=
             *facts{id, valid_from, content, nous_id, confidence, tier,
                    valid_to, superseded_by, source_session_id, recorded_at,
                    access_count, last_accessed_at, stability_hours, fact_type,
-                   scope, visibility},
+                   scope, project_id, visibility},
             id = $id,
             is_forgotten = true,
             forgotten_at = $now,
@@ -212,7 +212,7 @@ fn forget_fact_with_current_schema(
         :put facts {id, valid_from => content, nous_id, confidence, tier,
                     valid_to, superseded_by, source_session_id, recorded_at,
                     access_count, last_accessed_at, stability_hours, fact_type,
-                    scope, visibility, is_forgotten, forgotten_at, forget_reason}
+                    scope, project_id, visibility, is_forgotten, forgotten_at, forget_reason}
     ";
     let mut params = BTreeMap::new();
     params.insert("id".to_owned(), DataValue::Str(fact_id.as_str().into()));

--- a/crates/aletheia-routing/src/lib.rs
+++ b/crates/aletheia-routing/src/lib.rs
@@ -266,7 +266,7 @@ mod tests {
                 .rolling_stats(
                     &provider,
                     &TaskCategory::Feature,
-                    Duration::from_secs(7 * 24 * 60 * 60),
+                    Duration::from_hours(168),
                 )
                 .await
             {

--- a/crates/aletheia-routing/src/lib.rs
+++ b/crates/aletheia-routing/src/lib.rs
@@ -263,11 +263,7 @@ mod tests {
 
         for _ in 0..10 {
             if let Some(stats) = store
-                .rolling_stats(
-                    &provider,
-                    &TaskCategory::Feature,
-                    Duration::from_hours(168),
-                )
+                .rolling_stats(&provider, &TaskCategory::Feature, Duration::from_hours(168))
                 .await
             {
                 assert_eq!(stats.successes, 1);

--- a/crates/aletheia-sessions-migrate/src/verify.rs
+++ b/crates/aletheia-sessions-migrate/src/verify.rs
@@ -333,10 +333,12 @@ fn dest_per_session_counts(db: &FjallDb) -> Result<std::collections::BTreeMap<St
 }
 
 fn hex(bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
     let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        write!(&mut s, "{b:02x}").expect("writing to String is infallible"); // kanon:ignore RUST/expect WHY: fmt::Write for String never returns Err
+    for &b in bytes {
+        // WHY: a hex nibble is always 0..=15, so `from_digit` always returns
+        // `Some`; the `unwrap_or` fallback is unreachable but keeps this panic-free.
+        s.push(char::from_digit(u32::from(b >> 4), 16).unwrap_or('0'));
+        s.push(char::from_digit(u32::from(b & 0x0f), 16).unwrap_or('0'));
     }
     s
 }

--- a/crates/dianoia/src/research/mod.rs
+++ b/crates/dianoia/src/research/mod.rs
@@ -1,7 +1,6 @@
 //! Multi-level parallel research: domain types, prompts, merge, and deduplication.
 
 use std::collections::HashSet;
-use std::fmt::Write as _;
 
 use serde::{Deserialize, Serialize};
 
@@ -216,8 +215,9 @@ fn format_markdown(findings: &[ResearchFinding]) -> String {
     let mut out = String::from("# Research Summary\n");
 
     for finding in findings {
-        write!(out, "\n## {}\n\n", finding.domain.heading())
-            .expect("writing to String is infallible"); // kanon:ignore RUST/expect WHY: fmt::Write for String never returns Err
+        out.push_str("\n## ");
+        out.push_str(finding.domain.heading());
+        out.push_str("\n\n");
         match finding.status {
             FindingStatus::Complete => {
                 out.push_str(&finding.content);

--- a/crates/energeia/src/pipeline/execution.rs
+++ b/crates/energeia/src/pipeline/execution.rs
@@ -477,6 +477,10 @@ async fn run_qa_and_generate_corrective(
     clippy::indexing_slicing,
     reason = "test assertions on known-length collections"
 )]
+#[expect(
+    clippy::disallowed_types,
+    reason = "std::sync::Mutex is sufficient for synchronous capture in test mocks"
+)]
 mod tests {
     use std::collections::VecDeque;
     use std::future::Future;

--- a/crates/energeia/src/session/isolation.rs
+++ b/crates/energeia/src/session/isolation.rs
@@ -138,7 +138,7 @@ impl IsolationResolver {
         let entries = self.list_worktrees()?;
 
         if entries.iter().any(|entry| same_path(entry, &worktree)) {
-            self.open_worktree(&worktree)?;
+            Self::open_worktree(&worktree)?;
             return Ok(worktree);
         }
 
@@ -152,7 +152,7 @@ impl IsolationResolver {
         }
 
         self.create_worktree(&worktree)?;
-        self.open_worktree(&worktree)?;
+        Self::open_worktree(&worktree)?;
         Ok(worktree)
     }
 
@@ -177,7 +177,7 @@ impl IsolationResolver {
         Ok(parse_worktree_paths(&output.stdout))
     }
 
-    fn open_worktree(&self, worktree: &Path) -> std::result::Result<(), ResolveError> {
+    fn open_worktree(worktree: &Path) -> std::result::Result<(), ResolveError> {
         if !worktree.is_dir() {
             return Err(ResolveError::WorktreeOpen(WorktreeOpenError {
                 reason: CompactString::from(format!(
@@ -246,7 +246,7 @@ impl IsolationResolver {
         ) {
             Ok(_) => Ok(()),
             Err(remove_reason) => {
-                let entries = self.list_worktrees().map_err(|err| err.into_reason())?;
+                let entries = self.list_worktrees().map_err(ResolveError::into_reason)?;
                 if entries.iter().any(|entry| same_path(entry, &worktree)) {
                     Err(remove_reason)
                 } else {
@@ -317,7 +317,7 @@ where
 fn display_args(args: &[OsString]) -> String {
     args.iter()
         .map(|arg| arg.to_string_lossy())
-        .map(|arg| arg.into_owned())
+        .map(std::borrow::Cow::into_owned)
         .collect::<Vec<_>>()
         .join(" ")
 }
@@ -423,6 +423,10 @@ fn emit_outcome(outcome: &IsolationResult) {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::similar_names,
+    reason = "test bindings `resolver`/`resolved` are clear in context"
+)]
 mod tests {
     use std::fs;
 

--- a/crates/energeia/src/session/options.rs
+++ b/crates/energeia/src/session/options.rs
@@ -171,6 +171,7 @@ impl Default for EngineConfig {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
 

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -4,6 +4,10 @@
 )]
 use snafu::ResultExt;
 #[cfg(feature = "mneme-engine")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "exhaustive 1:1 field-to-column marshalling; splitting would obscure the mapping"
+)]
 pub(super) fn fact_to_params(
     fact: &crate::knowledge::Fact,
 ) -> std::collections::BTreeMap<String, crate::engine::DataValue> {

--- a/crates/episteme/src/recall_tests/visibility.rs
+++ b/crates/episteme/src/recall_tests/visibility.rs
@@ -3,6 +3,7 @@
     clippy::indexing_slicing,
     reason = "test assertions: index access is guarded by prior length checks"
 )]
+#![expect(clippy::expect_used, reason = "test assertions")]
 
 use crate::knowledge::Visibility;
 use crate::recall::{FactorScores, ProjectRecallScope, ScoredResult};

--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -429,13 +429,13 @@ mod tests {
         let provider = CcProvider {
             cc_binary: PathBuf::from("/usr/local/bin/claude"),
             default_model: "claude-opus-4-6".to_owned(),
-            timeout: Duration::from_secs(300),
+            timeout: Duration::from_mins(5),
         };
         assert_eq!(
             provider.cli_binary(),
             &PathBuf::from("/usr/local/bin/claude")
         );
-        assert_eq!(provider.subprocess_timeout(), Duration::from_secs(300));
+        assert_eq!(provider.subprocess_timeout(), Duration::from_mins(5));
         assert_eq!(provider.cli_product_name(), "claude");
     }
 }

--- a/crates/hermeneus/src/complexity/tier1.rs
+++ b/crates/hermeneus/src/complexity/tier1.rs
@@ -129,7 +129,7 @@ impl Tier1Registry {
 /// # Example
 ///
 /// ```rust
-/// use hermeneus::complexity::tier1::RegexReplaceHandler;
+/// use hermeneus::complexity::tier1::{RegexReplaceHandler, Tier1Handler};
 ///
 /// // Match simple arithmetic and return a fixed message.
 /// let handler = RegexReplaceHandler::new(
@@ -194,7 +194,7 @@ impl Tier1Handler for RegexReplaceHandler {
 /// # Example
 ///
 /// ```rust
-/// use hermeneus::complexity::tier1::ExactMatchHandler;
+/// use hermeneus::complexity::tier1::{ExactMatchHandler, Tier1Handler};
 ///
 /// let handler = ExactMatchHandler::new("ack-ok", "ok", "Acknowledged.");
 /// assert!(handler.try_handle("  OK  ").is_some());

--- a/crates/hermeneus/src/openai/wire/request.rs
+++ b/crates/hermeneus/src/openai/wire/request.rs
@@ -374,10 +374,6 @@ impl<'a> ResponsesRequest<'a> {
 /// Messages with mixed content (text + `tool_use` + `tool_result`) expand
 /// into multiple chat messages: OpenAI requires each tool result to live
 /// in its own `role: "tool"` message correlated by `tool_call_id`.
-#[expect(
-    clippy::too_many_lines,
-    reason = "one function per Anthropic role keeps the wire mapping readable in one place"
-)]
 fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
     match msg.role {
         Role::System => {
@@ -407,10 +403,8 @@ fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
                     let mut text_parts: Vec<String> = Vec::new();
                     for block in blocks {
                         match block {
-                            ContentBlock::Text { text, .. } => {
-                                if !text.is_empty() {
-                                    text_parts.push(text.clone());
-                                }
+                            ContentBlock::Text { text, .. } if !text.is_empty() => {
+                                text_parts.push(text.clone());
                             }
                             ContentBlock::ToolResult {
                                 tool_use_id,
@@ -450,10 +444,8 @@ fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
                 Content::Blocks(blocks) => {
                     for block in blocks {
                         match block {
-                            ContentBlock::Text { text, .. } => {
-                                if !text.is_empty() {
-                                    text_parts.push(text.clone());
-                                }
+                            ContentBlock::Text { text, .. } if !text.is_empty() => {
+                                text_parts.push(text.clone());
                             }
                             ContentBlock::ToolUse { id, name, input } => {
                                 // WHY: OpenAI requires arguments as a JSON

--- a/crates/melete/src/contradiction.rs
+++ b/crates/melete/src/contradiction.rs
@@ -1,7 +1,5 @@
 //! Cross-chunk contradiction detection via LLM comparison.
 
-use std::fmt::Write;
-
 use snafu::ResultExt;
 
 use hermeneus::provider::LlmProvider;
@@ -105,7 +103,10 @@ pub(crate) async fn detect_contradictions(
 
     let mut numbered = String::new();
     for (i, chunk) in chunks.iter().enumerate() {
-        writeln!(numbered, "{}. {chunk}", i + 1);
+        numbered.push_str(&(i + 1).to_string());
+        numbered.push_str(". ");
+        numbered.push_str(chunk);
+        numbered.push('\n');
     }
 
     let request = CompletionRequest {

--- a/crates/melete/src/flush.rs
+++ b/crates/melete/src/flush.rs
@@ -1,7 +1,5 @@
 //! Memory flush types for amnesia prevention across distillation boundaries.
 
-use std::fmt::Write;
-
 /// Items to flush to persistent storage before distillation.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MemoryFlush {
@@ -79,7 +77,9 @@ impl MemoryFlush {
         write_section(&mut out, "Facts", &self.facts);
 
         if let Some(state) = &self.task_state {
-            writeln!(out, "## Task State\n{state}\n");
+            out.push_str("## Task State\n");
+            out.push_str(state);
+            out.push_str("\n\n");
         }
 
         out.trim_end().to_owned()
@@ -90,16 +90,17 @@ fn write_section(out: &mut String, heading: &str, items: &[FlushItem]) {
     if items.is_empty() {
         return;
     }
-    writeln!(out, "## {heading}");
+    out.push_str("## ");
+    out.push_str(heading);
+    out.push('\n');
     for item in items {
-        writeln!(
-            out,
-            "- [{}] {} (source: {})",
-            item.timestamp,
-            item.content,
-            item.source.label()
-        )
-        .expect("writing to String is infallible"); // kanon:ignore RUST/expect WHY: fmt::Write for String never returns Err
+        out.push_str("- [");
+        out.push_str(&item.timestamp);
+        out.push_str("] ");
+        out.push_str(&item.content);
+        out.push_str(" (source: ");
+        out.push_str(item.source.label());
+        out.push_str(")\n");
     }
     out.push('\n');
 }

--- a/crates/melete/src/prompt.rs
+++ b/crates/melete/src/prompt.rs
@@ -1,7 +1,5 @@
 //! Distillation prompt construction.
 
-use std::fmt::Write;
-
 use hermeneus::types::{Content, ContentBlock, Message, Role};
 
 use crate::distill::DistillSection;
@@ -17,7 +15,10 @@ pub(crate) fn build_system_prompt(sections: &[DistillSection]) -> String {
     );
 
     for section in sections {
-        writeln!(prompt, "{}\n{}\n", section.heading(), section.description());
+        prompt.push_str(&section.heading());
+        prompt.push('\n');
+        prompt.push_str(section.description());
+        prompt.push_str("\n\n");
     }
 
     prompt.push_str(
@@ -48,7 +49,11 @@ pub(crate) fn format_messages(messages: &[Message], include_tool_calls: bool) ->
 
         match &msg.content {
             Content::Text(text) => {
-                writeln!(output, "[{role_label}]\n{text}\n");
+                output.push('[');
+                output.push_str(role_label);
+                output.push_str("]\n");
+                output.push_str(text);
+                output.push_str("\n\n");
             }
             Content::Blocks(blocks) => {
                 let mut block_text = String::new();
@@ -59,7 +64,11 @@ pub(crate) fn format_messages(messages: &[Message], include_tool_calls: bool) ->
                             block_text.push('\n');
                         }
                         ContentBlock::ToolUse { name, input, .. } if include_tool_calls => {
-                            writeln!(block_text, "[Tool call: {name}({input})]");
+                            block_text.push_str("[Tool call: ");
+                            block_text.push_str(name);
+                            block_text.push('(');
+                            block_text.push_str(&input.to_string());
+                            block_text.push_str(")]\n");
                         }
                         ContentBlock::ToolResult {
                             content, is_error, ..
@@ -71,10 +80,16 @@ pub(crate) fn format_messages(messages: &[Message], include_tool_calls: bool) ->
                             };
                             let summary = content.text_summary();
                             let truncated = truncate_tool_result(&summary);
-                            writeln!(block_text, "[{prefix}: {truncated}]");
+                            block_text.push('[');
+                            block_text.push_str(prefix);
+                            block_text.push_str(": ");
+                            block_text.push_str(truncated);
+                            block_text.push_str("]\n");
                         }
                         ContentBlock::Thinking { thinking, .. } => {
-                            writeln!(block_text, "[Thinking: {thinking}]");
+                            block_text.push_str("[Thinking: ");
+                            block_text.push_str(thinking);
+                            block_text.push_str("]\n");
                         }
                         _ => {
                             // NOTE: other content block types not rendered in prompt summary
@@ -82,7 +97,11 @@ pub(crate) fn format_messages(messages: &[Message], include_tool_calls: bool) ->
                     }
                 }
                 if !block_text.is_empty() {
-                    writeln!(output, "[{role_label}]\n{block_text}");
+                    output.push('[');
+                    output.push_str(role_label);
+                    output.push_str("]\n");
+                    output.push_str(&block_text);
+                    output.push('\n');
                 }
             }
             _ => {

--- a/crates/nous/src/actor/tests/lifecycle_and_panic.rs
+++ b/crates/nous/src/actor/tests/lifecycle_and_panic.rs
@@ -417,11 +417,7 @@ async fn turn_records_after_action_outcome_in_empirical_store() {
     let provider = ProviderId::new("test-model");
     for _ in 0..20 {
         if let Some(stats) = store
-            .rolling_stats(
-                &provider,
-                &TaskCategory::Feature,
-                Duration::from_secs(7 * 24 * 60 * 60),
-            )
+            .rolling_stats(&provider, &TaskCategory::Feature, Duration::from_hours(168))
             .await
         {
             assert_eq!(stats.successes, 1);

--- a/crates/nous/src/instinct.rs
+++ b/crates/nous/src/instinct.rs
@@ -100,6 +100,7 @@ pub(crate) fn record_observations(
     clippy::indexing_slicing,
     reason = "test: vec indices are valid after asserting len"
 )]
+#[expect(clippy::expect_used, reason = "test assertions")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -436,11 +436,7 @@ mod tests {
         let provider = ProviderId::new("claude-sonnet-4-20250514");
         for _ in 0..20 {
             if let Some(stats) = store
-                .rolling_stats(
-                    &provider,
-                    &TaskCategory::Feature,
-                    Duration::from_secs(7 * 24 * 60 * 60),
-                )
+                .rolling_stats(&provider, &TaskCategory::Feature, Duration::from_hours(168))
                 .await
             {
                 assert_eq!(stats.successes, 1);

--- a/crates/organon/src/receipts.rs
+++ b/crates/organon/src/receipts.rs
@@ -58,10 +58,6 @@ impl ReceiptSigner {
     /// # Errors
     /// Returns [`VerifyError::Malformed`] if the receipt is not valid base64url,
     /// or [`VerifyError::HmacMismatch`] if the HMAC does not match.
-    #[expect(
-        clippy::expect_used,
-        reason = "32-byte key is always valid for Hmac<Sha256>"
-    )]
     pub fn verify(
         &self,
         receipt: &str,


### PR DESCRIPTION
## Why

`kanon gate --full` failed on `main`, blocking the `Gate-Passed:` trailer that the `gate-attestation` check requires — so every merge was blocked. This restores a green gate.

## What

Three focused commits:

1. **#4144 forget fix** (cherry-picked) — `forget_fact_with_current_schema` hand-writes a CozoScript `:put` against the `facts` relation but omitted the `project_id` column added by the mneme partition-by-project change, so `nous_forget` failed at runtime (`required column project_id not provided by input`). Carries `project_id` through the read and the `:put`.

2. **clippy deny-level errors** — the gate's clippy step runs with `-D warnings`, and a set of deny-level lints + one doc-test compile error (`E0599`) failed it:
   - `expect_used` on infallible `String` writes (dianoia, melete, aletheia-sessions-migrate) → rewritten with `push_str`/`push` / `char::from_digit`, dropping the now-unused `fmt::Write` imports.
   - `expect_used` / `disallowed_types` in test modules → annotated `#[expect(...)]` matching the existing test-allow convention.
   - `E0599 try_handle` — hermeneus `tier1` doctests now import `Tier1Handler`.
   - unused `use super::*` (aletheia-lexica); `Duration::from_hours(168)` (aletheia-routing).

3. **remaining clippy pedantic warnings** (also blocking under `-D warnings`) — `writeln!`→`push_str` rewrites, `collapsible_match` guards, readable `Duration` units, `unused_self`→associated fn, redundant-closure→method-ref, `similar_names` test expect, removed two now-unfulfilled lint expects, and a justified `too_many_lines` expect on the flat field-marshalling fn.

## Verification

`kanon gate --full` is green end-to-end (fmt + check + dependency audit + clippy + test + lint + fleet-names) and the tip commit carries the earned `Gate-Passed:` trailer.