### PR TITLE
fix(episteme): sanitize FTS query text so recall survives questions and punctuation

### DIFF
--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -732,9 +732,39 @@ pub(super) fn rows_to_recall_results(
     Ok(out)
 }
 
+/// Reduce a natural-language message to a bag-of-terms full-text-search query.
+///
+/// WHY: The FTS `query:` argument of `~facts:content_fts{... query: $query_text ...}`
+/// is parsed by Cozo's *own* full-text query grammar, in which characters such as
+/// `?`, `*`, `"`, parentheses and boolean keywords are operators. Binding a raw user
+/// message (e.g. any question, which ends in `?`) therefore triggers an FTS parse
+/// error that is swallowed, silently disabling knowledge recall for that turn
+/// (#4156). Keeping only alphanumeric word tokens yields a universally valid
+/// bare-term query that preserves recall on the meaningful words while dropping all
+/// FTS-syntax characters. Returns an empty string when the message has no word
+/// characters; callers treat that as "no text query".
+#[cfg(feature = "mneme-engine")]
+pub(super) fn sanitize_fts_query(raw: &str) -> String {
+    raw.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 #[cfg(feature = "mneme-engine")]
 pub(super) fn build_hybrid_query(q: &super::HybridQuery) -> String {
     use super::queries;
+
+    // WHY: When the message has no full-text terms (e.g. an emoji- or
+    // punctuation-only message that `sanitize_fts_query` reduces to ""), the FTS
+    // `query: ""` argument is itself an FTS parse error (#4156). Emit an empty
+    // `bm25` relation in that case so vector + graph search still run; the
+    // `$query_text` param is then left unbound by the caller.
+    let bm25_rule = if sanitize_fts_query(&q.text).is_empty() {
+        "bm25[id, score] <- []".to_owned()
+    } else {
+        "bm25[id, score] := ~facts:content_fts{id | query: $query_text, k: $k, score_kind: 'bm25', bind_score: score}".to_owned()
+    };
 
     let graph_rules = if q.seed_entities.is_empty() {
         "graph[id, score] <- []".to_owned()
@@ -753,7 +783,9 @@ pub(super) fn build_hybrid_query(q: &super::HybridQuery) -> String {
              graph[id, sum(score)] := graph_raw[id, score]"
         )
     };
-    queries::HYBRID_SEARCH_BASE.replace("{GRAPH_RULES}", &graph_rules)
+    queries::HYBRID_SEARCH_BASE
+        .replace("{BM25_RULE}", &bm25_rule)
+        .replace("{GRAPH_RULES}", &graph_rules)
 }
 
 #[cfg(feature = "mneme-engine")]
@@ -1238,5 +1270,85 @@ mod tests {
             script.contains("50") || script.contains("$ef"),
             "script should reference the ef parameter"
         );
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // sanitize_fts_query — FTS query-string hardening (#4156)
+    // ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn build_hybrid_query_omits_fts_when_no_text_terms() {
+        use super::super::HybridQuery;
+        let query = HybridQuery {
+            // Punctuation-only message reduces to an empty FTS query (#4156).
+            text: "???".to_owned(),
+            embedding: vec![0.1_f32; 384],
+            seed_entities: Vec::new(),
+            limit: 20,
+            ef: 50,
+        };
+        let script = build_hybrid_query(&query);
+        assert!(
+            script.contains("bm25[id, score] <- []"),
+            "empty-text query should emit an empty bm25 relation, got: {script}"
+        );
+        assert!(
+            !script.contains("content_fts"),
+            "empty-text query must not reference the FTS index, got: {script}"
+        );
+        assert!(
+            !script.contains("$query_text"),
+            "empty-text query must not reference the unbound $query_text param, got: {script}"
+        );
+    }
+
+    #[test]
+    fn build_hybrid_query_includes_fts_when_text_present() {
+        use super::super::HybridQuery;
+        let query = HybridQuery {
+            text: "cozo databases".to_owned(),
+            embedding: vec![0.1_f32; 384],
+            seed_entities: Vec::new(),
+            limit: 20,
+            ef: 50,
+        };
+        let script = build_hybrid_query(&query);
+        assert!(
+            script.contains("content_fts") && script.contains("$query_text"),
+            "text query should reference the FTS index and $query_text, got: {script}"
+        );
+    }
+
+    #[test]
+    fn sanitize_fts_query_strips_question_mark() {
+        // The trailing '?' is an FTS-special character that previously caused a
+        // parse error disabling recall on every question (#4156).
+        assert_eq!(
+            sanitize_fts_query("what do you remember about cozo?"),
+            "what do you remember about cozo"
+        );
+    }
+
+    #[test]
+    fn sanitize_fts_query_drops_fts_operators_and_punctuation() {
+        // Quotes, parentheses, wildcards and other FTS operators must not reach
+        // the engine as syntax — they are reduced to plain whitespace separators.
+        assert_eq!(
+            sanitize_fts_query("\"foo*\" AND (bar) -baz?!"),
+            "foo AND bar baz"
+        );
+    }
+
+    #[test]
+    fn sanitize_fts_query_collapses_whitespace() {
+        assert_eq!(sanitize_fts_query("  hello\t\nworld  "), "hello world");
+    }
+
+    #[test]
+    fn sanitize_fts_query_empty_when_no_word_chars() {
+        // A message with no alphanumerics yields an empty query rather than
+        // invalid FTS syntax.
+        assert_eq!(sanitize_fts_query("???"), "");
+        assert_eq!(sanitize_fts_query(""), "");
     }
 }

