### PR TITLE
feat(graphe): portability raw entry points for #4163 (PR1/4)

### DIFF
--- a/_llm/L3-api-index/graphe.md
+++ b/_llm/L3-api-index/graphe.md
@@ -466,6 +466,14 @@ impl SessionStore {
 }
 ```
 
+```rust
+impl SessionStore {
+    pub fn get_history_raw (&self, session_id: &str, limit: Option<i64>) -> Result<Vec<Message>>;
+    pub fn insert_message_raw (&self, msg: &Message) -> Result<()>;
+    pub fn import_session (&self, session: &Session, force: bool) -> Result<Session>;
+}
+```
+
 ## `src/types.rs`
 
 ```rust

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-29T21:09:32Z"
+generated_at = "2026-05-29T21:11:34Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -98,8 +98,8 @@ l3_token_estimate = 1107
 [[crates]]
 name = "graphe"
 path = "crates/graphe"
-source_hash = "3f2dbe18c49d631ab65bd8a1a0fc5b8f08b67a3135acd12174eca3bcc07a7423"
-l3_token_estimate = 4977
+source_hash = "f2073b5f00d97e82ae716ee4c5ed3c4bce8b58624dabbe0eb6d4e700f4e4a16f"
+l3_token_estimate = 5049
 
 [[crates]]
 name = "hermeneus"

--- a/crates/graphe/Cargo.toml
+++ b/crates/graphe/Cargo.toml
@@ -14,6 +14,11 @@ workspace = true
 default = []
 # WHY: gates error variants that reference tokio::task::JoinError; no runtime dep.
 mneme-engine = ["dep:tokio"]
+# WHY: gates raw entry points that bypass distilled-message filtering and
+# preserve caller-supplied timestamps/metrics. Used only by agent export/import
+# (issue #4163) — recall/serve must NOT enable this, or they will silently
+# leak distilled messages or wedge updated_at indexes with past timestamps.
+portability = []
 test-core = []
 test-full = []
 

--- a/crates/graphe/src/store/fjall_store.rs
+++ b/crates/graphe/src/store/fjall_store.rs
@@ -1562,6 +1562,240 @@ impl SessionStore {
     }
 }
 
