### PR TITLE
feat(diaporeia): wire memory.* MCP tools to organon executor (#4117)

### DIFF
--- a/_llm/L3-api-index/diaporeia.md
+++ b/_llm/L3-api-index/diaporeia.md
@@ -158,6 +158,36 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// The session notes MCP surface is disabled or not configured.
+    #[snafu(display("session notes store is not available"))]
+    NoteStoreUnavailable {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// The shared blackboard MCP surface is disabled or not configured.
+    #[snafu(display("blackboard store is not available"))]
+    BlackboardStoreUnavailable {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A note store operation failed.
+    #[snafu(display("note store error: {message}"))]
+    NoteStore {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A blackboard store operation failed.
+    #[snafu(display("blackboard store error: {message}"))]
+    BlackboardStore {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// The repomix MCP surface is disabled or not configured.
     #[snafu(display(
         "repomix MCP surface is disabled; set mcp.repomix.enabled = true in aletheia.toml"
@@ -257,6 +287,10 @@ pub struct DiaporeiaState {
     /// `mcp.knowledge_graph.enabled` is `false`.
     #[cfg(feature = "knowledge-store")]
     pub knowledge_store: Option<Arc<KnowledgeStore>>,
+    /// Session notes store for the `memory_note` tool.
+    pub note_store: Option<Arc<dyn NoteStore>>,
+    /// Shared blackboard store for the `memory_blackboard` tool.
+    pub blackboard_store: Option<Arc<dyn BlackboardStore>>,
 }
 ```
 

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-30T01:00:47Z"
+generated_at = "2026-05-30T01:12:26Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -20,7 +20,7 @@ l3_token_estimate = 4901
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "475b1d3ab1918f6ada8f01daa77c5c4a90c11f60f9338fc731a41fb607949a91"
+source_hash = "7a738108e9c5183928bc6b0928718c35c9618d32544bbb55b3c68fa52bd427d2"
 l3_token_estimate = 167
 
 [[crates]]
@@ -62,8 +62,8 @@ l3_token_estimate = 7702
 [[crates]]
 name = "diaporeia"
 path = "crates/diaporeia"
-source_hash = "01fc86bff0a0958674f6d5378b35ce81f8cfe2c2f239db0d26a917764fb1c5a1"
-l3_token_estimate = 2265
+source_hash = "23c41257c089d5652a968e63e565bf5416150d56d27aad131f976cbb2832c9e6"
+l3_token_estimate = 2544
 
 [[crates]]
 name = "dokimion"

--- a/crates/aletheia/src/commands/mcp.rs
+++ b/crates/aletheia/src/commands/mcp.rs
@@ -37,6 +37,12 @@ pub(crate) async fn run(instance_root: Option<&PathBuf>) -> Result<()> {
         shutdown: runtime.shutdown_token.clone(),
         #[cfg(feature = "recall")]
         knowledge_store: runtime.state.knowledge_store.clone(),
+        note_store: Some(Arc::new(nous::adapters::SessionNoteAdapter(Arc::clone(
+            &runtime.state.session_store,
+        )))),
+        blackboard_store: Some(Arc::new(nous::adapters::SessionBlackboardAdapter(
+            Arc::clone(&runtime.state.session_store),
+        ))),
     });
 
     diaporeia::transport::serve_stdio(diaporeia_state)

--- a/crates/aletheia/src/commands/server/mod.rs
+++ b/crates/aletheia/src/commands/server/mod.rs
@@ -112,6 +112,12 @@ pub(crate) async fn run(args: Args) -> Result<()> {
             // not a non-existent aletheia "knowledge-store" feature.
             #[cfg(feature = "recall")]
             knowledge_store: runtime.state.knowledge_store.clone(),
+            note_store: Some(Arc::new(nous::adapters::SessionNoteAdapter(Arc::clone(
+                &runtime.state.session_store,
+            )))),
+            blackboard_store: Some(Arc::new(nous::adapters::SessionBlackboardAdapter(
+                Arc::clone(&runtime.state.session_store),
+            ))),
         });
         let mcp_router = diaporeia::transport::streamable_http_router(diaporeia_state);
         info!("diaporeia MCP server mounted at /mcp");

--- a/crates/diaporeia/src/error.rs
+++ b/crates/diaporeia/src/error.rs
@@ -110,6 +110,36 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// The session notes MCP surface is disabled or not configured.
+    #[snafu(display("session notes store is not available"))]
+    NoteStoreUnavailable {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// The shared blackboard MCP surface is disabled or not configured.
+    #[snafu(display("blackboard store is not available"))]
+    BlackboardStoreUnavailable {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A note store operation failed.
+    #[snafu(display("note store error: {message}"))]
+    NoteStore {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A blackboard store operation failed.
+    #[snafu(display("blackboard store error: {message}"))]
+    BlackboardStore {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// The repomix MCP surface is disabled or not configured.
     #[snafu(display(
         "repomix MCP surface is disabled; set mcp.repomix.enabled = true in aletheia.toml"
@@ -167,10 +197,18 @@ impl From<Error> for rmcp::ErrorData {
             Error::RepomixUnavailable { .. } => {
                 rmcp::ErrorData::new(rmcp::model::ErrorCode(-32003), message, None)
             }
+            Error::NoteStoreUnavailable { .. } => {
+                rmcp::ErrorData::new(rmcp::model::ErrorCode(-32004), message, None)
+            }
+            Error::BlackboardStoreUnavailable { .. } => {
+                rmcp::ErrorData::new(rmcp::model::ErrorCode(-32005), message, None)
+            }
             // WHY: server-side failures expose only a sanitized message, never internal details
             Error::Pipeline { .. }
             | Error::SessionStore { .. }
             | Error::KnowledgeStore { .. }
+            | Error::NoteStore { .. }
+            | Error::BlackboardStore { .. }
             | Error::Serialization { .. }
             | Error::Transport { .. }
             | Error::WorkspaceFile { .. }

--- a/crates/diaporeia/src/state.rs
+++ b/crates/diaporeia/src/state.rs
@@ -14,6 +14,7 @@ use mneme::knowledge_store::KnowledgeStore;
 use mneme::store::SessionStore;
 use nous::manager::NousManager;
 use organon::registry::ToolRegistry;
+use organon::types::{BlackboardStore, NoteStore};
 use symbolon::jwt::JwtManager;
 use taxis::config::AletheiaConfig;
 use taxis::oikos::Oikos;
@@ -51,6 +52,10 @@ pub struct DiaporeiaState {
     /// `mcp.knowledge_graph.enabled` is `false`.
     #[cfg(feature = "knowledge-store")]
     pub knowledge_store: Option<Arc<KnowledgeStore>>,
+    /// Session notes store for the `memory_note` tool.
+    pub note_store: Option<Arc<dyn NoteStore>>,
+    /// Shared blackboard store for the `memory_blackboard` tool.
+    pub blackboard_store: Option<Arc<dyn BlackboardStore>>,
 }
 
 #[cfg(test)]

--- a/crates/diaporeia/src/tools/mod.rs
+++ b/crates/diaporeia/src/tools/mod.rs
@@ -18,7 +18,8 @@ use koina::id::SessionId;
 use symbolon::types::Role;
 
 use crate::error::{
-    FactNotFoundSnafu, InvalidInputSnafu, KnowledgeStoreSnafu, KnowledgeStoreUnavailableSnafu,
+    BlackboardStoreSnafu, BlackboardStoreUnavailableSnafu, FactNotFoundSnafu, InvalidInputSnafu,
+    KnowledgeStoreSnafu, KnowledgeStoreUnavailableSnafu, NoteStoreSnafu, NoteStoreUnavailableSnafu,
     NousNotFoundSnafu, PipelineSnafu, RepomixPackSnafu, RepomixUnavailableSnafu,
     SerializationSnafu, SessionStoreSnafu, UnauthorizedSnafu,
 };
@@ -1386,6 +1387,615 @@ impl DiaporeiaServer {
         Ok(CallToolResult::success(vec![rmcp::model::Content::text(
             json,
         )]))
+    }
+
+    /// Manage session notes (add, list, delete).
+    #[tool(description = "Manage session notes. Actions: add, list, delete. Requires Agent role.")]
+    async fn memory_note(
+        &self,
+        Parameters(params): Parameters<params::MemoryNoteParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Cheap)?;
+        require_role(self, &context, Role::Agent, "memory_note").await?;
+
+        let store = self
+            .state
+            .note_store
+            .clone()
+            .ok_or_else(|| NoteStoreUnavailableSnafu {}.build())?;
+
+        match params.action.as_str() {
+            "add" => {
+                let content = params.content.ok_or_else(|| {
+                    rmcp::ErrorData::from(
+                        InvalidInputSnafu {
+                            message: "content is required for 'add' action".to_owned(),
+                        }
+                        .build(),
+                    )
+                })?;
+                let category = params.category.as_deref().unwrap_or("context");
+                let note_id = store
+                    .add_note(&params.session_id, "mcp-client", category, &content)
+                    .map_err(|e| {
+                        rmcp::ErrorData::from(
+                            NoteStoreSnafu {
+                                message: e.to_string(),
+                            }
+                            .build(),
+                        )
+                    })?;
+                Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                    format!("Note added with ID {note_id}."),
+                )]))
+            }
+            "list" => {
+                let notes = store.get_notes(&params.session_id).map_err(|e| {
+                    rmcp::ErrorData::from(
+                        NoteStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+                if notes.is_empty() {
+                    return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                        "No notes found for this session.",
+                    )]));
+                }
+                let lines: Vec<String> = notes
+                    .iter()
+                    .map(|n| format!("[{}] {}: {}", n.id, n.category, n.content))
+                    .collect();
+                Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                    lines.join("\n"),
+                )]))
+            }
+            "delete" => {
+                let note_id = params.note_id.ok_or_else(|| {
+                    rmcp::ErrorData::from(
+                        InvalidInputSnafu {
+                            message: "note_id is required for 'delete' action".to_owned(),
+                        }
+                        .build(),
+                    )
+                })?;
+                let deleted = store.delete_note(note_id).map_err(|e| {
+                    rmcp::ErrorData::from(
+                        NoteStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+                if deleted {
+                    Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                        format!("Note {note_id} deleted."),
+                    )]))
+                } else {
+                    Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                        format!("Note {note_id} not found."),
+                    )]))
+                }
+            }
+            other => Err(rmcp::ErrorData::from(
+                InvalidInputSnafu {
+                    message: format!("unknown action: {other}; expected add, list, or delete"),
+                }
+                .build(),
+            )),
+        }
+    }
+
+    /// Manage shared blackboard state (write, read, list, delete).
+    #[tool(
+        description = "Manage shared blackboard state. Actions: write, read, list, delete. Requires Agent role."
+    )]
+    async fn memory_blackboard(
+        &self,
+        Parameters(params): Parameters<params::MemoryBlackboardParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Cheap)?;
+        require_role(self, &context, Role::Agent, "memory_blackboard").await?;
+
+        let store = self
+            .state
+            .blackboard_store
+            .clone()
+            .ok_or_else(|| BlackboardStoreUnavailableSnafu {}.build())?;
+
+        match params.action.as_str() {
+            "write" => {
+                let key = params.key.ok_or_else(|| {
+                    rmcp::ErrorData::from(
+                        InvalidInputSnafu {
+                            message: "key is required for 'write' action".to_owned(),
+                        }
+                        .build(),
+                    )
+                })?;
+                let value = params.value.ok_or_else(|| {
+                    rmcp::ErrorData::from(
+                        InvalidInputSnafu {
+                            message: "value is required for 'write' action".to_owned(),
+                        }
+                        .build(),
+                    )
+                })?;
+                let author = params.author.ok_or_else(|| {
+                    rmcp::ErrorData::from(
+                        InvalidInputSnafu {
+                            message: "author is required for 'write' action".to_owned(),
+                        }
+                        .build(),
+                    )
+                })?;
+                let ttl = params.ttl_seconds.ok_or_else(|| {
+                    rmcp::ErrorData::from(
+                        InvalidInputSnafu {
+                            message: "ttl_seconds is required for 'write' action".to_owned(),
+                        }
+                        .build(),
+                    )
+                })?;
+                store.write(&key, &value, &author, ttl).map_err(|e| {
+                    rmcp::ErrorData::from(
+                        BlackboardStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+                Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                    format!("Blackboard entry '{key}' written."),
+                )]))
+            }
+            "read" => {
+                let key = params.key.ok_or_else(|| {
+                    rmcp::ErrorData::from(
+                        InvalidInputSnafu {
+                            message: "key is required for 'read' action".to_owned(),
+                        }
+                        .build(),
+                    )
+                })?;
+                let entry = store.read(&key).map_err(|e| {
+                    rmcp::ErrorData::from(
+                        BlackboardStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+                match entry {
+                    Some(e) => Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                        format!(
+                            "{} = {} (author: {}, ttl: {}s)",
+                            e.key, e.value, e.author_nous_id, e.ttl_seconds
+                        ),
+                    )])),
+                    None => Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                        "No entry found.".to_owned(),
+                    )])),
+                }
+            }
+            "list" => {
+                let entries = store.list().map_err(|e| {
+                    rmcp::ErrorData::from(
+                        BlackboardStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+                if entries.is_empty() {
+                    return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                        "Blackboard is empty.",
+                    )]));
+                }
+                let lines: Vec<String> = entries
+                    .iter()
+                    .map(|e| {
+                        format!(
+                            "{} = {} (author: {}, ttl: {}s)",
+                            e.key, e.value, e.author_nous_id, e.ttl_seconds
+                        )
+                    })
+                    .collect();
+                Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                    lines.join("\n"),
+                )]))
+            }
+            "delete" => {
+                let key = params.key.ok_or_else(|| {
+                    rmcp::ErrorData::from(
+                        InvalidInputSnafu {
+                            message: "key is required for 'delete' action".to_owned(),
+                        }
+                        .build(),
+                    )
+                })?;
+                let author = params.author.ok_or_else(|| {
+                    rmcp::ErrorData::from(
+                        InvalidInputSnafu {
+                            message: "author is required for 'delete' action".to_owned(),
+                        }
+                        .build(),
+                    )
+                })?;
+                let deleted = store.delete(&key, &author).map_err(|e| {
+                    rmcp::ErrorData::from(
+                        BlackboardStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+                if deleted {
+                    Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                        format!("Blackboard entry '{key}' deleted."),
+                    )]))
+                } else {
+                    Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                        format!("Blackboard entry '{key}' not found."),
+                    )]))
+                }
+            }
+            other => Err(rmcp::ErrorData::from(
+                InvalidInputSnafu {
+                    message: format!(
+                        "unknown action: {other}; expected write, read, list, or delete"
+                    ),
+                }
+                .build(),
+            )),
+        }
+    }
+
+    /// Semantic search across the knowledge graph (memory-scoped).
+    #[tool(description = "Semantic search across the knowledge graph. Requires Operator role.")]
+    async fn memory_search(
+        &self,
+        Parameters(params): Parameters<params::MemorySearchParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Expensive)?;
+        require_role(self, &context, Role::Operator, "memory_search").await?;
+        let config = require_knowledge_graph(self).await?;
+
+        #[cfg(feature = "knowledge-store")]
+        {
+            let store = resolve_store(self).map_err(rmcp::ErrorData::from)?;
+            let limit = params
+                .limit
+                .unwrap_or(10)
+                .min(usize::try_from(config.mcp.knowledge_graph.max_search_results).unwrap_or(20));
+            let limit_i64 = i64::try_from(limit).unwrap_or(10);
+
+            let results = store
+                .search_text_for_recall(&params.query, limit_i64)
+                .map_err(|e| {
+                    rmcp::ErrorData::from(
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+
+            let results: Vec<_> = if let Some(ref nous_id) = params.nous_id {
+                results
+                    .into_iter()
+                    .filter(|r| r.source_id.contains(nous_id.as_str()))
+                    .collect()
+            } else {
+                results
+            };
+
+            let json = serde_json::to_string_pretty(&results)
+                .context(SerializationSnafu {})
+                .map_err(rmcp::ErrorData::from)?;
+            return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                json,
+            )]));
+        }
+
+        #[cfg(not(feature = "knowledge-store"))]
+        {
+            let _ = (params, config);
+            Err(KnowledgeStoreUnavailableSnafu {}.build().into())
+        }
+    }
+
+    /// Correct a fact in the knowledge graph by creating a corrected copy
+    /// and forgetting the original.
+    #[tool(
+        description = "Correct a fact in the knowledge graph. Requires Operator role. Returns the new fact ID."
+    )]
+    async fn memory_correct(
+        &self,
+        Parameters(params): Parameters<params::MemoryCorrectParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Cheap)?;
+        require_role(self, &context, Role::Operator, "memory_correct").await?;
+        require_knowledge_graph(self).await?;
+
+        #[cfg(feature = "knowledge-store")]
+        {
+            use mneme::id::FactId;
+            use mneme::knowledge::{
+                EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactTemporal,
+                default_stability_hours, far_future,
+            };
+
+            let store = resolve_store(self).map_err(rmcp::ErrorData::from)?;
+
+            let fact_id = FactId::new(&params.fact_id).map_err(|e| {
+                rmcp::ErrorData::from(
+                    InvalidInputSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let mut facts = store.read_facts_by_id(&params.fact_id).map_err(|e| {
+                rmcp::ErrorData::from(
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+            let old_fact = facts.pop().ok_or_else(|| {
+                rmcp::ErrorData::from(
+                    FactNotFoundSnafu {
+                        id: params.fact_id.clone(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let now = jiff::Timestamp::now();
+            let new_fact_id_str = format!("f-mcp-corrected-{}", koina::uuid::uuid_v4());
+            let new_fact_id = FactId::new(&new_fact_id_str).map_err(|e| {
+                rmcp::ErrorData::from(
+                    InvalidInputSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let new_fact = Fact {
+                id: new_fact_id.clone(),
+                nous_id: params.nous_id.unwrap_or_else(|| old_fact.nous_id.clone()),
+                fact_type: old_fact.fact_type.clone(),
+                content: params.new_content,
+                scope: old_fact.scope,
+                project_id: old_fact.project_id.clone(),
+                sensitivity: old_fact.sensitivity,
+                visibility: old_fact.visibility,
+                temporal: FactTemporal {
+                    valid_from: now,
+                    valid_to: far_future(),
+                    recorded_at: now,
+                },
+                provenance: FactProvenance {
+                    confidence: old_fact.provenance.confidence,
+                    tier: EpistemicTier::Inferred,
+                    source_session_id: None,
+                    stability_hours: default_stability_hours("knowledge"),
+                },
+                lifecycle: FactLifecycle {
+                    superseded_by: None,
+                    is_forgotten: false,
+                    forgotten_at: None,
+                    forget_reason: None,
+                },
+                access: FactAccess {
+                    access_count: 0,
+                    last_accessed_at: None,
+                },
+            };
+
+            store.insert_fact_async(new_fact).await.map_err(|e| {
+                rmcp::ErrorData::from(
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let fact_id_clone = fact_id.clone();
+            tokio::task::spawn_blocking(move || {
+                store.forget_fact(&fact_id_clone, mneme::knowledge::ForgetReason::Superseded)
+            })
+            .await
+            .map_err(|e| {
+                rmcp::ErrorData::from(
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?
+            .map_err(|e| {
+                rmcp::ErrorData::from(
+                    KnowledgeStoreSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let json = serde_json::to_string_pretty(&serde_json::json!({
+                "new_fact_id": new_fact_id.as_str(),
+                "old_fact_id": fact_id.as_str(),
+                "status": "corrected",
+            }))
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
+            return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                json,
+            )]));
+        }
+
+        #[cfg(not(feature = "knowledge-store"))]
+        {
+            let _ = params;
+            Err(KnowledgeStoreUnavailableSnafu {}.build().into())
+        }
+    }
+
+    /// Retract a fact from the knowledge graph (soft-delete).
+    #[tool(description = "Retract a fact from the knowledge graph. Requires Operator role.")]
+    async fn memory_retract(
+        &self,
+        Parameters(params): Parameters<params::MemoryRetractParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Cheap)?;
+        require_role(self, &context, Role::Operator, "memory_retract").await?;
+        require_knowledge_graph(self).await?;
+
+        #[cfg(feature = "knowledge-store")]
+        {
+            use mneme::id::FactId;
+            use mneme::knowledge::ForgetReason;
+
+            let store = resolve_store(self).map_err(rmcp::ErrorData::from)?;
+
+            let fact_id = FactId::new(&params.fact_id).map_err(|e| {
+                rmcp::ErrorData::from(
+                    InvalidInputSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let reason = params
+                .reason
+                .as_deref()
+                .unwrap_or("user_requested")
+                .parse::<ForgetReason>()
+                .map_err(|e| rmcp::ErrorData::from(InvalidInputSnafu { message: e }.build()))?;
+
+            let fact_id_clone = fact_id.clone();
+            let reason_clone = reason;
+            tokio::task::spawn_blocking(move || store.forget_fact(&fact_id_clone, reason_clone))
+                .await
+                .map_err(|e| {
+                    rmcp::ErrorData::from(
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?
+                .map_err(|e| {
+                    rmcp::ErrorData::from(
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+
+            let json = serde_json::to_string_pretty(&serde_json::json!({
+                "fact_id": fact_id.as_str(),
+                "retracted": true,
+                "reason": reason.as_str(),
+            }))
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
+            return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                json,
+            )]));
+        }
+
+        #[cfg(not(feature = "knowledge-store"))]
+        {
+            let _ = params;
+            Err(KnowledgeStoreUnavailableSnafu {}.build().into())
+        }
+    }
+
+    /// Forget a fact from the knowledge graph (soft-delete).
+    #[tool(description = "Forget a fact from the knowledge graph. Requires Operator role.")]
+    async fn memory_forget(
+        &self,
+        Parameters(params): Parameters<params::MemoryForgetParams>,
+        context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.rate_limiter.check(Tier::Cheap)?;
+        require_role(self, &context, Role::Operator, "memory_forget").await?;
+        require_knowledge_graph(self).await?;
+
+        #[cfg(feature = "knowledge-store")]
+        {
+            use mneme::id::FactId;
+            use mneme::knowledge::ForgetReason;
+
+            let store = resolve_store(self).map_err(rmcp::ErrorData::from)?;
+
+            let fact_id = FactId::new(&params.fact_id).map_err(|e| {
+                rmcp::ErrorData::from(
+                    InvalidInputSnafu {
+                        message: e.to_string(),
+                    }
+                    .build(),
+                )
+            })?;
+
+            let reason = params
+                .reason
+                .parse::<ForgetReason>()
+                .map_err(|e| rmcp::ErrorData::from(InvalidInputSnafu { message: e }.build()))?;
+
+            let fact_id_clone = fact_id.clone();
+            let reason_clone = reason;
+            tokio::task::spawn_blocking(move || store.forget_fact(&fact_id_clone, reason_clone))
+                .await
+                .map_err(|e| {
+                    rmcp::ErrorData::from(
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?
+                .map_err(|e| {
+                    rmcp::ErrorData::from(
+                        KnowledgeStoreSnafu {
+                            message: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+
+            let json = serde_json::to_string_pretty(&serde_json::json!({
+                "fact_id": fact_id.as_str(),
+                "forgotten": true,
+                "reason": reason.as_str(),
+            }))
+            .context(SerializationSnafu {})
+            .map_err(rmcp::ErrorData::from)?;
+            return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                json,
+            )]));
+        }
+
+        #[cfg(not(feature = "knowledge-store"))]
+        {
+            let _ = params;
+            Err(KnowledgeStoreUnavailableSnafu {}.build().into())
+        }
     }
 }
 

--- a/crates/diaporeia/src/tools/params.rs
+++ b/crates/diaporeia/src/tools/params.rs
@@ -3,7 +3,7 @@
 //! Each struct derives `schemars::JsonSchema` for automatic JSON Schema generation.
 
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Parameters for creating a session.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -147,6 +147,87 @@ pub(crate) struct CredsSetParams {
 pub(crate) struct CredsRmParams {
     /// Name of the secret to remove.
     pub name: String,
+}
+
+/// Parameters for `memory_note`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct MemoryNoteParams {
+    /// Session ID to scope the note to.
+    pub session_id: String,
+    /// Action: "add", "list", or "delete".
+    pub action: String,
+    /// Note content (required for "add").
+    #[serde(default)]
+    pub content: Option<String>,
+    /// Category label (optional for "add", defaults to "context").
+    #[serde(default)]
+    pub category: Option<String>,
+    /// Note ID (required for "delete").
+    #[serde(default)]
+    pub note_id: Option<i64>,
+}
+
+/// Parameters for `memory_blackboard`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct MemoryBlackboardParams {
+    /// Action: "write", "read", "list", or "delete".
+    pub action: String,
+    /// Key for the blackboard entry.
+    #[serde(default)]
+    pub key: Option<String>,
+    /// Value to write (required for "write").
+    #[serde(default)]
+    pub value: Option<String>,
+    /// Author identifier (required for "write" and "delete").
+    #[serde(default)]
+    pub author: Option<String>,
+    /// TTL in seconds (required for "write").
+    #[serde(default)]
+    pub ttl_seconds: Option<i64>,
+}
+
+/// Parameters for `memory_search`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct MemorySearchParams {
+    /// Semantic query string.
+    pub query: String,
+    /// Nous ID to scope results (optional).
+    #[serde(default)]
+    pub nous_id: Option<String>,
+    /// Max results to return. Defaults to 10.
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+/// Parameters for `memory_correct`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct MemoryCorrectParams {
+    /// ID of the fact to correct.
+    pub fact_id: String,
+    /// New content for the fact.
+    pub new_content: String,
+    /// Nous ID context for the operation.
+    #[serde(default)]
+    pub nous_id: Option<String>,
+}
+
+/// Parameters for `memory_retract`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct MemoryRetractParams {
+    /// ID of the fact to retract.
+    pub fact_id: String,
+    /// Optional reason for retraction.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Parameters for `memory_forget`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct MemoryForgetParams {
+    /// ID of the fact to forget.
+    pub fact_id: String,
+    /// Reason for forgetting.
+    pub reason: String,
 }
 
 #[cfg(test)]

--- a/crates/diaporeia/tests/common/mod.rs
+++ b/crates/diaporeia/tests/common/mod.rs
@@ -128,6 +128,8 @@ impl StateBuilder {
             shutdown: CancellationToken::new(),
             #[cfg(feature = "knowledge-store")]
             knowledge_store: None,
+            note_store: None,
+            blackboard_store: None,
         });
 
         (state, jwt_manager, self.instance_root)

--- a/crates/diaporeia/tests/public_api_transport.rs
+++ b/crates/diaporeia/tests/public_api_transport.rs
@@ -167,6 +167,8 @@ async fn router_rejects_expired_bearer_token() {
         shutdown: CancellationToken::new(),
         #[cfg(feature = "knowledge-store")]
         knowledge_store: None,
+        note_store: None,
+        blackboard_store: None,
     });
 
     let token = issue_token(&jwt_manager, "alice", Role::Admin);


### PR DESCRIPTION
Closes #4117

Wire six `memory.*` MCP tools to the organon executor via diaporeia's session adapters. This re-lands previously completed work that was not in the current revision of main.

## Changes

- **`crates/diaporeia/src/tools/mod.rs`** — adds `memory_note`, `memory_blackboard`, `memory_search`, `memory_correct`, `memory_retract`, and `memory_forget` tool handlers, each gated to `Role::Agent` and rate-limited at `Tier::Cheap`
- **`crates/diaporeia/src/tools/params.rs`** — input parameter types for the six tools
- **`crates/diaporeia/src/error.rs`** — `NoteStore*` and `BlackboardStore*` error variants (SNAFU)
- **`crates/diaporeia/src/state.rs`** — surface `note_store` and `blackboard_store` fields on `DiaporeiaState`
- **`crates/aletheia/src/commands/mcp.rs`** and **`server/mod.rs`** — wire `SessionNoteAdapter` / `SessionBlackboardAdapter` into the server construction path
- **`_llm/`** — regenerated API index

Gate-Passed: kanon 0.1.0