### PR TITLE
security(taxis): unify SENSITIVE_KEYS source for redact and encrypt (#4254)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "agora",
  "aletheia-routing",
@@ -178,11 +178,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.28.0"
+version = "0.28.1"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "jiff",
  "koina",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "futures",
  "jiff",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "jiff",
  "koina",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "eidos",
  "jiff",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "jiff",
  "koina",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "aletheia-routing",
  "compact_str",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "episteme"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "cargo_metadata",
  "fjall",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "criterion",
  "eidos",
@@ -3768,7 +3768,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "criterion",
  "jiff",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "arboard",
  "clap",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "criterion",
  "fjall",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "eidos",
  "episteme",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6006,7 +6006,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6455,7 +6455,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "jiff",
  "snafu",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "docx-rs",
  "quick-xml 0.39.2",
@@ -6488,7 +6488,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -6504,7 +6504,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -6516,7 +6516,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6525,7 +6525,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -6537,7 +6537,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -6563,7 +6563,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-text"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "krilla 0.7.0",
  "poiesis-core",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "comemo",
  "jiff",
@@ -6589,7 +6589,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6976,7 +6976,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -8393,7 +8393,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8740,7 +8740,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -8859,7 +8859,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -8971,14 +8971,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/taxis/src/encrypt.rs
+++ b/crates/taxis/src/encrypt.rs
@@ -16,6 +16,7 @@ use snafu::ResultExt;
 use tracing::warn;
 
 use crate::error::{self, Result};
+use crate::sensitive::key_is_sensitive;
 
 /// Prefix marking an encrypted config value.
 pub(crate) const ENCRYPTED_PREFIX: &str = "enc:";
@@ -299,18 +300,6 @@ pub fn encrypt_config_file(toml_path: &Path, primary_key: &[u8; KEY_LEN]) -> Res
     Ok(count)
 }
 
-/// Keys in TOML whose string values are considered sensitive and eligible for
-/// encryption. Matches the patterns used by `redact.rs`.
-const SENSITIVE_TOML_KEYS: &[&str] = &[
-    "signingKey",
-    "signing_key",
-    "token",
-    "secret",
-    "password",
-    "apiKey",
-    "api_key",
-];
-
 /// Recursively decrypt all `enc:`-prefixed string values in a TOML value tree.
 ///
 /// If `primary_key` is `None`, logs a warning for each encrypted value found
@@ -399,10 +388,7 @@ fn encrypt_recursive(
 }
 
 fn is_sensitive_key(key: &str) -> bool {
-    let lower = key.to_lowercase();
-    SENSITIVE_TOML_KEYS
-        .iter()
-        .any(|s| lower == s.to_lowercase())
+    key_is_sensitive(key)
 }
 
 #[cfg(test)]
@@ -607,6 +593,29 @@ mod tests {
             decrypted, "my-secret-key",
             "decrypted sensitive value should match original"
         );
+    }
+
+    #[test]
+    fn encrypt_covers_auth_token_refresh_token_session_secret() {
+        // REGRESSION (#4254): these were redacted on display but left in
+        // plaintext at rest. After unifying on substring matching, they
+        // must all be encrypted.
+        let key = fixture_key();
+        let toml_str = r#"
+            [providers.openai]
+            api_key = "sk-openai-plaintext"
+            auth_token = "bearer-secret"
+            refresh_token = "refresh-secret"
+            session_secret = "session-secret"
+        "#;
+        let mut value: toml::Value = toml::from_str(toml_str).unwrap();
+        let count = encrypt_sensitive_values(&mut value, &key).unwrap();
+
+        assert_eq!(count, 4, "all four sensitive fields must be encrypted");
+        for field in ["api_key", "auth_token", "refresh_token", "session_secret"] {
+            let v = value["providers"]["openai"][field].as_str().unwrap();
+            assert!(is_encrypted(v), "{field} must be encrypted at rest");
+        }
     }
 
     #[test]

--- a/crates/taxis/src/lib.rs
+++ b/crates/taxis/src/lib.rs
@@ -29,6 +29,10 @@ pub mod redact;
 pub mod registry;
 /// Hot-reload classification: restart vs live update.
 pub mod reload;
