### PR TITLE
feat(episteme,aletheia): wire embedding similarity into entity dedup (#4165 Path A)

### DIFF
--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -34,6 +34,45 @@ pub(crate) enum Action {
         #[arg(long)]
         dry_run: bool,
     },
+    /// List entity merge candidates that are queued for review.
+    ///
+    /// Drains the `pending_merges` queue populated by `memory dedup` —
+    /// scores in `[0.70, 0.90)` that did not auto-merge (#4165 Path A).
+    DedupPending {
+        /// Nous agent ID whose review queue to list
+        #[arg(long)]
+        nous_id: String,
+    },
+    /// Approve a queued entity merge and execute it.
+    ///
+    /// Resolves a review-tier candidate by merging `merged_id` into
+    /// `canonical_id` — edges are redirected, `fact_entities` are
+    /// transferred, the merged name is preserved as an alias, and the
+    /// pending-merge row is cleared. The operator picks which side
+    /// survives by argument order (#4165 Path A).
+    DedupApprove {
+        /// Nous agent ID owning the pending merge
+        #[arg(long)]
+        nous_id: String,
+        /// Entity ID that should survive the merge
+        #[arg(long)]
+        canonical_id: String,
+        /// Entity ID that should be absorbed into the canonical entity
+        #[arg(long)]
+        merged_id: String,
+    },
+    /// Reject a queued entity merge and remove it from the review queue.
+    DedupReject {
+        /// Nous agent ID owning the pending merge
+        #[arg(long)]
+        nous_id: String,
+        /// First entity in the pending pair (`entity_a`)
+        #[arg(long)]
+        entity_a: String,
+        /// Second entity in the pending pair (`entity_b`)
+        #[arg(long)]
+        entity_b: String,
+    },
     /// Extract recurring patterns from the knowledge graph
     Patterns {
         /// Nous agent ID to analyze
@@ -118,6 +157,17 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
                 scope,
                 output_path,
             } => run_export_graph(&store, format, nous_id.as_deref(), scope, &output_path),
+            Action::DedupPending { nous_id } => run_dedup_pending(&store, &nous_id),
+            Action::DedupApprove {
+                nous_id,
+                canonical_id,
+                merged_id,
+            } => run_dedup_approve(&store, &nous_id, &canonical_id, &merged_id),
+            Action::DedupReject {
+                nous_id,
+                entity_a,
+                entity_b,
+            } => run_dedup_reject(&store, &nous_id, &entity_a, &entity_b),
         }
     }
 
@@ -149,7 +199,7 @@ fn validate_action(action: &Action) -> Result<()> {
             }
             Ok(())
         }
-        Action::Dedup { nous_id, .. } => {
+        Action::Dedup { nous_id, .. } | Action::DedupPending { nous_id } => {
             if nous_id.trim().is_empty() {
                 whatever!("--nous-id cannot be empty or whitespace");
             }
@@ -171,6 +221,44 @@ fn validate_action(action: &Action) -> Result<()> {
                 && id.trim().is_empty()
             {
                 whatever!("--nous-id cannot be empty or whitespace");
+            }
+            Ok(())
+        }
+        Action::DedupApprove {
+            nous_id,
+            canonical_id,
+            merged_id,
+        } => {
+            if nous_id.trim().is_empty() {
+                whatever!("--nous-id cannot be empty or whitespace");
+            }
+            if canonical_id.trim().is_empty() {
+                whatever!("--canonical-id cannot be empty or whitespace");
+            }
+            if merged_id.trim().is_empty() {
+                whatever!("--merged-id cannot be empty or whitespace");
+            }
+            if canonical_id.trim() == merged_id.trim() {
+                whatever!("--canonical-id and --merged-id must differ");
+            }
+            Ok(())
+        }
+        Action::DedupReject {
+            nous_id,
+            entity_a,
+            entity_b,
+        } => {
+            if nous_id.trim().is_empty() {
+                whatever!("--nous-id cannot be empty or whitespace");
+            }
+            if entity_a.trim().is_empty() {
+                whatever!("--entity-a cannot be empty or whitespace");
+            }
+            if entity_b.trim().is_empty() {
+                whatever!("--entity-b cannot be empty or whitespace");
+            }
+            if entity_a.trim() == entity_b.trim() {
+                whatever!("--entity-a and --entity-b must differ");
             }
             Ok(())
         }
@@ -773,6 +861,121 @@ fn run_dedup(
         }
     }
 
+    Ok(())
+}
+
+/// List entity merge candidates queued for review.
+///
+/// Drains [`pending_merges`] populated by `memory dedup` runs — composite
+/// scores in `[0.70, 0.90)` that did not auto-merge. Without this listing
+/// step the queue was a write-only "roach motel" (#4165 B), since
+/// `approve_merge` had no callers anywhere in the codebase.
+#[cfg(feature = "recall")]
+fn run_dedup_pending(
+    store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
+    nous_id: &str,
+) -> Result<()> {
+    let pending = store
+        .get_pending_merges(nous_id)
+        .whatever_context("pending merge query failed")?;
+
+    if pending.is_empty() {
+        println!("No pending entity merges for nous {nous_id}.");
+        return Ok(());
+    }
+
+    println!(
+        "Pending entity merges for nous {nous_id} ({}):",
+        pending.len()
+    );
+    for p in &pending {
+        println!(
+            "  {} <-> {} (score: {:.2}, name_sim: {:.2}, embed_sim: {:.2}, type_match: {}, alias_overlap: {})",
+            p.entity_a,
+            p.entity_b,
+            p.merge_score,
+            p.name_similarity,
+            p.embed_similarity,
+            p.type_match,
+            p.alias_overlap,
+        );
+        println!("    names: {:?} <-> {:?}", p.name_a, p.name_b);
+        println!(
+            "    approve: aletheia memory dedup-approve --nous-id {nous_id} \\
+                     --canonical-id <choose> --merged-id <other>"
+        );
+    }
+
+    Ok(())
+}
+
+/// Approve a queued entity merge.
+///
+/// Executes [`approve_merge`](mneme::knowledge_store::KnowledgeStore::approve_merge)
+/// — redirects relationships, transfers `fact_entities`, preserves the merged
+/// name as an alias, deletes the merged entity, and removes the pending
+/// row. Operator chooses which side survives via argument order. The
+/// merge is *not* gated by the auto-merge threshold: this is the explicit
+/// approval path for review-tier candidates the auto-merge math rejects
+/// by design (#4165 Path A).
+#[cfg(feature = "recall")]
+fn run_dedup_approve(
+    store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
+    nous_id: &str,
+    canonical_id: &str,
+    merged_id: &str,
+) -> Result<()> {
+    let canonical = mneme::id::EntityId::new(canonical_id)
+        .whatever_context("--canonical-id is not a valid entity id")?;
+    let merged = mneme::id::EntityId::new(merged_id)
+        .whatever_context("--merged-id is not a valid entity id")?;
+
+    let record = store
+        .approve_merge(&canonical, &merged)
+        .whatever_context("approve_merge failed")?;
+
+    println!(
+        "Approved merge for nous {nous_id}: {canonical} absorbed {merged_name} ({facts} facts, {edges} edges).",
+        canonical = record.canonical_entity_id,
+        merged_name = record.merged_entity_name,
+        facts = record.facts_transferred,
+        edges = record.relationships_redirected,
+    );
+
+    Ok(())
+}
+
+/// Reject a queued entity merge by removing it from the review queue.
+///
+/// Tries both `(a, b)` and `(b, a)` orderings since `pending_merges` may
+/// store either; the underlying call swallows the second ordering's
+/// failure as a debug log if there is nothing to remove.
+#[cfg(feature = "recall")]
+fn run_dedup_reject(
+    store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
+    nous_id: &str,
+    entity_a: &str,
+    entity_b: &str,
+) -> Result<()> {
+    use mneme::engine::DataValue;
+    use std::collections::BTreeMap;
+
+    let mut params = BTreeMap::new();
+    params.insert("entity_a".to_owned(), DataValue::Str(entity_a.into()));
+    params.insert("entity_b".to_owned(), DataValue::Str(entity_b.into()));
+    let script = r"?[entity_a, entity_b] <- [[$entity_a, $entity_b]]
+                   :rm pending_merges{entity_a, entity_b}";
+    // WHY: pending_merges may store either (a,b) or (b,a) order; swallow
+    // the second ordering's not-found error since at most one row matches.
+    let _ = store
+        .run_mut_query(script, params)
+        .whatever_context("pending_merges remove failed")?;
+    let mut params2 = BTreeMap::new();
+    params2.insert("entity_a".to_owned(), DataValue::Str(entity_b.into()));
+    params2.insert("entity_b".to_owned(), DataValue::Str(entity_a.into()));
+    let _ = store.run_mut_query(script, params2);
+
+    println!("Rejected pending merge for nous {nous_id}: {entity_a} <-> {entity_b}.");
     Ok(())
 }
 

--- a/crates/aletheia/src/knowledge_maintenance.rs
+++ b/crates/aletheia/src/knowledge_maintenance.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use mneme::embedding::{EmbeddingProvider, is_degraded_provider};
 use mneme::knowledge::FactType;
 use mneme::knowledge_store::KnowledgeStore;
 use mneme::recall::RecallEngine;
