### PR TITLE
fix(pylon): enforce nous_id scope on per-agent nous handlers

### DIFF
--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -8,7 +8,7 @@ use axum::response::IntoResponse;
 use symbolon::types::Role;
 
 use crate::error::{ApiError, ErrorResponse, FieldError, NousNotFoundSnafu, ValidationFailedSnafu};
-use crate::extract::{Claims, require_role};
+use crate::extract::{Claims, require_nous_access, require_role};
 use crate::state::NousState;
 
 #[path = "nous_dto.rs"]
@@ -30,11 +30,18 @@ pub use nous_dto::{
 )]
 pub async fn list(State(state): State<NousState>, claims: Claims) -> Json<NousListResponse> {
     let include_private = claims.role >= Role::Operator;
+    let scoped = claims.nous_id.as_deref();
     let nous: Vec<NousSummary> = state
         .nous_manager
         .configs()
         .into_iter()
         .filter(|c| include_private || !c.private)
+        // WHY: a token scoped to a single agent must not see other agents in
+        // the discovery list. Without this filter, a scoped Operator could
+        // enumerate every agent's id, model, and name even though the per-
+        // handler `require_nous_access` blocks them from acting on those
+        // agents.
+        .filter(|c| scoped.is_none_or(|s| s == c.id.as_ref()))
         .map(|c| NousSummary {
             id: c.id.to_string(),
             name: c.name.clone().unwrap_or_else(|| c.id.to_string()),
@@ -64,9 +71,10 @@ pub async fn list(State(state): State<NousState>, claims: Claims) -> Json<NousLi
 )]
 pub async fn get_status(
     State(state): State<NousState>,
-    _claims: Claims,
+    claims: Claims,
     Path(id): Path<String>,
 ) -> Result<Json<NousStatus>, ApiError> {
+    require_nous_access(&claims, &id)?;
     let config = state
         .nous_manager
         .get_config(&id)
@@ -115,9 +123,10 @@ pub async fn get_status(
 )]
 pub async fn tools(
     State(state): State<NousState>,
-    _claims: Claims,
+    claims: Claims,
     Path(id): Path<String>,
 ) -> Result<Json<ToolsResponse>, ApiError> {
+    require_nous_access(&claims, &id)?;
     let config = state
         .nous_manager
         .get_config(&id)
@@ -171,6 +180,7 @@ pub async fn recover(
     Path(id): Path<String>,
 ) -> Result<Json<RecoverResponse>, ApiError> {
     require_role(&claims, Role::Operator)?;
+    require_nous_access(&claims, &id)?;
     let handle = state
         .nous_manager
         .get(&id)

--- a/crates/pylon/tests/common/mod.rs
+++ b/crates/pylon/tests/common/mod.rs
@@ -227,6 +227,16 @@ pub fn issue_test_token_as(state: &AppState, role: Role) -> String {
         .expect("issue test token")
 }
 
+/// Issue a JWT scoped to a single `nous_id`, mirroring how an agent-scoped
+/// token would be minted in production. Combined with `Claims` extraction,
+/// scope enforcement via `require_nous_access` rejects cross-agent calls.
+pub fn issue_test_token_scoped(state: &AppState, role: Role, nous_id: &str) -> String {
+    state
+        .jwt_manager
+        .issue_access("test-user", role, Some(nous_id))
+        .expect("issue test token")
+}
+
 pub fn bearer(token: &str) -> String {
     format!("{BEARER_PREFIX}{token}")
 }

--- a/crates/pylon/tests/public_api_router_auth.rs
+++ b/crates/pylon/tests/public_api_router_auth.rs
@@ -15,7 +15,8 @@ use symbolon::types::Role;
 
 mod common;
 use common::{
-    TestEnv, bearer, issue_test_token, issue_test_token_as, permissive_security, read_body_json,
+    TestEnv, bearer, issue_test_token, issue_test_token_as, issue_test_token_scoped,
+    permissive_security, read_body_json,
 };
 
 // Split: build_router construction + auth contracts.
@@ -322,6 +323,116 @@ async fn knowledge_write_routes_reject_valid_bearer_with_readonly_role() {
             "{} {}",
             route.method,
             route.path
+        );
+    }
+}
+
+// ── scoped tokens must not reach agents outside their scope ────────────────
+
+/// Per-agent routes that take an `{id}` path parameter and therefore must
+/// reject a token whose `nous_id` scope does not match the requested agent.
+fn nous_per_agent_routes() -> [(Method, &'static str); 3] {
+    [
+        (Method::GET, "/api/v1/nous/other-agent"),
+        (Method::GET, "/api/v1/nous/other-agent/tools"),
+        (Method::POST, "/api/v1/nous/other-agent/recover"),
+    ]
+}
+
+#[tokio::test]
+async fn nous_routes_reject_token_scoped_to_a_different_agent() {
+    // WHY: a JWT scoped to nous_id=syn must not be able to read status,
+    // enumerate tools, or trigger recovery on `other-agent`. Without
+    // `require_nous_access` on these handlers, an Operator token scoped to
+    // one agent could affect every other agent in the system.
+    let env = TestEnv::new().await;
+    let token = issue_test_token_scoped(&env.state, Role::Operator, "syn");
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    for (method, path) in nous_per_agent_routes() {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method.clone())
+                    .uri(path)
+                    .header("authorization", bearer(&token))
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "{method} {path} must reject cross-agent scoped tokens",
+        );
+        let body = read_body_json(response).await;
+        assert_eq!(
+            body["error"]["code"], "forbidden",
+            "{method} {path} must use the forbidden error envelope"
+        );
+    }
+}
+
+#[tokio::test]
+async fn nous_routes_admit_token_scoped_to_matching_agent() {
+    // WHY: the scope check must be additive — a token scoped to `syn`
+    // still reaches handlers for `/api/v1/nous/syn/...`. Asserts the new
+    // `require_nous_access` calls do not break the happy path.
+    let env = TestEnv::builder().with_actor(true).build().await;
+    let token = issue_test_token_scoped(&env.state, Role::Operator, "syn");
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::get("/api/v1/nous/syn/tools")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "matching scope must reach the handler"
+    );
+}
+
+#[tokio::test]
+async fn nous_list_hides_other_agents_from_scoped_token() {
+    // WHY: a token scoped to a single nous_id should not be able to
+    // enumerate other agents via GET /api/v1/nous, even if those agents
+    // are public. The list filters by the caller's scope (#enumeration).
+    let env = TestEnv::new().await;
+    let token = issue_test_token_scoped(&env.state, Role::Operator, "syn");
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::get(format!("{API_V1}/nous"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_json(response).await;
+    let entries = body["nous"]
+        .as_array()
+        .expect("nous list must be an array");
+    for entry in entries {
+        let id = entry["id"].as_str().expect("entry must have id");
+        assert_eq!(
+            id, "syn",
+            "scoped token must only see its own agent; saw `{id}`"
         );
     }
 }


### PR DESCRIPTION
## Summary

`Claims.nous_id` is a per-token scope: setting it limits a JWT to a single agent. The `require_nous_access` helper exists to enforce that scope, and the sessions handlers (`close`, `archive`, `unarchive`, `purge`, `rename`, `create`) already call it before acting on `session.nous_id`.

The `/api/v1/nous/{id}/...` handlers did not. An Operator token scoped to one agent could call any other agent's endpoints:

- `GET /api/v1/nous/{id}` — read any agent's lifecycle, model, context window, thinking budget
- `GET /api/v1/nous/{id}/tools` — enumerate any agent's tool allowlist
- `POST /api/v1/nous/{id}/recover` — reset any agent's degraded actor

This PR adds `require_nous_access(&claims, &id)` to those three handlers so a scoped token gets `403 forbidden` when targeting an agent outside its scope.

It also tightens `GET /api/v1/nous` (list): a scoped Operator previously saw every public agent in the registry, letting them enumerate ids/names/models for agents they cannot act on. The list now filters by the caller's scope (in addition to the existing `private` filter on role).

## Details

**Handlers updated** (`handlers/nous.rs`):
- `get_status`: claims param renamed `_claims` → `claims`, calls `require_nous_access`
- `tools`: same treatment
- `recover`: already had `require_role(Operator)`; adds `require_nous_access` after it (defense-in-depth — both gates must pass)
- `list`: adds a `scoped.is_none_or(|s| s == c.id.as_ref())` filter

**Test infrastructure** (`tests/common/mod.rs`):
- New `issue_test_token_scoped(state, role, nous_id)` helper mirrors how the binary mints scoped tokens (`JwtManager::issue_access(sub, role, Some(nous_id))`).

**Regression tests** (`tests/public_api_router_auth.rs`):
- `nous_routes_reject_token_scoped_to_a_different_agent`: scoped-to-`syn` token gets 403 on each per-agent route for `other-agent` (status, tools, recover) and the error envelope code is `forbidden`.
- `nous_routes_admit_token_scoped_to_matching_agent`: scoped-to-`syn` token still reaches `/api/v1/nous/syn/tools` (no false-positive break).
- `nous_list_hides_other_agents_from_scoped_token`: a scoped Operator listing `/api/v1/nous` sees only their own agent's id.

## Test plan

- [x] `cargo test -p pylon --lib` (451 pass)
- [x] `cargo test -p pylon --tests` (17 pass)
- [x] `cargo clippy -p pylon --tests` (clean)
- [ ] CI gate