### PR TITLE
verify(nous): confirm daimon's three hard-won agent constraints (#4109)

### DIFF
--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-30T00:42:02Z"
+generated_at = "2026-05-30T01:00:47Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -86,7 +86,7 @@ l3_token_estimate = 19912
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "8e2743a3f5dbf5033bd2d8bd42b37330ddec4d99f0809bebcad581279cb61173"
+source_hash = "3ac97e8a225ab406fbd95aaef49ee665e2ec27e0db3877ad0f90e1bd24228a39"
 l3_token_estimate = 31579
 
 [[crates]]
@@ -146,7 +146,7 @@ l3_token_estimate = 51
 [[crates]]
 name = "nous"
 path = "crates/nous"
-source_hash = "e82b495db5c5a8550f31821575f22126a776da79aca6a8e7e74cf589078dc907"
+source_hash = "fb1d3ad939cef382cf4887856bcf0f113367c28ca8fcfdd95994320f8398f589"
 l3_token_estimate = 33105
 
 [[crates]]

--- a/crates/episteme/src/extract/engine.rs
+++ b/crates/episteme/src/extract/engine.rs
@@ -603,6 +603,15 @@ Rules:
                 || crate::knowledge::FactType::classify(&content),
                 crate::knowledge::FactType::from_str_lossy,
             );