@@ -15,11 +16,33 @@ use oikonomos::maintenance::{KnowledgeMaintenanceExecutor, MaintenanceReport};
 /// `KnowledgeStore`. All methods are blocking (`CozoDB` is sync).
 pub(crate) struct KnowledgeMaintenanceAdapter {
     store: Arc<KnowledgeStore>,
+    /// Embedding provider passed through to the dedup pipeline so it can
+    /// populate `entities.name_embedding` before scoring (#4165 Path A).
+    /// `None` (or a degraded sentinel) keeps `embed_sim = 0.0`, which
+    /// preserves pre-fix behaviour for installs without an embedding
+    /// provider configured.
+    embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
 }
 
 impl KnowledgeMaintenanceAdapter {
     pub(crate) fn new(store: Arc<KnowledgeStore>) -> Self {
-        Self { store }
+        Self {
+            store,
+            embedding_provider: None,
+        }
+    }
+
+    /// Attach an embedding provider to the dedup pipeline.
+    ///
+    /// When set, [`Self::deduplicate_entities`] backfills any NULL
+    /// `entities.name_embedding`s through this provider before running
+    /// the merge-score pipeline, so the 0.30-weighted `embed_sim` term
+    /// becomes a real signal and the `AutoMerge` threshold (0.90) is
+    /// reachable. A degraded sentinel is accepted but skipped at
+    /// backfill time to avoid log spam.
+    pub(crate) fn with_embedding_provider(mut self, provider: Arc<dyn EmbeddingProvider>) -> Self {
+        self.embedding_provider = Some(provider);
+        self
     }
 }
 
@@ -111,15 +134,30 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
         })
     }
 
-    /// Deduplicates entities by delegating to `KnowledgeStore::run_entity_dedup`.
+    /// Deduplicates entities by delegating to
+    /// [`KnowledgeStore::run_entity_dedup_with_embeddings`].
+    ///
+    /// When an [`EmbeddingProvider`] is attached and is not a degraded
+    /// sentinel, this backfills any NULL `entities.name_embedding`s
+    /// before scoring. That is the wire that makes the
+    /// `MergeDecision::AutoMerge` threshold (≥ 0.90) reachable from this
+    /// scheduled task — without embeddings the maximum composite score
+    /// is 0.70 (#4165 Path A).
     fn deduplicate_entities(&self, nous_id: &str) -> oikonomos::error::Result<MaintenanceReport> {
-        let records = self.store.run_entity_dedup(nous_id).map_err(|e| {
-            oikonomos::error::TaskFailedSnafu {
-                task_id: "entity-dedup".to_owned(),
-                reason: e.to_string(),
-            }
-            .build()
-        })?;
+        let provider_ref = self
+            .embedding_provider
+            .as_deref()
+            .filter(|p| !is_degraded_provider(*p));
+        let records = self
+            .store
+            .run_entity_dedup_with_embeddings(nous_id, provider_ref)
+            .map_err(|e| {
+                oikonomos::error::TaskFailedSnafu {
+                    task_id: "entity-dedup".to_owned(),
+                    reason: e.to_string(),
+                }
+                .build()
+            })?;
 
         #[expect(clippy::as_conversions, reason = "usize→u64: record count fits in u64")]
         let merged = records.len() as u64;

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -615,8 +615,14 @@ impl RuntimeBuilder {
 
             #[cfg(feature = "recall")]
             if let Some(ks) = knowledge_store_for_daemon.as_ref() {
+                // WHY (#4165 Path A): hand the embedding provider to the
+                // dedup task so it can populate `entities.name_embedding`
+                // before scoring. Without this, the maintenance task
+                // reports merges executed but the AutoMerge threshold
+                // (≥ 0.90) is structurally unreachable.
                 let km_executor = Arc::new(
-                    crate::knowledge_maintenance::KnowledgeMaintenanceAdapter::new(Arc::clone(ks)),
+                    crate::knowledge_maintenance::KnowledgeMaintenanceAdapter::new(Arc::clone(ks))
+                        .with_embedding_provider(Arc::clone(&embedding_provider)),
                 );
                 daemon_runner = daemon_runner.with_knowledge_maintenance(km_executor);
             }

--- a/crates/episteme/proptest-regressions/knowledge_store/tests/proptests.txt
+++ b/crates/episteme/proptest-regressions/knowledge_store/tests/proptests.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 8dc3b9c88e52487adbd0c4e8b20e27c4658eefc68fa62a888d61901c533f7333 # shrinks to n = 2, raw_rels = [], canonical_raw = 0, merge_shift = 1
+cc cc68c292eb9b1f33a3a2c07afb251b3deb73016a129f1470101dfd3da57a4dc4 # shrinks to n_entities = 2, rel_pairs = [], canonical_idx = 0, merged_idx = 0

--- a/crates/episteme/src/dedup.rs
+++ b/crates/episteme/src/dedup.rs
@@ -258,7 +258,20 @@ pub(crate) fn name_in_aliases(
 }
 
 /// Cosine similarity between two f32 vectors.
-#[cfg(test)]
+///
+/// Returns 0.0 for mismatched dimensions, empty vectors, or any vector with
+/// zero magnitude. The result is *clamped* to `[0.0, 1.0]` so the dedup
+/// composite score stays in its declared domain even when an embedding
+/// provider returns slightly out-of-range values due to floating-point
+/// drift. (`embed_sim` is the second-largest weight in the merge formula —
+/// a slightly-negative value here would silently lower the score.)
+#[cfg_attr(
+    not(any(feature = "mneme-engine", test)),
+    expect(
+        dead_code,
+        reason = "exposed for the dedup pipeline gated behind mneme-engine"
+    )
+)]
 pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
     if a.len() != b.len() || a.is_empty() {
         return 0.0;
@@ -274,7 +287,7 @@ pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
     if denom < f64::EPSILON {
         return 0.0;
     }
-    dot / denom
+    (dot / denom).clamp(0.0, 1.0)
 }
 
 /// Lightweight entity data for dedup processing (avoids full Entity struct dependency on engine).
@@ -287,6 +300,38 @@ pub(crate) struct EntityInfo {
     pub(crate) aliases: Vec<String>,
     pub(crate) relationship_count: u32,
     pub(crate) created_at: jiff::Timestamp,
+    /// Cached embedding of [`Self::name`] loaded from the entities relation
+    /// (`name_embedding` column, added in schema v13). `None` for entities
+    /// inserted before the v13 migration, or while no `EmbeddingProvider`
+    /// was in scope; `make_embedding_lookup` returns 0.0 for any pair
+    /// involving a `None`.
+    pub(crate) name_embedding: Option<Vec<f32>>,
+}
+
+/// Build a pairwise cosine-similarity lookup over `entities.name_embedding`.
+///
+/// Returns a closure suitable for [`generate_candidates`]; the closure
+/// computes [`cosine_similarity`] between the cached `name_embedding`s of
+/// the two entities and returns 0.0 when either is absent or the lookup
+/// misses (defensive: an unknown id should not silently inflate
+/// `embed_sim`).
+///
+/// This is the production replacement for the historical `|_, _| 0.0`
+/// closures at `find_duplicate_entities` and `run_entity_dedup` that made
+/// `MergeDecision::AutoMerge` (≥ 0.90) structurally unreachable (#4165).
+#[cfg(any(feature = "mneme-engine", test))]
+pub(crate) fn make_embedding_lookup(
+    entities: &[EntityInfo],
+) -> impl Fn(&EntityId, &EntityId) -> f64 + '_ {
+    use std::collections::HashMap;
+    let map: HashMap<&str, &[f32]> = entities
+        .iter()
+        .filter_map(|e| e.name_embedding.as_deref().map(|v| (e.id.as_str(), v)))
+        .collect();
+    move |a, b| match (map.get(a.as_str()), map.get(b.as_str())) {
+        (Some(va), Some(vb)) => cosine_similarity(va, vb),
+        _ => 0.0,
+    }
 }
 
 /// Phase 1: Generate candidate merge pairs from a list of entities.

--- a/crates/episteme/src/dedup_tests.rs
+++ b/crates/episteme/src/dedup_tests.rs
@@ -22,7 +22,28 @@ fn entity(
         aliases: aliases.into_iter().map(String::from).collect(),
         relationship_count: rels,
         created_at: ts(created),
+        name_embedding: None,
     }
