### PR TITLE
fix(lint): drive taxis rust-lint violations to zero

### DIFF
--- a/crates/taxis/src/config/agents.rs
+++ b/crates/taxis/src/config/agents.rs
@@ -288,7 +288,7 @@ impl Default for CachingConfig {
 #[serde(rename_all = "camelCase")]
 pub struct NousDefinition {
     /// Unique agent identifier (matches the `nous/{id}/` directory name).
-    pub id: String,
+    pub id: String, // kanon:ignore RUST/primitive-for-domain-id — wire/serde config field: id maps to the agent's directory name in TOML, not a runtime domain identifier
     /// Human-readable display name.
     #[serde(default)]
     pub name: Option<String>,

--- a/crates/taxis/src/config/behavior/provider.rs
+++ b/crates/taxis/src/config/behavior/provider.rs
@@ -121,6 +121,7 @@ pub enum DeploymentTarget {
 /// Matches on this in `crates/aletheia/src/runtime/setup.rs` to pick between
 /// the Anthropic HTTP client, OpenAI-compatible HTTP client, or a subprocess
 /// adapter.
+// kanon:ignore RUST/no-debug-derive-on-public-types — ProviderKind is a classification enum with no secret fields; derived Debug leaks only non-secret metadata
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -240,6 +240,7 @@ impl Default for SandboxSettings {
 /// - `"auto"` (default): instance credential file → env vars → Claude Code credentials
 /// - `"api-key"`: only instance credential file and env vars
 /// - `"claude-code"`: prefer Claude Code's `~/.claude/.credentials.json`
+// kanon:ignore RUST/no-debug-derive-on-public-types — CredentialConfig holds only env-var names and strategy strings, not actual secrets; derived Debug leaks no credentials
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -56,11 +56,13 @@ impl Default for ObservabilitySettings {
 }
 
 /// Root configuration for an Aletheia instance.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)] // kanon:ignore RUST/no-debug-derive-on-public-types
+// kanon:ignore RUST/no-debug-derive-on-public-types
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 #[rustfmt::skip]
-pub struct AletheiaConfig { // kanon:ignore RUST/config-deny-unknown-fields
+// kanon:ignore RUST/config-deny-unknown-fields
+pub struct AletheiaConfig {
     /// Agent definitions and shared defaults.
     pub agents: AgentsConfig,
     /// HTTP gateway settings (port, bind address, auth, TLS, CORS).
@@ -244,7 +246,8 @@ pub struct ModelPricing {
 }
 
 /// Maps a channel source to a nous agent.
-#[derive(Debug, Clone, Serialize, Deserialize)] // kanon:ignore RUST/no-debug-derive-on-public-types
+// kanon:ignore RUST/no-debug-derive-on-public-types
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChannelBinding {
     /// Channel type (e.g., "signal").
@@ -252,10 +255,12 @@ pub struct ChannelBinding {
     /// Source pattern: phone number, group ID, or "*" for default.
     pub source: String,
     /// Nous ID to route to.
+    // kanon:ignore RUST/primitive-for-domain-id — wire/serde config field: nous_id is a TOML routing string, not a runtime domain identifier
     pub nous_id: String,
     /// Session key pattern. Supports `{source}` and `{group}` placeholders.
     #[serde(default = "default_session_pattern")]
-    pub session_key: String, // kanon:ignore RUST/plain-string-secret
+    // kanon:ignore RUST/plain-string-secret
+    pub session_key: String,
 }
 
 fn default_session_pattern() -> String {
@@ -267,7 +272,8 @@ fn default_session_pattern() -> String {
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 #[rustfmt::skip]
-pub struct EmbeddingSettings { // kanon:ignore RUST/config-deny-unknown-fields
+// kanon:ignore RUST/config-deny-unknown-fields
+pub struct EmbeddingSettings {
     /// Provider type: "mock", "candle".
     pub provider: String,
     /// Provider-specific model name.
@@ -291,7 +297,8 @@ impl Default for EmbeddingSettings {
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 #[rustfmt::skip]
-pub struct ChannelsConfig { // kanon:ignore RUST/config-deny-unknown-fields
+// kanon:ignore RUST/config-deny-unknown-fields
+pub struct ChannelsConfig {
     /// Signal messenger transport configuration.
     pub signal: SignalConfig,
     /// Matrix messenger transport configuration.
@@ -303,7 +310,8 @@ pub struct ChannelsConfig { // kanon:ignore RUST/config-deny-unknown-fields
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 #[rustfmt::skip]
-pub struct SignalConfig { // kanon:ignore RUST/config-deny-unknown-fields
+// kanon:ignore RUST/config-deny-unknown-fields
+pub struct SignalConfig {
     /// Whether the Signal channel is active.
     pub enabled: bool,
     /// Named Signal accounts keyed by account label.
@@ -324,7 +332,8 @@ impl Default for SignalConfig {
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 #[rustfmt::skip]
-pub struct SignalAccountConfig { // kanon:ignore RUST/config-deny-unknown-fields
+// kanon:ignore RUST/config-deny-unknown-fields
+pub struct SignalAccountConfig {
     /// Whether this account is active.
     pub enabled: bool,
     /// Hostname for the signal-cli JSON-RPC HTTP interface.
@@ -351,7 +360,8 @@ impl Default for SignalAccountConfig {
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 #[rustfmt::skip]
-pub struct MatrixConfig { // kanon:ignore RUST/config-deny-unknown-fields
+// kanon:ignore RUST/config-deny-unknown-fields
+pub struct MatrixConfig {
     /// Whether the Matrix channel is active.
     pub enabled: bool,
     /// Named Matrix accounts keyed by account label.
@@ -359,17 +369,20 @@ pub struct MatrixConfig { // kanon:ignore RUST/config-deny-unknown-fields
 }
 
 /// Configuration for a single Matrix account.
+// kanon:ignore RUST/no-debug-derive-on-public-types — MatrixAccountConfig holds only homeserver URL and env-var name, not actual tokens; derived Debug leaks no secrets
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 #[rustfmt::skip]
-pub struct MatrixAccountConfig { // kanon:ignore RUST/config-deny-unknown-fields
+// kanon:ignore RUST/config-deny-unknown-fields
+pub struct MatrixAccountConfig {
     /// Whether this account is active.
     pub enabled: bool,
     /// Matrix homeserver base URL, e.g. `https://matrix.example.org`.
     pub homeserver: String,
     /// Environment variable that contains the Matrix access token.
-    pub access_token_env: String, // kanon:ignore RUST/plain-string-secret
+    // kanon:ignore RUST/plain-string-secret
+    pub access_token_env: String,
     /// Matrix user ID for this account. Used to ignore echoed self messages.
     pub user_id: Option<String>,
     /// Whether to auto-start the `/sync` receive loop on server boot.

--- a/crates/taxis/src/error.rs
+++ b/crates/taxis/src/error.rs
@@ -15,6 +15,7 @@ use snafu::Snafu;
     missing_docs,
     reason = "snafu error variant fields (source, location, path, reason) are self-documenting via display format"
 )]
+// kanon:ignore RUST/non-exhaustive-enum — already #[non_exhaustive]; false positive from attribute ordering
 pub enum Error {
     /// The instance root directory does not exist.
     #[snafu(display("instance root not found: {}", path.display()))]

--- a/crates/taxis/src/interpolate.rs
+++ b/crates/taxis/src/interpolate.rs
@@ -61,12 +61,14 @@ pub fn interpolate_env_vars(content: &str) -> Result<String> {
             clippy::string_slice,
             reason = "dollar_pos from str::find is a valid UTF-8 boundary"
         )]
+        // kanon:ignore RUST/indexing-slicing — dollar_pos from str::find on rest, always a valid UTF-8 boundary
         result.push_str(&rest[..dollar_pos]);
         #[expect(
             clippy::string_slice,
             reason = "dollar_pos + 2 skips ASCII '$' + '{', always a valid UTF-8 boundary"
         )]
         {
+            // kanon:ignore RUST/indexing-slicing — dollar_pos + 2 skips ASCII '${', always a valid UTF-8 boundary
             rest = &rest[dollar_pos + 2..];
         }
 
@@ -79,12 +81,14 @@ pub fn interpolate_env_vars(content: &str) -> Result<String> {
             clippy::string_slice,
             reason = "close_pos from str::find is a valid UTF-8 boundary"
         )]
+        // kanon:ignore RUST/indexing-slicing — close_pos from str::find on rest, always a valid UTF-8 boundary
         let expr = &rest[..close_pos];
         #[expect(
             clippy::string_slice,
             reason = "close_pos + 1 skips ASCII '}', always a valid UTF-8 boundary"
         )]
         {
+            // kanon:ignore RUST/indexing-slicing — close_pos + 1 skips ASCII '}', always a valid UTF-8 boundary
             rest = &rest[close_pos + 1..];
         }
 
@@ -103,11 +107,13 @@ fn resolve_expr(expr: &str) -> Result<String> {
             clippy::string_slice,
             reason = "sep is a valid UTF-8 boundary returned by str::find on ASCII ':-'"
         )]
+        // kanon:ignore RUST/indexing-slicing — sep from str::find on expr, always a valid UTF-8 boundary
         let var = &expr[..sep];
         #[expect(
             clippy::string_slice,
             reason = "sep + 2 skips ASCII ':-', valid UTF-8 boundary"
         )]
+        // kanon:ignore RUST/indexing-slicing — sep + 2 skips ASCII ':-', always a valid UTF-8 boundary
         let default = &expr[sep + 2..];
         Ok(env::var(var).unwrap_or_else(|_| default.to_owned()))
     } else if let Some(sep) = expr.find(":?") {
@@ -115,11 +121,13 @@ fn resolve_expr(expr: &str) -> Result<String> {
             clippy::string_slice,
             reason = "sep is a valid UTF-8 boundary returned by str::find on ASCII ':?'"
         )]
+        // kanon:ignore RUST/indexing-slicing — sep from str::find on expr, always a valid UTF-8 boundary
         let var = &expr[..sep];
         #[expect(
             clippy::string_slice,
             reason = "sep + 2 skips ASCII ':?', valid UTF-8 boundary"
         )]
+        // kanon:ignore RUST/indexing-slicing — sep + 2 skips ASCII ':?', always a valid UTF-8 boundary
         let message = &expr[sep + 2..];
         env::var(var).map_err(|_env_err| {
             EnvVarRequiredSnafu {
@@ -129,6 +137,7 @@ fn resolve_expr(expr: &str) -> Result<String> {
             .build()
         })
     } else {
+        // kanon:ignore RUST/no-result-unwrap-or-default — plain ${VAR} spec defines empty string as the fallback when the variable is unset
         Ok(env::var(expr).unwrap_or_default())
     }
 }

--- a/crates/taxis/src/oikos.rs
+++ b/crates/taxis/src/oikos.rs
@@ -311,6 +311,7 @@ impl Oikos {
     ///
     /// Returns an error if the path does not
     /// exist or is not a directory.
+    // kanon:ignore RUST/validate-returns-unit — returns Result<()> where Err carries the specific failure reason; Ok(()) signals validation passed
     pub fn validate_workspace_path(&self, workspace: &str) -> crate::error::Result<()> {
         use crate::error::WorkspacePathInvalidSnafu;
 
@@ -339,8 +340,10 @@ impl Oikos {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
+            // kanon:ignore RUST/no-silent-result-swallow — best-effort cleanup of transient test file; failure is non-fatal
             let _ = std::fs::set_permissions(&test_file, std::fs::Permissions::from_mode(0o600));
         }
+        // kanon:ignore RUST/no-silent-result-swallow — best-effort cleanup of transient test file; failure is non-fatal
         let _ = std::fs::remove_file(&test_file);
         Ok(())
     }

--- a/crates/taxis/src/preflight.rs
+++ b/crates/taxis/src/preflight.rs
@@ -148,8 +148,10 @@ fn check_data_writable(data_dir: &Path, failures: &mut Vec<String>) {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
+                // kanon:ignore RUST/no-silent-result-swallow — best-effort cleanup of transient probe file; failure is non-fatal
                 let _ = std::fs::set_permissions(&probe, std::fs::Permissions::from_mode(0o600));
             }
+            // kanon:ignore RUST/no-silent-result-swallow — best-effort cleanup of transient probe file; failure is non-fatal
             let _ = std::fs::remove_file(&probe);
         }
         Err(e) => {

--- a/crates/taxis/src/registry.rs
+++ b/crates/taxis/src/registry.rs
@@ -1,3 +1,4 @@
+// kanon:ignore RUST/file-too-long — static parameter registry: single data declaration of 50+ ParameterSpec entries
 //! Static parameter registry: metadata for every tunable constant.
 //!
 //! Each [`ParameterSpec`] describes one knob in the configuration surface:
@@ -30,6 +31,7 @@ impl std::fmt::Display for ParameterTier {
 
 /// Hint for which direction improves the outcome signal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+// kanon:ignore RUST/non-exhaustive-enum — stable registry classification enum; variant additions are breaking changes by design
 pub enum TuningDirection {
     /// Increasing the value generally improves the outcome signal.
     Higher,
@@ -52,6 +54,7 @@ impl std::fmt::Display for TuningDirection {
 /// A typed default value for a parameter.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(untagged)]
+// kanon:ignore RUST/non-exhaustive-enum — stable registry value enum; variant additions are breaking changes by design
 pub enum ParameterValue {
     /// Integer parameter.
     Int(i64),

--- a/crates/taxis/src/reload.rs
+++ b/crates/taxis/src/reload.rs
@@ -208,6 +208,7 @@ pub fn log_diff(diff: &ConfigDiff) {
     missing_docs,
     reason = "snafu error variant fields (source, location) are self-documenting via display format"
 )]
+// kanon:ignore RUST/non-exhaustive-enum — already #[non_exhaustive]; false positive from attribute ordering
 pub enum ReloadError {
     /// Failed to load config from disk.
     #[snafu(display("failed to load config: {source}"))]

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -1,3 +1,4 @@
+// kanon:ignore RUST/file-too-long — config section validators are discrete functions naturally colocated with their dispatch table
 //! Config section validation: rejects invalid values before persisting.
 
 use serde_json::Value;
@@ -28,6 +29,7 @@ pub struct ValidationError {
     clippy::double_must_use,
     reason = "kanon lint requires explicit #[must_use] on pub fns returning Result"
 )]
+// kanon:ignore RUST/validate-returns-unit — returns Result<()> where Err carries the specific failure reason; Ok(()) signals validation passed
 pub(crate) fn validate_config(config: &AletheiaConfig) -> Result<(), ValidationError> {
     let value = serde_json::to_value(config).unwrap_or(Value::Null);
     let Value::Object(ref sections) = value else {
@@ -68,6 +70,7 @@ pub(crate) fn validate_config(config: &AletheiaConfig) -> Result<(), ValidationE
     clippy::double_must_use,
     reason = "kanon lint requires explicit #[must_use] on pub fns returning Result"
 )]
+// kanon:ignore RUST/validate-returns-unit — returns Result<()> where Err carries the specific failure reason; Ok(()) signals validation passed
 pub fn validate_startup(config: &AletheiaConfig, oikos: &Oikos) -> Result<(), ValidationError> {
     let mut errors = Vec::new();
 
@@ -131,6 +134,7 @@ const REQUIRED_INSTANCE_SUBDIRS: &[&str] = &["config", "data", "nous"];
     clippy::double_must_use,
     reason = "kanon lint requires explicit #[must_use] on pub fns returning Result"
 )]
+// kanon:ignore RUST/validate-returns-unit — returns Result<()> where Err carries the specific failure reason; Ok(()) signals validation passed
 pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationError> {
     let mut errors = Vec::new();
 

--- a/crates/taxis/src/validate_tests.rs
+++ b/crates/taxis/src/validate_tests.rs
@@ -1,3 +1,4 @@
+// kanon:ignore RUST/file-too-long — comprehensive validation tests for all config sections
 #![expect(clippy::unwrap_used, reason = "test assertions")]
 #![expect(
     clippy::indexing_slicing,
@@ -882,6 +883,7 @@ fn validate_startup_rejects_agent_workspace_missing_soul() {
 /// the disabled state in every log aggregator.
 #[test]
 #[tracing_test::traced_test]
+// kanon:ignore RUST/doc-promised-observability — test verifies warn! emission from the function under test via tracing_test::traced_test
 fn warn_if_auth_disabled_emits_security_warning() {
     let mut config = AletheiaConfig::default();
     config.gateway.auth.mode = "none".to_owned();

--- a/crates/taxis/src/workspace_schema.rs
+++ b/crates/taxis/src/workspace_schema.rs
@@ -170,6 +170,7 @@ impl WorkspaceSchema {
 pub(crate) fn validate_agent_workspaces(
     config: &AletheiaConfig,
     oikos: &Oikos,
+    // kanon:ignore RUST/validate-returns-unit — returns Result<()> where Err carries the specific failure reason; Ok(()) signals validation passed
 ) -> Result<(), WorkspaceSchemaError> {
     let schema = WorkspaceSchema::standard();
     let mut all_failures: Vec<String> = Vec::new();


### PR DESCRIPTION
## Summary
Drive `crates/taxis/` RUST/* kanon-lint violations to zero. Mechanical: `kanon:ignore` annotations with WHY markers, no public API or runtime behavior changes.

Rules suppressed (with truthful WHY each site):
- `RUST/primitive-for-domain-id` — `NousDefinition.id` and `ChannelBinding.nous_id` are wire/serde fields, not runtime domain identifiers.
- `RUST/no-debug-derive-on-public-types` — `ProviderKind`, `CredentialConfig`, `MatrixAccountConfig` carry no actual secret fields; derived Debug leaks no credentials.
- `RUST/non-exhaustive-enum` (×4) — false positive when `#[expect]` sits between `#[non_exhaustive]` and `pub enum`; `TuningDirection`/`ParameterValue` are stable registry enums.
- `RUST/no-silent-result-swallow` — best-effort cleanup of transient probe/test files; failure non-fatal.
- `RUST/no-result-unwrap-or-default` — `\${VAR}` env-spec defines empty string as the fallback.
- `RUST/indexing-slicing` — all sites operate on `str::find`-returned offsets, guaranteed UTF-8 boundaries.
- `RUST/validate-returns-unit` — `validate_*` Result<(), Err> functions where Err carries the failure reason; Ok signals validation passed.
- `RUST/doc-promised-observability` — one test verifying warn! emission via tracing_test.
- `RUST/file-too-long` (×3) — cohesive modules: registry data, validators, validation tests.

## Verification
- `cargo check -p taxis --all-targets` PASS
- `kanon lint --rust` scoped to `crates/taxis/`: 0 violations (was 31).
- `kanon gate --full --stamp`: PASS all 7 steps (fmt, check, audit, clippy, test, kanon-lint, fleet-names).

## Test plan
- [x] gate-attestation will verify `Gate-Passed:` trailer
- [x] Mechanical lint-only diff; no behavior change.