### PR TITLE
fix(lint): drive aletheia-memory-mcp rust-lint to near-zero (3 security findings flagged for T0)

### DIFF
--- a/crates/aletheia-memory-mcp/src/error.rs
+++ b/crates/aletheia-memory-mcp/src/error.rs
@@ -7,6 +7,7 @@
 use snafu::Snafu;
 
 /// Errors produced by the memory MCP server.
+// kanon:ignore RUST/no-debug-derive-on-public-types — error variants contain only non-sensitive display messages and locations
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 #[non_exhaustive]
@@ -14,6 +15,7 @@ use snafu::Snafu;
     missing_docs,
     reason = "snafu error variant fields are self-documenting via display format"
 )]
+// kanon:ignore RUST/non-exhaustive-enum -- WHY: #[non_exhaustive] is already present; linter false-positive when intervening #[expect] separates the attribute from the enum keyword
 pub enum Error {
     /// Failed to open the knowledge store.
     #[snafu(display("failed to open knowledge store: {message}"))]

--- a/crates/aletheia-memory-mcp/src/server.rs
+++ b/crates/aletheia-memory-mcp/src/server.rs
@@ -158,6 +158,7 @@ impl MemoryServer {
     /// Returns `Err(WriteUnauthorized)` if:
     ///   - Write token is not configured
     ///   - Provided token does not match
+    // kanon:ignore RUST/validate-returns-unit — returns Result<()> where Err carries the specific failure reason; Ok(()) signals validation passed
     pub(crate) fn validate_write_token(&self, provided: &str) -> error::Result<()> {
         use subtle::ConstantTimeEq;
 

--- a/crates/aletheia-memory-mcp/src/tools.rs
+++ b/crates/aletheia-memory-mcp/src/tools.rs
@@ -1,3 +1,4 @@
+// kanon:ignore RUST/file-too-long — MCP tool implementations with inline datalog scripts; splitting would fragment the #[tool_router] impl and break the single-file routing convention.
 //! MCP tool implementations for the memory server.
 //!
 //! Read tools (`nous_search`, `nous_neighbors`, `nous_list_topics`, `nous_stats`)
@@ -26,6 +27,7 @@ use crate::error::{InvalidInputSnafu, KnowledgeStoreSnafu, SerializationSnafu};
 use crate::server::MemoryServer;
 
 /// Parameters for `nous_search`.
+// kanon:ignore RUST/no-debug-derive-on-public-types — contains only query text and limit; no sensitive data
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct NousSearchParams {
     /// Free-text query string; matched via BM25 against current fact content.
@@ -36,9 +38,11 @@ pub struct NousSearchParams {
 }
 
 /// Parameters for `nous_neighbors`.
+// kanon:ignore RUST/no-debug-derive-on-public-types — contains only a fact ID; no sensitive data
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct NousNeighborsParams {
     /// ID of the seed fact whose entity neighbors should be returned.
+    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
     pub fact_id: String,
 }
 
@@ -49,6 +53,7 @@ pub struct NousAnnotateParams {
     /// Session ID for the annotation (identifies the agent or source).
     pub session_id: Option<String>,
     /// Fact ID to annotate.
+    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
     pub fact_id: String,
     /// Annotation content — agent-authored note or observation.
     pub content: String,
@@ -61,8 +66,10 @@ pub struct NousAnnotateParams {
 #[non_exhaustive]
 pub struct NousSupersedeParams {
     /// ID of the fact being superseded.
+    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
     pub old_fact_id: String,
     /// ID of the new fact that supersedes it.
+    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
     pub new_fact_id: String,
     /// Reason for supersession.
     pub reason: String,
@@ -75,6 +82,7 @@ pub struct NousSupersedeParams {
 #[non_exhaustive]
 pub struct NousForgetParams {
     /// ID of the fact to forget.
+    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
     pub fact_id: String,
     /// Reason for forgetting.
     pub reason: String,
@@ -523,6 +531,7 @@ impl MemoryServer {
                     })?;
                 let fact_count = fact_count_result
                     .get_i64(0, "count(id)")
+                    // kanon:ignore RUST/no-result-unwrap-or-default — count query returns zero rows when no facts match; 0 is the semantically correct default
                     .unwrap_or_default();
 
                 // WHY: datalog rule heads use `name[args]`; concat! keeps each
@@ -546,6 +555,7 @@ impl MemoryServer {
                     })?;
                 let topic_count = topic_count_result
                     .get_i64(0, "count(fact_type)")
+                    // kanon:ignore RUST/no-result-unwrap-or-default — count query returns zero rows when no topics match; 0 is the semantically correct default
                     .unwrap_or_default();
 
                 let last_updated_script = r"


### PR DESCRIPTION
## Summary
Mechanical kanon-lint cleanup for `crates/aletheia-memory-mcp/` — 16 → **6 violations**. The remaining 6 are **deliberately not suppressed**: 3× `plain-string-secret` + 3× `no-debug-derive-on-public-types` linked to the same write-token capability fields. They are GENUINE security findings, flagged for human review rather than hidden behind annotations.

## What this PR fixes (with truthful WHY each)
- `RUST/primitive-for-domain-id` (5×) — `fact_id`/`old_fact_id`/`new_fact_id` are MCP JSON-wire fields required as String by schemars/serde.
- `RUST/no-debug-derive-on-public-types` (2×) — `NousSearchParams`/`NousNeighborsParams` carry only query text + limit / fact id; no secret fields.
- `RUST/non-exhaustive-enum` — `Error` is already `#[non_exhaustive]`; false positive from `#[expect]` ordering (escalations E6).
- `RUST/validate-returns-unit` — `validate_write_token` returns `Result<()>` where Err carries the precise failure reason.
- `RUST/file-too-long` — `tools.rs` colocates inline datalog scripts with the `#[tool_router]` impl; splitting would fragment the routing convention.
- `RUST/no-result-unwrap-or-default` (2×) — `count(...)` queries legitimately return 0 when no rows match.

## ⚠️ FOR T0 REVIEW — genuine security findings (intentionally not suppressed)
The following 6 violations on `crates/aletheia-memory-mcp/src/tools.rs` are **real**:

- L61, L77, L90 `RUST/plain-string-secret` — `NousAnnotateParams.write_token`, `NousSupersedeParams.write_token`, `NousForgetParams.write_token` are capability tokens passed as plain `String` in MCP tool parameters. They should be `SecretString` (per `RUST/plain-string-secret` rule).
- L50, L65, L81 `RUST/no-debug-derive-on-public-types` — those same three `NousAnnotateParams`/`NousSupersedeParams`/`NousForgetParams` derive `Debug`, so the write_token would print in any `Debug` log. Need a manual `Debug` impl that redacts the token (cf. how `hermeneus` `ProviderConfig` was just hardened in #4184).

Fixing both classes likely needs a single change: switch `pub write_token: String` → `pub write_token: SecretString` (with appropriate schemars/serde glue and manual Debug). That's a public-API + crypto-handling change → leaving the decision to T0.

## Verification
- `cargo check -p aletheia-memory-mcp --all-targets` PASS
- `kanon lint --rust` for the crate: 6 violations remaining, all listed above.
- `kanon gate --full --stamp` PASS all 7 steps.

## Test plan
- [x] gate-attestation will verify `Gate-Passed:` trailer
- [x] Mechanical lint-only diff; no runtime/protocol behavior change.
- [ ] **T0 decide**: address the 6 flagged security findings (SecretString + manual Debug redaction).