### PR TITLE
ci: add push-time cargo fmt check on main (substrate fix for #4329)

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,46 @@
+# WHY: cargo fmt drift on main creates a "first-touch tax" — every new
+# contributor's first commit fails `kanon gate` on lines they did not
+# touch, pushing them toward dishonest Gate-Passed stamps to restore
+# green CI. Catch drift at PR time so it cannot land, and re-check on
+# push to main so a merge race that introduces drift surfaces as a red
+# main rather than as silent contributor pain on the next PR. See
+# standards/CI.md § fmt and #4329 for the substrate rationale.
+name: Fmt
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# PROJECT: explicit top-level default deny; job-level permissions grant only what's needed
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt-check:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false # PROJECT: security hardening — never expose token to steps
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          components: rustfmt
+      - name: cargo fmt --all -- --check
+        # WHY: matches the local `kanon gate --tier light` fmt step exactly,
+        # so a green PR here means the gate trailer it carries is honestly
+        # stampable. Failure prints the diff hunks rustfmt would apply,
+        # which is enough for a contributor to fix without running cargo
+        # locally.
+        run: cargo fmt --all -- --check


### PR DESCRIPTION
Refs #4329.

## Summary

Adds `.github/workflows/fmt.yml` — a new `runs-on: ubuntu-latest`
workflow that runs `cargo fmt --all -- --check` on every PR targeting
main and on every push to main. ~30s with the stable toolchain warm,
no cargo build, no Rust compilation.

## Why

Per #4329, when fmt drift lands on main the next contributor's `kanon
gate` fails on code they did not touch. The "easy" remedy for AI
agents is to manually stamp `Gate-Passed:` without the gate having
passed — which silently breaks the trailer's truthfulness contract.

This is the cheapest-first checkbox from #4329: a push-time canary on
main plus a PR-time check so drift cannot land in the first place.
Pairs with the one-shot sweep already merged as #4330.

The trailer-HMAC and pre-receive-hook checkboxes from #4329 remain
open as separate, larger-touch follow-ups.

## What this does NOT do

- Does not edit `kanon gate` — the local pipeline still does the same
  `cargo fmt --check` as before. This is the CI-side mirror.
- Does not make the new check a required status check on its own —
  enabling that is a branch-protection toggle the operator owns.
- Does not address the trailer's substring-matching weakness (#4329
  fix #3) — separate concern, separate PR.

## Test plan

- [ ] PR run: workflow appears, passes against current main (#4330
  already cleared the drift).
- [ ] Failure injection: a follow-up `chore(test-only)` branch that
  deliberately reformats one file the wrong way fails the new check
  with a clear rustfmt diff in the log.
- [ ] After merge: push to main fires the workflow and the result
  appears under Actions for the merge commit.