### PR TITLE
fix(koina,nous): add gitleaks+trufflehog scanner-ignore to synthetic API key fixtures (closes #4119)

### DIFF
--- a/crates/koina/src/redact.rs
+++ b/crates/koina/src/redact.rs
@@ -47,14 +47,14 @@ mod tests {
 
     #[test]
     fn redacts_anthropic_api_key() {
-        let input = "using key sk-ant-api03-abcdef123456_789XYZ for requests"; // kanon:ignore SECURITY/hardcoded-openai-api-key -- synthetic key shape used by redaction self-test; not a real credential
+        let input = "using key sk-ant-api03-abcdef123456_789XYZ for requests"; // kanon:ignore SECURITY/hardcoded-openai-api-key + gitleaks:allow + trufflehog:ignore -- synthetic key shape used by redaction self-test; not a real credential
         let output = redact_sensitive(input);
         assert_eq!(output, "using key sk-ant-*** for requests");
     }
 
     #[test]
     fn redacts_generic_sk_key() {
-        let input = "key: sk-proj-abcdefghij1234567890abcdef"; // kanon:ignore SECURITY/hardcoded-openai-api-key -- synthetic key shape used by redaction self-test; not a real credential
+        let input = "key: sk-proj-abcdefghij1234567890abcdef"; // kanon:ignore SECURITY/hardcoded-openai-api-key + gitleaks:allow + trufflehog:ignore -- synthetic key shape used by redaction self-test; not a real credential
         let output = redact_sensitive(input);
         assert_eq!(output, "key: sk-***");
     }

--- a/crates/koina/src/redacting_layer.rs
+++ b/crates/koina/src/redacting_layer.rs
@@ -285,7 +285,7 @@ mod tests {
         let (buf, sub) = setup(&[], &[], 200);
         tracing::subscriber::with_default(sub, || {
             tracing::info!(
-                details = "key is sk-proj-abcdefghij1234567890abcdef end", // kanon:ignore SECURITY/hardcoded-openai-api-key -- synthetic key shape in tracing field; redaction self-test only
+                details = "key is sk-proj-abcdefghij1234567890abcdef end", // kanon:ignore SECURITY/hardcoded-openai-api-key + gitleaks:allow + trufflehog:ignore -- synthetic key shape in tracing field; redaction self-test only
                 "api check"
             );
         });

--- a/crates/nous/src/training/pii.rs
+++ b/crates/nous/src/training/pii.rs
@@ -335,10 +335,10 @@ mod tests {
 
     #[test]
     fn redacts_openai_api_key() {
-        let (out, changed) = redact("OPENAI=sk-proj-abcdefghij1234567890ABCDEF0123456789"); // kanon:ignore SECURITY/hardcoded-openai-api-key -- synthetic key shape for PII detection test; not a real credential
+        let (out, changed) = redact("OPENAI=sk-proj-abcdefghij1234567890ABCDEF0123456789"); // kanon:ignore SECURITY/hardcoded-openai-api-key + gitleaks:allow + trufflehog:ignore -- synthetic key shape for PII detection test; not a real credential
         assert!(changed);
         assert!(out.contains("[REDACTED:"));
-        assert!(!out.contains("sk-proj-abcdefghij1234567890ABCDEF0123456789")); // kanon:ignore SECURITY/hardcoded-openai-api-key -- synthetic key shape for PII detection test; not a real credential
+        assert!(!out.contains("sk-proj-abcdefghij1234567890ABCDEF0123456789")); // kanon:ignore SECURITY/hardcoded-openai-api-key + gitleaks:allow + trufflehog:ignore -- synthetic key shape for PII detection test; not a real credential
     }
 
     #[test]


### PR DESCRIPTION
Closes #4119.

## Background

aletheia#4119 disclosed `crates/koina/src/redact.rs` as containing a live OpenAI API key. Cross-validation by 3 independent reviewers (cross-validate run `20260528T212800Z`) revealed the string is the alphabetically-sequential synthetic fixture `sk-proj-abcdefghij1234567890abcdef` used by the redactor's own self-test, not a real credential. All 5 occurrences across koina + nous are properly annotated with `kanon:ignore SECURITY/hardcoded-openai-api-key` (kanon's own scanner skips them), but third-party scanners (gitleaks, trufflehog, etc.) re-flag the same fixtures because they don't recognize kanon's annotation syntax.

The operator rotated the OpenAI key at the dashboard out of caution before cross-validation; verified no actual leak after.

## Change

Add `gitleaks:allow` + `trufflehog:ignore` directives alongside the existing `kanon:ignore` tag on the 5 fixture lines:

- `crates/koina/src/redact.rs` line 50 (sk-ant-api03 fixture)
- `crates/koina/src/redact.rs` line 57 (sk-proj fixture)
- `crates/koina/src/redacting_layer.rs` line 288 (sk-proj fixture in tracing field)
- `crates/nous/src/training/pii.rs` lines 338, 341 (sk-proj fixture for PII detection test)

Comment-only; zero behavior change. Each fixture remains alphabetically-sequential (low entropy) and is inside `#[cfg(test)]` or test-only code paths.

## Why this is the fix (not history rewrite)

Cross-validate captured the convergent finding: the disclosure was a scanner false positive. A path-scoped `git-filter-repo` would have:
- Targeted the wrong commit (the disclosure cited f1fcff8 which actually touches `.github/workflows/llm-regen.yml`, not redact.rs)
- Missed 4 of the 5 fixture occurrences (path scope only covered redact.rs)
- Cost: 97 tag SHA rewrites, 7 PR rebases, signed-commit chain invalidation, active agent worktree desync
- Achieved: zero security benefit (no real credential to scrub)

Per the standing posture (PHILOSOPHY.md §Presence): the work is true at every level — the comment names what's actually there (synthetic test fixture; multi-scanner ignore directive) rather than performing security theater via history rewrite.

## Verification

```
grep -rn "sk-proj-abcdef\|sk-ant-api03-abcdef" crates/ | wc -l   # 5 lines
grep -rn "gitleaks:allow + trufflehog:ignore" crates/ | wc -l    # 5 lines
```