### PR TITLE
fix(aletheia/maintenance): size status table columns to longest name

### DIFF
--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -72,12 +72,30 @@ pub(crate) async fn run(action: Action, instance_root: Option<&PathBuf>) -> Resu
                         .whatever_context("failed to serialize status")?
                 );
             } else {
-                println!("{:<24} {:<8} {:<6} Last Run", "Task", "Enabled", "Runs");
-                println!("{}", "-".repeat(60));
+                let name_w = statuses
+                    .iter()
+                    .map(|s| s.name.len())
+                    .max()
+                    .unwrap_or(4)
+                    .max("Task".len());
+                let runs_w = statuses
+                    .iter()
+                    .map(|s| s.run_count.to_string().len())
+                    .max()
+                    .unwrap_or(1)
+                    .max("Runs".len());
+                println!(
+                    "{:<name_w$} {:<8} {:<runs_w$} Last Run",
+                    "Task", "Enabled", "Runs"
+                );
+                println!("{}", "-".repeat(name_w + 1 + 8 + 1 + runs_w + 1 + 8));
                 for s in &statuses {
                     let last = s.last_run.as_deref().unwrap_or("never");
                     let enabled = if s.enabled { "yes" } else { "no" };
-                    println!("{:<24} {:<8} {:<6} {}", s.name, enabled, s.run_count, last);
+                    println!(
+                        "{:<name_w$} {:<8} {:<runs_w$} {}",
+                        s.name, enabled, s.run_count, last
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `aletheia maintenance status` hard-coded the Task column to 24 chars, but 3 of 6 default-registered task names exceed that (\"Routing after-action store refresh\" 35, \"Fjall knowledge store backup\" 28, \"Prompt audit log retention\" 26), so the columns smeared:
  ```
  Task                     Enabled  Runs   Last Run
  Routing after-action store refresh yes      0      never
  Fjall knowledge store backup yes      0      never
  Prompt audit log retention yes      0      never
  ```
- Compute the Task and Runs widths from the actual data with a header floor; output now aligns regardless of name length.
- `--json` output path unchanged; no behavior change beyond presentation.

## After
```
Task                               Enabled  Runs Last Run
---------------------------------------------------------
Trace rotation                     yes      0    never
Instance drift detection           yes      0    never
Database size monitor              yes      0    never
Routing after-action store refresh yes      0    never
Fjall knowledge store backup       yes      0    never
Prompt audit log retention         yes      0    never
```

## Diff scope
- `crates/aletheia/src/commands/maintenance.rs` only. +21 / -3.

## Test plan
- [x] `cargo build -p aletheia --release` — green
- [x] `kanon gate --full --stamp` — PASS (fmt/check/clippy/test/lint/audit/fleet-names all green; trailer stamped)
- [x] Smoke-verified against a fresh `init -y` instance — table now aligns cleanly