### PR TITLE
fix(nous,episteme): stop double-wrapping recall errors and log failing read scripts

### DIFF
--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -1097,9 +1097,23 @@ impl KnowledgeStore {
         params: std::collections::BTreeMap<String, crate::engine::DataValue>,
     ) -> crate::error::Result<crate::engine::NamedRows> {
         use crate::engine::ScriptMutability;
+        // WHY: A failing read query (e.g. a CozoScript parse error on the recall
+        // path, #4156) is otherwise invisible — the error carries only the engine
+        // message, not the script that produced it. Capture the script text and
+        // the parameter key set so the exact failing query is recoverable from
+        // logs at debug level. Parameter values are deliberately not logged
+        // (they may carry user content); scripts use `$param` placeholders, so
+        // the script text itself contains no user data.
+        let param_keys: Vec<String> = params.keys().cloned().collect();
         self.db
             .run(script, params, ScriptMutability::Immutable)
             .map_err(|e| {
+                tracing::debug!(
+                    script,
+                    param_keys = ?param_keys,
+                    error = %e,
+                    "read query failed against the knowledge engine"
+                );
                 crate::error::EngineQuerySnafu {
                     message: e.to_string(),
                 }

--- a/crates/nous/src/recall/search.rs
+++ b/crates/nous/src/recall/search.rs
@@ -82,12 +82,11 @@ pub(super) fn vector_search_tiered(
     rewrite_provider: &dyn mneme::query_rewrite::RewriteProvider,
 ) -> error::Result<Vec<KnowledgeRecallResult>> {
     if let Some(result) = search.search_tiered(query, query_vec.clone(), k, 50, rewrite_provider) {
-        return result.map_err(|e| {
-            error::RecallSearchSnafu {
-                message: e.to_string(),
-            }
-            .build()
-        });
+        // WHY: `search_tiered` already wraps engine errors in `RecallSearchSnafu`
+        // (see search/search_impl.rs); return its result directly rather than
+        // wrapping a second time. The prior double-wrap produced the duplicated
+        // "recall search failed: recall search failed:" message. See #4156.
+        return result;
     }
     vector_search(search, query_vec, k)
 }


### PR DESCRIPTION
## What

Two of the three problems in #4156 (the diagnosability ones). The third — the actual on-default-provider recall failure — is fixed separately by #4166 (recall died at the LLM query-rewrite `max_tokens` wall before reaching any engine query).

### 1. Double `RecallSearchSnafu` wrap

`vector_search_tiered` (`recall/search.rs`) wrapped the result of `search_tiered` in `RecallSearchSnafu` a second time, but `search_tiered` (`recall/search/search_impl.rs`) already wraps engine errors in `RecallSearchSnafu`. That produced the duplicated `recall search failed: recall search failed:` chain. The inner result is now returned directly.

### 2. Failing read script invisible in logs

`KnowledgeStore::run_read` discarded which script failed, so a CozoScript parse error (the latent recall-path error described in the issue) carried only the engine message, not the query that produced it. The failing script (and parameter key set) is now logged at `debug` on the error path. Parameter **values** are not logged, and scripts use `$param` placeholders, so no user data is exposed — this is the one-line instrumentation the issue recommended to pin the latent parse error when it next reproduces under a working provider.

## Not included

- The latent parse error itself reproduces only with a working API-key provider (recall must pass rewrite first); the logging added here is what captures it when it next occurs.
- Compiling/running the `mneme-engine`-gated recall test surface in the gate (issue recommendation #3) is the cross-cutting coverage-gap item tracked as escalation E1.

Gate: `kanon gate --full --stamp` green (0 errors).

Refs #4156