### PR TITLE
fix(aletheia/koina): collapse DEFAULT_MODEL/DEFAULT_MODEL_SHORT to one constant (#4235)

### DIFF
--- a/crates/nous/src/distillation.rs
+++ b/crates/nous/src/distillation.rs
@@ -55,7 +55,11 @@ impl Default for DistillTriggerConfig {
         let b = taxis::config::AgentBehaviorDefaults::default();
         Self {
             max_history_share: 0.7,
-            model: "claude-sonnet-4-20250514".to_owned(),
+            // WHY (#4235): nous distillation overrides melete's DistillConfig::default()
+            // model via `model: config.model.clone()` (orchestrate fn). Pinning a literal
+            // here re-introduced the silent Sonnet-4.0 downgrade #4235 collapsed at the
+            // koina level — route through DEFAULT_MODEL so both layers stay aligned.
+            model: koina::defaults::DEFAULT_MODEL.to_owned(),
             verbatim_tail: 3,
             context_token_trigger: b.distillation_context_token_trigger,
             message_count_trigger: b.distillation_message_count_trigger as i64,


### PR DESCRIPTION
## Summary

Closes #4235. Two model-default constants in `koina::defaults` — `DEFAULT_MODEL` (Sonnet 4.0, date-pinned `claude-sonnet-4-20250514`) and `DEFAULT_MODEL_SHORT` (Sonnet 4.6, `claude-sonnet-4-6`) — were used inconsistently across the workspace:

| Callsite | Old | Now |
|---|---|---|
| `aletheia init`, `add-nous`, taxis `ModelSpec`, theatron wizard | `_SHORT` (4.6) | `DEFAULT_MODEL` (4.6) |
| pylon nous handler request fallback | `DEFAULT_MODEL` (4.0) | `DEFAULT_MODEL` (4.6) |
| `nous::spawn_svc::SONNET_MODEL` (Coder/Researcher role templates) | `DEFAULT_MODEL` (4.0) | `DEFAULT_MODEL` (4.6) |
| `aletheia agent_io` export fallback | `DEFAULT_MODEL` (4.0) | `DEFAULT_MODEL` (4.6) |
| `melete::distill::DistillConfig::default()` | `DEFAULT_MODEL` (4.0) | `DEFAULT_MODEL` (4.6) |
| `nous::distillation::DistillTriggerConfig::default()` | literal `"claude-sonnet-4-20250514"` (4.0) | `DEFAULT_MODEL` (4.6) |

Net effect: a freshly-initialized instance no longer config-scaffolds Sonnet 4.6 then silently routes runtime spawn / distillation / pylon fallback to a different model. Distillation in particular was a quiet downgrade — `nous::DistillTriggerConfig` hardcoded the date-pinned 4.0 ID outside the `koina` constant, so even with `melete`'s default updated, the orchestration layer overrode it. Both layers now route through `koina::defaults::DEFAULT_MODEL`.

## Approach

1. `crates/koina/src/defaults.rs` — delete `DEFAULT_MODEL_SHORT`; keep `DEFAULT_MODEL = "claude-sonnet-4-6"` with an extended doc comment naming every callsite and the failure mode the collapse prevents.
2. All consumers of `DEFAULT_MODEL_SHORT` (`add_nous`, `init/*`, taxis `ModelSpec`, theatron wizard) routed through `DEFAULT_MODEL`.
3. `nous::distillation::DistillTriggerConfig::default()` switched from the hardcoded `"claude-sonnet-4-20250514"` literal to `koina::defaults::DEFAULT_MODEL`.
4. Test fixtures that intentionally probe the **old** date-pinned Sonnet 4.0 ID (`recall_sources::llm_context` model catalog, `energeia` engine/http/session test fixtures, `nous::spawn_svc` mock provider list) keep that literal — they're testing specific-model behavior, not the workspace default.
5. Tests that pinned the **default-path** literal (`melete` distill default-model assertions, `nous` role-template assertion, `theatron::koilon` wizard assertion) flip to assert against `koina::defaults::DEFAULT_MODEL` so the assertion catches the failure mode it's pinning (silent value drift) rather than re-pinning a specific string.

## Regression test

Adds `crates/koina/tests/model_default_consistency.rs`:

- `default_model_value_pinned_to_sonnet_4_6` — locks the constant value so any drive-by edit surfaces in the diff.
- `only_one_default_model_constant_in_workspace` — walks every `crates/*/src/**/*.rs` file in the workspace and asserts no second `pub const DEFAULT_MODEL*: &str` declaration exists outside `crates/koina/src/defaults.rs`. Per the mandate's "fail loudly the moment two divergent values reappear", this is the cross-crate consistency check the original divergence escaped.
- `helper_detects_declaration_shapes` — pins the line-matcher's accept/reject set so a refactor of the helper can't silently weaken the workspace walk.

Module-private provider-internal constants (e.g. `hermeneus::kimi::DEFAULT_MODEL = "kimi/kimi-k2-thinking"`) are excluded by the `pub` filter — they're a provider's own default, not a workspace-wide one, and can't be imported and silently override the real default the way `DEFAULT_MODEL_SHORT` did.

## Gate

- `cargo fmt`, `cargo check --workspace`, `cargo clippy --workspace`, `cargo test --workspace`, `cargo audit`, `kanon lint`, fleet-names freshness — all PASS.
- `Gate-Passed: kanon 0.1.0` trailer on commit `a99bbe05`.

## Out of scope

- The `DOC` mention in the issue body about `recall_sources/llm_context.rs:230,388,398` was already deliberate (model catalog entries for the Sonnet 4 generation) — those stay literal.
- The `instance.example/config/aletheia.toml` and ADR templates that document the Sonnet 4.6 string aren't compile-time references; they continue to advertise the workspace default value directly.