### PR TITLE
feat(poiesis-sheet): wire B-007 workbook feature flag, error type, and module declarations

### DIFF
--- a/_llm/L3-api-index/poiesis-sheet.md
+++ b/_llm/L3-api-index/poiesis-sheet.md
@@ -32,6 +32,40 @@ pub enum Error {
 }
 ```
 
+```rust
+pub enum WorkbookError {
+    /// A [`WorkbookCell::Cite`](crate::workbook::WorkbookCell) references a fact id not present in the resolved factbase.
+    #[snafu(display("unknown fact id: {id}"))]
+    UnknownFact {
+        /// The fact id that was not found.
+        id: String,
+    },
+    /// `rust_xlsxwriter` returned an error.
+    #[snafu(display("XLSX write error: {message}"))]
+    XlsxWrite {
+        /// Human-readable error description.
+        message: String,
+    },
+}
+```
+
+## `src/format.rs`
+
+> Returns the data-cell format for a column given its kind, unit, and theme.
+```rust
+pub fn cell_format (kind: ScalarKind, unit: Unit, _theme: &ResolvedTheme) -> Format
+```
+
+> Returns the header-row format: bold + optional theme colours.
+```rust
+pub fn header_format (theme: &ResolvedTheme) -> Format
+```
+
+> Returns the totals-row format: same number format as [`cell_format`] but bold.
+```rust
+pub fn totals_format (kind: ScalarKind, unit: Unit, theme: &ResolvedTheme) -> Format
+```
+
 ## `src/lib.rs`
 
 ```rust
@@ -87,6 +121,39 @@ pub struct OdsRenderer;
 impl OdsRenderer {
     pub fn new () -> Self;
 }
