### PR TITLE
fix(aletheia/tls): reject --days 0 and overflowing --days instead of emitting already-expired certs

### DIFF
--- a/crates/aletheia/src/commands/tls.rs
+++ b/crates/aletheia/src/commands/tls.rs
@@ -40,6 +40,10 @@ pub(crate) fn run(action: &Action) -> Result<()> {
 }
 
 fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) -> Result<()> {
+    if days == 0 {
+        whatever!("tls generate: --days must be at least 1");
+    }
+
     std::fs::create_dir_all(output_dir)
         .with_whatever_context(|_| format!("failed to create {}", output_dir.display()))?;
 
@@ -58,7 +62,7 @@ fn generate_certs(output_dir: &Path, days: u32, sans: &[String], force: bool) ->
     }
 
     let cert = tls_self_signed::generate(sans, days, "Aletheia Dev")
-        .whatever_context("failed to generate self-signed certificate")?;
+        .with_whatever_context(|e| e.to_string())?;
 
     koina::fs::write_restricted(&cert_path, cert.cert_pem.as_bytes())
         .with_whatever_context(|_| format!("failed to write {}", cert_path.display()))?;

--- a/crates/aletheia/src/commands/tls_self_signed.rs
+++ b/crates/aletheia/src/commands/tls_self_signed.rs
@@ -31,6 +31,10 @@ pub(crate) enum Error {
     KeyParse,
     #[snafu(display("failed to sign certificate"))]
     Sign,
+    #[snafu(display(
+        "tls generate: --days {days} is too large; certificate expiry would overflow the representable timestamp range"
+    ))]
+    ExpiryOverflow { days: u32 },
 }
 
 /// A freshly generated self-signed certificate and its private key, both PEM-encoded.
@@ -67,7 +71,7 @@ pub(crate) fn generate(
     let now = Timestamp::now();
     let end = now
         .checked_add(jiff::SignedDuration::from_hours(i64::from(days) * 24))
-        .unwrap_or(now);
+        .map_err(|_e| Error::ExpiryOverflow { days })?;
 
     // ---- serial number (16 random bytes, positive) ----
     let mut serial = [0u8; 16];


### PR DESCRIPTION
Fixes #4161.

`tls generate` silently emitted already-expired certs for `--days 0` (notAfter == notBefore) and for `--days` values large enough to overflow the representable timestamp range (the old `checked_add(...).unwrap_or(now)` clamped silently), while still printing a false "Valid for N days".

- Reject `--days 0` early with a clear error.
- Replace the silent `unwrap_or(now)` overflow clamp with an explicit `ExpiryOverflow { days }` error so an out-of-range `--days` fails loudly instead of producing an instantly-expired cert.

Gate: `kanon gate --full --stamp` green (0 errors; all phases PASS).