### PR TITLE
fix(aletheia/skills): accept frontmatter `name:` as a valid title route (#4234)

### DIFF
--- a/crates/episteme/src/skill.rs
+++ b/crates/episteme/src/skill.rs
@@ -130,13 +130,17 @@ impl std::fmt::Display for SkillParseError {
 
 /// Parse a SKILL.md file into structured skill content.
 ///
-/// Supports optional YAML frontmatter (delimited by `---`) with `tools` and
-/// `domains` fields. Falls back to extracting from markdown sections.
+/// Accepts two title shapes (Claude-Code-compatible):
+/// 1. YAML frontmatter with `name:` (body may omit `# Title`).
+/// 2. Body `# Title` heading (frontmatter optional).
+///
+/// Description is taken from frontmatter `description:` when present, else
+/// from the body text after the H1, else from a `## When to Use` section.
 ///
 /// # Errors
 ///
-/// Returns an error if the document is empty, missing a top-level heading,
-/// or has no description.
+/// Returns an error naming the missing route(s) when no title can be found
+/// on either path, or when no description can be derived.
 pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillParseError> {
     let err = |reason: &str| SkillParseError {
         path: slug.to_owned(),
@@ -144,34 +148,23 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
     };
 
     let (frontmatter, body) = split_frontmatter(source);
-
-    let mut fm_tools: Vec<String> = Vec::new();
-    let mut fm_domains: Vec<String> = Vec::new();
-    let mut fm_triggers: Vec<String> = Vec::new();
-    let mut fm_always = false;
-    if let Some(fm) = frontmatter {
-        for line in fm.lines() {
-            let line = line.trim();
-            if let Some(rest) = line.strip_prefix("tools:") {
-                fm_tools = parse_yaml_array(rest);
-            } else if let Some(rest) = line.strip_prefix("domains:") {
-                fm_domains = parse_yaml_array(rest);
-            } else if let Some(rest) = line.strip_prefix("triggers:") {
-                fm_triggers = parse_yaml_array(rest);
-            } else if let Some(rest) = line.strip_prefix("always:") {
-                fm_always = rest.trim().eq_ignore_ascii_case("true");
-            }
-        }
-    }
+    let fm = parse_frontmatter(frontmatter);
 
     let mut lines = body.lines().peekable();
     while lines.peek().is_some_and(|l| l.trim().is_empty()) {
         lines.next();
     }
 
-    let title_line = lines.next().ok_or_else(|| err("empty document"))?;
-    if !title_line.starts_with("# ") {
-        return Err(err("missing top-level heading (# Title)"));
+    let has_h1 = lines.peek().is_some_and(|l| l.starts_with("# "));
+    if has_h1 {
+        lines.next();
+    } else if fm.name.is_none() {
+        // WHY: title can come from frontmatter `name:` (Claude-Code shape) or
+        // a body `# Title` (legacy aletheia shape). Naming both routes in the
+        // error keeps the failure mode legible — see #4234.
+        return Err(err(
+            "missing title: no `name:` in YAML frontmatter and no `# Title` heading in body",
+        ));
     }
 
     let mut desc_lines = Vec::new();
@@ -185,7 +178,7 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
             desc_lines.push(trimmed.to_owned());
         }
     }
-    let mut description = desc_lines.join(" ");
+    let mut description = fm.description.unwrap_or_else(|| desc_lines.join(" "));
 
     let mut current_section = String::new();
     let mut sections: std::collections::HashMap<String, Vec<String>> =
@@ -208,17 +201,17 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
 
     // kanon:ignore RUST/indexing-slicing — `&[][..]` is an empty-slice literal default for map_or; not real indexing
     let steps = extract_steps(sections.get("steps").map_or(&[][..], |v| v.as_slice()));
-    let tools_used = if fm_tools.is_empty() {
+    let tools_used = if fm.tools.is_empty() {
         // kanon:ignore RUST/indexing-slicing — `&[][..]` is an empty-slice literal default for map_or; not real indexing
         extract_tools(sections.get("tools used").map_or(&[][..], |v| v.as_slice()))
     } else {
-        fm_tools
+        fm.tools
     };
 
-    let domain_tags = if fm_domains.is_empty() {
+    let domain_tags = if fm.domains.is_empty() {
         derive_domain_tags(slug)
     } else {
-        fm_domains
+        fm.domains
     };
 
     if description.is_empty()
@@ -228,7 +221,11 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
     }
 
     if description.is_empty() {
-        return Err(err("no description found"));
+        // WHY: name the routes that were tried so a hand-authored SKILL.md
+        // can be fixed without diffing against the parser source — see #4234.
+        return Err(err(
+            "missing description: no `description:` in YAML frontmatter, no body text after the title, and no `## When to Use` section",
+        ));
     }
 
     Ok(SkillContent {
@@ -238,9 +235,51 @@ pub fn parse_skill_md(source: &str, slug: &str) -> Result<SkillContent, SkillPar
         tools_used,
         domain_tags,
         origin: "seeded".to_owned(),
-        triggers: fm_triggers,
-        always: fm_always,
+        triggers: fm.triggers,
+        always: fm.always,
     })
+}
+
+/// YAML frontmatter fields extracted from a SKILL.md document.
+#[derive(Debug, Default)]
+struct SkillFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    tools: Vec<String>,
+    domains: Vec<String>,
+    triggers: Vec<String>,
+    always: bool,
+}
+
+/// Extract SKILL.md frontmatter fields from the raw YAML block (if any).
+fn parse_frontmatter(raw: Option<&str>) -> SkillFrontmatter {
+    let mut fm = SkillFrontmatter::default();
+    let Some(raw) = raw else {
+        return fm;
+    };
+    for line in raw.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("name:") {
+            let value = parse_yaml_scalar(rest);
+            if !value.is_empty() {
+                fm.name = Some(value);
+            }
+        } else if let Some(rest) = line.strip_prefix("description:") {
+            let value = parse_yaml_scalar(rest);
+            if !value.is_empty() {
+                fm.description = Some(value);
+            }
+        } else if let Some(rest) = line.strip_prefix("tools:") {
+            fm.tools = parse_yaml_array(rest);
+        } else if let Some(rest) = line.strip_prefix("domains:") {
+            fm.domains = parse_yaml_array(rest);
+        } else if let Some(rest) = line.strip_prefix("triggers:") {
+            fm.triggers = parse_yaml_array(rest);
+        } else if let Some(rest) = line.strip_prefix("always:") {
+            fm.always = rest.trim().eq_ignore_ascii_case("true");
+        }
+    }
+    fm
 }
 
 /// Split optional YAML frontmatter from body.
