### PR TITLE
fix(hermeneus): ignore unenforceable max_tokens on CC/Kimi providers instead of erroring

### DIFF
--- a/crates/hermeneus/src/cc/process.rs
+++ b/crates/hermeneus/src/cc/process.rs
@@ -65,17 +65,27 @@ fn scrub_cc_auth_env(cmd: &mut Command) {
         .env_remove("CLAUDE_CODE_OAUTH_TOKEN");
 }
 
-fn ensure_max_tokens_supported(max_tokens: u32) -> Result<()> {
-    if max_tokens == 0 {
-        return Ok(());
+/// Warn (once) that a non-zero `max_tokens` cannot be honored by the CC
+/// subprocess provider, then ignore it.
+///
+/// WHY: The `claude` CLI exposes no max-output-token flag, so the cap is
+/// genuinely unenforceable here. Hard-erroring on any non-zero value (the prior
+/// behavior) broke every turn on the default zero-config CC provider — both the
+/// scaffolded `[agents.defaults] max_output_tokens` and the hardcoded
+/// recall-rewrite `max_tokens = 512` feed a non-zero value into this path. The
+/// turn should still run; degrade gracefully by ignoring the unenforceable cap
+/// with a single warning rather than failing the request. See aletheia#4158.
+fn warn_unenforceable_max_tokens(max_tokens: u32) {
+    use std::sync::Once;
+    static WARN_ONCE: Once = Once::new();
+    if max_tokens != 0 {
+        WARN_ONCE.call_once(|| {
+            tracing::warn!(
+                max_tokens,
+                "claude CLI cannot enforce a max output token limit; ignoring max_tokens for CC subprocess completions"
+            );
+        });
     }
-
-    Err(error::ApiRequestSnafu {
-        message: format!(
-            "CC subprocess cannot enforce max_tokens={max_tokens}: claude CLI does not expose a max output token flag"
-        ),
-    }
-    .build())
 }
 
 /// Outcome of a CC subprocess invocation.
@@ -129,7 +139,7 @@ pub(crate) async fn run_completion(
     max_tokens: u32,
     timeout: Duration,
 ) -> Result<CcOutput> {
-    ensure_max_tokens_supported(max_tokens)?;
+    warn_unenforceable_max_tokens(max_tokens);
 
     let mut cmd = Command::new(cc_binary);
     cmd.arg("-p")
@@ -407,7 +417,7 @@ pub(crate) async fn run_streaming(
     timeout: Duration,
     on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> Result<CcOutput> {
-    ensure_max_tokens_supported(max_tokens)?;
+    warn_unenforceable_max_tokens(max_tokens);
 
     let mut cmd = Command::new(cc_binary);
     cmd.arg("-p")

--- a/crates/hermeneus/src/cc/process_tests.rs
+++ b/crates/hermeneus/src/cc/process_tests.rs
@@ -377,24 +377,32 @@ async fn run_completion_spawn_failure_reports_binary_path() {
 }
 
 #[tokio::test]
-async fn run_completion_errors_when_max_tokens_requested() {
-    let binary = PathBuf::from("/bin/echo");
-    let err = run_completion(
-        &binary,
+async fn run_completion_tolerates_nonzero_max_tokens() {
+    // WHY: The claude CLI exposes no max-output-token flag, so a non-zero
+    // max_tokens is unenforceable and must be ignored (with a one-time warning),
+    // not rejected. Previously this hard-errored, breaking every turn on the
+    // default zero-config CC provider. See #4158.
+    let script = write_script(
+        "completion_max_tokens_ok",
+        r#"cat > /dev/null
+printf '{"type":"result","subtype":"success","result":"ok","is_error":false}\n'"#,
+    );
+
+    let output = run_completion(
+        &script,
         "claude-test-model",
         None,
         "hello",
         1024,
-        Duration::from_secs(5),
+        Duration::from_secs(10),
     )
     .await
-    .unwrap_err();
+    .unwrap();
 
-    let msg = err.to_string();
-    assert!(
-        msg.contains("cannot enforce max_tokens=1024"),
-        "error must explain unsupported max token limit, got: {msg}"
-    );
+    assert_eq!(output.result_text, "ok");
+    assert!(!output.is_error);
+
+    let _ = fs::remove_file(&script);
 }
 
 #[tokio::test]
@@ -553,26 +561,36 @@ async fn run_streaming_spawn_failure_reports_binary_path() {
 }
 
 #[tokio::test]
-async fn run_streaming_errors_when_max_tokens_requested() {
-    let binary = PathBuf::from("/bin/echo");
-    let mut on_delta = |_: &str| {};
-    let err = run_streaming(
-        &binary,
+async fn run_streaming_tolerates_nonzero_max_tokens() {
+    // WHY: As with run_completion, a non-zero max_tokens is unenforceable by the
+    // claude CLI and must be ignored rather than rejected, so streamed turns run
+    // on the default CC provider. See #4158.
+    let script = write_script(
+        "streaming_max_tokens_ok",
+        r#"cat > /dev/null
+printf '{"type":"assistant","message":{"type":"text","text":"hi"}}\n'
+printf '{"type":"result","subtype":"success","result":"hi","is_error":false}\n'"#,
+    );
+
+    let mut collected: Vec<String> = Vec::new();
+    let mut on_delta = |s: &str| collected.push(s.to_owned());
+
+    let output = run_streaming(
+        &script,
         "claude-test-model",
         None,
         "hello",
         2048,
-        Duration::from_secs(5),
+        Duration::from_secs(10),
         &mut on_delta,
     )
     .await
-    .unwrap_err();
+    .unwrap();
 
-    let msg = err.to_string();
-    assert!(
-        msg.contains("cannot enforce max_tokens=2048"),
-        "error must explain unsupported streaming max token limit, got: {msg}"
-    );
+    assert_eq!(output.result_text, "hi");
+    assert_eq!(collected, vec!["hi"]);
+
+    let _ = fs::remove_file(&script);
 }
 
 #[tokio::test]

--- a/crates/hermeneus/src/kimi/process.rs
+++ b/crates/hermeneus/src/kimi/process.rs
@@ -41,17 +41,26 @@ fn scrub_kimi_auth_env(cmd: &mut Command) {
     cmd.env_remove("MOONSHOT_API_KEY");
 }
 
-fn ensure_max_tokens_supported(max_tokens: u32) -> Result<()> {
-    if max_tokens == 0 {
-        return Ok(());
+/// Warn (once) that a non-zero `max_tokens` cannot be honored by the Kimi
+/// subprocess provider, then ignore it.
+///
+/// WHY: The `kimi` CLI exposes no max-output-token flag, so the cap is
+/// genuinely unenforceable here. Hard-erroring on any non-zero value (the prior
+/// behavior) broke every turn whenever a non-zero `max_output_tokens` (e.g. the
+/// scaffolded default) or the hardcoded recall-rewrite `max_tokens = 512` fed
+/// this path. The turn should still run; degrade gracefully by ignoring the
+/// unenforceable cap with a single warning rather than failing. See aletheia#4158.
+fn warn_unenforceable_max_tokens(max_tokens: u32) {
+    use std::sync::Once;
+    static WARN_ONCE: Once = Once::new();
+    if max_tokens != 0 {
+        WARN_ONCE.call_once(|| {
+            tracing::warn!(
+                max_tokens,
+                "kimi CLI cannot enforce a max output token limit; ignoring max_tokens for Kimi subprocess completions"
+            );
+        });
     }
-
-    Err(error::ApiRequestSnafu {
-        message: format!(
-            "Kimi subprocess cannot enforce max_tokens={max_tokens}: kimi CLI does not expose a max output token flag"
-        ),
-    }
-    .build())
 }
 
 fn compose_prompt(system_prompt: Option<&str>, prompt: &str) -> Result<String> {
@@ -135,7 +144,7 @@ pub(crate) async fn run_completion(
     prompt: &str,
     max_tokens: u32,
 ) -> Result<KimiOutput> {
-    ensure_max_tokens_supported(max_tokens)?;
+    warn_unenforceable_max_tokens(max_tokens);
     let prompt = compose_prompt(system_prompt, prompt)?;
     let mut child = spawn_kimi(
         config.kimi_binary,
@@ -215,7 +224,7 @@ pub(crate) async fn run_streaming(
     max_tokens: u32,
     on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> Result<KimiOutput> {
-    ensure_max_tokens_supported(max_tokens)?;
+    warn_unenforceable_max_tokens(max_tokens);
     let prompt = compose_prompt(system_prompt, prompt)?;
     let mut child = spawn_kimi(
         config.kimi_binary,

--- a/crates/hermeneus/src/kimi/process_tests.rs
+++ b/crates/hermeneus/src/kimi/process_tests.rs
@@ -257,14 +257,21 @@ exit 7"#,
 }
 
 #[tokio::test]
-async fn run_completion_rejects_max_tokens() {
-    let binary = PathBuf::from("/bin/echo");
+async fn run_completion_tolerates_nonzero_max_tokens() {
+    // WHY: The kimi CLI exposes no max-output-token flag, so a non-zero
+    // max_tokens is unenforceable and must be ignored (with a one-time warning),
+    // not rejected — otherwise every turn fails on the Kimi provider. See #4158.
+    let script = write_script(
+        "completion_max_tokens_ok",
+        r#"cat > /dev/null
+printf '{"role":"assistant","content":"ok"}\n'"#,
+    );
     let cwd = std::env::temp_dir();
-    let config = process_config(&binary, &cwd);
-    let err = run_completion(&config, None, "prompt", 100)
-        .await
-        .unwrap_err();
-    assert!(err.to_string().contains("cannot enforce max_tokens=100"));
+    let config = process_config(&script, &cwd);
+    let output = run_completion(&config, None, "prompt", 100).await.unwrap();
+    assert_eq!(output.result_text, "ok");
+
+    fs::remove_file(&script).unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

The `claude` and `kimi` CLIs expose no max-output-token flag, so the CC/Kimi subprocess providers previously **hard-errored** on any non-zero `max_tokens` (`ensure_max_tokens_supported`). That broke every chat turn and every recall query-rewrite on the default zero-config CC provider out of the box:

- the scaffolded `[agents.defaults] max_output_tokens = 16384` feeds generation (`execute`)
- the hardcoded recall-rewrite `max_tokens = 512` (`nous/pipeline/stages.rs`) feeds recall

Both land on a subprocess provider that rejected the value, so a fresh `init` + `serve` produced a server that 200s everywhere but returns empty responses with a misleading "provider unavailable" error.

## Change

Replace the hard error with a one-time `warn!` and ignore the unenforceable cap (fix (b) from the issue) in both `crates/hermeneus/src/cc/process.rs` and `crates/hermeneus/src/kimi/process.rs`. The cap genuinely cannot be honored at this boundary; the turn should still run. Applied at the provider boundary so it covers every `max_tokens` feed site (generation, recall rewrite, future callers) in one place.

The three tests that asserted the old reject-behavior are rewritten as script-driven tolerance tests proving a non-zero `max_tokens` now completes successfully.

## Impact

- Restores out-of-box chat on the default Claude Code provider.
- Also restores default-provider recall (the on-main symptom in #4156 died at the rewrite step for the same reason).

Gate: `kanon gate --full --stamp` green (0 errors; fmt/check/clippy/test/lint/audit all pass).

Fixes #4158