### PR TITLE
fix(pylon): enforce nous_id scope on session read handlers

### DIFF
--- a/crates/pylon/src/handlers/sessions/mod.rs
+++ b/crates/pylon/src/handlers/sessions/mod.rs
@@ -157,15 +157,26 @@ pub async fn create(
     ),
     security(("bearer_auth" = []))
 )]
-#[instrument(skip(state, _claims))]
+#[instrument(skip(state, claims))]
 pub async fn list_sessions(
     State(state): State<SessionsState>,
-    _claims: Claims,
+    claims: Claims,
     Query(params): Query<ListSessionsParams>,
 ) -> Result<Json<ListSessionsResponse>, ApiError> {
     use crate::pagination::{DEFAULT_LIMIT, MAX_LIMIT, PaginatedResponse};
 
-    let nous_id = params.nous_id;
+    // WHY: a token scoped to a single nous_id may only see its own agent's
+    // sessions, regardless of the `nous_id` query parameter. Without this
+    // override, a scoped caller could pass `?nous_id=other-agent` and read
+    // every session for that agent. If the caller's scope contradicts the
+    // requested filter, reject the request rather than silently rewriting it.
+    let nous_id = match (claims.nous_id.as_deref(), params.nous_id.as_deref()) {
+        (Some(scoped), Some(requested)) if scoped != requested => {
+            return Err(ApiError::forbidden("access denied for this agent"));
+        }
+        (Some(scoped), _) => Some(scoped.to_owned()),
+        (None, requested) => requested.map(str::to_owned),
+    };
     let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
 
     let state_clone = state.clone();
@@ -217,13 +228,14 @@ pub async fn list_sessions(
     ),
     security(("bearer_auth" = []))
 )]
-#[instrument(skip(state, _claims))]
+#[instrument(skip(state, claims))]
 pub async fn get_session(
     State(state): State<SessionsState>,
-    _claims: Claims,
+    claims: Claims,
     Path(id): Path<String>,
 ) -> Result<Json<SessionResponse>, ApiError> {
     let session = find_session(&state, &id).await?;
+    require_nous_access(&claims, &session.nous_id)?;
     // WHY: archived sessions must not be visible via normal GET (#3196).
     // The unarchive endpoint uses `find_session` directly (any status),
     // so this filter only affects the read path.
@@ -483,14 +495,15 @@ pub async fn rename(
     ),
     security(("bearer_auth" = []))
 )]
