### PR TITLE
fix(pylon): require bearer auth on insights and planning v1 routes

### DIFF
--- a/crates/pylon/src/handlers/insights.rs
+++ b/crates/pylon/src/handlers/insights.rs
@@ -10,6 +10,7 @@ use tracing::warn;
 use mneme::types::{Message, Role, Session};
 
 use crate::error::{ApiError, BadRequestSnafu, InternalSnafu, NousNotFoundSnafu};
+use crate::extract::Claims;
 use crate::insights::anomaly::detect_anomalies;
 use crate::state::InsightsState;
 use crate::types::insights::{
@@ -52,6 +53,7 @@ fn usize_to_f64(n: usize) -> f64 {
 )]
 pub async fn get_agent_perf(
     State(state): State<InsightsState>,
+    _claims: Claims,
 ) -> Json<AgentPerformanceListResponse> {
     // WHY: Collect agent configs outside spawn_blocking because configs()
     // returns references tied to the manager's lifetime.
@@ -126,6 +128,7 @@ pub async fn get_agent_perf(
 )]
 pub async fn get_agent_perf_one(
     State(state): State<InsightsState>,
+    _claims: Claims,
     Path(id): Path<String>,
 ) -> Result<Json<AgentPerformance>, ApiError> {
     let config = state
@@ -169,6 +172,7 @@ pub async fn get_agent_perf_one(
 )]
 pub async fn get_quality_metrics(
     State(state): State<InsightsState>,
+    _claims: Claims,
 ) -> Json<QualityMetricsResponse> {
     let state_clone = state.clone();
     let (sessions, messages) = tokio::task::spawn_blocking(move || {
@@ -261,6 +265,7 @@ fn validate_optional_date(field: &str, value: Option<&str>) -> Result<(), ApiErr
 )]
 pub async fn get_token_metrics(
     State(state): State<InsightsState>,
+    _claims: Claims,
     Query(query): Query<MetricsQuery>,
 ) -> Result<Json<TokenMetricsResponse>, ApiError> {
     validate_metrics_query(&query)?;
@@ -283,6 +288,7 @@ pub async fn get_token_metrics(
 )]
 pub async fn get_cost_metrics(
     State(state): State<InsightsState>,
+    _claims: Claims,
     Query(query): Query<MetricsQuery>,
 ) -> Result<Json<CostMetricsResponse>, ApiError> {
     validate_metrics_query(&query)?;
@@ -303,7 +309,10 @@ pub async fn get_cost_metrics(
     ),
     security(("bearer_auth" = []))
 )]
