### PR TITLE
feat(poiesis): add title, section, bullet, two-col component packs

### DIFF
--- a/crates/poiesis/components/bullet/recipe.toml
+++ b/crates/poiesis/components/bullet/recipe.toml
@@ -1,0 +1,18 @@
+[slide]
+layout = "title-content"
+
+[[shapes]]
+type = "text"
+zone = "header"
+text_field = "title"
+style = "heading"
+font_size = 28
+bold = true
+
+[[shapes]]
+type = "bullet-list"
+zone = "content"
+items_field = "items"
+style = "body"
+font_size = 18
+bullet_char = "•"

--- a/crates/poiesis/components/bullet/schema.json
+++ b/crates/poiesis/components/bullet/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["title", "items"],
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "items": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minLength": 1
+    },
+    "subtitle": { "type": "string" }
+  }
+}

--- a/crates/poiesis/components/bullet/template.html.j2
+++ b/crates/poiesis/components/bullet/template.html.j2
@@ -1,0 +1,16 @@
+<div class="zone-header">
+  <h2 style="font-family:var(--font-heading);font-size:1.75rem;font-weight:700;color:var(--theme-text);">{{ fields.title }}</h2>
+  {% if fields.subtitle %}
+  <p style="font-family:var(--font-body);font-size:1rem;color:var(--theme-text);opacity:0.7;margin-top:0.25rem;">{{ fields.subtitle }}</p>
+  {% endif %}
+</div>
+<div class="zone-content">
+  <ul style="font-family:var(--font-body);font-size:1.125rem;color:var(--theme-text);list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.75rem;">
+    {% for item in fields.items %}
+    <li style="display:flex;align-items:flex-start;gap:0.5rem;">
+      <span style="color:var(--theme-primary);font-weight:700;flex-shrink:0;">•</span>
+      <span>{{ item }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/crates/poiesis/components/bullet/tokens.toml
+++ b/crates/poiesis/components/bullet/tokens.toml
@@ -1,0 +1,1 @@
+tokens = ["--theme-primary", "--theme-text", "--font-heading", "--font-body"]

--- a/crates/poiesis/components/section/recipe.toml
+++ b/crates/poiesis/components/section/recipe.toml
@@ -1,0 +1,24 @@
+[slide]
+layout = "blank"
+
+[[shapes]]
+type = "text"
+zone = "header"
+text_field = "section_number"
+style = "eyebrow"
+font_size = 14
+
+[[shapes]]
+type = "text"
+zone = "body"
+text_field = "title"
+style = "section"
+font_size = 36
+bold = true
+
+[[shapes]]
+type = "text"
+zone = "content"
+text_field = "description"
+style = "body"
+font_size = 18

--- a/crates/poiesis/components/section/schema.json
+++ b/crates/poiesis/components/section/schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "section_number": { "type": "string" },
+    "description": { "type": "string" }
+  }
+}

--- a/crates/poiesis/components/section/template.html.j2
+++ b/crates/poiesis/components/section/template.html.j2
@@ -1,0 +1,11 @@
+<div class="zone-full" style="background:var(--theme-secondary);display:flex;flex-direction:column;justify-content:center;">
+  {% if fields.section_number %}
+  <div class="zone-header" style="font-family:var(--font-body);font-size:0.875rem;font-weight:600;color:var(--theme-primary);text-transform:uppercase;letter-spacing:0.1em;">{{ fields.section_number }}</div>
+  {% endif %}
+  <div class="zone-body" style="display:flex;flex-direction:column;justify-content:center;">
+    <h2 style="font-family:var(--font-heading);font-size:2.5rem;font-weight:700;color:var(--theme-text);line-height:1.2;">{{ fields.title }}</h2>
+    {% if fields.description %}
+    <p style="font-family:var(--font-body);font-size:1.125rem;color:var(--theme-text);opacity:0.75;margin-top:1rem;">{{ fields.description }}</p>
+    {% endif %}
+  </div>
+</div>

--- a/crates/poiesis/components/section/tokens.toml
+++ b/crates/poiesis/components/section/tokens.toml
@@ -1,0 +1,1 @@
+tokens = ["--theme-secondary", "--theme-primary", "--theme-text", "--font-heading", "--font-body"]

--- a/crates/poiesis/components/title/recipe.toml
+++ b/crates/poiesis/components/title/recipe.toml
@@ -1,0 +1,24 @@
+[slide]
+layout = "blank"
+
+[[shapes]]
+type = "text"
+zone = "header"
+text_field = "title"
+style = "title"
+font_size = 40
+bold = true
+
+[[shapes]]
+type = "text"
+zone = "subheader"
+text_field = "subtitle"
+style = "subtitle"
+font_size = 24
+
+[[shapes]]
+type = "text"
+zone = "footer"
+text_field = "author"
+style = "caption"
+font_size = 16

