### PR TITLE
fix(lint): clear residual rust-lint in aletheia-lexica and organon

### DIFF
--- a/crates/aletheia-lexica/src/lib.rs
+++ b/crates/aletheia-lexica/src/lib.rs
@@ -12,12 +12,13 @@ pub mod stopwords;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
     #[test]
     fn modules_are_reachable() {
-        assert!(!super::adjectives::UNFALSIFIABLE_ADJECTIVES.is_empty());
-        assert!(!super::keywords::CODING_KEYWORDS.is_empty());
-        assert!(!super::prefixes::CORRECTION_PREFIXES.is_empty());
-        assert!(!super::stopwords::ENGLISH_STOPWORDS.is_empty());
+        assert!(!adjectives::UNFALSIFIABLE_ADJECTIVES.is_empty());
+        assert!(!keywords::CODING_KEYWORDS.is_empty());
+        assert!(!prefixes::CORRECTION_PREFIXES.is_empty());
+        assert!(!stopwords::ENGLISH_STOPWORDS.is_empty());
     }
 }

--- a/crates/organon/src/testing.rs
+++ b/crates/organon/src/testing.rs
@@ -18,7 +18,7 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
 use koina::id::{NousId, SessionId, ToolName};
 use taxis::config::ToolLimitsConfig;
@@ -146,11 +146,9 @@ impl ToolExecutor for MockToolExecutor {
     ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
         let result = {
-            #[expect(
-                clippy::expect_used,
-                reason = "test-support: mock mutex is never poisoned in tests"
-            )]
-            let mut inner = self.inner.lock().expect("mock mutex poisoned"); // kanon:ignore RUST/expect
+            // Recover the guard even if another test thread panicked while holding
+            // the lock, so a poisoned mock never cascades panics into unrelated tests.
+            let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
             match &mut inner.mode {
                 MockMode::Text(t) => Ok(ToolResult::text(t.clone())),
                 MockMode::Error(e) => Ok(ToolResult::error(e.clone())),


### PR DESCRIPTION
Drives `aletheia-lexica` and `organon` to zero `kanon lint --summary --rust` violations.

- **aletheia-lexica**: add the conventional `use super::*` to the test module (RUST/test-missing-use-super) and drop the now-redundant `super::` path prefixes.
- **organon**: recover the mock executor's mutex guard via `PoisonError::into_inner` instead of `expect()`, so a panicking test thread cannot cascade lock poisoning into unrelated tests (RUST/lock-expect-panics — this rule is not inline-suppressible, so it needs a real fix). This removes the `expect()` and its `#[expect(clippy::expect_used)]` guard entirely.

Test-support / test-module only; no public API or runtime behavior change. Both crates verified at zero rust-lint and compiling; `kanon gate --full` green.