### PR TITLE
chore(ci): migrate required checks + llm-regen to self-hosted runners

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   gate-attestation:
     name: gate-attestation
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Pass trusted automation PRs
         if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'release-please[bot]' }}

--- a/.github/workflows/llm-regen.yml
+++ b/.github/workflows/llm-regen.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   regenerate:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
     # finding fails the job — suppressions require a deny.toml entry with
     # a WHY comment, not silent --ignore flags.
     name: cargo deny
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -67,7 +67,7 @@ jobs:
     # path; running cargo-audit independently protects against bugs or
     # config drift disabling one of the two. See standards/CI.md.
     name: cargo audit
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
GHA billing blocks the ubuntu-latest runners; required checks don't run on the release PR (#4042) and llm-regen auto-merge PRs pile up. Migrating security.yml + gate-attestation.yml + llm-regen.yml to self-hosted runners (matching kanon) is billing-independent. Counterpart to kanon#929.