### PR TITLE
fix(integration-tests): add project_id to engine-tests Fact fixtures

### DIFF
--- a/crates/integration-tests/tests/access_tracking.rs
+++ b/crates/integration-tests/tests/access_tracking.rs
@@ -41,6 +41,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str) -> Fact {
         content: content.to_owned(),
         fact_type: "inference".to_owned(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: ts(TS_2026),
             valid_to: far_future(),

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -35,6 +35,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: Epis
         content: content.to_owned(),
         fact_type: String::new(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: ts(TS_2026),
             valid_to: far_future(),
@@ -115,6 +116,7 @@ fn fact_round_trip() {
         content: "The researcher published findings on memory consolidation".to_owned(),
         fact_type: String::new(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: ts(TS_2026),
             valid_to: far_future(),

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -35,6 +35,7 @@ fn make_fact(id: &str, nous_id: &str, content: &str, confidence: f64, tier: Epis
         content: content.to_owned(),
         fact_type: String::new(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: ts(TS_2026),
             valid_to: far_future(),
@@ -100,6 +101,7 @@ fn correct_fact(
         content: new_content.to_owned(),
         fact_type: String::new(),
         scope: None,
+        project_id: None,
         temporal: FactTemporal {
             valid_from: ts(correction_time),
             valid_to: far_future(),


### PR DESCRIPTION
## Why

`cargo test -p integration-tests --features test-core` failed to compile: five `Fact { .. }` literals in the `engine-tests`-gated integration tests were missing the `project_id` field that the mneme partition-by-project change (#4125) added to `Fact`. The gate's `cargo test` does not enable that feature, so the breakage was invisible to CI — the same root cause as the #4144 forget bug.

## What

Set `project_id: None` on each affected fixture (access_tracking ×1, knowledge_engine ×2, knowledge_lifecycle ×2), matching the other test fact builders.

## Verification

- `cargo test -p integration-tests --features test-core --no-run` compiles cleanly (all test binaries build).
- `proskenion_contract` (5 tests) passes — the desktop↔server protocol contract is intact.
- `kanon gate --full` green (tip carries the earned `Gate-Passed:` trailer).

> Note: the gate not compiling the `engine-tests` feature is a coverage gap that let this drift land; flagged separately for follow-up.