### PR TITLE
fix(aletheia/koina): collapse DEFAULT_MODEL/DEFAULT_MODEL_SHORT to one constant (#4235)

### DIFF
--- a/crates/aletheia/src/commands/add_nous.rs
+++ b/crates/aletheia/src/commands/add_nous.rs
@@ -20,7 +20,7 @@ pub(crate) struct AddNousArgs {
     pub provider: String,
 
     /// Model identifier.
-    #[arg(long, default_value = koina::defaults::DEFAULT_MODEL_SHORT)]
+    #[arg(long, default_value = koina::defaults::DEFAULT_MODEL)]
     pub model: String,
 }
 

--- a/crates/aletheia/src/init/helpers.rs
+++ b/crates/aletheia/src/init/helpers.rs
@@ -84,7 +84,7 @@ mod tests {
                 .and_then(|v| v.get("model"))
                 .and_then(|v| v.get("primary"))
                 .and_then(toml::Value::as_str),
-            Some(koina::defaults::DEFAULT_MODEL_SHORT)
+            Some(koina::defaults::DEFAULT_MODEL)
         );
         let list = agents
             .get("list")
@@ -208,7 +208,7 @@ mod tests {
         );
         assert_eq!(
             config["agents"]["defaults"]["model"]["primary"].as_str(),
-            Some(koina::defaults::DEFAULT_MODEL_SHORT),
+            Some(koina::defaults::DEFAULT_MODEL),
             "default model should be claude-sonnet-4-6"
         );
     }

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -100,7 +100,7 @@ impl Default for Answers {
             root: PathBuf::from("./instance"),
             api_key: None,
             api_provider: "anthropic".to_owned(),
-            model: koina::defaults::DEFAULT_MODEL_SHORT.to_owned(),
+            model: koina::defaults::DEFAULT_MODEL.to_owned(),
             agent_id: koina::defaults::DEFAULT_AGENT_ID.to_owned(),
             agent_name: "Pronoea".to_owned(),
             bind: "localhost".to_owned(),
@@ -134,7 +134,7 @@ fn build_non_interactive_answers(
         root,
         api_key,
         api_provider: api_provider.unwrap_or_else(|| "anthropic".to_owned()),
-        model: model.unwrap_or_else(|| koina::defaults::DEFAULT_MODEL_SHORT.to_owned()),
+        model: model.unwrap_or_else(|| koina::defaults::DEFAULT_MODEL.to_owned()),
         auth_mode: auth_mode.unwrap_or_else(|| "none".to_owned()),
         credential_source,
         ..Answers::default()
@@ -285,7 +285,7 @@ fn collect_interactive(mut answers: Answers) -> Result<Answers, InitError> {
 
     let model: &str = cliclack::select("Default model")
         .item(
-            koina::defaults::DEFAULT_MODEL_SHORT,
+            koina::defaults::DEFAULT_MODEL,
             "claude-sonnet-4-6 (recommended)",
             "",
         )

--- a/crates/koina/src/defaults.rs
+++ b/crates/koina/src/defaults.rs
@@ -5,11 +5,22 @@
 /// Default configuration file path relative to instance root.
 pub const DEFAULT_CONFIG_PATH: &str = "config/aletheia.toml";
 
-/// Default LLM model identifier (full form).
-pub const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
-
-/// Default LLM model identifier (short form used in config files).
-pub const DEFAULT_MODEL_SHORT: &str = "claude-sonnet-4-6";
+/// Default LLM model identifier.
+///
+/// Single source of truth for the model every aletheia subsystem defaults to
+/// when no explicit model is configured: `aletheia init` scaffold, `add-nous`
+/// CLI default, runtime spawn fallback (`SONNET_MODEL`), pylon request
+/// fallback, `agent_io` export fallback, melete distillation default, taxis
+/// `ModelSpec` default, and theatron wizard model picker.
+///
+/// Defining the default in two places (formerly `DEFAULT_MODEL` and
+/// `DEFAULT_MODEL_SHORT`, #4235) routed `aletheia init` to one model and
+/// runtime spawn/distillation to a different one — a silent downgrade
+/// invisible at config time. Keep this as the only model default constant in
+/// the workspace; `crates/koina/tests/model_default_consistency.rs` walks the
+/// source tree and fails loudly if a second `DEFAULT_MODEL*` constant
+/// reappears.
+pub const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
 
 /// Default nous-agent identifier created by `aletheia init -y` and assumed by
 /// CLI subcommands that take `--nous-id`. Single source of truth so that

--- a/crates/koina/tests/model_default_consistency.rs
+++ b/crates/koina/tests/model_default_consistency.rs
@@ -1,0 +1,185 @@
+//! Cross-crate consistency test for `koina::defaults::DEFAULT_MODEL`.
+//!
+//! WHY (#4235): before this campaign there were two model-default constants
+//! — `DEFAULT_MODEL` (Sonnet 4.0, May 2025) and `DEFAULT_MODEL_SHORT`
+//! (Sonnet 4.6). The names suggested they were two forms of one model;
+//! they were two different models. `aletheia init` and `add-nous`
+//! scaffolded Sonnet 4.6 while runtime spawn, distillation, and pylon
+//! request-fallback silently routed to Sonnet 4.0 — a downgrade invisible
+//! at config time.
+//!
+//! The collapse to a single `DEFAULT_MODEL` only holds if it stays a
+//! single constant. This test walks the workspace and fails loudly if a
+//! second `DEFAULT_MODEL*` constant reappears anywhere outside the
+//! authoritative source-of-truth (`crates/koina/src/defaults.rs`).
+
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Resolve the workspace root via koina's `CARGO_MANIFEST_DIR` (== `crates/koina`).
+fn workspace_root() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest_dir)
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("workspace root resolves from CARGO_MANIFEST_DIR/../..")
+}
+
+/// Recursively collect every `.rs` file under `dir` into `out`.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip target/, .git/, fuzz corpora — they are not workspace source.
+            let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if matches!(name, "target" | ".git" | "node_modules") {
+                continue;
+            }
+            collect_rs_files(&path, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// True iff `line` declares a `pub const DEFAULT_MODEL[_*]: &str = ...`.
+///
+/// Restrictions are deliberate, both narrowing what counts as "drift":
+///
+/// 1. **`pub const` only.** A module-private `const DEFAULT_MODEL` inside a
+///    provider crate (e.g. `hermeneus::kimi::DEFAULT_MODEL =
+///    "kimi/kimi-k2-thinking"`) is that provider's local default, not a
+///    workspace-wide one — it cannot be imported and silently override the
+///    real default the way #4235's `DEFAULT_MODEL_SHORT` did.
+/// 2. **`: &str` only.** The drift pattern is two different *model name
+///    strings*. A numeric `DEFAULT_MODEL_VERSION: u32 = 4` is harmless.
+/// 3. **Name starts with `DEFAULT_MODEL`.** Matches the bare name and any
+///    suffixed variant (`_SHORT`, `_FULL`, `_FALLBACK`, …). The dual-name
+///    suffix is the specific pattern the issue called out.
+///
+/// A reviewer adding e.g. `pub const DEFAULT_MODEL_DIR: &str` to koina
+/// itself would trip this test as a false positive — that's fine; it's a
+/// loud prompt to either rename or add a justified allowlist entry.
+fn declares_pub_default_model_str(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let Some(rest) = trimmed.strip_prefix("pub const ") else {
+        return false;
+    };
+    let Some((ident, after)) = rest.split_once(':') else {
+        return false;
+    };
+    if !ident.trim_end().starts_with("DEFAULT_MODEL") {
+        return false;
+    }
+    after.trim_start().starts_with("&str")
+}
+
+#[test]
+fn default_model_value_pinned_to_sonnet_4_6() {
+    // WHY: the issue identified Sonnet 4.6 as the single shared default —
+    // `aletheia init`, `add-nous`, theatron wizard, and the documented
+    // `instance.example/config/aletheia.toml` all converged on it before
+    // the collapse. Pinning the constant here makes any future "drive-by
+    // bump" visible in the diff.
+    assert_eq!(koina::defaults::DEFAULT_MODEL, "claude-sonnet-4-6");
+}
+
+#[test]
+fn only_one_default_model_constant_in_workspace() {
+    let root = workspace_root();
+    let crates_dir = root.join("crates");
+    assert!(
+        crates_dir.is_dir(),
+        "expected workspace crates/ at {}",
+        crates_dir.display()
+    );
+
+    let mut files = Vec::new();
+    collect_rs_files(&crates_dir, &mut files);
+
+    let mut declarations: Vec<(PathBuf, usize, String)> = Vec::new();
+    for path in &files {
+        let Ok(text) = fs::read_to_string(path) else {
+            continue;
+        };
+        for (idx, line) in text.lines().enumerate() {
+            if declares_pub_default_model_str(line) {
+                declarations.push((path.clone(), idx + 1, line.trim().to_owned()));
+            }
+        }
+    }
+
+    // The one true source-of-truth (relative to workspace root for stable error messages).
+    let canonical = root.join("crates/koina/src/defaults.rs");
+
+    let extras: Vec<&(PathBuf, usize, String)> = declarations
+        .iter()
+        .filter(|(path, _, _)| path != &canonical)
+        .collect();
+
+    assert!(
+        extras.is_empty(),
+        "found `DEFAULT_MODEL*: &str` constants outside crates/koina/src/defaults.rs \
+         (re-introduces the #4235 silent-drift pattern):\n{}",
+        extras
+            .iter()
+            .map(|(p, line, src)| format!(
+                "  {}:{} — {}",
+                p.strip_prefix(&root).unwrap_or(p).display(),
+                line,
+                src
+            ))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    let in_canonical: Vec<&(PathBuf, usize, String)> = declarations
+        .iter()
+        .filter(|(path, _, _)| path == &canonical)
+        .collect();
+    assert_eq!(
+        in_canonical.len(),
+        1,
+        "expected exactly one `DEFAULT_MODEL*: &str` declaration in koina/src/defaults.rs, \
+         found {}: {:?}",
+        in_canonical.len(),
+        in_canonical
+            .iter()
+            .map(|(_, line, src)| format!("L{line}: {src}"))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn helper_detects_declaration_shapes() {
+    // WHY: the cross-crate test above is only as good as the line-pattern
+    // it matches. Lock the patterns it accepts here so a future refactor
+    // of the helper doesn't silently weaken the workspace walk.
+    assert!(declares_pub_default_model_str(
+        "pub const DEFAULT_MODEL: &str = \"x\";"
+    ));
+    assert!(declares_pub_default_model_str(
+        "    pub const DEFAULT_MODEL_SHORT: &str = \"y\";"
+    ));
+    assert!(declares_pub_default_model_str(
+        "pub const DEFAULT_MODEL_FALLBACK: &str = \"z\";"
+    ));
+    assert!(!declares_pub_default_model_str(
+        "const DEFAULT_MODEL: &str = \"kimi/kimi-k2-thinking\";"
+    ));
+    assert!(!declares_pub_default_model_str(
+        "pub const DEFAULT_AGENT_ID: &str = \"x\";"
+    ));
+    assert!(!declares_pub_default_model_str(
+        "pub const DEFAULT_MODEL_VERSION: u32 = 4;"
+    ));
+    assert!(!declares_pub_default_model_str(
+        "let DEFAULT_MODEL: &str = \"x\";"
+    ));
+}

--- a/crates/melete/src/distill_tests/threshold_prompt.rs
+++ b/crates/melete/src/distill_tests/threshold_prompt.rs
@@ -460,10 +460,14 @@ async fn distill_whitespace_only_response_returns_empty_summary_error() {
 
 #[test]
 fn config_default_model() {
+    // WHY (#4235): pin against the workspace-wide `DEFAULT_MODEL` constant
+    // rather than a literal, so distillation cannot silently diverge from
+    // what `aletheia init` and `add-nous` scaffold.
     let config = DistillConfig::default();
     assert_eq!(
-        config.model, "claude-sonnet-4-20250514",
-        "default model should be claude-sonnet-4-20250514"
+        config.model,
+        koina::defaults::DEFAULT_MODEL,
+        "default model should match koina::defaults::DEFAULT_MODEL"
     );
 }
 

--- a/crates/melete/tests/public_api_distill.rs
+++ b/crates/melete/tests/public_api_distill.rs
@@ -14,12 +14,14 @@ mod distill_config {
     use melete::distill::{DistillConfig, DistillSection};
 
     #[test]
-    fn default_uses_claude_sonnet_primary_model() {
-        // WHY: downstream callers read `config.model` straight through to the
-        // provider. Silently changing the default would re-route every
-        // distillation to a different model at potentially higher cost.
+    fn default_uses_workspace_default_model() {
+        // WHY: distillation's default model must track the workspace
+        // `koina::defaults::DEFAULT_MODEL` constant. Pinning a literal here
+        // is what produced #4235 — `aletheia init` defaulted to Sonnet 4.6
+        // while distillation silently downgraded to Sonnet 4.0. Assert
+        // against the constant so any future drift fails this test loudly.
         let config = DistillConfig::default();
-        assert_eq!(config.model, "claude-sonnet-4-20250514");
+        assert_eq!(config.model, koina::defaults::DEFAULT_MODEL);
     }
 
     #[test]

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -349,6 +349,16 @@ mod tests {
         (dir, oikos)
     }
 
+    // WHY (#4235): the Coder/Researcher role templates now resolve to
+    // `koina::defaults::DEFAULT_MODEL` (Sonnet 4.6), not the old date-pinned
+    // Sonnet 4.0 literal. The mock provider's supported-models list must
+    // include the workspace default so `spawn_and_run` can route Coder tasks.
+    const SUPPORTED_MOCK_MODELS: &[&str] = &[
+        koina::defaults::DEFAULT_MODEL,
+        "claude-sonnet-4-20250514",
+        "claude-haiku-4-5-20251001",
+    ];
+
     fn make_providers() -> Arc<ProviderRegistry> {
         let response = CompletionResponse {
             id: "msg_mock".to_owned(),
@@ -368,8 +378,7 @@ mod tests {
         };
         let mut providers = ProviderRegistry::new();
         providers.register(Box::new(
-            MockProvider::with_responses(vec![response])
-                .models(&["claude-sonnet-4-20250514", "claude-haiku-4-5-20251001"]),
+            MockProvider::with_responses(vec![response]).models(SUPPORTED_MOCK_MODELS),
         ));
         Arc::new(providers)
     }
@@ -407,9 +416,12 @@ mod tests {
     async fn spawn_inherits_empirical_router_and_records_outcome() {
         let (_dir, oikos) = make_oikos();
         let store = Arc::new(AfterActionStore::in_memory());
+        // WHY (#4235): align the router fixture with the Coder role template's
+        // model (`koina::defaults::DEFAULT_MODEL`) so the AfterActionStore key
+        // matches the model the spawn pipeline actually selects.
         let router: Arc<dyn aletheia_routing::Router> = Arc::new(RecordingRouter::new(
             Arc::clone(&store),
-            "claude-sonnet-4-20250514",
+            koina::defaults::DEFAULT_MODEL,
         ));
         let svc = make_spawn_service(oikos).with_runtime_services(InheritedSpawnServices {
             embedding_provider: None,
@@ -438,7 +450,7 @@ mod tests {
 
         assert!(!result.is_error, "unexpected error: {}", result.content);
 
-        let provider = ProviderId::new("claude-sonnet-4-20250514");
+        let provider = ProviderId::new(koina::defaults::DEFAULT_MODEL);
         for _ in 0..20 {
             if let Some(stats) = store
                 .rolling_stats(&provider, &TaskCategory::Feature, Duration::from_hours(168))
@@ -458,11 +470,16 @@ mod tests {
     #[test]
     fn spawn_uses_role_default_model() {
         use crate::roles::Role;
-        assert_eq!(Role::Coder.template().model, "claude-sonnet-4-20250514");
+        // WHY (#4235): Coder/Researcher templates inherit from `SONNET_MODEL
+        // = koina::defaults::DEFAULT_MODEL`. Assert against the constant so
+        // template/model drift is caught at the call site, not in production.
+        // Reviewer/Explorer/Runner pin specific dated IDs locally
+        // (Opus 4.0 / Haiku 4.5); those remain literal here.
+        assert_eq!(Role::Coder.template().model, koina::defaults::DEFAULT_MODEL);
         assert_eq!(Role::Reviewer.template().model, "claude-opus-4-20250514");
         assert_eq!(
             Role::Researcher.template().model,
-            "claude-sonnet-4-20250514"
+            koina::defaults::DEFAULT_MODEL
         );
         assert_eq!(Role::Explorer.template().model, "claude-haiku-4-5-20251001");
         assert_eq!(Role::Runner.template().model, "claude-haiku-4-5-20251001");
@@ -527,7 +544,7 @@ mod tests {
         }
 
         fn supported_models(&self) -> &[&str] {
-            &["claude-sonnet-4-20250514"]
+            SUPPORTED_MOCK_MODELS
         }
 
         #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]

--- a/crates/taxis/src/config/agents.rs
+++ b/crates/taxis/src/config/agents.rs
@@ -255,7 +255,7 @@ pub struct ModelSpec {
 impl Default for ModelSpec {
     fn default() -> Self {
         Self {
-            primary: koina::defaults::DEFAULT_MODEL_SHORT.to_owned(),
+            primary: koina::defaults::DEFAULT_MODEL.to_owned(),
             fallbacks: Vec::new(),
             retries_before_fallback: 2,
         }

--- a/crates/theatron/koilon/src/wizard/state.rs
+++ b/crates/theatron/koilon/src/wizard/state.rs
@@ -286,7 +286,7 @@ pub(crate) static AUTH_OPTIONS: &[SelectOption] = &[
 
 pub(crate) static MODEL_OPTIONS: &[SelectOption] = &[
     SelectOption {
-        value: koina::defaults::DEFAULT_MODEL_SHORT,
+        value: koina::defaults::DEFAULT_MODEL,
         label: "claude-sonnet-4-6 (recommended)",
     },
     SelectOption {
@@ -383,12 +383,7 @@ fn make_agent_step() -> StepState {
                 "pronoea",
                 "alphanumeric + hyphens, used in paths",
             ),
-            WizardField::select(
-                "Model",
-                MODEL_OPTIONS,
-                koina::defaults::DEFAULT_MODEL_SHORT,
-                "",
-            ),
+            WizardField::select("Model", MODEL_OPTIONS, koina::defaults::DEFAULT_MODEL, ""),
         ],
         cursor: 0,
         editing: None,
@@ -666,7 +661,7 @@ mod tests {
         assert_eq!(answers.auth_mode, "none");
         assert_eq!(answers.agent_name, "Pronoea");
         assert_eq!(answers.agent_id, "pronoea");
-        assert_eq!(answers.model, koina::defaults::DEFAULT_MODEL_SHORT);
+        assert_eq!(answers.model, koina::defaults::DEFAULT_MODEL);
         assert!(answers.api_key.is_none());
     }
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -737,7 +737,7 @@ The session history remains in the archive. Start a fresh session for new work.
 
 ### Configuration
 
-The distillation model defaults to `claude-sonnet-4-20250514`. To use a cheaper model for summaries, set `distillation_model` under `[agents.defaults]` in `instance/config/aletheia.toml`. This field is hot-reloadable (no restart needed).
+The distillation model defaults to the workspace-wide `koina::defaults::DEFAULT_MODEL` (currently `claude-sonnet-4-6`; the single source of truth, see #4235). To use a cheaper model for summaries, set `distillation_model` under `[agents.defaults]` in `instance/config/aletheia.toml`. This field is hot-reloadable (no restart needed).
 
 ---
 


### PR DESCRIPTION
Closes #4235.

## Summary

Two model-default constants in `koina::defaults` — `DEFAULT_MODEL` (Sonnet 4.0, date-pinned `claude-sonnet-4-20250514`) and `DEFAULT_MODEL_SHORT` (Sonnet 4.6, `claude-sonnet-4-6`) — were used inconsistently across the workspace:

| Subsystem | Was using | Effective model |
|---|---|---|
| `aletheia init`, `add-nous`, theatron wizard, taxis `ModelSpec` default | `DEFAULT_MODEL_SHORT` | Sonnet 4.6 |
| nous spawn (`SONNET_MODEL`), nous roles, melete distillation, pylon request fallback, agent_io export fallback | `DEFAULT_MODEL` | Sonnet 4.0 |

`aletheia init` scaffolded Sonnet 4.6; distillation, spawn, and pylon fallback silently routed to Sonnet 4.0 when no model was specified. Distillation in particular was a quiet downgrade invisible at config time. The constant names (`MODEL` / `MODEL_SHORT`) suggested two forms of one model; they were two different models.

## What changed

- `crates/koina/src/defaults.rs`: collapse to a single `DEFAULT_MODEL = "claude-sonnet-4-6"`. Delete `DEFAULT_MODEL_SHORT`. Doc-comment makes the single-source-of-truth claim explicit and points at the regression test.
- All 8 production call sites that referenced `DEFAULT_MODEL_SHORT` now reference `DEFAULT_MODEL`. Production call sites that referenced the old `DEFAULT_MODEL` are unchanged — they automatically pick up the new value.
- Tests that had been pinned to the buggy `"claude-sonnet-4-20250514"` literal via the default path (melete `DistillConfig::default()` model assertions, nous `Role::Coder` / `Role::Researcher` template-model assertions, spawn-pipeline mock providers, empirical router fixture) now assert against `koina::defaults::DEFAULT_MODEL` so the assertion catches the failure mode it pins (silent value drift) rather than re-pinning a specific string.
- Test fixtures that intentionally exercise the old date-pinned Sonnet 4.0 ID (hermeneus pricing/model catalog, `recall_sources::llm_context` model card, `energeia` session options, melete `build_prompt_downshift_*` cases) keep that literal — those probe specific model behaviors, not the workspace default.

## Regression test

Adds `crates/koina/tests/model_default_consistency.rs`:

- `default_model_value_pinned_to_sonnet_4_6` — locks the constant value so any future drive-by edit shows up in the diff.
- `only_one_default_model_constant_in_workspace` — walks every `crates/*/src/**/*.rs` file and asserts that no second `pub const DEFAULT_MODEL*: &str` declaration exists outside `crates/koina/src/defaults.rs`. Module-private provider-internal constants (e.g. `hermeneus::kimi::DEFAULT_MODEL = "kimi/kimi-k2-thinking"`) are not the workspace-drift pattern this issue describes and are excluded by the `pub` filter; the matcher's accept/reject set is pinned by `helper_detects_declaration_shapes` so a future refactor of the helper can't silently weaken the workspace walk.

This makes re-introducing the drift pattern — adding a second `pub const DEFAULT_MODEL_<SUFFIX>: &str` anywhere — a loud, named test failure instead of a silent runtime divergence.

## Verification

- `cargo test --workspace`: passes (no remaining failures).
- `cargo clippy --workspace --all-targets`: 0 errors.
- `kanon gate --full --stamp --force`: PASS (0 errors, 703 non-blocking warnings — same baseline as main).

## Out of scope (not addressed here)

- nous `OPUS_MODEL = "claude-opus-4-20250514"` and `HAIKU_MODEL = "claude-haiku-4-5-20251001"` in `roles/mod.rs` are independent role-template choices (Reviewer-only and Explorer/Runner-only respectively) — not the workspace default. Left as local consts.
- The hermeneus model catalog (`crates/hermeneus/src/models.rs`) is a registry of supported model IDs, not a default. Untouched.