--- a/crates/poiesis/components/title/schema.json
+++ b/crates/poiesis/components/title/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "subtitle": { "type": "string" },
+    "author": { "type": "string" },
+    "date": { "type": "string" }
+  }
+}

--- a/crates/poiesis/components/title/template.html.j2
+++ b/crates/poiesis/components/title/template.html.j2
@@ -1,0 +1,12 @@
+<div class="zone-full" style="display:flex;flex-direction:column;justify-content:center;align-items:center;background:var(--theme-primary);color:#fff;">
+  <h1 style="font-family:var(--font-heading);font-size:3rem;font-weight:700;text-align:center;margin-bottom:1rem;">{{ fields.title }}</h1>
+  {% if fields.subtitle %}
+  <p style="font-family:var(--font-body);font-size:1.5rem;opacity:0.85;text-align:center;margin-bottom:0.5rem;">{{ fields.subtitle }}</p>
+  {% endif %}
+  {% if fields.author %}
+  <p style="font-family:var(--font-body);font-size:1rem;opacity:0.7;text-align:center;">{{ fields.author }}</p>
+  {% endif %}
+  {% if fields.date %}
+  <p style="font-family:var(--font-body);font-size:0.9rem;opacity:0.6;text-align:center;margin-top:0.25rem;">{{ fields.date }}</p>
+  {% endif %}
+</div>

--- a/crates/poiesis/components/title/tokens.toml
+++ b/crates/poiesis/components/title/tokens.toml
@@ -1,0 +1,1 @@
+tokens = ["--theme-primary", "--theme-text", "--font-heading", "--font-body"]

--- a/crates/poiesis/components/two-col/recipe.toml
+++ b/crates/poiesis/components/two-col/recipe.toml
@@ -1,0 +1,24 @@
+[slide]
+layout = "two-column"
+
+[[shapes]]
+type = "text"
+zone = "header"
+text_field = "title"
+style = "heading"
+font_size = 28
+bold = true
+
+[[shapes]]
+type = "text"
+zone = "left-half"
+text_field = "left"
+style = "body"
+font_size = 16
+
+[[shapes]]
+type = "text"
+zone = "right-half"
+text_field = "right"
+style = "body"
+font_size = 16

--- a/crates/poiesis/components/two-col/schema.json
+++ b/crates/poiesis/components/two-col/schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["title", "left", "right"],
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "left": { "type": "string" },
+    "right": { "type": "string" },
+    "left_title": { "type": "string" },
+    "right_title": { "type": "string" }
+  }
+}

--- a/crates/poiesis/components/two-col/template.html.j2
+++ b/crates/poiesis/components/two-col/template.html.j2
@@ -1,0 +1,15 @@
+<div class="zone-header">
+  <h2 style="font-family:var(--font-heading);font-size:1.75rem;font-weight:700;color:var(--theme-text);">{{ fields.title }}</h2>
+</div>
+<div class="zone-left-half" style="padding-right:1rem;">
+  {% if fields.left_title %}
+  <h3 style="font-family:var(--font-heading);font-size:1.1rem;font-weight:600;color:var(--theme-primary);margin-bottom:0.5rem;">{{ fields.left_title }}</h3>
+  {% endif %}
+  <p style="font-family:var(--font-body);font-size:1rem;color:var(--theme-text);line-height:1.6;">{{ fields.left }}</p>
+</div>
+<div class="zone-right-half" style="padding-left:1rem;border-left:2px solid var(--theme-secondary);">
+  {% if fields.right_title %}
+  <h3 style="font-family:var(--font-heading);font-size:1.1rem;font-weight:600;color:var(--theme-primary);margin-bottom:0.5rem;">{{ fields.right_title }}</h3>
+  {% endif %}
+  <p style="font-family:var(--font-body);font-size:1rem;color:var(--theme-text);line-height:1.6;">{{ fields.right }}</p>
+</div>

--- a/crates/poiesis/components/two-col/tokens.toml
+++ b/crates/poiesis/components/two-col/tokens.toml
@@ -1,0 +1,1 @@
+tokens = ["--theme-primary", "--theme-secondary", "--theme-text", "--font-heading", "--font-body"]


### PR DESCRIPTION
Adds four component packs for the B-003 deck rendering system under `crates/poiesis/components/`:

- **title** — Title slide with optional subtitle, author, and date
- **section** — Section divider with number, title, and description
- **bullet** — Bullet list slide with title and items
- **two-col** — Two-column layout with optional column titles

Each pack includes `schema.json`, `recipe.toml`, `template.html.j2`, and `tokens.toml`.

No Rust code changes — pure asset files only.