### PR TITLE
ci: add timeout-minutes to every workflow job (#4331)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,7 @@ jobs:
   analyze-actions:
     name: Analyze (actions)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       security-events: write
       contents: read
@@ -42,6 +43,7 @@ jobs:
   analyze-rust:
     name: Analyze (rust)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,6 +16,13 @@ concurrency:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    # WHY: `gh pr checks --watch --interval 30 --required` is structurally an
+    # infinite loop — it exits only when polled checks reach a terminal state.
+    # During the #4319/#4320 runner OOM-disk window the required checks never
+    # reached terminal, which would have held this Actions slot until GitHub's
+    # 6h hosted ceiling forced it. 30 min covers a long honest verification
+    # cycle and fails clearly on indefinite queue. See #4331.
+    timeout-minutes: 30
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   fuzz:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -15,6 +15,7 @@ jobs:
   gate-attestation:
     name: gate-attestation
     runs-on: self-hosted
+    timeout-minutes: 5
     steps:
       # WHY: bypass keys off the PR author login, not github.actor. The actor
       # changes to a maintainer login whenever someone re-runs the workflow

--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   release-please:
     runs-on: self-hosted
+    timeout-minutes: 10
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -41,6 +42,7 @@ jobs:
     # WHY: ensures optional features compile; if they break, nobody knows until someone
     # enables them locally. See standards/RUST.md "Feature Flags" section.
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +102,7 @@ jobs:
             artifact: aletheia-macos-aarch64
             cross: false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -189,6 +192,7 @@ jobs:
   sbom:
     needs: [test]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:


### PR DESCRIPTION
Refs #4331.

## Summary

- Adds explicit `timeout-minutes:` to 12 workflow jobs across 8 files. After this, every `runs-on:` has a matching `timeout-minutes:`.
- Ceilings chosen 2–3× the observed honest-path median for each job; well under GitHub's 6h hosted ceiling and bounded versus the self-hosted *no ceiling at all* default.
- Worst offender (`dependabot-auto-merge`) gets an inline `WHY` comment so the next reader sees why a 30-min bound on a `gh pr checks --watch` loop is intentional.

## Ceilings

| Workflow | Job | timeout-minutes |
|---|---|---|
| codeql.yml | analyze-actions, analyze-rust | 30 |
| dependabot-auto-merge.yml | auto-merge | 30 |
| fuzz.yml | fuzz (matrix x3) | 60 |
| gate-attestation.yml | gate-attestation | 5 |
| pii-scan.yml | scan | 10 |
| release-please.yml | release-please | 10 |
| release.yml | test, build | 60 |
| release.yml | feature-check, sbom | 30 |
| stale.yml | stale | 10 |

## Why this is substrate-class

Per #4331:

1. The bound was implicit and inconsistent — half the workflows already had `timeout-minutes:` (3–15 min); the other half relied on GitHub's default (360 min hosted) or *no default at all* on `runs-on: self-hosted`.
2. `dependabot-auto-merge`'s `--watch` step is structurally an infinite loop. During the #4319/#4320 runner OOM-disk window the required checks never reached terminal — that run would have sat for the 6h hosted ceiling before GitHub forced it.
3. Self-hosted has no default ceiling. `release-please` and `gate-attestation` on `runs-on: self-hosted` could in principle run forever; a hung gate-attestation step would silently consume a runner and block every PR's required check.

## What this does NOT do

- No standards-doc note. "Every job MUST set `timeout-minutes`" belongs in `~/dev/kanon/crates/basanos/standards/`, not aletheia. Will land as a separate kanon PR.
- No `kanon lint` rule for the convention — also belongs in the kanon rule corpus.
- No change to existing `timeout-minutes:` values on llm-regen (10), no-ai-attribution (3), security/cargo-{deny,audit} (15), runner-housekeeping (10), runner-liveness (5).

## Verification

- `kanon gate --tier light --project aletheia`: PASS.
- `rg 'runs-on:' .github/workflows | wc -l` = `rg 'timeout-minutes:' .github/workflows | wc -l` = 19 (modulo one `runs-on:` mention inside a leading comment in runner-liveness.yml).

## Test plan

- [ ] Merge and observe the next workflow runs — every job's log shows the matching `Job timed out after N minutes` ceiling in its setup line.
- [ ] Failure injection: a synthetic infinite loop step in a throw-away PR fails at the declared ceiling, not at 360 min or never.