### PR TITLE
fix(episteme/embedding-eval): report file-not-found as IO error, not 'parse line 0'

### DIFF
--- a/crates/episteme/src/embedding_eval.rs
+++ b/crates/episteme/src/embedding_eval.rs
@@ -28,7 +28,7 @@
 //! println!("Recall@5: {}", run.baseline.recall_at_k);
 //! ```
 
-use snafu::Snafu;
+use snafu::{ResultExt, Snafu};
 use tracing::instrument;
 
 use crate::embedding::EmbeddingProvider;
@@ -71,6 +71,15 @@ pub enum EvalError {
     #[snafu(display("embedding failed during eval: {message}"))]
     EmbedFailed {
         message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Reading the JSONL dataset from disk failed.
+    #[snafu(display("cannot read eval dataset {}: {source}", path.display()))]
+    IoFailed {
+        path: std::path::PathBuf,
+        source: std::io::Error,
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -134,14 +143,11 @@ impl EvalDataset {
     ///
     /// # Errors
     ///
-    /// Returns [`EvalError::ParseFailed`] if reading or parsing fails.
+    /// Returns [`EvalError::IoFailed`] if the file cannot be read, or
+    /// [`EvalError::ParseFailed`] if any non-blank line is malformed.
     pub fn from_jsonl_file(path: &std::path::Path) -> EvalResult<Self> {
-        let contents = std::fs::read_to_string(path).map_err(|e| {
-            ParseFailedSnafu {
-                line: 0_usize,
-                message: format!("cannot read {}: {e}", path.display()),
-            }
-            .build()
+        let contents = std::fs::read_to_string(path).context(IoFailedSnafu {
+            path: path.to_path_buf(),
         })?;
         Self::from_jsonl_str(&contents)
     }
@@ -512,6 +518,27 @@ mod tests {
     fn parse_bad_json_returns_error() {
         let result = EvalDataset::from_jsonl_str("not json at all");
         assert!(result.is_err(), "bad json should return error");
+    }
+
+    #[test]
+    fn missing_jsonl_file_returns_io_error_not_parse_error() {
+        let result =
+            EvalDataset::from_jsonl_file(std::path::Path::new("/tmp/__no_such_eval_dataset__"));
+        let err = result.expect_err("missing file must error");
+        assert!(
+            matches!(err, EvalError::IoFailed { .. }),
+            "expected IoFailed for missing file, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.starts_with("cannot read eval dataset "),
+            "io error message should start with 'cannot read eval dataset', got: {msg}"
+        );
+        // The misleading "parse … line 0" framing must no longer appear.
+        assert!(
+            !msg.contains("parse"),
+            "io error must not mention parsing, got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Tail finding from the iter-23 eval-surface sweep (companion to #4255).

`EvalDataset::from_jsonl_file` wrapped `std::fs::read_to_string` errors in `EvalError::ParseFailed { line: 0, message: "cannot read …" }`, so a missing dataset showed up as:

```
Error: failed to load eval dataset
Caused by:
    failed to parse eval dataset line 0: cannot read /missing.jsonl: No such file or directory (os error 2)
```

The "parse … line 0" framing is misleading — the file just doesn't exist, and "line 0" implies a parsing problem when there is none.

Add a dedicated `EvalError::IoFailed { path, source }` variant and route IO failures through it. After the fix:

```
Error: failed to load eval dataset
Caused by:
    0: cannot read eval dataset /missing.jsonl: No such file or directory
    1: No such file or directory (os error 2)
```

## Test plan

- [x] New unit test `missing_jsonl_file_returns_io_error_not_parse_error` checks the variant matches, the display starts with `cannot read eval dataset`, and the word `parse` no longer appears in the message.
- [x] `cargo test -p episteme --lib embedding_eval` — 13 passed (12 existing + 1 new).
- [x] `kanon gate --full --stamp` — green; `Gate-Passed: kanon 0.1.0` applied.
- [x] Smoke-verified end-to-end against `target/release/aletheia eval-embeddings --dataset /missing.jsonl`.