### PR TITLE
chore(pylon): cargo fmt --all sweep (per #4329)

### DIFF
--- a/crates/pylon/src/handlers/planning.rs
+++ b/crates/pylon/src/handlers/planning.rs
@@ -364,13 +364,9 @@ mod tests {
     async fn get_verification_returns_real_result() {
         let dir = tempfile::tempdir().unwrap();
         let project_id = write_project(dir.path(), true);
-        let result = load_project_verification(
-            dir.path().to_path_buf(),
-            project_id.clone(),
-            None,
-        )
-        .await
-        .unwrap();
+        let result = load_project_verification(dir.path().to_path_buf(), project_id.clone(), None)
+            .await
+            .unwrap();
 
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["project_id"], project_id);

--- a/crates/pylon/src/tests/session.rs
+++ b/crates/pylon/src/tests/session.rs
@@ -749,10 +749,7 @@ async fn get_session_rejects_token_scoped_to_a_different_agent() {
 
     let resp = router
         .clone()
-        .oneshot(scoped_get(
-            &format!("/api/v1/sessions/{id}"),
-            "audit-bot",
-        ))
+        .oneshot(scoped_get(&format!("/api/v1/sessions/{id}"), "audit-bot"))
         .await
         .unwrap();
 
@@ -807,10 +804,7 @@ async fn history_accepts_token_scoped_to_matching_agent() {
 
     let resp = router
         .clone()
-        .oneshot(scoped_get(
-            &format!("/api/v1/sessions/{id}/history"),
-            "syn",
-        ))
+        .oneshot(scoped_get(&format!("/api/v1/sessions/{id}/history"), "syn"))
         .await
         .unwrap();
 
@@ -827,10 +821,7 @@ async fn list_sessions_rejects_query_filter_outside_scope() {
 
     let resp = router
         .clone()
-        .oneshot(scoped_get(
-            "/api/v1/sessions?nous_id=audit-bot",
-            "syn",
-        ))
+        .oneshot(scoped_get("/api/v1/sessions?nous_id=audit-bot", "syn"))
         .await
         .unwrap();
 
@@ -858,7 +849,11 @@ async fn list_sessions_implicitly_filters_to_scope_when_no_query() {
     let items = body["items"]
         .as_array()
         .expect("paginated response has items array");
-    assert_eq!(items.len(), 1, "scoped list returns only the in-scope session");
+    assert_eq!(
+        items.len(),
+        1,
+        "scoped list returns only the in-scope session"
+    );
     assert_eq!(items[0]["id"], id);
     assert_eq!(items[0]["nous_id"], "syn");
 }

--- a/crates/pylon/tests/public_api_router_auth.rs
+++ b/crates/pylon/tests/public_api_router_auth.rs
@@ -425,9 +425,7 @@ async fn nous_list_hides_other_agents_from_scoped_token() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let body = read_body_json(response).await;
-    let entries = body["nous"]
-        .as_array()
-        .expect("nous list must be an array");
+    let entries = body["nous"].as_array().expect("nous list must be an array");
     for entry in entries {
         let id = entry["id"].as_str().expect("entry must have id");
         assert_eq!(


### PR DESCRIPTION
Refs #4329.

## Summary

Mechanical `cargo fmt --all` on the 3 pylon files where drift accumulated since `ce4a5f9d` (`refactor(pylon): carve out wire DTO modules (#4070)`, 2026-05-25):

- `crates/pylon/src/handlers/planning.rs:364`
- `crates/pylon/src/tests/session.rs:749,807,827,858`
- `crates/pylon/tests/public_api_router_auth.rs:425`

3 files, +12/-23. No logic change — line-folding of function calls that rustfmt prefers on a single line at the current line-length limit.

## Why

#4329 documents the substrate-class friction: `cargo fmt --check` failing on `main` makes `kanon gate` fail for any contributor on their first attempt, even when their PR touches zero Rust. This PR is option (b) on #4329 ("sweep current drift") and is the cheapest of the four proposed fixes.

## Test plan

- [x] `cargo fmt --all -- --check` from this branch: clean.
- [x] `git diff -w` shows no whitespace-ignored changes — pure-formatting diff.
- [ ] After merge, the next substrate PR (#4326, #4327, #4328) can re-base and run `kanon gate --tier light --stamp` to produce an honest `Gate-Passed:` trailer.