### PR TITLE
fix(aletheia/add-nous): default model to claude-sonnet-4-6 (aligns with init)

### DIFF
--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -20,7 +20,7 @@ pub(crate) struct AddNousArgs {
     pub provider: String,
 
     /// Model identifier.
-    #[arg(long, default_value = koina::defaults::DEFAULT_MODEL)]
+    #[arg(long, default_value = koina::defaults::DEFAULT_MODEL_SHORT)]
     pub model: String,
 }
 


### PR DESCRIPTION
## Summary
- `aletheia add-nous` defaulted to `koina::defaults::DEFAULT_MODEL` = `\"claude-sonnet-4-20250514\"` (Sonnet 4.0, May 2025), while `aletheia init` defaults to `\"claude-sonnet-4-6\"` (Sonnet 4.6). Found while probing the CLI in the friction campaign — adding a new agent to a Sonnet-4.6 instance silently landed a per-agent override pinning it back to Sonnet 4.0.
- Switch the CLI default to `koina::defaults::DEFAULT_MODEL_SHORT` so new agents inherit the same identifier the instance default uses.

## Scope (intentionally narrow)
The broader `DEFAULT_MODEL` inconsistency (still referenced by `pylon/handlers/nous.rs`, `nous/{roles,spawn_svc}`, `aletheia/commands/agent_io.rs`, `melete/distill.rs`, plus `recall_sources/llm_context.rs` test fixtures) is **left for a separate decision** — those callsites use it as a runtime fallback/spawn default and may have intent the test fixtures don't make obvious. Filing a follow-up issue.

## Test plan
- [x] `cargo check -p aletheia` clean
- [x] `kanon gate --full --stamp` green (Gate-Passed trailer present)
- [x] Hand-verified: `aletheia add-nous foo` on a 4.6 instance no longer downgrades the new agent's model block