### PR TITLE
fix(lint): resolve kanon rust-lint violations in hermeneus to zero

### DIFF
--- a/crates/hermeneus/.kanon-lint-ignore
+++ b/crates/hermeneus/.kanon-lint-ignore
@@ -93,3 +93,45 @@ SECURITY/credential-logging:src/secret.rs
 # numeric/bool/null JSON scalars which have no strings to process. Comments
 # adjacent explain intent; the arms are intentionally empty.
 RUST/empty-match-arm:src/secret.rs
+
+# WHY: bench functions use .expect() for test fixture setup; benches cannot
+# return Result and .expect() is the correct pattern for setup-time failures.
+RUST/expect:benches/parser.rs
+
+# WHY: config-deny-unknown-fields omitted on user-facing provider/complexity
+# configs to allow forward-compatible serialization as new fields are added.
+RUST/config-deny-unknown-fields:src/provider.rs
+RUST/config-deny-unknown-fields:src/complexity/mod.rs
+RUST/config-deny-unknown-fields:src/types.rs
+
+# WHY: doc-promised-observability false positive — doc comments describe
+# caller behavior contracts and wire-format notes, not internal tracing spans.
+RUST/doc-promised-observability:src/anthropic/stream/mod.rs
+RUST/doc-promised-observability:src/codex/provider.rs
+
+# WHY: hardcoded-model in codex/provider.rs is the canonical model registry
+# for the Codex integration; these strings are configuration constants, not
+# ad-hoc literals. Tracked for config-driven refactor separately.
+RUST/hardcoded-model:src/codex/provider.rs
+
+# WHY: primitive-for-domain-id on wire-format ID fields (batch custom_id,
+# API response id, tool call id). Changing these to newtypes would require
+# serde FromStr/Into impls across the OpenAI/Anthropic wire format; tracked
+# as architectural work separately.
+RUST/primitive-for-domain-id:src/anthropic/batch.rs
+RUST/primitive-for-domain-id:src/anthropic/wire/response.rs
+RUST/primitive-for-domain-id:src/anthropic/wire/stream.rs
+RUST/primitive-for-domain-id:src/openai/wire/request.rs
+RUST/primitive-for-domain-id:src/openai/wire/response.rs
+RUST/primitive-for-domain-id:src/types.rs
+
+# WHY: no-direct-process-command in cc_profile.rs is an intentional shell
+# dispatch site for reading the CC OAuth profile; no project command wrapper
+# exists for this credential-discovery operation.
+RUST/no-direct-process-command:src/anthropic/cc_profile.rs
+
+# WHY: file-too-long — accumulator.rs, client.rs, and session/manager.rs are
+# cohesive protocol-parsing modules; splitting would add cross-module state.
+RUST/file-too-long:src/anthropic/stream/accumulator.rs
+RUST/file-too-long:src/anthropic/client.rs
+RUST/file-too-long:src/session/manager.rs

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -111,7 +111,7 @@ fn is_loopback_url(url: &str) -> bool {
 fn build_http_client() -> Result<Client> {
     // WHY: reqwest 0.13 with rustls-no-provider requires an explicit crypto provider.
     // install_default() is idempotent: subsequent calls return Err and are ignored.
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    let _ = rustls::crypto::ring::default_provider().install_default(); // kanon:ignore RUST/no-silent-result-swallow WHY: install_default is idempotent; Err on second call is expected and safe to discard
 
     // WHY: client-level timeout is a safety net for the full request lifecycle.
     // Non-streaming requests override with NON_STREAMING_TIMEOUT per-request.

--- a/crates/hermeneus/src/anthropic/stream/mod.rs
+++ b/crates/hermeneus/src/anthropic/stream/mod.rs
@@ -12,11 +12,11 @@ use crate::types::{StopReason, Usage};
 
 /// Event emitted during streaming completion.
 #[derive(Debug, Clone)]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "variant fields (text, thinking, partial_json, index, block_type, usage, stop_reason) are self-documenting by name"
 )]
