### PR TITLE
fix(aletheia/init+check-config): separate auth.mode policy gate from structural validation (#4240)

### DIFF
--- a/crates/aletheia/src/runtime/builder_validation.rs
+++ b/crates/aletheia/src/runtime/builder_validation.rs
@@ -95,6 +95,20 @@ impl RuntimeBuilder {
             all_ok = false;
         }
 
+        // WHY(#4240): mirror the server-startup `warn_if_auth_disabled` so
+        // `check-config` reports the disabled-auth posture without failing.
+        // The hard env-opt-in gate fires at the config API (`PUT /config/gateway`),
+        // not when reading a TOML file — operators with filesystem control of
+        // aletheia.toml are trusted.
+        if self.config.gateway.auth.mode == "none" {
+            print_line(format_args!(
+                "  [warn] gateway.auth: mode = \"none\" — all requests served as role '{}'; \
+                 the config API still requires {}=1 to accept this via PUT",
+                self.config.gateway.auth.none_role,
+                taxis::validate::ALLOW_AUTH_NONE_ENV,
+            ));
+        }
+
         print_line(format_args!(""));
         if all_ok {
             print_line(format_args!("Configuration OK"));

--- a/crates/aletheia/tests/smoke_test.rs
+++ b/crates/aletheia/tests/smoke_test.rs
@@ -226,6 +226,68 @@ fn init_with_missing_api_key_fails_usefully() {
     );
 }
 
+// ── Init -> check-config round trip exits 0 ──────────────────────────────────
+
+/// `aletheia init -y` followed by `aletheia check-config` against the same
+/// instance must exit 0 — a fresh init should always produce a config that
+/// check-config accepts. Regression test for #4240, which fixed the case
+/// where init wrote `gateway.auth.mode = "none"` but check-config rejected
+/// it as a hard FAIL unless the operator had set `ALETHEIA_ALLOW_AUTH_NONE=1`.
+#[test]
+fn init_yes_followed_by_check_config_exits_zero() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let instance_path = tmp.path().join("instance");
+
+    let init_out = aletheia()
+        .args([
+            "init",
+            "--instance-root",
+            instance_path
+                .to_str()
+                .expect("instance path is valid UTF-8"),
+            "--yes",
+        ])
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("ALETHEIA_ALLOW_AUTH_NONE")
+        .output()
+        .expect("failed to run aletheia init");
+    assert!(
+        init_out.status.success(),
+        "init -y must exit 0; got {:?}\nstdout: {}\nstderr: {}",
+        init_out.status.code(),
+        String::from_utf8_lossy(&init_out.stdout),
+        String::from_utf8_lossy(&init_out.stderr),
+    );
+
+    let check_out = aletheia()
+        .args([
+            "-r",
+            instance_path
+                .to_str()
+                .expect("instance path is valid UTF-8"),
+            "check-config",
+        ])
+        .env_remove("ALETHEIA_ALLOW_AUTH_NONE")
+        .output()
+        .expect("failed to run aletheia check-config");
+
+    let stdout = String::from_utf8_lossy(&check_out.stdout);
+    let stderr = String::from_utf8_lossy(&check_out.stderr);
+    assert!(
+        check_out.status.success(),
+        "check-config on fresh init must exit 0; got {:?}\nstdout: {stdout}\nstderr: {stderr}",
+        check_out.status.code(),
+    );
+    assert!(
+        stdout.contains("Configuration OK"),
+        "check-config output should report Configuration OK; got: {stdout}"
+    );
+    assert!(
+        stdout.contains("[warn] gateway.auth"),
+        "check-config must surface the disabled-auth posture as a [warn], not a [FAIL]; got: {stdout}"
+    );
+}
+
 // ── Import: missing file produces useful error ───────────────────────────────
 
 #[test]

--- a/crates/pylon/src/handlers/config.rs
+++ b/crates/pylon/src/handlers/config.rs
@@ -340,6 +340,49 @@ pub async fn reload_config(
     ))
 }
 
