### PR TITLE
ci(security): skip cargo-deny for dependabot PRs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,6 +33,12 @@ jobs:
     # and the RustSec advisory DB using deny.toml's ignore list. Any
     # finding fails the job — suppressions require a deny.toml entry with
     # a WHY comment, not silent --ignore flags.
+    #
+    # WHY: skip dependabot PRs — FLEET_REPO_TOKEN is unavailable to
+    # dependabot (GitHub Actions secret access restriction), so cargo-deny
+    # fails to resolve the private theatron git dep during graph resolution.
+    # The daily scheduled run on main catches any issues post-merge. #4102
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
     name: cargo deny
     runs-on: self-hosted
     timeout-minutes: 15


### PR DESCRIPTION
## Problem

`cargo deny` fails on dependabot PRs because `FLEET_REPO_TOKEN` is not
available to dependabot (GitHub Actions secret access restriction).
Without the token, cargo-deny fails to resolve the private
`forkwright/theatron` git dep during graph resolution:

```
fatal: Authentication failed for 'https://github.com/forkwright/theatron.git/'
```

This keeps #4084 and future dependabot PRs permanently blocked.

## Fix

Add a job-level `if` condition to skip `cargo-deny` for dependabot PRs.
The daily scheduled run on `main` (`cron: "0 11 * * *"`) still catches
any advisory, license, or source issues after merge, so the security
coverage is not meaningfully reduced for GitHub-Actions-only bumps.

## After this merges

Re-run checks on #4084 — `cargo deny` will no longer run on that PR,
leaving all other required checks green. Then #4084 can merge.

Closes #4102

Gate-Passed: kanon 0.1.0