-#[instrument(skip(state, _claims))]
+#[instrument(skip(state, claims))]
 pub async fn history(
     State(state): State<SessionsState>,
-    _claims: Claims,
+    claims: Claims,
     Path(id): Path<String>,
     Query(params): Query<HistoryParams>,
 ) -> Result<Json<HistoryResponse>, ApiError> {
-    let _ = find_session(&state, &id).await?;
+    let session = find_session(&state, &id).await?;
+    require_nous_access(&claims, &session.nous_id)?;
 
     // WHY: Cap limit at max_history_limit and apply a sensible default so a single
     // request cannot fetch an unbounded number of messages.

--- a/crates/pylon/src/tests/helpers.rs
+++ b/crates/pylon/src/tests/helpers.rs
@@ -69,6 +69,15 @@ pub(super) fn token_for_role(role: symbolon::types::Role) -> String {
         .expect("test token")
 }
 
+/// Test helper: issue a JWT scoped to `nous_id`. Combined with the `Claims`
+/// extractor, the production `require_nous_access` helper rejects calls
+/// targeting any other agent's resources.
+pub(super) fn token_scoped_to(role: symbolon::types::Role, nous_id: &str) -> String {
+    test_jwt_manager()
+        .issue_access("test-user", role, Some(nous_id))
+        .expect("test scoped token")
+}
+
 pub(super) async fn test_state() -> (Arc<AppState>, tempfile::TempDir) {
     test_state_with_provider_private_and_auth_mode(true, false, "token").await
 }

--- a/crates/pylon/src/tests/session.rs
+++ b/crates/pylon/src/tests/session.rs
@@ -723,3 +723,142 @@ async fn unarchive_active_session_succeeds() {
     let body = body_json(resp).await;
     assert_eq!(body["status"], "active");
 }
+
+// ── scope enforcement on session reads ─────────────────────────────────────
+
+/// Authed request issued with a token scoped to `scope_nous_id`.
+fn scoped_get(uri: &str, scope_nous_id: &str) -> axum::http::Request<axum::body::Body> {
+    let token = token_scoped_to(symbolon::types::Role::Operator, scope_nous_id);
+    axum::http::Request::get(uri)
+        .header(
+            "authorization",
+            format!("{}{token}", koina::http::BEARER_PREFIX),
+        )
+        .body(axum::body::Body::empty())
+        .unwrap()
+}
+
+#[tokio::test]
+async fn get_session_rejects_token_scoped_to_a_different_agent() {
+    // WHY: GET /api/v1/sessions/{id} loaded by id only — without a scope
+    // check, a token scoped to `audit-bot` could read any `syn` session's
+    // metadata (created_at, message_count, origin display name).
+    let (router, _dir) = app().await;
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    let resp = router
+        .clone()
+        .oneshot(scoped_get(
+            &format!("/api/v1/sessions/{id}"),
+            "audit-bot",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_json(resp).await;
+    assert_eq!(body["error"]["code"], "forbidden");
+}
+
+#[tokio::test]
+async fn get_session_accepts_token_scoped_to_matching_agent() {
+    let (router, _dir) = app().await;
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    let resp = router
+        .clone()
+        .oneshot(scoped_get(&format!("/api/v1/sessions/{id}"), "syn"))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn history_rejects_token_scoped_to_a_different_agent() {
+    // WHY: GET /api/v1/sessions/{id}/history previously did not scope-check.
+    // A token scoped to `audit-bot` could read the full message history of
+    // any `syn` session — the most sensitive read in the sessions surface.
+    let (router, _dir) = app().await;
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    let resp = router
+        .clone()
+        .oneshot(scoped_get(
+            &format!("/api/v1/sessions/{id}/history"),
+            "audit-bot",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_json(resp).await;
+    assert_eq!(body["error"]["code"], "forbidden");
+}
+
+#[tokio::test]
+async fn history_accepts_token_scoped_to_matching_agent() {
+    let (router, _dir) = app().await;
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    let resp = router
+        .clone()
+        .oneshot(scoped_get(
+            &format!("/api/v1/sessions/{id}/history"),
+            "syn",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn list_sessions_rejects_query_filter_outside_scope() {
+    // WHY: ?nous_id=other-agent with a token scoped to `syn` previously
+    // returned that agent's sessions. The handler now rejects mismatched
+    // explicit filters rather than silently rewriting them, so a scoped
+    // caller can never observe other agents' session ids.
+    let (router, _dir) = app().await;
+
+    let resp = router
+        .clone()
+        .oneshot(scoped_get(
+            "/api/v1/sessions?nous_id=audit-bot",
+            "syn",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn list_sessions_implicitly_filters_to_scope_when_no_query() {
+    // WHY: a bare GET /api/v1/sessions from a scoped token must implicitly
+    // filter to that scope. Without this filter, the list would enumerate
+    // every session for every agent.
+    let (router, _dir) = app().await;
+
+    let created = create_test_session(&router).await;
+    let id = created["id"].as_str().unwrap();
+
+    let resp = router
+        .clone()
+        .oneshot(scoped_get("/api/v1/sessions", "syn"))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    let items = body["items"]
+        .as_array()
+        .expect("paginated response has items array");
+    assert_eq!(items.len(), 1, "scoped list returns only the in-scope session");
+    assert_eq!(items[0]["id"], id);
+    assert_eq!(items[0]["nous_id"], "syn");
+}


### PR DESCRIPTION
## Summary

A JWT scoped to `nous_id` should restrict the caller to that agent's resources. The write-side session handlers (`close`, `archive`, `unarchive`, `purge`, `rename`, `create`, `send_message`, `stream_turn`) already enforce this via `require_nous_access`. The read-side did not:

- `GET /api/v1/sessions/{id}` — returned session metadata for any session, regardless of the caller's scope
- `GET /api/v1/sessions/{id}/history` — returned the full conversation history (the most sensitive read in the sessions surface)
- `GET /api/v1/sessions[?nous_id=X]` — returned the requested agent's sessions regardless of scope; a bare query returned every session for every agent

A token scoped to `audit-bot` could therefore enumerate every `syn` session, read every message ever sent in those sessions, and pivot to other agents by guessing path parameters. This PR closes those gaps.

## Details

**handlers/sessions/mod.rs**:
- `get_session`: claims param wired in, calls `require_nous_access(&claims, &session.nous_id)` after `find_session` returns.
- `history`: same treatment; the `find_session` result is now bound to `session` (rather than discarded with `let _ =`) so the scope can be derived from `session.nous_id`.
- `list_sessions`: when `claims.nous_id` is set, the handler overrides the filter:
  - if the query passes `?nous_id=other` and `other` is outside the caller's scope, return `403 forbidden` (intentionally hard-reject rather than silently rewrite, so callers can never observe a different agent's session ids);
  - if no query filter is set, apply the scope implicitly.

**tests/helpers.rs**: new `token_scoped_to(role, nous_id)` helper mirrors how the binary mints scoped tokens (`JwtManager::issue_access(sub, role, Some(nous_id))`).

**tests/session.rs**: six new regression tests:
- `get_session_rejects_token_scoped_to_a_different_agent`
- `get_session_accepts_token_scoped_to_matching_agent`
- `history_rejects_token_scoped_to_a_different_agent`
- `history_accepts_token_scoped_to_matching_agent`
- `list_sessions_rejects_query_filter_outside_scope`
- `list_sessions_implicitly_filters_to_scope_when_no_query`

## Test plan

- [x] `cargo test -p pylon` (all 457 lib + 38 integration tests pass)
- [x] `cargo clippy -p pylon --tests` (clean)
- [ ] CI gate