+/// Run both structural and auth-policy validation for an incoming
+/// config PUT body.
+///
+/// WHY(#3383, #4240): `validate_section` is structural-only — it accepts
+/// `auth.mode = "none"` so file-load callers (`check-config`, server
+/// startup) do not falsely reject configs operators write directly. The
+/// API-level opt-in gate against silently disabling auth lives here and
+/// fires *only* on the config PUT path. Keeping this split in a helper
+/// also keeps `update_section` under the clippy too-many-lines limit.
+fn validate_section_for_put(section: &str, body: &Value) -> Result<(), ApiError> {
+    if let Err(err) = taxis::validate::validate_section(section, body) {
+        return Err(ApiError::ValidationFailed {
+            errors: err
+                .errors
+                .into_iter()
+                .map(|msg| FieldError {
+                    field: section.to_owned(),
+                    code: "invalid".to_owned(),
+                    message: msg,
+                })
+                .collect(),
+            location: snafu::location!(),
+        });
+    }
+    if section == "gateway"
+        && let Err(err) = taxis::validate::validate_auth_mode_policy(body)
+    {
+        return Err(ApiError::ValidationFailed {
+            errors: err
+                .errors
+                .into_iter()
+                .map(|msg| FieldError {
+                    field: section.to_owned(),
+                    code: "auth_mode_none_requires_opt_in".to_owned(),
+                    message: msg,
+                })
+                .collect(),
+            location: snafu::location!(),
+        });
+    }
+    Ok(())
+}
+
 /// PUT /api/v1/config/{section}: update and persist a config section.
 ///
 /// # Cancel safety
@@ -385,43 +428,7 @@ pub async fn update_section(
         | ConfigSectionPayload::Pricing(v) => v,
     };
 
-    if let Err(err) = taxis::validate::validate_section(&section, &body_value) {
-        return Err(ApiError::ValidationFailed {
-            errors: err
-                .errors
-                .into_iter()
-                .map(|msg| FieldError {
-                    field: section.clone(),
-                    code: "invalid".to_owned(),
-                    message: msg,
-                })
-                .collect(),
-            location: snafu::location!(),
-        });
-    }
-
-    // WHY(#3383, #4240): the auth.mode = "none" opt-in gate applies only to
-    // config PUTs through the API — operators with filesystem-level control
-    // over aletheia.toml are trusted, and `warn_if_auth_disabled` keeps the
-    // posture visible at server startup and on `check-config`. Without this
-    // separation, a fresh `aletheia init -y` produced a config that
-    // `check-config` then rejected.
-    if section == "gateway"
-        && let Err(err) = taxis::validate::validate_auth_mode_policy(&body_value)
-    {
-        return Err(ApiError::ValidationFailed {
-            errors: err
-                .errors
-                .into_iter()
-                .map(|msg| FieldError {
-                    field: section.clone(),
-                    code: "auth_mode_none_requires_opt_in".to_owned(),
-                    message: msg,
-                })
-                .collect(),
-            location: snafu::location!(),
-        });
-    }
+    validate_section_for_put(&section, &body_value)?;
 
     let mut config = state.config.write().await;
     let mut config_value = serde_json::to_value(&*config).map_err(|e| ApiError::Internal {

--- a/crates/pylon/src/handlers/config.rs
+++ b/crates/pylon/src/handlers/config.rs
@@ -400,6 +400,29 @@ pub async fn update_section(
         });
     }
 
