### PR TITLE
fix(aletheia/config): embed default-config snapshots so `config diff --from-version` works from installed binaries (#4160)

### DIFF
--- a/crates/aletheia/src/commands/config.rs
+++ b/crates/aletheia/src/commands/config.rs
@@ -15,6 +15,16 @@ use taxis::registry::{self, ParameterTier};
 
 use crate::error::Result;
 
+/// Bundled default-config snapshots, embedded at compile time so version-pair
+/// diffs work from any installed binary (not just a source checkout).
+///
+/// Adding a new snapshot is one line: drop a `vX.Y.Z.toml` under
+/// `instance.example/versions/` and append it here.
+const BUNDLED_SNAPSHOTS: &[(&str, &str)] = &[(
+    "v0.19.0",
+    include_str!("../../../../instance.example/versions/v0.19.0.toml"),
+)];
+
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum Action {
     /// Generate a new primary encryption key
@@ -42,12 +52,17 @@ pub(crate) enum Action {
         old: Option<PathBuf>,
         /// New config file path
         new: Option<PathBuf>,
-        /// Compare bundled default config for a version (e.g. v0.19.0)
+        /// Compare bundled default config for a version (e.g. v0.19.0).
+        /// Run `aletheia config diff --list-versions` to see what's bundled.
         #[arg(long)]
         from_version: Option<String>,
-        /// Compare bundled default config for a version (e.g. v0.20.0)
+        /// Compare bundled default config for a version (e.g. v0.20.0).
+        /// Run `aletheia config diff --list-versions` to see what's bundled.
         #[arg(long)]
         to_version: Option<String>,
+        /// List the bundled default-config snapshot versions and exit
+        #[arg(long, conflicts_with_all = ["old", "new", "from_version", "to_version"])]
+        list_versions: bool,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -72,14 +87,21 @@ pub(crate) fn run(action: &Action, instance_root: Option<&PathBuf>) -> Result<()
             new,
             from_version,
             to_version,
+            list_versions,
             json,
-        } => run_diff(
-            old.as_deref(),
-            new.as_deref(),
-            from_version.as_deref(),
-            to_version.as_deref(),
-            *json,
-        ),
+        } => {
+            if *list_versions {
+                run_list_versions(*json);
+                return Ok(());
+            }
+            run_diff(
+                old.as_deref(),
+                new.as_deref(),
+                from_version.as_deref(),
+                to_version.as_deref(),
+                *json,
+            )
+        }
     }
 }
 
@@ -212,16 +234,79 @@ struct ChangeEntry {
     new: String,
 }
 
-/// Resolve the path for a versioned default config snapshot.
+/// Look up a bundled default-config snapshot by version tag.
 ///
