### PR TITLE
fix(episteme,aletheia): carry scope/project_id/visibility through fact supersession

### DIFF
--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -159,15 +159,15 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
             let retract_script = r"
                 ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
                   access_count, last_accessed_at, stability_hours, fact_type,
-                  is_forgotten, forgotten_at, forget_reason] :=
+                  is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
                     *facts{id: $old_id, valid_from, content, nous_id, confidence, tier, source_session_id, recorded_at,
                            access_count, last_accessed_at, stability_hours, fact_type,
-                           is_forgotten, forgotten_at, forget_reason},
+                           is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
                     valid_to = $now,
                     superseded_by = $new_id
                 :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
                             access_count, last_accessed_at, stability_hours, fact_type,
-                            is_forgotten, forgotten_at, forget_reason}
+                            is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
             ";
             let mut params = std::collections::BTreeMap::new();
             params.insert(
@@ -253,14 +253,14 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
             let script = r"
                 ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
                   access_count, last_accessed_at, stability_hours, fact_type,
-                  is_forgotten, forgotten_at, forget_reason] :=
+                  is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
                     *facts{id: $fact_id, valid_from, content, nous_id, confidence, tier, superseded_by, source_session_id, recorded_at,
                            access_count, last_accessed_at, stability_hours, fact_type,
-                           is_forgotten, forgotten_at, forget_reason},
+                           is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
                     valid_to = $now
                 :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
                             access_count, last_accessed_at, stability_hours, fact_type,
-                            is_forgotten, forgotten_at, forget_reason}
+                            is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
             ";
             let mut params = std::collections::BTreeMap::new();
             params.insert(

--- a/crates/episteme/src/consolidation/engine.rs
+++ b/crates/episteme/src/consolidation/engine.rs
@@ -504,10 +504,12 @@ impl KnowledgeStore {
         let script = r"
 ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by,
    source_session_id, recorded_at, access_count, last_accessed_at,
-   stability_hours, fact_type, is_forgotten, forgotten_at, forget_reason] :=
+   stability_hours, fact_type, is_forgotten, forgotten_at, forget_reason,
+   scope, project_id, visibility] :=
     *facts{id, valid_from, content, nous_id, confidence, tier,
            source_session_id, recorded_at, access_count, last_accessed_at,
-           stability_hours, fact_type, is_forgotten, forgotten_at, forget_reason},
+           stability_hours, fact_type, is_forgotten, forgotten_at, forget_reason,
+           scope, project_id, visibility},
     id = $id,
     valid_to = $now,
     superseded_by = $superseding_id
@@ -515,7 +517,7 @@ impl KnowledgeStore {
 :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to,
             superseded_by, source_session_id, recorded_at, access_count,
             last_accessed_at, stability_hours, fact_type, is_forgotten,
-            forgotten_at, forget_reason}
+            forgotten_at, forget_reason, scope, project_id, visibility}
 ";
         let mut params = BTreeMap::new();
         params.insert("id".to_owned(), DataValue::Str(fact_id.as_str().into()));

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -206,10 +206,10 @@ fn schema_version_queryable() {
     })
     .expect("open_mem");
     let version = store.schema_version().expect("version");
-    // v8 -> v9: additive migration added the `fact_multiplicity` side-index
-    // that records source-observation count / first+last timestamps / spread
-    // for consolidated facts (see KnowledgeStore::SCHEMA_VERSION).
-    assert_eq!(version, 9);
+    // Tracks `KnowledgeStore::SCHEMA_VERSION`. Recent additive migrations:
+    // v8->v9 `fact_multiplicity` side-index; v10->v11 `scope`+`visibility` on
+    // `facts`; v11->v12 `project_id` on `facts`.
+    assert_eq!(version, 12);
 }
 
 // Verify ordering of multiple facts by confidence (descending).

--- a/crates/integration-tests/tests/knowledge_lifecycle.rs
+++ b/crates/integration-tests/tests/knowledge_lifecycle.rs
@@ -76,16 +76,16 @@ fn correct_fact(
     let script = r"
         ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
           access_count, last_accessed_at, stability_hours, fact_type,
-          is_forgotten, forgotten_at, forget_reason] :=
+          is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
             *facts{id, valid_from, content, nous_id, confidence, tier, source_session_id, recorded_at,
                    access_count, last_accessed_at, stability_hours, fact_type,
-                   is_forgotten, forgotten_at, forget_reason},
+                   is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
             id = $old_id,
             valid_to = $now,
             superseded_by = $new_id
         :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
                     access_count, last_accessed_at, stability_hours, fact_type,
-                    is_forgotten, forgotten_at, forget_reason}
+                    is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
     ";
     let mut params = BTreeMap::new();
     params.insert(String::from("old_id"), DataValue::Str(old_id.into()));
@@ -137,15 +137,15 @@ fn retract_fact(store: &Arc<KnowledgeStore>, fact_id: &str, retraction_time: &st
     let script = r"
         ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
           access_count, last_accessed_at, stability_hours, fact_type,
-          is_forgotten, forgotten_at, forget_reason] :=
+          is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
             *facts{id, valid_from, content, nous_id, confidence, tier, superseded_by, source_session_id, recorded_at,
                    access_count, last_accessed_at, stability_hours, fact_type,
-                   is_forgotten, forgotten_at, forget_reason},
+                   is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
             id = $fact_id,
             valid_to = $now
         :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to, superseded_by, source_session_id, recorded_at,
                     access_count, last_accessed_at, stability_hours, fact_type,
-                    is_forgotten, forgotten_at, forget_reason}
+                    is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
     ";
     let mut params = BTreeMap::new();
     params.insert(String::from("fact_id"), DataValue::Str(fact_id.into()));


### PR DESCRIPTION
## Problem

The `facts` relation gained `scope`+`visibility` (schema v11, #208/#63) and `project_id` (schema v12) as required value columns. Three production `:put facts` **supersession** scripts were never updated and omit those columns, so each fails at runtime with `EngineQuery { message: "required column scope not provided by input" }`:

- `aletheia::knowledge_adapter::correct_fact` — fact correction
- `aletheia::knowledge_adapter::retract_fact` — fact retraction
- `episteme::consolidation::engine` supersede — consolidation merge

This is the same class as #4144 (forget query). It surfaces in the gate's `cargo test` (episteme-affected) because the engine-tests replicas of these scripts panic, and `schema_version_queryable` asserted the long-stale `9` (actual: `12`). The local gate has been red on every episteme-touching change as a result.

## Fix

Read `scope, project_id, visibility` from `*facts` and carry them unchanged through the `:put` in all three scripts. Update the engine-tests replicas (`knowledge_lifecycle.rs`) identically, and correct the `schema_version_queryable` expectation to `12` (with an updated migration note).

## Verification

`kanon gate --full --stamp` passes (cargo fmt/check/clippy/audit/test/lint all green). Previously-failing `knowledge_lifecycle` (4) and `knowledge_engine::schema_version_queryable` now pass; full episteme suite (1207+ tests) green.

## Note

The engine-tests duplicate the adapter's CozoScript by hand (`// Replicates the adapter's correct_fact logic`); that duplication is what let the drift go unnoticed. Tracked separately — the tests should ideally drive the real adapter rather than copy its scripts.