+            // WHY: Identity-type facts ("I am X", "My name is Y") are self-descriptions
+            // about the agent, not episodic knowledge. Persisting them causes persona drift
+            // when they are later recalled as facts about external entities. The upstream
+            // is_self_reference filter catches subject="I/me" triples; this guard catches
+            // any Identity-typed fact that slipped through (e.g. third-person extraction).
+            if classified_type == crate::knowledge::FactType::Identity {
+                tracing::debug!(content = %content, "fact skipped at persist: identity-type self-description");
+                continue;
+            }
             let is_correction =
                 fact.is_correction || crate::conflict::is_correction_heuristic(&content);
             let confidence = if is_correction {

--- a/crates/episteme/src/extract/tests/daimon_constraints.rs
+++ b/crates/episteme/src/extract/tests/daimon_constraints.rs
@@ -1,0 +1,103 @@
+//! Regression tests for daimon agent constraint 2: anti-self-description (#4109).
+//!
+//! Identity-type facts must be skipped at the persist boundary so that
+//! self-description statements ("I am X", "My name is Y") extracted from
+//! agent output are never persisted as episodic memory facts.
+
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+use super::super::*;
+
+#[cfg(feature = "mneme-engine")]
+#[test]
+fn identity_typed_fact_skipped_at_persist() {
+    let store = crate::knowledge_store::KnowledgeStore::open_mem()
+        .expect("in-memory knowledge store should open successfully");
+    let engine = ExtractionEngine::new(ExtractionConfig::default());
+
+    let extraction = Extraction {
+        entities: vec![],
+        relationships: vec![],
+        // Explicitly marked as identity — simulates what the LLM might extract
+        // when the agent describes itself in third person ("The agent is named Claude").
+        facts: vec![ExtractedFact {
+            subject: "The agent".to_owned(),
+            predicate: "is named".to_owned(),
+            object: "Claude".to_owned(),
+            confidence: 0.95,
+            fact_type: Some("identity".to_owned()),
+            is_correction: false,
+        }],
+    };
+
+    let result = engine
+        .persist(&extraction, &store, "session:test", "syn")
+        .expect("persist should succeed");
+
+    assert_eq!(
+        result.facts_inserted, 0,
+        "identity-typed fact must not be persisted (anti-self-description constraint)"
+    );
+}
+
+#[cfg(feature = "mneme-engine")]
+#[test]
+fn non_identity_fact_is_persisted_normally() {
+    let store = crate::knowledge_store::KnowledgeStore::open_mem()
+        .expect("in-memory knowledge store should open successfully");
+    let engine = ExtractionEngine::new(ExtractionConfig::default());
+
+    let extraction = Extraction {
+        entities: vec![],
+        relationships: vec![],
+        facts: vec![ExtractedFact {
+            subject: "Aletheia".to_owned(),
+            predicate: "uses".to_owned(),
+            object: "Rust".to_owned(),
+            confidence: 0.9,
+            fact_type: Some("observation".to_owned()),
+            is_correction: false,
+        }],
+    };
+
+    let result = engine
+        .persist(&extraction, &store, "session:test", "syn")
+        .expect("persist should succeed");
+
+    assert_eq!(
+        result.facts_inserted, 1,
+        "non-identity observation fact must be persisted normally"
+    );
+}
+
+#[cfg(feature = "mneme-engine")]
+#[test]
+fn identity_classified_at_runtime_also_skipped() {
+    let store = crate::knowledge_store::KnowledgeStore::open_mem()
+        .expect("in-memory knowledge store should open successfully");
+    let engine = ExtractionEngine::new(ExtractionConfig::default());
+
+    // No explicit fact_type — the engine classifies via FactType::classify().
+    // "I am an AI assistant" → subject="I" contains identity pattern → Identity type.
+    let extraction = Extraction {
+        entities: vec![],
+        relationships: vec![],
+        facts: vec![ExtractedFact {
+            subject: "I".to_owned(),
+            predicate: "am".to_owned(),
+            object: "an AI assistant".to_owned(),
+            confidence: 0.95,
+            fact_type: None,
+            is_correction: false,
+        }],
+    };
+
+    let result = engine
+        .persist(&extraction, &store, "session:test", "syn")
+        .expect("persist should succeed");
+
+    assert_eq!(
+        result.facts_inserted, 0,
+        "runtime-classified identity fact must not be persisted"
+    );
+}

--- a/crates/episteme/src/extract/tests/mod.rs
+++ b/crates/episteme/src/extract/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Tests for the extraction module.
 mod bookkeeping;
 mod config_parsing;
+mod daimon_constraints;
 mod parsing;
 mod utilities;

--- a/crates/nous/src/bootstrap/bootstrap_tests/daimon_constraints.rs
+++ b/crates/nous/src/bootstrap/bootstrap_tests/daimon_constraints.rs
@@ -1,0 +1,204 @@
+//! Regression tests for the three hard-won daimon agent constraints (#4109).
+//!
+//! Each test verifies one constraint so a future regression can be
+//! pinpointed immediately rather than traced through integration tests.
+
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+use super::super::*;
+use super::{default_budget, setup_oikos};
+
+// ── Constraint 1: two-channel identity injection ────────────────────────────
+
+/// SOUL.md is Required — it must survive even under extreme budget pressure.
+///
+/// This is the "core identity channel": a Required section cannot be dropped
+/// by the budget trimmer regardless of how many other sections compete for tokens.
+#[tokio::test]
+async fn soul_required_survives_extreme_budget_pressure() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "Core identity text."),
+            ("USER.md", "Operator profile."),
+            ("CONTEXT.md", "Runtime context, large filler."),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    // Tiny budget: system_budget = min(5000 - 100 - 3000, 40) = 40 tokens.
+    // Enough for SOUL.md (~8 tokens); not enough for large operational files.
+    let mut budget = crate::budget::TokenBudget::new(5_000, 0.6, 100, 40);
+
+    let result = assembler
+        .assemble("test", &mut budget)
+        .await
+        .expect("assemble should succeed even under extreme budget pressure");
+
+    assert!(
+        result.sections_included.contains(&"SOUL.md".to_owned()),
+        "SOUL.md (Required) must be included even under extreme budget pressure"
+    );
+}
+
+/// IDENTITY.md uses the Identity slot (slot 0) so it appears before SOUL.md.
+///
+/// Under budget pressure, IDENTITY.md (Flexible) may be dropped while SOUL.md
+/// (Required) survives — the two slots provide independent priority tracks.
+#[tokio::test]
+async fn identity_slot_before_soul_persona_slot() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "Agent persona."),
+            ("IDENTITY.md", "Agent name and avatar."),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble("test", &mut budget)
+        .await
+        .expect("assemble should succeed");
+
+    let identity_pos = result
+        .sections_included
+        .iter()
+        .position(|s| s == "IDENTITY.md")
+        .expect("IDENTITY.md should be included when budget allows");
+    let soul_pos = result
+        .sections_included
+        .iter()
+        .position(|s| s == "SOUL.md")
+        .expect("SOUL.md should always be included");
+
+    assert!(
+        identity_pos < soul_pos,
+        "IDENTITY.md (Identity slot=0) must appear before SOUL.md (SoulPersona slot=1)"
+    );
+}
+
+/// SOUL.md (Required) survives when IDENTITY.md (Flexible) is dropped.
+///
+/// With a tiny budget, Flexible sections drop first. SOUL.md must remain.
+#[tokio::test]
+async fn soul_survives_when_identity_dropped() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "Persona text that must survive."),
+            ("IDENTITY.md", "Optional identity metadata."),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    // Very small budget: system_budget = min(5000 - 100 - 3000, 40) = 40 tokens.
+    // SOUL.md (~12 tokens) fits; IDENTITY.md (~12 tokens) also fits in theory.
+    // SOUL.md is Required so it must survive regardless.
+    let mut budget = crate::budget::TokenBudget::new(5_000, 0.6, 100, 40);
+
+    let result = assembler
+        .assemble("test", &mut budget)
+        .await
+        .expect("assemble should succeed");
+
+    assert!(
+        result.sections_included.contains(&"SOUL.md".to_owned()),
+        "SOUL.md (Required) must survive when budget forces Flexible sections to drop"
+    );
+    // IDENTITY.md may or may not be dropped depending on exact token counts,
+    // but SOUL.md must always be present regardless.
+}
+
+// ── Constraint 3: voice-exemplar cueing ─────────────────────────────────────
+
+/// VOICE.md (when present) is loaded and positioned in the `SoulPersona` slot.
+///
+/// This anchors the model's output style near the top of context, immediately
+/// after SOUL.md, from the first token (#4109 constraint 3).
+#[tokio::test]
+async fn voice_md_loaded_when_present() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "Agent persona."),
+            ("VOICE.md", "## Examples\n\nSample output style text here."),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble("test", &mut budget)
+        .await
+        .expect("assemble should succeed");
+
+    assert!(
+        result.sections_included.contains(&"VOICE.md".to_owned()),
+        "VOICE.md must be loaded when present to satisfy voice-exemplar constraint"
+    );
+    assert!(
+        result
+            .system_prompt
+            .contains("Sample output style text here."),
+        "VOICE.md content must appear in the system prompt"
+    );
+}
+
+/// VOICE.md is silently absent when the file does not exist.
+///
+/// The Optional priority ensures a missing VOICE.md does not cause errors.
+#[tokio::test]
+async fn voice_md_absent_when_missing() {
+    let (_dir, oikos) = setup_oikos("test", &[("SOUL.md", "Agent persona.")]);
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble("test", &mut budget)
+        .await
+        .expect("assemble should succeed without VOICE.md");
+
+    assert!(
+        !result.sections_included.contains(&"VOICE.md".to_owned()),
+        "missing VOICE.md must not cause an error or appear in sections"
+    );
+}
+
+/// VOICE.md appears after SOUL.md within the `SoulPersona` slot.
+///
+/// Both use `BootstrapSlot::SoulPersona`. Within the same slot, sections are
+/// sorted by priority: SOUL.md (Required=0) before VOICE.md (Optional=3).
+/// This keeps core persona before the voice exemplar.
+#[tokio::test]
+async fn voice_md_after_soul_in_same_slot() {
+    let (_dir, oikos) = setup_oikos(
+        "test",
+        &[
+            ("SOUL.md", "Agent persona."),
+            ("VOICE.md", "Voice exemplar sample."),
+        ],
+    );
+    let assembler = BootstrapAssembler::new(&oikos);
+    let mut budget = default_budget();
+
+    let result = assembler
+        .assemble("test", &mut budget)
+        .await
+        .expect("assemble should succeed");
+
+    let soul_pos = result
+        .sections_included
+        .iter()
+        .position(|s| s == "SOUL.md")
+        .expect("SOUL.md should always be included");
+    let voice_pos = result
+        .sections_included
+        .iter()
+        .position(|s| s == "VOICE.md")
+        .expect("VOICE.md should be included when budget allows");
+
+    assert!(
+        soul_pos < voice_pos,
+        "SOUL.md (Required) must appear before VOICE.md (Optional) in the same SoulPersona slot"
+    );
+}

