### PR TITLE
fix: repair desktop smoke test + serialize flaky architecture_fact tests

### DIFF
--- a/crates/organon/src/builtins/architecture_fact.rs
+++ b/crates/organon/src/builtins/architecture_fact.rs
@@ -338,23 +338,36 @@ mod tests {
         }
     }
 
-    /// Point the store at a fresh temp dir for each test via env var.
-    fn setup_temp_dir() -> tempfile::TempDir {
+    /// Serializes the tests in this module that mutate the process-global
+    /// `ALETHEIA_FACTS_DIR`. `#[tokio::test]` functions run concurrently, so
+    /// without this lock they race on the env var and `op_list_all` (and the
+    /// other store tests) intermittently observe another test's fact directory.
+    static FACTS_DIR_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// Point the store at a fresh temp dir for the duration of a test.
+    ///
+    /// Returns the `TempDir` (keeps the directory alive) and a guard that
+    /// serializes access to the shared `ALETHEIA_FACTS_DIR` env var. Both must
+    /// stay bound for the whole test body.
+    async fn setup_temp_dir() -> (tempfile::TempDir, tokio::sync::MutexGuard<'static, ()>) {
+        let guard = FACTS_DIR_LOCK.lock().await;
         let dir = tempfile::tempdir().expect("tempdir");
-        // WHY: The executor reads ALETHEIA_FACTS_DIR at call time, so we
-        // set it before each test invocation.  Tests are not run in parallel
-        // within this module so the env var is safe to mutate.
-        #[expect(unsafe_code, reason = "test-only env mutation; tests run sequentially")]
-        // SAFETY: single-threaded tokio test context; no concurrent env readers.
+        // WHY: the executor reads ALETHEIA_FACTS_DIR at call time; the guard
+        // above ensures no other test in this module mutates it concurrently.
+        #[expect(
+            unsafe_code,
+            reason = "test-only env mutation, serialized by FACTS_DIR_LOCK"
+        )]
+        // SAFETY: FACTS_DIR_LOCK serializes env mutation/reads across this module's tests.
         unsafe {
             std::env::set_var("ALETHEIA_FACTS_DIR", dir.path());
         };
