### PR TITLE
feat(poiesis-doc): add pandoc availability probe; pin pandoc in flake.nix (B-014)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6635,6 +6635,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tracing",
+ "which",
  "zip 8.5.1",
 ]
 
@@ -10909,6 +10910,15 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/poiesis/doc/Cargo.toml
+++ b/crates/poiesis/doc/Cargo.toml
@@ -21,6 +21,9 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 # XML parsing for inspect
 quick-xml = "0.39"
 
+# Pandoc binary discovery for the availability probe
+which = "8"
+
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/poiesis/doc/src/lib.rs
+++ b/crates/poiesis/doc/src/lib.rs
@@ -23,8 +23,10 @@
 //! `Heading1`, `Heading2`, `Normal`, etc.
 
 mod error;
+mod pandoc_probe;
 
 pub use error::Error;
+pub use pandoc_probe::{PandocProbe, PandocProbeError};
 
 use serde_json::Value;
 use snafu::ResultExt;

--- a/crates/poiesis/doc/src/pandoc_probe.rs
+++ b/crates/poiesis/doc/src/pandoc_probe.rs
@@ -1,0 +1,101 @@
+//! Pandoc binary availability probe.
+//!
+//! Call [`PandocProbe::check`] before invoking any Pandoc render path.
+//! If the binary is missing the error message tells the operator exactly
+//! how to fix it (run `nix develop` — pandoc is pinned in `flake.nix`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use snafu::Snafu;
+
+/// Confirmed pandoc installation: binary path and reported version.
+#[derive(Debug, Clone)]
+pub struct PandocProbe {
+    /// Absolute path to the `pandoc` binary.
+    pub path: PathBuf,
+    /// Version string reported by `pandoc --version`, e.g. `"3.1.13"`.
+    pub version: String,
+}
+
+impl PandocProbe {
+    /// Probe for `pandoc` on `PATH`.
+    ///
+    /// Returns the binary path and version on success. Returns an error with
+    /// an actionable message pointing at `nix develop` if pandoc is absent
+    /// or unresponsive.
+    ///
+    /// # Errors
+    ///
+    /// - [`PandocProbeError::NotFound`] when the binary is not on `PATH`.
+    /// - [`PandocProbeError::VersionCheckFailed`] when `pandoc --version` fails.
+    pub fn check() -> Result<Self, PandocProbeError> {
+        let path = which::which("pandoc").map_err(|_e| PandocProbeError::NotFound)?;
+
+        let output = Command::new(&path).arg("--version").output().map_err(|e| {
+            PandocProbeError::VersionCheckFailed {
+                path: path.clone(),
+                detail: e.to_string(),
+            }
+        })?;
+
+        if !output.status.success() {
+            return Err(PandocProbeError::VersionCheckFailed {
+                path,
+                detail: format!("exit status {}", output.status),
+            });
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let version = stdout
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("unknown")
+            .to_owned();
+
+        Ok(Self { path, version })
+    }
+}
+
+/// Error from the pandoc availability check.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum PandocProbeError {
+    /// `pandoc` binary not found on `PATH`.
+    #[snafu(display(
+        "pandoc not found on PATH — install via `nix develop` \
+         (pandoc is pinned in flake.nix), or use the `pdf` format which needs no pandoc"
+    ))]
+    NotFound,
+
+    /// `pandoc --version` found the binary but the command failed.
+    #[snafu(display("pandoc found at {} but `pandoc --version` failed: {detail}", path.display()))]
+    VersionCheckFailed {
+        /// Path where pandoc was found.
+        path: PathBuf,
+        /// Human-readable failure reason.
+        detail: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_check_returns_result() {
+        // Passes whether pandoc is present or absent — must not panic.
+        let _ = PandocProbe::check();
+    }
+
+    #[test]
+    fn probe_error_message_is_actionable() {
+        let msg = PandocProbeError::NotFound.to_string();
+        assert!(
+            msg.contains("nix develop"),
+            "error must mention `nix develop`"
+        );
+        assert!(msg.contains("flake.nix"), "error must mention flake.nix");
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
         pkgs.pkg-config
         pkgs.cmake
         pkgs.rustPlatform.bindgenHook
+        pkgs.pandoc
       ];
 
       # Shared source filter: include Rust sources, Cargo manifests,
@@ -102,6 +103,7 @@
           # Build tooling
           pkgs.cargo-deny
           pkgs.cargo-watch
+          pkgs.pandoc
 
           # Wayland session support
           pkgs.wayland-protocols


### PR DESCRIPTION
## B-014 — Pandoc availability check

Adds a startup probe that verifies `pandoc` is available before any Pandoc render path is invoked, and pins pandoc in `flake.nix`.

### Changes
- **poiesis-doc**: new `pandoc_probe` module exposing `PandocProbe::check()`. Returns `PandocProbeError::NotFound` with an actionable message pointing at `nix develop` and `flake.nix`.
- **flake.nix**: adds `pkgs.pandoc` to the dev shell (pinned via nixpkgs-unstable).
- Two tests: `probe_check_returns_result` (passes whether pandoc present or absent) and `probe_error_message_is_actionable` (asserts the error mentions `nix develop` and `flake.nix`).

### Ship order
B-013 → B-014 (this PR) → B-012 (pandoc backend scaffold).