--- a/crates/nous/src/bootstrap/bootstrap_tests/mod.rs
+++ b/crates/nous/src/bootstrap/bootstrap_tests/mod.rs
@@ -12,6 +12,7 @@ mod assemble_llm;
 mod assemble_packs;
 mod cache;
 mod conditional;
+mod daimon_constraints;
 mod slot_precedence;
 
 pub(super) fn setup_oikos(nous_id: &str, files: &[(&str, &str)]) -> (TempDir, Oikos) {

--- a/crates/nous/src/bootstrap/mod.rs
+++ b/crates/nous/src/bootstrap/mod.rs
@@ -417,6 +417,18 @@ const WORKSPACE_FILES: &[WorkspaceFileSpec] = &[
         load_tier: LoadTier::Always,
         slot: BootstrapSlot::SoulPersona,
     },
+    // WHY(#4109): voice-exemplar cueing — inject a sample of the operator's
+    // communication style near the top of the context to anchor model output
+    // style from the first token. VOICE.md is scaffolded by `aletheia init`
+    // and may contain writing examples, anti-patterns, and style notes.
+    // Optional: silently absent when the file does not exist.
+    WorkspaceFileSpec {
+        filename: "VOICE.md",
+        priority: SectionPriority::Optional,
+        truncatable: true,
+        load_tier: LoadTier::Always,
+        slot: BootstrapSlot::SoulPersona,
+    },
     WorkspaceFileSpec {
         filename: "USER.md",
         priority: SectionPriority::Important,
@@ -783,6 +795,20 @@ impl<'a> BootstrapAssembler<'a> {
         for section in sections {
             if budget.can_fit(section.tokens) {
                 budget.consume(section.tokens);
+                included.push(section);
+            } else if section.priority == SectionPriority::Required {
+                // WHY(#4109): Required sections (SOUL.md) are the primary identity
+                // channel. Including them even when the budget is exhausted prevents
+                // persona drift when the system prompt is compressed under token
+                // pressure. An over-budget Required section is always better than a
+                // missing one — the model cannot know who it is without it.
+                budget.consume(section.tokens);
+                warn!(
+                    section = section.name,
+                    tokens = section.tokens,
+                    remaining = budget.remaining(),
+                    "required section included despite budget exhaustion"
+                );
                 included.push(section);
             } else if section.truncatable && budget.remaining() > self.min_truncation_budget {
                 debug!(


### PR DESCRIPTION
Closes #4109

## Summary

- **Constraint 1 (two-channel injection):** Bootstrap assembler now forces Required sections (SOUL.md) through the token budget gate unconditionally. Previously, Required priority only prevented errors on missing files; under extreme budget pressure SOUL.md could be dropped, causing persona drift.
- **Constraint 2 (anti-self-description):** Identity-typed facts are skipped at the persist boundary in `ExtractionEngine::persist_with_scope`. The upstream `is_self_reference` filter catches `subject="I/me"` triples; this guard catches Identity-typed facts that slip through as third-person extracts ("The agent is named Claude").
- **Constraint 3 (voice-exemplar cueing):** VOICE.md added to `WORKSPACE_FILES` at the `SoulPersona` slot with Optional priority. When present, style examples are injected immediately after SOUL.md from the first token; absent files are skipped silently.

## Regression tests added

Six tests covering all three constraints:
- `nous/bootstrap_tests/daimon_constraints.rs` — three tests for constraints 1 and 3 (budget pressure, slot ordering, VOICE.md loading/ordering)
- `episteme/extract/tests/daimon_constraints.rs` — three tests for constraint 2 (explicit identity type, observation passthrough, runtime-classified identity)

## Gate

`Gate-Passed: kanon 0.1.0`