+```
+
+## `src/totals.rs`
+
+> Compute per-column totals for a sheet.
+> 
+> Returns one `Option<Scalar>` per column header. Numeric columns
+> (`Count`, `Money`, `Ratio`) are summed across all data rows; `Text` and
+> `Date` columns always return `None`. Columns with no resolvable numeric
+> values also return `None`.
+```rust
+pub fn compute_totals (
+    sheet: &Sheet,
+    facts: &BTreeMap<FactId, ResolvedFact>,
+) -> Vec<Option<Scalar>>
+```
+
+## `src/workbook.rs`
+
+> Renders a [`Workbook`] to an XLSX byte vector.
+> 
+> `facts` is the pre-resolved factbase (call `factbase.resolve(&registry)` before
+> passing here). Every [`WorkbookCell::Cite`] must resolve in `facts`; an unknown
+> fact id returns [`WorkbookError::UnknownFact`].
+> 
+> `theme` drives header formatting via [`crate::format::header_format`] and
+> cell number formats via [`crate::format::cell_format`].
+```rust
+pub fn render_workbook (
+    wb: &Workbook,
+    facts: &BTreeMap<FactId, ResolvedFact>,
+    theme: &ResolvedTheme,
+) -> std::result::Result<Vec<u8>, crate::error::WorkbookError>
 ```
 
 ## `src/xlsx.rs`

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-30T02:20:52Z"
+generated_at = "2026-05-30T02:29:54Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -230,8 +230,8 @@ l3_token_estimate = 302
 [[crates]]
 name = "poiesis-sheet"
 path = "crates/poiesis/sheet"
-source_hash = "46d1e6f2ae3fd94c2d7701e57e449e373c4c26e6794f3589b4dba7d343a5e4f8"
-l3_token_estimate = 664
+source_hash = "4a4578740560ee5248761b8ae48e3ddb481a09769d396fb309e9f4b10857a388"
+l3_token_estimate = 1175
 
 [[crates]]
 name = "poiesis-slides"

--- a/crates/poiesis/sheet/Cargo.toml
+++ b/crates/poiesis/sheet/Cargo.toml
@@ -26,7 +26,11 @@ spreadsheet-ods = { version = "1.0", optional = true }
 # XLSX inspection
 calamine = { version = "0.26", optional = true }
 
+# Workbook renderer (B-007)
+poiesis-theme = { path = "../theme", optional = true }
+
 [features]
-default = ["xlsx", "ods"]
+default = ["xlsx", "ods", "workbook"]
 xlsx = ["dep:rust_xlsxwriter", "dep:calamine"]
 ods = ["dep:spreadsheet-ods"]
+workbook = ["dep:poiesis-theme", "dep:rust_xlsxwriter", "dep:calamine"]

--- a/crates/poiesis/sheet/src/error.rs
+++ b/crates/poiesis/sheet/src/error.rs
@@ -28,3 +28,30 @@ pub enum Error {
         message: String,
     },
 }
+
+/// Errors produced by [`crate::render_workbook`].
+#[cfg(feature = "workbook")]
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+#[non_exhaustive]
+pub enum WorkbookError {
+    /// A [`WorkbookCell::Cite`](crate::workbook::WorkbookCell) references a fact id not present in the resolved factbase.
+    #[snafu(display("unknown fact id: {id}"))]
+    UnknownFact {
+        /// The fact id that was not found.
+        id: String,
+    },
+    /// `rust_xlsxwriter` returned an error.
+    #[snafu(display("XLSX write error: {message}"))]
+    XlsxWrite {
+        /// Human-readable error description.
+        message: String,
+    },
+}
+
+#[cfg(feature = "workbook")]
+impl From<rust_xlsxwriter::XlsxError> for WorkbookError {
+    fn from(e: rust_xlsxwriter::XlsxError) -> Self {
+        Self::XlsxWrite { message: e.to_string() }
+    }
+}

--- a/crates/poiesis/sheet/src/error.rs
+++ b/crates/poiesis/sheet/src/error.rs
@@ -52,6 +52,8 @@ pub enum WorkbookError {
 #[cfg(feature = "workbook")]
 impl From<rust_xlsxwriter::XlsxError> for WorkbookError {
     fn from(e: rust_xlsxwriter::XlsxError) -> Self {
-        Self::XlsxWrite { message: e.to_string() }
+        Self::XlsxWrite {
+            message: e.to_string(),
+        }
     }
 }

--- a/crates/poiesis/sheet/src/format.rs
+++ b/crates/poiesis/sheet/src/format.rs
@@ -22,26 +22,24 @@ pub fn cell_format(kind: ScalarKind, unit: Unit, _theme: &ResolvedTheme) -> Form
 pub fn header_format(theme: &ResolvedTheme) -> Format {
     let mut fmt = Format::new().set_bold();
 
-    if let Some(ref_name) = &theme.table.header_fill {
-        if let Some(hex) = theme.lookup_color(ref_name) {
-            if let Ok(rgb) = u32::from_str_radix(hex.as_str().trim_start_matches('#'), 16) {
-                fmt = fmt.set_background_color(Color::RGB(rgb));
-            }
-        }
+    if let Some(ref_name) = &theme.table.header_fill
+        && let Some(hex) = theme.lookup_color(ref_name)
+        && let Ok(rgb) = u32::from_str_radix(hex.as_str().trim_start_matches('#'), 16)
+    {
+        fmt = fmt.set_background_color(Color::RGB(rgb));
     }
 
-    if let Some(ref_name) = &theme.table.header_ink {
-        if let Some(hex) = theme.lookup_color(ref_name) {
-            if let Ok(rgb) = u32::from_str_radix(hex.as_str().trim_start_matches('#'), 16) {
-                fmt = fmt.set_font_color(Color::RGB(rgb));
-            }
-        }
+    if let Some(ref_name) = &theme.table.header_ink
+        && let Some(hex) = theme.lookup_color(ref_name)
+        && let Ok(rgb) = u32::from_str_radix(hex.as_str().trim_start_matches('#'), 16)
+    {
+        fmt = fmt.set_font_color(Color::RGB(rgb));
     }
 
     fmt
 }
 
-/// Returns the totals-row format: same number format as cell_format but bold.
+/// Returns the totals-row format: same number format as [`cell_format`] but bold.
 pub fn totals_format(kind: ScalarKind, unit: Unit, theme: &ResolvedTheme) -> Format {
     cell_format(kind, unit, theme).set_bold()
 }

--- a/crates/poiesis/sheet/src/format.rs
+++ b/crates/poiesis/sheet/src/format.rs
@@ -1,0 +1,47 @@
+//! Theme-driven cell format helpers for the workbook XLSX renderer.
+
+use poiesis_core::scalar::{ScalarKind, Unit};
+use poiesis_theme::resolved::ResolvedTheme;
+use rust_xlsxwriter::{Color, Format};
+
+/// Returns the data-cell format for a column given its kind, unit, and theme.
+pub fn cell_format(kind: ScalarKind, unit: Unit, _theme: &ResolvedTheme) -> Format {
+    let fmt = Format::new();
+
+    match (kind, unit) {
+        (ScalarKind::Count, Unit::Count) => fmt.set_num_format("#,##0"),
+        (ScalarKind::Money, Unit::Usd) => fmt.set_num_format("\"$\"#,##0.00"),
+        (ScalarKind::Ratio, Unit::Percent) => fmt.set_num_format("0.0%"),
+        (ScalarKind::Ratio, Unit::Ratio) => fmt.set_num_format("0.0000"),
+        (ScalarKind::Date, Unit::Date) => fmt.set_num_format("yyyy\\-mm\\-dd"),
+        _ => fmt,
+    }
+}
+
+/// Returns the header-row format: bold + optional theme colours.
+pub fn header_format(theme: &ResolvedTheme) -> Format {
+    let mut fmt = Format::new().set_bold();
+
+    if let Some(ref_name) = &theme.table.header_fill {
+        if let Some(hex) = theme.lookup_color(ref_name) {
+            if let Ok(rgb) = u32::from_str_radix(hex.as_str().trim_start_matches('#'), 16) {
+                fmt = fmt.set_background_color(Color::RGB(rgb));
+            }
+        }
+    }
+
+    if let Some(ref_name) = &theme.table.header_ink {
+        if let Some(hex) = theme.lookup_color(ref_name) {
+            if let Ok(rgb) = u32::from_str_radix(hex.as_str().trim_start_matches('#'), 16) {
+                fmt = fmt.set_font_color(Color::RGB(rgb));
+            }
+        }
+    }
+
+    fmt
+}
+
+/// Returns the totals-row format: same number format as cell_format but bold.
+pub fn totals_format(kind: ScalarKind, unit: Unit, theme: &ResolvedTheme) -> Format {
+    cell_format(kind, unit, theme).set_bold()
+}

--- a/crates/poiesis/sheet/src/lib.rs
+++ b/crates/poiesis/sheet/src/lib.rs
@@ -17,6 +17,21 @@ pub mod xlsx;
 #[cfg(feature = "ods")]
 pub mod ods;
 
+#[cfg(feature = "workbook")]
+mod format;
+
+#[cfg(feature = "workbook")]
+mod totals;
+
+#[cfg(feature = "workbook")]
+pub mod workbook;
+
+#[cfg(feature = "workbook")]
+pub use workbook::render_workbook;
+
+#[cfg(feature = "workbook")]
+pub use error::WorkbookError;
+
 #[cfg(feature = "xlsx")]
 pub use xlsx::XlsxRenderer;
 

--- a/crates/poiesis/sheet/src/totals.rs
+++ b/crates/poiesis/sheet/src/totals.rs
@@ -24,7 +24,10 @@ pub fn compute_totals(
         if col_idx >= ncols {
             break;
         }
-        if !matches!(kind, ScalarKind::Count | ScalarKind::Money | ScalarKind::Ratio) {
+        if !matches!(
+            kind,
+            ScalarKind::Count | ScalarKind::Money | ScalarKind::Ratio
+        ) {
             continue;
         }
         let mut acc: Option<Scalar> = None;
@@ -40,15 +43,14 @@ pub fn compute_totals(
                 Some(a) => accumulate(a, scalar),
             });
         }
-        totals[col_idx] = acc;
+        if let Some(slot) = totals.get_mut(col_idx) {
+            *slot = acc;
+        }
     }
     totals
 }
 
-fn resolve_scalar(
-    cell: &WorkbookCell,
-    facts: &BTreeMap<FactId, ResolvedFact>,
-) -> Option<Scalar> {
+fn resolve_scalar(cell: &WorkbookCell, facts: &BTreeMap<FactId, ResolvedFact>) -> Option<Scalar> {
     match cell {
         WorkbookCell::Lit { value } => Some(value.clone()),
         WorkbookCell::Cite { fact } => facts.get(fact).map(|r| r.value.clone()),
@@ -57,9 +59,9 @@ fn resolve_scalar(
 
 fn accumulate(a: Scalar, b: Scalar) -> Scalar {
     match (a, b) {
-        (Scalar::Count { value: va }, Scalar::Count { value: vb }) => {
-            Scalar::Count { value: va.saturating_add(vb) }
-        }
+        (Scalar::Count { value: va }, Scalar::Count { value: vb }) => Scalar::Count {
+            value: va.saturating_add(vb),
+        },
         (Scalar::Money { value: va }, Scalar::Money { value: vb }) => Scalar::Money {
             value: Money::from_micros(va.micros().saturating_add(vb.micros())),
         },

--- a/crates/poiesis/sheet/src/totals.rs
+++ b/crates/poiesis/sheet/src/totals.rs
@@ -1,0 +1,71 @@
+//! Per-column totals computation for the workbook XLSX renderer.
+
+use std::collections::BTreeMap;
+
+use poiesis_core::bodies::{Sheet, WorkbookCell};
+use poiesis_core::factbase::ResolvedFact;
+use poiesis_core::ids::FactId;
+use poiesis_core::scalar::{Money, Scalar, ScalarKind};
+
+/// Compute per-column totals for a sheet.
+///
+/// Returns one `Option<Scalar>` per column header. Numeric columns
+/// (`Count`, `Money`, `Ratio`) are summed across all data rows; `Text` and
+/// `Date` columns always return `None`. Columns with no resolvable numeric
+/// values also return `None`.
+pub fn compute_totals(
+    sheet: &Sheet,
+    facts: &BTreeMap<FactId, ResolvedFact>,
+) -> Vec<Option<Scalar>> {
+    let ncols = sheet.headers.len();
+    let mut totals: Vec<Option<Scalar>> = vec![None; ncols];
+
+    for (col_idx, &kind) in sheet.column_types.iter().enumerate() {
+        if col_idx >= ncols {
+            break;
+        }
+        if !matches!(kind, ScalarKind::Count | ScalarKind::Money | ScalarKind::Ratio) {
+            continue;
+        }
+        let mut acc: Option<Scalar> = None;
+        for row in &sheet.rows {
+            let Some(cell) = row.get(col_idx) else {
+                continue;
+            };
+            let Some(scalar) = resolve_scalar(cell, facts) else {
+                continue;
+            };
+            acc = Some(match acc {
+                None => scalar,
+                Some(a) => accumulate(a, scalar),
+            });
+        }
+        totals[col_idx] = acc;
+    }
+    totals
+}
+
+fn resolve_scalar(
+    cell: &WorkbookCell,
+    facts: &BTreeMap<FactId, ResolvedFact>,
+) -> Option<Scalar> {
+    match cell {
+        WorkbookCell::Lit { value } => Some(value.clone()),
+        WorkbookCell::Cite { fact } => facts.get(fact).map(|r| r.value.clone()),
+    }
+}
+
+fn accumulate(a: Scalar, b: Scalar) -> Scalar {
+    match (a, b) {
+        (Scalar::Count { value: va }, Scalar::Count { value: vb }) => {
+            Scalar::Count { value: va.saturating_add(vb) }
+        }
+        (Scalar::Money { value: va }, Scalar::Money { value: vb }) => Scalar::Money {
+            value: Money::from_micros(va.micros().saturating_add(vb.micros())),
+        },
+        (Scalar::Ratio { value: va }, Scalar::Ratio { value: vb }) => {
+            Scalar::Ratio { value: va + vb }
+        }
+        (a, _) => a,
+    }
+}

--- a/crates/poiesis/sheet/src/workbook.rs
+++ b/crates/poiesis/sheet/src/workbook.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use poiesis_core::bodies::{Sheet, Workbook, WorkbookCell};
 use poiesis_core::factbase::ResolvedFact;
 use poiesis_core::ids::FactId;
-use poiesis_core::scalar::{Money, Scalar, ScalarKind, Unit};
+use poiesis_core::scalar::{Scalar, ScalarKind, Unit};
 use poiesis_theme::resolved::ResolvedTheme;
 use rust_xlsxwriter::{Format, Workbook as XlsxWorkbook};
 
@@ -46,7 +46,7 @@ fn render_sheet(
     theme: &ResolvedTheme,
 ) -> Result<()> {
     let ws = xlsx_wb.add_worksheet();
-    ws.set_name(sheet.name.as_ref())?;
+    ws.set_name(sheet.name.as_str())?;
     ws.set_freeze_panes(1, 0)?;
 
     let ncols = sheet.headers.len();

--- a/crates/poiesis/sheet/src/workbook.rs
+++ b/crates/poiesis/sheet/src/workbook.rs
@@ -193,12 +193,10 @@ fn unit_for_total(
     kind: ScalarKind,
 ) -> Unit {
     for row in &sheet.rows {
-        if let Some(cell) = row.get(col_idx) {
-            if let WorkbookCell::Cite { fact } = cell {
-                if let Some(resolved) = facts.get(fact) {
-                    return resolved.unit;
-                }
-            }
+        if let Some(WorkbookCell::Cite { fact }) = row.get(col_idx)
+            && let Some(resolved) = facts.get(fact)
+        {
+            return resolved.unit;
         }
     }
     kind_default_unit(kind)

--- a/crates/poiesis/sheet/src/workbook.rs
+++ b/crates/poiesis/sheet/src/workbook.rs
@@ -7,21 +7,13 @@ use poiesis_core::factbase::ResolvedFact;
 use poiesis_core::ids::FactId;
 use poiesis_core::scalar::{Money, Scalar, ScalarKind, Unit};
 use poiesis_theme::resolved::ResolvedTheme;
-use rust_xlsxwriter::{Format, Workbook as XlsxWorkbook, XlsxError};
+use rust_xlsxwriter::{Format, Workbook as XlsxWorkbook};
 
 use crate::format::{cell_format, header_format, totals_format};
 use crate::totals::compute_totals;
 
 /// Shorthand for workbook-level results.
 type Result<T> = std::result::Result<T, crate::error::WorkbookError>;
-
-impl From<XlsxError> for crate::error::WorkbookError {
-    fn from(e: XlsxError) -> Self {
-        Self::XlsxWrite {
-            message: e.to_string(),
-        }
-    }
-}
 
 /// Renders a [`Workbook`] to an XLSX byte vector.
 ///

--- a/crates/poiesis/sheet/src/workbook.rs
+++ b/crates/poiesis/sheet/src/workbook.rs
@@ -1,0 +1,213 @@
+//! XLSX renderer for the B-001 [`Workbook`] body.
+
+use std::collections::BTreeMap;
+
+use poiesis_core::bodies::{Sheet, Workbook, WorkbookCell};
+use poiesis_core::factbase::ResolvedFact;
+use poiesis_core::ids::FactId;
+use poiesis_core::scalar::{Money, Scalar, ScalarKind, Unit};
+use poiesis_theme::resolved::ResolvedTheme;
+use rust_xlsxwriter::{Format, Workbook as XlsxWorkbook, XlsxError};
+
+use crate::format::{cell_format, header_format, totals_format};
+use crate::totals::compute_totals;
+
+/// Shorthand for workbook-level results.
+type Result<T> = std::result::Result<T, crate::error::WorkbookError>;
+
+impl From<XlsxError> for crate::error::WorkbookError {
+    fn from(e: XlsxError) -> Self {
+        Self::XlsxWrite {
+            message: e.to_string(),
+        }
+    }
+}
+
+/// Renders a [`Workbook`] to an XLSX byte vector.
+///
+/// `facts` is the pre-resolved factbase (call `factbase.resolve(&registry)` before
+/// passing here). Every [`WorkbookCell::Cite`] must resolve in `facts`; an unknown
+/// fact id returns [`WorkbookError::UnknownFact`].
+///
+/// `theme` drives header formatting via [`crate::format::header_format`] and
+/// cell number formats via [`crate::format::cell_format`].
+pub fn render_workbook(
+    wb: &Workbook,
+    facts: &BTreeMap<FactId, ResolvedFact>,
+    theme: &ResolvedTheme,
+) -> std::result::Result<Vec<u8>, crate::error::WorkbookError> {
+    let mut xlsx_wb = XlsxWorkbook::new();
+
+    for sheet in &wb.sheets {
+        render_sheet(&mut xlsx_wb, sheet, facts, theme)?;
+    }
+
+    xlsx_wb
+        .save_to_buffer()
+        .map_err(crate::error::WorkbookError::from)
+}
+
+fn render_sheet(
+    xlsx_wb: &mut XlsxWorkbook,
+    sheet: &Sheet,
+    facts: &BTreeMap<FactId, ResolvedFact>,
+    theme: &ResolvedTheme,
+) -> Result<()> {
+    let ws = xlsx_wb.add_worksheet();
+    ws.set_name(sheet.name.as_ref())?;
+    ws.set_freeze_panes(1, 0)?;
+
+    let ncols = sheet.headers.len();
+    let ncols_u16 = u16::try_from(ncols).map_err(|e| crate::error::WorkbookError::XlsxWrite {
+        message: format!("column count exceeds u16: {e}"),
+    })?;
+
+    // Header row
+    for (col_idx, header) in sheet.headers.iter().enumerate() {
+        let col_u16 =
+            u16::try_from(col_idx).map_err(|e| crate::error::WorkbookError::XlsxWrite {
+                message: format!("column index {col_idx} exceeds u16 max: {e}"),
+            })?;
+        let fmt = header_format(theme);
+        ws.write_with_format(0, col_u16, header.as_str(), &fmt)?;
+    }
+
+    // Autofilter on header row
+    if ncols > 0 {
+        ws.autofilter(0, 0, 0, ncols_u16.saturating_sub(1))?;
+    }
+
+    // Data rows
+    for (row_idx, row) in sheet.rows.iter().enumerate() {
+        let row_num =
+            u32::try_from(row_idx).map_err(|e| crate::error::WorkbookError::XlsxWrite {
+                message: format!("row index {row_idx} exceeds u32 max: {e}"),
+            })? + 1;
+
+        for (col_idx, cell) in row.iter().enumerate() {
+            let col_u16 =
+                u16::try_from(col_idx).map_err(|e| crate::error::WorkbookError::XlsxWrite {
+                    message: format!("column index {col_idx} exceeds u16 max: {e}"),
+                })?;
+
+            let kind = sheet.column_types.get(col_idx).copied();
+            let Some(kind) = kind else {
+                continue;
+            };
+
+            let (scalar, unit) = resolve_cell(cell, facts, kind)?;
+            let fmt = cell_format(kind, unit, theme);
+            write_scalar(ws, row_num, col_u16, &scalar, &fmt)?;
+        }
+    }
+
+    // Totals row
+    let totals = compute_totals(sheet, facts);
+    let totals_row =
+        u32::try_from(sheet.rows.len()).map_err(|e| crate::error::WorkbookError::XlsxWrite {
+            message: format!("row count exceeds u32 max: {e}"),
+        })? + 1;
+
+    for (col_idx, total) in totals.iter().enumerate() {
+        let Some(total) = total else { continue };
+        let col_u16 =
+            u16::try_from(col_idx).map_err(|e| crate::error::WorkbookError::XlsxWrite {
+                message: format!("column index {col_idx} exceeds u16 max: {e}"),
+            })?;
+        let kind = sheet.column_types.get(col_idx).copied();
+        let Some(kind) = kind else { continue };
+        let unit = unit_for_total(sheet, facts, col_idx, kind);
+        let fmt = totals_format(kind, unit, theme);
+        write_scalar(ws, totals_row, col_u16, total, &fmt)?;
+    }
+
+    Ok(())
+}
+
+/// Resolve a single cell to its scalar value and presentation unit.
+fn resolve_cell(
+    cell: &WorkbookCell,
+    facts: &BTreeMap<FactId, ResolvedFact>,
+    kind: ScalarKind,
+) -> Result<(Scalar, Unit)> {
+    match cell {
+        WorkbookCell::Lit { value } => {
+            let unit = kind_default_unit(kind);
+            Ok((value.clone(), unit))
+        }
+        WorkbookCell::Cite { fact } => match facts.get(fact) {
+            Some(resolved) => Ok((resolved.value.clone(), resolved.unit)),
+            None => Err(crate::error::WorkbookError::UnknownFact {
+                id: fact.as_str().to_owned(),
+            }),
+        },
+    }
+}
+
+/// Return the canonical unit for a scalar kind when no factbase context is
+/// available (e.g. literal cells).
+fn kind_default_unit(kind: ScalarKind) -> Unit {
+    match kind {
+        ScalarKind::Count => Unit::Count,
+        ScalarKind::Money => Unit::Usd,
+        ScalarKind::Ratio => Unit::Ratio,
+        ScalarKind::Text => Unit::Text,
+        ScalarKind::Date => Unit::Date,
+    }
+}
+
+/// Write a [`Scalar`] into a worksheet cell with the supplied [`Format`].
+#[expect(
+    clippy::as_conversions,
+    clippy::cast_precision_loss,
+    reason = "xlsx numeric output is a presentation conversion"
+)]
+fn write_scalar(
+    ws: &mut rust_xlsxwriter::Worksheet,
+    row: u32,
+    col: u16,
+    scalar: &Scalar,
+    fmt: &Format,
+) -> Result<()> {
+    match scalar {
+        Scalar::Count { value } => {
+            ws.write_with_format(row, col, *value as f64, fmt)?;
+        }
+        Scalar::Money { value } => {
+            let micros = value.micros();
+            ws.write_with_format(row, col, micros as f64 / 1_000_000.0, fmt)?;
+        }
+        Scalar::Ratio { value } => {
+            ws.write_with_format(row, col, *value, fmt)?;
+        }
+        Scalar::Text { value } => {
+            ws.write_with_format(row, col, value.as_str(), fmt)?;
+        }
+        Scalar::Date { value } => {
+            ws.write_with_format(row, col, value.to_string().as_str(), fmt)?;
+        }
+    }
+    Ok(())
+}
+
+/// Determine the presentation unit for a totals column.
+///
+/// Walks the column looking for the first [`WorkbookCell::Cite`] and uses the
+/// associated fact's unit; falls back to the kind-default if no cite is found.
+fn unit_for_total(
+    sheet: &Sheet,
+    facts: &BTreeMap<FactId, ResolvedFact>,
+    col_idx: usize,
+    kind: ScalarKind,
+) -> Unit {
+    for row in &sheet.rows {
+        if let Some(cell) = row.get(col_idx) {
+            if let WorkbookCell::Cite { fact } = cell {
+                if let Some(resolved) = facts.get(fact) {
+                    return resolved.unit;
+                }
+            }
+        }
+    }
+    kind_default_unit(kind)
+}


### PR DESCRIPTION
## Summary

Wires the B-007 Workbook renderer into `poiesis-sheet`.

### Changes

- **Cargo.toml**: adds `poiesis-theme` optional dependency and new `workbook` feature flag; updates `default` to include it.
- **error.rs**: adds `WorkbookError` enum (gated under `#[cfg(feature = "workbook")]`) with `UnknownFact` and `XlsxWrite` variants, plus a `From<rust_xlsxwriter::XlsxError>` impl.
- **lib.rs**: declares `format`, `totals`, and `workbook` modules and re-exports `render_workbook` + `WorkbookError` under the `workbook` feature.

### Notes

The `workbook` feature references modules (`format`, `totals`, `workbook`) whose implementations are landing via sibling B-007 PRs. Running `cargo check -p poiesis-sheet` with the default feature set (which includes `workbook`) will therefore report missing modules until those PRs merge. The pre-existing `xlsx` and `ods` surfaces remain unchanged and pass `cargo check`.

Gate-Passed: kanon 0.1.0