### PR TITLE
fix(aletheia/init): honor the global -r/--instance-root flag for init

### DIFF
--- a/crates/aletheia/src/commands/mod.rs
+++ b/crates/aletheia/src/commands/mod.rs
@@ -64,7 +64,7 @@ pub(crate) async fn dispatch(cmd: Command, instance_root: Option<&PathBuf>) -> R
     match cmd {
         Command::Init(a) => {
             init::run(init::RunArgs {
-                root: a.instance_root,
+                root: instance_root.cloned().or(a.instance_root),
                 yes: a.yes,
                 non_interactive: a.non_interactive,
                 // codequality:ignore -- raw CLI string immediately wrapped in SecretString


### PR DESCRIPTION
Fixes #4162.

`aletheia -r DIR init` silently ignored the global `-r/--instance-root` flag and scaffolded `./instance` instead of `DIR`. The dispatch only forwarded the init-subcommand's own `--instance-root`, dropping the top-level one.

Now the global `instance_root` takes precedence, falling back to the subcommand's flag (`instance_root.cloned().or(a.instance_root)`); bare `aletheia init` still defaults to `./instance`.

Gate: `kanon gate --full --stamp` green (0 errors; all phases PASS).