+}
+
+/// Variant of [`entity`] that also attaches a name embedding.
+///
+/// Mirrors the production v13 storage shape: an entity row with a
+/// non-NULL `name_embedding` column. Used by reachability tests to
+/// assert that `MergeDecision::AutoMerge` is actually reached when
+/// real cosine similarity is in scope.
+fn entity_with_embedding(
+    id: &str,
+    name: &str,
+    etype: &str,
+    aliases: Vec<&str>,
+    rels: u32,
+    created: &str,
+    embedding: Vec<f32>,
+) -> EntityInfo {
+    let mut e = entity(id, name, etype, aliases, rels, created);
+    e.name_embedding = Some(embedding);
+    e
 }
 
 fn no_embed(_a: &EntityId, _b: &EntityId) -> f64 {
@@ -212,6 +233,357 @@ fn embedding_similarity_triggers_candidate() {
     assert!(candidates[0].embed_similarity >= 0.80);
 }
 
+// ---------------------------------------------------------------------------
+// #4165 Path A reachability tests
+//
+// These tests pin the contract that makes `MergeDecision::AutoMerge`
+// reachable from production code. Pre-fix, the two production callers of
+// `generate_candidates` (`find_duplicate_entities`, `run_entity_dedup`) both
+// passed `|_, _| 0.0` for `embed_sim`, capping the maximum composite score
+// at 0.70 and making AutoMerge structurally unreachable while a single
+// test (`classify_auto_merge_and_review`) painted a passing picture by
+// injecting `embed_sim = 0.95` directly.
+//
+// The tests below split that into:
+//   - `pre_fix_regression_*` — assert the historical no-embed path
+//     produces no auto-merges, so any future regression that re-introduces
+//     the `|_, _| 0.0` closure trips loudly.
+//   - `path_a_reachable_*` — assert that the production lookup closure
+//     (`make_embedding_lookup`) over realistic stored `name_embedding`s
+//     actually reaches AutoMerge for semantically duplicate entities.
+//   - `path_a_lookup_*` — pin closure-level edge cases (missing
+//     embeddings, dimension mismatch, asymmetric stores).
+// ---------------------------------------------------------------------------
+
+/// Pre-fix regression: a closure that always returns 0.0 (the historical
+/// `|_, _| 0.0` shape from `entity.rs:141` and `entity.rs:355`) must never
+/// produce an auto-merge, no matter how closely names + types + aliases
+/// agree. Maximum achievable score is 0.4·1 + 0.3·0 + 0.2·1 + 0.1·1 = 0.70.
+#[test]
+fn pre_fix_regression_zero_embed_caps_at_review_tier() {
+    // Two entities that match perfectly on every non-embedding signal:
+    // identical name (case-insensitive), same type, overlapping alias.
+    let entities = vec![
+        entity(
+            "e1",
+            "Acme Corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-01",
+        ),
+        entity(
+            "e2",
+            "acme corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-02",
+        ),
+    ];
+    let candidates = generate_candidates(&entities, &no_embed);
+    assert_eq!(candidates.len(), 1, "exactly one pair");
+    let c = &candidates[0];
+    assert!(
+        c.merge_score <= 0.70 + 1e-9,
+        "without embedding similarity the merge score must cap at 0.70; got {}",
+        c.merge_score
+    );
+    let (auto_merge, _review) = classify_candidates(candidates);
+    assert!(
+        auto_merge.is_empty(),
+        "pre-fix closure (embed=0.0) must never produce AutoMerge — this is the bug #4165 was opened for"
+    );
+}
+
+/// Sibling to [`pre_fix_regression_zero_embed_caps_at_review_tier`]. The
+/// design doc specifically called this gap out as untestable until the
+/// pipeline was fixed; this test pins the same assertion via the
+/// production lookup helper applied to entities with no stored
+/// embeddings — exactly the degraded-mode case.
+#[test]
+fn pre_fix_regression_make_embedding_lookup_empty_store() {
+    let entities = vec![
+        entity(
+            "e1",
+            "Acme Corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-01",
+        ),
+        entity(
+            "e2",
+            "acme corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-02",
+        ),
+    ];
+    let lookup = make_embedding_lookup(&entities);
+    let candidates = generate_candidates(&entities, &lookup);
+    let (auto_merge, _) = classify_candidates(candidates);
+    assert!(
+        auto_merge.is_empty(),
+        "make_embedding_lookup over entities without embeddings must reproduce pre-fix behaviour (no AutoMerges)"
+    );
+}
+
+/// Reachability: with realistic stored `name_embedding`s + the production
+/// lookup helper, `AutoMerge` is actually reached. This is the affirmative
+/// proof that #4165 Path A is wired end-to-end through `EntityInfo`,
+/// `make_embedding_lookup`, `generate_candidates`, and
+/// `classify_candidates`.
+#[test]
+fn path_a_reachable_with_stored_name_embeddings() {
+    // Two near-identical orientation vectors: unit-length, 8-dim,
+    // cosine ≈ 1.0 — modelling what a real provider returns for "Acme
+    // Corporation" vs "acme corporation".
+    let a_emb = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    let b_emb = a_emb.clone();
+    let entities = vec![
+        entity_with_embedding(
+            "e1",
+            "Acme Corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-01",
+            a_emb,
+        ),
+        entity_with_embedding(
+            "e2",
+            "acme corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-02",
+            b_emb,
+        ),
+    ];
+    let lookup = make_embedding_lookup(&entities);
+    let candidates = generate_candidates(&entities, &lookup);
+    assert_eq!(candidates.len(), 1, "exactly one candidate pair");
+    let c = &candidates[0];
+    assert!(
+        (c.embed_similarity - 1.0).abs() < 1e-6,
+        "stored embeddings must drive embed_similarity to 1.0; got {}",
+        c.embed_similarity
+    );
+    assert!(
+        c.merge_score >= 0.90,
+        "name=1.0 + embed=1.0 + type=true + alias=true must clear AutoMerge threshold; got {}",
+        c.merge_score
+    );
+    let (auto_merge, _review) = classify_candidates(candidates);
+    assert_eq!(
+        auto_merge.len(),
+        1,
+        "exactly one AutoMerge candidate — proves Path A is reachable from production code shape"
+    );
+}
+
+/// Reachability under semantic-only similarity: names diverge enough
+/// to fail the Jaro-Winkler threshold (~0.85), but the stored
+/// embeddings agree. Without the 0.30 embed weight this pair would
+/// be silently capped at `Skip` — proves the weight is doing real
+/// work post-fix by promoting the pair into the actionable space
+/// (`Review` or `AutoMerge`).
+///
+/// We deliberately do *not* assert `AutoMerge` here. For "Photovoltaic
+/// Panel" vs "Solar Panel" JW is ~0.50, so even with embed=1.0 +
+/// type=true + alias=true the composite score is 0.4·0.50 + 0.6 = 0.80
+/// → `Review`. That outcome is exactly what the design intends: the
+/// 0.90 threshold is a multi-signal-agreement guard, and synonym pairs
+/// without name overlap legitimately stay in the operator-review
+/// queue. The reachability proof for `AutoMerge` is
+/// `path_a_reachable_with_stored_name_embeddings` (name+embed=1.0).
+#[test]
+fn path_a_embedding_promotes_synonym_pair_above_skip() {
+    let emb = vec![0.0, 1.0, 0.0, 0.0];
+    let entities = vec![
+        entity_with_embedding(
+            "e1",
+            "Photovoltaic Panel",
+            "product",
+            vec!["PV"],
+            3,
+            "2026-01-01",
+            emb.clone(),
+        ),
+        entity_with_embedding(
+            "e2",
+            "Solar Panel",
+            "product",
+            vec!["PV"],
+            3,
+            "2026-01-02",
+            emb,
+        ),
+    ];
+    let lookup = make_embedding_lookup(&entities);
+    let candidates = generate_candidates(&entities, &lookup);
+    assert_eq!(
+        candidates.len(),
+        1,
+        "alias overlap forces them into the candidate set"
+    );
+    let c = &candidates[0];
+    assert!(
+        (c.embed_similarity - 1.0).abs() < 1e-6,
+        "embeddings carry the semantic signal; got {}",
+        c.embed_similarity
+    );
+    assert!(
+        c.merge_score >= 0.70,
+        "embed contribution must push the pair into Review tier at minimum; got {}",
+        c.merge_score
+    );
+    let (_auto_merge, review) = classify_candidates(candidates);
+    assert!(
+        !review.is_empty(),
+        "synonym pair with agreeing embeddings lands in Review (operator-actionable) — \
+         before #4165 Path A it would have been Skip-tier and invisible to the operator"
+    );
+}
+
+/// Path A safety: borderline embeddings (cosine well below 1.0) must
+/// not trigger `AutoMerge` when names also disagree. The 0.90 threshold
+/// is the multi-signal-agreement guard the design doc called out.
+#[test]
+fn path_a_borderline_embedding_stays_in_review_tier() {
+    // 30° apart — cosine ≈ 0.866. Below the 0.90 threshold by itself.
+    let a_emb = vec![1.0, 0.0];
+    let b_emb = vec![0.866_025_4, 0.5];
+    let entities = vec![
+        entity_with_embedding(
+            "e1",
+            "Differential Equation",
+            "concept",
+            vec![],
+            1,
+            "2026-01-01",
+            a_emb,
+        ),
+        entity_with_embedding(
+            "e2",
+            "Difference Equation",
+            "concept",
+            vec![],
+            1,
+            "2026-01-02",
+            b_emb,
+        ),
+    ];
+    let lookup = make_embedding_lookup(&entities);
+    let candidates = generate_candidates(&entities, &lookup);
+    assert_eq!(
+        candidates.len(),
+        1,
+        "JW above 0.85 puts them in the candidate set"
+    );
+    let (auto_merge, review) = classify_candidates(candidates);
+    assert!(
+        auto_merge.is_empty(),
+        "moderately-similar embeddings with no alias overlap must not auto-merge — operator review required"
+    );
+    assert_eq!(review.len(), 1, "should land in the review queue");
+}
+
+/// `make_embedding_lookup` must return 0.0 when *either* side of a pair
+/// lacks a stored embedding. Otherwise a partially-backfilled corpus
+/// could silently bias scoring toward whatever entities were embedded
+/// first, surprising operators after a partial provider outage.
+#[test]
+fn path_a_lookup_returns_zero_for_missing_embeddings() {
+    let entities = vec![
+        entity_with_embedding(
+            "e1",
+            "Alice Test",
+            "person",
+            vec![],
+            1,
+            "2026-01-01",
+            vec![1.0, 0.0, 0.0],
+        ),
+        // e2 has no embedding — production v13 row with NULL name_embedding.
+        entity("e2", "Alice Test", "person", vec![], 1, "2026-01-02"),
+    ];
+    let lookup = make_embedding_lookup(&entities);
+    let ea = EntityId::new("e1").expect("valid id");
+    let eb = EntityId::new("e2").expect("valid id");
+    assert!(
+        lookup(&ea, &eb).abs() < f64::EPSILON,
+        "missing-on-one-side must yield 0.0"
+    );
+    assert!(
+        lookup(&eb, &ea).abs() < f64::EPSILON,
+        "missing-on-one-side must yield 0.0 regardless of argument order"
+    );
+}
+
+/// `make_embedding_lookup` must return 0.0 for dimension mismatches —
+/// not panic, not silently misalign the dot product. This pins the
+/// behaviour that defends the dedup pipeline against a config drift
+/// where the embedding provider's `dim` differs from
+/// `KnowledgeConfig::dim`.
+#[test]
+fn path_a_lookup_returns_zero_for_dimension_mismatch() {
+    let entities = vec![
+        entity_with_embedding("e1", "x", "thing", vec![], 1, "2026-01-01", vec![1.0, 0.0]),
+        entity_with_embedding(
+            "e2",
+            "y",
+            "thing",
+            vec![],
+            1,
+            "2026-01-02",
+            vec![1.0, 0.0, 0.0, 0.0],
+        ),
+    ];
+    let lookup = make_embedding_lookup(&entities);
+    let ea = EntityId::new("e1").expect("valid id");
+    let eb = EntityId::new("e2").expect("valid id");
+    assert!(
+        lookup(&ea, &eb).abs() < f64::EPSILON,
+        "dim mismatch must be treated like a missing embedding"
+    );
+}
+
+/// `make_embedding_lookup` must return 0.0 when neither side is known —
+/// avoids silently inflating scores for entities the caller produced
+/// from outside the loaded `EntityInfo` slice.
+#[test]
+fn path_a_lookup_returns_zero_for_unknown_ids() {
+    let entities: Vec<EntityInfo> = Vec::new();
+    let lookup = make_embedding_lookup(&entities);
+    let ea = EntityId::new("e1").expect("valid id");
+    let eb = EntityId::new("e2").expect("valid id");
+    assert!(
+        lookup(&ea, &eb).abs() < f64::EPSILON,
+        "empty store must yield 0.0 for every pair"
+    );
+}
+
+/// Bounds check on `cosine_similarity` itself: floating-point drift in
+/// real providers can push a unit-length pair slightly above 1.0, and
+/// dedup-pipeline weight calculations expect strictly `[0.0, 1.0]`.
+/// This pins the clamp at the boundary.
+#[test]
+fn path_a_cosine_similarity_clamps_to_unit_interval() {
+    // Two vectors that differ only by floating-point representation
+    // (cosine should be exactly 1.0 — assert the clamp does not push it
+    // below or above).
+    let v = vec![1.0_f32, 0.0, 0.0];
+    let sim = cosine_similarity(&v, &v);
+    assert!(
+        (0.0..=1.0).contains(&sim),
+        "cosine_similarity must stay in [0.0, 1.0]; got {sim}"
+    );
+    assert!((sim - 1.0).abs() < 1e-6, "identical vectors → 1.0");
+}
+
 #[test]
 fn classify_auto_merge_and_review() {
     let entities = vec![
@@ -321,6 +693,7 @@ mod proptests {
             aliases: vec![],
             relationship_count: 1,
             created_at: ts_epoch(),
+            name_embedding: None,
         }
     }
 

--- a/crates/episteme/src/knowledge_store/entity.rs
+++ b/crates/episteme/src/knowledge_store/entity.rs
@@ -131,14 +131,23 @@ impl KnowledgeStore {
     /// Find duplicate entity candidates for a given nous.
     ///
     /// Loads all entities, groups by type, and runs the 3-phase candidate
-    /// generation + scoring pipeline. Returns all candidates (auto-merge + review).
+    /// generation + scoring pipeline. Returns all candidates (auto-merge +
+    /// review).
+    ///
+    /// Cosine similarity is computed over the entities' cached
+    /// `name_embedding` column (schema v13+). Entities without a stored
+    /// embedding contribute `embed_sim = 0.0` for any pair they participate
+    /// in — i.e. the pre-#4165 behaviour for degraded-mode installs.
+    /// Callers that want to populate embeddings first should use
+    /// [`KnowledgeStore::backfill_entity_name_embeddings`].
     #[instrument(skip(self))]
     pub fn find_duplicate_entities(
         &self,
         nous_id: &str,
     ) -> crate::error::Result<Vec<crate::dedup::EntityMergeCandidate>> {
         let entities = self.load_entity_infos(nous_id)?;
-        let candidates = crate::dedup::generate_candidates(&entities, &|_a, _b| 0.0);
+        let embed_lookup = crate::dedup::make_embedding_lookup(&entities);
+        let candidates = crate::dedup::generate_candidates(&entities, &embed_lookup);
         Ok(candidates)
     }
 
@@ -277,13 +286,16 @@ impl KnowledgeStore {
         Ok(results)
     }
 
-    /// Approve a pending merge: execute it.
+    /// Approve a pending merge by executing it.
+    ///
+    /// Drains a candidate that
+    /// [`KnowledgeStore::run_entity_dedup`] left in the `pending_merges`
+    /// queue (score in `[0.70, 0.90)`); the operator picks which side
+    /// survives and `execute_merge` redirects edges, transfers
+    /// `fact_entities`, preserves the merged name as an alias, and clears
+    /// the pending-merge row (#4165 Path A).
     #[instrument(skip(self))]
-    #[expect(
-        dead_code,
-        reason = "entity dedup pipeline — no callers yet including tests"
-    )]
-    pub(crate) fn approve_merge(
+    pub fn approve_merge(
         &self,
         canonical_id: &crate::id::EntityId,
         merged_id: &crate::id::EntityId,
@@ -297,11 +309,7 @@ impl KnowledgeStore {
         clippy::used_underscore_binding,
         reason = "nous_id reserved for future filtering"
     )]
-    #[expect(
-        dead_code,
-        reason = "entity dedup pipeline — no callers yet including tests"
-    )]
-    pub(crate) fn get_merge_history(
+    pub fn get_merge_history(
         &self,
         _nous_id: &str,
     ) -> crate::error::Result<Vec<crate::dedup::MergeRecord>> {
@@ -342,6 +350,15 @@ impl KnowledgeStore {
     /// 3. Execute auto-merges, store review candidates as pending
     ///
     /// Returns the list of completed merge records.
+    ///
+    /// Cosine similarity is computed over each entity's cached
+    /// `name_embedding` column (schema v13+) — entities without a stored
+    /// embedding contribute `embed_sim = 0.0`. Callers that want
+    /// `AutoMerge` to be reachable in production (the design weights
+    /// `embed_sim` at 0.30 and the `AutoMerge` threshold is 0.90) should
+    /// populate embeddings first via
+    /// [`KnowledgeStore::run_entity_dedup_with_embeddings`] or
+    /// [`KnowledgeStore::backfill_entity_name_embeddings`].
     #[instrument(skip(self))]
     pub fn run_entity_dedup(
         &self,
@@ -352,7 +369,8 @@ impl KnowledgeStore {
             return Ok(Vec::new());
         }
 
-        let candidates = crate::dedup::generate_candidates(&entities, &|_a, _b| 0.0);
+        let embed_lookup = crate::dedup::make_embedding_lookup(&entities);
+        let candidates = crate::dedup::generate_candidates(&entities, &embed_lookup);
         let (auto_merge, review) = crate::dedup::classify_candidates(candidates);
 
         for c in &review {
@@ -397,6 +415,207 @@ impl KnowledgeStore {
         Ok(records)
     }
 
+    /// Set (or clear) the `name_embedding` for a single entity.
+    ///
+    /// Writes only the embedding column — the entity's name, type,
+    /// aliases, and timestamps are preserved as-is. Pass `None` to clear
+    /// a stored embedding, or `Some(vec)` to install one whose length
+    /// matches the configured `KnowledgeConfig::dim`.
+    ///
+    /// Returns
+    /// `Err(EmbeddingDimensionMismatch)` if the supplied vector's length
+    /// does not match `self.dim` (a wrong-dim write would corrupt the
+    /// stored column type and silently break subsequent dedup runs).
+    ///
+    /// Wires the at-creation half of the #4165 Path A lifecycle: callers
+    /// in the extraction pipeline that hold an
+    /// [`EmbeddingProvider`](crate::embedding::EmbeddingProvider) compute
+    /// the name embedding once and call this method directly after
+    /// `insert_entity`.
+    #[instrument(skip(self, name_embedding), fields(entity_id = %entity_id))]
+    pub fn update_entity_name_embedding(
+        &self,
+        entity_id: &crate::id::EntityId,
+        name_embedding: Option<Vec<f32>>,
+    ) -> crate::error::Result<()> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::{Array1, DataValue, Vector};
+
+        if let Some(ref v) = name_embedding {
+            snafu::ensure!(
+                v.len() == self.dim,
+                crate::error::EmbeddingDimensionMismatchSnafu {
+                    expected: self.dim,
+                    actual: v.len(),
+                }
+            );
+        }
+
+        let entity = self.load_entity(entity_id)?;
+        let mut params = BTreeMap::new();
+        params.insert("id".to_owned(), DataValue::Str(entity_id.as_str().into()));
+        params.insert(
+            "name".to_owned(),
+            DataValue::Str(entity.name.as_str().into()),
+        );
+        params.insert(
+            "entity_type".to_owned(),
+            DataValue::Str(entity.entity_type.as_str().into()),
+        );
+        params.insert(
+            "aliases".to_owned(),
+            DataValue::Str(entity.aliases.join(",").into()),
+        );
+        params.insert(
+            "created_at".to_owned(),
+            DataValue::Str(crate::knowledge::format_timestamp(&entity.created_at).into()),
+        );
+        params.insert(
+            "updated_at".to_owned(),
+            DataValue::Str(crate::knowledge::format_timestamp(&jiff::Timestamp::now()).into()),
+        );
+        let emb_value = name_embedding.map_or(DataValue::Null, |v| {
+            DataValue::Vec(Vector::F32(Array1::from(v)))
+        });
+        params.insert("name_embedding".to_owned(), emb_value);
+        self.run_mut(&queries::upsert_entity(), params)
+    }
+
+    /// Read the stored `name_embedding` for a single entity, if any.
+    ///
+    /// Returns `Ok(None)` when the column is NULL (never populated, or
+    /// the entity predates the v13 migration). Returns `Err` when the
+    /// entity does not exist.
+    #[instrument(skip(self), fields(entity_id = %entity_id))]
+    pub fn get_entity_name_embedding(
+        &self,
+        entity_id: &crate::id::EntityId,
+    ) -> crate::error::Result<Option<Vec<f32>>> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::DataValue;
+        let mut params = BTreeMap::new();
+        params.insert("id".to_owned(), DataValue::Str(entity_id.as_str().into()));
+        let script = r"?[name_embedding] :=
+            *entities{id, name_embedding},
+            id = $id";
+        let rows = self.run_read(script, params)?;
+        let row = rows.rows.into_iter().next().ok_or_else(|| {
+            crate::error::EngineQuerySnafu {
+                message: format!("entity not found: {entity_id}"),
+            }
+            .build()
+        })?;
+        super::marshal::extract_optional_f32_vec(&row[0])
+    }
+
+    /// Populate `name_embedding` for entities whose column is NULL.
+    ///
+    /// Walks every entity returned by [`load_entity_infos`], embeds those
+    /// whose `name_embedding` is `None` via `provider`, and writes the
+    /// result back through [`update_entity_name_embedding`]. Returns the
+    /// number of rows that were filled in.
+    ///
+    /// This is the lazy half of the #4165 Path A lifecycle: degraded-mode
+    /// installs and rows that predate v13 stay at `embed_sim = 0.0` until
+    /// a future dedup run is invoked with a provider in scope. Individual
+    /// embedding failures are logged and counted but do not abort the
+    /// scan — partial backfill is more useful than no backfill when only
+    /// a subset of names trips the embedding model.
+    ///
+    /// [`load_entity_infos`]: Self::load_entity_infos
+    /// [`update_entity_name_embedding`]: Self::update_entity_name_embedding
+    #[instrument(skip(self, provider))]
+    pub fn backfill_entity_name_embeddings(
+        &self,
+        provider: &dyn crate::embedding::EmbeddingProvider,
+        nous_id: &str,
+    ) -> crate::error::Result<u64> {
+        // WHY: avoid backfilling against a degraded sentinel — every
+        // call would return an error and inflate the failure counter
+        // without making the dedup pipeline any more accurate.
+        if crate::embedding::is_degraded_provider(provider) {
+            tracing::warn!(
+                nous_id,
+                "backfill_entity_name_embeddings: provider is degraded; skipping"
+            );
+            return Ok(0);
+        }
+
+        let entities = self.load_entity_infos(nous_id)?;
+        let mut filled: u64 = 0;
+        let mut failures: u32 = 0;
+        for e in &entities {
+            if e.name_embedding.is_some() {
+                continue;
+            }
+            match provider.embed(&e.name) {
+                Ok(vec) => {
+                    if let Err(err) = self.update_entity_name_embedding(&e.id, Some(vec)) {
+                        tracing::warn!(
+                            entity_id = %e.id,
+                            error = %err,
+                            "backfill: failed to write name_embedding"
+                        );
+                        failures = failures.saturating_add(1);
+                    } else {
+                        filled = filled.saturating_add(1);
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        entity_id = %e.id,
+                        error = %err,
+                        "backfill: failed to embed entity name"
+                    );
+                    failures = failures.saturating_add(1);
+                }
+            }
+        }
+        if failures > 0 {
+            tracing::info!(
+                filled,
+                failures,
+                "backfill_entity_name_embeddings complete (with failures)"
+            );
+        }
+        Ok(filled)
+    }
+
+    /// Run the dedup pipeline after backfilling missing name embeddings.
+    ///
+    /// When `provider` is `Some`, calls
+    /// [`backfill_entity_name_embeddings`](Self::backfill_entity_name_embeddings)
+    /// to populate any NULL `name_embedding`s before delegating to
+    /// [`run_entity_dedup`](Self::run_entity_dedup). When `provider` is
+    /// `None`, behaves identically to `run_entity_dedup` — degraded-mode
+    /// installs continue to produce review-tier candidates only, since
+    /// the maximum composite score without embeddings is 0.70 (#4165).
+    ///
+    /// Backfill failure (e.g. the provider rate-limited) is non-fatal:
+    /// the dedup scan still runs over whatever embeddings did land, so
+    /// callers always get *some* progress. Whichever entities were
+    /// successfully embedded contribute real `embed_sim` values; the rest
+    /// stay at 0.0 for this pass.
+    #[instrument(skip(self, provider))]
+    pub fn run_entity_dedup_with_embeddings(
+        &self,
+        nous_id: &str,
+        provider: Option<&dyn crate::embedding::EmbeddingProvider>,
+    ) -> crate::error::Result<Vec<crate::dedup::MergeRecord>> {
+        if let Some(p) = provider
+            && let Err(e) = self.backfill_entity_name_embeddings(p, nous_id)
+        {
+            tracing::warn!(
+                nous_id,
+                error = %e,
+                "backfill_entity_name_embeddings failed; falling back to embedded-or-null dedup"
+            );
+        }
+        self.run_entity_dedup(nous_id)
+    }
+
     /// Load all entities as lightweight `EntityInfo` structs.
     pub(super) fn load_entity_infos(
         &self,
@@ -404,13 +623,16 @@ impl KnowledgeStore {
     ) -> crate::error::Result<Vec<crate::dedup::EntityInfo>> {
         use std::collections::BTreeMap;
 
-        let script = r"?[id, name, entity_type, aliases, created_at] :=
-            *entities{id, name, entity_type, aliases, created_at}";
+        // WHY (#4165 Path A): pull `name_embedding` alongside the other
+        // entity fields so the dedup pipeline can compute real cosine
+        // similarity for the `embed_sim` term in the merge score.
+        let script = r"?[id, name, entity_type, aliases, created_at, name_embedding] :=
+            *entities{id, name, entity_type, aliases, created_at, name_embedding}";
         let rows = self.run_read(script, BTreeMap::new())?;
 
         let mut entities = Vec::new();
         for row in &rows.rows {
-            if row.len() < 5 {
+            if row.len() < 6 {
                 continue;
             }
             let id_str = extract_str(&row[0])?;
@@ -427,6 +649,7 @@ impl KnowledgeStore {
             };
             let created_at = crate::knowledge::parse_timestamp(&extract_str(&row[4])?)
                 .unwrap_or_else(jiff::Timestamp::now);
+            let name_embedding = super::marshal::extract_optional_f32_vec(&row[5])?;
 
             let rel_count = self.count_relationships(&id_str)?;
 
@@ -438,6 +661,7 @@ impl KnowledgeStore {
                 aliases,
                 relationship_count: u32::try_from(rel_count).unwrap_or(0),
                 created_at,
+                name_embedding,
             });
         }
         Ok(entities)
@@ -686,7 +910,7 @@ impl KnowledgeStore {
     ) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::DataValue;
+        use crate::engine::{Array1, DataValue, Vector};
         let entity = self.load_entity(entity_id)?;
         let lower_new = new_alias.to_lowercase();
 
@@ -699,6 +923,15 @@ impl KnowledgeStore {
         let mut aliases = entity.aliases;
         aliases.push(new_alias.to_owned());
         let aliases_str = aliases.join(",");
+
+        // WHY (#4165 Path A): the entities upsert now also requires
+        // `$name_embedding` — preserve the existing column value so the
+        // alias update does not silently clear a previously-populated
+        // embedding.
+        let existing_embedding = self.get_entity_name_embedding(entity_id)?;
+        let emb_value = existing_embedding.map_or(DataValue::Null, |v| {
+            DataValue::Vec(Vector::F32(Array1::from(v)))
+        });
 
         let mut params = BTreeMap::new();
         params.insert("id".to_owned(), DataValue::Str(entity_id.as_str().into()));
@@ -716,6 +949,7 @@ impl KnowledgeStore {
             "created_at".to_owned(),
             DataValue::Str(crate::knowledge::format_timestamp(&entity.created_at).into()),
         );
+        params.insert("name_embedding".to_owned(), emb_value);
         self.run_mut(&queries::upsert_entity(), params)
     }
 

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -142,6 +142,13 @@ pub(super) fn entity_to_params(
         "updated_at".to_owned(),
         DataValue::Str(crate::knowledge::format_timestamp(&entity.updated_at).into()),
     );
+    // WHY (#4165 Path A): the entities relation gained a nullable
+    // `name_embedding` column in v13. `Entity` does not carry the embedding
+    // (cross-crate change avoided); callers populate it via
+    // `KnowledgeStore::update_entity_name_embedding` or the dedup-time
+    // backfill. Default to Null here so `insert_entity` preserves prior
+    // behaviour for callers without an `EmbeddingProvider` in scope.
+    p.insert("name_embedding".to_owned(), DataValue::Null);
     p
 }
 
@@ -885,6 +892,39 @@ pub(super) fn extract_int(val: &crate::engine::DataValue) -> crate::error::Resul
         }
         .build()
     })
+}
+
+/// Extract a nullable `<F32; DIM>` vector column from a `DataValue`.
+///
+/// Returns `None` for `DataValue::Null` (e.g. an entity row whose
+/// `name_embedding` has not been populated yet); returns `Some` for a
+/// stored vector. Used by the dedup pipeline to feed real cosine
+/// similarity into the merge score (#4165 Path A).
+#[cfg(feature = "mneme-engine")]
+pub(super) fn extract_optional_f32_vec(
+    val: &crate::engine::DataValue,
+) -> crate::error::Result<Option<Vec<f32>>> {
+    use crate::engine::{DataValue, Vector};
+    match val {
+        DataValue::Null => Ok(None),
+        DataValue::Vec(Vector::F32(arr)) => Ok(Some(arr.to_vec())),
+        DataValue::Vec(Vector::F64(arr)) => {
+            // WHY: callers only ever write F32; defensively coerce F64 in
+            // case a stored column was widened by a future migration so the
+            // dedup pipeline does not silently fall back to embed_sim=0.0.
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_possible_truncation,
+                reason = "narrowing F64 → F32 for embedding storage parity; precision loss is acceptable here because cosine-similarity inputs are already normalised"
+            )]
+            let v: Vec<f32> = arr.iter().map(|x| *x as f32).collect();
+            Ok(Some(v))
+        }
+        other => Err(crate::error::ConversionSnafu {
+            message: format!("expected Vec(F32) or Null, got {other:?}"),
+        }
+        .build()),
+    }
 }
 
 #[cfg(feature = "mneme-engine")]