-pub async fn get_journal(Query(query): Query<JournalQuery>) -> Json<Vec<JournalEvent>> {
+pub async fn get_journal(
+    _claims: Claims,
+    Query(query): Query<JournalQuery>,
+) -> Json<Vec<JournalEvent>> {
     warn!(
         source = ?query.source,
         level = ?query.level,

--- a/crates/pylon/src/handlers/planning.rs
+++ b/crates/pylon/src/handlers/planning.rs
@@ -18,6 +18,7 @@ use dianoia::verify::{
 use dianoia::workspace::ProjectWorkspace;
 
 use crate::error::{ApiError, InternalSnafu, NotFoundSnafu};
+use crate::extract::Claims;
 use crate::state::PlanningState;
 
 #[path = "planning_dto.rs"]
@@ -44,6 +45,7 @@ use planning_dto::{
 )]
 pub(crate) async fn get_verification(
     State(state): State<PlanningState>,
+    _claims: Claims,
     Path(project_id): Path<String>,
 ) -> Result<Json<VerificationResult>, ApiError> {
     load_project_verification(state.planning_root, project_id, None)
@@ -67,6 +69,7 @@ pub(crate) async fn get_verification(
 )]
 pub(crate) async fn refresh_verification(
     State(state): State<PlanningState>,
+    _claims: Claims,
     Path(project_id): Path<String>,
     body: Option<Json<RefreshRequest>>,
 ) -> Result<Json<VerificationResult>, ApiError> {
@@ -76,7 +79,7 @@ pub(crate) async fn refresh_verification(
         .map(Json)
 }
 
-async fn load_project_verification(
+pub(crate) async fn load_project_verification(
     planning_root: PathBuf,
     project_id: String,
     criteria: Option<Vec<CriterionEvaluation>>,
@@ -320,32 +323,11 @@ impl From<&CriterionEvaluation> for CriterionInput {
     reason = "test: JSON keys and first requirement are known-present"
 )]
 mod tests {
-    use axum::body::Body;
-    use axum::http::{Request, StatusCode};
-    use axum::routing::{get, post};
-    use axum::{Router, body};
-    use tower::ServiceExt as _;
-
     use dianoia::phase::{Phase, PhaseState};
     use dianoia::plan::{Plan, PlanState};
     use dianoia::project::{Project, ProjectMode};
 
     use super::*;
-
-    fn planning_router(root: PathBuf) -> Router {
-        Router::new()
-            .route(
-                "/api/v1/planning/projects/{project_id}/verification",
-                get(get_verification),
-            )
-            .route(
-                "/api/v1/planning/projects/{project_id}/verification/refresh",
-                post(refresh_verification),
-            )
-            .with_state(PlanningState {
-                planning_root: root,
-            })
-    }
 
     fn write_project(root: &std::path::Path, complete: bool) -> String {
         let mut project = Project::new(
@@ -382,24 +364,15 @@ mod tests {
     async fn get_verification_returns_real_result() {
         let dir = tempfile::tempdir().unwrap();
         let project_id = write_project(dir.path(), true);
-        let app = planning_router(dir.path().to_path_buf());
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri(format!(
-                        "/api/v1/planning/projects/{project_id}/verification"
-                    ))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let result = load_project_verification(
+            dir.path().to_path_buf(),
+            project_id.clone(),
+            None,
+        )
+        .await
+        .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let bytes = body::to_bytes(response.into_body(), 64 * 1024)
-            .await
-            .unwrap();
-        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["project_id"], project_id);
         assert_eq!(json["requirements"][0]["status"], "verified");
         assert_eq!(json["requirements"][0]["coverage_pct"], 100);
@@ -407,41 +380,27 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_verification_accepts_synthetic_criterion_input() {
+        use planning_dto::EvidenceInput;
+
         let dir = tempfile::tempdir().unwrap();
         let project_id = write_project(dir.path(), false);
-        let app = planning_router(dir.path().to_path_buf());
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!(
-                        "/api/v1/planning/projects/{project_id}/verification/refresh"
-                    ))
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        serde_json::json!({
-                            "criteria": [{
-                                "criterion": "endpoint returns plan-validity result",
-                                "status": "met",
-                                "evidence": [{
-                                    "kind": "test",
-                                    "content": "synthetic endpoint test"
-                                }],
-                                "detail": "verified by synthetic request"
-                            }]
-                        })
-                        .to_string(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let criteria = vec![CriterionEvaluation {
+            phase_id: None,
+            criterion: "endpoint returns plan-validity result".to_owned(),
+            status: CriterionStatusInput::Met,
+            evidence: vec![EvidenceInput {
+                kind: "test".to_owned(),
+                content: "synthetic endpoint test".to_owned(),
+            }],
+            detail: "verified by synthetic request".to_owned(),
+            proposed_fix: None,
+        }];
+        let result =
+            load_project_verification(dir.path().to_path_buf(), project_id, Some(criteria))
+                .await
+                .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let bytes = body::to_bytes(response.into_body(), 64 * 1024)
-            .await
-            .unwrap();
-        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["requirements"][0]["status"], "verified");
         assert_eq!(
             json["requirements"][0]["evidence"][0]["artifact"],
@@ -452,17 +411,14 @@ mod tests {
     #[tokio::test]
     async fn get_verification_returns_not_found_for_missing_project() {
         let dir = tempfile::tempdir().unwrap();
-        let app = planning_router(dir.path().to_path_buf());
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/v1/planning/projects/missing/verification")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let result =
+            load_project_verification(dir.path().to_path_buf(), "missing".to_owned(), None).await;
+        let Err(err) = result else {
+            panic!("missing project should fail, got Ok");
+        };
+        assert!(
+            matches!(err, ApiError::NotFound { .. }),
+            "expected NotFound, got {err:?}"
+        );
     }
 }

--- a/crates/pylon/tests/public_api_router_auth.rs
+++ b/crates/pylon/tests/public_api_router_auth.rs
@@ -383,6 +383,122 @@ impl KnowledgeWriteRoute {
     }
 }
 
+/// Read-only `/api/v1/...` routes that must reject anonymous requests.
+///
+/// These handlers do not run inside a `route_layer` like knowledge does, and
+/// they do not perform write actions, but they read agent telemetry and
+/// planning state that should not be exposed without a verified bearer.
+fn unauthenticated_read_routes() -> [(Method, &'static str); 8] {
+    [
+        (Method::GET, "/api/v1/metrics/agents"),
+        (Method::GET, "/api/v1/metrics/agents/syn"),
+        (Method::GET, "/api/v1/metrics/quality"),
+        (Method::GET, "/api/v1/metrics/tokens"),
+        (Method::GET, "/api/v1/metrics/costs"),
+        (Method::GET, "/api/v1/journal"),
+        (
+            Method::GET,
+            "/api/v1/planning/projects/some-project/verification",
+        ),
+        (
+            Method::POST,
+            "/api/v1/planning/projects/some-project/verification/refresh",
+        ),
+    ]
+}
+
+#[tokio::test]
+async fn insights_and_planning_routes_reject_missing_bearer_token() {
+    // WHY: insights (`/api/v1/metrics/*`, `/api/v1/journal`) and planning
+    // (`/api/v1/planning/projects/{id}/verification[/refresh]`) handlers
+    // previously did not require Claims and were not behind a `route_layer`,
+    // so anonymous callers could read per-agent token/cost metrics and
+    // planning state. Regression test: every handler under those prefixes
+    // must reject anonymous requests with 401.
+    let env = TestEnv::new().await;
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    for (method, path) in unauthenticated_read_routes() {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method.clone())
+                    .uri(path)
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "{method} {path} must reject anonymous requests"
+        );
+    }
+}
+
+#[tokio::test]
+async fn insights_and_planning_routes_reject_invalid_bearer_token() {
+    let env = TestEnv::new().await;
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    for (method, path) in unauthenticated_read_routes() {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method.clone())
+                    .uri(path)
+                    .header("authorization", "Bearer not.a.valid.jwt")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "{method} {path} must reject invalid bearer"
+        );
+    }
+}
+
+#[tokio::test]
+async fn insights_routes_admit_authenticated_bearer() {
+    // WHY: the auth gate on these handlers should be additive: a valid
+    // bearer still gets through to the handler. Asserts the new Claims
+    // extractor does not break the happy path for the GET handlers.
+    let env = TestEnv::new().await;
+    let token = issue_test_token(&env.state);
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    for path in [
+        "/api/v1/metrics/agents",
+        "/api/v1/metrics/quality",
+        "/api/v1/journal",
+    ] {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::get(path)
+                    .header("authorization", bearer(&token))
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "{path} must succeed with a valid bearer"
+        );
+    }
+}
+
 fn knowledge_write_routes() -> [KnowledgeWriteRoute; 7] {
     [
         KnowledgeWriteRoute {


### PR DESCRIPTION
## Summary

Eight handlers under `/api/v1` advertised `security(("bearer_auth" = []))` in their OpenAPI specs but did not actually enforce auth — they neither took the `Claims` extractor nor lived inside a `route_layer(require_bearer_auth)` like the knowledge subtree. The router admitted anonymous requests, exposing:

- per-agent token & cost metrics (`/api/v1/metrics/agents`, `/api/v1/metrics/agents/{id}`, `/api/v1/metrics/tokens`, `/api/v1/metrics/costs`)
- conversation quality metrics (`/api/v1/metrics/quality`)
- the system journal (`/api/v1/journal`)
- arbitrary project planning state (`/api/v1/planning/projects/{id}/verification[/refresh]`)

This PR adds `_claims: Claims` to those eight handlers so the existing JWT extractor enforces auth before the handler body runs, restoring the contract advertised by the OpenAPI annotations.

## Details

**Handlers updated** (insights + planning, all under `/api/v1/...`):
- `handlers/insights.rs`: `get_agent_perf`, `get_agent_perf_one`, `get_quality_metrics`, `get_token_metrics`, `get_cost_metrics`, `get_journal`
- `handlers/planning.rs`: `get_verification`, `refresh_verification`

**Tests moved one tier down/up**:
- The planning `tests` module previously built `Router::with_state(PlanningState)` and hit handlers over HTTP, which is incompatible with `Claims` (the extractor requires `Arc<AppState>` as the outermost router state). Its three verification-logic tests now call `load_project_verification` directly — that helper is the actual unit being verified.
- HTTP-level auth coverage is added to `tests/public_api_router_auth.rs`, which already builds a real router via `build_router(TestEnv::new().state)`. Three new tests cover the eight previously-unprotected routes:
  1. anonymous request → 401
  2. invalid bearer → 401
  3. valid bearer → handler runs (no false-positive break)

## Test plan

- [x] `cargo test -p pylon` (all 451 lib + 17 router-auth integration tests pass)
- [x] `cargo clippy -p pylon --tests` (clean)
- [ ] CI gate