-/// Snapshots are stored in `instance.example/versions/` relative to the
-/// workspace root. The path is derived from `CARGO_MANIFEST_DIR` at compile
-/// time so the command works when run from the source tree.
-fn version_snapshot_path(version: &str) -> PathBuf {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    manifest_dir
-        .join("../../instance.example/versions")
-        .join(format!("{version}.toml"))
+/// Returns the embedded TOML source. Available versions are listed in
+/// `BUNDLED_SNAPSHOTS`.
+fn bundled_snapshot(version: &str) -> Option<&'static str> {
+    BUNDLED_SNAPSHOTS
+        .iter()
+        .find_map(|(v, body)| (*v == version).then_some(*body))
+}
+
+/// Comma-separated list of bundled snapshot versions, for error messages.
+fn bundled_versions_list() -> String {
+    BUNDLED_SNAPSHOTS
+        .iter()
+        .map(|(v, _)| *v)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Source of a config to diff: a filesystem path or an embedded bundled snapshot.
+#[derive(Debug)]
+enum DiffSource {
+    Path(PathBuf),
+    Bundled { version: String, body: &'static str },
+}
+
+impl DiffSource {
+    fn label(&self) -> String {
+        match self {
+            DiffSource::Path(p) => p.display().to_string(),
+            DiffSource::Bundled { version, .. } => format!("bundled:{version}"),
+        }
+    }
+
+    fn parse_toml(&self) -> Result<toml::Value> {
+        match self {
+            DiffSource::Path(p) => {
+                if !p.exists() {
+                    whatever!("config not found: {}", p.display());
+                }
+                parse_toml_file(p).whatever_context("failed to load config")
+            }
+            DiffSource::Bundled { version, body } => toml::from_str(body)
+                .with_whatever_context(|_| format!("failed to parse bundled snapshot {version}")),
+        }
+    }
+}
+
+fn resolve_version(version: &str) -> Result<DiffSource> {
+    match bundled_snapshot(version) {
+        Some(body) => Ok(DiffSource::Bundled {
+            version: version.to_owned(),
+            body,
+        }),
+        None => whatever!(
+            "no bundled snapshot for {version}; available: {}",
+            bundled_versions_list()
+        ),
+    }
+}
+
+fn run_list_versions(json: bool) {
+    let versions: Vec<&str> = BUNDLED_SNAPSHOTS.iter().map(|(v, _)| *v).collect();
+    if json {
+        let out = serde_json::to_string_pretty(&versions)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"));
+        println!("{out}");
+        return;
+    }
+    println!("Bundled default-config snapshots ({}):", versions.len());
+    for v in &versions {
+        println!("  {v}");
+    }
 }
 
 fn run_diff(
@@ -231,11 +316,12 @@ fn run_diff(
     to_version: Option<&str>,
     json: bool,
 ) -> Result<()> {
-    let (old_path, new_path) = match (old, new, from_version, to_version) {
-        (Some(old), Some(new), None, None) => (old.to_path_buf(), new.to_path_buf()),
-        (None, None, Some(from), Some(to)) => {
-            (version_snapshot_path(from), version_snapshot_path(to))
-        }
+    let (old_src, new_src) = match (old, new, from_version, to_version) {
+        (Some(old), Some(new), None, None) => (
+            DiffSource::Path(old.to_path_buf()),
+            DiffSource::Path(new.to_path_buf()),
+        ),
+        (None, None, Some(from), Some(to)) => (resolve_version(from)?, resolve_version(to)?),
         (Some(_), None, _, _) | (None, Some(_), _, _) => {
             whatever!("provide both <old.toml> and <new.toml> arguments");
         }
@@ -247,15 +333,8 @@ fn run_diff(
         }
     };
 
-    if !old_path.exists() {
-        whatever!("old config not found: {}", old_path.display());
-    }
-    if !new_path.exists() {
-        whatever!("new config not found: {}", new_path.display());
-    }
-
-    let old_toml = parse_toml_file(&old_path).whatever_context("failed to load old config")?;
-    let new_toml = parse_toml_file(&new_path).whatever_context("failed to load new config")?;
+    let old_toml = old_src.parse_toml()?;
+    let new_toml = new_src.parse_toml()?;
 
     let mut old_flat = BTreeMap::new();
     let mut new_flat = BTreeMap::new();
@@ -263,8 +342,8 @@ fn run_diff(
     flatten_toml(&new_toml, "", &mut new_flat);
 
     let mut diff = ConfigDiff {
-        old: old_path.display().to_string(),
-        new: new_path.display().to_string(),
+        old: old_src.label(),
+        new: new_src.label(),
         added: BTreeMap::new(),
         removed: BTreeMap::new(),
         changed: BTreeMap::new(),
@@ -369,6 +448,87 @@ fn flatten_toml(value: &toml::Value, prefix: &str, out: &mut BTreeMap<String, St
         scalar => {
             let formatted = scalar.to_string().trim().to_owned();
             out.insert(prefix.to_owned(), formatted);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn first_bundled() -> (&'static str, &'static str) {
+        // INVARIANT: bundled_snapshots_is_nonempty_and_parses() pins
+        // BUNDLED_SNAPSHOTS to be non-empty, so .first() is Some at runtime.
+        // We assert here defensively for the case where that ordering is
+        // perturbed under nextest / single-test runs.
+        let (v, body) = BUNDLED_SNAPSHOTS
+            .first()
+            .copied()
+            .unwrap_or_else(|| panic!("BUNDLED_SNAPSHOTS must be non-empty"));
+        (v, body)
+    }
+
+    #[test]
+    fn bundled_snapshots_is_nonempty_and_parses() {
+        assert!(
+            !BUNDLED_SNAPSHOTS.is_empty(),
+            "BUNDLED_SNAPSHOTS must include at least one version"
+        );
+        for (version, body) in BUNDLED_SNAPSHOTS {
+            toml::from_str::<toml::Value>(body)
+                .unwrap_or_else(|e| panic!("bundled snapshot {version} must parse as TOML: {e}"));
+        }
+    }
+
+    #[test]
+    fn bundled_snapshot_lookup_round_trips() {
+        for (version, body) in BUNDLED_SNAPSHOTS {
+            let looked_up = bundled_snapshot(version)
+                .unwrap_or_else(|| panic!("bundled_snapshot must find {version}"));
+            assert_eq!(looked_up, *body);
+        }
+    }
+
+    #[test]
+    fn bundled_snapshot_unknown_returns_none() {
+        assert!(bundled_snapshot("v999.999.999").is_none());
+    }
+
+    #[test]
+    fn resolve_version_succeeds_for_bundled() {
+        let (version, _) = first_bundled();
+        let src = match resolve_version(version) {
+            Ok(s) => s,
+            Err(e) => panic!("resolve_version must succeed for bundled {version}: {e}"),
+        };
+        match src {
+            DiffSource::Bundled { version: v, .. } => assert_eq!(v, version),
+            DiffSource::Path(_) => panic!("expected Bundled source"),
+        }
+    }
+
+    #[test]
+    fn resolve_version_rejects_unbundled_with_available_list() {
+        let Err(err) = resolve_version("v0.99.0") else {
+            panic!("must reject unbundled version");
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("v0.99.0") && msg.contains("available:"),
+            "error must name the missing version and list available ones: {msg}"
+        );
+        for (v, _) in BUNDLED_SNAPSHOTS {
+            assert!(msg.contains(v), "available list must include {v}: {msg}");
+        }
+    }
+
+    #[test]
+    fn version_pair_diff_runs_from_bundled_with_no_filesystem() {
+        let (version, _) = first_bundled();
+        if let Err(e) = run_diff(None, None, Some(version), Some(version), false) {
+            panic!(
+                "diff against own bundled snapshot {version} must succeed without filesystem: {e}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

`aletheia config diff --from-version <V> --to-version <V>` resolved snapshots via `env!("CARGO_MANIFEST_DIR").join("../../instance.example/versions/<v>.toml")`, which bakes the *builder's* source-tree path into the binary. An installed/distributed binary at any other location got `Error: new config not found: <stale build path>` for every version query — the help text's "bundled default config" was not actually bundled. (See #4160 for the live reproduction.)

This PR makes "bundled" true.

## What changed

- New `BUNDLED_SNAPSHOTS: &[(&str, &str)]` table embeds each snapshot at compile time via `include_str!`. Adding a new snapshot is a one-line entry next to the file include; runtime lookup is portable across any install location.
- `version_snapshot_path` → `bundled_snapshot` + `resolve_version` + a `DiffSource` enum that abstracts "filesystem path" vs "embedded body". The positional-file form is unchanged.
- Unknown versions now produce a structured error that names the missing version *and* lists what's available, e.g.
  ```
  Error: no bundled snapshot for v0.20.0; available: v0.19.0
  ```
  (previously: `Error: new config not found: /home/<builder>/dev/aletheia/...`)
- New `config diff --list-versions` flag (also supports `--json`) prints the bundled set, so operators can discover what's queryable without grepping the repo.
- Diff output now labels bundled sources as `bundled:vX.Y.Z` rather than a path that doesn't exist on the user's machine.

## Tests

Six new tests in `commands::config::tests`:

- `bundled_snapshots_is_nonempty_and_parses` — every embed parses as TOML at test time; future bad embeds fail fast.
- `bundled_snapshot_lookup_round_trips` / `_unknown_returns_none` cover the lookup function.
- `resolve_version_succeeds_for_bundled` / `_rejects_unbundled_with_available_list` cover the error path including the available-version list.
- `version_pair_diff_runs_from_bundled_with_no_filesystem` — the regression: a version-pair diff completes successfully with zero filesystem dependency.

All 246 `aletheia` bin tests pass. `kanon gate --full --stamp` PASS on `62ecc71a` (0 errors, 700 warnings non-blocking — same baseline as main).

## Smoke

```
$ aletheia config diff --list-versions
Bundled default-config snapshots (1):
  v0.19.0

$ aletheia config diff --from-version v0.19.0 --to-version v0.19.0
Config diff: bundled:v0.19.0 → bundled:v0.19.0
No differences found.

$ aletheia config diff --from-version v0.19.0 --to-version v0.20.0
Error: no bundled snapshot for v0.20.0; available: v0.19.0   (exit 1)

$ aletheia config diff /tmp/old.toml /tmp/new.toml   # positional unchanged
Config diff: /tmp/old.toml → /tmp/new.toml
No differences found.
```

## Out of scope

The issue also notes only one snapshot has ever been generated (v0.19.0, from 2026-04-17), with no release workflow to capture newer versions. That generation gap is real and would let operators meaningfully diff e.g. v0.26.0 → v0.27.0 across an upgrade. It needs a release-time hook plus backfill of v0.20.0..v0.27.0 — orthogonal to the embedding fix and best handled as a separate ship (substrate / release-flow work).

Closes #4160

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p aletheia --bin aletheia commands::config::`
- [x] `kanon gate --full --stamp` PASS
- [x] Smoke: `--list-versions`, self-diff, unknown-version, positional-file paths