--- a/crates/episteme/src/knowledge_store/search.rs
+++ b/crates/episteme/src/knowledge_store/search.rs
@@ -2,7 +2,7 @@ use snafu::ResultExt;
 
 use super::marshal::{
     build_hybrid_query, embedding_to_params, extract_str, rows_to_hybrid_results,
-    rows_to_recall_results,
+    rows_to_recall_results, sanitize_fts_query,
 };
 use tracing::instrument;
 
@@ -151,8 +151,18 @@ impl KnowledgeStore {
         use std::collections::BTreeMap;
 
         use crate::engine::DataValue;
+        // WHY: bind sanitized bare terms, not raw user text — see sanitize_fts_query (#4156).
+        // A text-only BM25 search with no terms cannot match anything and would be an
+        // FTS parse error, so return empty rather than running an empty FTS query.
+        let sanitized_text = sanitize_fts_query(query_text);
+        if sanitized_text.is_empty() {
+            return Ok(Vec::new());
+        }
         let mut params = BTreeMap::new();
-        params.insert("query_text".to_owned(), DataValue::Str(query_text.into()));
+        params.insert(
+            "query_text".to_owned(),
+            DataValue::Str(sanitized_text.into()),
+        );
         params.insert("k".to_owned(), DataValue::from(k));
 
         let rows = self.run_read(queries::BM25_RECALL, params)?;
@@ -381,10 +391,16 @@ impl KnowledgeStore {
 
         use crate::engine::{Array1, DataValue, Vector};
         let mut params = BTreeMap::new();
-        params.insert(
-            "query_text".to_owned(),
-            DataValue::Str(q.text.as_str().into()),
-        );
+        // WHY: bind sanitized bare terms, not raw user text — see sanitize_fts_query (#4156).
+        // Only bind $query_text when terms remain; otherwise build_hybrid_query emits an
+        // empty `bm25` relation and the unreferenced param must be omitted.
+        let sanitized_text = sanitize_fts_query(q.text.as_str());
+        if !sanitized_text.is_empty() {
+            params.insert(
+                "query_text".to_owned(),
+                DataValue::Str(sanitized_text.into()),
+            );
+        }
         params.insert(
             "query_vec".to_owned(),
             DataValue::Vec(Vector::F32(Array1::from(q.embedding.clone()))),

--- a/crates/episteme/src/knowledge_store/skills.rs
+++ b/crates/episteme/src/knowledge_store/skills.rs
@@ -2,7 +2,9 @@ use snafu::ResultExt;
 use tracing::instrument;
 
 use super::KnowledgeStore;
-use super::marshal::{compute_name_similarity, compute_tool_overlap, rows_to_facts};
+use super::marshal::{
+    compute_name_similarity, compute_tool_overlap, rows_to_facts, sanitize_fts_query,
+};
 
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
@@ -89,8 +91,18 @@ impl KnowledgeStore {
 
         use crate::engine::DataValue;
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        // WHY: bind sanitized bare terms, not raw user text — see sanitize_fts_query (#4156).
+        // No text terms means no full-text match is possible (and an empty FTS query is a
+        // parse error), so return empty rather than running the query.
+        let sanitized_text = sanitize_fts_query(query);
+        if sanitized_text.is_empty() {
+            return Ok(Vec::new());
+        }
         let mut params = BTreeMap::new();
-        params.insert("query_text".to_owned(), DataValue::Str(query.into()));
+        params.insert(
+            "query_text".to_owned(),
+            DataValue::Str(sanitized_text.into()),
+        );
         params.insert("nous_id".to_owned(), DataValue::Str(nous_id.into()));
         params.insert("k".to_owned(), DataValue::from(limit_i64 * 3));
         params.insert("limit".to_owned(), DataValue::from(limit_i64));

--- a/crates/episteme/src/knowledge_store/tests/ddl.rs
+++ b/crates/episteme/src/knowledge_store/tests/ddl.rs
@@ -35,7 +35,16 @@ fn query_templates_contain_params() {
     let supersede = queries::supersede_fact();
     assert!(supersede.contains("$old_id"));
     assert!(supersede.contains("$new_id"));
-    assert!(queries::HYBRID_SEARCH_BASE.contains("$query_text"));
+    // $query_text now lives in the BM25 rule injected by build_hybrid_query (#4156);
+    // verify it reaches the rendered query when the message has text terms.
+    let rendered = marshal::build_hybrid_query(&HybridQuery {
+        text: "cozo".into(),
+        embedding: vec![0.0; 4],
+        seed_entities: vec![],
+        limit: 5,
+        ef: 20,
+    });
+    assert!(rendered.contains("$query_text"));
     assert!(queries::HYBRID_SEARCH_BASE.contains("$query_vec"));
     assert!(queries::HYBRID_SEARCH_BASE.contains("ReciprocalRankFusion"));
 }

--- a/crates/episteme/src/query/queries.rs
+++ b/crates/episteme/src/query/queries.rs
@@ -341,10 +341,12 @@ pub(crate) const SEARCH_ENTITIES: &str = r"
 ";
 
 /// Hybrid search: BM25 + HNSW vector + graph neighborhood fused via RRF.
-/// Graph sub-rules are injected dynamically by `build_hybrid_query`.
-/// Params: `$query_text`, `$query_vec`, `$k`, `$ef`, `$limit`.
+/// The BM25 and graph sub-rules are injected dynamically by `build_hybrid_query`
+/// (`{BM25_RULE}` is the full-text rule, or an empty relation when the query has
+/// no text terms; `{GRAPH_RULES}` is the entity-graph expansion).
+/// Params: `$query_text` (only when text terms are present), `$query_vec`, `$k`, `$ef`, `$limit`.
 pub(crate) const HYBRID_SEARCH_BASE: &str = r"
-    bm25[id, score] := ~facts:content_fts{id | query: $query_text, k: $k, score_kind: 'bm25', bind_score: score}
+    {BM25_RULE}
 
     vec[id, score] :=
         ~embeddings:semantic_idx{id | query: $query_vec, k: $k, ef: $ef, bind_distance: raw_dist},

--- a/crates/integration-tests/tests/end_to_end.rs
+++ b/crates/integration-tests/tests/end_to_end.rs
@@ -345,7 +345,13 @@ async fn bootstrap_assembles_from_oikos() {
 }
 
 #[cfg(feature = "knowledge-store")]
-#[tokio::test]
+// WHY: multi_thread runtime is required. Once recall actually executes (see #4156),
+// the recall path drives query rewrite through `ProviderRecallBridge::complete_blocking`,
+// which uses `tokio::task::block_in_place` — that panics on the current-thread runtime.
+// The production server runs on the multi-threaded runtime (`#[tokio::main]`), so the
+// test must match it. Before #4156 this test passed only because recall silently failed
+// on the `?`-terminated query and never reached the blocking bridge.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_harness_wires_real_knowledge_store_and_embedding_provider() {
     let (harness, captured) = build_capturing_with_knowledge_store().await;
     let router = harness.router();


### PR DESCRIPTION
Closes #4156.

## Problem

Recall silently failed on essentially every streamed turn. The raw user message was bound straight into the Cozo full-text-search `query:` argument (`~facts:content_fts{... query: $query_text ...}`). Cozo parses that argument with its FTS grammar, where `?`, `"`, `(`/`)`, and boolean keywords are **operators**. Any question (ends in `?`) produced an FTS parse error that was swallowed, so recall produced nothing that turn — matching the "every turn" report.

## Fix

`sanitize_fts_query()` reduces the raw text to bare alphanumeric terms before binding, applied at all three FTS bind sites:

- `search_hybrid` (hybrid vector + FTS)
- BM25 recall
- skills FTS

Empty-query edge (punctuation-only input → `""`) is handled: the hybrid path emits `bm25 <- []` with `$query_text` unbound; BM25-only callers early-return empty (an empty FTS query is itself a parse error at `0..0`).

## Verification

- Live (init → serve → stream, patched binary): pre-fix a `?`-query hit an FTS parse error at col 32; post-fix both a normal `?`-query and `???` complete cleanly with zero parse errors and recall populated.
- New non-feature-gated-by-default unit tests cover the sanitizer (question marks, FTS operators, whitespace, empty). These run in the gate because `episteme/test-core = ["mneme-engine"]` and the gate runs `cargo nextest --workspace --features test-core` — so the recall sanitizer surface can no longer regress silently.
- The `end_to_end::http_harness_wires_real_knowledge_store_and_embedding_provider` test now exercises a real recall on a `?`-query (previously masked by this bug). That path drives query rewrite through `ProviderRecallBridge::complete_blocking`, which uses `tokio::task::block_in_place` — so the test is moved to the multi-threaded runtime, matching the production server (`#[tokio::main]`).
- `kanon gate --full --stamp` passes.

The double-wrapped recall error + read-script diagnostics that found this bug landed separately in #4170.