### PR TITLE
fix(lint): drive theatron/dokimion/pylon rust-lint stragglers to zero

### DIFF
--- a/crates/eval/src/benchmarks/judge.rs
+++ b/crates/eval/src/benchmarks/judge.rs
@@ -22,7 +22,7 @@ pub struct JudgeScore {
 }
 
 /// Configuration for the LLM judge endpoint.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct LlmJudgeConfig {
     /// OpenAI-compatible chat completions URL.
     pub endpoint: String,
@@ -34,6 +34,19 @@ pub struct LlmJudgeConfig {
     pub max_tokens: u32,
     /// Temperature (default 0.0 for deterministic judging).
     pub temperature: f32,
+}
+
+impl core::fmt::Debug for LlmJudgeConfig {
+    // WHY: hand-rolled Debug redacts api_key so structured logs / panics never leak the bearer token.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LlmJudgeConfig")
+            .field("endpoint", &self.endpoint)
+            .field("model", &self.model)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .field("max_tokens", &self.max_tokens)
+            .field("temperature", &self.temperature)
+            .finish()
+    }
 }
 
 // kanon:ignore RUST/hardcoded-model — default judge model constant for LLM-as-judge evaluator

--- a/crates/pylon/src/handlers/insights.rs
+++ b/crates/pylon/src/handlers/insights.rs
@@ -1,3 +1,4 @@
+// kanon:ignore RUST/file-too-long — cohesive insights surface: agent-perf, quality, token, cost, and journal handlers share helper bucketing/date-range/series functions and DTOs; splitting now would duplicate those helpers across sibling modules.
 //! Meta-insights handlers: agent performance, quality metrics, system journal.
 
 use std::collections::HashMap;

--- a/crates/pylon/src/handlers/knowledge/bulk_import.rs
+++ b/crates/pylon/src/handlers/knowledge/bulk_import.rs
@@ -18,6 +18,7 @@ mod bulk_import_dto;
 // because bulk_import.rs uses it internally via bulk_import_dto:: path, not via
 // the re-export itself. The pub use is intentional for the public pylon surface.
 // kanon:ignore RUST/allow-not-expect WHY: unused_imports fires only under some target/cfg combinations (rustc sees ImportFactError as unused via the re-export, but --all-targets clippy sees it used through the bulk_import_dto:: path), so #[expect] would be unfulfilled and itself warn; #[allow] is the correct tool for a conditionally-unused re-export.
+// kanon:ignore RUST/prefer-expect-over-allow WHY: same as RUST/allow-not-expect above — kanon emits the rule under both legacy and current names depending on basanos build; suppressing both keeps gate green across versions.
 #[allow(unused_imports)]
 pub use bulk_import_dto::{BulkImportRequest, BulkImportResponse, ImportFactError};
 

--- a/crates/theatron/src/lib.rs
+++ b/crates/theatron/src/lib.rs
@@ -85,13 +85,15 @@ pub use skene::sse::SseStream;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn public_types_accessible() {
         // WHY: smoke test verifying re-exports compile and link correctly
-        let _ = std::any::type_name::<super::ApiClient>();
-        let _ = std::any::type_name::<super::NousId>();
-        let _ = std::any::type_name::<super::SessionId>();
-        let _ = std::any::type_name::<super::StreamEvent>();
-        let _ = std::any::type_name::<super::SseEvent>();
+        let _ = std::any::type_name::<ApiClient>();
+        let _ = std::any::type_name::<NousId>();
+        let _ = std::any::type_name::<SessionId>();
+        let _ = std::any::type_name::<StreamEvent>();
+        let _ = std::any::type_name::<SseEvent>();
     }
 }


### PR DESCRIPTION
Four small independent fixes that close out the small remaining per-crate rust-lint debt across theatron, dokimion (eval), and pylon.

## Changes
- **crates/theatron/src/lib.rs** — add \`use super::*;\` to the test module and switch \`super::Foo\` paths to bare \`Foo\` (RUST/test-missing-use-super).
- **crates/eval/src/benchmarks/judge.rs** — \`LlmJudgeConfig\` carries an \`Option<String> api_key\` (an OpenAI-compatible bearer token). Drop \`#[derive(Debug)]\` and implement \`Debug\` manually to redact the API key as \`Some(\"<redacted>\")\` so structured logs and panics never leak it (RUST/no-debug-derive-on-public-types — security-positive change).
- **crates/pylon/src/handlers/insights.rs** — file-too-long (861 lines, limit 800). Suppressed with \`kanon:ignore RUST/file-too-long\` and a WHY: agent-perf, quality-metrics, token-metrics, cost-metrics and journal handlers all share bucketing/date-range/series helpers + DTOs; splitting now would duplicate those across sibling modules.
- **crates/pylon/src/handlers/knowledge/bulk_import.rs** — extend the existing \`kanon:ignore RUST/allow-not-expect\` with a parallel \`RUST/prefer-expect-over-allow\` ignore (basanos emits the rule under both legacy and current names depending on its build).

## Verification
- \`kanon lint --rust | grep -E "crates/(theatron|eval|pylon)/"\` → 0 hits in these crates.
- \`kanon gate --full --stamp\` PASS on this branch (cargo fmt / check / clippy / test / audit / kanon lint all PASS — 919 non-blocking warnings, 0 errors). Trailer carried.