### PR TITLE
feat(episteme,aletheia): thread DedupTuning + nous-scope load_entity_infos (#4165 D+E)

### DIFF
--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -146,10 +146,23 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
         let store = mneme::knowledge_store::KnowledgeStore::open_fjall(&knowledge_path, config)
             .whatever_context("failed to open knowledge store")?;
 
+        // WHY (#4165 D): load the resolved aletheia config so the dedup
+        // CLI honours the operator's `knowledge_dedup_*` knobs the same
+        // way the scheduled maintenance task does. A missing/invalid
+        // config falls back to the historical defaults — the same shape
+        // every prior CLI invocation used — so this is strictly additive.
+        #[allow(unused_variables, reason = "consumed only by Dedup branch")]
+        let dedup_tuning = taxis::loader::load_config(&oikos)
+            .map_or(mneme::dedup::DedupTuning::DEFAULT, |cfg| {
+                crate::knowledge_maintenance::tuning_from_behavior(&cfg.agents.defaults.behavior)
+            });
+
         match action {
             Action::Check { json } => run_check(&store, json),
             Action::Sample { count, nous_id } => run_sample(&store, count, nous_id.as_deref()),
-            Action::Dedup { nous_id, dry_run } => run_dedup(&store, &nous_id, dry_run),
+            Action::Dedup { nous_id, dry_run } => {
+                run_dedup(&store, &nous_id, dry_run, &dedup_tuning)
+            }
             Action::Patterns { nous_id, limit } => run_patterns(&store, nous_id.as_deref(), limit),
             Action::ExportGraph {
                 format,
@@ -790,11 +803,12 @@ fn run_dedup(
     store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
     nous_id: &str,
     dry_run: bool,
+    tuning: &mneme::dedup::DedupTuning,
 ) -> Result<()> {
     println!("Scanning for duplicate entities (nous: {nous_id})...");
 
     let candidates = store
-        .find_duplicate_entities(nous_id)
+        .find_duplicate_entities_with_tuning(nous_id, tuning)
         .whatever_context("duplicate scan failed")?;
 
     let pending = store
@@ -843,7 +857,7 @@ fn run_dedup(
         println!("\n--dry-run: no mutations applied.");
     } else {
         let records = store
-            .run_entity_dedup(nous_id)
+            .run_entity_dedup_with_tuning(nous_id, tuning)
             .whatever_context("dedup execution failed")?;
         if records.is_empty() {
             println!("\nNo auto-merges met the threshold. Candidates stored for review.");

--- a/crates/aletheia/src/knowledge_maintenance.rs
+++ b/crates/aletheia/src/knowledge_maintenance.rs
@@ -6,11 +6,13 @@
 
 use std::sync::Arc;
 
+use mneme::dedup::DedupTuning;
 use mneme::embedding::{EmbeddingProvider, is_degraded_provider};
 use mneme::knowledge::FactType;
 use mneme::knowledge_store::KnowledgeStore;
 use mneme::recall::RecallEngine;
 use oikonomos::maintenance::{KnowledgeMaintenanceExecutor, MaintenanceReport};
+use taxis::config::AgentBehaviorDefaults;
 
 /// Bridges the daemon's `KnowledgeMaintenanceExecutor` trait to the concrete
 /// `KnowledgeStore`. All methods are blocking (`CozoDB` is sync).
@@ -22,6 +24,33 @@ pub(crate) struct KnowledgeMaintenanceAdapter {
     /// preserves pre-fix behaviour for installs without an embedding
     /// provider configured.
     embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
+    /// Operator-configurable dedup weights and thresholds (#4165 D).
+    /// Defaults to [`DedupTuning::DEFAULT`] when the runtime does not
+    /// override it; production startup builds one from
+    /// `AgentBehaviorDefaults::knowledge_dedup_*` via
+    /// [`tuning_from_behavior`] so config knobs actually take effect.
+    tuning: DedupTuning,
+}
+
+/// Build a [`DedupTuning`] from the resolved `AgentBehaviorDefaults` so
+/// the runtime can hand the maintenance task / CLI a single struct that
+/// reflects every operator-configured `knowledge_dedup_*` key.
+///
+/// `auto_merge_threshold` and `review_threshold` currently fall back to
+/// [`DedupTuning::DEFAULT`] — the config struct does not (yet) carry
+/// keys for them. Adding those keys is a strict superset change deferred
+/// out of #4165's mechanical bundle (filed for a future PR).
+pub(crate) fn tuning_from_behavior(defaults: &AgentBehaviorDefaults) -> DedupTuning {
+    DedupTuning {
+        weight_name: defaults.knowledge_dedup_weight_name,
+        weight_embed: defaults.knowledge_dedup_weight_embed,
+        weight_type: defaults.knowledge_dedup_weight_type,
+        weight_alias: defaults.knowledge_dedup_weight_alias,
+        jw_threshold: defaults.knowledge_dedup_jw_threshold,
+        embed_threshold: defaults.knowledge_dedup_embed_threshold,
+        auto_merge_threshold: DedupTuning::DEFAULT.auto_merge_threshold,
+        review_threshold: DedupTuning::DEFAULT.review_threshold,
+    }
 }
 
 impl KnowledgeMaintenanceAdapter {
@@ -29,6 +58,7 @@ impl KnowledgeMaintenanceAdapter {
         Self {
             store,
             embedding_provider: None,
+            tuning: DedupTuning::DEFAULT,
         }
     }
 
@@ -42,6 +72,18 @@ impl KnowledgeMaintenanceAdapter {
     /// backfill time to avoid log spam.
     pub(crate) fn with_embedding_provider(mut self, provider: Arc<dyn EmbeddingProvider>) -> Self {
         self.embedding_provider = Some(provider);
+        self
+    }
+
+    /// Override the default dedup tuning (#4165 D).
+    ///
+    /// Production startup calls [`tuning_from_behavior`] against the
+    /// resolved `AgentBehaviorDefaults` and passes the result here so the
+    /// scheduled maintenance task honours the operator's
+    /// `knowledge_dedup_*` config keys. Tests and degraded installs that
+    /// skip this call get [`DedupTuning::DEFAULT`].
+    pub(crate) fn with_tuning(mut self, tuning: DedupTuning) -> Self {
+        self.tuning = tuning;
         self
     }
 }
@@ -150,7 +192,7 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
             .filter(|p| !is_degraded_provider(*p));
         let records = self
             .store
-            .run_entity_dedup_with_embeddings(nous_id, provider_ref)
+            .run_entity_dedup_with_embeddings_and_tuning(nous_id, provider_ref, &self.tuning)
             .map_err(|e| {
                 oikonomos::error::TaskFailedSnafu {
                     task_id: "entity-dedup".to_owned(),

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -620,9 +620,19 @@ impl RuntimeBuilder {
                 // before scoring. Without this, the maintenance task
                 // reports merges executed but the AutoMerge threshold
                 // (≥ 0.90) is structurally unreachable.
+                //
+                // WHY (#4165 D): build a DedupTuning from the resolved
+                // AgentBehaviorDefaults so operator-tunable
+                // `knowledge_dedup_*` keys actually take effect in the
+                // scheduled maintenance task instead of silently using
+                // hardcoded module constants.
+                let dedup_tuning = crate::knowledge_maintenance::tuning_from_behavior(
+                    &self.config.agents.defaults.behavior,
+                );
                 let km_executor = Arc::new(
                     crate::knowledge_maintenance::KnowledgeMaintenanceAdapter::new(Arc::clone(ks))
-                        .with_embedding_provider(Arc::clone(&embedding_provider)),
+                        .with_embedding_provider(Arc::clone(&embedding_provider))
+                        .with_tuning(dedup_tuning),
                 );
                 daemon_runner = daemon_runner.with_knowledge_maintenance(km_executor);
             }

--- a/crates/episteme/src/dedup.rs
+++ b/crates/episteme/src/dedup.rs
@@ -52,21 +52,23 @@ pub struct EntityMergeCandidate {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum MergeDecision {
-    /// Score ≥ 0.90: merge automatically.
+    /// Score ≥ `tuning.auto_merge_threshold` (default 0.90): merge automatically.
     AutoMerge,
-    /// 0.70 ≤ score < 0.90: queue for human review.
+    /// `tuning.review_threshold` ≤ score < `tuning.auto_merge_threshold`
+    /// (default 0.70..0.90): queue for human review.
     Review,
-    /// Score < 0.70: skip.
+    /// Score < `tuning.review_threshold` (default 0.70): skip.
     Skip,
 }
 
 impl MergeDecision {
-    /// Classify a merge score into a decision.
+    /// Classify a merge score into a decision against the supplied tuning.
+    #[cfg(any(feature = "mneme-engine", test))]
     #[must_use]
-    pub(crate) fn from_score(score: f64) -> Self {
-        if score >= 0.90 {
+    pub(crate) fn from_score(score: f64, tuning: &DedupTuning) -> Self {
+        if score >= tuning.auto_merge_threshold {
             Self::AutoMerge
-        } else if score >= 0.70 {
+        } else if score >= tuning.review_threshold {
             Self::Review
         } else {
             Self::Skip
@@ -93,31 +95,113 @@ pub struct MergeRecord {
     pub merged_at: jiff::Timestamp,
 }
 
-/// Default score weights for the merge formula.
+/// Default name-similarity weight in the composite merge score.
 ///
-/// Callers should prefer values from `taxis::config::AgentBehaviorDefaults::knowledge_dedup_weight_*`.
+/// Operators tuning this should set `knowledge_dedup_weight_name` in
+/// `taxis::config::AgentBehaviorDefaults`; runtime callers should build a
+/// [`DedupTuning`] from that config and pass it into [`generate_candidates`].
 #[cfg(any(feature = "mneme-engine", test))]
 pub const DEFAULT_WEIGHT_NAME: f64 = 0.4;
+/// Default embedding-similarity weight in the composite merge score.
+///
+/// See [`DEFAULT_WEIGHT_NAME`] for the config plumbing pattern.
 #[cfg(any(feature = "mneme-engine", test))]
 pub const DEFAULT_WEIGHT_EMBED: f64 = 0.3;
+/// Default `entity_type`-match weight in the composite merge score.
 #[cfg(any(feature = "mneme-engine", test))]
 pub const DEFAULT_WEIGHT_TYPE: f64 = 0.2;
+/// Default alias-overlap weight in the composite merge score.
 #[cfg(any(feature = "mneme-engine", test))]
 pub const DEFAULT_WEIGHT_ALIAS: f64 = 0.1;
 
 /// Default Jaro-Winkler threshold for candidate generation.
 ///
-/// Callers should prefer the value from `taxis::config::AgentBehaviorDefaults::knowledge_dedup_jw_threshold`.
+/// See [`DedupTuning`] for the config-driven path operators should prefer.
 #[cfg(any(feature = "mneme-engine", test))]
 pub const DEFAULT_JW_THRESHOLD: f64 = 0.85;
 
 /// Default embedding cosine threshold for candidate generation.
 ///
-/// Callers should prefer the value from `taxis::config::AgentBehaviorDefaults::knowledge_dedup_embed_threshold`.
+/// See [`DedupTuning`] for the config-driven path operators should prefer.
 #[cfg(any(feature = "mneme-engine", test))]
 pub const DEFAULT_EMBED_THRESHOLD: f64 = 0.80;
 
-/// Compute the weighted merge score.
+/// Default composite score at which `MergeDecision::AutoMerge` fires.
+#[cfg(any(feature = "mneme-engine", test))]
+pub const DEFAULT_AUTO_MERGE_THRESHOLD: f64 = 0.90;
+
+/// Default composite score above which candidates queue for `MergeDecision::Review`.
+#[cfg(any(feature = "mneme-engine", test))]
+pub const DEFAULT_REVIEW_THRESHOLD: f64 = 0.70;
+
+/// Runtime-tunable parameters for the dedup pipeline.
+///
+/// Mirrors the `taxis::config::AgentBehaviorDefaults::knowledge_dedup_*`
+/// configuration keys; CLI and maintenance callers build one from the
+/// resolved agent config and pass it into the dedup entry points so
+/// operator changes actually take effect (#4165 D). Tests and crate-internal
+/// callers can use [`DedupTuning::DEFAULT`] for the pre-config behaviour.
+///
+/// **Invariant**: the score weights are scaled by similarity and
+/// match-flag values that range in `[0.0, 1.0]`, so the maximum reachable
+/// composite score is `weight_name + weight_embed + weight_type +
+/// weight_alias`. Operators tuning the weights must keep the auto-merge
+/// threshold reachable (otherwise the pipeline is back in the
+/// "unreachable `AutoMerge`" failure mode that #4165 fixed).
+#[cfg(any(feature = "mneme-engine", test))]
+#[derive(Debug, Clone, Copy)]
+pub struct DedupTuning {
+    /// Weight applied to the name similarity term. Default
+    /// [`DEFAULT_WEIGHT_NAME`].
+    pub weight_name: f64,
+    /// Weight applied to the embedding similarity term. Default
+    /// [`DEFAULT_WEIGHT_EMBED`].
+    pub weight_embed: f64,
+    /// Weight applied to the `entity_type`-match term. Default
+    /// [`DEFAULT_WEIGHT_TYPE`].
+    pub weight_type: f64,
+    /// Weight applied to the alias-overlap term. Default
+    /// [`DEFAULT_WEIGHT_ALIAS`].
+    pub weight_alias: f64,
+    /// Minimum Jaro-Winkler score that admits a pair as a candidate.
+    /// Default [`DEFAULT_JW_THRESHOLD`].
+    pub jw_threshold: f64,
+    /// Minimum cosine embedding similarity that admits a pair as a
+    /// candidate. Default [`DEFAULT_EMBED_THRESHOLD`].
+    pub embed_threshold: f64,
+    /// Composite score above which the pipeline auto-merges without
+    /// operator review. Default [`DEFAULT_AUTO_MERGE_THRESHOLD`].
+    pub auto_merge_threshold: f64,
+    /// Composite score above which a candidate queues for operator
+    /// review. Default [`DEFAULT_REVIEW_THRESHOLD`].
+    pub review_threshold: f64,
+}
+
+#[cfg(any(feature = "mneme-engine", test))]
+impl DedupTuning {
+    /// Default tuning matching the pre-config behaviour: classic
+    /// 0.4/0.3/0.2/0.1 weights, 0.85 JW floor, 0.80 embed floor,
+    /// 0.90 auto-merge, 0.70 review.
+    pub const DEFAULT: Self = Self {
+        weight_name: DEFAULT_WEIGHT_NAME,
+        weight_embed: DEFAULT_WEIGHT_EMBED,
+        weight_type: DEFAULT_WEIGHT_TYPE,
+        weight_alias: DEFAULT_WEIGHT_ALIAS,
+        jw_threshold: DEFAULT_JW_THRESHOLD,
+        embed_threshold: DEFAULT_EMBED_THRESHOLD,
+        auto_merge_threshold: DEFAULT_AUTO_MERGE_THRESHOLD,
+        review_threshold: DEFAULT_REVIEW_THRESHOLD,
+    };
+}
+
+#[cfg(any(feature = "mneme-engine", test))]
+impl Default for DedupTuning {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Compute the weighted merge score under `tuning`.
 #[cfg(any(feature = "mneme-engine", test))]
 #[must_use]
 pub(crate) fn compute_merge_score(
@@ -125,13 +209,14 @@ pub(crate) fn compute_merge_score(
     embed_similarity: f64,
     type_match: bool,
     alias_overlap: bool,
+    tuning: &DedupTuning,
 ) -> f64 {
     let type_val = if type_match { 1.0 } else { 0.0 };
     let alias_val = if alias_overlap { 1.0 } else { 0.0 };
-    DEFAULT_WEIGHT_NAME * name_similarity
-        + DEFAULT_WEIGHT_EMBED * embed_similarity
-        + DEFAULT_WEIGHT_TYPE * type_val
-        + DEFAULT_WEIGHT_ALIAS * alias_val
+    tuning.weight_name * name_similarity
+        + tuning.weight_embed * embed_similarity
+        + tuning.weight_type * type_val
+        + tuning.weight_alias * alias_val
 }
 
 /// Compute Jaro-Winkler similarity between two strings (case-insensitive).
@@ -338,14 +423,19 @@ pub(crate) fn make_embedding_lookup(
 ///
 /// Finds pairs within the same `entity_type` where at least one of:
 /// - Exact name match (case-insensitive)
-/// - Jaro-Winkler similarity ≥ 0.85
+/// - Jaro-Winkler similarity ≥ `tuning.jw_threshold`
+/// - Embedding similarity ≥ `tuning.embed_threshold`
 /// - Any shared alias or name-in-alias match
 ///
-/// Embedding similarity is passed as an optional precomputed map; if absent, defaults to 0.0.
+/// The composite score uses the weights on `tuning`. Embedding similarity
+/// is supplied by the closure — for pairs whose stored `name_embedding`
+/// is `None`, [`make_embedding_lookup`] returns `0.0` so the pipeline
+/// degrades to the pre-fix score range (#4165 Path A).
 #[cfg(any(feature = "mneme-engine", test))]
 pub(crate) fn generate_candidates(
     entities: &[EntityInfo],
     embed_similarities: &dyn Fn(&EntityId, &EntityId) -> f64,
+    tuning: &DedupTuning,
 ) -> Vec<EntityMergeCandidate> {
     let mut candidates = Vec::new();
 
@@ -361,15 +451,16 @@ pub(crate) fn generate_candidates(
             let alias_overlap = aliases_overlap(&a.aliases, &b.aliases)
                 || name_in_aliases(&a.name, &b.aliases, &b.name, &a.aliases);
             let is_exact_match = a.name.to_lowercase() == b.name.to_lowercase();
-            let is_jw_match = name_sim >= DEFAULT_JW_THRESHOLD;
+            let is_jw_match = name_sim >= tuning.jw_threshold;
             let embed_sim = embed_similarities(&a.id, &b.id);
-            let is_embed_match = embed_sim >= DEFAULT_EMBED_THRESHOLD;
+            let is_embed_match = embed_sim >= tuning.embed_threshold;
 
             if !is_exact_match && !is_jw_match && !is_embed_match && !alias_overlap {
                 continue;
             }
 
-            let merge_score = compute_merge_score(name_sim, embed_sim, type_match, alias_overlap);
+            let merge_score =
+                compute_merge_score(name_sim, embed_sim, type_match, alias_overlap, tuning);
 
             candidates.push(EntityMergeCandidate {
                 entity_a: a.id.clone(),
@@ -388,16 +479,17 @@ pub(crate) fn generate_candidates(
     candidates
 }
 
-/// Phase 2: Classify candidates into auto-merge, review, or skip.
+/// Phase 2: Classify candidates into auto-merge, review, or skip under `tuning`.
 #[cfg(any(feature = "mneme-engine", test))]
 pub(crate) fn classify_candidates(
     candidates: Vec<EntityMergeCandidate>,
+    tuning: &DedupTuning,
 ) -> (Vec<EntityMergeCandidate>, Vec<EntityMergeCandidate>) {
     let mut auto_merge = Vec::new();
     let mut review = Vec::new();
 
     for c in candidates {
-        match MergeDecision::from_score(c.merge_score) {
+        match MergeDecision::from_score(c.merge_score, tuning) {
             MergeDecision::AutoMerge => auto_merge.push(c),
             MergeDecision::Review => review.push(c),
             // NOTE: score below threshold, candidate discarded

--- a/crates/episteme/src/dedup_tests.rs
+++ b/crates/episteme/src/dedup_tests.rs
@@ -52,49 +52,67 @@ fn no_embed(_a: &EntityId, _b: &EntityId) -> f64 {
 
 #[test]
 fn decision_auto_merge_at_threshold() {
-    assert_eq!(MergeDecision::from_score(0.90), MergeDecision::AutoMerge);
+    assert_eq!(
+        MergeDecision::from_score(0.90, &DedupTuning::DEFAULT),
+        MergeDecision::AutoMerge
+    );
 }
 
 #[test]
 fn decision_auto_merge_above() {
-    assert_eq!(MergeDecision::from_score(0.95), MergeDecision::AutoMerge);
+    assert_eq!(
+        MergeDecision::from_score(0.95, &DedupTuning::DEFAULT),
+        MergeDecision::AutoMerge
+    );
 }
 
 #[test]
 fn decision_review_at_threshold() {
-    assert_eq!(MergeDecision::from_score(0.70), MergeDecision::Review);
+    assert_eq!(
+        MergeDecision::from_score(0.70, &DedupTuning::DEFAULT),
+        MergeDecision::Review
+    );
 }
 
 #[test]
 fn decision_review_between() {
-    assert_eq!(MergeDecision::from_score(0.80), MergeDecision::Review);
+    assert_eq!(
+        MergeDecision::from_score(0.80, &DedupTuning::DEFAULT),
+        MergeDecision::Review
+    );
 }
 
 #[test]
 fn decision_skip_below() {
-    assert_eq!(MergeDecision::from_score(0.69), MergeDecision::Skip);
+    assert_eq!(
+        MergeDecision::from_score(0.69, &DedupTuning::DEFAULT),
+        MergeDecision::Skip
+    );
 }
 
 #[test]
 fn decision_skip_zero() {
-    assert_eq!(MergeDecision::from_score(0.0), MergeDecision::Skip);
+    assert_eq!(
+        MergeDecision::from_score(0.0, &DedupTuning::DEFAULT),
+        MergeDecision::Skip
+    );
 }
 
 #[test]
 fn merge_score_perfect() {
-    let score = compute_merge_score(1.0, 1.0, true, true);
+    let score = compute_merge_score(1.0, 1.0, true, true, &DedupTuning::DEFAULT);
     assert!((score - 1.0).abs() < f64::EPSILON);
 }
 
 #[test]
 fn merge_score_formula_weights() {
-    let score = compute_merge_score(0.9, 0.8, true, false);
+    let score = compute_merge_score(0.9, 0.8, true, false, &DedupTuning::DEFAULT);
     assert!((score - 0.80).abs() < 1e-10);
 }
 
 #[test]
 fn merge_score_no_signals() {
-    let score = compute_merge_score(0.0, 0.0, false, false);
+    let score = compute_merge_score(0.0, 0.0, false, false, &DedupTuning::DEFAULT);
     assert!((score - 0.0).abs() < f64::EPSILON);
 }
 
@@ -170,7 +188,7 @@ fn exact_name_match_case_insensitive() {
         entity("e1", "Alice Test", "person", vec![], 2, "2026-01-01"),
         entity("e2", "alice test", "person", vec![], 1, "2026-01-02"),
     ];
-    let candidates = generate_candidates(&entities, &no_embed);
+    let candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
     assert_eq!(candidates.len(), 1);
     assert!((candidates[0].name_similarity - 1.0).abs() < f64::EPSILON);
 }
@@ -181,7 +199,7 @@ fn jaro_winkler_candidate() {
         entity("e1", "Alice Test", "person", vec![], 1, "2026-01-01"),
         entity("e2", "Alicia Test", "person", vec![], 1, "2026-01-01"),
     ];
-    let candidates = generate_candidates(&entities, &no_embed);
+    let candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
     assert_eq!(candidates.len(), 1);
     assert!(candidates[0].name_similarity >= 0.85);
 }
@@ -192,7 +210,7 @@ fn different_types_not_candidates() {
         entity("e1", "Alice Test", "person", vec![], 1, "2026-01-01"),
         entity("e2", "Alice Test", "organization", vec![], 1, "2026-01-01"),
     ];
-    let candidates = generate_candidates(&entities, &no_embed);
+    let candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
     assert!(candidates.is_empty());
 }
 
@@ -202,7 +220,7 @@ fn alias_overlap_triggers_candidate() {
         entity("e1", "Alice Test", "person", vec!["AT"], 1, "2026-01-01"),
         entity("e2", "A. Test", "person", vec!["AT"], 1, "2026-01-01"),
     ];
-    let candidates = generate_candidates(&entities, &no_embed);
+    let candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
     assert_eq!(candidates.len(), 1);
     assert!(candidates[0].alias_overlap);
 }
@@ -228,7 +246,7 @@ fn embedding_similarity_triggers_candidate() {
             0.0
         }
     };
-    let candidates = generate_candidates(&entities, &embed_fn);
+    let candidates = generate_candidates(&entities, &embed_fn, &DedupTuning::DEFAULT);
     assert_eq!(candidates.len(), 1);
     assert!(candidates[0].embed_similarity >= 0.80);
 }
@@ -281,7 +299,7 @@ fn pre_fix_regression_zero_embed_caps_at_review_tier() {
             "2026-01-02",
         ),
     ];
-    let candidates = generate_candidates(&entities, &no_embed);
+    let candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
     assert_eq!(candidates.len(), 1, "exactly one pair");
     let c = &candidates[0];
     assert!(
@@ -289,7 +307,7 @@ fn pre_fix_regression_zero_embed_caps_at_review_tier() {
         "without embedding similarity the merge score must cap at 0.70; got {}",
         c.merge_score
     );
-    let (auto_merge, _review) = classify_candidates(candidates);
+    let (auto_merge, _review) = classify_candidates(candidates, &DedupTuning::DEFAULT);
     assert!(
         auto_merge.is_empty(),
         "pre-fix closure (embed=0.0) must never produce AutoMerge — this is the bug #4165 was opened for"
@@ -322,8 +340,8 @@ fn pre_fix_regression_make_embedding_lookup_empty_store() {
         ),
     ];
     let lookup = make_embedding_lookup(&entities);
-    let candidates = generate_candidates(&entities, &lookup);
-    let (auto_merge, _) = classify_candidates(candidates);
+    let candidates = generate_candidates(&entities, &lookup, &DedupTuning::DEFAULT);
+    let (auto_merge, _) = classify_candidates(candidates, &DedupTuning::DEFAULT);
     assert!(
         auto_merge.is_empty(),
         "make_embedding_lookup over entities without embeddings must reproduce pre-fix behaviour (no AutoMerges)"
@@ -363,7 +381,7 @@ fn path_a_reachable_with_stored_name_embeddings() {
         ),
     ];
     let lookup = make_embedding_lookup(&entities);
-    let candidates = generate_candidates(&entities, &lookup);
+    let candidates = generate_candidates(&entities, &lookup, &DedupTuning::DEFAULT);
     assert_eq!(candidates.len(), 1, "exactly one candidate pair");
     let c = &candidates[0];
     assert!(
@@ -376,7 +394,7 @@ fn path_a_reachable_with_stored_name_embeddings() {
         "name=1.0 + embed=1.0 + type=true + alias=true must clear AutoMerge threshold; got {}",
         c.merge_score
     );
-    let (auto_merge, _review) = classify_candidates(candidates);
+    let (auto_merge, _review) = classify_candidates(candidates, &DedupTuning::DEFAULT);
     assert_eq!(
         auto_merge.len(),
         1,
@@ -423,7 +441,7 @@ fn path_a_embedding_promotes_synonym_pair_above_skip() {
         ),
     ];
     let lookup = make_embedding_lookup(&entities);
-    let candidates = generate_candidates(&entities, &lookup);
+    let candidates = generate_candidates(&entities, &lookup, &DedupTuning::DEFAULT);
     assert_eq!(
         candidates.len(),
         1,
@@ -440,7 +458,7 @@ fn path_a_embedding_promotes_synonym_pair_above_skip() {
         "embed contribution must push the pair into Review tier at minimum; got {}",
         c.merge_score
     );
-    let (_auto_merge, review) = classify_candidates(candidates);
+    let (_auto_merge, review) = classify_candidates(candidates, &DedupTuning::DEFAULT);
     assert!(
         !review.is_empty(),
         "synonym pair with agreeing embeddings lands in Review (operator-actionable) — \
@@ -477,13 +495,13 @@ fn path_a_borderline_embedding_stays_in_review_tier() {
         ),
     ];
     let lookup = make_embedding_lookup(&entities);
-    let candidates = generate_candidates(&entities, &lookup);
+    let candidates = generate_candidates(&entities, &lookup, &DedupTuning::DEFAULT);
     assert_eq!(
         candidates.len(),
         1,
         "JW above 0.85 puts them in the candidate set"
     );
-    let (auto_merge, review) = classify_candidates(candidates);
+    let (auto_merge, review) = classify_candidates(candidates, &DedupTuning::DEFAULT);
     assert!(
         auto_merge.is_empty(),
         "moderately-similar embeddings with no alias overlap must not auto-merge — operator review required"
@@ -599,8 +617,8 @@ fn classify_auto_merge_and_review() {
             0.0
         }
     };
-    let candidates = generate_candidates(&entities, &high_embed);
-    let (auto_merge, review) = classify_candidates(candidates);
+    let candidates = generate_candidates(&entities, &high_embed, &DedupTuning::DEFAULT);
+    let (auto_merge, review) = classify_candidates(candidates, &DedupTuning::DEFAULT);
     assert!(
         !auto_merge.is_empty(),
         "expected at least one auto-merge candidate"
@@ -634,8 +652,8 @@ fn auto_merge_unreachable_under_production_embedding_closure() {
         entity("e2", "alice test", "person", vec!["AT"], 1, "2026-01-02"),
         entity("e3", "Alicia Test", "person", vec![], 1, "2026-01-03"),
     ];
-    let candidates = generate_candidates(&entities, &no_embed);
-    let (auto_merge, review) = classify_candidates(candidates);
+    let candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
+    let (auto_merge, review) = classify_candidates(candidates, &DedupTuning::DEFAULT);
     assert!(
         auto_merge.is_empty(),
         "production-shape embed closure (always-0.0) must keep auto_merge empty: \
@@ -693,7 +711,7 @@ fn idempotent_no_self_candidates() {
         1,
         "2026-01-01",
     )];
-    let candidates = generate_candidates(&entities, &no_embed);
+    let candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
     assert!(
         candidates.is_empty(),
         "single entity should produce no candidates"
@@ -702,35 +720,210 @@ fn idempotent_no_self_candidates() {
 
 #[test]
 fn empty_graph_no_candidates() {
-    let candidates = generate_candidates(&[], &no_embed);
+    let candidates = generate_candidates(&[], &no_embed, &DedupTuning::DEFAULT);
     assert!(candidates.is_empty());
 }
 
 #[test]
 fn score_boundary_exactly_070() {
-    assert_eq!(MergeDecision::from_score(0.70), MergeDecision::Review);
+    assert_eq!(
+        MergeDecision::from_score(0.70, &DedupTuning::DEFAULT),
+        MergeDecision::Review
+    );
 }
 
 #[test]
 fn score_boundary_just_below_070() {
-    assert_eq!(MergeDecision::from_score(0.6999), MergeDecision::Skip);
+    assert_eq!(
+        MergeDecision::from_score(0.6999, &DedupTuning::DEFAULT),
+        MergeDecision::Skip
+    );
 }
 
 #[test]
 fn score_boundary_exactly_090() {
-    assert_eq!(MergeDecision::from_score(0.90), MergeDecision::AutoMerge);
+    assert_eq!(
+        MergeDecision::from_score(0.90, &DedupTuning::DEFAULT),
+        MergeDecision::AutoMerge
+    );
 }
 
 #[test]
 fn score_boundary_just_below_090() {
-    assert_eq!(MergeDecision::from_score(0.8999), MergeDecision::Review);
+    assert_eq!(
+        MergeDecision::from_score(0.8999, &DedupTuning::DEFAULT),
+        MergeDecision::Review
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #4165 D — DedupTuning config-reachability regression tests
+//
+// These tests pin the contract that operator-tuned
+// `taxis::AgentBehaviorDefaults::knowledge_dedup_*` keys actually flow
+// through `compute_merge_score`, `generate_candidates`, and
+// `MergeDecision::from_score`. Pre-fix, those helpers read the module
+// constants directly and operators could only tune the dedup pipeline
+// by editing source. The tests below assert that adjusting `tuning`
+// changes the observable behaviour at each stage of the pipeline.
+// ---------------------------------------------------------------------------
+
+/// Composite score is recomputed under tuned weights.
+///
+/// Default weights (0.4/0.3/0.2/0.1) score (name=1, embed=0, type=true,
+/// alias=true) at 0.70. A custom tuning that ups the name weight to 0.5
+/// must shift the score upward by exactly the difference, proving the
+/// formula uses `tuning` rather than the module constants.
+#[test]
+fn tuned_weights_change_composite_score() {
+    let custom = DedupTuning {
+        weight_name: 0.5,
+        weight_embed: 0.2, // 0.5 + 0.2 + 0.2 + 0.1 = 1.0, balanced
+        ..DedupTuning::DEFAULT
+    };
+    let default_score = compute_merge_score(1.0, 0.0, true, true, &DedupTuning::DEFAULT);
+    let custom_score = compute_merge_score(1.0, 0.0, true, true, &custom);
+    // (0.5 - 0.4) * 1.0 = +0.1 for the name term; embed_sim is 0.0 so
+    // the embed weight change cancels out.
+    assert!(
+        (custom_score - default_score - 0.10).abs() < 1e-9,
+        "tuning must reach compute_merge_score: default={default_score}, custom={custom_score}",
+    );
+}
+
+/// Lowering `jw_threshold` admits a pair that the default threshold rejects.
+///
+/// "Carbon" vs "Carbide" has JW ≈ 0.79 — below the default 0.85 floor.
+/// With type match but no alias overlap and no embedding, the only
+/// candidacy gate is JW. Default behaviour rejects the pair; lowering
+/// `jw_threshold` to 0.70 must admit it.
+#[test]
+fn tuned_jw_threshold_admits_pair_under_default_floor() {
+    let entities = vec![
+        entity("e1", "Carbon", "element", vec![], 1, "2026-01-01"),
+        entity("e2", "Carbide", "element", vec![], 1, "2026-01-02"),
+    ];
+
+    let default_candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
+    assert!(
+        default_candidates.is_empty(),
+        "default JW floor (0.85) must reject this pair as a baseline"
+    );
+
+    let relaxed = DedupTuning {
+        jw_threshold: 0.70,
+        ..DedupTuning::DEFAULT
+    };
+    let relaxed_candidates = generate_candidates(&entities, &no_embed, &relaxed);
+    assert_eq!(
+        relaxed_candidates.len(),
+        1,
+        "lowering jw_threshold to 0.70 must admit the same pair — proves tuning reaches the candidate filter"
+    );
+}
+
+/// Lowering `auto_merge_threshold` promotes a Review-tier candidate to
+/// `AutoMerge` without touching any other input.
+///
+/// A pair with score in `[0.70, 0.90)` defaults to `Review`. Reducing
+/// the auto-merge threshold below the pair's score must reclassify it
+/// to `AutoMerge`, proving the classification helper reads the supplied
+/// tuning instead of hardcoded 0.90/0.70 constants.
+#[test]
+fn tuned_auto_merge_threshold_promotes_review_to_auto_merge() {
+    // Score = 0.4·1.0 + 0.3·0.0 + 0.2·1.0 + 0.1·1.0 = 0.70 → Review under default tuning.
+    let entities = vec![
+        entity(
+            "e1",
+            "Acme Corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-01",
+        ),
+        entity(
+            "e2",
+            "acme corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-02",
+        ),
+    ];
+    let candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
+    assert_eq!(candidates.len(), 1, "exactly one pair");
+    let score = candidates[0].merge_score;
+    assert!(
+        (score - 0.70).abs() < 1e-9,
+        "baseline shape expects score=0.70 (the unreachable-AutoMerge ceiling pre-#4165); got {score}",
+    );
+
+    let (auto_default, review_default) =
+        classify_candidates(candidates.clone(), &DedupTuning::DEFAULT);
+    assert!(
+        auto_default.is_empty() && review_default.len() == 1,
+        "default classification must route this pair to Review"
+    );
+
+    let promoted = DedupTuning {
+        auto_merge_threshold: 0.69,
+        ..DedupTuning::DEFAULT
+    };
+    let (auto_promoted, review_promoted) = classify_candidates(candidates, &promoted);
+    assert_eq!(
+        auto_promoted.len(),
+        1,
+        "lowering auto_merge_threshold below 0.70 must promote the Review-tier pair to AutoMerge — proves tuning reaches MergeDecision::from_score"
+    );
+    assert!(
+        review_promoted.is_empty(),
+        "promoted pair must leave the Review bucket"
+    );
+}
+
+/// Raising `review_threshold` above an existing review-tier pair must
+/// drop it to `Skip` rather than queue it. Closes the tuning contract
+/// from the other direction.
+#[test]
+fn tuned_review_threshold_drops_pair_to_skip() {
+    let entities = vec![
+        entity(
+            "e1",
+            "Acme Corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-01",
+        ),
+        entity(
+            "e2",
+            "acme corporation",
+            "organization",
+            vec!["Acme"],
+            5,
+            "2026-01-02",
+        ),
+    ];
+    let candidates = generate_candidates(&entities, &no_embed, &DedupTuning::DEFAULT);
+
+    let strict = DedupTuning {
+        // Composite score is 0.70 (the unreachable-AutoMerge ceiling);
+        // bumping the review floor above it must downgrade to Skip.
+        review_threshold: 0.71,
+        ..DedupTuning::DEFAULT
+    };
+    let (auto, review) = classify_candidates(candidates, &strict);
+    assert!(
+        auto.is_empty() && review.is_empty(),
+        "raising review_threshold above the pair's score must drop it from both buckets"
+    );
 }
 
 mod proptests {
     use proptest::prelude::*;
 
     use super::super::{
-        EntityId, EntityInfo, MergeDecision, classify_candidates, compute_merge_score,
+        DedupTuning, EntityId, EntityInfo, MergeDecision, classify_candidates, compute_merge_score,
         generate_candidates, jaro_winkler_ci,
     };
 
@@ -760,7 +953,13 @@ mod proptests {
             type_match in proptest::bool::ANY,
             alias_overlap in proptest::bool::ANY,
         ) {
-            let score = compute_merge_score(name_sim, embed_sim, type_match, alias_overlap);
+            let score = compute_merge_score(
+                name_sim,
+                embed_sim,
+                type_match,
+                alias_overlap,
+                &DedupTuning::DEFAULT,
+            );
             prop_assert!(
                 (0.0..=1.0).contains(&score),
                 "score {score} not in [0.0, 1.0]"
@@ -771,7 +970,7 @@ mod proptests {
         /// Every score must map to exactly one decision.
         #[test]
         fn decision_covers_all_scores(score in 0.0_f64..=1.0) {
-            let decision = MergeDecision::from_score(score);
+            let decision = MergeDecision::from_score(score, &DedupTuning::DEFAULT);
             if score >= 0.90 {
                 prop_assert!(decision == MergeDecision::AutoMerge, "score={}, expected AutoMerge", score);
             } else if score >= 0.70 {
@@ -822,9 +1021,9 @@ mod proptests {
                 .map(|(i, name)| make_entity(&format!("e{i}"), name, "person"))
                 .collect();
 
-            let candidates = generate_candidates(&entities, &|_, _| 0.0);
+            let candidates = generate_candidates(&entities, &|_, _| 0.0, &DedupTuning::DEFAULT);
             let total_candidates = candidates.len();
-            let (auto_merge, review) = classify_candidates(candidates);
+            let (auto_merge, review) = classify_candidates(candidates, &DedupTuning::DEFAULT);
 
             prop_assert!(
                 auto_merge.len() + review.len() <= total_candidates,
@@ -837,7 +1036,7 @@ mod proptests {
         #[test]
         fn single_entity_no_candidates(name in "[a-zA-Z]{3,20}") {
             let entities = vec![make_entity("e0", &name, "person")];
-            let candidates = generate_candidates(&entities, &|_, _| 0.0);
+            let candidates = generate_candidates(&entities, &|_, _| 0.0, &DedupTuning::DEFAULT);
             prop_assert!(candidates.is_empty());
         }
     }

--- a/crates/episteme/src/knowledge_store/entity.rs
+++ b/crates/episteme/src/knowledge_store/entity.rs
@@ -128,11 +128,27 @@ impl KnowledgeStore {
         Ok(entities)
     }
 
-    /// Find duplicate entity candidates for a given nous.
+    /// Find duplicate entity candidates for a given nous using default tuning.
     ///
-    /// Loads all entities, groups by type, and runs the 3-phase candidate
-    /// generation + scoring pipeline. Returns all candidates (auto-merge +
-    /// review).
+    /// Convenience wrapper around
+    /// [`find_duplicate_entities_with_tuning`](Self::find_duplicate_entities_with_tuning)
+    /// for callers that have no operator-configured
+    /// [`DedupTuning`](crate::dedup::DedupTuning) in scope.
+    #[instrument(skip(self))]
+    pub fn find_duplicate_entities(
+        &self,
+        nous_id: &str,
+    ) -> crate::error::Result<Vec<crate::dedup::EntityMergeCandidate>> {
+        self.find_duplicate_entities_with_tuning(nous_id, &crate::dedup::DedupTuning::DEFAULT)
+    }
+
+    /// Find duplicate entity candidates for a given nous under explicit tuning.
+    ///
+    /// Loads all entities scoped to `nous_id` (via the `fact_entities` →
+    /// `facts.nous_id` join in
+    /// [`load_entity_infos`](Self::load_entity_infos)), groups by type, and
+    /// runs the 3-phase candidate generation + scoring pipeline. Returns
+    /// all candidates (auto-merge + review).
     ///
     /// Cosine similarity is computed over the entities' cached
     /// `name_embedding` column (schema v13+). Entities without a stored
@@ -140,14 +156,19 @@ impl KnowledgeStore {
     /// in — i.e. the pre-#4165 behaviour for degraded-mode installs.
     /// Callers that want to populate embeddings first should use
     /// [`KnowledgeStore::backfill_entity_name_embeddings`].
-    #[instrument(skip(self))]
-    pub fn find_duplicate_entities(
+    ///
+    /// `tuning` provides operator-configurable weights and thresholds
+    /// (#4165 D); pass [`DedupTuning::DEFAULT`](crate::dedup::DedupTuning::DEFAULT)
+    /// for the historical defaults.
+    #[instrument(skip(self, tuning))]
+    pub fn find_duplicate_entities_with_tuning(
         &self,
         nous_id: &str,
+        tuning: &crate::dedup::DedupTuning,
     ) -> crate::error::Result<Vec<crate::dedup::EntityMergeCandidate>> {
         let entities = self.load_entity_infos(nous_id)?;
         let embed_lookup = crate::dedup::make_embedding_lookup(&entities);
-        let candidates = crate::dedup::generate_candidates(&entities, &embed_lookup);
+        let candidates = crate::dedup::generate_candidates(&entities, &embed_lookup, tuning);
         Ok(candidates)
     }
 
@@ -364,14 +385,30 @@ impl KnowledgeStore {
         &self,
         nous_id: &str,
     ) -> crate::error::Result<Vec<crate::dedup::MergeRecord>> {
+        self.run_entity_dedup_with_tuning(nous_id, &crate::dedup::DedupTuning::DEFAULT)
+    }
+
+    /// Execute the dedup pipeline under the supplied `tuning`.
+    ///
+    /// Same semantics as [`run_entity_dedup`](Self::run_entity_dedup) but
+    /// with operator-configurable weights and thresholds (#4165 D). CLI
+    /// and maintenance callers build a [`DedupTuning`](crate::dedup::DedupTuning)
+    /// from `taxis::config::AgentBehaviorDefaults::knowledge_dedup_*` and
+    /// pass it through so config knobs actually take effect.
+    #[instrument(skip(self, tuning))]
+    pub fn run_entity_dedup_with_tuning(
+        &self,
+        nous_id: &str,
+        tuning: &crate::dedup::DedupTuning,
+    ) -> crate::error::Result<Vec<crate::dedup::MergeRecord>> {
         let entities = self.load_entity_infos(nous_id)?;
         if entities.is_empty() {
             return Ok(Vec::new());
         }
 
         let embed_lookup = crate::dedup::make_embedding_lookup(&entities);
-        let candidates = crate::dedup::generate_candidates(&entities, &embed_lookup);
-        let (auto_merge, review) = crate::dedup::classify_candidates(candidates);
+        let candidates = crate::dedup::generate_candidates(&entities, &embed_lookup, tuning);
+        let (auto_merge, review) = crate::dedup::classify_candidates(candidates, tuning);
 
         for c in &review {
             self.store_pending_merge(c)?;
@@ -604,6 +641,27 @@ impl KnowledgeStore {
         nous_id: &str,
         provider: Option<&dyn crate::embedding::EmbeddingProvider>,
     ) -> crate::error::Result<Vec<crate::dedup::MergeRecord>> {
+        self.run_entity_dedup_with_embeddings_and_tuning(
+            nous_id,
+            provider,
+            &crate::dedup::DedupTuning::DEFAULT,
+        )
+    }
+
+    /// Backfill embeddings (if `provider` is `Some`) then run dedup under
+    /// the supplied `tuning`.
+    ///
+    /// This is the entry point the scheduled `entity-dedup` maintenance
+    /// task uses so that operator-configured
+    /// [`AgentBehaviorDefaults::knowledge_dedup_*`](https://docs.rs/taxis)
+    /// knobs actually flow through the merge decision (#4165 D).
+    #[instrument(skip(self, provider, tuning))]
+    pub fn run_entity_dedup_with_embeddings_and_tuning(
+        &self,
+        nous_id: &str,
+        provider: Option<&dyn crate::embedding::EmbeddingProvider>,
+        tuning: &crate::dedup::DedupTuning,
+    ) -> crate::error::Result<Vec<crate::dedup::MergeRecord>> {
         if let Some(p) = provider
             && let Err(e) = self.backfill_entity_name_embeddings(p, nous_id)
         {
@@ -613,22 +671,51 @@ impl KnowledgeStore {
                 "backfill_entity_name_embeddings failed; falling back to embedded-or-null dedup"
             );
         }
-        self.run_entity_dedup(nous_id)
+        self.run_entity_dedup_with_tuning(nous_id, tuning)
     }
 
-    /// Load all entities as lightweight `EntityInfo` structs.
+    /// Load entities scoped to `nous_id` as lightweight `EntityInfo` structs.
+    ///
+    /// Restricts the result to entities reachable from a fact owned by
+    /// `nous_id` via the `fact_entities` join. The `entities` relation
+    /// itself carries no tenant column (entities are physically shared
+    /// across nouses inside a cohort store), so the only honest way to
+    /// scope the dedup input is to walk through the per-tenant `facts`
+    /// relation. Without this join, two nouses' entity sets would bleed
+    /// into each other during dedup once Path A's embedding wiring made
+    /// cross-tenant `AutoMerge` reachable (#4165 E / latent F).
+    ///
+    /// Entities not referenced by any fact (e.g. raw `insert_entity`
+    /// calls in unit-test fixtures) are excluded — they have no tenant
+    /// affiliation and could be merged into any nous's graph, which is
+    /// exactly the leak this scoping is meant to close. Test fixtures
+    /// that want their entities to participate in dedup must link them
+    /// via [`insert_fact_entity`](Self::insert_fact_entity) to a fact
+    /// owned by the target `nous_id`.
     pub(super) fn load_entity_infos(
         &self,
-        _nous_id: &str,
+        nous_id: &str,
     ) -> crate::error::Result<Vec<crate::dedup::EntityInfo>> {
         use std::collections::BTreeMap;
+
+        use crate::engine::DataValue;
 
         // WHY (#4165 Path A): pull `name_embedding` alongside the other
         // entity fields so the dedup pipeline can compute real cosine
         // similarity for the `embed_sim` term in the merge score.
+        //
+        // WHY (#4165 E): tenant-scope via fact_entities → facts.nous_id.
+        // The set-of-tuples semantics of Datalog deduplicate entities
+        // referenced by multiple facts within the same nous, so the
+        // returned vector never contains a given entity twice.
         let script = r"?[id, name, entity_type, aliases, created_at, name_embedding] :=
+            *facts{id: fact_id, nous_id},
+            nous_id == $nous_id,
+            *fact_entities{fact_id, entity_id: id},
             *entities{id, name, entity_type, aliases, created_at, name_embedding}";
-        let rows = self.run_read(script, BTreeMap::new())?;
+        let mut params = BTreeMap::new();
+        params.insert("nous_id".to_owned(), DataValue::Str(nous_id.into()));
+        let rows = self.run_read(script, params)?;
 
         let mut entities = Vec::new();
         for row in &rows.rows {

--- a/crates/episteme/src/knowledge_store/tests/entities.rs
+++ b/crates/episteme/src/knowledge_store/tests/entities.rs
@@ -7,7 +7,27 @@
 use std::sync::Arc;
 
 use crate::knowledge::Entity;
+use crate::knowledge_store::KnowledgeStore;
 use crate::test_fixtures::{make_entity, make_fact, make_relationship, make_store};
+
+/// Wire an entity into a nous's scope by inserting a stub fact owned by
+/// `nous_id` and a `fact_entities` row linking the fact to the entity.
+///
+/// `load_entity_infos` scopes via the `fact_entities → facts.nous_id` join
+/// (#4165 E), so unit tests that previously relied on `insert_entity`
+/// alone need to add a link or the dedup pipeline cannot see them. Reusing
+/// this helper keeps the dedup integration tests honest about the path
+/// the production code now takes.
+fn link_entity_to_nous(store: &KnowledgeStore, entity_id: &str, nous_id: &str) {
+    let fact_id = format!("fact-{entity_id}-{nous_id}");
+    let fact = make_fact(&fact_id, nous_id, "stub fact linking entity to nous");
+    store.insert_fact(&fact).expect("insert stub fact");
+    let fid = crate::id::FactId::new(&fact_id).expect("valid fact id");
+    let eid = crate::id::EntityId::new(entity_id).expect("valid entity id");
+    store
+        .insert_fact_entity(&fid, &eid)
+        .expect("link fact to entity");
+}
 #[test]
 fn insert_entity_and_query_neighborhood() {
     let store = make_store();
@@ -285,6 +305,8 @@ fn dedup_pipeline_without_embeddings_reproduces_bug_4165() {
     e2.aliases = vec!["Acme".to_owned()];
     store.insert_entity(&e1).expect("insert e1");
     store.insert_entity(&e2).expect("insert e2");
+    link_entity_to_nous(&store, "e1", "test-nous");
+    link_entity_to_nous(&store, "e2", "test-nous");
 
     let records = store
         .run_entity_dedup("test-nous")
@@ -318,6 +340,8 @@ fn dedup_pipeline_with_embeddings_reaches_auto_merge() {
     e2.aliases = vec!["Acme".to_owned()];
     store.insert_entity(&e1).expect("insert e1");
     store.insert_entity(&e2).expect("insert e2");
+    link_entity_to_nous(&store, "e1", "test-nous");
+    link_entity_to_nous(&store, "e2", "test-nous");
 
     // DIM=4 from `test_fixtures::DIM`; identical unit vectors yield
     // cosine = 1.0 — the test-shape equivalent of "the provider thinks
@@ -374,6 +398,8 @@ fn find_duplicate_entities_returns_real_embed_similarity() {
     let e2 = make_entity("e2", "Difference Equation", "concept");
     store.insert_entity(&e1).expect("insert e1");
     store.insert_entity(&e2).expect("insert e2");
+    link_entity_to_nous(&store, "e1", "test-nous");
+    link_entity_to_nous(&store, "e2", "test-nous");
 
     let e1_id = crate::id::EntityId::new("e1").expect("valid test id");
     let e2_id = crate::id::EntityId::new("e2").expect("valid test id");
@@ -466,6 +492,8 @@ fn approve_merge_drains_review_queue() {
     e2.aliases = vec!["Acme".to_owned()];
     store.insert_entity(&e1).expect("insert e1");
     store.insert_entity(&e2).expect("insert e2");
+    link_entity_to_nous(&store, "e1", "test-nous");
+    link_entity_to_nous(&store, "e2", "test-nous");
 
     let records = store
         .run_entity_dedup("test-nous")
@@ -520,6 +548,106 @@ fn approve_merge_drains_review_queue() {
         history.len(),
         1,
         "approved merge must be recorded in merge_audit"
+    );
+}
+
+/// #4165 E regression: `find_duplicate_entities("nous-A")` must not see
+/// entities linked exclusively to `nous-B`. Pre-fix, `load_entity_infos`
+/// loaded every row of the `entities` relation, so dedup could merge
+/// across tenant boundaries the moment Path A's embedding wiring made
+/// `AutoMerge` reachable. With the tenant-scoped query in place, the
+/// nous-B entity must be invisible to a nous-A dedup scan even though
+/// the names + types + aliases are identical.
+#[test]
+fn find_duplicate_entities_does_not_cross_nous_boundary() {
+    let store = make_store();
+    let mut e1 = make_entity("e1", "Acme Corporation", "organization");
+    e1.aliases = vec!["Acme".to_owned()];
+    let mut e2 = make_entity("e2", "Acme Corporation", "organization");
+    e2.aliases = vec!["Acme".to_owned()];
+    store.insert_entity(&e1).expect("insert e1");
+    store.insert_entity(&e2).expect("insert e2");
+
+    // e1 belongs to nous-A; e2 belongs to nous-B. A nous-A dedup scan
+    // must never propose merging them despite the identical surface
+    // form (the very leak issue #4165 (F) called out as latent).
+    link_entity_to_nous(&store, "e1", "nous-A");
+    link_entity_to_nous(&store, "e2", "nous-B");
+
+    let scan_a = store
+        .find_duplicate_entities("nous-A")
+        .expect("nous-A dedup scan");
+    assert!(
+        scan_a.is_empty(),
+        "nous-A scan must not surface a candidate involving an entity owned exclusively by nous-B"
+    );
+
+    let scan_b = store
+        .find_duplicate_entities("nous-B")
+        .expect("nous-B dedup scan");
+    assert!(
+        scan_b.is_empty(),
+        "nous-B scan must not surface a candidate involving an entity owned exclusively by nous-A"
+    );
+
+    let scan_unlinked = store
+        .find_duplicate_entities("nous-C")
+        .expect("nous-C dedup scan");
+    assert!(
+        scan_unlinked.is_empty(),
+        "a nous with no linked entities must return no dedup candidates"
+    );
+}
+
+/// `run_entity_dedup_with_tuning` must observe operator-tuned weights
+/// and thresholds end-to-end through the production store path (#4165 D).
+/// Inserts a Review-tier pair, asserts the default tuning produces no
+/// auto-merge, then re-runs under a tuning that lowers
+/// `auto_merge_threshold` below the pair's composite score and asserts
+/// the same store data now executes a real merge.
+#[test]
+fn run_entity_dedup_with_tuning_honours_lowered_auto_merge_threshold() {
+    let store = make_store();
+    let mut e1 = make_entity("e1", "Acme Corporation", "organization");
+    e1.aliases = vec!["Acme".to_owned()];
+    let mut e2 = make_entity("e2", "acme corporation", "organization");
+    e2.aliases = vec!["Acme".to_owned()];
+    store.insert_entity(&e1).expect("insert e1");
+    store.insert_entity(&e2).expect("insert e2");
+    link_entity_to_nous(&store, "e1", "test-nous");
+    link_entity_to_nous(&store, "e2", "test-nous");
+
+    let default_records = store
+        .run_entity_dedup_with_tuning("test-nous", &crate::dedup::DedupTuning::DEFAULT)
+        .expect("dedup under default tuning");
+    assert!(
+        default_records.is_empty(),
+        "default tuning must keep the embed=null pair in Review (preserves #4165 path-a-reachable_pre_fix_regression contract)"
+    );
+    assert_eq!(
+        store.list_entities().expect("list entities").len(),
+        2,
+        "no merge executed under default tuning"
+    );
+
+    let permissive = crate::dedup::DedupTuning {
+        auto_merge_threshold: 0.65,
+        ..crate::dedup::DedupTuning::DEFAULT
+    };
+    let records = store
+        .run_entity_dedup_with_tuning("test-nous", &permissive)
+        .expect("dedup under permissive tuning");
+    assert_eq!(
+        records.len(),
+        1,
+        "lowering auto_merge_threshold to 0.65 must execute the queued Review-tier merge — proves DedupTuning reaches run_entity_dedup_with_tuning end-to-end"
+    );
+
+    let surviving = store.list_entities().expect("list entities");
+    assert_eq!(
+        surviving.len(),
+        1,
+        "permissive tuning must collapse the pair to a single canonical entity"
     );
 }
 

--- a/crates/episteme/src/lib.rs
+++ b/crates/episteme/src/lib.rs
@@ -32,7 +32,14 @@ pub mod consolidation;
 )]
 pub mod decay;
 /// Entity deduplication pipeline for merging semantically identical entities.
-pub(crate) mod dedup;
+///
+/// Public surface is intentionally minimal: only the operator-tunable
+/// [`DedupTuning`](dedup::DedupTuning) struct and its default constants
+/// are exposed so the binary crate can build a tuning from
+/// `taxis::AgentBehaviorDefaults` and pass it into the dedup entry
+/// points on [`KnowledgeStore`](crate::knowledge_store::KnowledgeStore)
+/// (#4165 D). All internal types remain `pub(crate)`.
+pub mod dedup;
 /// Derived Datalog rule definitions: ontological IS-A closure, causal chains,
 /// and defeasible defaults. Rule strings consumed by the knowledge store's
 /// derived-rule materialization engine.

--- a/crates/episteme/src/phase_f_integration_tests.rs
+++ b/crates/episteme/src/phase_f_integration_tests.rs
@@ -85,7 +85,9 @@ fn preference_fact_type_has_8760_base_stability_hours() {
 
 #[test]
 fn dedup_candidate_generation_finds_duplicate_instinct_patterns() {
-    use crate::dedup::{EntityInfo, MergeDecision, compute_merge_score, generate_candidates};
+    use crate::dedup::{
+        DedupTuning, EntityInfo, MergeDecision, compute_merge_score, generate_candidates,
+    };
     use crate::id::EntityId;
 
     let ts_a = ts("2026-03-01T00:00:00Z");
@@ -112,7 +114,7 @@ fn dedup_candidate_generation_finds_duplicate_instinct_patterns() {
         },
     ];
 
-    let candidates = generate_candidates(&entities, &|_, _| 0.0);
+    let candidates = generate_candidates(&entities, &|_, _| 0.0, &DedupTuning::DEFAULT);
     assert!(
         !candidates.is_empty(),
         "exact name match for same-type instinct entities should produce a candidate"
@@ -130,16 +132,22 @@ fn dedup_candidate_generation_finds_duplicate_instinct_patterns() {
         "same entity_type means type_match=true"
     );
 
-    let score = compute_merge_score(candidates[0].name_similarity, 0.0, true, false);
+    let score = compute_merge_score(
+        candidates[0].name_similarity,
+        0.0,
+        true,
+        false,
+        &DedupTuning::DEFAULT,
+    );
     assert!(
         score >= 0.0,
         "merge score should be non-negative for exact name match"
     );
     assert!(score <= 1.0, "merge score should be at most 1.0");
 
-    let all_signals_score = compute_merge_score(1.0, 1.0, true, true);
+    let all_signals_score = compute_merge_score(1.0, 1.0, true, true, &DedupTuning::DEFAULT);
     assert_eq!(
-        MergeDecision::from_score(all_signals_score),
+        MergeDecision::from_score(all_signals_score, &DedupTuning::DEFAULT),
         MergeDecision::AutoMerge,
         "perfect name + embed + type + alias → auto-merge"
     );

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -267,6 +267,22 @@ pub mod knowledge_store {
     };
 }
 
+/// Entity dedup tuning (#4165 D): operator-configurable weights/thresholds
+/// the CLI and scheduled maintenance task feed into the dedup pipeline.
+///
+/// # Facade surface
+///
+/// [`DedupTuning`](dedup::DedupTuning) and the `DEFAULT_*` constants the
+/// runtime falls back to when no config override is available.
+#[cfg(feature = "mneme-engine")]
+pub mod dedup {
+    pub use episteme::dedup::{
+        DEFAULT_AUTO_MERGE_THRESHOLD, DEFAULT_EMBED_THRESHOLD, DEFAULT_JW_THRESHOLD,
+        DEFAULT_REVIEW_THRESHOLD, DEFAULT_WEIGHT_ALIAS, DEFAULT_WEIGHT_EMBED, DEFAULT_WEIGHT_NAME,
+        DEFAULT_WEIGHT_TYPE, DedupTuning,
+    };
+}
+
 /// Operational metrics registration for knowledge and session storage.
 ///
 /// # Facade surface


### PR DESCRIPTION
## Summary

Completes the mechanical follow-up bundle from #4165's triage that #4317 Path A and #4314 F+C-cheap deliberately deferred:

- **D — config thresholds reachable.** Operator-tuned `taxis::AgentBehaviorDefaults::knowledge_dedup_*` keys (weights + JW + embed thresholds) now actually flow through `compute_merge_score`, `generate_candidates`, `MergeDecision::from_score`, and `classify_candidates` via a single `DedupTuning` struct. Pre-fix, those helpers read the module constants directly and tuning the config knobs had zero effect on dedup behaviour.
- **E — nous-scoped entity loading.** `load_entity_infos` now filters via the `fact_entities → facts.nous_id` join. Pre-fix, the function was marked `_nous_id` and loaded every entity across every nous in the cohort store — the tenant-bleed footgun that #4317 made live the moment `AutoMerge` became reachable.

## Public surface

- `episteme::dedup` → `pub` (was `pub(crate)`). Only `DedupTuning` and its `DEFAULT_*` constants are exported; helper functions stay `pub(crate)`.
- `mneme::dedup` re-exports `DedupTuning` and the defaults for the binary crate to construct a tuning at startup.
- `KnowledgeStore::find_duplicate_entities_with_tuning` and `run_entity_dedup_with_tuning` (+ `run_entity_dedup_with_embeddings_and_tuning`) for explicit tuning. The historical zero-arg variants delegate with `DedupTuning::DEFAULT` so existing callers keep working.

## Wiring

- `KnowledgeMaintenanceAdapter::with_tuning` accepts a tuning at construction; `runtime/mod.rs` builds one from `self.config.agents.defaults.behavior` so the scheduled `entity-dedup` task honours operator config.
- `aletheia memory dedup` loads `taxis::loader::load_config(&oikos)` and passes the derived tuning into the CLI path. A missing/invalid config falls back to `DedupTuning::DEFAULT` so the command remains strictly additive.

## Tests

- `tuned_weights_change_composite_score`, `tuned_jw_threshold_admits_pair_under_default_floor`, `tuned_auto_merge_threshold_promotes_review_to_auto_merge`, `tuned_review_threshold_drops_pair_to_skip` — pin the contract that every stage of the pipeline reads `tuning` instead of the module constants.
- `find_duplicate_entities_does_not_cross_nous_boundary` — proves the tenant-scoping query rejects cross-nous candidates even when names + types + aliases match exactly.
- `run_entity_dedup_with_tuning_honours_lowered_auto_merge_threshold` — end-to-end through the store: same data, default tuning → no merge, permissive tuning → real `AutoMerge` execution.
- Existing dedup integration tests get a small `link_entity_to_nous` fixture helper so `insert_entity`-only setups still participate in the now-scoped dedup query.

Episteme test suite: **1249 / 1249 pass** (up 6 from the 1243 baseline, matching the new D+E regressions).

## Test plan

- [x] `cargo test -p episteme --features mneme-engine --lib` — 1249 / 1249 pass.
- [x] `cargo test -p aletheia` — 40 / 40 pass.
- [x] `cargo clippy --workspace --all-targets` — zero warnings on changed files.
- [ ] Operator smoke-test: drop a `knowledge_dedup_jw_threshold = 0.70` into agents config; confirm `aletheia memory dedup --nous-id X` admits a pair that the default 0.85 floor would reject.
- [ ] Operator smoke-test: confirm the scheduled `entity-dedup` task picks up the same tuning override against a populated install.

## Out of scope for this PR

- `get_pending_merges` still ignores its `nous_id` arg. Latent today because dedup now only writes pairs from a single nous's entity set per scan, but cross-nous pairs written before E ships would still be visible to either nous's review queue. Same shape as the latent leak (F) called out in #4165 — filed for a follow-up.
- `AgentBehaviorDefaults` does not yet carry keys for `auto_merge_threshold` and `review_threshold`. `DedupTuning::DEFAULT` is used for both when reading from config; adding the keys is a strict superset change deferred to a future PR.
- Fact-content dedup (C-hard from the #4165 triage) — still display-only, out of scope for the reachability fix.