### PR TITLE
fix(pylon): accept bodiless POST /knowledge/facts/{id}/forget and default the reason

### DIFF
--- a/crates/pylon/src/handlers/knowledge/dto.rs
+++ b/crates/pylon/src/handlers/knowledge/dto.rs
@@ -101,7 +101,7 @@ pub struct ForgetRequest {
     pub reason: String,
 }
 
-fn default_forget_reason() -> String {
+pub(crate) fn default_forget_reason() -> String {
     "user_requested".to_string()
 }
 

--- a/crates/pylon/src/handlers/knowledge/mutation.rs
+++ b/crates/pylon/src/handlers/knowledge/mutation.rs
@@ -18,7 +18,7 @@ use super::{ForgetRequest, UpdateConfidenceRequest, UpdateSensitivityRequest};
     path = "/api/v1/knowledge/facts/{id}/forget",
     params(("id" = String, Path, description = "Fact ID")),
     request_body(
-        content = serde_json::Value,
+        content = Option<serde_json::Value>,
         description = "Optional forget reason: `{reason?}` (default: user_requested)",
         content_type = "application/json"
     ),
@@ -37,7 +37,7 @@ pub async fn forget_fact(
     State(state): State<KnowledgeState>,
     claims: Claims,
     Path(id): Path<String>,
-    Json(body): Json<ForgetRequest>,
+    body: Option<Json<ForgetRequest>>,
 ) -> Result<StatusCode, ApiError> {
     require_role(&claims, Role::Operator)?;
     #[cfg(feature = "knowledge-store")]
@@ -47,7 +47,7 @@ pub async fn forget_fact(
             location: snafu::location!(),
         })?;
         let reason = body
-            .reason
+            .map_or_else(super::dto::default_forget_reason, |Json(b)| b.reason)
             .parse::<mneme::knowledge::ForgetReason>()
             .unwrap_or(mneme::knowledge::ForgetReason::UserRequested);
         return match store.forget_fact_async(fact_id, reason).await {


### PR DESCRIPTION
Fixes #4155.

`POST /api/v1/knowledge/facts/{id}/forget` required a `Json<ForgetRequest>` extractor, so a bodiless request was rejected at the HTTP layer (415 without `Content-Type`, 400 "EOF" with `Content-Type` but empty body) — even though the OpenAPI body is documented optional, `ForgetRequest.reason` carries a serde default, and the sibling `restore_fact` handler accepts no body. This trips up any client wiring a forget/restore pair (notably the proskenion desktop client).

- Change the extractor to `Option<Json<ForgetRequest>>` and resolve the reason via `map_or_else(default_forget_reason, ...)`, so a missing/empty body defaults to `user_requested`.
- Update the `#[utoipa::path]` `request_body` content to `Option<serde_json::Value>` to match the now-truly-optional body.
- Make `default_forget_reason` `pub(crate)` so the handler can reuse it.
- Successful-path response unchanged (204 No Content); `restore_fact` untouched.

Gate: `kanon gate --full --stamp` green (0 errors; all phases PASS).

---
**⚠️ FOR T0 REVIEW — not auto-merged.** This is a public-API behavior change (415/400 → accepted for bodiless forget), so per merge-autonomy I'm leaving it for operator review rather than auto-merging.