### PR TITLE
ci: add timeout-minutes to every workflow job (substrate fix for #4331)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,7 @@ jobs:
   analyze-actions:
     name: Analyze (actions)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       security-events: write
       contents: read
@@ -42,6 +43,7 @@ jobs:
   analyze-rust:
     name: Analyze (rust)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,6 +16,12 @@ concurrency:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    # WHY: the watch step below polls `gh pr checks --watch` with no upper
+    # bound — when a required check stays queued (e.g. during the #4320
+    # disk-OOM blind window), this job would otherwise hold an Actions
+    # slot for the full 360-min hosted ceiling. 30 min covers a normal
+    # verification cycle and surfaces indefinite queues quickly.
+    timeout-minutes: 30
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,6 +19,10 @@ concurrency:
 jobs:
   fuzz:
     runs-on: ubuntu-latest
+    # WHY: per matrix target — toolchain pull + cargo-fuzz install
+    # (~5 min cold) + 300s of fuzzing + artifact upload. 60 min leaves
+    # comfortable headroom without letting a hung fuzz target burn a slot.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -15,6 +15,11 @@ jobs:
   gate-attestation:
     name: gate-attestation
     runs-on: self-hosted
+    # WHY: self-hosted runners have NO default per-job ceiling. The job
+    # body is a `git log` walk and a single `grep -q "^Gate-Passed:"`
+    # check; bounded by PR commit count. 5 min protects every other PR
+    # from a hung trailer scan freezing the only aletheia runner.
+    timeout-minutes: 5
     steps:
       # WHY: bypass keys off the PR author login, not github.actor. The actor
       # changes to a maintainer login whenever someone re-runs the workflow

--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,10 @@ concurrency:
 jobs:
   release-please:
     runs-on: self-hosted
+    # WHY: self-hosted has no default ceiling. release-please-action is
+    # GitHub-API-bound; a network or SDK retry loop must not hold the
+    # only aletheia runner indefinitely.
+    timeout-minutes: 10
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -41,6 +42,7 @@ jobs:
     # WHY: ensures optional features compile; if they break, nobody knows until someone
     # enables them locally. See standards/RUST.md "Feature Flags" section.
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +102,7 @@ jobs:
             artifact: aletheia-macos-aarch64
             cross: false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -189,6 +192,7 @@ jobs:
   sbom:
     needs: [test]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:


### PR DESCRIPTION
Refs #4331.

## Summary

Adds an explicit `timeout-minutes:` to the 12 workflow jobs that
previously had none, picking the conservative ceilings from the audit
table in #4331:

| Workflow | Job | Ceiling |
|---|---|---|
| `gate-attestation` | `gate-attestation` | 5 |
| `codeql` | `analyze-actions`, `analyze-rust` | 30 |
| `fuzz` | `fuzz` (matrix x3) | 60 |
| `pii-scan` | `scan` | 10 |
| `release` | `test`, `build` | 60 |
| `release` | `feature-check`, `sbom` | 30 |
| `release-please` | `release-please` | 10 |
| `dependabot-auto-merge` | `auto-merge` | 30 |
| `stale` | `stale` | 10 |

After this PR, every `runs-on:` line in `.github/workflows/` has a
paired `timeout-minutes:` (13/13 files, 22/22 jobs).

## Why

Per #4331, jobs without a per-job ceiling rely on GitHub's defaults —
which are 360 min on hosted runners and **unbounded on self-hosted**.
The compounding scenario is real: during the #4320 disk-OOM blind
window, `dependabot-auto-merge`'s `gh pr checks --watch --interval 30
--required` would have sat on its Actions slot for up to 6 hours; and
`gate-attestation` / `release-please` on `runs-on: self-hosted` could
in principle have held the only aletheia runner indefinitely, blocking
every PR. The bound is now explicit, recoverable from a hang, and
consistent across the file.

## Notes

- WHY comments are added to the four cases where the chosen ceiling is
  non-obvious or driven by an observed failure mode (`auto-merge`'s
  watch step, `fuzz` cold-start, the two self-hosted required jobs).
  The rest are conservative ubuntu-latest standards that match the
  pre-existing per-job overrides in `security.yml` / `llm-regen.yml`.
- The standards-doc note (`standards/CI.md`: "Every job MUST set
  `timeout-minutes`") and the `kanon lint` rule checkboxes from #4331
  remain open as separate follow-ups — neither is required for the
  defense-in-depth fix this PR lands.

## What this does NOT do

- Does not change any `runs-on:` value.
- Does not change the watch-step poll interval in
  `dependabot-auto-merge.yml` — the 30 min ceiling fails the job fast
  on indefinite queue, which is the substrate behavior #4331 calls
  for; tightening the inner loop is a separate concern.

## Test plan

- [ ] Next PR pickup: each affected workflow's job summary in Actions
  shows the per-job timeout in the run metadata.
- [ ] Failure injection (optional): a deliberate `sleep 9999` in any
  affected workflow fails at the configured ceiling instead of GitHub's
  6-hour default.