### PR TITLE
ci: add per-job disk preflight to self-hosted workflows (substrate fix for #4319)

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -17,6 +17,25 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 5
     steps:
+      - name: Substrate preflight — abort on low disk
+        # WHY: Substrate fix for #4319. Self-hosted runner host disk
+        # exhaustion kills Worker mid-step with an opaque ENOSPC. Aborting
+        # at step 1 with a clear marker converts the silent substrate
+        # failure into a named, operator-actionable one. The 95% threshold
+        # matches `runner-housekeeping` so daily prune at 03:00 UTC is
+        # first defense and this is the per-job last line.
+        shell: bash
+        run: |
+          set -u
+          used=$(df --output=pcent / | tail -1 | tr -d ' %')
+          echo "self-hosted root usage: ${used}%"
+          if [ "${used}" -ge 95 ]; then
+            echo "::error::self-hosted runner root at ${used}% (>= 95% threshold)."
+            echo "::error::Aborting before checkout to avoid mid-step ENOSPC kill (#4319)."
+            echo "::error::Operator: dispatch runner-housekeeping or free disk on the runner host, then re-run."
+            exit 1
+          fi
+
       # WHY: bypass keys off the PR author login, not github.actor. The actor
       # changes to a maintainer login whenever someone re-runs the workflow
       # (e.g. clicking "Re-run failed jobs" on a dependabot PR), which silently

--- a/.github/workflows/llm-regen.yml
+++ b/.github/workflows/llm-regen.yml
@@ -43,6 +43,24 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 10
     steps:
+      - name: Substrate preflight — abort on low disk
+        # WHY: Substrate fix for #4319. Self-hosted runner host disk
+        # exhaustion kills Worker mid-step with an opaque ENOSPC. Aborting
+        # at step 1 with a clear marker converts the silent substrate
+        # failure into a named, operator-actionable one. The 95% threshold
+        # matches `runner-housekeeping` so daily prune at 03:00 UTC is
+        # first defense and this is the per-job last line.
+        shell: bash
+        run: |
+          set -u
+          used=$(df --output=pcent / | tail -1 | tr -d ' %')
+          echo "self-hosted root usage: ${used}%"
+          if [ "${used}" -ge 95 ]; then
+            echo "::error::self-hosted runner root at ${used}% (>= 95% threshold)."
+            echo "::error::Aborting before checkout to avoid mid-step ENOSPC kill (#4319)."
+            echo "::error::Operator: dispatch runner-housekeeping or free disk on the runner host, then re-run."
+            exit 1
+          fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2

--- a/.github/workflows/no-ai-attribution.yml
+++ b/.github/workflows/no-ai-attribution.yml
@@ -27,6 +27,25 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 3
     steps:
+      - name: Substrate preflight — abort on low disk
+        # WHY: Substrate fix for #4319. Self-hosted runner host disk
+        # exhaustion kills Worker mid-step with an opaque ENOSPC. Aborting
+        # at step 1 with a clear marker converts the silent substrate
+        # failure into a named, operator-actionable one. The 95% threshold
+        # matches `runner-housekeeping` so daily prune at 03:00 UTC is
+        # first defense and this is the per-job last line.
+        shell: bash
+        run: |
+          set -u
+          used=$(df --output=pcent / | tail -1 | tr -d ' %')
+          echo "self-hosted root usage: ${used}%"
+          if [ "${used}" -ge 95 ]; then
+            echo "::error::self-hosted runner root at ${used}% (>= 95% threshold)."
+            echo "::error::Aborting before checkout to avoid mid-step ENOSPC kill (#4319)."
+            echo "::error::Operator: dispatch runner-housekeeping or free disk on the runner host, then re-run."
+            exit 1
+          fi
+
       # WHY: bypass keys off the PR author login, not github.actor. The actor
       # changes to a maintainer login whenever someone re-runs the workflow
       # (e.g. clicking "Re-run failed jobs" on an automation PR), which silently

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,24 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Substrate preflight — abort on low disk
+        # WHY: Substrate fix for #4319. Self-hosted runner host disk
+        # exhaustion kills Worker mid-step with an opaque ENOSPC. Aborting
+        # at step 1 with a clear marker converts the silent substrate
+        # failure into a named, operator-actionable one. The 95% threshold
+        # matches `runner-housekeeping` so daily prune at 03:00 UTC is
+        # first defense and this is the per-job last line.
+        shell: bash
+        run: |
+          set -u
+          used=$(df --output=pcent / | tail -1 | tr -d ' %')
+          echo "self-hosted root usage: ${used}%"
+          if [ "${used}" -ge 95 ]; then
+            echo "::error::self-hosted runner root at ${used}% (>= 95% threshold)."
+            echo "::error::Aborting before checkout to avoid mid-step ENOSPC kill (#4319)."
+            echo "::error::Operator: dispatch runner-housekeeping or free disk on the runner host, then re-run."
+            exit 1
+          fi
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,25 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
+      - name: Substrate preflight — abort on low disk
+        # WHY: Substrate fix for #4319. On 2026-05-28 the verda host hit
+        # 100% on /, killing Runner.Worker mid-step with an opaque ENOSPC
+        # that surfaced as "cargo deny failed" on PR #4312. Aborting at
+        # step 1 with a clear marker converts the silent substrate
+        # failure into a named, operator-actionable one. The 95%
+        # threshold matches `runner-housekeeping` so daily prune at
+        # 03:00 UTC is first defense and this is the per-job last line.
+        shell: bash
+        run: |
+          set -u
+          used=$(df --output=pcent / | tail -1 | tr -d ' %')
+          echo "self-hosted root usage: ${used}%"
+          if [ "${used}" -ge 95 ]; then
+            echo "::error::self-hosted runner root at ${used}% (>= 95% threshold)."
+            echo "::error::Aborting before checkout to avoid mid-step ENOSPC kill (#4319)."
+            echo "::error::Operator: dispatch runner-housekeeping or free disk on the runner host, then re-run."
+            exit 1
+          fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false # PROJECT: security hardening — never expose token to steps
@@ -70,6 +89,21 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
+      - name: Substrate preflight — abort on low disk
+        # WHY: See cargo-deny job above; same #4319 rationale per
+        # self-hosted job to keep the abort signal local to the failing
+        # work unit.
+        shell: bash
+        run: |
+          set -u
+          used=$(df --output=pcent / | tail -1 | tr -d ' %')
+          echo "self-hosted root usage: ${used}%"
+          if [ "${used}" -ge 95 ]; then
+            echo "::error::self-hosted runner root at ${used}% (>= 95% threshold)."
+            echo "::error::Aborting before checkout to avoid mid-step ENOSPC kill (#4319)."
+            echo "::error::Operator: dispatch runner-housekeeping or free disk on the runner host, then re-run."
+            exit 1
+          fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false


### PR DESCRIPTION
Refs #4319.

## Summary

Adds a "fail fast on low disk" preflight as the first step in every self-hosted job on this repo: `security` (cargo-deny, cargo-audit), `gate-attestation`, `no-ai-attribution`, `release-please`, and `_llm` regeneration. The check reads `df --output=pcent /` and aborts the job at step 1 with a clear `::error::` annotation when the root filesystem is at >=95% used.

## Why

Per #4319, the verda runner host hit 100% on `/dev/vda4` on 2026-05-28 and killed `Runner.Worker` mid-step. The failure surfaced as an opaque "cargo deny failed" on PR #4312 — indistinguishable from a real cargo deny finding, sending PR authors to debug the wrong layer.

`runner-housekeeping` already prunes Docker and `_diag` logs daily at 03:00 UTC, but that is a defense-in-depth floor and does not stop a mid-day spike (a sibling agent worktree, a large `/tmp/perf-fixed.data`, etc.) from filling the disk between sweeps. Per-job preflight is the per-work-unit last line: a job that cannot complete safely refuses to start and prints what the operator needs to act on.

Same 95% threshold as the housekeeping cron's headroom budget so the two policies stay consistent.

## What this does NOT do

- `runner-housekeeping` itself is not guarded — its job is to free disk, so it must run even when disk is full. By design.
- `runner-liveness` is `ubuntu-latest` and unaffected.
- Hosted (`ubuntu-latest`) jobs (`fmt`, `pii-scan`, `codeql`, etc.) are unaffected — their disk is GitHub-managed, not substrate-shared.
- Does not auto-restart runners, auto-page operators, or auto-prune beyond housekeeping. Each is a separate concern with separate trade-offs.

## Test plan

- [ ] PR's own security/gate-attestation/no-ai-attribution jobs run green (preflight prints "self-hosted root usage: <85%" and falls through to checkout).
- [ ] `workflow_dispatch` of `runner-housekeeping` continues to succeed regardless of disk state (no preflight added).
- [ ] Manual fault injection (optional): fill `/tmp` to >95% on the runner host, push a no-op commit, confirm preflight fires with the named error message rather than letting a downstream step blow up.