--- a/crates/episteme/src/knowledge_store/migration.rs
+++ b/crates/episteme/src/knowledge_store/migration.rs
@@ -2,7 +2,7 @@
     clippy::indexing_slicing,
     reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
 )]
-use super::{KNOWLEDGE_DDL, KnowledgeStore, fts_ddl};
+use super::{KNOWLEDGE_DDL, KnowledgeStore, entities_ddl, fts_ddl};
 
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
@@ -907,6 +907,118 @@ impl KnowledgeStore {
             })?;
 
         tracing::info!("knowledge schema migration v11 -> v12 complete");
+        Ok(())
+    }
+
+    /// Migrate v12 → v13: add `name_embedding` to `entities`.
+    ///
+    /// Wires Path A of the memory-dedup reachability fix (#4165). The
+    /// dedup pipeline weights `embed_sim` at 0.30; with no column to store
+    /// per-entity name embeddings, both production callers passed
+    /// `|_, _| 0.0`, capping the composite score at 0.70 and making
+    /// `MergeDecision::AutoMerge` (≥ 0.90) structurally unreachable. This
+    /// migration adds a nullable `name_embedding: <F32; DIM>?` column;
+    /// existing rows are backfilled with NULL (preserving prior behaviour),
+    /// and callers with an [`EmbeddingProvider`] in scope can populate
+    /// embeddings via [`KnowledgeStore::update_entity_name_embedding`] or
+    /// the dedup-time backfill in
+    /// [`KnowledgeStore::run_entity_dedup_with_embeddings`].
+    ///
+    /// [`EmbeddingProvider`]: crate::embedding::EmbeddingProvider
+    pub(super) fn migrate_v12_to_v13(&self) -> crate::error::Result<()> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::{DataValue, ScriptMutability};
+        tracing::info!("migrating knowledge schema v12 -> v13");
+
+        let all_entities = self
+            .db
+            .run(
+                r"?[id, name, entity_type, aliases, created_at, updated_at] :=
+                    *entities{id, name, entity_type, aliases, created_at, updated_at}",
+                BTreeMap::new(),
+                ScriptMutability::Immutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v12->v13 read entities: {e}"),
+                }
+                .build()
+            })?;
+
+        self.db
+            .run(
+                "::remove entities",
+                BTreeMap::new(),
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v12->v13 remove entities: {e}"),
+                }
+                .build()
+            })?;
+
+        let entities_script = entities_ddl(self.dim);
+        self.db
+            .run(&entities_script, BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v12->v13 recreate entities: {e}"),
+                }
+                .build()
+            })?;
+
+        for row in &all_entities.rows {
+            let script = r"
+                ?[id, name, entity_type, aliases, created_at, updated_at, name_embedding] <- [[
+                    $id, $name, $entity_type, $aliases, $created_at, $updated_at, null
+                ]]
+                :put entities {id => name, entity_type, aliases, created_at, updated_at, name_embedding}
+            ";
+            let mut params = BTreeMap::new();
+            for (i, name) in [
+                "id",
+                "name",
+                "entity_type",
+                "aliases",
+                "created_at",
+                "updated_at",
+            ]
+            .iter()
+            .enumerate()
+            {
+                if let Some(val) = row.get(i) {
+                    params.insert((*name).to_owned(), val.clone());
+                }
+            }
+            self.db
+                .run(script, params, ScriptMutability::Mutable)
+                .map_err(|e| {
+                    crate::error::EngineQuerySnafu {
+                        message: format!("v12->v13 reinsert entity: {e}"),
+                    }
+                    .build()
+                })?;
+        }
+
+        let mut params = BTreeMap::new();
+        params.insert("key".to_owned(), DataValue::Str("schema".into()));
+        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
+        self.db
+            .run(
+                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
+                params,
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v12->v13 version write failed: {e}"),
+                }
+                .build()
+            })?;
+
+        tracing::info!("knowledge schema migration v12 -> v13 complete");
         Ok(())
     }
 }

