### PR TITLE
fix(aletheia): rewrite KS-not-initialized error to point at real recovery

### DIFF
--- a/crates/aletheia/src/commands/ingest.rs
+++ b/crates/aletheia/src/commands/ingest.rs
@@ -42,8 +42,10 @@ pub(crate) async fn run(args: &IngestArgs, instance_root: Option<&PathBuf>) -> R
         let knowledge_path = oikos.knowledge_cohort_db("shared");
         if !knowledge_path.exists() && !oikos.knowledge_db().exists() {
             whatever!(
-                "knowledge store not found at {}\n  \
-                 Has this instance been initialized with recall enabled?",
+                "knowledge store not initialized at {}\n  \
+                 The store is created lazily by the running server. Either:\n    \
+                   1. Start the server once to bootstrap it:  aletheia\n    \
+                   2. Or route this command through a running server with --url",
                 knowledge_path.display()
             );
         }

--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -93,8 +93,10 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
         let knowledge_path = oikos.knowledge_cohort_db("shared");
         if !knowledge_path.exists() && !oikos.knowledge_db().exists() {
             whatever!(
-                "knowledge store not found at {}\n  \
-                 Has this instance been initialized with recall enabled?",
+                "knowledge store not initialized at {}\n  \
+                 The store is created lazily by the running server. Either:\n    \
+                   1. Start the server once to bootstrap it:  aletheia\n    \
+                   2. Or route this command through a running server with --url",
                 knowledge_path.display()
             );
         }

--- a/crates/aletheia/src/commands/repl.rs
+++ b/crates/aletheia/src/commands/repl.rs
@@ -67,8 +67,10 @@ fn run_repl(instance_root: Option<&PathBuf>) -> Result<()> {
 
     if !knowledge_path.exists() && !oikos.knowledge_db().exists() {
         snafu::whatever!(
-            "knowledge store not found at {}\n  \
-             Has this instance been initialized with recall enabled?",
+            "knowledge store not initialized at {}\n  \
+             The store is created lazily by the running server. Either:\n    \
+               1. Start the server once to bootstrap it:  aletheia\n    \
+               2. Or route this command through a running server with --url",
             knowledge_path.display()
         );
     }


### PR DESCRIPTION
Closes #4247.

## Summary
- `aletheia ingest`, `aletheia repl`, and `aletheia memory <subcmd>` all hit the same direct-fjall knowledge-store existence check and emit the same misleading wording: `"Has this instance been initialized with recall enabled?"` — but **no such flag exists** in `init --help`.
- The KS at `data/knowledge.fjall/shared` is created **lazily** by the running server on first write. A fresh-init instance never has it; the first direct-fjall command before the server has bootstrapped always hits this error.
- Rewrites the message at all three sites to point at the real recovery (start the server once, or pass `--url <running-server>`).

## Diff scope
- `crates/aletheia/src/commands/ingest.rs` — message replaced
- `crates/aletheia/src/commands/repl.rs` — message replaced
- `crates/aletheia/src/commands/memory/mod.rs` — message replaced

String-only change. No behavior change. +12/-6 across 3 files.

## New wording

```
Error: knowledge store not initialized at <path>
  The store is created lazily by the running server. Either:
    1. Start the server once to bootstrap it:  aletheia
    2. Or route this command through a running server with --url
```

## Test plan
- [x] `cargo build -p aletheia --release` — green
- [x] `kanon gate --full --stamp` — PASS (cargo fmt / check / clippy / test / lint / audit / fleet-names all green; trailer stamped)
- [x] Smoke-verified all 3 sites against a fresh `init -y` instance: `aletheia repl`, `aletheia memory check`, `aletheia ingest <path>` — each emits the new wording