### PR TITLE
feat(poiesis-core): land B-001 envelope + factbase + open component registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6605,8 +6605,12 @@ dependencies = [
 name = "poiesis-core"
 version = "0.29.0"
 dependencies = [
+ "indexmap 2.14.0",
  "jiff",
+ "serde",
+ "serde_json",
  "snafu",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]

--- a/_llm/L3-api-index/poiesis-core.md
+++ b/_llm/L3-api-index/poiesis-core.md
@@ -62,6 +62,132 @@ pub struct Image {
 }
 ```
 
+## `src/bodies.rs`
+
+```rust
+pub struct Deck {
+    /// The deck-wide aspect ratio (e.g. [`AspectRatio::WIDESCREEN_16_9`]).
+    pub aspect: AspectRatio,
+    /// Slides in display order.
+    pub slides: Vec<Slide>,
+}
+```
+
+```rust
+pub struct Slide {
+    /// The component pack this slide instantiates.
+    pub component: ComponentId,
+    /// The slide field payload; opaque to this crate aside from schema
+    /// validation.
+    pub fields: serde_json::Value,
+    /// Optional speaker notes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+}
+```
+
+```rust
+pub struct Workbook {
+    /// Sheets in tab order.
+    pub sheets: Vec<Sheet>,
+}
+```
+
+```rust
+pub struct Sheet {
+    /// Sheet display name.
+    pub name: SheetName,
+    /// The header row.
+    pub headers: Vec<String>,
+    /// The data rows; each row must have `headers.len()` cells.
+    pub rows: Vec<Vec<WorkbookCell>>,
+    /// Per-column scalar kind; drives format-at-the-boundary in the
+    /// rendering crate.
+    pub column_types: Vec<ScalarKind>,
+}
+```
+
+```rust
+pub enum WorkbookCell {
+    /// A typed literal value (typically `Scalar::Text` for labels).
+    Lit {
+        /// The literal.
+        value: Scalar,
+    },
+    /// A reference into [`crate::factbase::Factbase`] for any numeric value.
+    Cite {
+        /// The cited fact id.
+        fact: FactId,
+    },
+}
+```
+
+```rust
+pub struct DocumentBody {
+    /// The wrapped legacy document.
+    pub document: Document,
+}
+```
+
+```rust
+impl DocumentBody {
+    pub fn new (document: Document) -> Self;
+}
+```
+
+## `src/components.rs`
+
+```rust
+pub struct TokenRef(pub String);
+```
+
+```rust
+impl TokenRef {
+    pub fn new (s: impl Into<String>) -> Self;
+}
+```
+
+```rust
+pub struct ComponentDef {
+    /// The component id; matches the pack directory name.
+    pub id: ComponentId,
+    /// The JSON-schema document validating `Slide.fields` payloads.
+    pub schema: Value,
+    /// Default values merged into `Slide.fields` before validation.
+    pub defaults: Value,
+    /// Filesystem path of the HTML template (consumed by [[B-003]]).
+    pub html: PathBuf,
+    /// Filesystem path of the OOXML recipe (consumed by [[B-004]]).
+    pub ooxml: PathBuf,
+    /// Theme tokens this component reads.
+    pub tokens: Vec<TokenRef>,
+}
+```
+
+```rust
+pub struct ComponentRegistry {
+    by_id: BTreeMap<ComponentId, ComponentDef>,
+}
+```
+
+```rust
+impl ComponentRegistry {
+    pub fn new () -> Self;
+    pub fn insert (&mut self, def: ComponentDef);
+    pub fn get (&self, id: &ComponentId) -> Option<&ComponentDef>;
+    pub fn iter (&self) -> impl Iterator<Item = &ComponentDef>;
+    pub fn list_components (&self) -> Vec<ComponentId>;
+    pub fn len (&self) -> usize;
+    pub fn is_empty (&self) -> bool;
+    pub fn discover (&mut self, root: &Path) -> Result<usize, RegistryError>;
+    pub fn validate_fields (
+        &self,
+        id: &ComponentId,
+        fields: &Value,
+    ) -> Result<Value, RegistryError>;
+}
+```
+
 ## `src/document.rs`
 
 ```rust
@@ -77,6 +203,526 @@ pub struct Document {
 impl Document {
     pub fn new (title: impl Into<String>) -> Self;
     pub fn push (&mut self, block: Block);
+}
+```
+
+## `src/envelope.rs`
+
+```rust
+pub struct Meta {
+    /// Deliverable title; required.
+    pub title: String,
+    /// Optional author.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// Optional creation timestamp; renderers may stamp document properties.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<Timestamp>,
+    /// Optional subject; threaded into PDF/DOCX/PPTX core properties.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    /// Optional list of keywords / tags.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+}
+```
+
+```rust
+impl Meta {
+    pub fn new (title: impl Into<String>) -> Result<Self, SpecError>;
+    pub fn validate (&self) -> Result<(), SpecError>;
+}
+```
+
+```rust
+pub enum Body {
+    /// A deck of slides.
+    Deck(Deck),
+    /// A prose document (wraps the pre-envelope
+    /// [`crate::document::Document`]).
+    Document(DocumentBodyRepr),
+    /// A workbook of sheets.
+    Workbook(Workbook),
+}
+```
+
+```rust
+pub struct DocumentBodyRepr {
+    /// The document title — duplicated from [`Meta`] for self-containment
+    /// at the body level (renderers that only see `Body` still have a
+    /// title to thread through).
+    pub title: String,
+}
+```
+
+```rust
+impl Body {
+    pub fn kind (&self) -> BodyKind;
+}
+```
+
+```rust
+pub struct DeliverableSpec {
+    /// Typed metadata.
+    pub meta: Meta,
+    /// Theme reference; resolved against the theme registry ([[B-002]]).
+    pub theme: ThemeId,
+    /// The factbase carrying every cited number.
+    pub facts: Factbase,
+    /// The body — deck, document, or workbook.
+    pub body: Body,
+}
+```
+
+```rust
+impl DeliverableSpec {
+    pub fn validate (
+        &self,
+        components: &ComponentRegistry,
+        known_themes: &[ThemeId],
+    ) -> Result<(), crate::error::PoiesisError>;
+    pub fn body_kind (&self) -> BodyKind;
+    pub fn referenced_components (&self) -> Vec<ComponentId>;
+}
+```
+
+## `src/error.rs`
+
+```rust
+pub enum IdError {
+    /// The input string was empty.
+    #[snafu(display("{kind} identifier cannot be empty"))]
+    Empty {
+        /// Human-readable identifier kind, e.g. `"component"`.
+        kind: &'static str,
+    },
+    /// The input contained a character that is not allowed for this kind.
+    #[snafu(display(
+        "{kind} identifier {input:?} contains invalid character {ch:?} (allowed: {allowed})"
+    ))]
+    InvalidChar {
+        /// Human-readable identifier kind.
+        kind: &'static str,
+        /// The offending input string.
+        input: String,
+        /// The first invalid character encountered.
+        ch: char,
+        /// Description of the allowed character set.
+        allowed: &'static str,
+    },
+    /// The input exceeded the maximum allowed length.
+    #[snafu(display("{kind} identifier {input:?} length {got} exceeds maximum {max}"))]
+    TooLong {
+        /// Human-readable identifier kind.
+        kind: &'static str,
+        /// The offending input string.
+        input: String,
+        /// The actual length.
+        got: usize,
+        /// The maximum allowed length.
+        max: usize,
+    },
+}
+```
+
+```rust
+pub enum ScalarError {
+    /// Unknown unit name.
+    #[snafu(display("unknown unit {input:?} (known: count, usd, percent, ratio, date, text)"))]
+    UnknownUnit {
+        /// The offending input string.
+        input: String,
+    },
+    /// Aspect ratio could not be parsed in `"W:H"` form.
+    #[snafu(display("aspect ratio {input:?} is not in W:H form with positive integers"))]
+    BadAspect {
+        /// The offending input string.
+        input: String,
+    },
+    /// Tolerance must be in the closed unit interval `[0.0, 1.0]`.
+    #[snafu(display("tolerance {value} is outside [0.0, 1.0]"))]
+    BadTolerance {
+        /// The offending value.
+        value: f64,
+    },
+    /// A monetary amount was outside the representable range.
+    #[snafu(display("monetary amount {input:?} is malformed or exceeds representable range"))]
+    BadMoney {
+        /// The offending input string.
+        input: String,
+    },
+}
+```
+
+```rust
+pub enum FactbaseError {
+    /// A `FactId` referenced from a `Claim` or `Derived`/`Reference` source
+    /// is not present in the factbase.
+    #[snafu(display("unknown fact reference {id:?} from {referenced_by}"))]
+    UnknownFact {
+        /// The unresolved fact identifier (as a string for error surfacing).
+        id: String,
+        /// What referenced it (claim id, derived source, etc.).
+        referenced_by: String,
+    },
+    /// A cycle was detected in the `Derived`/`Reference` dependency graph.
+    /// `path` is the cycle path in declaration order.
+    #[snafu(display("cycle in factbase: {}", path.join(" -> ")))]
+    Cycle {
+        /// The fact ids forming the cycle, head repeated at the tail.
+        path: Vec<String>,
+    },
+    /// A claim references a fact whose `Source` requires a data adapter that
+    /// is not configured.
+    #[snafu(display(
+        "claim {claim_id:?} requires data source {data_source:?} but no adapter is configured"
+    ))]
+    MissingDataSource {
+        /// The claim that triggered the error.
+        claim_id: String,
+        /// The data source id named by the claim's underlying fact.
+        data_source: String,
+    },
+    /// A `Derived` expression named an arithmetic operator the evaluator does
+    /// not implement.
+    #[snafu(display("unsupported derived expression: {detail}"))]
+    BadDerived {
+        /// Free-form description of why the expression cannot be evaluated.
+        detail: String,
+    },
+    /// A `Derived` expression's operand types are incompatible.
+    #[snafu(display("type mismatch in derived expression: {detail}"))]
+    DerivedTypeMismatch {
+        /// Free-form description of the mismatch.
+        detail: String,
+    },
+}
+```
+
+```rust
+pub enum RegistryError {
+    /// A pack directory was missing a required artifact.
+    #[snafu(display("component pack {component:?} missing required file {file}"))]
+    MissingPackFile {
+        /// The component id whose pack is incomplete.
+        component: String,
+        /// The file path expected within the pack directory.
+        file: String,
+    },
+    /// A pack's `schema.json` was unreadable or not valid JSON.
+    #[snafu(display("component pack {component:?} has malformed schema.json: {detail}"))]
+    MalformedSchema {
+        /// The component id whose schema failed to parse.
+        component: String,
+        /// Parser-emitted detail.
+        detail: String,
+    },
+    /// A pack's `recipe.toml` was unreadable or not valid TOML.
+    #[snafu(display("component pack {component:?} has malformed recipe.toml: {detail}"))]
+    MalformedRecipe {
+        /// The component id whose recipe failed to parse.
+        component: String,
+        /// Parser-emitted detail.
+        detail: String,
+    },
+    /// I/O error while discovering or reading a pack.
+    #[snafu(display("component pack discovery I/O failure at {path}: {detail}"))]
+    Io {
+        /// The filesystem path where I/O failed.
+        path: String,
+        /// OS-emitted detail.
+        detail: String,
+    },
+    /// A `Slide.fields` payload failed schema validation.
+    /// `pointer` is a JSON-pointer (RFC 6901) naming the path inside the payload.
+    #[snafu(display("slot validation failed at {pointer}: {detail}"))]
+    SlotValidation {
+        /// JSON-pointer into the offending payload.
+        pointer: String,
+        /// Free-form description of the rule that rejected the value.
+        detail: String,
+    },
+    /// A `Slide` referenced a component id that is not registered.
+    #[snafu(display("slide references unknown component {component:?}"))]
+    UnknownComponent {
+        /// The unresolved component id.
+        component: String,
+    },
+}
+```
+
+```rust
+pub enum SpecError {
+    /// A required `Meta` field was missing.
+    #[snafu(display("meta field {field:?} is required but missing"))]
+    MissingMetaField {
+        /// The field name.
+        field: &'static str,
+    },
+    /// A `ThemeId` referenced by the envelope is not known to the theme
+    /// registry. The theme registry itself lives in `poiesis-theme`; this
+    /// error is surfaced when an envelope is checked against a registry that
+    /// does not contain its theme.
+    #[snafu(display("envelope references unknown theme {theme:?}"))]
+    UnknownTheme {
+        /// The unresolved theme id.
+        theme: String,
+    },
+    /// The body kind in the spec did not match the body kind expected by the
+    /// renderer or theme.
+    #[snafu(display("body kind mismatch: spec carries {got}, expected {expected}"))]
+    BodyKindMismatch {
+        /// The body kind in the spec.
+        got: &'static str,
+        /// The body kind expected.
+        expected: &'static str,
+    },
+}
+```
+
+```rust
+pub enum PoiesisError {
+    /// Identifier construction failed.
+    #[snafu(display("{source}"))]
+    Id {
+        /// The wrapped identifier error.
+        source: IdError,
+    },
+    /// Scalar/unit/aspect/tolerance parsing failed.
+    #[snafu(display("{source}"))]
+    Scalar {
+        /// The wrapped scalar error.
+        source: ScalarError,
+    },
+    /// Factbase resolution failed.
+    #[snafu(display("{source}"))]
+    Factbase {
+        /// The wrapped factbase error.
+        source: FactbaseError,
+    },
+    /// Component registry operation failed.
+    #[snafu(display("{source}"))]
+    Registry {
+        /// The wrapped registry error.
+        source: RegistryError,
+    },
+    /// Spec parsing or validation failed.
+    #[snafu(display("{source}"))]
+    Spec {
+        /// The wrapped spec error.
+        source: SpecError,
+    },
+}
+```
+
+## `src/factbase.rs`
+
+```rust
+pub struct Fact {
+    /// Identifier referenced by `Cite`/`Reference`/`Derived`.
+    pub id: FactId,
+    /// The typed value. For `Sql`/`Derived` facts the value is the cached or
+    /// computed result; for `Manual`/`File` it is the authored value.
+    pub value: Scalar,
+    /// Presentation unit (drives formatting and dimensional checks).
+    pub unit: Unit,
+    /// Where this fact comes from.
+    pub source: Source,
+    /// When the fact was last captured / asserted.
+    pub captured: Timestamp,
+}
+```
+
+```rust
+pub enum Source {
+    /// Resolved via the named data adapter (e.g. a CSV reader, SQL driver).
+    Sql {
+        /// Adapter id; must resolve in the configured [`DataSourceRegistry`].
+        data_source: DataSourceId,
+        /// The query (SQL string, or whatever the adapter accepts).
+        query: String,
+        /// A friendly name for the table/view used in error messages.
+        table: String,
+    },
+    /// An arithmetic expression over other facts.
+    Derived {
+        /// The expression.
+        formula: Expr,
+        /// The fact ids consumed by `formula`, in dependency order.
+        inputs: Vec<FactId>,
+    },
+    /// An alias for another fact.
+    Reference {
+        /// The aliased fact id.
+        fact: FactId,
+    },
+    /// An operator-asserted value with no programmatic provenance.
+    Manual {
+        /// Free-form note.
+        note: String,
+        /// Who captured the value.
+        captured_by: String,
+    },
+    /// A value extracted from a file at a locator.
+    File {
+        /// Filesystem path.
+        path: PathBuf,
+        /// In-file locator (CSV cell `A1`, JSON pointer `/totals/0`, etc.).
+        locator: String,
+    },
+}
+```
+
+```rust
+pub enum Expr {
+    /// `a + b`.
+    Add {
+        /// First operand fact id.
+        a: FactId,
+        /// Second operand fact id.
+        b: FactId,
+    },
+    /// `a - b`.
+    Sub {
+        /// Minuend fact id.
+        a: FactId,
+        /// Subtrahend fact id.
+        b: FactId,
+    },
+    /// `a * b`.
+    Mul {
+        /// First operand fact id.
+        a: FactId,
+        /// Second operand fact id.
+        b: FactId,
+    },
+    /// `a / b` evaluated as a ratio (`f64`).
+    Div {
+        /// Numerator fact id.
+        a: FactId,
+        /// Denominator fact id.
+        b: FactId,
+    },
+    /// Sum over a list of facts (each must have a compatible unit).
+    Sum {
+        /// The fact ids to sum.
+        terms: Vec<FactId>,
+    },
+}
+```
+
+```rust
+pub struct Claim {
+    /// Identifier of this claim.
+    pub id: ClaimId,
+    /// Human-readable form of the claim as it appears in prose.
+    pub text: String,
+    /// The fact asserted.
+    pub asserts: FactId,
+    /// Where in the deliverable the claim lives (slide, paragraph, sheet cell).
+    pub location: Location,
+    /// Numeric tolerance used by the QA gate when comparing fact vs. claim.
+    #[serde(default = "default_strict_tolerance")]
+    pub tolerance: Tolerance,
+}
+```
+
+```rust
+pub struct Location {
+    /// Body coordinate (e.g. `"deck/slide/3"`, `"document/section/2"`,
+    /// `"workbook/Receipts/B7"`).
+    pub at: String,
+}
+```
+
+> The trait every data adapter implements.
+> 
+> Adapters live out of `poiesis-core`; consumers register them through a
+> [`DataSourceRegistry`] before calling [`Factbase::resolve`]. A factbase
+> with no `Source::Sql` facts needs no adapters.
+```rust
+pub trait DataSource : Send + Sync {
+    fn id (&self) -> &DataSourceId;
+    fn query (&self, query: &str, table: &str) -> Result<Scalar, String>;
+}
+```
+
+```rust
+pub struct DataSourceRegistry {
+    adapters: HashMap<DataSourceId, Box<dyn DataSource>>,
+}
+```
+
+```rust
+impl DataSourceRegistry {
+    pub fn new () -> Self;
+    pub fn register (&mut self, adapter: Box<dyn DataSource>);
+    pub fn get (&self, id: &DataSourceId) -> Option<&dyn DataSource>;
+}
+```
+
+```rust
+pub struct Factbase {
+    /// Facts in declaration order.
+    pub facts: indexmap::IndexMap<FactId, Fact>,
+    /// Claims in declaration order.
+    pub claims: indexmap::IndexMap<ClaimId, Claim>,
+}
+```
+
+```rust
+pub struct ResolvedFact {
+    /// The fact id.
+    pub id: FactId,
+    /// The resolved value (for `Derived`/`Sql`, the computed result; for the
+    /// other kinds, the authored value).
+    pub value: Scalar,
+    /// The presentation unit.
+    pub unit: Unit,
+}
+```
+
+```rust
+impl Factbase {
+    pub fn new () -> Self;
+    pub fn add_fact (&mut self, fact: Fact);
+    pub fn add_claim (&mut self, claim: Claim);
+    pub fn validate (&self) -> Result<(), FactbaseError>;
+    pub fn resolve (
+        &self,
+        adapters: &DataSourceRegistry,
+    ) -> Result<BTreeMap<FactId, ResolvedFact>, FactbaseError>;
+}
+```
+
+## `src/lib.rs`
+
+```rust
+pub struct Artifact {
+    /// The format identifier, e.g. `"pdf"`, `"pptx"`, `"docx"`, `"xlsx"`,
+    /// `"html"`.
+    pub format: String,
+    /// The body kind the artifact represents.
+    pub body_kind: BodyKind,
+    /// The complete byte payload.
+    pub bytes: Vec<u8>,
+}
+```
+
+```rust
+pub enum BodyKind {
+    /// A deck composed of [`bodies::Slide`]s.
+    Deck,
+    /// A prose document (pre-envelope [`document::Document`]).
+    Document,
+    /// A workbook of named [`bodies::Sheet`]s.
+    Workbook,
+}
+```
+
+```rust
+impl BodyKind {
+    pub fn as_str (self) -> &'static str;
 }
 ```
 
@@ -145,5 +791,128 @@ pub enum Span {
         /// Destination URL.
         url: String,
     },
+}
+```
+
+## `src/scalar.rs`
+
+```rust
+pub enum ScalarKind {
+    /// Whole-number counts (`Count(i64)`).
+    Count,
+    /// Monetary amounts (`Money` — `i64` micro-units).
+    Money,
+    /// Dimensionless ratios (`Ratio(f64)`); use [`Unit::Percent`] when display
+    /// should multiply by 100.
+    Ratio,
+    /// Free-form text values.
+    Text,
+    /// Calendar dates.
+    Date,
+}
+```
+
+```rust
+impl ScalarKind {
+    pub fn as_str (self) -> &'static str;
+}
+```
+
+```rust
+pub struct Money(i64);
+```
+
+```rust
+impl Money {
+    pub const fn from_micros (micros: i64) -> Self;
+    pub const fn micros (self) -> i64;
+    pub fn from_units (units: i64) -> Result<Self, ScalarError>;
+    pub fn from_units_and_fraction (units: i64, fraction: u32) -> Result<Self, ScalarError>;
+}
+```
+
+```rust
+pub enum Scalar {
+    /// Whole-number count.
+    Count {
+        /// The count.
+        value: i64,
+    },
+    /// Monetary amount (see [`Money`]).
+    Money {
+        /// The amount.
+        value: Money,
+    },
+    /// Dimensionless ratio (`0.5` = 50%); pair with [`Unit::Percent`] for display.
+    Ratio {
+        /// The ratio.
+        value: f64,
+    },
+    /// Free-form text.
+    Text {
+        /// The text.
+        value: String,
+    },
+    /// Calendar date.
+    Date {
+        /// The date.
+        value: Date,
+    },
+}
+```
+
+```rust
+impl Scalar {
+    pub fn kind (&self) -> ScalarKind;
+}
+```
+
+```rust
+pub enum Unit {
+    /// A dimensionless count (people, sessions, line items).
+    Count,
+    /// US dollars (presentation currency; see [`Money`] for value shape).
+    Usd,
+    /// Dimensionless percentage; display multiplies the underlying ratio by 100.
+    Percent,
+    /// Dimensionless ratio; display leaves the underlying ratio as-is.
+    Ratio,
+    /// A calendar date.
+    Date,
+    /// Free-form text (label, slug, name).
+    Text,
+}
+```
+
+```rust
+impl Unit {
+    pub fn as_str (self) -> &'static str;
+    pub fn compatible_with (self, kind: ScalarKind) -> bool;
+}
+```
+
+```rust
+pub struct AspectRatio {
+    width: u16,
+    height: u16,
+}
+```
+
+```rust
+impl AspectRatio {
+    pub fn new (width: u16, height: u16) -> Result<Self, ScalarError>;
+    pub fn width (self) -> u16;
+    pub fn height (self) -> u16;
+}
+```
+
+```rust
+pub struct Tolerance(f64);
+```
+
+```rust
+impl Tolerance {
+    pub fn new (value: f64) -> Result<Self, ScalarError>;
+    pub fn as_f64 (self) -> f64;
 }
 ```

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-29T18:52:52Z"
+generated_at = "2026-05-29T21:09:32Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -170,8 +170,8 @@ l3_token_estimate = 3902
 [[crates]]
 name = "poiesis-core"
 path = "crates/poiesis/core"
