### PR TITLE
fix(aletheia/memory): pin auto-merge unreachable failure mode + honest --help (#4165 F+C-cheap)

### DIFF
--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -25,7 +25,7 @@ pub(crate) enum Action {
         #[arg(long)]
         nous_id: Option<String>,
     },
-    /// Find and merge duplicate entities/facts
+    /// Find and merge duplicate entities (fact-merge not implemented; see #4165)
     Dedup {
         /// Nous agent ID to deduplicate
         #[arg(long)]

--- a/crates/episteme/src/dedup_tests.rs
+++ b/crates/episteme/src/dedup_tests.rs
@@ -237,6 +237,59 @@ fn classify_auto_merge_and_review() {
     assert!(total >= 1);
 }
 
+/// Pins the failure mode named in aletheia#4165(A): with the production
+/// embedding-similarity closure (`|_,_| 0.0`) — the ONLY closure any production
+/// caller passes — the `AutoMerge` bucket is mathematically unreachable.
+///
+/// Max achievable score under embed=0.0 for two identical-name, same-type,
+/// alias-overlapping entities is:
+///   0.4·name(1.0) + 0.3·embed(0.0) + 0.2·type(1.0) + 0.1·alias(1.0) = 0.70
+/// The `AutoMerge` threshold is 0.90. So under the production closure no candidate
+/// can ever reach `AutoMerge` — `run_entity_dedup` always returns zero records
+/// and the maintenance task's `"N entities merged automatically"` log is
+/// structurally always N=0.
+///
+/// This test asserts that property using the SAME fixture as
+/// `classify_auto_merge_and_review` above: the sibling test feeds embed=0.95
+/// and proves `AutoMerge` works *with* embeddings; this test feeds embed=0.0
+/// and proves `AutoMerge` is unreachable *without* them. The pair flips green→red
+/// the moment a real embedding path is wired (per the operator decision in
+/// `planning/research/memory-dedup-reachability.md`), making the change visible.
+#[test]
+fn auto_merge_unreachable_under_production_embedding_closure() {
+    let entities = vec![
+        entity("e1", "Alice Test", "person", vec!["AT"], 2, "2026-01-01"),
+        entity("e2", "alice test", "person", vec!["AT"], 1, "2026-01-02"),
+        entity("e3", "Alicia Test", "person", vec![], 1, "2026-01-03"),
+    ];
+    let candidates = generate_candidates(&entities, &no_embed);
+    let (auto_merge, review) = classify_candidates(candidates);
+    assert!(
+        auto_merge.is_empty(),
+        "production-shape embed closure (always-0.0) must keep auto_merge empty: \
+         max achievable score is 0.4 + 0 + 0.2 + 0.1 = 0.70 < 0.90 AutoMerge threshold; \
+         saw {} candidate(s) with scores [{}]",
+        auto_merge.len(),
+        auto_merge
+            .iter()
+            .map(|c| format!("{:.3}", c.merge_score))
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    assert!(
+        !review.is_empty(),
+        "the e1/e2 exact-name pair should still surface as Review under embed=0.0 \
+         (score 0.70 = Review threshold), so operators can drain via the review queue"
+    );
+    for c in &review {
+        assert!(
+            c.merge_score < 0.90,
+            "Review candidate score {:.3} must be below AutoMerge threshold",
+            c.merge_score
+        );
+    }
+}
+
 #[test]
 fn canonical_most_relationships() {
     let a = entity("e1", "Alice Test", "person", vec![], 5, "2026-01-02");


### PR DESCRIPTION
## Closes part of #4165

Two mechanical pieces from the [operator's Phase-1 triage on #4165](https://github.com/forkwright/aletheia/issues/4165#issuecomment-4566554736) (clauses F and C-cheap). Both are independently shippable and do not touch the AutoMerge reachability path that's gated on the operator's Path-A vs Path-B decision (see #4305).

### F) Test pins the failure mode named in #4165(A)

Adds `auto_merge_unreachable_under_production_embedding_closure` next to the existing `classify_auto_merge_and_review` (`crates/episteme/src/dedup_tests.rs`). Same fixture; the sibling test feeds `embed=0.95` and proves AutoMerge works *with* embeddings. The new test feeds the production closure (`|_,_| 0.0` — what `find_duplicate_entities` and `run_entity_dedup` literally pass) and asserts:

- `auto_merge.is_empty()` — max achievable score under embed=0.0 for two identical-name, same-type, alias-overlapping entities is 0.4·1.0 + 0.3·0.0 + 0.2·1.0 + 0.1·1.0 = **0.70**, which is the Review threshold; AutoMerge (≥ 0.90) is unreachable by construction.
- `!review.is_empty()` — the exact-name pair still surfaces at score 0.70, so the review queue is the only execution channel until/unless Path A wires embeddings.
- every review candidate scores `< 0.90`, so future drift can't degrade the assertion silently.

This is the test that, had it existed when the embedding hookup was deferred, would have caught the divergence on day one. It will flip green→red→green the moment a real embedding path is wired — making the change visible exactly when it lands.

### C-cheap) Drop \"facts\" from `aletheia memory dedup --help`

The subcommand doc said \"Find and merge duplicate entities/facts\", but no production path ever merges facts — the hash-dupe scan only *displays* them. The honest framing names entities only and points to #4165 for the deferred fact-merge work. `crates/aletheia/src/commands/memory/mod.rs:28`.

## Verification

- `cargo nextest run -p episteme --features mneme-engine --lib dedup_tests` — 40/40 pass including the new test.
- `cargo clippy --workspace --all-targets --no-deps` — clean.

## What this PR does NOT do

- Does not touch the AutoMerge reachability path (operator-decision-gated on #4305 / #4165 Path A vs B).
- Does not implement #4165 clauses B (approval path), D (config thresholds), or E (nous-id scoping). Each warrants its own scoping conversation — E in particular requires schema work since the `entities` relation has no `nous_id` column today.

## Standing rules

- Conventional commit (`fix(aletheia/memory): …`).
- No AI indicators.
- One commit (`6208efb5`).