+    // WHY(#3383, #4240): the auth.mode = "none" opt-in gate applies only to
+    // config PUTs through the API — operators with filesystem-level control
+    // over aletheia.toml are trusted, and `warn_if_auth_disabled` keeps the
+    // posture visible at server startup and on `check-config`. Without this
+    // separation, a fresh `aletheia init -y` produced a config that
+    // `check-config` then rejected.
+    if section == "gateway"
+        && let Err(err) = taxis::validate::validate_auth_mode_policy(&body_value)
+    {
+        return Err(ApiError::ValidationFailed {
+            errors: err
+                .errors
+                .into_iter()
+                .map(|msg| FieldError {
+                    field: section.clone(),
+                    code: "auth_mode_none_requires_opt_in".to_owned(),
+                    message: msg,
+                })
+                .collect(),
+            location: snafu::location!(),
+        });
+    }
+
     let mut config = state.config.write().await;
     let mut config_value = serde_json::to_value(&*config).map_err(|e| ApiError::Internal {
         message: format!("failed to serialize config: {e}"),

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -291,20 +291,21 @@ pub fn auth_none_lan_opt_in_enabled() -> bool {
 fn validate_gateway(value: &Value, errors: &mut Vec<String>) {
     check_port(value, "port", "port", errors);
 
+    // WHY: structural validity only — accept any of the three known auth modes.
+    // The `auth.mode = "none"` policy gate (env-var opt-in) lives in
+    // [`validate_auth_mode_policy`] so it fires only when a config PUT through
+    // the config API attempts to disable auth, not when a TOML file containing
+    // `mode = "none"` is loaded at startup or inspected by `check-config`.
+    // Operators have filesystem-level control of the file; the loud startup
+    // warning emitted by [`warn_if_auth_disabled`] handles operator visibility.
+    // (#3383 — original opt-in; #4240 — separated from file-load path)
     if let Some(auth) = value.get("auth")
         && let Some(mode) = auth.get("mode").and_then(Value::as_str)
+        && !VALID_AUTH_MODES.contains(&mode)
     {
-        if !VALID_AUTH_MODES.contains(&mode) {
-            errors.push(format!(
-                "gateway.auth.mode '{mode}' is invalid; must be one of: none, token, jwt"
-            ));
-        } else if mode == "none" && !auth_none_opt_in_enabled() {
-            errors.push(format!(
-                "gateway.auth.mode = \"none\" disables all authentication and is \
-                 rejected by default; set the environment variable {ALLOW_AUTH_NONE_ENV}=1 \
-                 on the server process to opt in (intended for local dev only)"
-            ));
-        }
+        errors.push(format!(
+            "gateway.auth.mode '{mode}' is invalid; must be one of: none, token, jwt"
+        ));
     }
 
     if let Some(cors) = value.get("cors") {
@@ -314,6 +315,47 @@ fn validate_gateway(value: &Value, errors: &mut Vec<String>) {
     if let Some(body_limit) = value.get("bodyLimit") {
         check_positive_u64(body_limit, "maxBytes", errors);
     }
+}
+
+/// Reject `gateway.auth.mode = "none"` unless the operator has set
+/// `ALETHEIA_ALLOW_AUTH_NONE=1`. This is the config-API-level gate that
+/// prevents a config PUT from silently disabling authentication.
+///
+/// Call this *in addition to* [`validate_section`] when handling a
+/// `PUT /config/gateway` request. Server startup and `check-config` do not
+/// call this — operators with filesystem-level control of `aletheia.toml`
+/// are trusted, and the loud [`warn_if_auth_disabled`] emission keeps the
+/// posture visible. (#3383, #4240)
+///
+/// # Errors
+///
+/// Returns [`ValidationError`] if `auth.mode = "none"` and the env opt-in
+/// is not set. Any other gateway section value (or absent `auth.mode`) is
+/// accepted.
+#[must_use]
+#[expect(
+    clippy::double_must_use,
+    reason = "kanon lint requires explicit #[must_use] on pub fns returning Result"
+)]
+// kanon:ignore RUST/validate-returns-unit — returns Result<()> where Err carries the specific failure reason; Ok(()) signals validation passed
+pub fn validate_auth_mode_policy(gateway_value: &Value) -> Result<(), ValidationError> {
+    let Some(auth) = gateway_value.get("auth") else {
+        return Ok(());
+    };
+    let Some(mode) = auth.get("mode").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    if mode == "none" && !auth_none_opt_in_enabled() {
+        return ValidationSnafu {
+            errors: vec![format!(
+                "gateway.auth.mode = \"none\" disables all authentication and is \
+                 rejected by default; set the environment variable {ALLOW_AUTH_NONE_ENV}=1 \
+                 on the server process to opt in (intended for local dev only)"
+            )],
+        }
+        .fail();
+    }
+    Ok(())
 }
 
 /// Return `true` when the operator has set `ALETHEIA_ALLOW_AUTH_NONE=1`.

--- a/crates/taxis/src/validate_tests.rs
+++ b/crates/taxis/src/validate_tests.rs
@@ -247,11 +247,12 @@ fn provider_aliases_deserialize_to_typed_config() {
 /// without a mutex the opt-in gate flips under another test's feet.
 static AUTH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// `auth.mode = "none"` is rejected by default: disabling authentication
-/// must be an explicit opt-in so a config PUT cannot silently remove access
-/// control. (#3383)
+/// `auth.mode = "none"` via the config API is rejected unless the operator
+/// has explicitly opted in via `ALETHEIA_ALLOW_AUTH_NONE=1`. This is the
+/// `validate_auth_mode_policy` gate that callers must invoke in addition to
+/// the structural `validate_section`. (#3383, #4240)
 #[test]
-fn auth_mode_none_env_gate() {
+fn auth_mode_none_policy_env_gate() {
     let _guard = AUTH_ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -266,12 +267,13 @@ fn auth_mode_none_env_gate() {
         std::env::remove_var(crate::validate::ALLOW_AUTH_NONE_ENV);
     }
 
-    // Without opt-in: reject, and point the operator at the env var.
     let section = json!({ "auth": { "mode": "none" } });
-    let rejected = validate_section("gateway", &section);
+
+    // Without opt-in: policy gate rejects, error points the operator at the env var.
+    let rejected = crate::validate::validate_auth_mode_policy(&section);
     assert!(
         rejected.is_err(),
-        "auth_mode = none must be rejected without env opt-in"
+        "auth_mode = none must be rejected by the policy gate without env opt-in"
     );
     let err = rejected.unwrap_err();
     assert!(
@@ -281,7 +283,15 @@ fn auth_mode_none_env_gate() {
         "error should mention the env-var opt-in: {err:?}"
     );
 
-    // With opt-in: accept.
+    // Structural validation alone is permissive: a config PUT must call BOTH
+    // validate_section AND validate_auth_mode_policy to preserve the gate.
+    let structural = validate_section("gateway", &section);
+    assert!(
+        structural.is_ok(),
+        "validate_section is now structural-only and must accept mode=none: {structural:?}"
+    );
+
+    // With opt-in: policy gate accepts.
     #[expect(
         unsafe_code,
         reason = "std::env::set_var requires unsafe in edition 2024; serialised via AUTH_ENV_LOCK"
@@ -290,7 +300,7 @@ fn auth_mode_none_env_gate() {
     unsafe {
         std::env::set_var(crate::validate::ALLOW_AUTH_NONE_ENV, "1");
     }
-    let accepted = validate_section("gateway", &section);
+    let accepted = crate::validate::validate_auth_mode_policy(&section);
 
     #[expect(
         unsafe_code,
@@ -304,6 +314,50 @@ fn auth_mode_none_env_gate() {
     assert!(
         accepted.is_ok(),
         "auth_mode = none must be accepted with env opt-in: {accepted:?}"
+    );
+}
+
+/// File-load path (server startup, `check-config`) accepts `auth.mode = "none"`
+/// regardless of the env opt-in; the gate is policy-level, not structural.
+/// Operators with filesystem control of aletheia.toml are trusted; visibility
+/// is preserved via the loud `warn_if_auth_disabled` emission. (#4240)
+#[test]
+fn validate_section_gateway_accepts_mode_none_without_opt_in() {
+    let _guard = AUTH_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    #[expect(
+        unsafe_code,
+        reason = "std::env::remove_var requires unsafe in edition 2024; serialised via AUTH_ENV_LOCK"
+    )]
+    // SAFETY: `AUTH_ENV_LOCK` serialises ALLOW_AUTH_NONE_ENV mutations across tests.
+    unsafe {
+        std::env::remove_var(crate::validate::ALLOW_AUTH_NONE_ENV);
+    }
+
+    let section = json!({ "auth": { "mode": "none" } });
+    let outcome = validate_section("gateway", &section);
+    assert!(
+        outcome.is_ok(),
+        "validate_section('gateway', mode=none) must accept on the file-load path: {outcome:?}"
+    );
+}
+
+/// Structural mode validation still rejects unknown auth modes — this is not
+/// a policy gate and applies to all paths. (#3383)
+#[test]
+fn validate_section_gateway_rejects_unknown_auth_mode() {
+    let section = json!({ "auth": { "mode": "telepathy" } });
+    let result = validate_section("gateway", &section);
+    assert!(
+        result.is_err(),
+        "unknown auth.mode must be rejected as a structural error"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.errors.iter().any(|e| e.contains("telepathy")),
+        "error should mention the bad mode: {err:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

`aletheia init -y` writes `gateway.auth.mode = "none"` as the dev-friendly default. Until this fix, the same `validate_section` that powers the config-PUT API also fired during `check-config` and server startup, so a fresh init produced a config the next two first-class commands both rejected unless the operator had set `ALETHEIA_ALLOW_AUTH_NONE=1`. Bad first-five-minutes UX, and inconsistent with the doc comment on `auth_none_opt_in_enabled` which already described the intended split: *reading a TOML file at startup is accepted regardless; the gate is for config PUTs through the API.*

## Approach

- Split the env-opt-in gate out of `validate_gateway` into a new `pub validate_auth_mode_policy` in `taxis::validate`. `validate_section("gateway", …)` is now structural-only: it still rejects unknown auth modes, but `mode = "none"` is accepted regardless of the env var.
- Call `validate_auth_mode_policy` explicitly in the pylon config PUT handler so #3383's gate against silently disabling auth via the API is preserved.
- Emit a `[warn] gateway.auth: mode = "none" …` line in `check-config` for `mode = "none"`, mirroring `warn_if_auth_disabled` at server startup. Operators still see the posture; they no longer get a misleading `[FAIL]` on a fresh init.
- Extract `validate_section_for_put` helper in pylon so `update_section` stays under `clippy::too_many_lines`.

This matches option (1) from #4240's suggested-fixes list ("`check-config` softens to a WARN for `mode = "none"`") while preserving #3383 at the config-PUT API where it actually matters.

## End-to-end

```
$ aletheia init --instance-root /tmp/fresh --yes
Instance created at /tmp/fresh
$ aletheia -r /tmp/fresh check-config
Instance root: /tmp/fresh
  [pass] instance layout
  [pass] config loaded
  [pass] agents
  [pass] gateway
  …
  [warn] gateway.auth: mode = "none" — all requests served as role 'admin'; the config API still requires ALETHEIA_ALLOW_AUTH_NONE=1 to accept this via PUT

Configuration OK
$ echo $?
0
```

On main today the same sequence exits 1 with `[FAIL] gateway: …`.

## Tests

- `taxis::validate::validate_tests::auth_mode_none_policy_env_gate` — replaces the prior `auth_mode_none_env_gate`; asserts the new policy function rejects mode=none without the env opt-in and accepts with it.
- `validate_section_gateway_accepts_mode_none_without_opt_in` — asserts the new file-load behavior.
- `validate_section_gateway_rejects_unknown_auth_mode` — keeps the structural mode-name check exercised.
- `aletheia::tests::smoke_test::init_yes_followed_by_check_config_exits_zero` — the e2e regression test the mandate called out.

All targeted tests pass; full taxis (249), pylon (451), and aletheia smoke (40) suites green; `kanon gate --full --stamp` PASS on all 7 phases.

## Security note

This refactor preserves the #3383 gate (the only path that could silently disable auth via the config API) and the #3716 gate (mode=none on a non-loopback bind). The behavior change is narrow: file-load callers (`check-config`, server startup via `validate_section`) now accept mode=none with a warning instead of a hard fail. Filesystem-level operators are trusted, which matches the pre-existing intent stated in the `auth_none_opt_in_enabled` doc comment.

**Open for T0 review — not auto-merged.** Touches auth validation policy and a public taxis API addition.

Closes #4240