### PR TITLE
ci: add runner liveness monitor (substrate fix for #4320)

### DIFF
--- a/.github/workflows/runner-liveness.yml
+++ b/.github/workflows/runner-liveness.yml
@@ -1,0 +1,70 @@
+# WHY: The self-hosted runner pool is a single point of failure for
+# every required check on this repo (gate-attestation, security,
+# release-please, no-ai-attribution, llm-regen all `runs-on:
+# self-hosted`). When the pool goes dark — runner crash, host down,
+# network split — every PR's checks sit in `queued` indefinitely with
+# no operator-visible signal. The 2026-05-28 disk-OOM incident
+# (#4320) sat for 30+ minutes before anyone noticed the pool was
+# empty.
+#
+# This workflow polls the GitHub API every 15 minutes from
+# `ubuntu-latest` (independent of the self-hosted pool) and fails
+# loudly if no online + idle runner is available. A failing scheduled
+# run on a hosted workflow generates a notification through the
+# standard GitHub Actions failure email path — no extra alerting
+# wiring needed.
+name: Runner Liveness
+
+on:
+  schedule:
+    # NOTE: */15 keeps the time-to-detection bounded at ~15 min, the
+    # same order as the disk-OOM blind spot from #4320, without
+    # spamming the actions-runners GitHub API quota (96 reads/day).
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  check-pool:
+    name: assert one online idle self-hosted runner
+    # WHY: must be ubuntu-latest. If we ran on self-hosted, the
+    # workflow could not fire when the pool is the thing being
+    # checked, defeating the purpose.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Query repo self-hosted runners
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # WHY: the default `GITHUB_TOKEN` can read this repo's runner
+        # list (actions:read is implicit in the workflow-default
+        # permissions). `gh api --jq` keeps the parse server-side; we
+        # only echo the summarized status to the run log.
+        run: |
+          set -u
+          runners_json=$(gh api -H 'Accept: application/vnd.github+json' \
+            "repos/${{ github.repository }}/actions/runners" \
+            --jq '.runners')
+
+          total=$(echo "$runners_json" | jq 'length')
+          online=$(echo "$runners_json" | jq '[.[] | select(.status == "online")] | length')
+          online_idle=$(echo "$runners_json" | jq '[.[] | select(.status == "online" and .busy == false)] | length')
+
+          echo "self-hosted runners: total=$total online=$online online_idle=$online_idle"
+          echo "$runners_json" | jq -r '.[] | "  \(.name)\tstatus=\(.status)\tbusy=\(.busy)\tlabels=\([.labels[].name] | join(","))"'
+
+          if [ "$online" -eq 0 ]; then
+            echo "::error::no online self-hosted runner for ${{ github.repository }}"
+            echo "::error::all subsequent checks on this repo are stalled until a runner comes back"
+            exit 1
+          fi
+
+          if [ "$online_idle" -eq 0 ]; then
+            echo "::warning::all online runners are busy; queue depth may grow"
+          fi


### PR DESCRIPTION
Refs #4320.

## Summary

Adds `.github/workflows/runner-liveness.yml` — a `runs-on: ubuntu-latest` workflow firing every 15 minutes that queries the GitHub Actions runner API for this repo and **hard-fails** when no self-hosted runner is `status: online`. Failure on a hosted scheduled workflow generates the standard GitHub-native failure-email notification — no separate alerting wiring.

Per-runner status (name / status / busy / labels) is logged on every fire for forensic comparison.

## Why

Per #4320, a single self-hosted runner going dark freezes every required check on this repo (`gate-attestation`, `security`, `release-please`, `no-ai-attribution`, `llm-regen` are all `runs-on: self-hosted`). On 2026-05-28 the pool was dark for 30+ minutes after the disk-OOM crash before anyone noticed. The monitor *must* run on `ubuntu-latest` — running on `self-hosted` would mean the check cannot fire when the pool is the thing being checked.

15-minute cadence keeps time-to-detection bounded; 96 reads/day is well within the API quota for the workflow token.

## What this does NOT do

- Does not auto-restart runners — recovery is operator-owned.
- Does not open issues — failing scheduled workflows already notify; an issue surface would race with itself every 15 min and need dedup.
- Does not check disk (preflight, separate PR under #4320).

## Test plan

- [ ] `workflow_dispatch` on merge to verify summary line lists registered runners.
- [ ] Failure injection: stop the verda runner, wait for next fire (≤15 min), confirm the failure email arrives.