### PR TITLE
ci(infra): add stale agent workdir reaper to housekeeping cron

### DIFF
--- a/.github/workflows/runner-housekeeping.yml
+++ b/.github/workflows/runner-housekeeping.yml
@@ -65,5 +65,32 @@ jobs:
           find "$diag_dir" -type f \( -name "Worker_*" -o -name "Runner_*" \) -mtime +7 -print -delete | wc -l
         continue-on-error: true
 
+      - name: Reap stale agent workdirs
+        # WHY: Agent workdirs under ~/_*-* accumulate 10–260 GB each. Any
+        # workdir whose done.flag is older than 24h is safe to remove; the
+        # sentinel is written by the wrapper script after the agent exits.
+        # The 32 GB + 41 GB + 260 GB (DONE) observed on 2026-05-28 were
+        # this gap — the preflight and Docker prune above address future
+        # spikes but do not reclaim existing bloat. #4319 §c / #4323 §d
+        run: |
+          set -u
+          home="${HOME:-/home/ck}"
+          reaped=0
+          now=$(date +%s)
+          threshold=86400
+          for workdir in "$home"/_*-*/; do
+            [ -d "$workdir" ] || continue
+            flag="$workdir/done.flag"
+            [ -f "$flag" ] || continue
+            age=$(( now - $(stat -c %Y "$flag") ))
+            if [ "$age" -gt "$threshold" ]; then
+              echo "reaping $workdir (done.flag age ${age}s)"
+              rm -rf "$workdir"
+              reaped=$((reaped + 1))
+            fi
+          done
+          echo "reaped $reaped stale workdirs"
+        continue-on-error: true
+
       - name: Report disk after
         run: df -h / | head -2


### PR DESCRIPTION
## Problem

Agent workdirs under `~/_*-*` accumulate 10–260 GB each (32 GB + 41 GB
+ 260 GB observed on 2026-05-28). The daily housekeeping cron
(`runner-housekeeping.yml`) pruned Docker images and runner `_diag` logs
but left agent workdirs untouched, so disk bloat kept accumulating
between manual cleanups.

## Fix

Add a `Reap stale agent workdirs` step to the existing housekeeping job.
The step iterates `~/_*-*/` directories, checks for a `done.flag` file
older than 24 h (written by the wrapper script on agent exit), and
removes the directory. The step is `continue-on-error: true` so a
permissions error on one dir does not block the rest of housekeeping.

## Safety

The reaper only removes directories that:
1. Match the `~/_*-*` glob (agent workdir naming convention)
2. Contain a `done.flag` sentinel (explicit DONE signal from wrapper)
3. Whose `done.flag` is ≥ 24 h old (enough margin to avoid active runs)

Active workdirs that have not written `done.flag` are left untouched.

Addresses #4319 §c (stale-workdir reaper) and #4323 §d.

Gate-Passed: kanon 0.1.0