--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -20,7 +20,8 @@
 //!         visibility: String }
 //!
 //! entities { id: String => name: String, entity_type: String, aliases: String,
-//!            created_at: String, updated_at: String }
+//!            created_at: String, updated_at: String,
+//!            name_embedding: <F32; DIM>? }
 //!
 //! relationships { src: String, dst: String => relation: String, weight: Float,
 //!                 created_at: String }
@@ -94,6 +95,11 @@ pub const KNOWLEDGE_DDL: &[&str] = &[
         project_id: String?,
         visibility: String default 'private'
     }",
+    // WHY: index 1 is a sentinel — `init_schema` skips this entry and runs
+    // the dim-parameterized `entities_ddl(self.dim)` instead so the relation
+    // carries a `name_embedding: <F32; DIM>?` column for the dedup pipeline
+    // (#4165 Path A). The literal here documents the pre-v13 shape but is
+    // not executed against any database.
     r":create entities {
         id: String =>
         name: String,
@@ -174,6 +180,27 @@ pub const KNOWLEDGE_DDL: &[&str] = &[
         contributed_at: String
     }",
 ];
+
+/// Datalog DDL for the entities relation. Dimension is parameterized so the
+/// `name_embedding` column can hold a fixed-size F32 vector matching the
+/// configured embedding provider. Nullable: entities created before the
+/// dedup-reachability fix (#4165) and entities inserted while no provider is
+/// configured leave the column NULL; the dedup pipeline treats NULL as
+/// `embed_sim = 0.0` for those pairs (degraded-mode behaviour).
+#[instrument]
+pub fn entities_ddl(dim: usize) -> String {
+    format!(
+        r":create entities {{
+            id: String =>
+            name: String,
+            entity_type: String,
+            aliases: String,
+            created_at: String,
+            updated_at: String,
+            name_embedding: <F32; {dim}>?
+        }}"
+    )
+}
 
 /// Datalog DDL for the embeddings relation. Dimension is parameterized.
 #[instrument]
