### PR TITLE
ci: add preflight disk check to self-hosted jobs (substrate fix for #4320)

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -16,6 +16,27 @@ jobs:
     name: gate-attestation
     runs-on: self-hosted
     steps:
+      # WHY: Preflight disk check runs first, before any checkout or
+      # heavyweight step writes data. When the host is near full the
+      # worker would otherwise crash with `IOException: No space left
+      # on device` mid-step, the log buffer never flushes, and the
+      # failure surfaces to operators as an opaque domain error (see
+      # #4320). Inline (not composite) so it can run before the
+      # conditional checkout below. Runs unconditionally — bot PRs
+      # still need the runner to have headroom.
+      - name: Preflight disk check
+        env:
+          PREFLIGHT_THRESHOLD: "90"
+        run: |
+          set -u
+          used=$(df -P / | awk 'NR==2 {print $5}' | tr -d '%')
+          echo "preflight: / used=${used}% threshold=${PREFLIGHT_THRESHOLD}%"
+          df -h /
+          if [ "$used" -ge "$PREFLIGHT_THRESHOLD" ]; then
+            echo "::error::preflight: disk usage ${used}% on / exceeds threshold ${PREFLIGHT_THRESHOLD}%; aborting before heavyweight step crashes the worker (see #4320)"
+            exit 1
+          fi
+
       # WHY: bypass keys off the PR author login, not github.actor. The actor
       # changes to a maintainer login whenever someone re-runs the workflow
       # (e.g. clicking "Re-run failed jobs" on a dependabot PR), which silently

--- a/.github/workflows/llm-regen.yml
+++ b/.github/workflows/llm-regen.yml
@@ -43,6 +43,22 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 10
     steps:
+      # WHY: Preflight disk check — fail loudly before checkout when
+      # the host is near full. See #4320 (runner OOM-disk masquerades
+      # as opaque cargo-deny / checkout failure).
+      - name: Preflight disk check
+        env:
+          PREFLIGHT_THRESHOLD: "90"
+        run: |
+          set -u
+          used=$(df -P / | awk 'NR==2 {print $5}' | tr -d '%')
+          echo "preflight: / used=${used}% threshold=${PREFLIGHT_THRESHOLD}%"
+          df -h /
+          if [ "$used" -ge "$PREFLIGHT_THRESHOLD" ]; then
+            echo "::error::preflight: disk usage ${used}% on / exceeds threshold ${PREFLIGHT_THRESHOLD}%; aborting before heavyweight step crashes the worker (see #4320)"
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2

--- a/.github/workflows/no-ai-attribution.yml
+++ b/.github/workflows/no-ai-attribution.yml
@@ -27,6 +27,21 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 3
     steps:
+      # WHY: Preflight disk check — runs first regardless of trusted-bot
+      # waiver because host-level disk OOM affects every job. See #4320.
+      - name: Preflight disk check
+        env:
+          PREFLIGHT_THRESHOLD: "90"
+        run: |
+          set -u
+          used=$(df -P / | awk 'NR==2 {print $5}' | tr -d '%')
+          echo "preflight: / used=${used}% threshold=${PREFLIGHT_THRESHOLD}%"
+          df -h /
+          if [ "$used" -ge "$PREFLIGHT_THRESHOLD" ]; then
+            echo "::error::preflight: disk usage ${used}% on / exceeds threshold ${PREFLIGHT_THRESHOLD}%; aborting before heavyweight step crashes the worker (see #4320)"
+            exit 1
+          fi
+
       # WHY: bypass keys off the PR author login, not github.actor. The actor
       # changes to a maintainer login whenever someone re-runs the workflow
       # (e.g. clicking "Re-run failed jobs" on an automation PR), which silently

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,20 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # WHY: Preflight disk check — see #4320.
+      - name: Preflight disk check
+        env:
+          PREFLIGHT_THRESHOLD: "90"
+        run: |
+          set -u
+          used=$(df -P / | awk 'NR==2 {print $5}' | tr -d '%')
+          echo "preflight: / used=${used}% threshold=${PREFLIGHT_THRESHOLD}%"
+          df -h /
+          if [ "$used" -ge "$PREFLIGHT_THRESHOLD" ]; then
+            echo "::error::preflight: disk usage ${used}% on / exceeds threshold ${PREFLIGHT_THRESHOLD}%; aborting before heavyweight step crashes the worker (see #4320)"
+            exit 1
+          fi
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,22 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
+      # WHY: Preflight disk check — runs first so a disk-OOM crash
+      # surfaces as "preflight failed" instead of as the opaque
+      # "cargo deny failed" that triggered #4320.
+      - name: Preflight disk check
+        env:
+          PREFLIGHT_THRESHOLD: "90"
+        run: |
+          set -u
+          used=$(df -P / | awk 'NR==2 {print $5}' | tr -d '%')
+          echo "preflight: / used=${used}% threshold=${PREFLIGHT_THRESHOLD}%"
+          df -h /
+          if [ "$used" -ge "$PREFLIGHT_THRESHOLD" ]; then
+            echo "::error::preflight: disk usage ${used}% on / exceeds threshold ${PREFLIGHT_THRESHOLD}%; aborting before heavyweight step crashes the worker (see #4320)"
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false # PROJECT: security hardening — never expose token to steps
@@ -70,6 +86,20 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
+      # WHY: Preflight disk check — same rationale as cargo-deny above.
+      - name: Preflight disk check
+        env:
+          PREFLIGHT_THRESHOLD: "90"
+        run: |
+          set -u
+          used=$(df -P / | awk 'NR==2 {print $5}' | tr -d '%')
+          echo "preflight: / used=${used}% threshold=${PREFLIGHT_THRESHOLD}%"
+          df -h /
+          if [ "$used" -ge "$PREFLIGHT_THRESHOLD" ]; then
+            echo "::error::preflight: disk usage ${used}% on / exceeds threshold ${PREFLIGHT_THRESHOLD}%; aborting before heavyweight step crashes the worker (see #4320)"
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false


### PR DESCRIPTION
Refs #4320.

## Summary

Adds an inline preflight disk check as the first step of every `runs-on: self-hosted` job (6 jobs across 5 workflows). Each step runs `df -P /`, parses the used percentage, and fails the job with a recognizable `::error::` message before any heavyweight step writes data. Threshold is 90% (configurable per-job).

## Why

Per #4320, when the runner host fills, the Worker crashes on the next disk write with `IOException: No space left on device`, the log buffer never flushes, and GitHub Actions reports the step as `failure` with **no diagnostic uploaded**. The 2026-05-28 incident on PR #4312 had an agent ready to start editing `deny.toml` because the opaque "cargo deny failed" looked like a domain failure.

The preflight is the recognizable error string: `preflight: disk usage X% on / exceeds threshold 90%; aborting before heavyweight step crashes the worker (see #4320)`.

## Why inline (not composite action)

A composite `.github/actions/preflight-disk/action.yml` was drafted first but requires a checkout to be present before `uses: ./...` can resolve — defeating "run before the first write." `gate-attestation.yml` and `no-ai-attribution.yml` also have conditional bot-waiver checkouts that a composite cannot run before. Inline keeps preflight strictly first and strictly checkout-free; the ~10-line script is small enough that the indirection cost would exceed the duplication cost.

## What this does NOT do

- No auto-recovery — a failed preflight stalls the job until the housekeeping cron (#4326) or operator cleanup reduces usage. The stall is desired.
- Single-mount check (`/`). Per-mount thresholds can be added if a different mount becomes the failure surface.
- No `runs-on:` changes.

## Test plan

- [ ] Merge and observe next PR pickup — each self-hosted job's log starts with a `preflight:` line showing current `/` usage.
- [ ] Failure injection: fill `/` to ≥90% on verda, re-run a PR, confirm the job fails at the preflight step with the recognizable error message and `df -h` output, NOT later in checkout / cargo-deny.