### PR TITLE
docs(instance): refresh stale v0.13.x version references to v0.29.0+ line

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -9,7 +9,8 @@
    ```
 3. Download the tarball from [GitHub Releases](https://github.com/forkwright/aletheia/releases):
    ```bash
-   VERSION=v0.13.0
+   # Set VERSION to the release you are installing, e.g. v0.30.0
+   VERSION=vX.Y.Z
    curl -L "https://github.com/forkwright/aletheia/releases/download/${VERSION}/aletheia-linux-x86_64-${VERSION}.tar.gz" \
      -o aletheia.tar.gz
    ```
@@ -24,7 +25,7 @@
 6. Extract and replace the binary:
    ```bash
    tar xzf aletheia.tar.gz
-   sudo cp "aletheia-${VERSION}/aletheia" /usr/local/bin/aletheia
+   cp "aletheia-${VERSION}/aletheia" ~/.local/bin/aletheia
    ```
 7. Start the service:
    ```bash

--- a/instance.example/nous/_default/MEMORY.md
+++ b/instance.example/nous/_default/MEMORY.md
@@ -6,7 +6,7 @@ Keep this file lean. Delete entries that are no longer relevant. Move entries th
 
 ## System
 
-- Runtime: Aletheia v0.13.11 (self-hosted, single binary, Rust)
+- Runtime: Aletheia v0.29.0+ (self-hosted, single binary, Rust)
 - Source: https://github.com/forkwright/aletheia
 - Standing order: log bugs and improvements as issues on the repo
 - Config: instance/config/aletheia.toml (TOML cascade: defaults → file → env)


### PR DESCRIPTION
## Summary

- `docs/UPGRADING.md`: curl example had `VERSION=v0.13.0` hardcoded. Replace with `vX.Y.Z` placeholder + comment. Also align install path to `~/.local/bin/aletheia` (not `sudo cp /usr/local/bin`) matching current convention.
- `instance.example/nous/_default/MEMORY.md`: referenced `Aletheia v0.13.11`; update to `v0.29.0+` to reflect the current release line.

Docs-only change; no Rust gate needed.

Closes #3877.

## Test plan

- [ ] grep for `v0.13` in docs/ and instance.example/ returns no matches (except lz4_flex transitive-dep note in FJALL-EVALUATION.md)
- [ ] UPGRADING.md reads correctly as a guide for operators on the current release line