### PR TITLE
fix(diaporeia/mcp): unbreak `aletheia mcp` stdio + HTTP transport startup

### DIFF
--- a/crates/diaporeia/src/server.rs
+++ b/crates/diaporeia/src/server.rs
@@ -13,6 +13,7 @@ use rmcp::model::{
 use rmcp::tool_handler;
 
 use symbolon::types::Role;
+use taxis::config::McpRateLimitConfig;
 
 use crate::error::UnauthorizedSnafu;
 use crate::rate_limit::{RateLimiter, Tier};
@@ -35,22 +36,18 @@ pub struct DiaporeiaServer {
 }
 
 impl DiaporeiaServer {
-    /// Create a new server instance with shared state.
+    /// Create a new server instance with shared state and a rate-limit snapshot.
     ///
-    /// Each instance gets its own rate limiter (per-session limiting).
-    /// Configuration is read from the shared config at construction time.
+    /// Each instance gets its own rate limiter (per-session limiting). The
+    /// caller passes a `McpRateLimitConfig` snapshot taken at transport
+    /// setup time so this constructor can run inside a tokio runtime
+    /// (`tokio::sync::RwLock::blocking_read` panics from inside the runtime,
+    /// which is where both stdio and HTTP transports invoke this).
     #[must_use]
-    pub fn with_state(state: Arc<DiaporeiaState>) -> Self {
-        let rate_limiter = {
-            // NOTE: blocking read is acceptable here because this runs once per
-            // session creation, not in a hot loop. The RwLock is only contended
-            // during config reload.
-            let config = state.config.blocking_read();
-            Arc::new(RateLimiter::from_config(&config.mcp.rate_limit))
-        };
+    pub fn with_state(state: Arc<DiaporeiaState>, rate_cfg: &McpRateLimitConfig) -> Self {
         Self {
             state,
-            rate_limiter,
+            rate_limiter: Arc::new(RateLimiter::from_config(rate_cfg)),
             tool_router: Self::tool_router(),
         }
     }

--- a/crates/diaporeia/src/transport.rs
+++ b/crates/diaporeia/src/transport.rs
@@ -42,11 +42,21 @@ pub fn streamable_http_router_with_config(
     state: Arc<DiaporeiaState>,
     config: rmcp::transport::streamable_http_server::StreamableHttpServerConfig,
 ) -> axum::Router {
+    // Snapshot the rate-limit config (and bind) ONCE at setup using try_read,
+    // so the per-session factory below stays sync. The same snapshot is reused
+    // for every session in this transport's lifetime; config-reload between
+    // sessions is rare and acceptable to miss until the next transport startup.
+    let (bind, rate_cfg) = state.config.try_read().map_or_else(
+        |_| {
+            (
+                "localhost".to_owned(),
+                taxis::config::McpRateLimitConfig::default(),
+            )
+        },
+        |cfg| (cfg.gateway.bind.clone(), cfg.mcp.rate_limit.clone()),
+    );
+
     if state.auth_mode == "none" {
-        let bind = state
-            .config
-            .try_read()
-            .map_or_else(|_| "localhost".to_owned(), |cfg| cfg.gateway.bind.clone());
         let is_loopback = bind == "localhost" || bind == "127.0.0.1" || bind == "::1";
 
         if is_loopback {
@@ -65,7 +75,7 @@ pub fn streamable_http_router_with_config(
 
     let auth_state = Arc::clone(&state);
     let service = StreamableHttpService::new(
-        move || Ok(DiaporeiaServer::with_state(Arc::clone(&state))),
+        move || Ok(DiaporeiaServer::with_state(Arc::clone(&state), &rate_cfg)),
         LocalSessionManager::default().into(),
         config,
     );
@@ -83,7 +93,8 @@ pub fn streamable_http_router_with_config(
 /// closes or the shutdown token fires.
 #[tracing::instrument(skip_all)]
 pub async fn serve_stdio(state: Arc<DiaporeiaState>) -> Result<()> {
-    let server = DiaporeiaServer::with_state(state);
+    let rate_cfg = state.config.read().await.mcp.rate_limit.clone();
+    let server = DiaporeiaServer::with_state(state, &rate_cfg);
     let service = server
         .serve(rmcp::transport::io::stdio())
         .await

--- a/crates/diaporeia/tests/public_api_claims_state.rs
+++ b/crates/diaporeia/tests/public_api_claims_state.rs
@@ -131,11 +131,8 @@ fn state_shutdown_token_propagates_cancellation() {
 #[test]
 fn server_constructs_from_state() {
     let (state, _jwt, _tmp) = StateBuilder::new().build();
-
-    // WHY: `with_state` performs a blocking read of the config RwLock. Running
-    // it in a plain `#[test]` (no tokio runtime entered) avoids the
-    // "Cannot block the current thread from within a runtime" panic.
-    let server = DiaporeiaServer::with_state(Arc::clone(&state));
+    let rate_cfg = state.config.try_read().unwrap().mcp.rate_limit.clone();
+    let server = DiaporeiaServer::with_state(Arc::clone(&state), &rate_cfg);
 
     // Cloning the server must produce an independent handle that shares state.
     let _clone = server.clone();
@@ -147,6 +144,19 @@ fn server_is_send_sync_and_clone() {
     assert_send_sync::<DiaporeiaServer>();
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn server_constructs_from_inside_tokio_runtime() {
+    // REGRESSION: `aletheia mcp` (stdio) panicked at startup because
+    // `with_state` previously held a `blocking_read()` on the config
+    // `tokio::sync::RwLock` — which panics with "Cannot block the
+    // current thread from within a runtime" when invoked from inside
+    // the runtime. The transport now snapshots the rate-limit config
+    // before constructing the server. This test guards both transports.
+    let (state, _jwt, _tmp) = StateBuilder::new().build();
+    let rate_cfg = state.config.read().await.mcp.rate_limit.clone();
+    let _server = DiaporeiaServer::with_state(Arc::clone(&state), &rate_cfg);
+}
+
 #[test]
 fn multiple_servers_share_same_state() {
     // WHY: pylon mounts its own DiaporeiaServer and any test/tooling may
@@ -156,9 +166,10 @@ fn multiple_servers_share_same_state() {
     // but they all share session store, nous manager, and shutdown token.
     let (state, _jwt, _tmp) = StateBuilder::new().build();
     let initial_strong = Arc::strong_count(&state);
+    let rate_cfg = state.config.try_read().unwrap().mcp.rate_limit.clone();
 
-    let server_a = DiaporeiaServer::with_state(Arc::clone(&state));
-    let server_b = DiaporeiaServer::with_state(Arc::clone(&state));
+    let server_a = DiaporeiaServer::with_state(Arc::clone(&state), &rate_cfg);
+    let server_b = DiaporeiaServer::with_state(Arc::clone(&state), &rate_cfg);
 
     // Both servers hold strong references to the shared state.
     assert!(
@@ -185,7 +196,8 @@ fn server_construction_snapshots_config_independently_of_later_mutations() {
     // must not panic or deadlock an already-constructed server — the server
     // owns its own rate limiter after construction.
     let (state, _jwt, _tmp) = StateBuilder::new().build();
-    let server = DiaporeiaServer::with_state(Arc::clone(&state));
+    let rate_cfg = state.config.try_read().unwrap().mcp.rate_limit.clone();
+    let server = DiaporeiaServer::with_state(Arc::clone(&state), &rate_cfg);
 
     // Mutate the shared config after construction. This must not panic or
     // affect the live server's behaviour.

--- a/crates/diaporeia/tests/public_api_repomix.rs
+++ b/crates/diaporeia/tests/public_api_repomix.rs
@@ -44,17 +44,9 @@ use common::{StateBuilder, issue_token};
 // -------------------------------------------------------------------
 
 /// Build a test router in stateless+json mode.
-///
-/// WHY: `DiaporeiaServer::with_state` uses `blocking_read()` which panics
-/// when called from within a tokio runtime. We construct the server on a
-/// dedicated OS thread and clone it into the service factory.
 fn test_router(state: &Arc<DiaporeiaState>) -> axum::Router {
-    let server = std::thread::spawn({
-        let state = Arc::clone(state);
-        move || DiaporeiaServer::with_state(state)
-    })
-    .join()
-    .expect("construct server on blocking thread");
+    let rate_cfg = state.config.try_read().unwrap().mcp.rate_limit.clone();
+    let server = DiaporeiaServer::with_state(Arc::clone(state), &rate_cfg);
 
     let auth_state = Arc::clone(state);
     let service = rmcp::transport::streamable_http_server::tower::StreamableHttpService::new(


### PR DESCRIPTION
## Summary

`aletheia mcp` (the stdio MCP subcommand) panics at startup before reading any input:

```
thread 'main' panicked at crates/diaporeia/src/server.rs:48:
Cannot block the current thread from within a runtime.
```

`DiaporeiaServer::with_state` called `blocking_read()` on the `tokio::sync::RwLock` holding the runtime config. That panics from inside the tokio runtime regardless of contention level — which is exactly where both transports invoke it:

- `serve_stdio` runs inside `#[tokio::main]` → panic immediately on `aletheia mcp` startup.
- HTTP service factory closure runs inside the runtime per session → panic on every MCP HTTP request.

The existing `tests/public_api_repomix.rs` test workaround already documents the panic and spawns an OS thread to dodge it; the `server_constructs_from_state` test sidesteps it by not entering a runtime at all. Production callers had no such workaround.

## Fix

Refactor `with_state` to take a `McpRateLimitConfig` snapshot prepared by the caller, so the constructor itself never reads the lock:

- `serve_stdio` (already `async`): snapshots via `.read().await`.
- `streamable_http_router_with_config` (sync, but called from async context): snapshots once via `try_read` at setup; the per-session factory borrows the captured snapshot.
- Tests snapshot the same way and drop the OS-thread workaround.

Adds a new `#[tokio::test(flavor = "multi_thread")]` regression — `server_constructs_from_inside_tokio_runtime` — that builds the server from inside a runtime; this would have panicked on `main`.

## Smoke

`aletheia mcp` stdio now answers JSON-RPC `initialize` + `tools/list` cleanly and exits 0:

```
$ printf '<initialize>\n<initialized>\n<tools/list>\n' | ALETHEIA_ALLOW_AUTH_NONE=1 aletheia -r /tmp/x mcp
{"jsonrpc":"2.0","id":1,"result":{...22 tools...}}
$ echo $?
0
```

Was: exit 101 + the panic above.

## Diff

4 files, +48 / −36. All 93 diaporeia tests pass. Workspace builds clean.

## Gate

`kanon gate --full --stamp`: 0 errors, 688 warnings (within baseline; non-blocking), all 7 phases PASS. Truthful `Gate-Passed:` trailer on the commit.

## Notes for review

- This is a `pub` API signature change (`with_state(state) → with_state(state, &rate_cfg)`), but it's the minimal change that fixes the bug — the lock has to be read somewhere outside the constructor for it to work from inside a tokio runtime. The HTTP factory closure has to be sync, so reading-once-at-setup is the cleanest path.
- The rate-limit config snapshot is taken at transport setup time. Multiple sessions over the same HTTP transport share the snapshot; config-reload between sessions is rare and only takes effect at the next transport startup — same semantics as the prior code in practice (the previous code re-read per session, but per-session re-reads inside a runtime never actually worked because they always panicked).
- Found by friction sweep, opus-CC mission Priority-1, iter 30, against current main (8f7e18a7).

Refs: friction sweep campaign, mission iter 30.