### PR TITLE
ci(aletheia): add no-ai-attribution PR gate for body, title, commits (#4278)

### DIFF
--- a/.github/workflows/no-ai-attribution.yml
+++ b/.github/workflows/no-ai-attribution.yml
@@ -1,0 +1,105 @@
+# WHY (#4278): kanon's WORKFLOW/no-ai-attribution rule catches AI-indicator
+# leaks in commit messages during `kanon gate`, but only commit messages and
+# only if gate ran locally. PR bodies are a separate surface — GitHub squashes
+# the PR body into the merge commit, so an emoji in the PR body becomes an
+# emoji in main's git history even with clean commits.
+#
+# This is the defense-in-depth gate. Mirrors the basanos::ai_attribution regex
+# verbatim so the rule moves in lock-step with the source-of-truth check.
+# Required-check enablement is an operator action (Settings → Branches).
+name: No AI Attribution
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no-ai-attribution:
+    name: no-ai-attribution
+    runs-on: self-hosted
+    timeout-minutes: 3
+    steps:
+      - name: Pass trusted automation PRs
+        if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'release-please[bot]' || github.actor == 'github-actions[bot]' }}
+        run: echo "AI attribution check waived for trusted automation actor."
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'release-please[bot]' && github.actor != 'github-actions[bot]' }}
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # WHY: regex mirrors kanon `crates/basanos/src/ai_attribution.rs`
+      # `ai_attribution_pattern()` verbatim. Basanos owns the source-of-truth
+      # pattern (used by both the `WORKFLOW/no-ai-attribution` lint rule and
+      # the MCP forge-tool guards). If basanos updates its pattern, this gate
+      # must update too; there is no automated cross-repo sync, so any drift
+      # observed should be filed as a friction issue against this workflow.
+      - name: Scan PR body and title for AI attribution
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'release-please[bot]' && github.actor != 'github-actions[bot]' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Mirror of basanos::ai_attribution::AI_ATTRIBUTION_PATTERN.
+          # POSIX ERE; case-insensitive applied via grep -i.
+          PATTERN='Co-Authored-By:[[:space:]]+.*(Claude|GPT|Codex|Kimi|Moonshot|Gemini|Anthropic|OpenAI)|🤖|🧠|Generated with .*Claude|Generated with .*Codex|claude\.com/claude-code'
+
+          BODY=$(gh pr view "$PR_NUMBER" --json body --jq .body)
+          TITLE=$(gh pr view "$PR_NUMBER" --json title --jq .title)
+
+          fail=0
+
+          if printf '%s' "$BODY" | grep -niE "$PATTERN"; then
+            echo "::error::PR body contains AI generation indicator(s) above."
+            echo "::error::Remove the indicator(s) from the PR body and push or edit again."
+            fail=1
+          fi
+
+          if printf '%s' "$TITLE" | grep -niE "$PATTERN"; then
+            echo "::error::PR title contains AI generation indicator(s) above."
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "PR body and title clean of AI attribution."
+
+      - name: Scan PR commits for AI attribution
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'release-please[bot]' && github.actor != 'github-actions[bot]' }}
+        run: |
+          set -euo pipefail
+
+          PATTERN='Co-Authored-By:[[:space:]]+.*(Claude|GPT|Codex|Kimi|Moonshot|Gemini|Anthropic|OpenAI)|🤖|🧠|Generated with .*Claude|Generated with .*Codex|claude\.com/claude-code'
+
+          # WHY: defense-in-depth — `kanon gate` already enforces
+          # WORKFLOW/no-ai-attribution on the commit-message range when run
+          # locally. This re-scan in CI catches the case where gate was
+          # skipped or stamped manually.
+          commits=$(git log --format="%H" "origin/${{ github.base_ref }}..HEAD")
+          fail=0
+          for sha in $commits; do
+            message=$(git log -1 --format="%B" "$sha")
+            if printf '%s' "$message" | grep -niE "$PATTERN"; then
+              echo "::error::Commit $sha contains AI generation indicator(s) above."
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Reword or rebase the offending commit(s) and push again."
+            exit 1
+          fi
+
+          echo "All PR commits clean of AI attribution."


### PR DESCRIPTION
## Summary

Closes #4278.

`kanon gate`'s `WORKFLOW/no-ai-attribution` rule catches AI-indicator boilerplate in **commit-message bodies** when run locally. But PR bodies are a separate surface — GitHub squashes the PR body into the merge commit, so an emoji in the PR body becomes an emoji in main's git history even when every individual commit is clean.

This actually happened on `5e293c5f` (#4216 squash): `kanon gate` had run, every commit was clean, but the PR body contained `\"🤖 Mechanical lint annotation — auto-mergeable per merge-autonomy rules.\"` and got squashed into history. Multiple `gh pr edit` scrub attempts failed the round-trip verify (1969 uploaded vs 1995 returned bytes) before auto-merge fired. This is the defense-in-depth gate for that failure class.

## What this gate does

`.github/workflows/no-ai-attribution.yml` runs on every `pull_request` to `main`:

1. **PR body + title scan** — fetches both via `gh pr view --json body,title --jq …` and greps against the same regex basanos uses. Per-line `::error::` annotations make the offending text visible directly in the PR view.
2. **Commit-message re-scan** — walks `origin/<base_ref>..HEAD`, fails on any indicator. Belt-and-braces for cases where `kanon gate` was skipped or the trailer hand-stamped.
3. **Same actor waiver as `gate-attestation.yml`** — `dependabot[bot]`, `release-please[bot]`, `github-actions[bot]` are passed through.

## Regex source-of-truth

Mirrors `crates/basanos/src/ai_attribution.rs` `ai_attribution_pattern()` verbatim:

\`\`\`
(?i)Co-Authored-By:\\s+.*(Claude|GPT|Codex|Kimi|Moonshot|Gemini|Anthropic|OpenAI)|🤖|🧠|Generated with .*Claude|Generated with .*Codex|claude\\.com/claude-code
\`\`\`

There is no automated cross-repo sync (basanos lives in kanon; this gate lives in aletheia). The workflow's WHY-comment calls this out and asks any observed drift be filed as a friction issue. Pinning a build-time check would require either making the basanos const public or shelling a parser against kanon source from aletheia CI — both are heavier than the maintenance cost of two regex literals.

## Verification

- YAML loads (`python3 -c \"import yaml; yaml.safe_load(open('…'))\"`).
- Positive case: regex matches the literal #4216 leak line.
- Negative case: regex does not match a clean PR body.
- `kanon gate --full --stamp --force`: PASS (after one flake-retry on `thesauros::tools::tests::shell_executor_truncates_at_char_boundary` — passes in isolation, fails sometimes under workspace parallelism; unrelated to this change, also flakes on main).
- `Gate-Passed: kanon 0.1.0` trailer on commit.

## Operator step for full effect

Add `no-ai-attribution / no-ai-attribution` to the required-checks set in main's branch protection. Without that, the gate runs and surfaces failures in the PR view but does not block squash. Strictly an improvement either way; only required-check status gates the merge.

## Out of scope

- Source-side dispatch-wrapper sanitization (option 1 in the issue). That fix lives in kanon dispatch tooling and is the long-term substrate fix; this PR is the aletheia-side defense that doesn't depend on cross-repo coordination.
- Prompt-level changes to kimi/CC (option 3). Less reliable; covered by basanos + this gate as a backstop.