### PR TITLE
fix(symbolon): gate KeyringCredentialProvider::with_identifiers behind cfg(test)

### DIFF
--- a/crates/symbolon/src/credential/keyring_provider.rs
+++ b/crates/symbolon/src/credential/keyring_provider.rs
@@ -30,6 +30,7 @@ impl KeyringCredentialProvider {
     }
 
     /// Create a provider with custom service and username identifiers.
+    #[cfg(test)]
     #[must_use]
     pub(crate) fn with_identifiers(
         service: impl Into<String>,


### PR DESCRIPTION
## Summary

The associated function \`KeyringCredentialProvider::with_identifiers\` is only called from the \`#[cfg(test)] mod keyring_provider_tests\` sibling module. When the lib target is built without the test cfg (which clippy does for \`--all-targets\`), the function appears unused and triggers \`dead_code\`.

Under \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`, this turns into a hard error, blocking the gate for any PR whose clippy scope reaches \`symbolon\` — i.e. anything touching \`aletheia/\` or other downstream crates. Several in-flight lint cleanup PRs hit this.

\`#[cfg(test)]\` is the minimal, truthful annotation: the function is in fact test-only.

## Test plan
- [x] \`cargo clippy -p symbolon --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test -p symbolon --all-features keyring_provider_tests\` — green (function still callable from tests)
- [x] \`kanon gate --full --stamp\` — PASS, Gate-Passed trailer attached.