-source_hash = "9811022b7ab7f2b7dbb1d11595904dd3368f875ca3b4657e438fe99d62a5c15a"
-l3_token_estimate = 851
+source_hash = "f6cc9b1ce8bf972fea5cd2880c3367bb07f1014695fae10861e37f30fcc31f10"
+l3_token_estimate = 5949
 
 [[crates]]
 name = "poiesis-diff"

--- a/crates/poiesis/core/Cargo.toml
+++ b/crates/poiesis/core/Cargo.toml
@@ -12,5 +12,9 @@ publish = false
 workspace = true
 
 [dependencies]
-jiff = { workspace = true }
+jiff = { workspace = true, features = ["serde"] }
 snafu = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+indexmap = { workspace = true, features = ["std"] }

--- a/crates/poiesis/core/src/bodies.rs
+++ b/crates/poiesis/core/src/bodies.rs
@@ -1,0 +1,147 @@
+//! The three body arms wrapped by an envelope: deck, document, workbook.
+//!
+//! Each body is the minimal data carrier the render-side B-NNN entries need.
+//! Concrete layout decisions (`layout.json`, slot tables, EMU coordinate
+//! math) live in those render entries — this module names the data only.
+
+use serde::{Deserialize, Serialize};
+
+use crate::document::Document;
+use crate::ids::{ComponentId, FactId, SheetName};
+use crate::scalar::{AspectRatio, Scalar, ScalarKind};
+
+/// A deck composed of slides at a fixed aspect ratio.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Deck {
+    /// The deck-wide aspect ratio (e.g. [`AspectRatio::WIDESCREEN_16_9`]).
+    pub aspect: AspectRatio,
+    /// Slides in display order.
+    pub slides: Vec<Slide>,
+}
+
+/// One slide, parameterised by a component id and a field payload.
+///
+/// The `component` field names an entry in the [`crate::components::ComponentRegistry`];
+/// the `fields` payload is validated against that component's schema at
+/// parse time. `notes` is optional speaker notes as plain prose text
+/// (rich-text upgrades belong to the render entries).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Slide {
+    /// The component pack this slide instantiates.
+    pub component: ComponentId,
+    /// The slide field payload; opaque to this crate aside from schema
+    /// validation.
+    pub fields: serde_json::Value,
+    /// Optional speaker notes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+}
+
+/// A workbook of named sheets.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Workbook {
+    /// Sheets in tab order.
+    pub sheets: Vec<Sheet>,
+}
+
+/// One sheet of a workbook.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Sheet {
+    /// Sheet display name.
+    pub name: SheetName,
+    /// The header row.
+    pub headers: Vec<String>,
+    /// The data rows; each row must have `headers.len()` cells.
+    pub rows: Vec<Vec<WorkbookCell>>,
+    /// Per-column scalar kind; drives format-at-the-boundary in the
+    /// rendering crate.
+    pub column_types: Vec<ScalarKind>,
+}
+
+/// A workbook cell value.
+///
+/// Numeric cells MUST be `Cite` references into the factbase (this carries
+/// the "no naked numbers" rule into the workbook body). Free-form labels
+/// remain as `Lit(Scalar::Text)`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WorkbookCell {
+    /// A typed literal value (typically `Scalar::Text` for labels).
+    Lit {
+        /// The literal.
+        value: Scalar,
+    },
+    /// A reference into [`crate::factbase::Factbase`] for any numeric value.
+    Cite {
+        /// The cited fact id.
+        fact: FactId,
+    },
+}
+
+/// The document body — a thin newtype wrapping the pre-envelope
+/// [`Document`] so the envelope can carry it without breaking the legacy
+/// `poiesis::Renderer::render(&Document)` path.
+///
+/// The Pandoc-aligned `Block` / `Inline` evolution named in the planning
+/// doc is render-side work; it ships with [[B-006]] and gains a typed
+/// `DocBlock` enum at that time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DocumentBody {
+    /// The wrapped legacy document.
+    pub document: Document,
+}
+
+impl DocumentBody {
+    /// Wrap a legacy [`Document`] in the new body.
+    #[must_use]
+    pub fn new(document: Document) -> Self {
+        Self { document }
+    }
+}
+
+impl From<Document> for DocumentBody {
+    fn from(document: Document) -> Self {
+        Self::new(document)
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::ids::ComponentId;
+    use serde_json::json;
+
+    #[test]
+    fn deck_round_trips_via_serde() {
+        let d = Deck {
+            aspect: AspectRatio::WIDESCREEN_16_9,
+            slides: vec![Slide {
+                component: ComponentId::new("title").unwrap(),
+                fields: json!({"text": "Hello"}),
+                notes: Some("speaker notes".to_owned()),
+            }],
+        };
+        let s = serde_json::to_string(&d).unwrap();
+        let back: Deck = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, d);
+    }
+
+    #[test]
+    fn workbook_cell_lit_serialises_with_kind_tag() {
+        let cell = WorkbookCell::Lit {
+            value: Scalar::Text {
+                value: "Total".to_owned(),
+            },
+        };
+        let s = serde_json::to_string(&cell).unwrap();
+        assert!(s.contains("\"kind\":\"lit\""));
+    }
+
+    #[test]
+    fn document_body_wraps_legacy_document() {
+        let doc = Document::new("untitled");
+        let body: DocumentBody = doc.into();
+        assert_eq!(body.document.metadata.title, "untitled");
+    }
+}

