### PR TITLE
fix(aletheia): align ingest default --nous-id with init's scaffold (#4245)

### DIFF
--- a/crates/aletheia/src/commands/ingest.rs
+++ b/crates/aletheia/src/commands/ingest.rs
@@ -17,7 +17,7 @@ pub(crate) struct IngestArgs {
     #[arg(short, long, default_value = "auto")]
     pub format: String,
     /// Nous agent ID that will own the extracted facts.
-    #[arg(short, long, default_value = "default")]
+    #[arg(short, long, default_value = koina::defaults::DEFAULT_AGENT_ID)]
     // kanon:ignore RUST/primitive-for-domain-id — CLI arg struct field; clap parses from string, newtype would require custom FromStr
     pub nous_id: String,
     /// Preview without mutating the knowledge store.
@@ -425,6 +425,19 @@ mod tests {
             dry_run: true,
             url: "http://127.0.0.1:1".to_owned(),
         }
+    }
+
+    /// Regression for #4245: the CLI `--nous-id` default must equal the
+    /// agent id that `init -y` scaffolds. Both now resolve to the shared
+    /// `koina::defaults::DEFAULT_AGENT_ID` constant, so this test plus the
+    /// `scaffold_creates_pronoea_agent` assertion in `init::helpers` pin the
+    /// two callsites against one source of truth.
+    #[test]
+    fn ingest_default_nous_id_matches_shared_default_agent_id() {
+        use clap::Parser as _;
+
+        let args = IngestArgs::try_parse_from(["ingest", "/tmp/x"]).unwrap();
+        assert_eq!(args.nous_id, koina::defaults::DEFAULT_AGENT_ID);
     }
 
     #[test]

--- a/crates/aletheia/src/init/helpers.rs
+++ b/crates/aletheia/src/init/helpers.rs
@@ -93,7 +93,7 @@ mod tests {
         assert_eq!(list.len(), 1);
         assert_eq!(
             list[0].get("id").and_then(toml::Value::as_str),
-            Some("pronoea")
+            Some(koina::defaults::DEFAULT_AGENT_ID)
         );
         assert_eq!(
             list[0].get("name").and_then(toml::Value::as_str),

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -101,7 +101,7 @@ impl Default for Answers {
             api_key: None,
             api_provider: "anthropic".to_owned(),
             model: koina::defaults::DEFAULT_MODEL_SHORT.to_owned(),
-            agent_id: "pronoea".to_owned(),
+            agent_id: koina::defaults::DEFAULT_AGENT_ID.to_owned(),
             agent_name: "Pronoea".to_owned(),
             bind: "localhost".to_owned(),
             auth_mode: "none".to_owned(),

--- a/crates/koina/src/defaults.rs
+++ b/crates/koina/src/defaults.rs
@@ -11,6 +11,12 @@ pub const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
 /// Default LLM model identifier (short form used in config files).
 pub const DEFAULT_MODEL_SHORT: &str = "claude-sonnet-4-6";
 
+/// Default nous-agent identifier created by `aletheia init -y` and assumed by
+/// CLI subcommands that take `--nous-id`. Single source of truth so that
+/// `init`'s scaffolded agent and `ingest`'s default flag value cannot drift
+/// (#4245).
+pub const DEFAULT_AGENT_ID: &str = "pronoea";
+
 /// Default maximum output tokens per LLM response.
 pub const MAX_OUTPUT_TOKENS: u32 = 16_384;
 

--- a/docs/INGEST.md
+++ b/docs/INGEST.md
@@ -15,7 +15,7 @@ aletheia ingest <PATH> [--format <FORMAT>] [--nous-id <ID>] [--dry-run] [--url <
 | Flag        | Default                       | Meaning                                                    |
 | ----------- | ----------------------------- | ---------------------------------------------------------- |
 | `--format`  | `auto`                        | One of `markdown`, `md`, `text`, `plain_text`, `json`, `jsonl`, `auto` |
-| `--nous-id` | `default`                     | Owning nous (agent) for ingested facts                     |
+| `--nous-id` | `pronoea`                     | Owning nous (agent) for ingested facts; matches the agent `init -y` scaffolds. Override with `--nous-id <ID>` to target a different nous. |
 | `--dry-run` | off                           | Parse + report but do not write to the store               |
 | `--url`     | `http://127.0.0.1:18789`      | Forward to a running server instead of writing directly    |
 


### PR DESCRIPTION
## Summary
- Introduces `koina::defaults::DEFAULT_AGENT_ID = "pronoea"` as the single source of truth for the agent id that `aletheia init -y` scaffolds and that `aletheia ingest --nous-id` defaults to.
- `init::Answers::default()` and `IngestArgs::nous_id` (clap `default_value`) both reference the constant, so the two callsites can no longer drift silently.
- Updates `docs/INGEST.md` to reflect the new default (was: `default`, now: `pronoea`).
- Migrates the existing `init::helpers::default_answers_produce_valid_config` assertion off the bare literal `"pronoea"` onto the shared constant.

## Why
A user following the documented hello-world path (`init -y`, then `ingest some-file.md` with no `--nous-id`) targeted a nous_id (`"default"`) that didn't exist in the freshly scaffolded instance, because `init` always creates only `pronoea`. The mandate for #4245 is "align defaults — fix is one of two places"; this PR aligns them by routing both through a shared constant, which is strictly less work for future readers than picking either literal to win.

## Test plan
- New: `commands::ingest::tests::ingest_default_nous_id_matches_shared_default_agent_id` parses `IngestArgs` from a no-flag invocation and asserts the resulting `nous_id` equals `koina::defaults::DEFAULT_AGENT_ID`.
- Migrated: `init::helpers::tests::default_answers_produce_valid_config` already runs `Answers::default()` end-to-end through `write_config_atomically` and now asserts the scaffolded agent id matches the same constant — so the constant pins both callsites.
- `cargo test -p aletheia --bin aletheia commands::ingest::` → 11/11 pass
- `cargo test -p aletheia --bin aletheia init::` → 11/11 pass
- `kanon gate --full --stamp` → PASS (0 errors, 700 warnings non-blocking; same baseline as main)

Closes #4245