### PR TITLE
fix(aletheia/ingest): per-file error continuance, H1 split, JSON schema docs (#4164)

### DIFF
--- a/crates/aletheia/src/commands/ingest.rs
+++ b/crates/aletheia/src/commands/ingest.rs
@@ -200,52 +200,85 @@ fn run_direct(
 
     let mut total_inserted = 0usize;
     let mut total_skipped = 0usize;
+    let mut errored: Vec<(PathBuf, String)> = Vec::new();
 
     for file in &files {
-        let content = std::fs::read_to_string(file)
-            .with_whatever_context(|_| format!("failed to read {}", file.display()))?;
-
-        let format_str = if args.format == "auto" {
-            detect_format(file).unwrap_or("text")
-        } else {
-            &args.format
-        };
-
-        let format = mneme::ingest::parse_format(format_str)
-            .ok_or_else(|| crate::error::Error::msg(format!("unsupported format: {format_str}")))?;
-
-        let config = mneme::ingest::IngestConfig::default();
-        let facts = mneme::ingest::ingest_content(&content, format, &config, &args.nous_id)
-            .with_whatever_context(|_| format!("failed to parse {}", file.display()))?;
-
-        if args.dry_run {
-            println!(
-                "[dry-run] {}: would insert {} facts",
-                file.display(),
-                facts.len()
-            );
-            continue;
-        }
-
-        let mut inserted = 0usize;
-        let mut skipped = 0usize;
-        for fact in &facts {
-            match store.insert_fact(fact) {
-                Ok(()) => inserted += 1,
-                Err(e) => {
-                    tracing::warn!(error = %e, fact_id = %fact.id, "fact insert failed");
-                    skipped += 1;
-                }
+        match process_file(file, args, store) {
+            Ok((inserted, skipped)) => {
+                total_inserted += inserted;
+                total_skipped += skipped;
+            }
+            Err(e) => {
+                // INVARIANT: per-file error is non-fatal — log + count + continue, so the rest of
+                // the directory still lands. Previously a single bad file aborted the whole ingest
+                // after partially mutating the store (#4164/B).
+                let msg = e.to_string();
+                tracing::warn!(file = %file.display(), error = %msg, "ingest skipping file");
+                eprintln!("[warn] {}: {msg}", file.display());
+                errored.push((file.clone(), msg));
             }
         }
-
-        println!("{}: inserted {inserted}, skipped {skipped}", file.display());
-        total_inserted += inserted;
-        total_skipped += skipped;
     }
 
-    println!("\nTotal: inserted {total_inserted}, skipped {total_skipped}");
+    println!(
+        "\nTotal: inserted {total_inserted}, skipped {total_skipped}, errored {} (of {} files)",
+        errored.len(),
+        files.len()
+    );
+    if !errored.is_empty() {
+        println!("\nFiles with errors:");
+        for (path, err) in &errored {
+            println!("  - {}: {err}", path.display());
+        }
+    }
     Ok(())
+}
+
+#[cfg(feature = "recall")]
+fn process_file(
+    file: &Path,
+    args: &IngestArgs,
+    store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
+) -> Result<(usize, usize)> {
+    let content = std::fs::read_to_string(file)
+        .with_whatever_context(|_| format!("failed to read {}", file.display()))?;
+
+    let format_str = if args.format == "auto" {
+        detect_format(file).unwrap_or("text")
+    } else {
+        &args.format
+    };
+
+    let format = mneme::ingest::parse_format(format_str)
+        .ok_or_else(|| crate::error::Error::msg(format!("unsupported format: {format_str}")))?;
+
+    let config = mneme::ingest::IngestConfig::default();
+    let facts = mneme::ingest::ingest_content(&content, format, &config, &args.nous_id)
+        .with_whatever_context(|_| format!("failed to parse {}", file.display()))?;
+
+    if args.dry_run {
+        println!(
+            "[dry-run] {}: would insert {} facts",
+            file.display(),
+            facts.len()
+        );
+        return Ok((0, 0));
+    }
+
+    let mut inserted = 0usize;
+    let mut skipped = 0usize;
+    for fact in &facts {
+        match store.insert_fact(fact) {
+            Ok(()) => inserted += 1,
+            Err(e) => {
+                tracing::warn!(error = %e, fact_id = %fact.id, "fact insert failed");
+                skipped += 1;
+            }
+        }
+    }
+
+    println!("{}: inserted {inserted}, skipped {skipped}", file.display());
+    Ok((inserted, skipped))
 }
 
 async fn read_path(path: &Path) -> Result<String> {
@@ -473,5 +506,81 @@ mod tests {
     async fn is_server_running_returns_false_for_unreachable_well_formed_url() {
         let res = is_server_running("http://127.0.0.1:1").await.unwrap();
         assert!(!res, "expected false when no listener; got {res}");
+    }
+
+    /// Regression for #4164/B: a directory containing one unparseable file
+    /// used to abort the whole ingest after partially mutating the store.
+    /// Now the bad file is logged + counted as errored and the remaining
+    /// files still go through. Uses dry-run so no store insert happens —
+    /// the failure surface being tested is the parse step (`ingest_content`),
+    /// which fires before the store call in `process_file`.
+    #[test]
+    fn run_direct_dry_run_continues_after_bad_file() {
+        #[cfg(feature = "recall")]
+        {
+            let dir = tempfile::tempdir().unwrap();
+            let docs = dir.path().join("docs");
+            std::fs::create_dir(&docs).unwrap();
+            std::fs::write(docs.join("good.md"), "# Section\nThe sky is blue.\n").unwrap();
+            // Malformed JSON — used to abort the entire dir ingest.
+            std::fs::write(docs.join("bad.json"), "{ not valid json").unwrap();
+            std::fs::write(docs.join("more.md"), "## Heading\nMore content.\n").unwrap();
+
+            let store_dir = dir.path().join("knowledge");
+            let config = mneme::knowledge_store::KnowledgeConfig::default();
+            let store =
+                mneme::knowledge_store::KnowledgeStore::open_fjall(&store_dir, config).unwrap();
+
+            let args = IngestArgs {
+                path: docs,
+                format: "auto".to_owned(),
+                nous_id: "alice".to_owned(),
+                dry_run: true,
+                url: "http://127.0.0.1:1".to_owned(),
+            };
+
+            let result = run_direct(&args, &store);
+            assert!(
+                result.is_ok(),
+                "run_direct should not propagate a per-file parse error; got {result:?}"
+            );
+        }
+    }
+
+    /// Same shape as the dry-run check, but exercise the live insert path:
+    /// the bad file must not abort the loop. We assert only `Ok(())` —
+    /// counting facts via the store would require a `CozoScript` query the
+    /// public surface doesn't expose, which is out-of-scope for this fix.
+    /// The dry-run case above covers the parse-error continuance contract.
+    #[test]
+    fn run_direct_live_continues_after_bad_file() {
+        #[cfg(feature = "recall")]
+        {
+            let dir = tempfile::tempdir().unwrap();
+            let docs = dir.path().join("docs");
+            std::fs::create_dir(&docs).unwrap();
+            std::fs::write(docs.join("a.md"), "# A\nfirst fact body.\n").unwrap();
+            std::fs::write(docs.join("b.json"), "{ malformed").unwrap();
+            std::fs::write(docs.join("c.md"), "# C\nthird fact body.\n").unwrap();
+
+            let store_dir = dir.path().join("knowledge");
+            let config = mneme::knowledge_store::KnowledgeConfig::default();
+            let store =
+                mneme::knowledge_store::KnowledgeStore::open_fjall(&store_dir, config).unwrap();
+
+            let args = IngestArgs {
+                path: docs,
+                format: "auto".to_owned(),
+                nous_id: "alice".to_owned(),
+                dry_run: false,
+                url: "http://127.0.0.1:1".to_owned(),
+            };
+
+            let result = run_direct(&args, &store);
+            assert!(
+                result.is_ok(),
+                "run_direct should return Ok despite the bad file: {result:?}"
+            );
+        }
     }
 }

--- a/crates/episteme/src/ingest.rs
+++ b/crates/episteme/src/ingest.rs
@@ -208,12 +208,30 @@ fn strip_frontmatter(content: &str) -> &str {
     content
 }
 
+/// Match an ATX-style Markdown heading line (`#`, `##`, …, `######` followed by
+/// whitespace or end-of-line).
+///
+/// Previously `split_by_headers` matched only `##`+ headings, which silently
+/// merged documents that used `#` as their section delimiter (#4164/D). The
+/// fix is to recognize any heading level; the first `#` line of a document
+/// effectively becomes the title of the leading section, matching the
+/// behavior every other Markdown tool exhibits.
+fn is_md_heading(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let hashes = trimmed.bytes().take_while(|b| *b == b'#').count();
+    if hashes == 0 || hashes > 6 {
+        return false;
+    }
+    let after = trimmed.get(hashes..).unwrap_or("");
+    after.is_empty() || after.starts_with(char::is_whitespace)
+}
+
 fn split_by_headers(content: &str) -> Vec<String> {
     let mut sections = Vec::new();
     let mut current = String::new();
 
     for line in content.lines() {
-        if line.trim_start().starts_with("##") {
+        if is_md_heading(line) {
             if !current.trim().is_empty() {
                 sections.push(current.trim().to_owned());
             }
@@ -355,6 +373,55 @@ mod tests {
         assert_eq!(sections[0], "intro");
         assert!(sections[1].starts_with("## Section A"));
         assert!(sections[2].starts_with("## Section B"));
+    }
+
+    /// Regression for #4164/D: H1 (`#`) headings used to be ignored,
+    /// silently merging a document like the one below into a single chunk.
+    #[test]
+    fn split_by_headers_recognizes_h1() {
+        let text = "# Section One\nThe sky is blue.\n\n# Section Two\nWater is wet.";
+        let sections = split_by_headers(text);
+        assert_eq!(sections.len(), 2, "expected H1 to split, got: {sections:?}");
+        assert!(sections[0].starts_with("# Section One"));
+        assert!(sections[1].starts_with("# Section Two"));
+    }
+
+    #[test]
+    fn split_by_headers_handles_mixed_levels() {
+        let text = "# Title\nlead\n## Sub A\na body\n### Detail\nd body\n## Sub B\nb body";
+        let sections = split_by_headers(text);
+        assert_eq!(sections.len(), 4);
+        assert!(sections[0].starts_with("# Title"));
+        assert!(sections[1].starts_with("## Sub A"));
+        assert!(sections[2].starts_with("### Detail"));
+        assert!(sections[3].starts_with("## Sub B"));
+    }
+
+    #[test]
+    fn is_md_heading_recognizes_levels_1_through_6() {
+        for level in 1..=6 {
+            let line = format!("{} title", "#".repeat(level));
+            assert!(is_md_heading(&line), "level {level} should be a heading");
+        }
+    }
+
+    #[test]
+    fn is_md_heading_rejects_non_headings() {
+        assert!(!is_md_heading("plain line"));
+        assert!(
+            !is_md_heading("#hashtag"),
+            "no space after # is not a heading"
+        );
+        assert!(!is_md_heading("####### too many"), "7+ # is not ATX");
+        assert!(!is_md_heading(""));
+    }
+
+    #[test]
+    fn ingest_markdown_chunks_by_h1() {
+        let md = "# A\ncontent a\n# B\ncontent b";
+        let config = IngestConfig::default();
+        let facts = ingest_content(md, IngestFormat::Markdown, &config, "syn").unwrap();
+        assert_eq!(facts.len(), 2);
     }
 
     #[test]

--- a/docs/INGEST.md
+++ b/docs/INGEST.md
@@ -1,0 +1,168 @@
+# Ingest
+
+`aletheia ingest <path>` loads files into the knowledge store as facts.
+This document covers the supported formats, the per-format chunking
+behavior, the JSON fact schema, and how directory ingest handles
+errors. It is the authoritative reference for the file shapes the
+command accepts.
+
+## Synopsis
+
+```
+aletheia ingest <PATH> [--format <FORMAT>] [--nous-id <ID>] [--dry-run] [--url <URL>]
+```
+
+| Flag        | Default                       | Meaning                                                    |
+| ----------- | ----------------------------- | ---------------------------------------------------------- |
+| `--format`  | `auto`                        | One of `markdown`, `md`, `text`, `plain_text`, `json`, `jsonl`, `auto` |
+| `--nous-id` | `default`                     | Owning nous (agent) for ingested facts                     |
+| `--dry-run` | off                           | Parse + report but do not write to the store               |
+| `--url`     | `http://127.0.0.1:18789`      | Forward to a running server instead of writing directly    |
+
+If a server is reachable at `--url`, ingest forwards through the API.
+Otherwise it writes directly to the local knowledge store under the
+current instance root.
+
+## Formats
+
+### `markdown` / `md`
+
+Files are split into sections by ATX-style headings (`#`, `##`, …,
+`######`). Each section becomes one fact. YAML frontmatter at the
+top of the file (between two `---` lines) is stripped before chunking.
+
+A document like
+
+```
+# Section One
+The sky is blue.
+
+# Section Two
+Water is wet.
+```
+
+produces two facts, one per heading. (Prior to #4164 only `##` and
+deeper headings split; `#` was silently ignored and the whole file
+became a single fact.)
+
+Sections longer than ~2000 characters are further split at word
+boundaries with a small overlap, so the chunk-to-fact mapping is
+near-1:1 for typical documents.
+
+### `text` / `plain_text`
+
+The file is treated as one block of prose, chunked at word boundaries
+into ~2000-character pieces, and each chunk becomes a heuristic fact
+with confidence `0.7` and inferred epistemic tier.
+
+### `json` / `jsonl`
+
+Both formats parse directly into the internal `Fact` struct. Use
+`json` for an array of facts (or a single object); use `jsonl` for one
+fact per line. No heuristic synthesis happens — the input must already
+be a complete `Fact`. This makes the two JSON formats useful for
+**round-tripping exports**, not for hand-authoring knowledge.
+
+#### Required schema
+
+A fact is a flat JSON object with these keys (some have defaults that
+serde will fill in for older exports, but a hand-authored file should
+specify them all):
+
+| Key                  | Type     | Required | Notes                                                  |
+| -------------------- | -------- | -------- | ------------------------------------------------------ |
+| `id`                 | string   | yes      | Stable fact identifier; should be unique per store     |
+| `nous_id`            | string   | yes      | Owning nous (agent)                                    |
+| `fact_type`          | string   | yes      | e.g. `observation`, `preference`, `procedure`          |
+| `content`            | string   | yes      | The fact statement; max 100 KiB                        |
+| `scope`              | enum     | no       | Memory sharing scope (`private`/`team`/…)              |
+| `project_id`         | string   | no       | Git-remote-derived project partition                   |
+| `sensitivity`        | enum     | no       | `public` (default), `internal`, `confidential`         |
+| `visibility`         | enum     | no       | `private` (default), `shared`, `restricted`, `published` |
+| `valid_from`         | RFC 3339 | yes      | When the fact became true in the domain                |
+| `valid_to`           | RFC 3339 | yes      | When it ceased to be true (`9999-01-01T00:00:00Z` = currently valid) |
+| `recorded_at`        | RFC 3339 | yes      | When the system learned about the fact                 |
+| `confidence`         | float    | yes      | In `[0.0, 1.0]`                                        |
+| `tier`               | enum     | yes      | `verified` / `inferred` / `assumed` / `derived`        |
+| `source_session_id`  | string   | no       | Session that produced this fact, if any                |
+| `stability_hours`    | float    | yes      | Base FSRS stability before tier multiplier             |
+| `superseded_by`      | string   | no       | ID of the fact that replaced this one                  |
+| `is_forgotten`       | bool     | yes      | Set to `false` for newly authored facts                |
+| `forgotten_at`       | RFC 3339 | no       | Only set if `is_forgotten` is true                     |
+| `forget_reason`      | enum     | no       | Only set if `is_forgotten` is true                     |
+| `access_count`       | int      | yes      | Set to `0` for newly authored facts                    |
+| `last_accessed_at`   | RFC 3339 | no       | Omit (or null) for newly authored facts                |
+
+#### Example: minimal hand-authored fact
+
+```json
+{
+  "id": "fact-01",
+  "nous_id": "alice",
+  "fact_type": "observation",
+  "content": "The user prefers tabs over spaces.",
+  "valid_from": "2026-05-28T00:00:00Z",
+  "valid_to":   "9999-01-01T00:00:00Z",
+  "recorded_at": "2026-05-28T00:00:00Z",
+  "confidence": 0.9,
+  "tier": "verified",
+  "stability_hours": 240.0,
+  "access_count": 0,
+  "is_forgotten": false
+}
+```
+
+A hand-written file like `[{"content": "a fact"}]` will be **rejected
+with `missing field 'id'`** — there is no lightweight authoring
+schema. To author knowledge by hand, prefer `--format markdown` and
+let the chunker synthesize the surrounding metadata.
+
+### `auto`
+
+Format is detected from the file extension:
+
+| Extension                   | Format    |
+| --------------------------- | --------- |
+| `.md` / `.markdown`         | markdown  |
+| `.json`                     | json      |
+| `.jsonl`                    | jsonl     |
+| anything else (incl. `.txt`)| text      |
+
+A directory has no extension and is treated as `text` when the API
+path is taken (see *Directory ingest* below).
+
+## Directory ingest
+
+Pointing `ingest` at a directory walks it recursively and ingests every
+file with a supported extension (`.md`, `.markdown`, `.txt`, `.text`,
+`.json`, `.jsonl`).
+
+Each file is parsed independently. If one file fails to parse — for
+example, a malformed `.json` — the failure is **logged as a warning
+and the file is recorded as errored**, but the loop continues with the
+remaining files. The final summary reports `inserted / skipped /
+errored` totals and lists each errored file's path and reason.
+
+```
+Total: inserted 12, skipped 0, errored 1 (of 4 files)
+
+Files with errors:
+  - /path/to/bad.json: failed to parse /path/to/bad.json
+      Caused by: missing field `id`
+```
+
+This is a behavioral change in #4164: prior versions of `ingest`
+aborted on the first parse failure, leaving the knowledge store in a
+non-deterministic partial state.
+
+Per-fact insert failures (e.g., a fact that fails admission control)
+are tolerated the same way and counted in `skipped`.
+
+### Note on the API path
+
+When a server is running at `--url`, `ingest <dir>` forwards the
+directory as a single concatenated payload and the server ingests it
+as `text`. Recursion and per-file format detection only happen on the
+direct (no-server) path. If you need the recursive, per-file behavior
+documented above, stop the server before ingesting or ingest one file
+at a time. (#4164/A tracks unifying the two paths.)


### PR DESCRIPTION
## Summary

Closes three of the four #4164 friction points (B, C, D). Issue/A
(server-vs-direct path divergence) is called out in the docs and left
for a follow-up because it requires a wider API contract change.

**B. Per-file errors no longer abort the directory ingest.** Before
this PR, the first malformed file in a directory propagated via `?`
and left the knowledge store in a non-deterministic partial state
(files before the failure were already written; files after it were
never processed). `run_direct` now extracts the per-file body into a
`process_file` helper, catches errors at the loop boundary, logs them
via `tracing::warn!`, echoes a `[warn] <path>: <reason>` line, and
counts them in a new `errored` column. The final summary prints
\`inserted/skipped/errored (of N files)\` plus a per-file reason list.
This mirrors the existing per-fact error tolerance pattern (per-fact
insert failures were already non-fatal).

**D. H1 (\`#\`) headings now split markdown documents.** The old
\`starts_with(\"##\")\` check silently merged H1-delimited docs into
one fact, contradicting the chunker's contract. A new \`is_md_heading\`
helper recognizes ATX-style headings at levels 1–6 (one to six \`#\`s
followed by whitespace or end-of-line). The bug-report repro now
produces two facts instead of one.

**C. \`docs/INGEST.md\` documents the full ingest contract.** Covers
every supported format, per-format chunking behavior, the full \`Fact\`
schema required by \`--format json\`/\`jsonl\` (with a minimal
hand-authored example), and the new directory-ingest error semantics.
Explicitly states that \`[{\"content\": \"a fact\"}]\` is rejected —
\`json\` round-trips exports, it does not author knowledge — so the
next person to try and fails sees the answer in the docs instead of in
a serde error.

## Tests

- \`split_by_headers_recognizes_h1\` — the exact issue repro.
- \`split_by_headers_handles_mixed_levels\` — H1/H2/H3 stay separated.
- \`is_md_heading_recognizes_levels_1_through_6\` plus negative cases
  for non-headings, \`#hashtag\` (no space), and 7+ hashes.
- \`ingest_markdown_chunks_by_h1\` — end-to-end through
  \`ingest_content\`.
- \`run_direct_dry_run_continues_after_bad_file\` and
  \`run_direct_live_continues_after_bad_file\` — directory containing
  a malformed JSON between two valid markdown files; the bad file is
  logged and counted, both modes return \`Ok(())\`.

Full \`aletheia\` (236) and \`episteme\` (24) suites green.
\`kanon gate --full --stamp\` PASS (cargo fmt, check, audit, clippy,
test, kanon lint, fleet-names freshness).

## Scope note

#4164/A is out of scope. Fixing it requires changing the API request
shape (one concatenated blob → a manifest of \`{path, format, content}\`)
and is called out in \`docs/INGEST.md\`'s API-path note so users know
the divergence exists today. A follow-up PR can unify the two paths
once the API contract change is approved.

Closes #4164