### PR TITLE
chore(ci): migrate release-please workflow to self-hosted runners

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
GHA billing blocks the release-please workflow itself (separate from the required-checks workflows, already migrated in #4206), so #4042 never gets updated. Aligns with kanon#929. Counterpart to aletheia#4206.