### PR TITLE
ci(_llm): skip llm-regen on pushes that cannot change L3 output (#4322)

### DIFF
--- a/.github/workflows/llm-regen.yml
+++ b/.github/workflows/llm-regen.yml
@@ -13,8 +13,22 @@
 name: _llm Regeneration
 
 on:
+  # WHY: paths-ignore skips the run entirely when every changed file is in a
+  # path that cannot affect L3 output. The L3 extractor only reads `*.rs`
+  # files (scripts/llm-extract-l3.py), so doc-only or self-trigger pushes
+  # (chore(_llm) merges) burn runner time without producing a new regen PR.
+  # The internal `detect` step still no-ops on mixed pushes; this is the
+  # cheap event-level pre-filter for the pure-skip case.
   push:
     branches: [main]
+    paths-ignore:
+      - "_llm/**"
+      - "docs/**"
+      - "planning/**"
+      - "decisions/**"
+      - ".github/**"
+      - "instance.example/**"
+      - "**.md"
 
 permissions:
   contents: write


### PR DESCRIPTION
## What

Adds `paths-ignore:` to `.github/workflows/llm-regen.yml`'s `push` trigger so the workflow does not start when the entire diff is in a path that cannot affect the L3 output.

```yaml
on:
  push:
    branches: [main]
    paths-ignore:
      - "_llm/**"
      - "docs/**"
      - "planning/**"
      - "decisions/**"
      - ".github/**"
      - "instance.example/**"
      - "**.md"
```

## Why

The L3 extractor (`scripts/llm-extract-l3.py`) only reads `*.rs`. Pushes that touch only `_llm/`, docs, planning, decisions, workflow YAML, instance.example, or markdown can never produce a new regen PR — they always no-op the internal `detect` step, but still burn a self-hosted runner slot and contribute to queue depth (#4319/#4320).

Concrete savings:
- self-trigger after merging `chore(_llm)` regen PRs (4 such runs in the last 100 on 2026-05-28)
- docs-only pushes (`docs/planning/memory dedup reachability` from 2026-05-28 22:25Z)
- workflow edits

GitHub's `paths-ignore` skips iff every file matches; mixed pushes (`crates/foo/src/lib.rs` + `crates/foo/README.md`) still trigger correctly. The internal `detect` step is unchanged — it remains the source of truth for "does the diff touch a known workspace crate."

## Verification after merge

- `gh run list --workflow=llm-regen.yml` does NOT show the SHA of the next merged `chore(_llm)` regen PR.
- A `**.md`-only push to main does NOT appear in that list.
- A normal `crates/**/*.rs` push still triggers the workflow.

Closes #4322.