--- a/crates/poiesis/core/src/components.rs
+++ b/crates/poiesis/core/src/components.rs
@@ -1,0 +1,682 @@
+//! The open component registry.
+//!
+//! Components are discovered from a filesystem root (default
+//! `crates/poiesis/components/<id>/` per the architecture contract); each
+//! pack is a directory containing:
+//!
+//! | file              | required | purpose                                                    |
+//! |-------------------|----------|------------------------------------------------------------|
+//! | `schema.json`     | yes      | JSON schema validating the `Slide.fields` payload          |
+//! | `recipe.toml`     | yes      | declarative OOXML recipe ([[B-004]] consumes)               |
+//! | `template.html.j2`| yes      | minijinja template ([[B-003]] consumes)                     |
+//! | `defaults.json`   | no       | smart defaults merged before schema validation             |
+//! | `tokens.toml`     | no       | theme tokens this component reads (drives coverage lint)    |
+//!
+//! Discovery returns a [`ComponentRegistry`] whose
+//! [`ComponentRegistry::validate_fields`] is what [`crate::envelope`] calls
+//! to reject planted-bad `Slide.fields` payloads at the boundary.
+//!
+//! **The JSON-schema validator shipped here is intentionally minimal.** It
+//! enforces the subset of Draft-7 that the v1.0.0 component packs need:
+//! `type` (object/array/string/number/integer/boolean/null),
+//! `required` array, `properties` map, `items` schema, `enum` allow-list,
+//! `minLength` / `maxLength`. The richer surface (regex `pattern`,
+//! `$ref`, `oneOf`, `allOf`) is deferred to a vendored validator the
+//! moment a component pack needs it; this keeps the dep tree narrow.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{
+    MalformedRecipeSnafu, MalformedSchemaSnafu, MissingPackFileSnafu, RegistryError,
+    SlotValidationSnafu,
+};
+use crate::ids::ComponentId;
+
+const PACK_SCHEMA: &str = "schema.json";
+const PACK_RECIPE: &str = "recipe.toml";
+const PACK_TEMPLATE: &str = "template.html.j2";
+const PACK_DEFAULTS: &str = "defaults.json";
+const PACK_TOKENS: &str = "tokens.toml";
+
+/// A theme token name a component consumes. Free-form by design; the theme
+/// registry ([[B-002]]) is responsible for resolving the token.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TokenRef(pub String);
+
+impl TokenRef {
+    /// Wrap a string as a token reference.
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+/// A discovered component pack.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComponentDef {
+    /// The component id; matches the pack directory name.
+    pub id: ComponentId,
+    /// The JSON-schema document validating `Slide.fields` payloads.
+    pub schema: Value,
+    /// Default values merged into `Slide.fields` before validation.
+    pub defaults: Value,
+    /// Filesystem path of the HTML template (consumed by [[B-003]]).
+    pub html: PathBuf,
+    /// Filesystem path of the OOXML recipe (consumed by [[B-004]]).
+    pub ooxml: PathBuf,
+    /// Theme tokens this component reads.
+    pub tokens: Vec<TokenRef>,
+}
+
+/// The registered set of components, keyed by [`ComponentId`].
+#[derive(Debug, Clone, Default)]
+pub struct ComponentRegistry {
+    by_id: BTreeMap<ComponentId, ComponentDef>,
+}
+
+impl ComponentRegistry {
+    /// Construct an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a [`ComponentDef`]; replaces any prior definition for the
+    /// same id.
+    pub fn insert(&mut self, def: ComponentDef) {
+        self.by_id.insert(def.id.clone(), def);
+    }
+
+    /// Look up a component by id.
+    #[must_use]
+    pub fn get(&self, id: &ComponentId) -> Option<&ComponentDef> {
+        self.by_id.get(id)
+    }
+
+    /// Iterate every registered component in id-sorted order.
+    pub fn iter(&self) -> impl Iterator<Item = &ComponentDef> {
+        self.by_id.values()
+    }
+
+    /// Enumerate every registered component id in sorted order — the
+    /// agent-facing palette.
+    #[must_use]
+    pub fn list_components(&self) -> Vec<ComponentId> {
+        self.by_id.keys().cloned().collect()
+    }
+
+    /// Number of registered components.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// True if no components are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Discover every valid component pack under `root` and merge it into
+    /// this registry. Returns the number of components newly registered.
+    ///
+    /// A pack directory whose name fails [`ComponentId`] validation is
+    /// skipped (it cannot be a valid component id). A pack missing a
+    /// required file or carrying a malformed schema or recipe returns an
+    /// error and the discovery aborts — better-loud than silently-partial.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`RegistryError`] encountered during discovery.
+    pub fn discover(&mut self, root: &Path) -> Result<usize, RegistryError> {
+        if !root.exists() {
+            // An absent root is a no-op, not an error; consumers may ship
+            // with no packs and add them later via [`Self::insert`].
+            return Ok(0);
+        }
+        let entries = fs::read_dir(root).map_err(|e| RegistryError::Io {
+            path: root.display().to_string(),
+            detail: e.to_string(),
+        })?;
+        let mut newly = 0usize;
+        let mut dirs: Vec<PathBuf> = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(|e| RegistryError::Io {
+                path: root.display().to_string(),
+                detail: e.to_string(),
+            })?;
+            let path = entry.path();
+            let ft = entry.file_type().map_err(|e| RegistryError::Io {
+                path: path.display().to_string(),
+                detail: e.to_string(),
+            })?;
+            if ft.is_dir() {
+                dirs.push(path);
+            }
+        }
+        dirs.sort();
+        for dir in dirs {
+            let Some(name) = dir.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let Ok(id) = ComponentId::new(name) else {
+                continue;
+            };
+            let def = load_pack(id, &dir)?;
+            self.insert(def);
+            newly += 1;
+        }
+        Ok(newly)
+    }
+
+    /// Validate a `Slide.fields` payload against the component's schema.
+    ///
+    /// On success returns the payload with defaults merged in. On failure
+    /// returns a [`RegistryError::SlotValidation`] whose `pointer` is a
+    /// JSON-pointer (RFC 6901) into the payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryError::UnknownComponent`] if `id` is not registered
+    /// and [`RegistryError::SlotValidation`] if the schema rejects the
+    /// merged payload.
+    pub fn validate_fields(
+        &self,
+        id: &ComponentId,
+        fields: &Value,
+    ) -> Result<Value, RegistryError> {
+        let def = self
+            .get(id)
+            .ok_or_else(|| RegistryError::UnknownComponent {
+                component: id.as_str().to_owned(),
+            })?;
+        let merged = merge_defaults(&def.defaults, fields);
+        let mut errors: Vec<SchemaIssue> = Vec::new();
+        validate_against_schema(&def.schema, &merged, "", &mut errors);
+        if let Some(first) = errors.into_iter().next() {
+            return SlotValidationSnafu {
+                pointer: first.pointer,
+                detail: first.detail,
+            }
+            .fail();
+        }
+        Ok(merged)
+    }
+}
+
+fn load_pack(id: ComponentId, dir: &Path) -> Result<ComponentDef, RegistryError> {
+    let schema_path = dir.join(PACK_SCHEMA);
+    let recipe_path = dir.join(PACK_RECIPE);
+    let template_path = dir.join(PACK_TEMPLATE);
+    if !schema_path.exists() {
+        return MissingPackFileSnafu {
+            component: id.as_str(),
+            file: PACK_SCHEMA,
+        }
+        .fail();
+    }
+    if !recipe_path.exists() {
+        return MissingPackFileSnafu {
+            component: id.as_str(),
+            file: PACK_RECIPE,
+        }
+        .fail();
+    }
+    if !template_path.exists() {
+        return MissingPackFileSnafu {
+            component: id.as_str(),
+            file: PACK_TEMPLATE,
+        }
+        .fail();
+    }
+
+    let schema_text = fs::read_to_string(&schema_path).map_err(|e| RegistryError::Io {
+        path: schema_path.display().to_string(),
+        detail: e.to_string(),
+    })?;
+    let schema: Value = serde_json::from_str(&schema_text).map_err(|e| {
+        MalformedSchemaSnafu {
+            component: id.as_str(),
+            detail: e.to_string(),
+        }
+        .build()
+    })?;
+
+    let recipe_text = fs::read_to_string(&recipe_path).map_err(|e| RegistryError::Io {
+        path: recipe_path.display().to_string(),
+        detail: e.to_string(),
+    })?;
+    // Recipe parse failure should be reported; we only need to detect parse
+    // errors here — the structured recipe types belong to [[B-004]].
+    let _recipe: toml::Value = toml::from_str(&recipe_text).map_err(|e| {
+        MalformedRecipeSnafu {
+            component: id.as_str(),
+            detail: e.to_string(),
+        }
+        .build()
+    })?;
+
+    let defaults = load_optional_json(&dir.join(PACK_DEFAULTS), id.as_str())?;
+    let tokens = load_optional_tokens(&dir.join(PACK_TOKENS), id.as_str())?;
+
+    Ok(ComponentDef {
+        id,
+        schema,
+        defaults,
+        html: template_path,
+        ooxml: recipe_path,
+        tokens,
+    })
+}
+
+fn load_optional_json(path: &Path, component: &str) -> Result<Value, RegistryError> {
+    if !path.exists() {
+        return Ok(Value::Object(serde_json::Map::new()));
+    }
+    let text = fs::read_to_string(path).map_err(|e| RegistryError::Io {
+        path: path.display().to_string(),
+        detail: e.to_string(),
+    })?;
+    serde_json::from_str(&text).map_err(|e| {
+        MalformedSchemaSnafu {
+            component,
+            detail: e.to_string(),
+        }
+        .build()
+    })
+}
+
+#[derive(Deserialize)]
+struct TokensManifest {
+    #[serde(default)]
+    tokens: Vec<String>,
+}
+
+fn load_optional_tokens(path: &Path, component: &str) -> Result<Vec<TokenRef>, RegistryError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let text = fs::read_to_string(path).map_err(|e| RegistryError::Io {
+        path: path.display().to_string(),
+        detail: e.to_string(),
+    })?;
+    let parsed: TokensManifest = toml::from_str(&text).map_err(|e| {
+        MalformedRecipeSnafu {
+            component,
+            detail: e.to_string(),
+        }
+        .build()
+    })?;
+    Ok(parsed.tokens.into_iter().map(TokenRef::new).collect())
+}
+
+/// Merge `defaults` into `fields`: for an object, missing keys are populated
+/// from defaults; for any other shape, `fields` wins outright. This is a
+/// deliberately shallow merge — JSON-Schema layered defaults are not in
+/// scope at the v1.0.0 boundary.
+fn merge_defaults(defaults: &Value, fields: &Value) -> Value {
+    match (defaults, fields) {
+        (Value::Object(d), Value::Object(f)) => {
+            let mut out = serde_json::Map::with_capacity(d.len() + f.len());
+            for (k, v) in d {
+                out.insert(k.clone(), v.clone());
+            }
+            for (k, v) in f {
+                out.insert(k.clone(), v.clone());
+            }
+            Value::Object(out)
+        }
+        _ => fields.clone(),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SchemaIssue {
+    pointer: String,
+    detail: String,
+}
+
+/// Run the minimal JSON-schema check. Walks `schema` against `value` and
+/// pushes any issues found into `errors`. Mutating-out so the caller can
+/// pick the first issue (parse-don't-validate prefers fail-fast surfacing).
+fn validate_against_schema(
+    schema: &Value,
+    value: &Value,
+    pointer: &str,
+    errors: &mut Vec<SchemaIssue>,
+) {
+    let Value::Object(schema_obj) = schema else {
+        // A non-object schema is treated as "any" — useful for `true` /
+        // empty-object schemas during early authoring.
+        return;
+    };
+
+    if let Some(Value::String(expected)) = schema_obj.get("type")
+        && !value_matches_type(value, expected)
+    {
+        errors.push(SchemaIssue {
+            pointer: pointer.to_owned(),
+            detail: format!("expected type {expected:?}, got {}", value_type_name(value)),
+        });
+        return;
+    }
+
+    if let Some(Value::Array(allowed)) = schema_obj.get("enum")
+        && !allowed.contains(value)
+    {
+        errors.push(SchemaIssue {
+            pointer: pointer.to_owned(),
+            detail: format!("value not in enum (allowed: {} options)", allowed.len()),
+        });
+        return;
+    }
+
+    match value {
+        Value::Object(obj) => {
+            if let Some(Value::Array(required)) = schema_obj.get("required") {
+                for req in required {
+                    if let Value::String(req_name) = req
+                        && !obj.contains_key(req_name)
+                    {
+                        errors.push(SchemaIssue {
+                            pointer: format!("{pointer}/{req_name}"),
+                            detail: "required property missing".to_owned(),
+                        });
+                    }
+                }
+            }
+            if let Some(Value::Object(props)) = schema_obj.get("properties") {
+                for (key, sub_schema) in props {
+                    if let Some(sub_value) = obj.get(key) {
+                        let sub_pointer = format!("{pointer}/{key}");
+                        validate_against_schema(sub_schema, sub_value, &sub_pointer, errors);
+                    }
+                }
+            }
+        }
+        Value::Array(items) => {
+            if let Some(item_schema) = schema_obj.get("items") {
+                for (i, item) in items.iter().enumerate() {
+                    let sub_pointer = format!("{pointer}/{i}");
+                    validate_against_schema(item_schema, item, &sub_pointer, errors);
+                }
+            }
+        }
+        Value::String(s) => {
+            let len = s.chars().count();
+            if let Some(min) = schema_obj.get("minLength").and_then(Value::as_u64)
+                && let Ok(min_us) = usize::try_from(min)
+                && len < min_us
+            {
+                errors.push(SchemaIssue {
+                    pointer: pointer.to_owned(),
+                    detail: format!("string shorter than minLength {min}"),
+                });
+            }
+            if let Some(max) = schema_obj.get("maxLength").and_then(Value::as_u64)
+                && let Ok(max_us) = usize::try_from(max)
+                && len > max_us
+            {
+                errors.push(SchemaIssue {
+                    pointer: pointer.to_owned(),
+                    detail: format!("string longer than maxLength {max}"),
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn value_matches_type(value: &Value, expected: &str) -> bool {
+    match expected {
+        "object" => value.is_object(),
+        "array" => value.is_array(),
+        "string" => value.is_string(),
+        "number" => value.is_number(),
+        "integer" => value.is_i64() || value.is_u64(),
+        "boolean" => value.is_boolean(),
+        "null" => value.is_null(),
+        _ => true,
+    }
+}
+
+fn value_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Object(_) => "object",
+        Value::Array(_) => "array",
+        Value::String(_) => "string",
+        Value::Number(_) => "number",
+        Value::Bool(_) => "boolean",
+        Value::Null => "null",
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test assertions over serde_json::Value require indexing"
+)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+
+    fn write_pack(root: &Path, id: &str, schema: &str, recipe: &str) {
+        let dir = root.join(id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(PACK_SCHEMA), schema).unwrap();
+        fs::write(dir.join(PACK_RECIPE), recipe).unwrap();
+        let mut tpl = fs::File::create(dir.join(PACK_TEMPLATE)).unwrap();
+        writeln!(tpl, "<div></div>").unwrap();
+    }
+
+    #[test]
+    fn discovery_picks_up_valid_packs() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write_pack(
+            root,
+            "title",
+            r#"{"type":"object","required":["text"],"properties":{"text":{"type":"string"}}}"#,
+            "[ooxml]\nkind = \"title\"\n",
+        );
+        write_pack(
+            root,
+            "stat_cards",
+            r#"{"type":"object"}"#,
+            "[ooxml]\nkind = \"stat_cards\"\n",
+        );
+        let mut registry = ComponentRegistry::new();
+        let n = registry.discover(root).expect("discovery succeeds");
+        assert_eq!(n, 2);
+        assert_eq!(registry.len(), 2);
+        let listed = registry.list_components();
+        assert_eq!(
+            listed,
+            vec![
+                ComponentId::new("stat_cards").unwrap(),
+                ComponentId::new("title").unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn discovery_absent_root_is_no_op() {
+        let tmp = tempdir();
+        let missing = tmp.path().join("does_not_exist");
+        let mut registry = ComponentRegistry::new();
+        let n = registry.discover(&missing).expect("no-op");
+        assert_eq!(n, 0);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn discovery_rejects_pack_missing_required_file() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        let dir = root.join("broken");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(PACK_SCHEMA), "{}").unwrap();
+        // Missing recipe + template.
+        let mut registry = ComponentRegistry::new();
+        let err = registry.discover(root).expect_err("missing files");
+        assert!(matches!(err, RegistryError::MissingPackFile { .. }));
+    }
+
+    #[test]
+    fn validate_fields_accepts_well_formed() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write_pack(
+            root,
+            "title",
+            r#"{"type":"object","required":["text"],"properties":{"text":{"type":"string"}}}"#,
+            "[ooxml]\nkind = \"title\"\n",
+        );
+        let mut registry = ComponentRegistry::new();
+        registry.discover(root).unwrap();
+        let id = ComponentId::new("title").unwrap();
+        let merged = registry
+            .validate_fields(&id, &json!({"text": "Welcome"}))
+            .expect("valid");
+        assert_eq!(merged["text"], "Welcome");
+    }
+
+    #[test]
+    fn validate_fields_rejects_missing_required_with_pointer() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write_pack(
+            root,
+            "title",
+            r#"{"type":"object","required":["text"],"properties":{"text":{"type":"string"}}}"#,
+            "[ooxml]\nkind = \"title\"\n",
+        );
+        let mut registry = ComponentRegistry::new();
+        registry.discover(root).unwrap();
+        let id = ComponentId::new("title").unwrap();
+        let err = registry
+            .validate_fields(&id, &json!({}))
+            .expect_err("required missing");
+        match err {
+            RegistryError::SlotValidation { pointer, .. } => {
+                assert_eq!(pointer, "/text");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_fields_rejects_wrong_type_with_pointer() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write_pack(
+            root,
+            "hero",
+            r#"{"type":"object","required":["count"],"properties":{"count":{"type":"integer"}}}"#,
+            "[ooxml]\nkind = \"hero\"\n",
+        );
+        let mut registry = ComponentRegistry::new();
+        registry.discover(root).unwrap();
+        let id = ComponentId::new("hero").unwrap();
+        let err = registry
+            .validate_fields(&id, &json!({"count": "three"}))
+            .expect_err("wrong type");
+        match err {
+            RegistryError::SlotValidation { pointer, detail } => {
+                assert_eq!(pointer, "/count");
+                assert!(detail.contains("integer"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_fields_merges_defaults() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write_pack(
+            root,
+            "title",
+            r#"{"type":"object","required":["text","color"],"properties":{"text":{"type":"string"},"color":{"type":"string"}}}"#,
+            "[ooxml]\nkind = \"title\"\n",
+        );
+        fs::write(
+            root.join("title").join(PACK_DEFAULTS),
+            r#"{"color":"black"}"#,
+        )
+        .unwrap();
+        let mut registry = ComponentRegistry::new();
+        registry.discover(root).unwrap();
+        let id = ComponentId::new("title").unwrap();
+        let merged = registry
+            .validate_fields(&id, &json!({"text": "Hello"}))
+            .expect("merged");
+        assert_eq!(merged["color"], "black");
+        assert_eq!(merged["text"], "Hello");
+    }
+
+    #[test]
+    fn validate_fields_rejects_unknown_component() {
+        let registry = ComponentRegistry::new();
+        let id = ComponentId::new("nope").unwrap();
+        let err = registry
+            .validate_fields(&id, &json!({}))
+            .expect_err("unknown");
+        assert!(matches!(err, RegistryError::UnknownComponent { .. }));
+    }
+
+    #[test]
+    fn malformed_schema_is_surfaced_on_discovery() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        let dir = root.join("bad");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(PACK_SCHEMA), "{this is not json").unwrap();
+        fs::write(dir.join(PACK_RECIPE), "[ooxml]\n").unwrap();
+        fs::write(dir.join(PACK_TEMPLATE), "<div/>").unwrap();
+        let mut registry = ComponentRegistry::new();
+        let err = registry.discover(root).expect_err("bad schema");
+        assert!(matches!(err, RegistryError::MalformedSchema { .. }));
+    }
+
+    fn tempdir() -> TestTempDir {
+        TestTempDir::new()
+    }
+
+    /// Minimal scoped tempdir helper that avoids pulling the `tempfile`
+    /// crate as a workspace dep. Creates a unique directory under the
+    /// system tempdir and removes it on drop.
+    struct TestTempDir {
+        path: PathBuf,
+    }
+
+    impl TestTempDir {
+        fn new() -> Self {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+            let pid = std::process::id();
+            let path = std::env::temp_dir().join(format!("poiesis-core-test-{pid}-{n}"));
+            fs::create_dir_all(&path).expect("create tempdir");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}

--- a/crates/poiesis/core/src/envelope.rs
+++ b/crates/poiesis/core/src/envelope.rs
@@ -1,0 +1,395 @@
+//! The deliverable envelope — what every render path consumes and what the
+//! QA gate runs over.
+//!
+//! A [`DeliverableSpec`] carries typed [`Meta`], a [`crate::ids::ThemeId`]
+//! (resolved by the theme registry in [[B-002]]), a
+//! [`crate::factbase::Factbase`], and a [`Body`]. The body is one of
+//! [`crate::bodies::Deck`], [`crate::bodies::DocumentBody`], or
+//! [`crate::bodies::Workbook`] — typed sum so the render-side trait can
+//! match on body kind without re-deriving it from string tags.
+
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::BodyKind;
+use crate::bodies::{Deck, Workbook};
+use crate::components::ComponentRegistry;
+use crate::error::{MissingMetaFieldSnafu, SpecError, UnknownThemeSnafu};
+use crate::factbase::Factbase;
+use crate::ids::{ComponentId, ThemeId};
+
+/// Typed metadata required by every deliverable.
+///
+/// Required fields are enforced at parse time: a [`Meta`] without `title`
+/// cannot be constructed. Optional fields are typed as `Option<…>` so the
+/// `None` case is explicit at the call site.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Meta {
+    /// Deliverable title; required.
+    pub title: String,
+    /// Optional author.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// Optional creation timestamp; renderers may stamp document properties.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<Timestamp>,
+    /// Optional subject; threaded into PDF/DOCX/PPTX core properties.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    /// Optional list of keywords / tags.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+}
+
+impl Meta {
+    /// Construct a [`Meta`] with the required `title` and no optionals.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpecError::MissingMetaField`] if `title` is empty.
+    pub fn new(title: impl Into<String>) -> Result<Self, SpecError> {
+        let title = title.into();
+        if title.is_empty() {
+            return MissingMetaFieldSnafu { field: "title" }.fail();
+        }
+        Ok(Self {
+            title,
+            author: None,
+            created: None,
+            subject: None,
+            keywords: Vec::new(),
+        })
+    }
+
+    /// Validate a deserialised `Meta`, surfacing missing-required failures
+    /// even when the value came from JSON / TOML where serde already
+    /// admitted the empty case.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpecError::MissingMetaField`] if `title` is empty.
+    pub fn validate(&self) -> Result<(), SpecError> {
+        if self.title.is_empty() {
+            return MissingMetaFieldSnafu { field: "title" }.fail();
+        }
+        Ok(())
+    }
+}
+
+/// The body of a deliverable — a typed sum over the three supported kinds.
+// kanon:ignore RUST/non-exhaustive-enum — exhaustive match is part of the
+// stable API; new body kinds are an explicit additive evolution.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Body {
+    /// A deck of slides.
+    Deck(Deck),
+    /// A prose document (wraps the pre-envelope
+    /// [`crate::document::Document`]).
+    Document(DocumentBodyRepr),
+    /// A workbook of sheets.
+    Workbook(Workbook),
+}
+
+/// Serde-friendly representation of [`DocumentBody`] — the legacy
+/// [`crate::document::Document`] does not derive `Serialize` / `Deserialize`
+/// today, so the envelope path carries an opaque serializable wrapper.
+/// Render-side code consumes [`crate::bodies::DocumentBody`] directly
+/// through [`Body::as_document_body`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DocumentBodyRepr {
+    /// The document title — duplicated from [`Meta`] for self-containment
+    /// at the body level (renderers that only see `Body` still have a
+    /// title to thread through).
+    pub title: String,
+}
+
+impl Body {
+    /// The body kind tag — useful for branch-on-kind dispatch.
+    #[must_use]
+    pub fn kind(&self) -> BodyKind {
+        match self {
+            Self::Deck(_) => BodyKind::Deck,
+            Self::Document(_) => BodyKind::Document,
+            Self::Workbook(_) => BodyKind::Workbook,
+        }
+    }
+}
+
+/// The top-level deliverable envelope.
+///
+/// `DeliverableSpec` is what scaffolding produces, what QA runs over, and
+/// what render-side B-NNN entries take as input. The four arms are
+/// orthogonal: `meta`, `theme`, `facts`, and `body` are validated
+/// independently at the boundary; rejecting a malformed spec is a
+/// deterministic walk over these four.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeliverableSpec {
+    /// Typed metadata.
+    pub meta: Meta,
+    /// Theme reference; resolved against the theme registry ([[B-002]]).
+    pub theme: ThemeId,
+    /// The factbase carrying every cited number.
+    pub facts: Factbase,
+    /// The body — deck, document, or workbook.
+    pub body: Body,
+}
+
+impl DeliverableSpec {
+    /// Validate the spec at the boundary:
+    ///
+    /// - `meta` required fields,
+    /// - factbase citation graph (cycles, dangling references),
+    /// - if `body == Deck`, every `Slide.component` resolves in
+    ///   `components` and `Slide.fields` passes the component schema.
+    ///
+    /// The theme reference is checked against `known_themes` when supplied;
+    /// pass an empty slice to skip theme-registry validation (useful for
+    /// early scaffolding callers that don't yet have a registry on hand).
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`crate::error::PoiesisError`] the walk
+    /// encounters.
+    pub fn validate(
+        &self,
+        components: &ComponentRegistry,
+        known_themes: &[ThemeId],
+    ) -> Result<(), crate::error::PoiesisError> {
+        self.meta.validate()?;
+        self.facts.validate()?;
+        if !known_themes.is_empty() && !known_themes.contains(&self.theme) {
+            return Err(UnknownThemeSnafu {
+                theme: self.theme.as_str(),
+            }
+            .build()
+            .into());
+        }
+        if let Body::Deck(deck) = &self.body {
+            for slide in &deck.slides {
+                // validate_fields enforces both schema correctness and
+                // component-id resolution; we discard the merged payload
+                // here, render-side callers re-merge before rendering.
+                let _ = components.validate_fields(&slide.component, &slide.fields)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// True if `body` matches the expected [`BodyKind`].
+    #[must_use]
+    pub fn body_kind(&self) -> BodyKind {
+        self.body.kind()
+    }
+
+    /// Enumerate the component ids the deck body references. Empty for
+    /// document and workbook bodies. Useful for the theme coverage lint
+    /// and for the agent palette in [[B-010]].
+    #[must_use]
+    pub fn referenced_components(&self) -> Vec<ComponentId> {
+        match &self.body {
+            Body::Deck(deck) => {
+                let mut ids: Vec<ComponentId> =
+                    deck.slides.iter().map(|s| s.component.clone()).collect();
+                ids.sort();
+                ids.dedup();
+                ids
+            }
+            Body::Document(_) | Body::Workbook(_) => Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::bodies::{Slide, Workbook};
+    use crate::factbase::{Fact, Source};
+    use crate::ids::{ComponentId, FactId, ThemeId};
+    use crate::scalar::{AspectRatio, Scalar, Unit};
+    use jiff::Timestamp;
+    use serde_json::json;
+
+    fn ts() -> Timestamp {
+        Timestamp::UNIX_EPOCH
+    }
+
+    fn empty_factbase() -> Factbase {
+        Factbase::new()
+    }
+
+    #[test]
+    fn meta_rejects_empty_title() {
+        let err = Meta::new("").expect_err("empty title must reject");
+        assert!(matches!(
+            err,
+            SpecError::MissingMetaField { field: "title" }
+        ));
+    }
+
+    #[test]
+    fn meta_validate_catches_post_deserialise_emptiness() {
+        let m = Meta {
+            title: String::new(),
+            author: None,
+            created: None,
+            subject: None,
+            keywords: Vec::new(),
+        };
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn deliverable_workbook_validates_with_empty_factbase() {
+        let spec = DeliverableSpec {
+            meta: Meta::new("Q1 receipts").unwrap(),
+            theme: ThemeId::new("summus").unwrap(),
+            facts: empty_factbase(),
+            body: Body::Workbook(Workbook { sheets: Vec::new() }),
+        };
+        spec.validate(&ComponentRegistry::new(), &[])
+            .expect("workbook with no facts validates");
+        assert_eq!(spec.body_kind(), BodyKind::Workbook);
+    }
+
+    #[test]
+    fn deliverable_unknown_theme_rejects_when_registry_supplied() {
+        let spec = DeliverableSpec {
+            meta: Meta::new("Untitled").unwrap(),
+            theme: ThemeId::new("missing").unwrap(),
+            facts: empty_factbase(),
+            body: Body::Document(DocumentBodyRepr {
+                title: "Untitled".to_owned(),
+            }),
+        };
+        let known = vec![ThemeId::new("summus").unwrap()];
+        let err = spec
+            .validate(&ComponentRegistry::new(), &known)
+            .expect_err("unknown theme rejects");
+        match err {
+            crate::error::PoiesisError::Spec {
+                source: SpecError::UnknownTheme { theme },
+            } => {
+                assert_eq!(theme, "missing");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deliverable_deck_with_unknown_component_rejects() {
+        let spec = DeliverableSpec {
+            meta: Meta::new("Pitch").unwrap(),
+            theme: ThemeId::new("summus").unwrap(),
+            facts: empty_factbase(),
+            body: Body::Deck(Deck {
+                aspect: AspectRatio::WIDESCREEN_16_9,
+                slides: vec![Slide {
+                    component: ComponentId::new("ghost").unwrap(),
+                    fields: json!({}),
+                    notes: None,
+                }],
+            }),
+        };
+        let err = spec
+            .validate(&ComponentRegistry::new(), &[])
+            .expect_err("unknown component rejects");
+        match err {
+            crate::error::PoiesisError::Registry {
+                source: crate::error::RegistryError::UnknownComponent { component },
+            } => {
+                assert_eq!(component, "ghost");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deliverable_facts_cycle_propagates() {
+        let mut facts = Factbase::new();
+        facts.add_fact(Fact {
+            id: FactId::new("a").unwrap(),
+            value: Scalar::Count { value: 0 },
+            unit: Unit::Count,
+            source: Source::Reference {
+                fact: FactId::new("b").unwrap(),
+            },
+            captured: ts(),
+        });
+        facts.add_fact(Fact {
+            id: FactId::new("b").unwrap(),
+            value: Scalar::Count { value: 0 },
+            unit: Unit::Count,
+            source: Source::Reference {
+                fact: FactId::new("a").unwrap(),
+            },
+            captured: ts(),
+        });
+        let spec = DeliverableSpec {
+            meta: Meta::new("cycle test").unwrap(),
+            theme: ThemeId::new("summus").unwrap(),
+            facts,
+            body: Body::Workbook(Workbook { sheets: Vec::new() }),
+        };
+        let err = spec
+            .validate(&ComponentRegistry::new(), &[])
+            .expect_err("cycle");
+        assert!(matches!(
+            err,
+            crate::error::PoiesisError::Factbase {
+                source: crate::error::FactbaseError::Cycle { .. },
+            }
+        ));
+    }
+
+    #[test]
+    fn round_trip_via_serde_preserves_envelope() {
+        let spec = DeliverableSpec {
+            meta: Meta::new("Roundtrip").unwrap(),
+            theme: ThemeId::new("summus").unwrap(),
+            facts: empty_factbase(),
+            body: Body::Workbook(Workbook { sheets: Vec::new() }),
+        };
+        let s = serde_json::to_string(&spec).unwrap();
+        let back: DeliverableSpec = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, spec);
+    }
+
+    #[test]
+    fn referenced_components_lists_used_ids_sorted_and_deduped() {
+        let spec = DeliverableSpec {
+            meta: Meta::new("Pitch").unwrap(),
+            theme: ThemeId::new("summus").unwrap(),
+            facts: empty_factbase(),
+            body: Body::Deck(Deck {
+                aspect: AspectRatio::WIDESCREEN_16_9,
+                slides: vec![
+                    Slide {
+                        component: ComponentId::new("title").unwrap(),
+                        fields: json!({}),
+                        notes: None,
+                    },
+                    Slide {
+                        component: ComponentId::new("statement").unwrap(),
+                        fields: json!({}),
+                        notes: None,
+                    },
+                    Slide {
+                        component: ComponentId::new("title").unwrap(),
+                        fields: json!({}),
+                        notes: None,
+                    },
+                ],
+            }),
+        };
+        let ids = spec.referenced_components();
+        assert_eq!(
+            ids,
+            vec![
+                ComponentId::new("statement").unwrap(),
+                ComponentId::new("title").unwrap(),
+            ]
+        );
+    }
+}

--- a/crates/poiesis/core/src/error.rs
+++ b/crates/poiesis/core/src/error.rs
@@ -1,0 +1,273 @@
+//! Error types for parse-don't-validate boundaries.
+//!
+//! Every typed constructor in [`crate::ids`], [`crate::scalar`], [`crate::factbase`],
+//! [`crate::components`], and [`crate::envelope`] returns one of these on failure.
+//! Errors carry the offending input plus, where applicable, a JSON-pointer path
+//! into the source document so the caller can surface a precise rejection.
+
+use snafu::Snafu;
+
+/// Errors raised when constructing a typed identifier (`ComponentId`,
+/// `ThemeId`, `FactId`, `ClaimId`, `SheetName`, `DataSourceId`).
+#[derive(Debug, Clone, PartialEq, Eq, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum IdError {
+    /// The input string was empty.
+    #[snafu(display("{kind} identifier cannot be empty"))]
+    Empty {
+        /// Human-readable identifier kind, e.g. `"component"`.
+        kind: &'static str,
+    },
+    /// The input contained a character that is not allowed for this kind.
+    #[snafu(display(
+        "{kind} identifier {input:?} contains invalid character {ch:?} (allowed: {allowed})"
+    ))]
+    InvalidChar {
+        /// Human-readable identifier kind.
+        kind: &'static str,
+        /// The offending input string.
+        input: String,
+        /// The first invalid character encountered.
+        ch: char,
+        /// Description of the allowed character set.
+        allowed: &'static str,
+    },
+    /// The input exceeded the maximum allowed length.
+    #[snafu(display("{kind} identifier {input:?} length {got} exceeds maximum {max}"))]
+    TooLong {
+        /// Human-readable identifier kind.
+        kind: &'static str,
+        /// The offending input string.
+        input: String,
+        /// The actual length.
+        got: usize,
+        /// The maximum allowed length.
+        max: usize,
+    },
+}
+
+/// Errors raised when parsing a typed value (`Scalar`, `Unit`, `AspectRatio`,
+/// `Tolerance`).
+#[derive(Debug, Clone, PartialEq, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum ScalarError {
+    /// Unknown unit name.
+    #[snafu(display("unknown unit {input:?} (known: count, usd, percent, ratio, date, text)"))]
+    UnknownUnit {
+        /// The offending input string.
+        input: String,
+    },
+    /// Aspect ratio could not be parsed in `"W:H"` form.
+    #[snafu(display("aspect ratio {input:?} is not in W:H form with positive integers"))]
+    BadAspect {
+        /// The offending input string.
+        input: String,
+    },
+    /// Tolerance must be in the closed unit interval `[0.0, 1.0]`.
+    #[snafu(display("tolerance {value} is outside [0.0, 1.0]"))]
+    BadTolerance {
+        /// The offending value.
+        value: f64,
+    },
+    /// A monetary amount was outside the representable range.
+    #[snafu(display("monetary amount {input:?} is malformed or exceeds representable range"))]
+    BadMoney {
+        /// The offending input string.
+        input: String,
+    },
+}
+
+/// Errors raised when validating or resolving a `Factbase`.
+#[derive(Debug, Clone, PartialEq, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum FactbaseError {
+    /// A `FactId` referenced from a `Claim` or `Derived`/`Reference` source
+    /// is not present in the factbase.
+    #[snafu(display("unknown fact reference {id:?} from {referenced_by}"))]
+    UnknownFact {
+        /// The unresolved fact identifier (as a string for error surfacing).
+        id: String,
+        /// What referenced it (claim id, derived source, etc.).
+        referenced_by: String,
+    },
+    /// A cycle was detected in the `Derived`/`Reference` dependency graph.
+    /// `path` is the cycle path in declaration order.
+    #[snafu(display("cycle in factbase: {}", path.join(" -> ")))]
+    Cycle {
+        /// The fact ids forming the cycle, head repeated at the tail.
+        path: Vec<String>,
+    },
+    /// A claim references a fact whose `Source` requires a data adapter that
+    /// is not configured.
+    #[snafu(display(
+        "claim {claim_id:?} requires data source {data_source:?} but no adapter is configured"
+    ))]
+    MissingDataSource {
+        /// The claim that triggered the error.
+        claim_id: String,
+        /// The data source id named by the claim's underlying fact.
+        data_source: String,
+    },
+    /// A `Derived` expression named an arithmetic operator the evaluator does
+    /// not implement.
+    #[snafu(display("unsupported derived expression: {detail}"))]
+    BadDerived {
+        /// Free-form description of why the expression cannot be evaluated.
+        detail: String,
+    },
+    /// A `Derived` expression's operand types are incompatible.
+    #[snafu(display("type mismatch in derived expression: {detail}"))]
+    DerivedTypeMismatch {
+        /// Free-form description of the mismatch.
+        detail: String,
+    },
+}
+
+/// Errors raised by the component registry: discovery, schema parse, slot
+/// validation.
+#[derive(Debug, Clone, PartialEq, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum RegistryError {
+    /// A pack directory was missing a required artifact.
+    #[snafu(display("component pack {component:?} missing required file {file}"))]
+    MissingPackFile {
+        /// The component id whose pack is incomplete.
+        component: String,
+        /// The file path expected within the pack directory.
+        file: String,
+    },
+    /// A pack's `schema.json` was unreadable or not valid JSON.
+    #[snafu(display("component pack {component:?} has malformed schema.json: {detail}"))]
+    MalformedSchema {
+        /// The component id whose schema failed to parse.
+        component: String,
+        /// Parser-emitted detail.
+        detail: String,
+    },
+    /// A pack's `recipe.toml` was unreadable or not valid TOML.
+    #[snafu(display("component pack {component:?} has malformed recipe.toml: {detail}"))]
+    MalformedRecipe {
+        /// The component id whose recipe failed to parse.
+        component: String,
+        /// Parser-emitted detail.
+        detail: String,
+    },
+    /// I/O error while discovering or reading a pack.
+    #[snafu(display("component pack discovery I/O failure at {path}: {detail}"))]
+    Io {
+        /// The filesystem path where I/O failed.
+        path: String,
+        /// OS-emitted detail.
+        detail: String,
+    },
+    /// A `Slide.fields` payload failed schema validation.
+    /// `pointer` is a JSON-pointer (RFC 6901) naming the path inside the payload.
+    #[snafu(display("slot validation failed at {pointer}: {detail}"))]
+    SlotValidation {
+        /// JSON-pointer into the offending payload.
+        pointer: String,
+        /// Free-form description of the rule that rejected the value.
+        detail: String,
+    },
+    /// A `Slide` referenced a component id that is not registered.
+    #[snafu(display("slide references unknown component {component:?}"))]
+    UnknownComponent {
+        /// The unresolved component id.
+        component: String,
+    },
+}
+
+/// Errors raised when parsing or validating a [`crate::envelope::DeliverableSpec`].
+#[derive(Debug, Clone, PartialEq, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum SpecError {
+    /// A required `Meta` field was missing.
+    #[snafu(display("meta field {field:?} is required but missing"))]
+    MissingMetaField {
+        /// The field name.
+        field: &'static str,
+    },
+    /// A `ThemeId` referenced by the envelope is not known to the theme
+    /// registry. The theme registry itself lives in `poiesis-theme`; this
+    /// error is surfaced when an envelope is checked against a registry that
+    /// does not contain its theme.
+    #[snafu(display("envelope references unknown theme {theme:?}"))]
+    UnknownTheme {
+        /// The unresolved theme id.
+        theme: String,
+    },
+    /// The body kind in the spec did not match the body kind expected by the
+    /// renderer or theme.
+    #[snafu(display("body kind mismatch: spec carries {got}, expected {expected}"))]
+    BodyKindMismatch {
+        /// The body kind in the spec.
+        got: &'static str,
+        /// The body kind expected.
+        expected: &'static str,
+    },
+}
+
+/// Umbrella error covering every parse-don't-validate boundary in this crate.
+#[derive(Debug, Clone, PartialEq, Snafu)]
+pub enum PoiesisError {
+    /// Identifier construction failed.
+    #[snafu(display("{source}"))]
+    Id {
+        /// The wrapped identifier error.
+        source: IdError,
+    },
+    /// Scalar/unit/aspect/tolerance parsing failed.
+    #[snafu(display("{source}"))]
+    Scalar {
+        /// The wrapped scalar error.
+        source: ScalarError,
+    },
+    /// Factbase resolution failed.
+    #[snafu(display("{source}"))]
+    Factbase {
+        /// The wrapped factbase error.
+        source: FactbaseError,
+    },
+    /// Component registry operation failed.
+    #[snafu(display("{source}"))]
+    Registry {
+        /// The wrapped registry error.
+        source: RegistryError,
+    },
+    /// Spec parsing or validation failed.
+    #[snafu(display("{source}"))]
+    Spec {
+        /// The wrapped spec error.
+        source: SpecError,
+    },
+}
+
+impl From<IdError> for PoiesisError {
+    fn from(source: IdError) -> Self {
+        Self::Id { source }
+    }
+}
+
+impl From<ScalarError> for PoiesisError {
+    fn from(source: ScalarError) -> Self {
+        Self::Scalar { source }
+    }
+}
+
+impl From<FactbaseError> for PoiesisError {
+    fn from(source: FactbaseError) -> Self {
+        Self::Factbase { source }
+    }
+}
+
+impl From<RegistryError> for PoiesisError {
+    fn from(source: RegistryError) -> Self {
+        Self::Registry { source }
+    }
+}
+
+impl From<SpecError> for PoiesisError {
+    fn from(source: SpecError) -> Self {
+        Self::Spec { source }
+    }
+}

--- a/crates/poiesis/core/src/factbase.rs
+++ b/crates/poiesis/core/src/factbase.rs
@@ -1,0 +1,804 @@
+//! The single home for every number cited by a deliverable.
+//!
+//! A [`Factbase`] is a collection of typed [`Fact`]s and [`Claim`]s. Every
+//! numeric value a renderer emits is a `Cite(FactId)` reference into the
+//! factbase — naked numbers are rejected by [`crate::components`] schema
+//! validation and by the QA gate downstream. Facts may be `Manual` (operator
+//! assertion), `File` (CSV cell / JSON path), `Sql` (resolved via a
+//! [`DataSource`] adapter), `Derived` (an arithmetic expression over other
+//! facts), or `Reference` (an alias for another fact).
+//!
+//! [`Factbase::resolve`] walks the dependency graph in declaration order,
+//! detecting cycles and unsourced references before any data adapter is
+//! invoked. Adapters are optional: a factbase with no `Sql` facts is
+//! resolvable without configuring any [`DataSource`].
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::PathBuf;
+
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{
+    BadDerivedSnafu, CycleSnafu, DerivedTypeMismatchSnafu, FactbaseError, MissingDataSourceSnafu,
+    UnknownFactSnafu,
+};
+use crate::ids::{ClaimId, DataSourceId, FactId};
+use crate::scalar::{Money, Scalar, Tolerance, Unit};
+
+/// A typed, sourced value that may be cited by a deliverable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Fact {
+    /// Identifier referenced by `Cite`/`Reference`/`Derived`.
+    pub id: FactId,
+    /// The typed value. For `Sql`/`Derived` facts the value is the cached or
+    /// computed result; for `Manual`/`File` it is the authored value.
+    pub value: Scalar,
+    /// Presentation unit (drives formatting and dimensional checks).
+    pub unit: Unit,
+    /// Where this fact comes from.
+    pub source: Source,
+    /// When the fact was last captured / asserted.
+    pub captured: Timestamp,
+}
+
+/// The provenance of a [`Fact`].
+// kanon:ignore RUST/non-exhaustive-enum — exhaustive match is part of the
+// stable API; new sources are an explicit additive evolution.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Source {
+    /// Resolved via the named data adapter (e.g. a CSV reader, SQL driver).
+    Sql {
+        /// Adapter id; must resolve in the configured [`DataSourceRegistry`].
+        data_source: DataSourceId,
+        /// The query (SQL string, or whatever the adapter accepts).
+        query: String,
+        /// A friendly name for the table/view used in error messages.
+        table: String,
+    },
+    /// An arithmetic expression over other facts.
+    Derived {
+        /// The expression.
+        formula: Expr,
+        /// The fact ids consumed by `formula`, in dependency order.
+        inputs: Vec<FactId>,
+    },
+    /// An alias for another fact.
+    Reference {
+        /// The aliased fact id.
+        fact: FactId,
+    },
+    /// An operator-asserted value with no programmatic provenance.
+    Manual {
+        /// Free-form note.
+        note: String,
+        /// Who captured the value.
+        captured_by: String,
+    },
+    /// A value extracted from a file at a locator.
+    File {
+        /// Filesystem path.
+        path: PathBuf,
+        /// In-file locator (CSV cell `A1`, JSON pointer `/totals/0`, etc.).
+        locator: String,
+    },
+}
+
+/// An arithmetic expression in a `Derived` source.
+///
+/// Kept intentionally narrow at the v1.0.0 boundary: addition, subtraction,
+/// multiplication, division, sum, mean. Sufficient for the offsite deck
+/// claims and the workbook total rows; not a calculator. The QA gate
+/// extends the surface in [[B-008]].
+// kanon:ignore RUST/non-exhaustive-enum — additive evolution is the intended
+// migration path; keeping exhaustive matches keeps the gate honest.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum Expr {
+    /// `a + b`.
+    Add {
+        /// First operand fact id.
+        a: FactId,
+        /// Second operand fact id.
+        b: FactId,
+    },
+    /// `a - b`.
+    Sub {
+        /// Minuend fact id.
+        a: FactId,
+        /// Subtrahend fact id.
+        b: FactId,
+    },
+    /// `a * b`.
+    Mul {
+        /// First operand fact id.
+        a: FactId,
+        /// Second operand fact id.
+        b: FactId,
+    },
+    /// `a / b` evaluated as a ratio (`f64`).
+    Div {
+        /// Numerator fact id.
+        a: FactId,
+        /// Denominator fact id.
+        b: FactId,
+    },
+    /// Sum over a list of facts (each must have a compatible unit).
+    Sum {
+        /// The fact ids to sum.
+        terms: Vec<FactId>,
+    },
+}
+
+/// A claim made by some location in the deliverable, asserting a fact.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Claim {
+    /// Identifier of this claim.
+    pub id: ClaimId,
+    /// Human-readable form of the claim as it appears in prose.
+    pub text: String,
+    /// The fact asserted.
+    pub asserts: FactId,
+    /// Where in the deliverable the claim lives (slide, paragraph, sheet cell).
+    pub location: Location,
+    /// Numeric tolerance used by the QA gate when comparing fact vs. claim.
+    #[serde(default = "default_strict_tolerance")]
+    pub tolerance: Tolerance,
+}
+
+fn default_strict_tolerance() -> Tolerance {
+    Tolerance::STRICT
+}
+
+/// A coarse pointer into the deliverable for surfacing where a claim lives.
+///
+/// Free-form by intent: render-side B-NNN will refine this to typed
+/// references once their bodies stabilise. The QA gate echoes this verbatim
+/// in its findings, so authors and reviewers can locate the claim.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Location {
+    /// Body coordinate (e.g. `"deck/slide/3"`, `"document/section/2"`,
+    /// `"workbook/Receipts/B7"`).
+    pub at: String,
+}
+
+/// The trait every data adapter implements.
+///
+/// Adapters live out of `poiesis-core`; consumers register them through a
+/// [`DataSourceRegistry`] before calling [`Factbase::resolve`]. A factbase
+/// with no `Source::Sql` facts needs no adapters.
+pub trait DataSource: Send + Sync {
+    /// The id this adapter handles.
+    fn id(&self) -> &DataSourceId;
+
+    /// Execute `query` against the adapter and return a single scalar value.
+    ///
+    /// # Errors
+    ///
+    /// Implementations return a string error; the resolver wraps it in
+    /// [`FactbaseError::BadDerived`] with the adapter id as context. (The
+    /// dedicated `SqlAdapterError` variant is intentionally postponed to
+    /// [[B-008]] when the first real adapter ships.)
+    fn query(&self, query: &str, table: &str) -> Result<Scalar, String>;
+}
+
+/// Container for registered [`DataSource`] adapters.
+///
+/// Empty by default. A factbase with `Source::Sql` facts whose data-source
+/// id is not registered fails resolution with
+/// [`FactbaseError::MissingDataSource`].
+#[derive(Default)]
+pub struct DataSourceRegistry {
+    adapters: HashMap<DataSourceId, Box<dyn DataSource>>,
+}
+
+impl std::fmt::Debug for DataSourceRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DataSourceRegistry")
+            .field("adapter_ids", &self.adapters.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl DataSourceRegistry {
+    /// Construct an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a [`DataSource`] adapter; replaces any prior adapter for the
+    /// same id.
+    pub fn register(&mut self, adapter: Box<dyn DataSource>) {
+        let id = adapter.id().clone();
+        self.adapters.insert(id, adapter);
+    }
+
+    /// Look up an adapter by id.
+    #[must_use]
+    pub fn get(&self, id: &DataSourceId) -> Option<&dyn DataSource> {
+        self.adapters.get(id).map(std::convert::AsRef::as_ref)
+    }
+}
+
+/// A collection of [`Fact`]s and [`Claim`]s forming the citation graph.
+///
+/// Order is preserved (`indexmap::IndexMap`) so resolution and serialisation
+/// honour declaration order; this matches the source spec's "resolve in
+/// declaration order" requirement.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Factbase {
+    /// Facts in declaration order.
+    pub facts: indexmap::IndexMap<FactId, Fact>,
+    /// Claims in declaration order.
+    pub claims: indexmap::IndexMap<ClaimId, Claim>,
+}
+
+/// The outcome of resolving a single fact.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedFact {
+    /// The fact id.
+    pub id: FactId,
+    /// The resolved value (for `Derived`/`Sql`, the computed result; for the
+    /// other kinds, the authored value).
+    pub value: Scalar,
+    /// The presentation unit.
+    pub unit: Unit,
+}
+
+impl Factbase {
+    /// Construct an empty factbase.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a fact; preserves declaration order.
+    pub fn add_fact(&mut self, fact: Fact) {
+        let id = fact.id.clone();
+        self.facts.insert(id, fact);
+    }
+
+    /// Add a claim; preserves declaration order.
+    pub fn add_claim(&mut self, claim: Claim) {
+        let id = claim.id.clone();
+        self.claims.insert(id, claim);
+    }
+
+    /// Validate the citation graph without resolving values.
+    ///
+    /// Checks every claim's `asserts` and every `Source::Reference`/`Derived`
+    /// input resolves to a known fact id; checks the `Derived`/`Reference`
+    /// dependency graph is acyclic. Returns the first error encountered.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FactbaseError::UnknownFact`] for dangling references and
+    /// [`FactbaseError::Cycle`] for a cyclic dependency chain.
+    pub fn validate(&self) -> Result<(), FactbaseError> {
+        for claim in self.claims.values() {
+            if !self.facts.contains_key(&claim.asserts) {
+                return UnknownFactSnafu {
+                    id: claim.asserts.as_str(),
+                    referenced_by: format!("claim {}", claim.id),
+                }
+                .fail();
+            }
+        }
+        for fact in self.facts.values() {
+            for input in source_inputs(&fact.source) {
+                if !self.facts.contains_key(input) {
+                    return UnknownFactSnafu {
+                        id: input.as_str(),
+                        referenced_by: format!("source of fact {}", fact.id),
+                    }
+                    .fail();
+                }
+            }
+        }
+        self.detect_cycle()?;
+        Ok(())
+    }
+
+    /// Resolve every fact in declaration order.
+    ///
+    /// Calls `validate` first; on success, computes `Derived` values,
+    /// follows `Reference` aliases, and dispatches `Sql` queries through
+    /// `adapters`. `Manual` and `File` facts resolve to their authored value
+    /// (file extraction is the caller's responsibility — this resolver does
+    /// not read files).
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`FactbaseError`] encountered during validation or
+    /// resolution.
+    pub fn resolve(
+        &self,
+        adapters: &DataSourceRegistry,
+    ) -> Result<BTreeMap<FactId, ResolvedFact>, FactbaseError> {
+        self.validate()?;
+        let order = self.topo_order();
+        let mut resolved: BTreeMap<FactId, ResolvedFact> = BTreeMap::new();
+        for id in order {
+            let Some(entry) = self.facts.get(&id) else {
+                continue;
+            };
+            let value = match &entry.source {
+                Source::Manual { .. } | Source::File { .. } => entry.value.clone(),
+                Source::Reference { fact } => match resolved.get(fact) {
+                    Some(r) => r.value.clone(),
+                    None => entry.value.clone(),
+                },
+                Source::Derived { formula, .. } => evaluate_expr(formula, &resolved)?,
+                Source::Sql {
+                    data_source,
+                    query,
+                    table,
+                } => match adapters.get(data_source) {
+                    Some(adapter) => match adapter.query(query.as_str(), table.as_str()) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            return BadDerivedSnafu {
+                                detail: format!("adapter {data_source} returned error: {e}"),
+                            }
+                            .fail();
+                        }
+                    },
+                    None => {
+                        return MissingDataSourceSnafu {
+                            claim_id: entry.id.as_str(),
+                            data_source: data_source.as_str(),
+                        }
+                        .fail();
+                    }
+                },
+            };
+            resolved.insert(
+                entry.id.clone(),
+                ResolvedFact {
+                    id: entry.id.clone(),
+                    value,
+                    unit: entry.unit,
+                },
+            );
+        }
+        Ok(resolved)
+    }
+
+    /// Detect cycles in the `Derived`/`Reference` dependency graph.
+    fn detect_cycle(&self) -> Result<(), FactbaseError> {
+        let mut marks: HashMap<&FactId, Mark> =
+            self.facts.keys().map(|id| (id, Mark::None)).collect();
+        let mut stack: Vec<&FactId> = Vec::new();
+        for root in self.facts.keys() {
+            if matches!(marks.get(root), Some(Mark::Done)) {
+                continue;
+            }
+            self.dfs_cycle(root, &mut marks, &mut stack)?;
+        }
+        Ok(())
+    }
+
+    fn dfs_cycle<'a>(
+        &'a self,
+        node: &'a FactId,
+        marks: &mut HashMap<&'a FactId, Mark>,
+        stack: &mut Vec<&'a FactId>,
+    ) -> Result<(), FactbaseError> {
+        match marks.get(node) {
+            Some(Mark::Done) => return Ok(()),
+            Some(Mark::InProgress) => {
+                let mut path: Vec<String> = stack.iter().map(|f| f.as_str().to_owned()).collect();
+                path.push(node.as_str().to_owned());
+                if let Some(first) = path.iter().position(|p| p == node.as_str()) {
+                    let cycle: Vec<String> = path.into_iter().skip(first).collect();
+                    return CycleSnafu { path: cycle }.fail();
+                }
+                return CycleSnafu { path }.fail();
+            }
+            _ => {}
+        }
+        marks.insert(node, Mark::InProgress);
+        stack.push(node);
+        if let Some(fact) = self.facts.get(node) {
+            for input in source_inputs(&fact.source) {
+                if let Some((k, _)) = self.facts.get_key_value(input) {
+                    self.dfs_cycle(k, marks, stack)?;
+                }
+            }
+        }
+        stack.pop();
+        marks.insert(node, Mark::Done);
+        Ok(())
+    }
+
+    /// Topological order in declaration-priority: facts with no dependencies
+    /// first, then facts depending on already-emitted facts. Within an
+    /// independent set, the original declaration order is preserved.
+    fn topo_order(&self) -> Vec<FactId> {
+        let mut visited: BTreeSet<FactId> = BTreeSet::new();
+        let mut order: Vec<FactId> = Vec::with_capacity(self.facts.len());
+        for id in self.facts.keys() {
+            self.dfs_topo(id, &mut visited, &mut order);
+        }
+        order
+    }
+
+    fn dfs_topo(&self, node: &FactId, visited: &mut BTreeSet<FactId>, order: &mut Vec<FactId>) {
+        if visited.contains(node) {
+            return;
+        }
+        if let Some(fact) = self.facts.get(node) {
+            for input in source_inputs(&fact.source) {
+                self.dfs_topo(input, visited, order);
+            }
+        }
+        visited.insert(node.clone());
+        if self.facts.contains_key(node) {
+            order.push(node.clone());
+        }
+    }
+}
+
+/// Borrow the fact ids that a `Source` depends on.
+fn source_inputs(source: &Source) -> Vec<&FactId> {
+    match source {
+        Source::Reference { fact } => vec![fact],
+        Source::Derived { inputs, .. } => inputs.iter().collect(),
+        Source::Sql { .. } | Source::Manual { .. } | Source::File { .. } => Vec::new(),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Mark {
+    None,
+    InProgress,
+    Done,
+}
+
+fn evaluate_expr(
+    expr: &Expr,
+    resolved: &BTreeMap<FactId, ResolvedFact>,
+) -> Result<Scalar, FactbaseError> {
+    match expr {
+        Expr::Add { a, b } => binary_op(a, b, resolved, "+", |x, y| x + y, i64::checked_add),
+        Expr::Sub { a, b } => binary_op(a, b, resolved, "-", |x, y| x - y, i64::checked_sub),
+        Expr::Mul { a, b } => binary_op(a, b, resolved, "*", |x, y| x * y, i64::checked_mul),
+        Expr::Div { a, b } => {
+            let left = lookup(a, resolved)?;
+            let right = lookup(b, resolved)?;
+            let lf = scalar_to_f64(&left.value)?;
+            let rf = scalar_to_f64(&right.value)?;
+            if rf == 0.0 {
+                return BadDerivedSnafu {
+                    detail: format!("division by zero: {a} / {b}"),
+                }
+                .fail();
+            }
+            Ok(Scalar::Ratio { value: lf / rf })
+        }
+        Expr::Sum { terms } => {
+            let mut iter = terms.iter();
+            let Some(head_id) = iter.next() else {
+                return Ok(Scalar::Count { value: 0 });
+            };
+            let head = lookup(head_id, resolved)?;
+            let mut acc = head.value.clone();
+            for term_id in iter {
+                let next = lookup(term_id, resolved)?;
+                acc = add_scalars(&acc, &next.value)?;
+            }
+            Ok(acc)
+        }
+    }
+}
+
+fn lookup<'a>(
+    id: &FactId,
+    resolved: &'a BTreeMap<FactId, ResolvedFact>,
+) -> Result<&'a ResolvedFact, FactbaseError> {
+    resolved.get(id).ok_or_else(|| FactbaseError::UnknownFact {
+        id: id.as_str().to_owned(),
+        referenced_by: "derived expression".to_owned(),
+    })
+}
+
+fn binary_op(
+    lhs_id: &FactId,
+    rhs_id: &FactId,
+    resolved: &BTreeMap<FactId, ResolvedFact>,
+    op_name: &str,
+    f_op: fn(f64, f64) -> f64,
+    i_op: fn(i64, i64) -> Option<i64>,
+) -> Result<Scalar, FactbaseError> {
+    let lhs = lookup(lhs_id, resolved)?;
+    let rhs = lookup(rhs_id, resolved)?;
+    match (&lhs.value, &rhs.value) {
+        (Scalar::Count { value: lv }, Scalar::Count { value: rv }) => {
+            let summed = i_op(*lv, *rv).ok_or_else(|| FactbaseError::BadDerived {
+                detail: format!("integer overflow in {lhs_id} {op_name} {rhs_id}"),
+            })?;
+            Ok(Scalar::Count { value: summed })
+        }
+        (Scalar::Money { value: lv }, Scalar::Money { value: rv }) => match op_name {
+            "+" => Ok(Scalar::Money {
+                value: Money::from_micros(lv.micros() + rv.micros()),
+            }),
+            "-" => Ok(Scalar::Money {
+                value: Money::from_micros(lv.micros() - rv.micros()),
+            }),
+            _ => BadDerivedSnafu {
+                detail: format!("operator {op_name} not defined on money pair {lhs_id}, {rhs_id}"),
+            }
+            .fail(),
+        },
+        (Scalar::Ratio { value: lv }, Scalar::Ratio { value: rv }) => Ok(Scalar::Ratio {
+            value: f_op(*lv, *rv),
+        }),
+        _ => DerivedTypeMismatchSnafu {
+            detail: format!(
+                "{op_name} requires same-typed operands; got {} and {}",
+                lhs.value.kind(),
+                rhs.value.kind()
+            ),
+        }
+        .fail(),
+    }
+}
+
+fn add_scalars(lhs: &Scalar, rhs: &Scalar) -> Result<Scalar, FactbaseError> {
+    match (lhs, rhs) {
+        (Scalar::Count { value: lv }, Scalar::Count { value: rv }) => {
+            let summed = lv
+                .checked_add(*rv)
+                .ok_or_else(|| FactbaseError::BadDerived {
+                    detail: "integer overflow in sum".to_owned(),
+                })?;
+            Ok(Scalar::Count { value: summed })
+        }
+        (Scalar::Money { value: lv }, Scalar::Money { value: rv }) => Ok(Scalar::Money {
+            value: Money::from_micros(lv.micros() + rv.micros()),
+        }),
+        (Scalar::Ratio { value: lv }, Scalar::Ratio { value: rv }) => {
+            Ok(Scalar::Ratio { value: lv + rv })
+        }
+        _ => DerivedTypeMismatchSnafu {
+            detail: format!(
+                "sum requires same-typed operands; got {} and {}",
+                lhs.kind(),
+                rhs.kind()
+            ),
+        }
+        .fail(),
+    }
+}
+
+/// Lossy `i64`-to-`f64` conversion is acceptable here: the divide-then-
+/// compare in [`Expr::Div`] only needs to land within tolerance and the QA
+/// gate compares with [`Tolerance`], not raw equality. The casts cannot
+/// truncate (i64 → f64 is widening), only lose mantissa precision for
+/// magnitudes above `2^53`, which is well outside the deliverable range.
+#[expect(
+    clippy::as_conversions,
+    clippy::cast_precision_loss,
+    reason = "ratio output is a precision-tolerant aggregate"
+)]
+fn scalar_to_f64(s: &Scalar) -> Result<f64, FactbaseError> {
+    match s {
+        Scalar::Count { value } => Ok(*value as f64),
+        Scalar::Money { value } => Ok((value.micros() as f64) / 1_000_000.0),
+        Scalar::Ratio { value } => Ok(*value),
+        Scalar::Text { .. } | Scalar::Date { .. } => DerivedTypeMismatchSnafu {
+            detail: format!("cannot convert {} to numeric", s.kind()),
+        }
+        .fail(),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use jiff::Timestamp;
+
+    fn ts() -> Timestamp {
+        Timestamp::UNIX_EPOCH
+    }
+
+    fn manual_fact(id: &str, value: Scalar, unit: Unit) -> Fact {
+        Fact {
+            id: FactId::new(id).unwrap(),
+            value,
+            unit,
+            source: Source::Manual {
+                note: "test".to_owned(),
+                captured_by: "tester".to_owned(),
+            },
+            captured: ts(),
+        }
+    }
+
+    #[test]
+    fn empty_factbase_validates() {
+        let fb = Factbase::new();
+        assert!(fb.validate().is_ok());
+        let resolved = fb.resolve(&DataSourceRegistry::new()).unwrap();
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
+    fn manual_facts_resolve_to_authored_value() {
+        let mut fb = Factbase::new();
+        fb.add_fact(manual_fact("a", Scalar::Count { value: 7 }, Unit::Count));
+        let resolved = fb.resolve(&DataSourceRegistry::new()).unwrap();
+        let a = resolved.get(&FactId::new("a").unwrap()).unwrap();
+        assert_eq!(a.value, Scalar::Count { value: 7 });
+    }
+
+    #[test]
+    fn derived_sum_resolves() {
+        let mut fb = Factbase::new();
+        fb.add_fact(manual_fact("a", Scalar::Count { value: 3 }, Unit::Count));
+        fb.add_fact(manual_fact("b", Scalar::Count { value: 4 }, Unit::Count));
+        fb.add_fact(Fact {
+            id: FactId::new("total").unwrap(),
+            value: Scalar::Count { value: 0 },
+            unit: Unit::Count,
+            source: Source::Derived {
+                formula: Expr::Add {
+                    a: FactId::new("a").unwrap(),
+                    b: FactId::new("b").unwrap(),
+                },
+                inputs: vec![FactId::new("a").unwrap(), FactId::new("b").unwrap()],
+            },
+            captured: ts(),
+        });
+        let resolved = fb.resolve(&DataSourceRegistry::new()).unwrap();
+        let total = resolved.get(&FactId::new("total").unwrap()).unwrap();
+        assert_eq!(total.value, Scalar::Count { value: 7 });
+    }
+
+    #[test]
+    fn reference_resolves_to_target_value() {
+        let mut fb = Factbase::new();
+        fb.add_fact(manual_fact(
+            "source",
+            Scalar::Count { value: 42 },
+            Unit::Count,
+        ));
+        fb.add_fact(Fact {
+            id: FactId::new("alias").unwrap(),
+            value: Scalar::Count { value: 0 },
+            unit: Unit::Count,
+            source: Source::Reference {
+                fact: FactId::new("source").unwrap(),
+            },
+            captured: ts(),
+        });
+        let resolved = fb.resolve(&DataSourceRegistry::new()).unwrap();
+        let alias = resolved.get(&FactId::new("alias").unwrap()).unwrap();
+        assert_eq!(alias.value, Scalar::Count { value: 42 });
+    }
+
+    #[test]
+    fn cycle_is_detected_with_path_in_error() {
+        let mut fb = Factbase::new();
+        fb.add_fact(Fact {
+            id: FactId::new("a").unwrap(),
+            value: Scalar::Count { value: 0 },
+            unit: Unit::Count,
+            source: Source::Reference {
+                fact: FactId::new("b").unwrap(),
+            },
+            captured: ts(),
+        });
+        fb.add_fact(Fact {
+            id: FactId::new("b").unwrap(),
+            value: Scalar::Count { value: 0 },
+            unit: Unit::Count,
+            source: Source::Reference {
+                fact: FactId::new("a").unwrap(),
+            },
+            captured: ts(),
+        });
+        let err = fb.validate().expect_err("cycle must be detected");
+        let path = match err {
+            FactbaseError::Cycle { path } => path,
+            other => panic!("expected Cycle, got {other:?}"),
+        };
+        assert!(path.contains(&"a".to_owned()));
+        assert!(path.contains(&"b".to_owned()));
+    }
+
+    #[test]
+    fn unknown_reference_rejects_with_named_id() {
+        let mut fb = Factbase::new();
+        fb.add_fact(Fact {
+            id: FactId::new("orphan").unwrap(),
+            value: Scalar::Count { value: 0 },
+            unit: Unit::Count,
+            source: Source::Reference {
+                fact: FactId::new("missing").unwrap(),
+            },
+            captured: ts(),
+        });
+        let err = fb.validate().expect_err("dangling reference must reject");
+        assert!(matches!(err, FactbaseError::UnknownFact { id, .. } if id == "missing"));
+    }
+
+    #[test]
+    fn unknown_claim_target_rejects() {
+        let mut fb = Factbase::new();
+        fb.add_claim(Claim {
+            id: ClaimId::new("c1").unwrap(),
+            text: "x is 1".to_owned(),
+            asserts: FactId::new("absent").unwrap(),
+            location: Location {
+                at: "deck/slide/1".to_owned(),
+            },
+            tolerance: Tolerance::STRICT,
+        });
+        let err = fb.validate().expect_err("claim of absent fact rejects");
+        assert!(matches!(err, FactbaseError::UnknownFact { id, .. } if id == "absent"));
+    }
+
+    #[test]
+    fn sql_without_adapter_rejects_with_named_data_source() {
+        let mut fb = Factbase::new();
+        fb.add_fact(Fact {
+            id: FactId::new("from_db").unwrap(),
+            value: Scalar::Count { value: 0 },
+            unit: Unit::Count,
+            source: Source::Sql {
+                data_source: DataSourceId::new("redshift_prod").unwrap(),
+                query: "SELECT 1".to_owned(),
+                table: "totals".to_owned(),
+            },
+            captured: ts(),
+        });
+        let err = fb
+            .resolve(&DataSourceRegistry::new())
+            .expect_err("missing adapter");
+        match err {
+            FactbaseError::MissingDataSource { data_source, .. } => {
+                assert_eq!(data_source, "redshift_prod");
+            }
+            other => panic!("expected MissingDataSource, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn type_mismatch_in_derived_rejects() {
+        let mut fb = Factbase::new();
+        fb.add_fact(manual_fact(
+            "count",
+            Scalar::Count { value: 3 },
+            Unit::Count,
+        ));
+        fb.add_fact(manual_fact(
+            "money",
+            Scalar::Money {
+                value: Money::from_units(7).expect("in range"),
+            },
+            Unit::Usd,
+        ));
+        fb.add_fact(Fact {
+            id: FactId::new("mix").unwrap(),
+            value: Scalar::Count { value: 0 },
+            unit: Unit::Count,
+            source: Source::Derived {
+                formula: Expr::Add {
+                    a: FactId::new("count").unwrap(),
+                    b: FactId::new("money").unwrap(),
+                },
+                inputs: vec![FactId::new("count").unwrap(), FactId::new("money").unwrap()],
+            },
+            captured: ts(),
+        });
+        let err = fb
+            .resolve(&DataSourceRegistry::new())
+            .expect_err("type mismatch");
+        assert!(matches!(err, FactbaseError::DerivedTypeMismatch { .. }));
+    }
+}

--- a/crates/poiesis/core/src/ids.rs
+++ b/crates/poiesis/core/src/ids.rs
@@ -1,0 +1,306 @@
+//! Typed identifier newtypes for the envelope, factbase, and registry.
+//!
+//! Every identifier the agent or operator authors lands here as a typed
+//! newtype whose construction enforces a charset and a length bound. Bare
+//! `String`s are forbidden at the public surface; raw construction is a
+//! `TryFrom<&str>` returning [`IdError`].
+//!
+//! The charset is intentionally narrow (lowercase ASCII letters, digits,
+//! `_`, `-`) for `ComponentId`, `ThemeId`, `DataSourceId` because they map
+//! to filesystem paths. `FactId`, `ClaimId`, `SheetName` accept a slightly
+//! wider set so spec authors can write human-recognisable names.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{EmptySnafu, IdError, InvalidCharSnafu, TooLongSnafu};
+
+const FS_SAFE_MAX: usize = 64;
+const HUMAN_NAME_MAX: usize = 128;
+
+/// An identifier whose characters must be safe to embed in a filesystem path:
+/// lowercase ASCII `a-z`, digits `0-9`, `_`, `-`. First character must be a
+/// letter.
+fn validate_fs_safe(input: &str, kind: &'static str) -> Result<(), IdError> {
+    if input.is_empty() {
+        return EmptySnafu { kind }.fail();
+    }
+    if input.len() > FS_SAFE_MAX {
+        return TooLongSnafu {
+            kind,
+            input,
+            got: input.len(),
+            max: FS_SAFE_MAX,
+        }
+        .fail();
+    }
+    let mut chars = input.chars();
+    let Some(first) = chars.next() else {
+        return EmptySnafu { kind }.fail();
+    };
+    if !first.is_ascii_lowercase() {
+        return InvalidCharSnafu {
+            kind,
+            input,
+            ch: first,
+            allowed: "first character must be lowercase ASCII letter (a-z)",
+        }
+        .fail();
+    }
+    for ch in chars {
+        let ok = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_' || ch == '-';
+        if !ok {
+            return InvalidCharSnafu {
+                kind,
+                input,
+                ch,
+                allowed: "lowercase ASCII letters, digits, '_', '-'",
+            }
+            .fail();
+        }
+    }
+    Ok(())
+}
+
+/// An identifier that may carry human-readable characters: ASCII letters,
+/// digits, `_`, `-`, `.`, space. Disallows control characters and ASCII
+/// quotes/brackets that would confuse error messages.
+fn validate_human_name(input: &str, kind: &'static str) -> Result<(), IdError> {
+    if input.is_empty() {
+        return EmptySnafu { kind }.fail();
+    }
+    if input.len() > HUMAN_NAME_MAX {
+        return TooLongSnafu {
+            kind,
+            input,
+            got: input.len(),
+            max: HUMAN_NAME_MAX,
+        }
+        .fail();
+    }
+    for ch in input.chars() {
+        let ok = ch.is_ascii_alphanumeric()
+            || matches!(ch, '_' | '-' | '.' | ' ' | ':' | '/')
+            || (!ch.is_ascii() && !ch.is_control());
+        if !ok {
+            return InvalidCharSnafu {
+                kind,
+                input,
+                ch,
+                allowed: "alphanumerics, underscore, hyphen, dot, space, colon, slash, non-ASCII non-control",
+            }
+            .fail();
+        }
+    }
+    Ok(())
+}
+
+macro_rules! fs_safe_id {
+    ($name:ident, $kind:literal, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+        #[serde(try_from = "String", into = "String")]
+        pub struct $name(String);
+
+        impl $name {
+            #[doc = concat!("Construct a `", stringify!($name), "` from a string, validating charset and length.")]
+            ///
+            /// # Errors
+            ///
+            /// Returns [`IdError`] if the input is empty, too long, or contains
+            /// disallowed characters.
+            pub fn new(s: impl Into<String>) -> Result<Self, IdError> {
+                let s = s.into();
+                validate_fs_safe(&s, $kind)?;
+                Ok(Self(s))
+            }
+
+            /// Borrow the inner string slice.
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = IdError;
+            fn try_from(s: String) -> Result<Self, Self::Error> {
+                Self::new(s)
+            }
+        }
+
+        impl TryFrom<&str> for $name {
+            type Error = IdError;
+            fn try_from(s: &str) -> Result<Self, Self::Error> {
+                Self::new(s.to_owned())
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+    };
+}
+
+macro_rules! human_id {
+    ($name:ident, $kind:literal, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+        #[serde(try_from = "String", into = "String")]
+        pub struct $name(String);
+
+        impl $name {
+            #[doc = concat!("Construct a `", stringify!($name), "` from a string, validating charset and length.")]
+            ///
+            /// # Errors
+            ///
+            /// Returns [`IdError`] if the input is empty, too long, or contains
+            /// disallowed characters.
+            pub fn new(s: impl Into<String>) -> Result<Self, IdError> {
+                let s = s.into();
+                validate_human_name(&s, $kind)?;
+                Ok(Self(s))
+            }
+
+            /// Borrow the inner string slice.
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = IdError;
+            fn try_from(s: String) -> Result<Self, Self::Error> {
+                Self::new(s)
+            }
+        }
+
+        impl TryFrom<&str> for $name {
+            type Error = IdError;
+            fn try_from(s: &str) -> Result<Self, Self::Error> {
+                Self::new(s.to_owned())
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+    };
+}
+
+fs_safe_id!(
+    ComponentId,
+    "component",
+    "Identifier of a component pack discovered under `components/<id>/`."
+);
+fs_safe_id!(
+    ThemeId,
+    "theme",
+    "Identifier of a theme registered with `poiesis-theme`."
+);
+fs_safe_id!(
+    DataSourceId,
+    "data_source",
+    "Identifier of a configured [`crate::factbase::DataSource`] adapter."
+);
+human_id!(
+    FactId,
+    "fact",
+    "Identifier of a [`crate::factbase::Fact`] entry in a `Factbase`."
+);
+human_id!(
+    ClaimId,
+    "claim",
+    "Identifier of a [`crate::factbase::Claim`] entry in a `Factbase`."
+);
+human_id!(
+    SheetName,
+    "sheet",
+    "Display name of a workbook sheet; constrained to safe characters."
+);
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_id_accepts_canonical() {
+        let id = ComponentId::new("stat_cards").expect("canonical id is valid");
+        assert_eq!(id.as_str(), "stat_cards");
+    }
+
+    #[test]
+    fn component_id_rejects_empty() {
+        let err = ComponentId::new("").expect_err("empty id must reject");
+        assert!(matches!(err, IdError::Empty { kind: "component" }));
+    }
+
+    #[test]
+    fn component_id_rejects_uppercase() {
+        let err = ComponentId::new("StatCards").expect_err("uppercase must reject");
+        assert!(matches!(err, IdError::InvalidChar { ch: 'S', .. }));
+    }
+
+    #[test]
+    fn component_id_rejects_leading_digit() {
+        let err = ComponentId::new("2up").expect_err("leading digit must reject");
+        assert!(matches!(err, IdError::InvalidChar { ch: '2', .. }));
+    }
+
+    #[test]
+    fn component_id_rejects_overlong() {
+        let s = "a".repeat(FS_SAFE_MAX + 1);
+        let err = ComponentId::new(s).expect_err("overlong id must reject");
+        assert!(matches!(err, IdError::TooLong { .. }));
+    }
+
+    #[test]
+    fn theme_id_round_trips_via_serde() {
+        let id = ThemeId::new("summus").expect("canonical theme is valid");
+        let json = serde_json::to_string(&id).expect("serialize");
+        assert_eq!(json, "\"summus\"");
+        let back: ThemeId = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, id);
+    }
+
+    #[test]
+    fn fact_id_accepts_human_chars() {
+        let id = FactId::new("revenue.fy26.q1").expect("human name with dot is valid");
+        assert_eq!(id.as_str(), "revenue.fy26.q1");
+    }
+
+    #[test]
+    fn fact_id_rejects_quote() {
+        let err = FactId::new("bad\"name").expect_err("quote must reject");
+        assert!(matches!(err, IdError::InvalidChar { ch: '"', .. }));
+    }
+
+    #[test]
+    fn sheet_name_accepts_space() {
+        let n = SheetName::new("Q1 Receipts").expect("spaces allowed in sheet names");
+        assert_eq!(n.as_str(), "Q1 Receipts");
+    }
+
+    #[test]
+    fn serde_rejects_invalid_via_try_from() {
+        let err: Result<ComponentId, _> = serde_json::from_str("\"BAD\"");
+        assert!(err.is_err());
+    }
+}

--- a/crates/poiesis/core/src/lib.rs
+++ b/crates/poiesis/core/src/lib.rs
@@ -1,26 +1,133 @@
 #![deny(missing_docs)]
-//! poiesis-core: format-agnostic document model and Renderer trait.
+//! poiesis-core: typed deliverable envelope, factbase, and open component
+//! registry — the model every poiesis render path consumes and the QA gate
+//! runs over.
 //!
-//! Poiesis (ποίησις): "making, creation." The core crate defines a
-//! format-agnostic document tree that all poiesis backends consume.
-//! Backends implement the [`Renderer`] trait to produce format-specific bytes.
+//! Poiesis (ποίησις): "making, creation."
+//!
+//! # Substrate at a glance
+//!
+//! This crate exposes four layered surfaces:
+//!
+//! 1. **Identifiers and scalars** ([`ids`], [`scalar`]) — typed newtypes for
+//!    every name and value the operator authors. Parse-don't-validate at the
+//!    boundary; renderers and QA never see naked strings or floats.
+//! 2. **Factbase** ([`factbase`]) — every cited number lives here, tagged
+//!    with a [`scalar::Unit`] and a [`factbase::Source`]. The citation graph
+//!    is DAG-resolved with cycle detection before any data adapter is
+//!    invoked.
+//! 3. **Open component registry** ([`components`]) — slide / block component
+//!    packs discovered from a filesystem root. Adding a component means
+//!    dropping a pack; no core recompile.
+//! 4. **Envelope** ([`envelope`]) — a [`envelope::DeliverableSpec`] wraps
+//!    typed [`envelope::Meta`], a [`ids::ThemeId`], a
+//!    [`factbase::Factbase`], and a [`envelope::Body`] that selects between
+//!    [`bodies::Deck`], [`bodies::DocumentBody`], or [`bodies::Workbook`].
+//!
+//! # Compatibility with the existing `Document` path
+//!
+//! The pre-envelope [`document::Document`] / [`block::Block`] /
+//! [`renderer::Renderer`] surface is preserved verbatim for the in-tree
+//! `organon` consumer. The new envelope wraps a [`document::Document`]
+//! inside [`bodies::DocumentBody`], so no existing call site changes. The
+//! render-side trait evolution to
+//! `render(&DeliverableSpec, &ResolvedTheme) → Artifact` ships with the
+//! render-side B-NNN entries; this crate carries the typed [`Artifact`]
+//! shape only.
 
-/// Block-level document elements: headings, paragraphs, tables, lists, images.
+// New B-001 surface.
+/// Typed bodies wrapping the existing [`document::Document`] and adding
+/// [`bodies::Deck`] / [`bodies::Workbook`] siblings.
+pub mod bodies;
+/// Open component registry: discovery, schema-validated
+/// [`components::ComponentDef`]s.
+pub mod components;
+/// The deliverable envelope: typed metadata, theme reference, factbase,
+/// body.
+pub mod envelope;
+/// Error types raised at every parse-don't-validate boundary.
+pub mod error;
+/// The factbase: typed facts, sources, claims, and the DAG resolver.
+pub mod factbase;
+/// Typed identifier newtypes (component, theme, fact, claim, sheet, data
+/// source).
+pub mod ids;
+/// Typed scalars, units, aspect ratio, tolerance.
+pub mod scalar;
+
+// Pre-existing surface retained verbatim for organon back-compat.
+/// Block-level document elements: headings, paragraphs, tables, lists,
+/// images.
 pub mod block;
 /// Top-level [`Document`] type assembling metadata and content blocks.
 pub mod document;
 /// Document metadata: title, author, creation timestamp.
 pub mod metadata;
-/// [`Renderer`] trait for format backends.
+/// [`Renderer`] trait for format backends (legacy signature; render-side
+/// B-NNN evolve this).
 pub mod renderer;
 /// Inline rich text spans: plain, bold, italic, code, links.
 pub mod rich_text;
 
+// Re-exports — pre-existing.
 pub use block::{Block, Image, ListItem, Table};
 pub use document::Document;
 pub use metadata::Metadata;
 pub use renderer::Renderer;
 pub use rich_text::{RichText, Span};
+
+// Re-exports — new B-001 surface.
+pub use bodies::{Deck, DocumentBody, Sheet, Slide, Workbook, WorkbookCell};
+pub use components::{ComponentDef, ComponentRegistry, TokenRef};
+pub use envelope::{Body, DeliverableSpec, Meta};
+pub use error::{FactbaseError, IdError, PoiesisError, RegistryError, ScalarError, SpecError};
+pub use factbase::{
+    Claim, DataSource, DataSourceRegistry, Expr, Fact, Factbase, Location, ResolvedFact, Source,
+};
+pub use ids::{ClaimId, ComponentId, DataSourceId, FactId, SheetName, ThemeId};
+pub use scalar::{AspectRatio, Money, Scalar, ScalarKind, Tolerance, Unit};
+
+/// The typed output of a renderer in the envelope-aware world.
+///
+/// `Artifact` carries the produced bytes plus the format identifier and the
+/// concrete body kind the render produced. The pre-existing
+/// [`Renderer::render`] still returns bare `Vec<u8>`; render-side B-NNN
+/// entries (B-003 / B-004 / B-006 / B-007) evolve to producing `Artifact`
+/// via a new trait that they own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Artifact {
+    /// The format identifier, e.g. `"pdf"`, `"pptx"`, `"docx"`, `"xlsx"`,
+    /// `"html"`.
+    pub format: String,
+    /// The body kind the artifact represents.
+    pub body_kind: BodyKind,
+    /// The complete byte payload.
+    pub bytes: Vec<u8>,
+}
+
+/// The kind tag of a [`bodies`] arm; useful for runtime dispatch in the
+/// renderer trait that B-003+ will introduce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BodyKind {
+    /// A deck composed of [`bodies::Slide`]s.
+    Deck,
+    /// A prose document (pre-envelope [`document::Document`]).
+    Document,
+    /// A workbook of named [`bodies::Sheet`]s.
+    Workbook,
+}
+
+impl BodyKind {
+    /// Short canonical name used in errors and serialised form.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Deck => "deck",
+            Self::Document => "document",
+            Self::Workbook => "workbook",
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/poiesis/core/src/scalar.rs
+++ b/crates/poiesis/core/src/scalar.rs
@@ -1,0 +1,511 @@
+//! Typed values that replace naked numbers and strings at the model boundary.
+//!
+//! Every numeric value that enters a deliverable lives in a [`Scalar`] tagged
+//! with a [`Unit`]. The render-side never sees a bare `f64`; the QA gate
+//! reasons in typed units. Money is represented in integer micro-units to
+//! avoid pulling a decimal arithmetic crate while preserving exact accounting
+//! to four-decimal precision.
+
+use std::fmt;
+use std::str::FromStr;
+
+use jiff::civil::Date;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{
+    BadAspectSnafu, BadMoneySnafu, BadToleranceSnafu, ScalarError, UnknownUnitSnafu,
+};
+
+/// The kind tag describing the shape of a [`Scalar`].
+///
+/// `ScalarKind` is what the model carries when it needs to talk about a
+/// scalar's *type* without an instance — workbook column types are the
+/// motivating consumer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScalarKind {
+    /// Whole-number counts (`Count(i64)`).
+    Count,
+    /// Monetary amounts (`Money` — `i64` micro-units).
+    Money,
+    /// Dimensionless ratios (`Ratio(f64)`); use [`Unit::Percent`] when display
+    /// should multiply by 100.
+    Ratio,
+    /// Free-form text values.
+    Text,
+    /// Calendar dates.
+    Date,
+}
+
+impl ScalarKind {
+    /// Short canonical name used in error messages and serialized form.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Count => "count",
+            Self::Money => "money",
+            Self::Ratio => "ratio",
+            Self::Text => "text",
+            Self::Date => "date",
+        }
+    }
+}
+
+impl fmt::Display for ScalarKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Monetary amount stored as signed micro-units (1 unit = 1e-6 of the
+/// presentation currency). The `i64` micro-unit range covers ±9.22 × 10¹²
+/// major units, comfortably more than any deliverable will carry while
+/// staying inside the native `serde_json` integer range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Money(i64);
+
+impl Money {
+    /// Construct a `Money` directly from micro-units.
+    #[must_use]
+    pub const fn from_micros(micros: i64) -> Self {
+        Self(micros)
+    }
+
+    /// The amount in micro-units.
+    #[must_use]
+    pub const fn micros(self) -> i64 {
+        self.0
+    }
+
+    /// Build a `Money` from a major-unit integer (e.g. `from_units(150)` = $150.00).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ScalarError::BadMoney`] if multiplication overflows the
+    /// representable range (`±9.22e12` major units).
+    pub fn from_units(units: i64) -> Result<Self, ScalarError> {
+        units
+            .checked_mul(1_000_000)
+            .map(Self)
+            .ok_or_else(|| ScalarError::BadMoney {
+                input: units.to_string(),
+            })
+    }
+
+    /// Build a `Money` from a `(major, micros_fraction)` pair.
+    ///
+    /// `fraction` is the micro-unit portion in `[0, 1_000_000)`; this lets
+    /// callers express e.g. `$1.23` as `Money::from_units_and_fraction(1, 230_000)`
+    /// without floating-point.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ScalarError::BadMoney`] if `fraction` is out of range or
+    /// the magnitude overflows.
+    pub fn from_units_and_fraction(units: i64, fraction: u32) -> Result<Self, ScalarError> {
+        if fraction >= 1_000_000 {
+            return BadMoneySnafu {
+                input: format!("{units}.{fraction:06}"),
+            }
+            .fail();
+        }
+        let sign: i64 = if units < 0 { -1 } else { 1 };
+        let abs_units = units.checked_abs().ok_or_else(|| ScalarError::BadMoney {
+            input: format!("{units}.{fraction:06}"),
+        })?;
+        let scaled = abs_units
+            .checked_mul(1_000_000)
+            .ok_or_else(|| ScalarError::BadMoney {
+                input: format!("{units}.{fraction:06}"),
+            })?;
+        let summed =
+            scaled
+                .checked_add(i64::from(fraction))
+                .ok_or_else(|| ScalarError::BadMoney {
+                    input: format!("{units}.{fraction:06}"),
+                })?;
+        Ok(Self(sign * summed))
+    }
+}
+
+impl fmt::Display for Money {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let micros = self.0;
+        let sign = if micros < 0 { "-" } else { "" };
+        let abs = micros.unsigned_abs();
+        let units = abs / 1_000_000;
+        let fraction = abs % 1_000_000;
+        if fraction == 0 {
+            write!(f, "{sign}{units}")
+        } else {
+            let mut frac = format!("{fraction:06}");
+            while frac.ends_with('0') {
+                frac.pop();
+            }
+            write!(f, "{sign}{units}.{frac}")
+        }
+    }
+}
+
+/// A typed scalar value.
+///
+/// `Scalar` is the model-side representation of an authored value. It is
+/// always paired with a [`Unit`] at the [`crate::factbase::Fact`] level so
+/// callers know *what* the number means in addition to its raw shape.
+// kanon:ignore RUST/non-exhaustive-enum — exhaustive match is part of the
+// stable API; new kinds are an explicit additive evolution.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Scalar {
+    /// Whole-number count.
+    Count {
+        /// The count.
+        value: i64,
+    },
+    /// Monetary amount (see [`Money`]).
+    Money {
+        /// The amount.
+        value: Money,
+    },
+    /// Dimensionless ratio (`0.5` = 50%); pair with [`Unit::Percent`] for display.
+    Ratio {
+        /// The ratio.
+        value: f64,
+    },
+    /// Free-form text.
+    Text {
+        /// The text.
+        value: String,
+    },
+    /// Calendar date.
+    Date {
+        /// The date.
+        value: Date,
+    },
+}
+
+impl Scalar {
+    /// The kind tag of this scalar.
+    #[must_use]
+    pub fn kind(&self) -> ScalarKind {
+        match self {
+            Self::Count { .. } => ScalarKind::Count,
+            Self::Money { .. } => ScalarKind::Money,
+            Self::Ratio { .. } => ScalarKind::Ratio,
+            Self::Text { .. } => ScalarKind::Text,
+            Self::Date { .. } => ScalarKind::Date,
+        }
+    }
+}
+
+/// The presentation unit attached to a [`Scalar`].
+///
+/// Units describe meaning, not magnitude — `Percent` does not multiply the
+/// underlying ratio; it tells the renderer to format `0.42` as `42%`. The
+/// QA gate uses units to reject arithmetic that crosses incompatible
+/// dimensions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Unit {
+    /// A dimensionless count (people, sessions, line items).
+    Count,
+    /// US dollars (presentation currency; see [`Money`] for value shape).
+    Usd,
+    /// Dimensionless percentage; display multiplies the underlying ratio by 100.
+    Percent,
+    /// Dimensionless ratio; display leaves the underlying ratio as-is.
+    Ratio,
+    /// A calendar date.
+    Date,
+    /// Free-form text (label, slug, name).
+    Text,
+}
+
+impl Unit {
+    /// The canonical name as serialized.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Count => "count",
+            Self::Usd => "usd",
+            Self::Percent => "percent",
+            Self::Ratio => "ratio",
+            Self::Date => "date",
+            Self::Text => "text",
+        }
+    }
+
+    /// Whether this unit is compatible with the given [`ScalarKind`].
+    ///
+    /// `Unit::Percent` and `Unit::Ratio` pair with `ScalarKind::Ratio`;
+    /// `Unit::Usd` pairs with `ScalarKind::Money`; the rest pair 1:1 with
+    /// their like-named kind.
+    #[must_use]
+    pub fn compatible_with(self, kind: ScalarKind) -> bool {
+        matches!(
+            (self, kind),
+            (Self::Count, ScalarKind::Count)
+                | (Self::Usd, ScalarKind::Money)
+                | (Self::Percent | Self::Ratio, ScalarKind::Ratio)
+                | (Self::Date, ScalarKind::Date)
+                | (Self::Text, ScalarKind::Text)
+        )
+    }
+}
+
+impl fmt::Display for Unit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Unit {
+    type Err = ScalarError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "count" => Ok(Self::Count),
+            "usd" => Ok(Self::Usd),
+            "percent" => Ok(Self::Percent),
+            "ratio" => Ok(Self::Ratio),
+            "date" => Ok(Self::Date),
+            "text" => Ok(Self::Text),
+            _ => UnknownUnitSnafu { input: s }.fail(),
+        }
+    }
+}
+
+/// A slide aspect ratio expressed as `width:height` integer pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct AspectRatio {
+    width: u16,
+    height: u16,
+}
+
+impl AspectRatio {
+    /// 16:9 widescreen.
+    pub const WIDESCREEN_16_9: Self = Self {
+        width: 16,
+        height: 9,
+    };
+    /// 4:3 standard.
+    pub const STANDARD_4_3: Self = Self {
+        width: 4,
+        height: 3,
+    };
+
+    /// Construct an aspect ratio from a `(width, height)` integer pair.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ScalarError::BadAspect`] if either dimension is zero.
+    pub fn new(width: u16, height: u16) -> Result<Self, ScalarError> {
+        if width == 0 || height == 0 {
+            return BadAspectSnafu {
+                input: format!("{width}:{height}"),
+            }
+            .fail();
+        }
+        Ok(Self { width, height })
+    }
+
+    /// The width component.
+    #[must_use]
+    pub fn width(self) -> u16 {
+        self.width
+    }
+
+    /// The height component.
+    #[must_use]
+    pub fn height(self) -> u16 {
+        self.height
+    }
+}
+
+impl fmt::Display for AspectRatio {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.width, self.height)
+    }
+}
+
+impl FromStr for AspectRatio {
+    type Err = ScalarError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(':').collect();
+        let [w, h] = match parts.as_slice() {
+            [w, h] => [*w, *h],
+            _ => return BadAspectSnafu { input: s }.fail(),
+        };
+        let Ok(width) = w.parse::<u16>() else {
+            return BadAspectSnafu { input: s }.fail();
+        };
+        let Ok(height) = h.parse::<u16>() else {
+            return BadAspectSnafu { input: s }.fail();
+        };
+        Self::new(width, height)
+    }
+}
+
+impl TryFrom<String> for AspectRatio {
+    type Error = ScalarError;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::from_str(&s)
+    }
+}
+
+impl From<AspectRatio> for String {
+    fn from(value: AspectRatio) -> Self {
+        value.to_string()
+    }
+}
+
+/// A numeric tolerance used by the QA gate when comparing computed and
+/// claimed values. `0.0` requires exact equality; `0.01` allows a 1%
+/// relative difference.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "f64", into = "f64")]
+pub struct Tolerance(f64);
+
+impl Tolerance {
+    /// Strict-equality tolerance; the default for claim verification.
+    pub const STRICT: Self = Self(0.0);
+
+    /// Construct a tolerance in the closed unit interval `[0.0, 1.0]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ScalarError::BadTolerance`] if the value is `NaN`, negative,
+    /// or greater than `1.0`.
+    pub fn new(value: f64) -> Result<Self, ScalarError> {
+        if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+            return BadToleranceSnafu { value }.fail();
+        }
+        Ok(Self(value))
+    }
+
+    /// The tolerance as an `f64`.
+    #[must_use]
+    pub fn as_f64(self) -> f64 {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for Tolerance {
+    type Error = ScalarError;
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<Tolerance> for f64 {
+    fn from(value: Tolerance) -> Self {
+        value.0
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn money_from_units_round_trips() {
+        let m = Money::from_units(150).expect("in range");
+        assert_eq!(m.micros(), 150_000_000);
+        assert_eq!(m.to_string(), "150");
+    }
+
+    #[test]
+    fn money_fractional_displays_trimmed() {
+        let m = Money::from_units_and_fraction(1, 230_000).expect("valid");
+        assert_eq!(m.to_string(), "1.23");
+    }
+
+    #[test]
+    fn money_negative_displays_with_sign() {
+        let m = Money::from_units(-42).expect("in range");
+        assert_eq!(m.to_string(), "-42");
+    }
+
+    #[test]
+    fn money_rejects_out_of_range_fraction() {
+        let err = Money::from_units_and_fraction(1, 1_000_000).expect_err("rejected");
+        assert!(matches!(err, ScalarError::BadMoney { .. }));
+    }
+
+    #[test]
+    fn unit_round_trips_via_string() {
+        for u in [
+            Unit::Count,
+            Unit::Usd,
+            Unit::Percent,
+            Unit::Ratio,
+            Unit::Date,
+            Unit::Text,
+        ] {
+            let back: Unit = u.as_str().parse().expect("parse");
+            assert_eq!(back, u);
+        }
+    }
+
+    #[test]
+    fn unit_rejects_unknown() {
+        let err: Result<Unit, _> = "furlong".parse();
+        assert!(matches!(err, Err(ScalarError::UnknownUnit { .. })));
+    }
+
+    #[test]
+    fn unit_compatibility_holds() {
+        assert!(Unit::Percent.compatible_with(ScalarKind::Ratio));
+        assert!(Unit::Ratio.compatible_with(ScalarKind::Ratio));
+        assert!(Unit::Usd.compatible_with(ScalarKind::Money));
+        assert!(!Unit::Count.compatible_with(ScalarKind::Money));
+        assert!(!Unit::Date.compatible_with(ScalarKind::Count));
+    }
+
+    #[test]
+    fn aspect_ratio_parses_and_round_trips() {
+        let a: AspectRatio = "16:9".parse().expect("parse");
+        assert_eq!(a, AspectRatio::WIDESCREEN_16_9);
+        assert_eq!(a.to_string(), "16:9");
+    }
+
+    #[test]
+    fn aspect_ratio_rejects_zero_height() {
+        let err: Result<AspectRatio, _> = "16:0".parse();
+        assert!(matches!(err, Err(ScalarError::BadAspect { .. })));
+    }
+
+    #[test]
+    fn tolerance_rejects_negative_and_nan() {
+        assert!(matches!(
+            Tolerance::new(-0.1),
+            Err(ScalarError::BadTolerance { .. })
+        ));
+        assert!(matches!(
+            Tolerance::new(f64::NAN),
+            Err(ScalarError::BadTolerance { .. })
+        ));
+        assert!(matches!(
+            Tolerance::new(1.5),
+            Err(ScalarError::BadTolerance { .. })
+        ));
+    }
+
+    #[test]
+    fn scalar_kind_matches_variant() {
+        let s = Scalar::Count { value: 7 };
+        assert_eq!(s.kind(), ScalarKind::Count);
+    }
+
+    #[test]
+    fn scalar_round_trips_via_serde() {
+        let s = Scalar::Money {
+            value: Money::from_units(100).expect("in range"),
+        };
+        let json = serde_json::to_string(&s).expect("ser");
+        let back: Scalar = serde_json::from_str(&json).expect("de");
+        assert_eq!(back, s);
+    }
+}

--- a/crates/poiesis/core/tests/acceptance_b001.rs
+++ b/crates/poiesis/core/tests/acceptance_b001.rs
@@ -1,0 +1,564 @@
+//! B-001 acceptance tests.
+//!
+//! Mirrors the five acceptance criteria from the planning entry:
+//!
+//! 1. Round-trip a valid spec.
+//! 2. Reject planted-bad specs with precise (JSON-pointer) errors.
+//! 3. Drop-a-pack works (filesystem discovery + slot validation without core
+//!    recompile).
+//! 4. Factbase resolves; the citation graph is DAG-checked.
+//! 5. Current `organon`-shaped `Document` → `Renderer` path compiles and runs
+//!    unchanged.
+
+#![expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "integration tests can panic-on-fail; serde_json::Value indexing is the natural access pattern"
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use jiff::Timestamp;
+use poiesis_core::{
+    AspectRatio, Block, Body, Claim, ClaimId, ComponentId, ComponentRegistry, DataSourceRegistry,
+    Deck, DeliverableSpec, Document, DocumentBody, Expr, Fact, FactId, Factbase, Location, Meta,
+    Metadata, Money, Renderer, RichText, Scalar, ScalarKind, Sheet, SheetName, Slide, Source, Span,
+    ThemeId, Tolerance, Unit, Workbook, WorkbookCell,
+};
+use serde_json::json;
+
+// =========================================================================
+// Acceptance #1 — round-trip a valid spec for each body kind.
+// =========================================================================
+
+#[test]
+fn acceptance_round_trip_deck_spec() {
+    let spec = DeliverableSpec {
+        meta: Meta::new("offsite-2026-q1").expect("title"),
+        theme: ThemeId::new("summus").expect("theme id"),
+        facts: empty_factbase(),
+        body: Body::Deck(Deck {
+            aspect: AspectRatio::WIDESCREEN_16_9,
+            slides: vec![Slide {
+                component: ComponentId::new("title").expect("component id"),
+                fields: json!({"text": "Welcome"}),
+                notes: None,
+            }],
+        }),
+    };
+    let json_text = serde_json::to_string(&spec).expect("ser");
+    let back: DeliverableSpec = serde_json::from_str(&json_text).expect("de");
+    assert_eq!(back, spec);
+}
+
+#[test]
+fn acceptance_round_trip_workbook_spec() {
+    let spec = DeliverableSpec {
+        meta: Meta::new("Q1 ledger").expect("title"),
+        theme: ThemeId::new("summus").expect("theme id"),
+        facts: empty_factbase(),
+        body: Body::Workbook(Workbook {
+            sheets: vec![Sheet {
+                name: SheetName::new("Receipts").expect("sheet name"),
+                headers: vec!["Description".to_owned(), "Amount".to_owned()],
+                rows: vec![vec![
+                    WorkbookCell::Lit {
+                        value: Scalar::Text {
+                            value: "Software".to_owned(),
+                        },
+                    },
+                    WorkbookCell::Lit {
+                        value: Scalar::Money {
+                            value: Money::from_units(150).expect("range"),
+                        },
+                    },
+                ]],
+                column_types: vec![ScalarKind::Text, ScalarKind::Money],
+            }],
+        }),
+    };
+    let json_text = serde_json::to_string(&spec).expect("ser");
+    let back: DeliverableSpec = serde_json::from_str(&json_text).expect("de");
+    assert_eq!(back, spec);
+}
+
+#[test]
+fn acceptance_round_trip_document_spec() {
+    let spec = DeliverableSpec {
+        meta: Meta::new("README").expect("title"),
+        theme: ThemeId::new("summus").expect("theme id"),
+        facts: empty_factbase(),
+        body: Body::Document(poiesis_core::envelope::DocumentBodyRepr {
+            title: "README".to_owned(),
+        }),
+    };
+    let json_text = serde_json::to_string(&spec).expect("ser");
+    let back: DeliverableSpec = serde_json::from_str(&json_text).expect("de");
+    assert_eq!(back, spec);
+}
+
+// =========================================================================
+// Acceptance #2 — reject planted-bad specs with precise errors.
+// =========================================================================
+
+#[test]
+fn acceptance_reject_missing_required_meta_field() {
+    let m = Meta {
+        title: String::new(),
+        author: None,
+        created: None,
+        subject: None,
+        keywords: Vec::new(),
+    };
+    let err = m.validate().expect_err("empty title rejects");
+    match err {
+        poiesis_core::SpecError::MissingMetaField { field } => assert_eq!(field, "title"),
+        other => panic!("unexpected: {other:?}"),
+    }
+}
+
+#[test]
+fn acceptance_reject_unknown_component_in_deck() {
+    let spec = DeliverableSpec {
+        meta: Meta::new("pitch").expect("title"),
+        theme: ThemeId::new("summus").expect("theme id"),
+        facts: empty_factbase(),
+        body: Body::Deck(Deck {
+            aspect: AspectRatio::WIDESCREEN_16_9,
+            slides: vec![Slide {
+                component: ComponentId::new("ghost").expect("id"),
+                fields: json!({}),
+                notes: None,
+            }],
+        }),
+    };
+    let err = spec
+        .validate(&ComponentRegistry::new(), &[])
+        .expect_err("unknown component rejects");
+    match err {
+        poiesis_core::PoiesisError::Registry {
+            source: poiesis_core::RegistryError::UnknownComponent { component },
+        } => assert_eq!(component, "ghost"),
+        other => panic!("unexpected: {other:?}"),
+    }
+}
+
+#[test]
+fn acceptance_reject_bad_slot_type_with_json_pointer() {
+    let tmp = TestTempDir::new();
+    write_pack(
+        tmp.path(),
+        "hero",
+        r#"{"type":"object","required":["count"],"properties":{"count":{"type":"integer"}}}"#,
+        "[ooxml]\nkind = \"hero\"\n",
+    );
+    let mut registry = ComponentRegistry::new();
+    registry.discover(tmp.path()).expect("discover");
+    let spec = DeliverableSpec {
+        meta: Meta::new("pitch").expect("title"),
+        theme: ThemeId::new("summus").expect("theme id"),
+        facts: empty_factbase(),
+        body: Body::Deck(Deck {
+            aspect: AspectRatio::WIDESCREEN_16_9,
+            slides: vec![Slide {
+                component: ComponentId::new("hero").expect("id"),
+                fields: json!({"count": "three"}),
+                notes: None,
+            }],
+        }),
+    };
+    let err = spec
+        .validate(&registry, &[])
+        .expect_err("bad slot type rejects");
+    match err {
+        poiesis_core::PoiesisError::Registry {
+            source: poiesis_core::RegistryError::SlotValidation { pointer, detail },
+        } => {
+            assert_eq!(pointer, "/count");
+            assert!(detail.contains("integer"));
+        }
+        other => panic!("unexpected: {other:?}"),
+    }
+}
+
+#[test]
+fn acceptance_reject_unknown_theme_when_registry_supplied() {
+    let spec = DeliverableSpec {
+        meta: Meta::new("x").expect("title"),
+        theme: ThemeId::new("missing").expect("theme id"),
+        facts: empty_factbase(),
+        body: Body::Document(poiesis_core::envelope::DocumentBodyRepr {
+            title: "x".to_owned(),
+        }),
+    };
+    let known = vec![ThemeId::new("summus").expect("theme id")];
+    let err = spec
+        .validate(&ComponentRegistry::new(), &known)
+        .expect_err("unknown theme rejects");
+    assert!(matches!(
+        err,
+        poiesis_core::PoiesisError::Spec {
+            source: poiesis_core::SpecError::UnknownTheme { .. }
+        }
+    ));
+}
+
+#[test]
+fn acceptance_reject_citation_cycle_with_path() {
+    let mut facts = Factbase::new();
+    facts.add_fact(Fact {
+        id: FactId::new("a").expect("id"),
+        value: Scalar::Count { value: 0 },
+        unit: Unit::Count,
+        source: Source::Reference {
+            fact: FactId::new("b").expect("id"),
+        },
+        captured: Timestamp::UNIX_EPOCH,
+    });
+    facts.add_fact(Fact {
+        id: FactId::new("b").expect("id"),
+        value: Scalar::Count { value: 0 },
+        unit: Unit::Count,
+        source: Source::Reference {
+            fact: FactId::new("a").expect("id"),
+        },
+        captured: Timestamp::UNIX_EPOCH,
+    });
+    let spec = DeliverableSpec {
+        meta: Meta::new("cycle").expect("title"),
+        theme: ThemeId::new("summus").expect("theme id"),
+        facts,
+        body: Body::Workbook(Workbook { sheets: Vec::new() }),
+    };
+    let err = spec
+        .validate(&ComponentRegistry::new(), &[])
+        .expect_err("cycle");
+    let path = match err {
+        poiesis_core::PoiesisError::Factbase {
+            source: poiesis_core::FactbaseError::Cycle { path },
+        } => path,
+        other => panic!("expected Cycle, got {other:?}"),
+    };
+    assert!(path.contains(&"a".to_owned()));
+    assert!(path.contains(&"b".to_owned()));
+}
+
+#[test]
+fn acceptance_reject_unsourced_claim() {
+    let mut facts = Factbase::new();
+    facts.add_claim(Claim {
+        id: ClaimId::new("c1").expect("id"),
+        text: "x is 7".to_owned(),
+        asserts: FactId::new("absent").expect("id"),
+        location: Location {
+            at: "deck/slide/1".to_owned(),
+        },
+        tolerance: Tolerance::STRICT,
+    });
+    let err = facts.validate().expect_err("unsourced claim rejects");
+    assert!(matches!(
+        err,
+        poiesis_core::FactbaseError::UnknownFact { ref id, .. } if id == "absent"
+    ));
+}
+
+// =========================================================================
+// Acceptance #3 — drop-a-pack works.
+// =========================================================================
+
+#[test]
+fn acceptance_drop_a_pack_discovers_validates_and_lists() {
+    let tmp = TestTempDir::new();
+    write_pack(
+        tmp.path(),
+        "title",
+        r#"{"type":"object","required":["text"],"properties":{"text":{"type":"string","minLength":1}}}"#,
+        "[ooxml]\nkind = \"title\"\n",
+    );
+    write_pack(
+        tmp.path(),
+        "statement",
+        r#"{"type":"object","required":["body"],"properties":{"body":{"type":"string"}}}"#,
+        "[ooxml]\nkind = \"statement\"\n",
+    );
+
+    let mut registry = ComponentRegistry::new();
+    let n = registry.discover(tmp.path()).expect("discover succeeds");
+    assert_eq!(n, 2);
+
+    let listed = registry.list_components();
+    assert_eq!(
+        listed,
+        vec![
+            ComponentId::new("statement").expect("id"),
+            ComponentId::new("title").expect("id"),
+        ]
+    );
+
+    let title_id = ComponentId::new("title").expect("id");
+    let merged = registry
+        .validate_fields(&title_id, &json!({"text": "Welcome"}))
+        .expect("valid fields");
+    assert_eq!(merged["text"], "Welcome");
+
+    let err = registry
+        .validate_fields(&title_id, &json!({}))
+        .expect_err("missing required rejects");
+    assert!(matches!(
+        err,
+        poiesis_core::RegistryError::SlotValidation { ref pointer, .. } if pointer == "/text"
+    ));
+}
+
+// =========================================================================
+// Acceptance #4 — factbase resolves, with cycle detection.
+// =========================================================================
+
+#[test]
+fn acceptance_factbase_resolves_in_declaration_order() {
+    let mut facts = Factbase::new();
+    facts.add_fact(manual("a", Scalar::Count { value: 10 }, Unit::Count));
+    facts.add_fact(manual("b", Scalar::Count { value: 32 }, Unit::Count));
+    facts.add_fact(Fact {
+        id: FactId::new("total").expect("id"),
+        value: Scalar::Count { value: 0 },
+        unit: Unit::Count,
+        source: Source::Derived {
+            formula: Expr::Add {
+                a: FactId::new("a").expect("id"),
+                b: FactId::new("b").expect("id"),
+            },
+            inputs: vec![FactId::new("a").expect("id"), FactId::new("b").expect("id")],
+        },
+        captured: Timestamp::UNIX_EPOCH,
+    });
+    facts.add_fact(Fact {
+        id: FactId::new("alias_total").expect("id"),
+        value: Scalar::Count { value: 0 },
+        unit: Unit::Count,
+        source: Source::Reference {
+            fact: FactId::new("total").expect("id"),
+        },
+        captured: Timestamp::UNIX_EPOCH,
+    });
+
+    let resolved = facts.resolve(&DataSourceRegistry::new()).expect("resolves");
+    let total = resolved
+        .get(&FactId::new("total").expect("id"))
+        .expect("total present");
+    assert_eq!(total.value, Scalar::Count { value: 42 });
+    let alias = resolved
+        .get(&FactId::new("alias_total").expect("id"))
+        .expect("alias present");
+    assert_eq!(alias.value, Scalar::Count { value: 42 });
+}
+
+#[test]
+fn acceptance_factbase_resolves_money_and_ratio() {
+    let mut facts = Factbase::new();
+    facts.add_fact(manual(
+        "revenue",
+        Scalar::Money {
+            value: Money::from_units(1000).expect("range"),
+        },
+        Unit::Usd,
+    ));
+    facts.add_fact(manual(
+        "cost",
+        Scalar::Money {
+            value: Money::from_units(600).expect("range"),
+        },
+        Unit::Usd,
+    ));
+    facts.add_fact(Fact {
+        id: FactId::new("profit").expect("id"),
+        value: Scalar::Money {
+            value: Money::from_micros(0),
+        },
+        unit: Unit::Usd,
+        source: Source::Derived {
+            formula: Expr::Sub {
+                a: FactId::new("revenue").expect("id"),
+                b: FactId::new("cost").expect("id"),
+            },
+            inputs: vec![
+                FactId::new("revenue").expect("id"),
+                FactId::new("cost").expect("id"),
+            ],
+        },
+        captured: Timestamp::UNIX_EPOCH,
+    });
+    facts.add_fact(Fact {
+        id: FactId::new("margin").expect("id"),
+        value: Scalar::Ratio { value: 0.0 },
+        unit: Unit::Percent,
+        source: Source::Derived {
+            formula: Expr::Div {
+                a: FactId::new("profit").expect("id"),
+                b: FactId::new("revenue").expect("id"),
+            },
+            inputs: vec![
+                FactId::new("profit").expect("id"),
+                FactId::new("revenue").expect("id"),
+            ],
+        },
+        captured: Timestamp::UNIX_EPOCH,
+    });
+
+    let resolved = facts.resolve(&DataSourceRegistry::new()).expect("resolves");
+    let profit = resolved
+        .get(&FactId::new("profit").expect("id"))
+        .expect("profit present");
+    assert_eq!(
+        profit.value,
+        Scalar::Money {
+            value: Money::from_units(400).expect("range"),
+        }
+    );
+    let margin = resolved
+        .get(&FactId::new("margin").expect("id"))
+        .expect("margin present");
+    let Scalar::Ratio { value: m } = margin.value else {
+        panic!("margin is not a ratio");
+    };
+    assert!((m - 0.4).abs() < 1e-9);
+}
+
+#[test]
+fn acceptance_factbase_skips_sql_when_no_adapter_configured() {
+    // A factbase with NO Sql facts must resolve cleanly without any
+    // DataSource adapter (the "no data deps for a deck with no Sql facts"
+    // contract).
+    let mut facts = Factbase::new();
+    facts.add_fact(manual("only", Scalar::Count { value: 1 }, Unit::Count));
+    let resolved = facts
+        .resolve(&DataSourceRegistry::new())
+        .expect("no-Sql factbase resolves with empty registry");
+    assert_eq!(resolved.len(), 1);
+}
+
+// =========================================================================
+// Acceptance #5 — legacy organon → Document → Renderer path still works.
+// =========================================================================
+
+/// A stand-in for organon's render path: take a `Document`, produce bytes
+/// via a `Renderer`. This compiles iff the pre-envelope surface remains
+/// unchanged, which is the contract we promised.
+struct PlaintextRenderer;
+
+impl Renderer for PlaintextRenderer {
+    type Error = std::io::Error;
+
+    fn render(&self, doc: &Document) -> Result<Vec<u8>, Self::Error> {
+        let mut buf = String::new();
+        buf.push_str(&doc.metadata.title);
+        buf.push('\n');
+        for block in &doc.content {
+            match block {
+                Block::Heading { text, .. } | Block::Paragraph(text) => {
+                    buf.push_str(&text.plain_text());
+                    buf.push('\n');
+                }
+                Block::Table(_) | Block::List { .. } | Block::Image(_) | Block::PageBreak => {}
+            }
+        }
+        Ok(buf.into_bytes())
+    }
+
+    fn format(&self) -> &'static str {
+        "txt"
+    }
+}
+
+#[test]
+fn acceptance_legacy_renderer_path_compiles_and_runs() {
+    let doc = Document {
+        metadata: Metadata {
+            title: "Hello".to_owned(),
+            author: Some("Operator".to_owned()),
+            created: None,
+        },
+        content: vec![
+            Block::Heading {
+                level: 1,
+                text: RichText {
+                    spans: vec![Span::Plain("World".to_owned())],
+                },
+            },
+            Block::Paragraph(RichText {
+                spans: vec![Span::Plain("Hello, world.".to_owned())],
+            }),
+        ],
+    };
+    let renderer = PlaintextRenderer;
+    let bytes = renderer.render(&doc).expect("renders");
+    let text = String::from_utf8(bytes).expect("utf8");
+    assert!(text.starts_with("Hello\nWorld\nHello, world."));
+    assert_eq!(renderer.format(), "txt");
+}
+
+#[test]
+fn acceptance_legacy_document_round_trips_through_envelope() {
+    // Wrap a legacy Document inside the new envelope's Body::Document arm
+    // (via DocumentBody). The Document itself is preserved verbatim.
+    let doc = Document::new("Hello");
+    let body = DocumentBody::new(doc);
+    assert_eq!(body.document.metadata.title, "Hello");
+}
+
+// =========================================================================
+// Helpers.
+// =========================================================================
+
+fn empty_factbase() -> Factbase {
+    Factbase::new()
+}
+
+fn manual(id: &str, value: Scalar, unit: Unit) -> Fact {
+    Fact {
+        id: FactId::new(id).expect("id"),
+        value,
+        unit,
+        source: Source::Manual {
+            note: "test".to_owned(),
+            captured_by: "tester".to_owned(),
+        },
+        captured: Timestamp::UNIX_EPOCH,
+    }
+}
+
+fn write_pack(root: &Path, id: &str, schema: &str, recipe: &str) {
+    let dir = root.join(id);
+    fs::create_dir_all(&dir).expect("mkdir");
+    fs::write(dir.join("schema.json"), schema).expect("write schema");
+    fs::write(dir.join("recipe.toml"), recipe).expect("write recipe");
+    fs::write(dir.join("template.html.j2"), "<div></div>").expect("write template");
+}
+
+/// Scoped tempdir helper; avoids pulling tempfile.
+struct TestTempDir {
+    path: PathBuf,
+}
+
+impl TestTempDir {
+    fn new() -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let pid = std::process::id();
+        let path = std::env::temp_dir().join(format!("poiesis-acceptance-{pid}-{n}"));
+        fs::create_dir_all(&path).expect("mkdir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TestTempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}


### PR DESCRIPTION
## Summary

- Lands the typed core that today's `poiesis-core` lacks: `DeliverableSpec` envelope, `Factbase` (with `Source`/`Claim`/DAG resolver), open `ComponentRegistry`, typed `Scalar`/`Unit`/`Money`/`AspectRatio`/`Tolerance`, and parse-don't-validate identifier newtypes.
- Additive only — pre-envelope `Document`/`Block`/`Renderer` surface preserved verbatim; `organon` keeps working unchanged (acceptance #5 covered).
- Unblocks the Wave-2 fan-out (B-002 theme, B-003/B-004 deck, B-005 charts, B-007 workbook, B-008 QA, B-009 brief).

## What lands (per `planning/poiesis-evolution/B-001`)

- **Envelope** (`envelope::DeliverableSpec`): typed `Meta` with required-field enforcement, `ThemeId` (resolves via [[B-002]] registry), `Factbase`, and a `Body` sum over `Deck`/`Document`/`Workbook`.
- **Typed scalars** (`scalar`): `Scalar` (Count/Money/Ratio/Text/Date), `Unit` (count/usd/percent/ratio/date/text), `Money` as i64 micro-units (no decimal-arithmetic dep), `AspectRatio`, `Tolerance` — no naked numbers reach the QA gate.
- **Typed identifiers** (`ids`): `ComponentId`, `ThemeId`, `FactId`, `ClaimId`, `SheetName`, `DataSourceId` — charset and length enforced at construction; serde `TryFrom` rejects invalid.
- **Factbase** (`factbase`): `Fact`, `Source` (`Sql`/`Derived`/`Reference`/`Manual`/`File`), `Claim`, citation-graph DAG resolver with cycle detection (returns the cycle path) and unsourced-reference detection. `DataSource` trait + `DataSourceRegistry` defined per the architecture contract; no in-tree adapters.
- **Open component registry** (`components`): `ComponentDef` packs discovered from `crates/poiesis/components/<id>/` (schema.json + recipe.toml + template.html.j2 + optional defaults/tokens). `list_components()` exposes the agent palette. Schema validation is a minimal in-crate JSON-Schema subset (type/required/properties/items/enum/minLength/maxLength); failure carries a JSON-pointer (RFC 6901).
- **Typed Artifact** shape so render-side B-NNN entries have the output type ready when they evolve `Renderer`.

## Acceptance (per `B-001-poiesis-model-registry.md` §Acceptance)

15 integration tests in `crates/poiesis/core/tests/acceptance_b001.rs`:

1. Round-trip valid spec for each body kind (deck / workbook / document).
2. Reject planted-bad specs with precise errors: missing required meta field, unknown component, bad slot type with JSON-pointer, unknown theme, citation cycle (path in error), unsourced claim.
3. Drop-a-pack discovery: filesystem walk, schema validation, slot-validation rejection — no core recompile.
4. Factbase resolves in declaration order, including Manual + Derived (Add/Sub/Div) + Reference; Sql skipped cleanly when no adapter configured.
5. Legacy `Document` → `Renderer` path compiles and produces bytes through a stand-in renderer; legacy `Document` wraps into `DocumentBody`.

Plus 54 unit tests across the new modules.

## Scope discipline

Per R2 risk guidance: landed ONLY envelope + factbase + component-registry parse-don't-validate. Deferred to later waves:
- Renderer trait evolution to `render(&DeliverableSpec, &ResolvedTheme) → Artifact` — owned by B-003/B-004 (render-side).
- Pandoc-aligned `DocBlock`/`Inline` evolution — owned by B-006.
- Second / worked component packs — owned by B-003/B-004 (the render entries that consume them).
- Real `DataSource` adapter implementations — out of tree until a non-trivial consumer materializes.

## Compatibility

`organon` is the only in-tree consumer of `poiesis::Renderer`. Verified: `cargo check -p organon` builds clean against this branch. The legacy `Renderer::render(&Document) → Vec<u8>` signature is untouched; the deprecation alias dance promised in §5.1 happens when the render-side B-NNN actually swap traits (next release, not this one).

## Test plan

- [x] `cargo test -p poiesis-core` — 54 unit + 15 acceptance tests pass
- [x] `cargo clippy -p poiesis-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check -p organon` — back-compat preserved
- [x] `cargo check --workspace --features test-core --all-targets` — clean
- [ ] CI gate passes (Gate-Passed trailer will be stamped on green)