### PR TITLE
fix(aletheia/eval): reject malformed --url, zero --timeout, and zero --top-k

### DIFF
--- a/crates/aletheia/src/commands/eval.rs
+++ b/crates/aletheia/src/commands/eval.rs
@@ -30,7 +30,25 @@ pub(crate) struct EvalArgs {
     pub jsonl_output: Option<String>,
 }
 
+/// Reject obviously-broken inputs before talking to the server, so operators
+/// get a precise error instead of a generic "no scenarios passed" downstream.
+fn validate_args(args: &EvalArgs) -> Result<()> {
+    if args.timeout == 0 {
+        whatever!(
+            "--timeout must be greater than 0 seconds (got 0; a zero timeout fails every scenario instantly)"
+        );
+    }
+    // The scenario-list path never reaches the network, so don't reject its URL.
+    if args.scenario.as_deref() != Some("list")
+        && let Err(e) = reqwest::Url::parse(&args.url)
+    {
+        whatever!("--url is not a valid URL: {e} (got {:?})", args.url);
+    }
+    Ok(())
+}
+
 pub(crate) async fn run(args: EvalArgs) -> Result<()> {
+    validate_args(&args)?;
     let EvalArgs {
         url,
         token,
@@ -94,4 +112,51 @@ pub(crate) async fn run(args: EvalArgs) -> Result<()> {
         whatever!("{} scenario(s) failed", report.failed);
     }
     Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn args_with(url: &str, timeout: u64, scenario: Option<&str>) -> EvalArgs {
+        EvalArgs {
+            url: url.to_owned(),
+            token: None,
+            scenario: scenario.map(str::to_owned),
+            json: false,
+            timeout,
+            jsonl_output: None,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_timeout_zero() {
+        let err = validate_args(&args_with("http://127.0.0.1:18789", 0, None)).unwrap_err();
+        assert!(
+            err.to_string().contains("--timeout must be greater than 0"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_malformed_url() {
+        let err = validate_args(&args_with("not a url", 30, None)).unwrap_err();
+        assert!(
+            err.to_string().contains("--url is not a valid URL"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_skips_url_check_for_scenario_list() {
+        // `--scenario list` never touches the network; URL doesn't matter.
+        validate_args(&args_with("not a url", 30, Some("list"))).unwrap();
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_args() {
+        validate_args(&args_with("http://127.0.0.1:18789", 30, None)).unwrap();
+        validate_args(&args_with("https://example.com:8443/path", 1, Some("ping"))).unwrap();
+    }
 }

--- a/crates/aletheia/src/commands/eval_embeddings.rs
+++ b/crates/aletheia/src/commands/eval_embeddings.rs
@@ -204,10 +204,21 @@ fn print_table(run: &mneme::embedding_eval::EvalRunResult) {
     println!();
 }
 
+/// Reject obviously-broken inputs up-front so operators don't get a
+/// meaningless table (e.g. `Recall@0: 0.0%`) instead of an error.
+fn validate_args(args: &EvalEmbeddingsArgs) -> Result<()> {
+    if args.top_k == 0 {
+        snafu::whatever!("--top-k must be greater than 0 (got 0; Recall@0 is undefined)");
+    }
+    Ok(())
+}
+
 /// Entry point for the `eval-embeddings` subcommand.
 pub(crate) fn run(args: &EvalEmbeddingsArgs) -> Result<()> {
     use mneme::embedding::{EmbeddingConfig, create_provider};
     use mneme::embedding_eval::{EvalDataset, compare_models};
+
+    validate_args(args)?;
 
     // Load dataset.
     let dataset = EvalDataset::from_jsonl_file(&args.dataset)
@@ -282,5 +293,38 @@ pub(crate) fn run(args: &EvalEmbeddingsArgs) -> Result<()> {
                 .map_or(0.0, |c| c.recall_at_k * 100.0),
             run.baseline.recall_at_k * 100.0,
         )
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn args_with(top_k: usize) -> EvalEmbeddingsArgs {
+        EvalEmbeddingsArgs {
+            dataset: PathBuf::from("/dev/null"),
+            corpus: None,
+            top_k,
+            baseline_provider: "candle".to_owned(),
+            candidate_provider: None,
+            json: false,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_top_k_zero() {
+        let err = validate_args(&args_with(0)).unwrap_err();
+        assert!(
+            err.to_string().contains("--top-k must be greater than 0"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_positive_top_k() {
+        validate_args(&args_with(1)).unwrap();
+        validate_args(&args_with(5)).unwrap();
+        validate_args(&args_with(100)).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Three small CLI arg-validation gaps on `aletheia eval` and `aletheia eval-embeddings` surfaced during the friction sweep:

- `aletheia eval --url 'not a url' --timeout 1` was accepted by clap and surfaced downstream as "no scenarios passed — is the server running at not a url?", which blames the server rather than the typo'd URL.
- `aletheia eval --url http://… --timeout 0` was likewise accepted and reached the catch-all "no scenarios passed" message even though every scenario must time out instantly at `timeout_secs=0`.
- `aletheia eval-embeddings --dataset … --top-k 0` ran the full evaluation pipeline and printed `Recall@0: 0.0%` / `GATE PASSED` with no signal that K=0 is nonsense.

Each subcommand now has a tiny `validate_args()` pre-check (same shape as the prior `aletheia ingest` fix in #4243):

- `eval`: rejects `--timeout 0`, and rejects `--url` values that fail `reqwest::Url::parse`. The `--scenario list` path is skipped because it never touches the network.
- `eval-embeddings`: rejects `--top-k 0`.

6 unit tests cover each path (zero-timeout, malformed URL, list-scenario URL skip, well-formed args; top-k=0 reject, positive top-k accept).

## Test plan

- [x] `cargo test -p aletheia --bins -- eval` — 8 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `kanon gate --full --stamp` — green; `Gate-Passed: kanon 0.1.0` trailer applied
- [x] Smoke-verified against `target/release/aletheia`:
  - `eval --url 'not a url'` → `Error: --url is not a valid URL: relative URL without a base (got "not a url")`
  - `eval --timeout 0` → `Error: --timeout must be greater than 0 seconds …`
  - `eval-embeddings --top-k 0` → `Error: --top-k must be greater than 0 (got 0; Recall@0 is undefined)`
  - Happy path (`--top-k 1`) still passes through with `GATE PASSED`

Found during the iter-23 friction sweep; mechanical, no behavior change on valid inputs.