### PR TITLE
fix(lint): drive fuzz harness rust-lint to zero

### DIFF
--- a/fuzz/fuzz_targets/fuzz_config_parsing.rs
+++ b/fuzz/fuzz_targets/fuzz_config_parsing.rs
@@ -13,10 +13,12 @@ fuzz_target!(|data: &[u8]| {
     // 1. AletheiaConfig from JSON: the runtime config update path.
     //    Tests camelCase rename, default handling, nested struct parsing,
     //    HashMap keys, Vec elements, and enum variants.
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<taxis::config::AletheiaConfig>(data);
 
     // 2. AletheiaConfig from TOML: the file-based config loading path.
     if let Ok(s) = std::str::from_utf8(data) {
+        // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
         let _ = toml::from_str::<taxis::config::AletheiaConfig>(s);
     }
 
@@ -39,17 +41,25 @@ fuzz_target!(|data: &[u8]| {
         ];
 
         for section in SECTIONS {
+            // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
             let _ = taxis::validate::validate_section(section, &value);
         }
     }
 
     // 4. Individual config struct deserialization: tighter surface coverage.
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<taxis::config::GatewayConfig>(data);
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<taxis::config::AgentsConfig>(data);
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<taxis::config::ChannelsConfig>(data);
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<taxis::config::MaintenanceSettings>(data);
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<taxis::config::CredentialConfig>(data);
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<taxis::config::EmbeddingSettings>(data);
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<taxis::config::NousDefinition>(data);
 
     // 5. JSON roundtrip of default config: ensures serialize/deserialize symmetry.

--- a/fuzz/fuzz_targets/fuzz_knowledge_roundtrip.rs
+++ b/fuzz/fuzz_targets/fuzz_knowledge_roundtrip.rs
@@ -29,6 +29,7 @@ static FACT_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64
 fuzz_target!(|data: &[u8]| {
     // 1. Fact JSON deserialization: malformed content, invalid confidence,
     //    missing fields, unexpected types, oversized payloads.
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<Fact>(data);
 
     // 2. Timestamp parsing: ISO 8601, date-only, far-future sentinel,
@@ -46,13 +47,17 @@ fuzz_target!(|data: &[u8]| {
         }
 
         // 3. FactType classification: keyword heuristics on arbitrary strings.
+        // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
         let _ = FactType::classify(s);
+        // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
         let _ = FactType::from_str_lossy(s);
 
         // 4. ForgetReason parsing: enum from string.
+        // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
         let _ = s.parse::<ForgetReason>();
 
         // 5. EpistemicTier serde roundtrip.
+        // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
         let _ = serde_json::from_str::<EpistemicTier>(s);
     }
 
@@ -176,6 +181,7 @@ fuzz_target!(|data: &[u8]| {
             // The fact we just inserted should be retrievable (unless the store
             // hit an internal limit). We don't assert exact count because other
             // fuzz iterations may have inserted facts concurrently.
+            // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
             let _ = facts.len();
         }
     }

--- a/fuzz/fuzz_targets/fuzz_tool_dispatch.rs
+++ b/fuzz/fuzz_targets/fuzz_tool_dispatch.rs
@@ -11,15 +11,18 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     // 1. ContentBlock tagged-enum deserialization (includes ToolUse variant).
     //    Malformed JSON, unexpected `type` tags, missing fields, extra fields.
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<hermeneus::types::ContentBlock>(data);
 
     // 2. ToolCall deserialization: the struct persisted per-turn.
     //    Unexpected types in `input` (Value), missing optional `result`, etc.
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<nous::pipeline::ToolCall>(data);
 
     // 3. ToolName validation: arbitrary strings against the allowlist regex.
     //    Empty, oversized (>128), unicode, special chars, null bytes.
     if let Ok(s) = std::str::from_utf8(data) {
+        // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
         let _ = koina::id::ToolName::new(s);
     }
 
@@ -51,16 +54,20 @@ fuzz_target!(|data: &[u8]| {
                         let (name, hash) = part.split_at(mid);
                         // WHY: is_error derived from byte to exercise both paths.
                         let is_error = mid % 2 == 0;
+                        // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
                         let _ = detector.record(name, hash, is_error);
                     }
                 }
             }
             // Verify invariants hold after arbitrary input.
+            // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
             let _ = detector.call_count();
+            // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
             let _ = detector.pattern_count();
         }
     }
 
     // 6. InteractionSignal serde roundtrip: enum variant coverage.
+    // kanon:ignore RUST/no-silent-result-swallow — fuzz harness; malformed input is expected and errors are intentionally discarded
     let _ = serde_json::from_slice::<nous::pipeline::InteractionSignal>(data);
 });


### PR DESCRIPTION
Annotate the three fuzz harnesses' intentional \`let _ = ...\` Result discards with \`kanon:ignore RUST/no-silent-result-swallow\` and a WHY (fuzz harness — malformed input is expected; errors are intentionally discarded).

## Scope
- fuzz/fuzz_targets/fuzz_config_parsing.rs (10 sites)
- fuzz/fuzz_targets/fuzz_knowledge_roundtrip.rs (6 sites)
- fuzz/fuzz_targets/fuzz_tool_dispatch.rs (7 sites)

Total: 23 RUST/no-silent-result-swallow → 0 in \`fuzz/\`.

## Verification
- \`kanon lint --rust | grep ^/home...fuzz/\` → 0 hits.
- \`kanon gate --full --stamp\` PASS (cargo fmt / check / clippy / test / audit / kanon lint all PASS).

Note: the wave7 kimi lane attempted to also edit theatron/skene+proskenion (introducing silent error-swallows in production code); those out-of-scope edits were discarded — this PR contains ONLY the fuzz/ annotation work.