### PR TITLE
fix(aletheia/memory): honor --nous-id in `memory patterns` queries (#4268)

### DIFF
--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -825,12 +825,15 @@ fn find_content_hash_duplicates(
 #[cfg(feature = "recall")]
 fn run_patterns(
     store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
-    _nous_id: Option<&str>,
+    nous_id: Option<&str>,
     limit: u16,
 ) -> Result<()> {
-    println!("=== Knowledge Graph Patterns ===\n");
+    match nous_id {
+        Some(nid) => println!("=== Knowledge Graph Patterns (nous: {nid}) ===\n"),
+        None => println!("=== Knowledge Graph Patterns ===\n"),
+    }
 
-    let cooccurrence = find_entity_cooccurrence(store, i64::from(limit))?;
+    let cooccurrence = find_entity_cooccurrence(store, nous_id, i64::from(limit))?;
     if cooccurrence.is_empty() {
         println!("Entity co-occurrence: no patterns found");
     } else {
@@ -842,7 +845,7 @@ fn run_patterns(
 
     println!();
 
-    let chains = find_relationship_chains(store, i64::from(limit))?;
+    let chains = find_relationship_chains(store, nous_id, i64::from(limit))?;
     if chains.is_empty() {
         println!("Relationship chains: no patterns found");
     } else {
@@ -854,7 +857,7 @@ fn run_patterns(
 
     println!();
 
-    let hubs = find_hub_entities(store, i64::from(limit))?;
+    let hubs = find_hub_entities(store, nous_id, i64::from(limit))?;
     if hubs.is_empty() {
         println!("Hub entities: no patterns found");
     } else {
@@ -870,14 +873,24 @@ fn run_patterns(
 #[cfg(feature = "recall")]
 fn find_entity_cooccurrence(
     store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
+    nous_id: Option<&str>,
     limit: i64,
 ) -> Result<Vec<(String, String, i64)>> {
+    use mneme::engine::DataValue;
     use std::collections::BTreeMap;
+    let mut params = BTreeMap::new();
+    let nous_join = match nous_id {
+        Some(nid) => {
+            params.insert("nid".to_owned(), DataValue::Str(nid.into()));
+            ",\n            *facts{id: fid, nous_id: $nid}"
+        }
+        None => "",
+    };
     let script = format!(
         r"
         cooccur[ea, eb, count(fid)] :=
             *fact_entities{{fact_id: fid, entity_id: ea}},
-            *fact_entities{{fact_id: fid, entity_id: eb}},
+            *fact_entities{{fact_id: fid, entity_id: eb}}{nous_join},
             ea < eb
 
         ?[name_a, name_b, cnt] :=
@@ -891,7 +904,7 @@ fn find_entity_cooccurrence(
         "
     );
     let result = store
-        .run_query(&script, BTreeMap::new())
+        .run_query(&script, params)
         .whatever_context("co-occurrence query failed")?;
     Ok((0..result.row_count())
         .filter_map(|i| {
@@ -906,20 +919,35 @@ fn find_entity_cooccurrence(
 #[cfg(feature = "recall")]
 fn find_relationship_chains(
     store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
+    nous_id: Option<&str>,
     limit: i64,
 ) -> Result<Vec<(String, i64)>> {
+    use mneme::engine::DataValue;
     use std::collections::BTreeMap;
-    let script = format!(
-        r"
-        ?[relation, count(src)] :=
-            *relationships{{src, relation}}
+    let mut params = BTreeMap::new();
+    let body = match nous_id {
+        Some(nid) => {
+            params.insert("nid".to_owned(), DataValue::Str(nid.into()));
+            r"
+        in_nous[eid] :=
+            *fact_entities{fact_id: fid, entity_id: eid},
+            *facts{id: fid, nous_id: $nid}
 
-        :sort -count(src)
-        :limit {limit}
+        ?[relation, count(src)] :=
+            *relationships{src, relation},
+            in_nous[src]
         "
-    );
+        }
+        None => {
+            r"
+        ?[relation, count(src)] :=
+            *relationships{src, relation}
+        "
+        }
+    };
+    let script = format!("{body}\n        :sort -count(src)\n        :limit {limit}\n        ");
     let result = store
-        .run_query(&script, BTreeMap::new())
+        .run_query(&script, params)
         .whatever_context("relationship chain query failed")?;
     Ok((0..result.row_count())
         .filter_map(|i| {
@@ -933,16 +961,39 @@ fn find_relationship_chains(
 #[cfg(feature = "recall")]
 fn find_hub_entities(
     store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
+    nous_id: Option<&str>,
     limit: i64,
 ) -> Result<Vec<(String, i64)>> {
+    use mneme::engine::DataValue;
     use std::collections::BTreeMap;
-    let script = format!(
-        r"
-        degree[eid, count(other)] :=
-            *relationships{{src: eid, dst: other}}
-        degree[eid, count(other)] :=
-            *relationships{{src: other, dst: eid}}
+    let mut params = BTreeMap::new();
+    let degree_rules = match nous_id {
+        Some(nid) => {
+            params.insert("nid".to_owned(), DataValue::Str(nid.into()));
+            r"
+        in_nous[eid] :=
+            *fact_entities{fact_id: fid, entity_id: eid},
+            *facts{id: fid, nous_id: $nid}
 
+        degree[eid, count(other)] :=
+            *relationships{src: eid, dst: other},
+            in_nous[eid]
+        degree[eid, count(other)] :=
+            *relationships{src: other, dst: eid},
+            in_nous[eid]
+        "
+        }
+        None => {
+            r"
+        degree[eid, count(other)] :=
+            *relationships{src: eid, dst: other}
+        degree[eid, count(other)] :=
+            *relationships{src: other, dst: eid}
+        "
+        }
+    };
+    let script = format!(
+        r"{degree_rules}
         ?[name, total] :=
             degree[eid, cnt],
             total = cnt,
@@ -953,7 +1004,7 @@ fn find_hub_entities(
         "
     );
     let result = store
-        .run_query(&script, BTreeMap::new())
+        .run_query(&script, params)
         .whatever_context("hub entity query failed")?;
     Ok((0..result.row_count())
         .filter_map(|i| {

--- a/crates/aletheia/src/commands/memory/tests.rs
+++ b/crates/aletheia/src/commands/memory/tests.rs
@@ -403,6 +403,222 @@ fn load_filtered_facts_respects_nous_filter() {
     );
 }
 
+fn link_fact_to_entity(
+    store: &Arc<mneme::knowledge_store::KnowledgeStore>,
+    fact_id: &FactId,
+    entity_id: &EntityId,
+) {
+    use std::collections::BTreeMap;
+    let mut params = BTreeMap::new();
+    params.insert(
+        "fact_id".to_owned(),
+        mneme::engine::DataValue::Str(fact_id.as_str().into()),
+    );
+    params.insert(
+        "entity_id".to_owned(),
+        mneme::engine::DataValue::Str(entity_id.as_str().into()),
+    );
+    params.insert(
+        "created_at".to_owned(),
+        mneme::engine::DataValue::Str(
+            mneme::knowledge::format_timestamp(&jiff::Timestamp::now()).into(),
+        ),
+    );
+    store
+        .run_mut_query(
+            r"?[fact_id, entity_id, created_at] <- [[$fact_id, $entity_id, $created_at]]
+              :put fact_entities {fact_id, entity_id => created_at}",
+            params,
+        )
+        .expect("link fact to entity");
+}
+
+// --- pattern queries respect nous_id scope (regression: #4268) ---
+//
+// Seeds two parallel sub-graphs under two distinct nous_ids and asserts that
+// `find_*` filters strictly: queries with `Some(nid)` see only that nous's
+// facts/entities/relationships; queries with `None` see the global graph.
+
+fn seed_two_nous_subgraphs(store: &Arc<mneme::knowledge_store::KnowledgeStore>) {
+    // Entities used by nous-1
+    let alice = make_entity("ent-alice", "Alice", "person");
+    let bob = make_entity("ent-bob", "Bob", "person");
+    // Entities used by nous-2
+    let carol = make_entity("ent-carol", "Carol", "person");
+    let dan = make_entity("ent-dan", "Dan", "person");
+    for e in [&alice, &bob, &carol, &dan] {
+        store.insert_entity(e).expect("insert entity");
+    }
+
+    // nous-1 facts: each mentions both Alice and Bob → cooccurrence count = 2
+    let f1 = make_fact("fact-n1-1", "nous-1", "Alice met Bob");
+    let f2 = make_fact("fact-n1-2", "nous-1", "Alice and Bob co-author");
+    store.insert_fact(&f1).expect("insert f1");
+    store.insert_fact(&f2).expect("insert f2");
+    link_fact_to_entity(store, &f1.id, &alice.id);
+    link_fact_to_entity(store, &f1.id, &bob.id);
+    link_fact_to_entity(store, &f2.id, &alice.id);
+    link_fact_to_entity(store, &f2.id, &bob.id);
+
+    // nous-2 facts: each mentions both Carol and Dan → cooccurrence count = 2
+    let f3 = make_fact("fact-n2-1", "nous-2", "Carol met Dan");
+    let f4 = make_fact("fact-n2-2", "nous-2", "Carol and Dan collaborate");
+    store.insert_fact(&f3).expect("insert f3");
+    store.insert_fact(&f4).expect("insert f4");
+    link_fact_to_entity(store, &f3.id, &carol.id);
+    link_fact_to_entity(store, &f3.id, &dan.id);
+    link_fact_to_entity(store, &f4.id, &carol.id);
+    link_fact_to_entity(store, &f4.id, &dan.id);
+
+    // Relationships: distinct relation names per sub-graph so the chain query
+    // produces a unique signature per nous.
+    store
+        .insert_relationship(&make_relationship("ent-alice", "ent-bob", "knows"))
+        .expect("rel knows");
+    store
+        .insert_relationship(&make_relationship("ent-carol", "ent-dan", "follows"))
+        .expect("rel follows");
+}
+
+#[test]
+fn find_entity_cooccurrence_scoped_to_nous() {
+    let store = test_store();
+    seed_two_nous_subgraphs(&store);
+
+    let all = super::find_entity_cooccurrence(&store, None, 50).expect("unfiltered query");
+    let names: Vec<(String, String)> = all.iter().map(|(a, b, _)| (a.clone(), b.clone())).collect();
+    assert!(
+        names
+            .iter()
+            .any(|(a, b)| { (a == "Alice" && b == "Bob") || (a == "Bob" && b == "Alice") }),
+        "unfiltered cooccurrence includes Alice/Bob: got {names:?}"
+    );
+    assert!(
+        names
+            .iter()
+            .any(|(a, b)| { (a == "Carol" && b == "Dan") || (a == "Dan" && b == "Carol") }),
+        "unfiltered cooccurrence includes Carol/Dan: got {names:?}"
+    );
+
+    let nous1 = super::find_entity_cooccurrence(&store, Some("nous-1"), 50)
+        .expect("nous-1 cooccurrence query");
+    let n1_names: Vec<(String, String)> = nous1
+        .iter()
+        .map(|(a, b, _)| (a.clone(), b.clone()))
+        .collect();
+    assert!(
+        n1_names
+            .iter()
+            .all(|(a, b)| { (a != "Carol" && b != "Carol") && (a != "Dan" && b != "Dan") }),
+        "nous-1 cooccurrence must exclude nous-2 entities (Carol/Dan): got {n1_names:?}"
+    );
+    assert!(
+        n1_names
+            .iter()
+            .any(|(a, b)| { (a == "Alice" && b == "Bob") || (a == "Bob" && b == "Alice") }),
+        "nous-1 cooccurrence still includes Alice/Bob: got {n1_names:?}"
+    );
+
+    let nous2 = super::find_entity_cooccurrence(&store, Some("nous-2"), 50)
+        .expect("nous-2 cooccurrence query");
+    let n2_names: Vec<(String, String)> = nous2
+        .iter()
+        .map(|(a, b, _)| (a.clone(), b.clone()))
+        .collect();
+    assert!(
+        n2_names
+            .iter()
+            .all(|(a, b)| { (a != "Alice" && b != "Alice") && (a != "Bob" && b != "Bob") }),
+        "nous-2 cooccurrence must exclude nous-1 entities (Alice/Bob): got {n2_names:?}"
+    );
+    assert!(
+        n2_names
+            .iter()
+            .any(|(a, b)| { (a == "Carol" && b == "Dan") || (a == "Dan" && b == "Carol") }),
+        "nous-2 cooccurrence still includes Carol/Dan: got {n2_names:?}"
+    );
+
+    let unknown =
+        super::find_entity_cooccurrence(&store, Some("nous-none"), 50).expect("unknown nous query");
+    assert!(
+        unknown.is_empty(),
+        "unknown nous_id returns empty cooccurrence: got {unknown:?}"
+    );
+}
+
+#[test]
+fn find_relationship_chains_scoped_to_nous() {
+    let store = test_store();
+    seed_two_nous_subgraphs(&store);
+
+    let all = super::find_relationship_chains(&store, None, 50).expect("unfiltered chains");
+    let all_rels: Vec<String> = all.iter().map(|(r, _)| r.clone()).collect();
+    assert!(
+        all_rels.contains(&"knows".to_owned()),
+        "unfiltered has knows"
+    );
+    assert!(
+        all_rels.contains(&"follows".to_owned()),
+        "unfiltered has follows"
+    );
+
+    let nous1 = super::find_relationship_chains(&store, Some("nous-1"), 50).expect("nous-1 chains");
+    let n1_rels: Vec<String> = nous1.iter().map(|(r, _)| r.clone()).collect();
+    assert!(
+        n1_rels.contains(&"knows".to_owned()),
+        "nous-1 has knows: got {n1_rels:?}"
+    );
+    assert!(
+        !n1_rels.contains(&"follows".to_owned()),
+        "nous-1 must exclude follows (belongs to nous-2): got {n1_rels:?}"
+    );
+
+    let nous2 = super::find_relationship_chains(&store, Some("nous-2"), 50).expect("nous-2 chains");
+    let n2_rels: Vec<String> = nous2.iter().map(|(r, _)| r.clone()).collect();
+    assert!(
+        n2_rels.contains(&"follows".to_owned()),
+        "nous-2 has follows: got {n2_rels:?}"
+    );
+    assert!(
+        !n2_rels.contains(&"knows".to_owned()),
+        "nous-2 must exclude knows (belongs to nous-1): got {n2_rels:?}"
+    );
+}
+
+#[test]
+fn find_hub_entities_scoped_to_nous() {
+    let store = test_store();
+    seed_two_nous_subgraphs(&store);
+
+    let all = super::find_hub_entities(&store, None, 50).expect("unfiltered hubs");
+    let all_names: Vec<String> = all.iter().map(|(n, _)| n.clone()).collect();
+    for name in ["Alice", "Bob", "Carol", "Dan"] {
+        assert!(
+            all_names.contains(&name.to_owned()),
+            "unfiltered hubs include {name}: got {all_names:?}"
+        );
+    }
+
+    let nous1 = super::find_hub_entities(&store, Some("nous-1"), 50).expect("nous-1 hubs");
+    let n1_names: Vec<String> = nous1.iter().map(|(n, _)| n.clone()).collect();
+    assert!(
+        n1_names.contains(&"Alice".to_owned()),
+        "nous-1 hubs include Alice: got {n1_names:?}"
+    );
+    assert!(
+        n1_names.contains(&"Bob".to_owned()),
+        "nous-1 hubs include Bob: got {n1_names:?}"
+    );
+    assert!(
+        !n1_names.contains(&"Carol".to_owned()),
+        "nous-1 hubs exclude Carol (belongs to nous-2): got {n1_names:?}"
+    );
+    assert!(
+        !n1_names.contains(&"Dan".to_owned()),
+        "nous-1 hubs exclude Dan (belongs to nous-2): got {n1_names:?}"
+    );
+}
+
 #[test]
 fn sensitivity_dot_color_maps_correctly() {
     assert_eq!(


### PR DESCRIPTION
## Summary

`aletheia memory patterns --nous-id <NID>` previously ignored the flag (the parameter was declared `_nous_id` and never plumbed through). All three pattern queries — entity co-occurrence, relationship chains, hub entities — returned global, workspace-wide results regardless of which agent the operator named, while the CLI help advertised `--nous-id` as "Nous agent ID to analyze." For multi-nous workspaces this corrupted any per-agent quality review and silently leaked sibling-agent data into a report nominally scoped to one agent.

## Change

Plumb `nous_id: Option<&str>` through `run_patterns` to each find_ function and adapt the Datalog scripts:

- **co-occurrence**: the inner `cooccur[ea, eb, count(fid)]` rule joins `*facts{id: fid, nous_id: \$nid}` when scoped, so each shared fact must belong to the requested nous.
- **chains** and **hubs**: relationships and entities have no `nous_id` column (entities are workspace-global, reused across nouses), so scope via an intermediate `in_nous[eid]` rule that materializes the set of entities participating in any fact of the requested nous, then filter `*relationships` to edges whose src endpoint is in that set. Edge-count semantics are preserved.

The `None` path keeps the original queries verbatim — no behavior change for callers that don't pass `--nous-id`.

## Tests

Three new regression tests in `commands::memory::tests` seed two parallel sub-graphs under `nous-1` (Alice/Bob, relation \"knows\") and `nous-2` (Carol/Dan, relation \"follows\") and assert:

- `find_entity_cooccurrence(Some(\"nous-1\"), …)` returns only Alice/Bob, never Carol/Dan; the converse for nous-2; unfiltered returns both; unknown nous_id returns empty.
- `find_relationship_chains(Some(\"nous-1\"), …)` returns \"knows\" and excludes \"follows\"; converse for nous-2.
- `find_hub_entities(Some(\"nous-1\"), …)` includes Alice/Bob and excludes Carol/Dan.

All 34 tests in `commands::memory::tests` pass. `kanon gate --full --stamp --force` green (0 errors).

## Closes

Closes #4268.

## Test plan

- [x] `cargo test -p aletheia --features recall --bin aletheia commands::memory::tests::find_` — 3/3 pass
- [x] `cargo test -p aletheia --features recall --bin aletheia commands::memory::` — 34/34 pass (no regression)
- [x] `kanon gate --full --stamp --force` — PASS fmt / check / audit / clippy / test / lint / fleet-names