+// ── Portability (issue #4163) ──────────────────────────────────────────────
+//
+// Raw entry points that bypass the distilled-message filter and preserve
+// caller-supplied timestamps/metrics. Used by the agent portability code
+// (`aletheia agent export`/`import`) to round-trip an agent without silent
+// data loss. Recall and serve paths must NOT call these — they would leak
+// distilled summaries to the LLM and wedge the `idx:nous:...:upd:...`
+// index with past timestamps.
+
+#[cfg(feature = "portability")]
+impl SessionStore {
+    /// Get message history including distilled messages, preserving seq order.
+    ///
+    /// Unlike [`Self::get_history`], the distilled flag is not used to filter
+    /// rows: every message persisted for `session_id` is returned. This is the
+    /// faithful read used by agent export — the recall path must continue to
+    /// use [`Self::get_history`].
+    ///
+    /// # Errors
+    /// Returns an error if the partition scan fails.
+    #[instrument(skip(self))]
+    pub fn get_history_raw(&self, session_id: &str, limit: Option<i64>) -> Result<Vec<Message>> {
+        use std::collections::VecDeque;
+
+        use fjall::Readable;
+
+        let messages_part = self.partition("messages")?;
+        let prefix = format!("{session_id}:");
+        let upper = format!("{session_id};\x00");
+        let snap = self.db.read_tx();
+
+        let limit = limit.and_then(|lim| usize::try_from(lim).ok());
+        let mut messages: VecDeque<Message> = VecDeque::new();
+        for guard in snap.range(&messages_part, prefix.as_str()..upper.as_str()) {
+            let (k, v) = guard
+                .into_inner()
+                .map_err(|e| storage_error(format!("fjall get_history_raw: {e}")))?;
+            // Skip the `next_seq:{session_id}` counter row, which shares the
+            // partition but is not a Message.
+            if k.starts_with(b"next_seq:") {
+                continue;
+            }
+            let msg = serde_json::from_slice::<Message>(&v).context(error::StoredJsonSnafu)?;
+            messages.push_back(msg);
+            if let Some(lim) = limit
+                && messages.len() > lim
+            {
+                messages.pop_front();
+            }
+        }
+
+        Ok(messages.into_iter().collect())
+    }
+
+    /// Insert a message at its declared seq, preserving caller-supplied
+    /// `created_at` and `is_distilled` and NOT mutating session metrics or
+    /// `updated_at`.
+    ///
+    /// The `next_seq` counter is advanced to `max(current, msg.seq)` and the
+    /// global `msg_id` counter to `max(current, msg.id)` so a subsequent
+    /// [`Self::append_message`] will not collide.
+    ///
+    /// The owning session must already exist (call [`Self::import_session`]
+    /// first when restoring from an export).
+    ///
+    /// # Errors
+    /// Returns an error if the session does not exist or any commit fails.
+    #[instrument(skip(self, msg), fields(session_id = %msg.session_id, seq = msg.seq))]
+    pub fn insert_message_raw(&self, msg: &Message) -> Result<()> {
+        use fjall::Readable;
+
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let messages_part = self.partition("messages")?;
+        let sessions_part = self.partition("sessions")?;
+        let counters_part = self.partition("counters")?;
+
+        // Refuse if the session does not exist — the message would be
+        // orphaned and never appear in list/recall views.
+        let snap = self.db.read_tx();
+        if snap
+            .get(&sessions_part, msg.session_id.as_str())
+            .map_err(|e| storage_error(format!("fjall insert_message_raw session check: {e}")))?
+            .is_none()
+        {
+            return Err(error::SessionNotFoundSnafu {
+                id: msg.session_id.clone(),
+            }
+            .build());
+        }
+
+        let next_seq_key = format!("next_seq:{}", msg.session_id);
+        let current_seq = snap
+            .get(&messages_part, next_seq_key.as_str())
+            .map_err(|e| storage_error(format!("fjall insert_message_raw seq read: {e}")))?
+            .map_or(0u64, |b| decode_u64(&b));
+        let current_msg_id = snap
+            .get(&counters_part, "msg_id")
+            .map_err(|e| storage_error(format!("fjall insert_message_raw msg_id read: {e}")))?
+            .map_or(0u64, |b| decode_u64(&b));
+        drop(snap);
+
+        let msg_seq_u64 = u64::try_from(msg.seq).map_err(|src| {
+            storage_error(format!(
+                "insert_message_raw: negative seq {}: {src}",
+                msg.seq
+            ))
+        })?;
+        let msg_id_u64 = u64::try_from(msg.id).map_err(|src| {
+            storage_error(format!("insert_message_raw: negative id {}: {src}", msg.id))
+        })?;
+        let new_next_seq = current_seq.max(msg_seq_u64);
+        let new_msg_id = current_msg_id.max(msg_id_u64);
+
+        let msg_key = format!("{}:{}", msg.session_id, pad_u64(msg_seq_u64));
+        let msg_data = serde_json::to_vec(msg).context(error::StoredJsonSnafu)?;
+
+        let mut tx = self.db.write_tx();
+        tx.insert(&messages_part, msg_key.as_str(), msg_data.as_slice());
+        tx.insert(
+            &messages_part,
+            next_seq_key.as_str(),
+            encode_u64(new_next_seq),
+        );
+        tx.insert(&counters_part, "msg_id", encode_u64(new_msg_id));
+        tx.commit().map_err(|e| {
+            error::StorageSnafu {
+                message: format!("fjall insert_message_raw commit: {e}"),
+            }
+            .build()
+        })?;
+        Ok(())
+    }
+
+    /// Write a session record preserving every caller-supplied field
+    /// (`status`, `created_at`, `updated_at`, `metrics`, `origin`).
+    ///
+    /// Indexes are written using the supplied `updated_at`, so a list scan
+    /// observes the imported session at its true age — not "now". This is
+    /// what keeps maintenance sweepers honest after an import.
+    ///
+    /// Idempotency: returns an error if a session with the same `id` already
+    /// exists, or if the `(nous_id, session_key)` slot is occupied by a
+    /// *different* session id, unless `force` is true. Re-importing the same
+    /// session id with `force=true` overwrites cleanly.
+    ///
+    /// # Errors
+    /// Returns an error on idempotency violation (without force) or any
+    /// commit failure.
+    #[instrument(skip(self, session), fields(id = %session.id, nous_id = %session.nous_id))]
+    pub fn import_session(&self, session: &Session, force: bool) -> Result<Session> {
+        use fjall::Readable;
+
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let sessions_part = self.partition("sessions")?;
+
+        let snap = self.db.read_tx();
+        let existing_self = snap
+            .get(&sessions_part, session.id.as_str())
+            .map_err(|e| storage_error(format!("fjall import_session existing: {e}")))?;
+        let key_idx = Self::session_key_index_key(&session.nous_id, &session.session_key);
+        let existing_key_owner = snap
+            .get(&sessions_part, key_idx.as_str())
+            .map_err(|e| storage_error(format!("fjall import_session key idx: {e}")))?
+            .map(|b| String::from_utf8_lossy(&b).into_owned());
+        drop(snap);
+
+        if !force {
+            if existing_self.is_some() {
+                return Err(storage_error(format!(
+                    "import_session: session '{}' already exists (use force to overwrite)",
+                    session.id
+                )));
+            }
+            if let Some(owner) = existing_key_owner.as_deref()
+                && owner != session.id.as_str()
+            {
+                return Err(storage_error(format!(
+                    "import_session: ({}, {}) is already owned by session '{}' \
+                     (use force to overwrite)",
+                    session.nous_id, session.session_key, owner
+                )));
+            }
+        }
+
+        // If forcing an overwrite where session_id exists with a different
+        // updated_at, remove the stale nous index entry so listings don't
+        // duplicate or shadow the import.
+        let mut tx = self.db.write_tx();
+        if let Some(prev_bytes) = existing_self {
+            let prev: Session =
+                serde_json::from_slice(&prev_bytes).context(error::StoredJsonSnafu)?;
+            if prev.updated_at != session.updated_at {
+                let stale_idx =
+                    Self::session_nous_index_key(&prev.nous_id, &prev.updated_at, &prev.id);
+                tx.remove(&sessions_part, stale_idx.as_str());
+            }
+        }
+
+        // Stamp provenance — same as write_session would do, but with the
+        // imported session's timestamps already in place.
+        let mut stamped = session.clone();
+        stamped.artefact_meta = Some(stamped.stamp());
+        let data = serde_json::to_vec(&stamped).context(error::StoredJsonSnafu)?;
+
+        tx.insert(&sessions_part, session.id.as_str(), data.as_slice());
+        tx.insert(&sessions_part, key_idx.as_str(), session.id.as_bytes());
+        let nous_idx =
+            Self::session_nous_index_key(&session.nous_id, &session.updated_at, &session.id);
+        tx.insert(&sessions_part, nous_idx.as_str(), b"");
+
+        tx.commit().map_err(|e| {
+            error::StorageSnafu {
+                message: format!("fjall import_session commit: {e}"),
+            }
+            .build()
+        })?;
+
+        metrics::record_session_created(&session.nous_id, session.session_type.as_str());
+        info!(
+            id = session.id,
+            nous_id = session.nous_id,
+            status = %session.status,
+            "imported session"
+        );
+        Ok(stamped)
+    }
+}
+
 /// Check whether a blackboard row has expired.
 fn is_expired(row: &BlackboardRow) -> bool {
     let Some(ref expires_at) = row.expires_at else {

--- a/crates/graphe/src/store/fjall_store_tests.rs
+++ b/crates/graphe/src/store/fjall_store_tests.rs
@@ -381,3 +381,273 @@ fn ping_succeeds() {
     let store = test_store();
     store.ping().expect("ping should succeed");
 }
+
+// ── Portability raw entry points (issue #4163) ─────────────────────────────
+
+#[cfg(feature = "portability")]
+mod portability {
+    use crate::test_fixtures::test_store;
+    use crate::types::{
+        Message, Role, Session, SessionMetrics, SessionOrigin, SessionStatus, SessionType,
+    };
+
+    fn seed_session(store: &super::super::SessionStore) -> String {
+        let session = store
+            .create_session("ses-raw", "syn", "main", None, Some("mock-model"))
+            .expect("create session");
+        store
+            .append_message(&session.id, Role::User, "msg-1", None, None, 10)
+            .expect("append 1");
+        store
+            .append_message(&session.id, Role::Assistant, "msg-2", None, None, 10)
+            .expect("append 2");
+        store
+            .append_message(&session.id, Role::User, "msg-3", None, None, 10)
+            .expect("append 3");
+        session.id
+    }
+
+    #[test]
+    fn get_history_raw_includes_distilled_messages() {
+        let store = test_store();
+        let id = seed_session(&store);
+
+        store
+            .mark_messages_distilled(&id, &[1, 2])
+            .expect("mark distilled");
+
+        let filtered = store.get_history(&id, None).expect("filtered");
+        assert_eq!(filtered.len(), 1, "non-raw view drops distilled");
+        assert_eq!(filtered[0].seq, 3);
+
+        let raw = store.get_history_raw(&id, None).expect("raw");
+        assert_eq!(raw.len(), 3, "raw view keeps all messages");
+        let mut seqs: Vec<i64> = raw.iter().map(|m| m.seq).collect();
+        seqs.sort_unstable();
+        assert_eq!(seqs, vec![1, 2, 3]);
+        let distilled_count = raw.iter().filter(|m| m.is_distilled).count();
+        assert_eq!(distilled_count, 2, "is_distilled flag preserved");
+    }
+
+    #[test]
+    fn insert_message_raw_preserves_seq_and_created_at() {
+        let store = test_store();
+        let s = store
+            .create_session("ses-raw2", "syn", "main", None, None)
+            .expect("create");
+
+        let msg = Message {
+            id: 99,
+            session_id: s.id.clone(),
+            seq: 42,
+            role: Role::User,
+            content: "raw insert".to_owned(),
+            tool_call_id: None,
+            tool_name: None,
+            token_estimate: 7,
+            is_distilled: true,
+            created_at: "2024-06-15T12:00:00Z".to_owned(),
+        };
+        store.insert_message_raw(&msg).expect("raw insert");
+
+        let raw = store.get_history_raw(&s.id, None).expect("read raw");
+        assert_eq!(raw.len(), 1);
+        assert_eq!(raw[0].seq, 42);
+        assert_eq!(raw[0].created_at, "2024-06-15T12:00:00Z");
+        assert!(raw[0].is_distilled);
+        assert_eq!(raw[0].content, "raw insert");
+        assert_eq!(raw[0].id, 99);
+    }
+
+    #[test]
+    fn insert_message_raw_does_not_touch_session_updated_at() {
+        let store = test_store();
+        let s = store
+            .create_session("ses-raw3", "syn", "main", None, None)
+            .expect("create");
+        let original_updated_at = s.updated_at.clone();
+
+        let msg = Message {
+            id: 1,
+            session_id: s.id.clone(),
+            seq: 1,
+            role: Role::User,
+            content: "preserve".to_owned(),
+            tool_call_id: None,
+            tool_name: None,
+            token_estimate: 3,
+            is_distilled: false,
+            created_at: "2024-01-01T00:00:00Z".to_owned(),
+        };
+        store.insert_message_raw(&msg).expect("raw insert");
+
+        let after = store
+            .find_session_by_id(&s.id)
+            .expect("query")
+            .expect("session");
+        assert_eq!(
+            after.updated_at, original_updated_at,
+            "raw insert must not bump session.updated_at"
+        );
+        assert_eq!(
+            after.metrics.message_count, 0,
+            "raw insert must not bump message_count"
+        );
+        assert_eq!(
+            after.metrics.token_count_estimate, 0,
+            "raw insert must not bump token_count_estimate"
+        );
+    }
+
+    #[test]
+    fn insert_message_raw_then_append_does_not_collide() {
+        // After raw insert at seq=5, a subsequent append must advance to seq=6.
+        let store = test_store();
+        let s = store
+            .create_session("ses-raw4", "syn", "main", None, None)
+            .expect("create");
+
+        let raw_msg = Message {
+            id: 50,
+            session_id: s.id.clone(),
+            seq: 5,
+            role: Role::User,
+            content: "imported".to_owned(),
+            tool_call_id: None,
+            tool_name: None,
+            token_estimate: 1,
+            is_distilled: false,
+            created_at: "2024-01-01T00:00:00Z".to_owned(),
+        };
+        store.insert_message_raw(&raw_msg).expect("raw insert");
+
+        let next_seq = store
+            .append_message(&s.id, Role::Assistant, "fresh", None, None, 1)
+            .expect("append");
+        assert_eq!(next_seq, 6, "append must not collide with raw seq");
+    }
+
+    fn import_session_record(id: &str, status: SessionStatus, updated_at: &str) -> Session {
+        Session {
+            id: id.to_owned(),
+            nous_id: "syn".to_owned(),
+            session_key: format!("key-{id}"),
+            status,
+            model: Some("mock-model".to_owned()),
+            session_type: SessionType::Primary,
+            created_at: "2024-01-01T00:00:00Z".to_owned(),
+            updated_at: updated_at.to_owned(),
+            metrics: SessionMetrics {
+                token_count_estimate: 1234,
+                message_count: 56,
+                last_input_tokens: 11,
+                bootstrap_hash: Some("deadbeef".to_owned()),
+                distillation_count: 2,
+                last_distilled_at: Some("2024-02-01T00:00:00Z".to_owned()),
+                computed_context_tokens: 999,
+            },
+            origin: SessionOrigin {
+                parent_session_id: None,
+                thread_id: None,
+                transport: Some("signal".to_owned()),
+                display_name: Some("Archived Run".to_owned()),
+            },
+            artefact_meta: None,
+        }
+    }
+
+    #[test]
+    fn import_session_preserves_status_timestamps_and_metrics() {
+        let store = test_store();
+        let original =
+            import_session_record("ses-imp1", SessionStatus::Archived, "2024-03-15T12:00:00Z");
+
+        store.import_session(&original, false).expect("import");
+
+        let restored = store
+            .find_session_by_id("ses-imp1")
+            .expect("query")
+            .expect("session");
+        assert_eq!(restored.status, SessionStatus::Archived);
+        assert_eq!(restored.created_at, "2024-01-01T00:00:00Z");
+        assert_eq!(restored.updated_at, "2024-03-15T12:00:00Z");
+        assert_eq!(restored.metrics.message_count, 56);
+        assert_eq!(restored.metrics.token_count_estimate, 1234);
+        assert_eq!(restored.metrics.distillation_count, 2);
+        assert_eq!(
+            restored.origin.display_name.as_deref(),
+            Some("Archived Run")
+        );
+    }
+
+    #[test]
+    fn import_session_refuses_overwrite_without_force() {
+        let store = test_store();
+        let s = import_session_record("ses-imp2", SessionStatus::Active, "2024-04-01T00:00:00Z");
+
+        store.import_session(&s, false).expect("first import");
+        let err = store
+            .import_session(&s, false)
+            .expect_err("second without force must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already exists") || msg.contains("already owned"),
+            "error should mention idempotency, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn import_session_with_force_overwrites_cleanly() {
+        let store = test_store();
+        let mut s =
+            import_session_record("ses-imp3", SessionStatus::Active, "2024-04-01T00:00:00Z");
+        store.import_session(&s, false).expect("first");
+        s.status = SessionStatus::Archived;
+        s.updated_at = "2024-05-01T00:00:00Z".to_owned();
+        store.import_session(&s, true).expect("force overwrite");
+
+        let restored = store
+            .find_session_by_id("ses-imp3")
+            .expect("query")
+            .expect("session");
+        assert_eq!(restored.status, SessionStatus::Archived);
+        assert_eq!(restored.updated_at, "2024-05-01T00:00:00Z");
+    }
+
+    #[test]
+    fn import_session_rejects_session_key_collision_with_different_id() {
+        let store = test_store();
+        let s1 = import_session_record("ses-imp-a", SessionStatus::Active, "2024-04-01T00:00:00Z");
+        store.import_session(&s1, false).expect("first");
+
+        let mut s2 = s1.clone();
+        s2.id = "ses-imp-b".to_owned();
+        let err = store
+            .import_session(&s2, false)
+            .expect_err("different id colliding session_key must fail");
+        assert!(err.to_string().contains("already owned"), "error: {err}");
+    }
+
+    #[test]
+    fn import_session_with_past_updated_at_appears_in_listing() {
+        // Sweeper-safety: a past updated_at must produce a valid nous index
+        // entry such that list_sessions returns the imported row.
+        let store = test_store();
+        let s = import_session_record(
+            "ses-imp-old",
+            SessionStatus::Archived,
+            "2020-01-01T00:00:00Z",
+        );
+        store.import_session(&s, false).expect("import");
+
+        let listed = store
+            .list_sessions(Some("syn"))
+            .expect("list")
+            .into_iter()
+            .filter(|row| row.id == "ses-imp-old")
+            .collect::<Vec<_>>();
+        assert_eq!(listed.len(), 1, "imported session must be discoverable");
+        assert_eq!(listed[0].updated_at, "2020-01-01T00:00:00Z");
+        assert_eq!(listed[0].status, SessionStatus::Archived);
+    }
+}

--- a/crates/mneme/Cargo.toml
+++ b/crates/mneme/Cargo.toml
@@ -13,8 +13,11 @@ workspace = true
 [features]
 # WHY: graphe's fjall backend is now unconditional. mneme re-exports the
 # session store API; mneme-engine layers the Datalog knowledge store on top.
-default = ["graph-algo", "mneme-engine"]
+default = ["graph-algo", "mneme-engine", "portability"]
 graph-algo = ["episteme/graph-algo"]
+# Agent export/import raw entry points (issue #4163). Default-on so the
+# aletheia CLI gets faithful round-trips without an explicit feature pick.
+portability = ["graphe/portability"]
 # Optional HTTP cross-encoder reranker support from episteme.
 reranker = ["episteme/reranker"]
 # Optional GLiNER bookkeeping provider support from episteme.


### PR DESCRIPTION
## Summary
- `agent export/import` is silently lossy on four axes (REPORT.md §1.7); this is **PR1 of 4** — the storage primitives the faithful producer/consumer need.
- New `portability` feature on `graphe` gates three raw entry points so recall/serve cannot accidentally call them. The feature is default-on in `mneme` so the `aletheia` CLI picks it up without an explicit pick.
- `get_history_raw(session_id, limit)` returns every message in seq order, including `is_distilled=true` rows that `get_history` filters out.
- `insert_message_raw(msg)` persists at the supplied seq, preserving `created_at` and `is_distilled`, and does **not** mutate `session.updated_at` or metrics. `next_seq` and the global `msg_id` counter are bumped to `max(current, supplied)` so a later `append_message` still advances monotonically.
- `import_session(session, force)` writes a session record + indexes using caller-supplied `status`/`created_at`/`updated_at`/metrics. Refuses idempotency-violating overwrite (same id, or session_key slot owned by a different id) unless `force` is set.

## Test plan
- [x] `cargo test -p graphe` (no portability) — 14/14 pass
- [x] `cargo test -p graphe --features portability` — 17 portability + 23 existing pass
- [x] `kanon gate --full --stamp` — all 7 steps green, `Gate-Passed: kanon 0.1.0` trailer
- [ ] PR2 will exercise these primitives from the producer side
- [ ] PR3 will exercise these primitives from the consumer side
- [ ] PR4 fidelity tests will assert the round-trip property end-to-end

Stacks on `origin/main`. Followups are PR2 (`agent_io` producer), PR3 (consumer), PR4 (fidelity tests). Refs #4163.