### PR TITLE
fix(proskenion): repair desktop app build (drifted Debug field + eval API)

### DIFF
--- a/crates/theatron/proskenion/src/state/connection.rs
+++ b/crates/theatron/proskenion/src/state/connection.rs
@@ -115,7 +115,6 @@ impl std::fmt::Debug for ConnectionConfig {
             )
             .field("auto_reconnect", &self.auto_reconnect)
             .field("connect_timeout_secs", &self.connect_timeout_secs)
-            .field("retry_backoff_ms", &self.retry_backoff_ms)
             .finish()
     }
 }

--- a/crates/theatron/proskenion/src/views/files/toolbar.rs
+++ b/crates/theatron/proskenion/src/views/files/toolbar.rs
@@ -114,7 +114,7 @@ pub(crate) fn ViewerToolbar(
                                 "navigator.clipboard.writeText('{}')",
                                 path.replace('\'', "\\'")
                             );
-                            if document::eval(&js).is_err() {
+                            if document::eval(&js).await.is_err() {
                                 tracing::warn!("failed to copy file path to clipboard");
                                 copied.set(false);
                                 return;


### PR DESCRIPTION
## Why

The desktop app (`proskenion`) did **not compile** on `main`. It is excluded from the workspace (GTK/webkit2gtk system deps) and not built in CI, so two errors had drifted in undetected:

1. `state/connection.rs:118` (E0609) — the manual `Debug` impl referenced a removed `retry_backoff_ms` field.
2. `views/files/toolbar.rs:117` (E0599) — `document::eval(&js).is_err()`, but Dioxus `eval` returns an `Eval` future, not a `Result`.

## What

1. Dropped the stale `retry_backoff_ms` line from the `Debug` impl (field no longer exists; referenced nowhere else).
2. Added `.await` to the toolbar `eval` call so it matches the other call sites (`chat.rs`, `command_palette.rs`) and actually drives the clipboard-write before checking the result.

## Verification

`cargo build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml` now compiles cleanly (no errors, no warnings). The root-workspace `kanon gate --full` is green (tip carries the `Gate-Passed:` trailer); note the main-workspace gate does not cover `proskenion` since it is excluded.

## Review note

Leaving this for maintainer review rather than auto-merging: change #2 alters desktop-app runtime behavior (the clipboard copy now awaits the eval). Separately, `proskenion` has accumulated a backlog of `clippy -D warnings` lint debt (it is outside CI) — out of scope here; flagged for a dedicated cleanup.