@@ -257,6 +296,24 @@ fn split_frontmatter(source: &str) -> (Option<&str>, &str) {
     } else {
         (None, source)
     }
+}
+
+/// Parse a YAML scalar value (the bit after `key:`).
+///
+/// Strips surrounding whitespace and a single layer of matching single or
+/// double quotes. Returns the empty string for values that are missing,
+/// whitespace-only, or empty after quote stripping.
+fn parse_yaml_scalar(s: &str) -> String {
+    let s = s.trim();
+    let stripped = s
+        .strip_prefix('"')
+        .and_then(|inner| inner.strip_suffix('"'))
+        .or_else(|| {
+            s.strip_prefix('\'')
+                .and_then(|inner| inner.strip_suffix('\''))
+        })
+        .unwrap_or(s);
+    stripped.to_owned()
 }
 
 /// Parse a simple YAML inline array like `[web_fetch, web_search]`.

--- a/crates/episteme/src/skill_tests.rs
+++ b/crates/episteme/src/skill_tests.rs
@@ -95,21 +95,130 @@ fn parse_skill_derives_domain_tags_from_slug() {
 
 #[test]
 fn parse_skill_missing_heading_fails() {
+    // WHY (#4234): with no frontmatter `name:` AND no body `# Title`, the
+    // error must name *both* routes that were tried — silent rejection of a
+    // hand-authored SKILL.md was the failure mode the issue surfaced.
     let bad = "No heading here\n\n## Steps\n1. Do stuff";
     let err = parse_skill_md(bad, "bad-skill").expect_err("bad skill md must fail");
     assert!(
-        err.reason.contains("missing top-level heading"),
-        "error reason should mention missing heading"
+        err.reason.contains("missing title"),
+        "error reason should mention missing title, got: {}",
+        err.reason
+    );
+    assert!(
+        err.reason.contains("`name:`") && err.reason.contains("`# Title`"),
+        "error reason should name both the frontmatter and body routes, got: {}",
+        err.reason
     );
 }
 
 #[test]
 fn parse_skill_empty_doc_fails() {
+    // WHY (#4234): empty doc has neither route — same title error as above.
     let err = parse_skill_md("", "empty").expect_err("empty skill md must fail");
     assert!(
-        err.reason.contains("empty document"),
-        "error reason should mention empty document"
+        err.reason.contains("missing title"),
+        "error reason should mention missing title, got: {}",
+        err.reason
     );
+}
+
+#[test]
+fn parse_skill_frontmatter_only_no_h1_succeeds() {
+    // WHY (#4234): Claude-Code-style SKILL.md files use frontmatter `name:`
+    // + `description:` with no body `# Title`. Aletheia must accept this
+    // shape — silent rejection was the bug.
+    let src = "---\nname: example\ndescription: A test skill\n---\nBody without H1.\n";
+    let skill = parse_skill_md(src, "example").expect("frontmatter-only SKILL.md must parse");
+    assert_eq!(skill.name, "example", "name should match slug");
+    assert_eq!(
+        skill.description, "A test skill",
+        "description should come from frontmatter when no body description present"
+    );
+}
+
+#[test]
+fn parse_skill_frontmatter_description_overrides_body() {
+    // WHY (#4234): when both routes provide a description, frontmatter wins
+    // (it's the canonical, machine-readable source). Pins the precedence.
+    let src = "---\nname: example\ndescription: From frontmatter\n---\n# Example\nFrom body.\n";
+    let skill = parse_skill_md(src, "example").expect("parse ok");
+    assert_eq!(
+        skill.description, "From frontmatter",
+        "frontmatter description should take precedence over body text"
+    );
+}
+
+#[test]
+fn parse_skill_frontmatter_with_h1_still_works() {
+    // WHY (#4234): the aletheia exporter writes both `name:` in frontmatter
+    // AND a body `# Title`. This regression test pins that round-trip.
+    let src =
+        "---\nname: example\ndescription: Round-trip test\n---\n\n# Example\n\n## Steps\n1. Go\n";
+    let skill = parse_skill_md(src, "example").expect("round-trip shape must parse");
+    assert_eq!(skill.description, "Round-trip test");
+    assert_eq!(skill.steps, vec!["Go"]);
+}
+
+#[test]
+fn parse_skill_no_name_no_h1_with_description_still_fails() {
+    // WHY (#4234): description alone is not enough — title is required.
+    // Pins that the title gate is independent of the description gate.
+    let src = "---\ndescription: A test skill\n---\nBody without title.\n";
+    let err = parse_skill_md(src, "slug").expect_err("must fail without title");
+    assert!(
+        err.reason.contains("missing title"),
+        "error should mention missing title, got: {}",
+        err.reason
+    );
+}
+
+#[test]
+fn parse_skill_frontmatter_name_no_description_fails() {
+    // WHY (#4234): with `name:` but no description anywhere, the error must
+    // name all three description routes that were tried.
+    let src = "---\nname: example\n---\n";
+    let err = parse_skill_md(src, "example").expect_err("must fail without description");
+    assert!(
+        err.reason.contains("missing description"),
+        "error should mention missing description, got: {}",
+        err.reason
+    );
+    assert!(
+        err.reason.contains("`description:`")
+            && err.reason.contains("body text")
+            && err.reason.contains("When to Use"),
+        "error should name all three description routes, got: {}",
+        err.reason
+    );
+}
+
+#[test]
+fn parse_skill_frontmatter_description_quoted() {
+    // WHY (#4234): the aletheia exporter quotes descriptions containing
+    // colons. The parser must strip those quotes when re-reading.
+    let src = "---\nname: example\ndescription: \"Error handling: a deep dive\"\n---\nBody.\n";
+    let skill = parse_skill_md(src, "example").expect("parse ok");
+    assert_eq!(
+        skill.description, "Error handling: a deep dive",
+        "frontmatter quote-stripping should restore the original description"
+    );
+}
+
+#[test]
+fn parse_skill_frontmatter_empty_name_falls_back_to_h1() {
+    // WHY (#4234): an empty `name:` value is treated as absent — the H1 gate
+    // re-engages so we don't accept blank-name skills silently.
+    let src_no_h1 = "---\nname:\ndescription: x\n---\nBody.\n";
+    let err = parse_skill_md(src_no_h1, "slug").expect_err("empty name + no H1 must fail");
+    assert!(
+        err.reason.contains("missing title"),
+        "empty name should not satisfy title requirement, got: {}",
+        err.reason
+    );
+
+    let src_with_h1 = "---\nname:\ndescription: x\n---\n# Title\nBody.\n";
+    parse_skill_md(src_with_h1, "slug").expect("empty name + H1 must parse");
 }
 
 #[test]
@@ -129,8 +238,9 @@ fn parse_skill_no_description_at_all_fails() {
     let err = parse_skill_md(md, "no-desc")
         .expect_err("skill without any description must fail to parse");
     assert!(
-        err.reason.contains("no description"),
-        "error reason should mention missing description"
+        err.reason.contains("missing description"),
+        "error reason should mention missing description, got: {}",
+        err.reason
     );
 }
 

--- a/crates/episteme/tests/public_api.rs
+++ b/crates/episteme/tests/public_api.rs
@@ -611,11 +611,14 @@ mod parse_skill_md {
 
     #[test]
     fn rejects_empty_document() {
+        // WHY (#4234): an empty document has neither a frontmatter `name:`
+        // nor a body `# Title`, so it fails the title gate with the
+        // both-routes-named message.
         let err = parse_skill_md("", "my-skill").expect_err("empty must error");
         assert_eq!(err.path, "my-skill");
         assert!(
-            err.reason.contains("empty"),
-            "expected 'empty document' reason, got: {}",
+            err.reason.contains("missing title"),
+            "expected missing-title reason, got: {}",
             err.reason
         );
     }


### PR DESCRIPTION
## Summary

`parse_skill_md` now accepts two title shapes (Claude-Code-compatible):
1. YAML frontmatter `name:` with optional body H1.
2. Body `# Title` heading (frontmatter optional).

Before this change, hand-authored SKILL.md files that follow the published Claude-Code convention (frontmatter only, no body H1) were silently rejected. The aletheia exporter has always written both shapes so the on-disk round-trip was symmetric — ingest was strictly stricter than emit, and the divergence broke any user trying to seed-skills from a `.claude/skills/` tree.

The fix parses `name:` and `description:` from frontmatter as first-class fields (alongside the existing `tools:`/`domains:`/`triggers:`/`always:`). When both routes provide a description, the frontmatter wins — it's the canonical, machine-readable source.

## Error messages now name every route that was tried

So a parse failure can be diagnosed without diffing against the parser:

```
missing title: no `name:` in YAML frontmatter and no `# Title` heading in body
missing description: no `description:` in YAML frontmatter, no body text after the title, and no `## When to Use` section
```

(Per the issue's "silent rejection" framing — the mid-axis failure mode was that the parser knew which route it tried but didn't say so. These messages make the failure mode legible.)

## Tests added (regression bar)

In `crates/episteme/src/skill_tests.rs`:

- `parse_skill_frontmatter_only_no_h1_succeeds` — the exact repro from the issue body (`name:` + `description:` + body with no H1) now parses.
- `parse_skill_frontmatter_description_overrides_body` — pins frontmatter precedence over body text.
- `parse_skill_frontmatter_with_h1_still_works` — round-trip regression: aletheia's own exporter writes both, must still parse.
- `parse_skill_no_name_no_h1_with_description_still_fails` — title gate is independent of description gate.
- `parse_skill_frontmatter_name_no_description_fails` — asserts the three-route description error names all three.
- `parse_skill_frontmatter_description_quoted` — exporter quotes descriptions with colons; parser must strip.
- `parse_skill_frontmatter_empty_name_falls_back_to_h1` — empty `name:` treated as absent (no blank-name skills accepted silently).
- `parse_skill_missing_heading_fails` updated to assert both routes are named in the error.

Also updated the assertion in the corresponding `tests/public_api.rs` integration test (`rejects_empty_document`) to match the new error message.

## Live repro

```
$ aletheia seed-skills --dir skills --nous-id pronoea --dry-run
Found 1 skill(s) in skills

[dry-run] Would seed 1 skill(s) for nous 'pronoea':
  example: 0 steps, 0 tools, tags: [example]
```

(Was: `SKIP example: failed to parse example: missing top-level heading (# Title)` → `1 skill(s) skipped due to parse errors`.)

## Refactor note

Frontmatter parsing extracted to a private `parse_frontmatter` helper returning a `SkillFrontmatter` struct, to keep `parse_skill_md` under the 100-line `too_many_lines` clippy ceiling.

## Verification

- 141 episteme lib tests + 34 public_api tests + 252 aletheia binary tests green.
- `kanon gate --full --stamp` PASS (0 errors, 702 warnings = main baseline).

Closes #4234