@@ -496,7 +523,7 @@ pub struct KnowledgeStore {
 
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
-    const SCHEMA_VERSION: i64 = 12;
+    const SCHEMA_VERSION: i64 = 13;
 
     /// Open an in-memory knowledge store with default configuration.
     ///
@@ -732,10 +759,20 @@ impl KnowledgeStore {
             if current_version < 12 {
                 self.migrate_v11_to_v12()?;
             }
+            if current_version < 13 {
+                self.migrate_v12_to_v13()?;
+            }
             return Ok(());
         }
 
-        for ddl in KNOWLEDGE_DDL {
+        // WHY: skip KNOWLEDGE_DDL[1] — the entities relation needs a
+        // dim-parameterized `name_embedding` column for the dedup pipeline
+        // (#4165 Path A). It is created explicitly via `entities_ddl(self.dim)`
+        // below; the static literal at index 1 is documentation-only.
+        for (i, ddl) in KNOWLEDGE_DDL.iter().enumerate() {
+            if i == 1 {
+                continue;
+            }
             self.db
                 .run(ddl, BTreeMap::new(), ScriptMutability::Mutable)
                 .map_err(|e| {
@@ -745,6 +782,16 @@ impl KnowledgeStore {
                     .build()
                 })?;
         }
+
+        let entities_script = entities_ddl(self.dim);
+        self.db
+            .run(&entities_script, BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
 
         let emb_ddl = embeddings_ddl(self.dim);
         self.db

--- a/crates/episteme/src/knowledge_store/tests/entities.rs
+++ b/crates/episteme/src/knowledge_store/tests/entities.rs
@@ -262,3 +262,281 @@ fn insert_entity_unicode() {
         .expect("neighborhood query");
     assert!(rows.is_empty() || !rows.is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// #4165 Path A — end-to-end pipeline tests
+//
+// `dedup_tests.rs` covers `generate_candidates` + `make_embedding_lookup` in
+// isolation; the tests below exercise the actual `KnowledgeStore` API —
+// schema v13 column, `update_entity_name_embedding`, `find_duplicate_entities`,
+// `run_entity_dedup`, and the `approve_merge` queue. This is the reachability
+// proof that the pipeline survives the journey through Cozo storage round-trips.
+// ---------------------------------------------------------------------------
+
+/// Pre-fix shape: insert two near-identical entities without populating
+/// `name_embedding`, then run the production `run_entity_dedup`. The bug
+/// the design doc described — no auto-merges possible — must reproduce.
+#[test]
+fn dedup_pipeline_without_embeddings_reproduces_bug_4165() {
+    let store = make_store();
+    let mut e1 = make_entity("e1", "Acme Corporation", "organization");
+    e1.aliases = vec!["Acme".to_owned()];
+    let mut e2 = make_entity("e2", "acme corporation", "organization");
+    e2.aliases = vec!["Acme".to_owned()];
+    store.insert_entity(&e1).expect("insert e1");
+    store.insert_entity(&e2).expect("insert e2");
+
+    let records = store
+        .run_entity_dedup("test-nous")
+        .expect("dedup should succeed even with no embeddings");
+    assert!(
+        records.is_empty(),
+        "pre-fix shape (no embeddings stored) must produce zero auto-merges — this is the unreachability bug #4165 documented"
+    );
+
+    // The pair should still land in the review queue (score 0.70).
+    let pending = store
+        .get_pending_merges("test-nous")
+        .expect("read pending merges");
+    assert_eq!(
+        pending.len(),
+        1,
+        "the pair should be queued for review even without embeddings"
+    );
+}
+
+/// Reachability: populate both entities' `name_embedding`s, run the
+/// production `run_entity_dedup`, and assert a real auto-merge was
+/// executed. This is the end-to-end proof that #4165 Path A reaches
+/// `MergeDecision::AutoMerge` from production code.
+#[test]
+fn dedup_pipeline_with_embeddings_reaches_auto_merge() {
+    let store = make_store();
+    let mut e1 = make_entity("e1", "Acme Corporation", "organization");
+    e1.aliases = vec!["Acme".to_owned()];
+    let mut e2 = make_entity("e2", "acme corporation", "organization");
+    e2.aliases = vec!["Acme".to_owned()];
+    store.insert_entity(&e1).expect("insert e1");
+    store.insert_entity(&e2).expect("insert e2");
+
+    // DIM=4 from `test_fixtures::DIM`; identical unit vectors yield
+    // cosine = 1.0 — the test-shape equivalent of "the provider thinks
+    // these names mean the same thing".
+    let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+    let e1_id = crate::id::EntityId::new("e1").expect("valid test id");
+    let e2_id = crate::id::EntityId::new("e2").expect("valid test id");
+    store
+        .update_entity_name_embedding(&e1_id, Some(emb.clone()))
+        .expect("write e1 name_embedding");
+    store
+        .update_entity_name_embedding(&e2_id, Some(emb))
+        .expect("write e2 name_embedding");
+
+    // Round-trip check that the embedding survives storage.
+    let roundtrip = store
+        .get_entity_name_embedding(&e1_id)
+        .expect("read e1 name_embedding");
+    assert!(
+        matches!(roundtrip, Some(ref v) if v.len() == 4),
+        "stored name_embedding must round-trip with the configured dim"
+    );
+
+    let records = store
+        .run_entity_dedup("test-nous")
+        .expect("dedup with embeddings");
+    assert_eq!(
+        records.len(),
+        1,
+        "with name embeddings stored, the production dedup pipeline must reach AutoMerge — proves #4165 Path A is wired end-to-end"
+    );
+    let record = &records[0];
+    assert!(
+        record.merge_score >= 0.90,
+        "executed merge score must clear the AutoMerge threshold; got {}",
+        record.merge_score
+    );
+
+    // After auto-merge, the merged entity is gone and only canonical remains.
+    let surviving = store.list_entities().expect("list_entities");
+    assert_eq!(
+        surviving.len(),
+        1,
+        "auto-merge must collapse the duplicate pair to a single canonical entity"
+    );
+}
+
+/// Reachability via `find_duplicate_entities`: returns candidates whose
+/// `embed_similarity` is the real cosine of the stored vectors, not 0.0.
+#[test]
+fn find_duplicate_entities_returns_real_embed_similarity() {
+    let store = make_store();
+    let e1 = make_entity("e1", "Differential Equation", "concept");
+    let e2 = make_entity("e2", "Difference Equation", "concept");
+    store.insert_entity(&e1).expect("insert e1");
+    store.insert_entity(&e2).expect("insert e2");
+
+    let e1_id = crate::id::EntityId::new("e1").expect("valid test id");
+    let e2_id = crate::id::EntityId::new("e2").expect("valid test id");
+    // 30° apart → cosine ≈ 0.866 (well above 0 but below 1).
+    store
+        .update_entity_name_embedding(&e1_id, Some(vec![1.0_f32, 0.0, 0.0, 0.0]))
+        .expect("e1 emb");
+    store
+        .update_entity_name_embedding(&e2_id, Some(vec![0.866_025_4_f32, 0.5, 0.0, 0.0]))
+        .expect("e2 emb");
+
+    let candidates = store
+        .find_duplicate_entities("test-nous")
+        .expect("find_duplicate_entities");
+    assert_eq!(candidates.len(), 1, "JW similar names form one candidate");
+    let c = &candidates[0];
+    assert!(
+        c.embed_similarity > 0.85 && c.embed_similarity < 0.95,
+        "find_duplicate_entities must surface real cosine similarity from stored embeddings; got {}",
+        c.embed_similarity
+    );
+}
+
+/// `update_entity_name_embedding` must reject vectors whose length does
+/// not match `KnowledgeConfig::dim`. A silent wrong-dim write would
+/// corrupt the typed column and break every subsequent dedup run.
+#[test]
+fn update_entity_name_embedding_rejects_wrong_dimension() {
+    let store = make_store();
+    let entity = make_entity("e1", "Alice", "person");
+    store.insert_entity(&entity).expect("insert entity");
+    let id = crate::id::EntityId::new("e1").expect("valid test id");
+    let wrong_dim = vec![1.0_f32; 7]; // DIM is 4 in tests
+    let err = store
+        .update_entity_name_embedding(&id, Some(wrong_dim))
+        .expect_err("must reject wrong-dim embedding");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("dimension"),
+        "error message should mention dimension; got: {msg}"
+    );
+}
+
+/// `update_entity_name_embedding(_, None)` clears a stored embedding —
+/// useful for tests, operators reverting a bad backfill, and admission
+/// policies that disqualify a stored vector after the fact.
+#[test]
+fn update_entity_name_embedding_clears_with_none() {
+    let store = make_store();
+    let entity = make_entity("e1", "Alice", "person");
+    store.insert_entity(&entity).expect("insert entity");
+    let id = crate::id::EntityId::new("e1").expect("valid test id");
+    store
+        .update_entity_name_embedding(&id, Some(vec![1.0_f32, 0.0, 0.0, 0.0]))
+        .expect("set embedding");
+    assert!(
+        store
+            .get_entity_name_embedding(&id)
+            .expect("get embedding")
+            .is_some(),
+        "embedding should be present after set"
+    );
+    store
+        .update_entity_name_embedding(&id, None)
+        .expect("clear embedding");
+    assert!(
+        store
+            .get_entity_name_embedding(&id)
+            .expect("get embedding")
+            .is_none(),
+        "embedding should be cleared after None write"
+    );
+}
+
+/// `approve_merge` is the operational half of #4165 Path A. Insert two
+/// entities that land in the review queue (score in `[0.70, 0.90)`),
+/// then approve the merge and assert that:
+///   1. The merged entity is gone.
+///   2. The canonical entity carries the merged name as an alias.
+///   3. `pending_merges` no longer contains the pair.
+///   4. `merge_audit` records the resolution.
+#[test]
+fn approve_merge_drains_review_queue() {
+    let store = make_store();
+    // Two entities that match on every non-embedding signal: cap at 0.70
+    // → review tier, not auto-merge.
+    let mut e1 = make_entity("e1", "Acme Corporation", "organization");
+    e1.aliases = vec!["Acme".to_owned()];
+    let mut e2 = make_entity("e2", "acme corporation", "organization");
+    e2.aliases = vec!["Acme".to_owned()];
+    store.insert_entity(&e1).expect("insert e1");
+    store.insert_entity(&e2).expect("insert e2");
+
+    let records = store
+        .run_entity_dedup("test-nous")
+        .expect("dedup populates pending_merges");
+    assert!(
+        records.is_empty(),
+        "no auto-merge expected for embed=null pair"
+    );
+    let pending = store
+        .get_pending_merges("test-nous")
+        .expect("pending merges");
+    assert_eq!(pending.len(), 1, "pair should be queued for review");
+
+    let e1_id = crate::id::EntityId::new("e1").expect("valid test id");
+    let e2_id = crate::id::EntityId::new("e2").expect("valid test id");
+    let record = store
+        .approve_merge(&e1_id, &e2_id)
+        .expect("approve_merge must succeed for queued pair");
+    assert_eq!(record.canonical_entity_id, e1_id);
+    assert_eq!(record.merged_entity_id, e2_id);
+
+    let surviving = store.list_entities().expect("list_entities");
+    assert_eq!(surviving.len(), 1, "approved merge must collapse the pair");
+    assert_eq!(surviving[0].id, e1_id);
+    // NOTE: `add_alias_to_entity` skips adding the merged name when it
+    // matches the canonical name case-insensitively; with names that
+    // collide on lowercase ("Acme Corporation" vs "acme corporation")
+    // no new alias is introduced. The pre-existing "Acme" alias must
+    // still be preserved as the audit trail for the merged identity.
+    assert!(
+        surviving[0]
+            .aliases
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("Acme")),
+        "canonical entity must preserve its existing aliases through merge: got {:?}",
+        surviving[0].aliases
+    );
+
+    let pending_after = store
+        .get_pending_merges("test-nous")
+        .expect("pending merges after approve");
+    assert!(
+        pending_after.is_empty(),
+        "approved row must be removed from pending_merges; got {} remaining",
+        pending_after.len()
+    );
+
+    let history = store
+        .get_merge_history("test-nous")
+        .expect("merge_audit history");
+    assert_eq!(
+        history.len(),
+        1,
+        "approved merge must be recorded in merge_audit"
+    );
+}
+
+/// Schema v13 invariant: a freshly initialised store must accept reads
+/// against the `name_embedding` column. This guards against future
+/// refactors that drop the column from the static DDL or skip the
+/// dim-parameterised `entities_ddl` branch in `init_schema`.
+#[test]
+fn entities_relation_has_name_embedding_column_in_fresh_store() {
+    let store = make_store();
+    let rows = store
+        .run_query(
+            r"?[id, name_embedding] := *entities{id, name_embedding}",
+            std::collections::BTreeMap::new(),
+        )
+        .expect(
+            "fresh store must accept a query against the name_embedding column — schema v13 contract",
+        );
+    assert!(rows.is_empty(), "empty store should return no rows");
+}

--- a/crates/episteme/src/phase_f_integration_tests.rs
+++ b/crates/episteme/src/phase_f_integration_tests.rs
@@ -99,6 +99,7 @@ fn dedup_candidate_generation_finds_duplicate_instinct_patterns() {
             aliases: vec![],
             relationship_count: 5,
             created_at: ts_a,
+            name_embedding: None,
         },
         EntityInfo {
             id: EntityId::new("instinct-grep-2").expect("valid test id"),
@@ -107,6 +108,7 @@ fn dedup_candidate_generation_finds_duplicate_instinct_patterns() {
             aliases: vec![],
             relationship_count: 3,
             created_at: ts_b,
+            name_embedding: None,
         },
     ];
 

--- a/crates/episteme/src/query/queries.rs
+++ b/crates/episteme/src/query/queries.rs
@@ -249,14 +249,28 @@ pub(crate) fn supersede_fact() -> String {
 }
 
 /// Insert or update an entity.
-/// Params: `$id`, `$name`, `$entity_type`, `$aliases`, `$created_at`, `$updated_at`.
+/// Params: `$id`, `$name`, `$entity_type`, `$aliases`, `$created_at`,
+/// `$updated_at`, `$name_embedding`.
+///
+/// `$name_embedding` may be `DataValue::Null` for callers without an
+/// `EmbeddingProvider` in scope; the dedup pipeline treats NULL as
+/// `embed_sim = 0.0`. See `KnowledgeStore::update_entity_name_embedding`
+/// and `KnowledgeStore::run_entity_dedup_with_embeddings` for the
+/// backfill path (#4165 / Path A).
 #[must_use]
 pub(crate) fn upsert_entity() -> String {
     use EntitiesField::*;
     QueryBuilder::new()
         .put(Relation::Entities)
         .keys(&[Id])
-        .values(&[Name, EntityType, Aliases, CreatedAt, UpdatedAt])
+        .values(&[
+            Name,
+            EntityType,
+            Aliases,
+            CreatedAt,
+            UpdatedAt,
+            NameEmbedding,
+        ])
         .done()
         .build_script()
 }

--- a/crates/episteme/src/query/schema.rs
+++ b/crates/episteme/src/query/schema.rs
@@ -87,6 +87,10 @@ pub enum EntitiesField {
     Aliases,
     CreatedAt,
     UpdatedAt,
+    /// Nullable embedding of [`Self::Name`]; populated by the dedup pipeline
+    /// (#4165) when an `EmbeddingProvider` is in scope. NULL for entities
+    /// inserted in degraded mode or before the v13 schema migration.
+    NameEmbedding,
 }
 
 /// Fields in the `relationships` relation.

--- a/crates/episteme/src/query/schema/field_impl.rs
+++ b/crates/episteme/src/query/schema/field_impl.rs
@@ -41,6 +41,7 @@ impl Field for EntitiesField {
             Self::Aliases => "aliases",
             Self::CreatedAt => "created_at",
             Self::UpdatedAt => "updated_at",
+            Self::NameEmbedding => "name_embedding",
         }
     }
 }

--- a/crates/episteme/src/query/tests/builders.rs
+++ b/crates/episteme/src/query/tests/builders.rs
@@ -114,11 +114,15 @@ fn test_builder_matches_supersede_fact() {
 
 #[test]
 fn test_builder_matches_upsert_entity() {
+    // Includes the v13 `name_embedding` column added by #4165 Path A —
+    // the dedup pipeline needs a stable place to cache per-entity name
+    // embeddings so cosine similarity becomes a real signal in the
+    // merge-score composite.
     let original = r"
-    ?[id, name, entity_type, aliases, created_at, updated_at] <- [
-        [$id, $name, $entity_type, $aliases, $created_at, $updated_at]
+    ?[id, name, entity_type, aliases, created_at, updated_at, name_embedding] <- [
+        [$id, $name, $entity_type, $aliases, $created_at, $updated_at, $name_embedding]
     ]
-    :put entities {id => name, entity_type, aliases, created_at, updated_at}
+    :put entities {id => name, entity_type, aliases, created_at, updated_at, name_embedding}
 ";
     let built = queries::upsert_entity();
     assert_eq!(

--- a/crates/episteme/src/query/tests/datalog.rs
+++ b/crates/episteme/src/query/tests/datalog.rs
@@ -202,6 +202,7 @@ fn test_field_names_match_schema() {
         "aliases",
         "created_at",
         "updated_at",
+        "name_embedding",
     ];
     let entities_enum: Vec<&str> = [
         EntitiesField::Id,
@@ -210,6 +211,7 @@ fn test_field_names_match_schema() {
         EntitiesField::Aliases,
         EntitiesField::CreatedAt,
         EntitiesField::UpdatedAt,
+        EntitiesField::NameEmbedding,
     ]
     .iter()
     .map(|f| f.name())

--- a/crates/episteme/src/verification/tests.rs
+++ b/crates/episteme/src/verification/tests.rs
@@ -209,7 +209,12 @@ fn fresh_store_migrates_to_current_schema() {
 
     let store = KnowledgeStore::open_mem().expect("open_mem should succeed");
     let v = store.schema_version().expect("read schema version");
-    assert_eq!(v, 12, "fresh store should initialize at schema version 12");
+    // #4165 Path A bumped to v13 to add the nullable `name_embedding`
+    // column on the entities relation.
+    assert_eq!(
+        v, 13,
+        "fresh store should initialize at the current schema version"
+    );
 
     // Probe the new relations exist by querying them (empty result is fine).
     let probe_pubs = store.run_query("?[id] := *published_facts{id}", BTreeMap::new());


### PR DESCRIPTION
## Summary

Closes #4165. Implements Path A of the #4305 design doc: make
`MergeDecision::AutoMerge` reachable from production code by wiring
real cosine similarity through the entity dedup pipeline.

Before this PR, both production callers of `generate_candidates`
(`find_duplicate_entities` and `run_entity_dedup`) passed `|_, _| 0.0`
for `embed_sim`. The composite score is `0.4·name + 0.3·embed + 0.2·type + 0.1·alias`,
so the maximum achievable score was `0.4·1 + 0.3·0 + 0.2·1 + 0.1·1 = 0.70` —
strictly below the `0.90` AutoMerge threshold. The CLI printed "stored
for review" and the maintenance task logged "N entities merged
automatically" with `N` structurally always 0.

### Path A wiring

1. **Schema v13** — `entities` gains a nullable `name_embedding: <F32; DIM>?`
   column. `entities_ddl(dim)` parameterises the column to the
   configured embedding dim, matching `embeddings_ddl`. `migrate_v12_to_v13`
   reads existing rows, drops + recreates the relation, and reinserts
   with `name_embedding = null` (degraded-mode default).

2. **Lifecycle** —
   - At-creation: `update_entity_name_embedding(id, Option<Vec<f32>>)`
     lets the extraction pipeline cache the embedding right after
     `insert_entity`. Rejects wrong-dim vectors with
     `EmbeddingDimensionMismatch`.
   - Lazy / scheduled: `backfill_entity_name_embeddings(provider, nous_id)`
     walks NULL rows and embeds them; individual failures are logged
     but do not abort the scan. `run_entity_dedup_with_embeddings`
     composes both: the maintenance task now hands the runtime
     `EmbeddingProvider` to the dedup adapter so backfill happens
     automatically before each scheduled scan.

3. **Dedup closure** — `make_embedding_lookup` builds a HashMap over
   loaded `EntityInfo`s and returns a closure that computes
   `cosine_similarity` for pairs whose embeddings are both present,
   `0.0` otherwise. `cosine_similarity` is now clamped to `[0.0, 1.0]`
   to defend against floating-point drift from real providers.

4. **Approval path** — `approve_merge` is promoted to `pub` and
   exposed through three new CLI subcommands:
   - `aletheia memory dedup-pending --nous-id ID`
   - `aletheia memory dedup-approve --nous-id ID --canonical-id ID --merged-id ID`
   - `aletheia memory dedup-reject --nous-id ID --entity-a ID --entity-b ID`

   The `pending_merges` queue (review-tier candidates that did not
   auto-merge) is now drainable; previously it was a write-only sink.

### Degraded-mode behaviour

When no `EmbeddingProvider` is configured, rows stay at
`name_embedding = null`, the closure returns `0.0`, and the pipeline
behaves identically to pre-fix. This is the design's "70% non-embedding
floor" — operators without an embedding model still get a review queue,
just no auto-merges.

## Tests

Two reachability regression families pin the contract:

* **`pre_fix_regression_*`** — assert the no-embed shape produces zero
  auto-merges, so any future regression to `|_, _| 0.0` trips loudly.
* **`path_a_reachable_*`** + DB integration tests
  (`dedup_pipeline_with_embeddings_reaches_auto_merge`,
   `find_duplicate_entities_returns_real_embed_similarity`,
   `approve_merge_drains_review_queue`,
   `entities_relation_has_name_embedding_column_in_fresh_store`,
   `update_entity_name_embedding_rejects_wrong_dimension`,
   `update_entity_name_embedding_clears_with_none`) — exercise the
  full pipeline (schema v13 column round-trip,
  `update_entity_name_embedding`, `find_duplicate_entities`,
  `run_entity_dedup`, and `approve_merge`) and assert that duplicates
  with stored embeddings actually clear the 0.90 threshold from the
  production code shape.

Episteme test suite: **1242 / 1242 pass**.

## Test plan

- [x] `cargo test -p episteme --features mneme-engine --lib` — 1242 / 1242 pass.
- [x] `kanon gate --stamp` — Gate-Passed (`cargo fmt` / `check` / `clippy` / `nextest` / `kanon lint` / `audit` / `fleet-names`).
- [ ] Operator smoke-test: run `aletheia memory dedup-pending` against an instance with stored duplicates, then `dedup-approve` one row, then re-run `dedup-pending` to confirm the row is drained.
- [ ] Operator smoke-test: confirm the scheduled `entity-dedup` maintenance task reports `N > 0` merges after a populated install with a configured embedding provider.

## Out of scope for this PR

- **Mechanical bundle (B/D/E/F + C-cheap from #4165 triage)** — config
  threshold plumbing (`taxis::AgentBehaviorDefaults::knowledge_dedup_*`),
  `--nous-id` scoping for `load_entity_infos`, `--help` text fix, and
  the regression test that survives a future code-shape change. These
  ship safely under any contract per the design doc and are filed for
  a follow-up PR.
- **Fact-content dedup (C-hard)** — `find_content_hash_duplicates` still
  only displays, never merges. Out of scope for the entity-dedup
  reachability fix.