### PR TITLE
fix(aletheia/backup): verify rejects non-fjall directories instead of scaffolding them

### DIFF
--- a/crates/aletheia/src/commands/backup.rs
+++ b/crates/aletheia/src/commands/backup.rs
@@ -140,6 +140,18 @@ fn run_verify(path: &Path) -> Result<()> {
 }
 
 pub(crate) fn verify_backup(path: &Path) -> Result<VerifyResult> {
+    // WHY: FjallDb::open_existing eagerly creates `version`, `keyspaces/`, and
+    // a fresh journal in the target directory if it doesn't already look like a
+    // fjall store. That makes `backup verify <empty-dir>` report PASS while
+    // silently dropping ~64 MB of fjall scaffolding into the user's path. Guard
+    // against that by requiring the fjall marker file before opening.
+    if !path.join("version").is_file() {
+        whatever!(
+            "not a fjall backup (missing `version` marker): {}",
+            path.display()
+        );
+    }
+
     let fdb = koina::fjall::FjallDb::open_existing(path)
         .map_err(|e| crate::error::Error::msg(format!("failed to open backup: {e}")))?;
 
@@ -529,5 +541,24 @@ mod tests {
     fn verify_backup_nonexistent_path_fails() {
         let result = run_verify(Path::new("/tmp/nonexistent-fjall-backup-xyz"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn verify_backup_rejects_non_fjall_directory() {
+        // WHY: A bare or unrelated directory must not be silently scaffolded
+        // into a fjall store by `backup verify`; that would corrupt the user's
+        // path and falsely report PASS.
+        let tmp = tempfile::tempdir().unwrap();
+        let msg = match verify_backup(tmp.path()) {
+            Ok(_) => panic!("expected rejection of non-fjall dir"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("not a fjall backup"),
+            "unexpected error: {msg}"
+        );
+        // The pre-check must not create any fjall scaffolding.
+        assert!(!tmp.path().join("version").exists());
+        assert!(!tmp.path().join("keyspaces").exists());
     }
 }


### PR DESCRIPTION
## Summary
`aletheia backup verify <PATH>` called `FjallDb::open_existing(path)`, which eagerly creates the fjall layout (`version`, `keyspaces/`, an empty journal allocated at ~64 MB) in any directory it touches. The practical effect was that pointing `verify` at an empty or unrelated directory silently dropped tens of megabytes of fjall scaffolding into it AND reported `Status: PASS — 0 keys`, giving the user no way to tell that the path wasn't a real backup.

Pre-check for the `version` marker file in `verify_backup` before opening fjall and refuse the path with a clear error. Real backups created by `aletheia backup create` always carry a `version` file, so this only gates accidental misuse.

## Test plan
- [x] New regression test `verify_backup_rejects_non_fjall_directory` passes: rejects non-fjall dir AND asserts no fjall scaffolding was written
- [x] Existing 4 backup tests still pass (`verify_backup_empty_db_passes`, `verify_backup_with_data_passes`, `verify_backup_detects_bad_json`, `verify_backup_nonexistent_path_fails`)
- [x] `kanon gate --full --stamp` green (Gate-Passed trailer present)
- [x] Hand-verified: `aletheia backup verify <empty-dir>` now returns `Error: not a fjall backup (missing \`version\` marker)` + exit 1, dir unchanged

## How it was found
Probed `backup verify` against `mkdir empty/` (zero files): before this patch, the command silently wrote `0.jnl` (67MB), `keyspaces/`, `lock`, and `version` into that directory and reported PASS. After: the directory is left untouched and the command errors out before touching fjall.