### PR TITLE
fix(aletheia/migrate-memory): add project_id and visibility to imported Fact

### DIFF
--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -19,7 +19,7 @@ use mneme::embedding::{
 use mneme::id::{EmbeddingId, FactId};
 use mneme::knowledge::{
     EmbeddedChunk, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
-    far_future, parse_timestamp,
+    Visibility, far_future, parse_timestamp,
 };
 use mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
 use taxis::loader::load_config;
@@ -299,6 +299,8 @@ fn import_fact(
         content: record.content.clone(),
         fact_type: String::new(),
         scope: None,
+        // Qdrant-migrated facts predate project partitioning; they are global.
+        project_id: None,
         temporal: FactTemporal {
             valid_from,
             valid_to: far_future(),
@@ -321,6 +323,7 @@ fn import_fact(
             last_accessed_at: None,
         },
         sensitivity: mneme::knowledge::FactSensitivity::Public,
+        visibility: Visibility::Private,
     };
     knowledgedb
         .insert_fact(&fact)


### PR DESCRIPTION
## Summary

`cargo build --features migrate-qdrant` failed on main:

\`\`\`
error[E0063]: missing fields \`project_id\` and \`visibility\` in initializer of \`mneme::knowledge::Fact\`
   --> crates/aletheia/src/migrate_memory.rs:295:16
\`\`\`

The \`Fact\` struct gained \`project_id\` (project partitioning) and \`visibility\` (#3404/#3413 sovereignty) fields after the migration code was last touched. The default workspace gate doesn't compile this feature (docs/FEATURE-FLAGS.md: \"no\" default), so the break went unnoticed.

Migrated facts predate project partitioning and visibility tracking, so the natural defaults are:
- \`project_id: None\` — global; matches the existing \`scope: None\` choice
- \`visibility: Visibility::Private\` — matches the struct's serde-default and the fresh-init behavior in \`bin/seed_psyche_facts.rs\`

Same shape as #4144 (T0 fixed forget query's missing \`project_id\`).

## CI gap (noted)

No CI job exercises \`--features migrate-qdrant\`. The build break sat undetected because \`cargo check\` / clippy / nextest in the default gate skip optional features. Worth a follow-up to add a minimal compile-only check for this feature in CI, but out of scope for this PR.

## Verified

\`cargo build --features migrate-qdrant\` now compiles. \`kanon gate --full --stamp\` green: cargo fmt / check / audit / clippy / test / kanon lint / fleet-names — 0 errors, 689 warnings (non-blocking). Truthful \`Gate-Passed: kanon 0.1.0\` trailer.

## Test plan

- [x] \`cargo build -p aletheia --bin aletheia --features migrate-qdrant\` compiles cleanly
- [x] \`kanon gate --full --stamp\` green
- [x] Default-features build unaffected (Fact construction is identical aside from the two added fields)