-        dir
+        (dir, guard)
     }
 
     #[tokio::test]
     async fn op_put_then_get_roundtrip() {
-        let _dir = setup_temp_dir();
+        let (_dir, _guard) = setup_temp_dir().await;
         let ctx = mock_ctx();
         let executor = ArchitectureFactExecutor;
 
@@ -402,7 +415,7 @@ mod tests {
 
     #[tokio::test]
     async fn op_list_all() {
-        let _dir = setup_temp_dir();
+        let (_dir, _guard) = setup_temp_dir().await;
         let ctx = mock_ctx();
         let executor = ArchitectureFactExecutor;
 
@@ -442,7 +455,7 @@ mod tests {
 
     #[tokio::test]
     async fn op_search_returns_matching() {
-        let _dir = setup_temp_dir();
+        let (_dir, _guard) = setup_temp_dir().await;
         let ctx = mock_ctx();
         let executor = ArchitectureFactExecutor;
 
@@ -484,7 +497,7 @@ mod tests {
 
     #[tokio::test]
     async fn op_get_missing_returns_not_found_message() {
-        let _dir = setup_temp_dir();
+        let (_dir, _guard) = setup_temp_dir().await;
         let ctx = mock_ctx();
         let executor = ArchitectureFactExecutor;
 
@@ -506,7 +519,7 @@ mod tests {
 
     #[tokio::test]
     async fn op_put_missing_updated_by_is_error() {
-        let _dir = setup_temp_dir();
+        let (_dir, _guard) = setup_temp_dir().await;
         let ctx = mock_ctx();
         let executor = ArchitectureFactExecutor;
 
@@ -534,7 +547,7 @@ mod tests {
 
     #[tokio::test]
     async fn op_unknown_is_error() {
-        let _dir = setup_temp_dir();
+        let (_dir, _guard) = setup_temp_dir().await;
         let ctx = mock_ctx();
         let executor = ArchitectureFactExecutor;
 

--- a/scripts/smoke-proskenion.sh
+++ b/scripts/smoke-proskenion.sh
@@ -128,18 +128,19 @@ mkdir -p "$LOGDIR" "$CONFIG_HOME/aletheia" "$INSTANCE_ROOT"
 if [[ "$START_SERVER" == true ]]; then
     PORT="${ALETHEIA_SMOKE_PORT:-$(( 39000 + (RANDOM % 2000) ))}"
     SERVER_URL="$(printf 'http://127.0.0.1:%s' "$PORT")"
-    mkdir -p "$INSTANCE_ROOT/config"
-    {
-        echo "[gateway]"
-        echo 'bind = "localhost"'
-        printf 'port = %s\n' "$PORT"
-        echo
-        echo "[gateway.auth]"
-        echo 'mode = "none"'
-        echo 'none_role = "operator"'
-    } >"$INSTANCE_ROOT/config/aletheia.toml"
+    # WHY: `serve` requires a full instance layout (data/, logs/, nous/, ...) and
+    # at least one configured agent, not just a bare config file. `init -y`
+    # generates a complete valid instance whose default config already sets
+    # `gateway.auth.mode = "none"` and one agent. Bind/port are supplied on the
+    # CLI below, so no further config edits are needed.
+    if ! "$SERVER_BINARY" init --instance-root "$INSTANCE_ROOT" -y \
+        >"$LOGDIR/init.log" 2>&1; then
+        degrade "$(printf 'aletheia init failed; see %s/init.log' "$LOGDIR")"
+    fi
     log "$(printf 'starting server: %s --instance-root %s --bind 127.0.0.1 --port %s serve' "$SERVER_BINARY" "$INSTANCE_ROOT" "$PORT")"
-    "$SERVER_BINARY" \
+    # WHY: the smoke config sets `gateway.auth.mode = "none"`; the server rejects
+    # that by default and requires this explicit local-dev opt-in env var.
+    ALETHEIA_ALLOW_AUTH_NONE=1 "$SERVER_BINARY" \
         --instance-root "$INSTANCE_ROOT" \
         --bind 127.0.0.1 \
         --port "$PORT" \


### PR DESCRIPTION
Two test-reliability fixes found while exercising the desktop app end-to-end.

## 1. `scripts/smoke-proskenion.sh` — desktop smoke test always skipped

The smoke test had drifted out of sync with the server and never reached its health check, so it never actually launched proskenion:

- wrote `none_role` (snake_case) but `GatewayAuthConfig` is `rename_all = "camelCase"` + `deny_unknown_fields` → `unknown field \`none_role\`, expected \`noneRole\``;
- never ran `aletheia init`, so `serve` aborted on the missing instance layout (`data/`) and empty `agents.list`;
- did not set `ALETHEIA_ALLOW_AUTH_NONE=1`, now required to opt into `auth.mode = "none"`.

Fix: replace the hand-written partial config with `aletheia init -y` (emits a complete valid instance: auth=none + a default agent), keep bind/port on the CLI, and set the opt-in env var. The smoke test now passes — proskenion launches under xvfb, connects to the started server, and runs its bounded window cleanly.

## 2. `organon` — flaky `architecture_fact` store tests

`setup_temp_dir` mutates the process-global `ALETHEIA_FACTS_DIR`, with a comment claiming the module's tests do not run in parallel. They do (`#[tokio::test]` runs concurrently), so the six store tests raced on the env var and `op_list_all` intermittently saw another test's fact directory (`expected 2 facts` failing under a full `cargo test` while passing in isolation).

Fix: serialize the env-mutating tests with a module-static `tokio::sync::Mutex`; `setup_temp_dir` is now async and returns a guard each test holds for its body. `cargo test -p organon` is stable across repeated runs.

## Verification

`kanon gate --full` green (tip carries the `Gate-Passed:` trailer); `cargo test -p organon` stable over repeated runs; `scripts/smoke-proskenion.sh` passes.