+/// Shared "is this config key sensitive?" predicate used by redaction and
+/// at-rest encryption. Kept private to the crate so the two paths cannot
+/// drift again.
+mod sensitive;
 /// Test-only helpers (EnvJail) for unit + integration tests.
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;

--- a/crates/taxis/src/redact.rs
+++ b/crates/taxis/src/redact.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use tracing::debug;
 
 use crate::config::AletheiaConfig;
+use crate::sensitive::key_is_sensitive;
 
 const REDACTED: &str = "***";
 
@@ -13,9 +14,6 @@ const SENSITIVE_LEAVES: &[&[&str]] = &[
     &["gateway", "tls", "keyPath"],
     &["gateway", "tls", "certPath"],
 ];
-
-/// Object keys at any depth whose values are unconditionally redacted.
-const SENSITIVE_KEYS: &[&str] = &["token", "secret", "password", "apiKey", "api_key"];
 
 /// Serialize config to JSON, then redact sensitive fields.
 #[must_use]
@@ -40,12 +38,19 @@ fn redact_sensitive_leaves(root: &mut Value) {
     }
 }
 
+/// Test-only re-export of the recursive redaction pass so the cross-module
+/// property test in `sensitive` can exercise this code path without going
+/// through `redact()` (which requires a fully-populated `AletheiaConfig`).
+#[cfg(test)]
+pub(crate) fn redact_sensitive_keys_for_test(value: &mut Value) {
+    redact_sensitive_keys(value);
+}
+
 fn redact_sensitive_keys(value: &mut Value) {
     match value {
         Value::Object(map) => {
             for (key, val) in map.iter_mut() {
-                let key_lower = key.to_lowercase();
-                if SENSITIVE_KEYS.iter().any(|s| key_lower.contains(s)) {
+                if key_is_sensitive(key) {
                     if val.is_string() {
                         *val = Value::String(REDACTED.to_owned());
                     }

--- a/crates/taxis/src/sensitive.rs
+++ b/crates/taxis/src/sensitive.rs
@@ -1,0 +1,201 @@
+//! Single source of truth for the "is this key name sensitive?" predicate.
+//!
+//! Both the redact-on-display path (`redact.rs`) and the encrypt-at-rest path
+//! (`encrypt.rs`) used to maintain their own divergent lists with different
+//! matching strategies. `auth_token`, `refresh_token`, and `session_secret`
+//! were redacted on display but left in plaintext at rest — operators who ran
+//! `config encrypt` reasonably assumed their secrets were protected when they
+//! were not. See aletheia#4254.
+//!
+//! Failure-mode bias: substring matching errs on the side of MORE encryption /
+//! MORE redaction, which is the safe direction for both code paths.
+
+/// Lower-cased substrings that, if present in a config key name, mark the
+/// value as sensitive — for both redaction and at-rest encryption.
+pub(crate) const SENSITIVE_KEY_FRAGMENTS: &[&str] = &[
+    "token",
+    "secret",
+    "password",
+    "apikey",
+    "api_key",
+    "signingkey",
+    "signing_key",
+];
+
+/// Returns true if `key` should be redacted on display AND encrypted at rest.
+#[must_use]
+pub(crate) fn key_is_sensitive(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    SENSITIVE_KEY_FRAGMENTS.iter().any(|s| lower.contains(s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_canonical_names() {
+        assert!(key_is_sensitive("api_key"));
+        assert!(key_is_sensitive("apiKey"));
+        assert!(key_is_sensitive("password"));
+        assert!(key_is_sensitive("secret"));
+        assert!(key_is_sensitive("token"));
+        assert!(key_is_sensitive("signingKey"));
+        assert!(key_is_sensitive("signing_key"));
+    }
+
+    #[test]
+    fn matches_prefixed_and_suffixed_variants() {
+        // The whole point of unifying on substring matching: these were
+        // redacted on display but NOT encrypted at rest before #4254.
+        assert!(key_is_sensitive("auth_token"));
+        assert!(key_is_sensitive("authToken"));
+        assert!(key_is_sensitive("refresh_token"));
+        assert!(key_is_sensitive("refreshToken"));
+        assert!(key_is_sensitive("session_secret"));
+        assert!(key_is_sensitive("sessionSecret"));
+        assert!(key_is_sensitive("openai_api_key"));
+        assert!(key_is_sensitive("anthropicApiKey"));
+        assert!(key_is_sensitive("admin_password"));
+        assert!(key_is_sensitive("jwtSigningKey"));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert!(key_is_sensitive("API_KEY"));
+        assert!(key_is_sensitive("Password"));
+        assert!(key_is_sensitive("SECRET"));
+        assert!(key_is_sensitive("AuthToken"));
+    }
+
+    #[test]
+    fn rejects_unrelated_keys() {
+        assert!(!key_is_sensitive("port"));
+        assert!(!key_is_sensitive("host"));
+        assert!(!key_is_sensitive("model"));
+        assert!(!key_is_sensitive("provider"));
+        assert!(!key_is_sensitive("timeout_ms"));
+        assert!(!key_is_sensitive("name"));
+        assert!(!key_is_sensitive("description"));
+        assert!(!key_is_sensitive("enabled"));
+        assert!(!key_is_sensitive("path"));
+    }
+
+    /// Substring matching has a known small false-positive surface — keys
+    /// like `max_tokens` and `bootstrap_max_tokens` contain "token" and
+    /// will be flagged sensitive. This is the accepted failure-mode bias
+    /// (#4254): better to over-encrypt/over-redact than to leak a real
+    /// `auth_token`. Both paths only act on string values, so numeric
+    /// fields named like this are not affected at runtime.
+    #[test]
+    fn substring_rule_flags_token_like_numeric_keys() {
+        assert!(key_is_sensitive("max_tokens"));
+        assert!(key_is_sensitive("bootstrap_max_tokens"));
+        assert!(key_is_sensitive("context_tokens"));
+    }
+
+    #[test]
+    fn empty_key_is_not_sensitive() {
+        assert!(!key_is_sensitive(""));
+    }
+
+    /// Property test (#4254): the set of keys redacted on display must equal
+    /// the set of keys encrypted at rest. Built by exercising both paths on
+    /// the same input and comparing the resulting sensitivity decisions.
+    #[test]
+    fn redact_and_encrypt_agree_on_sensitive_keys() {
+        use crate::encrypt::encrypt_sensitive_values;
+
+        // Mix of obvious sensitive, subtle sensitive (prefixed/suffixed),
+        // and clearly non-sensitive keys.
+        let candidates = [
+            "api_key",
+            "apiKey",
+            "openai_api_key",
+            "anthropicApiKey",
+            "token",
+            "auth_token",
+            "authToken",
+            "refresh_token",
+            "refreshToken",
+            "id_token",
+            "secret",
+            "session_secret",
+            "client_secret",
+            "password",
+            "admin_password",
+            "signingKey",
+            "signing_key",
+            "jwtSigningKey",
+            // not sensitive — must stay plaintext / visible in both paths
+            "port",
+            "host",
+            "model",
+            "provider",
+            "timeout_ms",
+            "max_tokens",
+            "name",
+            "description",
+            "enabled",
+        ];
+
+        // What redact treats as sensitive (substring-matches the key).
+        let mut redact_object = serde_json::Map::new();
+        for k in candidates {
+            redact_object.insert((*k).to_owned(), serde_json::Value::String("v".to_owned()));
+        }
+        let mut redact_value = serde_json::Value::Object(redact_object);
+        crate::redact::redact_sensitive_keys_for_test(&mut redact_value);
+        let redact_sensitive: std::collections::BTreeSet<&str> = candidates
+            .iter()
+            .filter(|k| {
+                redact_value
+                    .as_object()
+                    .and_then(|m| m.get(**k))
+                    .and_then(serde_json::Value::as_str)
+                    == Some("***")
+            })
+            .copied()
+            .collect();
+
+        // What encrypt treats as sensitive (matches the key).
+        let fixture_key: [u8; 32] = {
+            let mut k = [0u8; 32];
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "INVARIANT: i is bounded by [u8; 32].len()=32; cast to u8 is exact"
+            )]
+            #[expect(
+                clippy::as_conversions,
+                reason = "INVARIANT: i is bounded by [u8; 32].len()=32; cast to u8 is exact"
+            )]
+            for (i, b) in k.iter_mut().enumerate() {
+                *b = (i as u8).wrapping_mul(7).wrapping_add(42);
+            }
+            k
+        };
+        let mut encrypt_table = toml::value::Table::new();
+        for k in candidates {
+            encrypt_table.insert((*k).to_owned(), toml::Value::String("v".to_owned()));
+        }
+        let mut encrypt_value = toml::Value::Table(encrypt_table);
+        #[expect(clippy::unwrap_used, reason = "test")]
+        let _count = encrypt_sensitive_values(&mut encrypt_value, &fixture_key).unwrap();
+        let encrypt_sensitive: std::collections::BTreeSet<&str> = candidates
+            .iter()
+            .filter(|k| {
+                encrypt_value
+                    .as_table()
+                    .and_then(|t| t.get(**k))
+                    .and_then(toml::Value::as_str)
+                    .is_some_and(|s| s.starts_with("enc:"))
+            })
+            .copied()
+            .collect();
+
+        assert_eq!(
+            redact_sensitive, encrypt_sensitive,
+            "redact and encrypt must agree on which keys are sensitive (#4254)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4254. Both the redact-on-display path and the encrypt-at-rest path
used to maintain their own divergent sensitive-key lists with different
matching strategies. Consequence: `auth_token`, `refresh_token`,
`session_secret`, etc. were redacted on display but left in plaintext at rest
indefinitely. Operators running `config encrypt` would reasonably conclude
their secrets were protected when they were not.

Refactor: new private module `crates/taxis/src/sensitive.rs` holds the single
`SENSITIVE_KEY_FRAGMENTS` constant and `key_is_sensitive(key) -> bool`
predicate. Both `redact.rs` and `encrypt.rs` now delegate to it; the two
paths cannot drift again because they call the same function.

## Strategy & failure-mode bias

Substring matching across the **union** of the prior `redact` and `encrypt`
sets (`token, secret, password, apikey, api_key, signingkey, signing_key`).

This is the safer direction for both code paths: better to over-encrypt
or over-redact than to leak a real `auth_token`. The known small
false-positive surface (e.g. `max_tokens` or `context_tokens` containing
"token") is harmless at runtime because both paths only act on string
values; numeric config fields are not affected.

## Tests

- 5 unit tests on `key_is_sensitive` — canonical names, prefixed/suffixed
  variants, case-insensitivity, non-sensitive keys, the accepted-by-design
  false-positive surface, empty key.
- **Cross-module property test** (`redact_and_encrypt_agree_on_sensitive_keys`):
  exercises both paths on the same set of ~27 candidate key names and asserts
  the resulting sensitivity decisions are identical. This is the structural
  invariant the issue called out as needing a property test.
- **Regression test** in `encrypt.rs` (`encrypt_covers_auth_token_refresh_token_session_secret`):
  confirms that the three keys named in the issue body are now encrypted at
  rest (was 1-of-4 before; now 4-of-4).

## Smoke-verified

```
$ aletheia init -y --instance-root .
$ cat >> config/aletheia.toml <<'INI'
[providers.openai]
api_key = "sk-plaintext-12345"
auth_token = "bearer-secret-token"
refresh_token = "refresh-secret"
INI
$ aletheia config init-key
$ aletheia config encrypt
Encrypted 3 sensitive value(s) in .../config/aletheia.toml
```

(Before this PR: 1 sensitive value encrypted.)

## Out of scope

The original issue's reproducer used `[providers.test_secret]` as the table
name. Because `test_secret` itself contains "secret", **both** the original
redact and original encrypt code stop recursing into that subtree (the
"sensitive key at non-string value" branch in both walkers). That recursion
edge is unrelated to the set-unification fix here — it's a pre-existing
quirk shared by both paths and is consistent with the unified shape. If
that turns out to be a real-world footgun, file a separate issue against
the recursion semantics.

## Disposition

Security-relevant per campaign mandate. NOT auto-merge. Open for T0 review.

## Test plan

- [x] `cargo test -p taxis` (317 passed locally)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p taxis -- -D warnings`
- [x] `kanon gate --full --stamp` PASS
- [x] Smoke: `config encrypt` end-to-end with the realistic reproducer
- [ ] Operator review of the substring-matching trade-off