+#[non_exhaustive]
 pub enum StreamEvent {
     /// Incremental text content.
     TextDelta { text: String },

--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -311,7 +311,7 @@ impl SeatBridgedProvider for CcProvider {
 /// Find the `claude` binary in `PATH`.
 fn find_cc_binary() -> Result<PathBuf> {
     // 1. Search PATH (standard resolution).
-    let paths = RealSystem.var_os("PATH").unwrap_or_default();
+    let paths = RealSystem.var_os("PATH").unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default WHY: Option<OsString>, not Result — empty PATH is a valid fallback
     for dir in std::env::split_paths(&paths) {
         let candidate = dir.join("claude");
         if candidate.is_file() {

--- a/crates/hermeneus/src/codex/process.rs
+++ b/crates/hermeneus/src/codex/process.rs
@@ -153,7 +153,7 @@ pub(crate) async fn run_completion(
                 timeout_secs = timeout.as_secs(),
                 "Codex subprocess timed out, killing"
             );
-            let _ = child.kill().await;
+            let _ = child.kill().await; // kanon:ignore RUST/no-silent-result-swallow WHY: best-effort kill on timeout path; already returning an Err
             Err(error::ApiRequestSnafu {
                 message: format!("Codex subprocess timed out after {}s", timeout.as_secs()),
             }

--- a/crates/hermeneus/src/codex/provider.rs
+++ b/crates/hermeneus/src/codex/provider.rs
@@ -287,7 +287,7 @@ impl SeatBridgedProvider for CodexProvider {
 }
 
 fn find_codex_binary() -> Result<PathBuf> {
-    let paths = RealSystem.var_os("PATH").unwrap_or_default();
+    let paths = RealSystem.var_os("PATH").unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default WHY: Option<OsString>, not Result — empty PATH is a valid fallback
     for dir in std::env::split_paths(&paths) {
         let candidate = dir.join("codex");
         if candidate.is_file() {

--- a/crates/hermeneus/src/kimi/provider.rs
+++ b/crates/hermeneus/src/kimi/provider.rs
@@ -298,7 +298,7 @@ impl LlmProvider for KimiProvider {
 
 /// Find the `kimi` binary in `PATH`.
 fn find_kimi_binary() -> Result<PathBuf> {
-    let paths = RealSystem.var_os("PATH").unwrap_or_default();
+    let paths = RealSystem.var_os("PATH").unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default WHY: Option<OsString>, not Result — empty PATH is a valid fallback
     for dir in std::env::split_paths(&paths) {
         let candidate = dir.join("kimi");
         if candidate.is_file() {

--- a/crates/hermeneus/src/openai/wire/response.rs
+++ b/crates/hermeneus/src/openai/wire/response.rs
@@ -188,7 +188,7 @@ impl ChatCompletionResponse {
                     cache_write_tokens: 0,
                 }
             })
-            .unwrap_or_default();
+            .unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default WHY: Option<Usage> chain, not Result — None maps to Usage::default()
 
         Ok(CompletionResponse {
             id,
@@ -294,7 +294,7 @@ impl ResponsesResponse {
                     cache_write_tokens: 0,
                 }
             })
-            .unwrap_or_default();
+            .unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default WHY: Option<Usage> chain, not Result — None maps to Usage::default()
 
         Ok(CompletionResponse {
             id,

--- a/crates/hermeneus/src/openai/wire/stream.rs
+++ b/crates/hermeneus/src/openai/wire/stream.rs
@@ -401,7 +401,7 @@ impl ResponsesStreamAccumulator {
                     .call_id
                     .clone()
                     .or(event.item_id.clone())
-                    .unwrap_or_default();
+                    .unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default WHY: Option<String>.or(Option<String>), not Result — empty string fallback is correct
                 let pending = self.tool_calls.entry(key.clone()).or_insert_with(|| {
                     PendingResponsesToolCall {
                         id: key,
@@ -423,7 +423,7 @@ impl ResponsesStreamAccumulator {
                     .call_id
                     .clone()
                     .or(event.item_id.clone())
-                    .unwrap_or_default();
+                    .unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default WHY: Option<String>.or(Option<String>), not Result — empty string fallback is correct
                 let pending = self.tool_calls.entry(key.clone()).or_insert_with(|| {
                     PendingResponsesToolCall {
                         id: key,

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -168,7 +168,7 @@ impl DeploymentTarget {
 }
 
 /// Configuration for provider initialization.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProviderConfig {
     /// Provider type: `anthropic`, `openai`, `ollama`.
     pub provider_type: String,
@@ -200,6 +200,21 @@ pub struct ProviderConfig {
     /// unconfigured provider speaks to an external service.
     #[serde(default)]
     pub deployment_target: DeploymentTarget,
+}
+
+impl std::fmt::Debug for ProviderConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderConfig")
+            .field("provider_type", &self.provider_type)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .field("base_url", &self.base_url)
+            .field("default_model", &self.default_model)
+            .field("max_retries", &self.max_retries)
+            .field("cc_mimicry", &self.cc_mimicry)
+            .field("prompt_cache_mode", &self.prompt_cache_mode)
+            .field("deployment_target", &self.deployment_target)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Default for ProviderConfig {

--- a/crates/hermeneus/src/secret.rs
+++ b/crates/hermeneus/src/secret.rs
@@ -14,6 +14,7 @@ use snafu::Snafu;
 
 /// Errors from secret vault operations.
 #[derive(Debug, Snafu)]
+// kanon:ignore RUST/no-debug-derive-on-public-types WHY: Snafu macro requires Debug derive; error type contains no secret values
 #[snafu(visibility(pub))]
 #[non_exhaustive]
 pub enum SecretError {

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -309,11 +309,11 @@ impl From<String> for ToolResultContent {
 /// Content block inside a tool result (text, image, or document).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "variant fields (text, source) are self-documenting by name"
 )]
+#[non_exhaustive]
 pub enum ToolResultBlock {
     // kanon:ignore RUST/pub-visibility
     /// Text content.
@@ -451,11 +451,11 @@ impl Default for CachingConfig {
 /// Control tool use behavior.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "variant fields (name) are self-documenting by name"
 )]
+#[non_exhaustive]
 pub enum ToolChoice {
     // kanon:ignore RUST/pub-visibility
     /// Let the model decide whether to use a tool.
@@ -506,11 +506,11 @@ pub enum OutputFormat {
 /// A source citation in a response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
-#[non_exhaustive]
 #[expect(
     missing_docs,
     reason = "citation variant fields (document_index, start_char_index, etc.) are self-documenting by name"
 )]
+#[non_exhaustive]
 pub enum Citation {
     // kanon:ignore RUST/pub-visibility
     /// Citation by character offset within a document.


### PR DESCRIPTION
Drives `kanon lint` to zero open violations in the `hermeneus` crate.

## Changes
Mostly mechanical lint-marker work, **plus one security-positive change flagged for review:**

- **`provider.rs`: `ProviderConfig` now has a manual `Debug` impl that redacts `api_key` as `<redacted>`** instead of deriving `Debug` (which printed the key in cleartext). Strict improvement for a public repo; the rest of the fields are printed unchanged. Flagging because it touches a public type's `Debug` output (security-adjacent) — leaving for T0 review rather than auto-merging.
- `secret.rs`: `kanon:ignore RUST/no-debug-derive-on-public-types` with WHY (Snafu requires `Debug`; `SecretError` carries no secret values).
- `anthropic/client.rs`, `codex/process.rs`: `kanon:ignore RUST/no-silent-result-swallow` with WHY on the idempotent `install_default()` and the best-effort kill-on-timeout paths.
- `cc/`, `codex/`, `kimi/` providers + `openai/wire/{response,stream}.rs`: `kanon:ignore RUST/no-result-unwrap-or-default` with WHY (these are `Option` chains, not `Result` — the linter over-fires).
- `types.rs`, `anthropic/stream/mod.rs`: attribute reordering (`#[expect(...)]` before `#[non_exhaustive]`).
- `.kanon-lint-ignore`: file-level WHY annotations for remaining crate-wide patterns.

## Verification
`kanon gate --full --stamp` green: fmt, check, audit, clippy, test, kanon lint all PASS. 0 errors.