### PR TITLE
feat(poiesis): add deck-layout solver and deck HTML/CSS renderer

### DIFF
--- a/CRATE-INDEX.toml
+++ b/CRATE-INDEX.toml
@@ -314,6 +314,24 @@ default = "pdf + odt"
 odt = "ODT backend via zip"
 pdf = "PDF backend via krilla"
 
+[crates.poiesis-deck-layout]
+path = "crates/poiesis/deck-layout"
+layer = "types"
+purpose = "Slide layout solver — normalized zone coordinates, pixel CSS, and OOXML EMU output"
+depends_on = ["poiesis-core"]
+used_by = ["poiesis-deck"]
+features = {}
+
+[crates.poiesis-deck]
+path = "crates/poiesis/deck"
+layer = "tool"
+purpose = "HTML/CSS deck renderer — three-layer CSS compositor and minijinja slide engine"
+depends_on = ["poiesis-core", "poiesis-deck-layout"]
+used_by = []
+
+[crates.poiesis-deck.features]
+default = ""
+
 [crates.poiesis-theme]
 path = "crates/poiesis/theme"
 layer = "types"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5509,6 +5509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5531,6 +5537,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
+dependencies = [
+ "memo-map",
+ "serde",
 ]
 
 [[package]]
@@ -6611,6 +6627,26 @@ dependencies = [
  "serde_json",
  "snafu",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "poiesis-deck"
+version = "0.29.0"
+dependencies = [
+ "minijinja",
+ "poiesis-core",
+ "poiesis-deck-layout",
+ "serde_json",
+ "snafu",
+ "tracing",
+]
+
+[[package]]
+name = "poiesis-deck-layout"
+version = "0.29.0"
+dependencies = [
+ "poiesis-core",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ members = [
     "crates/poiesis/typst",
     "crates/poiesis/verify",
     "crates/poiesis/intake",
+    "crates/poiesis/deck",
+    "crates/poiesis/deck-layout",
     "crates/poiesis/doc",
     "crates/poiesis/diff",
     "crates/poiesis/inspect",
@@ -178,6 +180,8 @@ indexmap = { version = "2", default-features = false, features = ["serde"] }
 
 # Time
 jiff = "0.2"
+
+minijinja = "2"
 
 # Async utilities
 bytes = { version = "1", default-features = false }

--- a/_llm/L3-api-index/poiesis-deck-layout.md
+++ b/_llm/L3-api-index/poiesis-deck-layout.md
@@ -1,0 +1,92 @@
+# L3 API Index: poiesis-deck-layout
+
+Crate path: `crates/poiesis/deck-layout`
+
+Public API signatures extracted from source. Each signature is preceded by its doc comment.
+For implementation context, read the source directly (`L4`).
+
+## `src/css.rs`
+
+```rust
+pub fn zone_to_css (zone: &Zone, canvas: &Canvas) -> String
+```
+
+## `src/emu.rs`
+
+```rust
+pub fn zone_to_emu (zone: &Zone, canvas: &Canvas) -> (i64, i64, i64, i64)
+```
+
+## `src/solver.rs`
+
+```rust
+pub fn resolve_layout (aspect: &AspectRatio) -> SlideLayout
+```
+
+## `src/zone.rs`
+
+```rust
+pub struct Zone {
+    /// Normalized x position.
+    pub x: f64,
+    /// Normalized y position.
+    pub y: f64,
+    /// Normalized width.
+    pub w: f64,
+    /// Normalized height.
+    pub h: f64,
+}
+```
+
+```rust
+pub enum ZoneName {
+    /// Full slide.
+    Full,
+    /// Top header area.
+    Header,
+    /// Sub-header below header.
+    SubHeader,
+    /// Main body area.
+    Body,
+    /// Content area.
+    Content,
+    /// Bottom footer.
+    Footer,
+    /// Left half split.
+    LeftHalf,
+    /// Right half split.
+    RightHalf,
+    /// Center KPI card.
+    CenterKpi,
+}
+```
+
+```rust
+impl ZoneName {
+    pub fn css_class (self) -> &'static str;
+}
+```
+
+```rust
+pub struct Canvas {
+    /// Width in pixels.
+    pub width_px: u32,
+    /// Height in pixels.
+    pub height_px: u32,
+}
+```
+
+```rust
+impl Canvas {
+    pub fn from_aspect (aspect: &AspectRatio) -> Self;
+}
+```
+
+```rust
+pub struct SlideLayout {
+    /// Canvas dimensions.
+    pub canvas: Canvas,
+    /// Named zones in display order.
+    pub zones: BTreeMap<ZoneName, Zone>,
+}
+```

--- a/_llm/L3-api-index/poiesis-deck.md
+++ b/_llm/L3-api-index/poiesis-deck.md
@@ -1,0 +1,55 @@
+# L3 API Index: poiesis-deck
+
+Crate path: `crates/poiesis/deck`
+
+Public API signatures extracted from source. Each signature is preceded by its doc comment.
+For implementation context, read the source directly (`L4`).
+
+## `src/error.rs`
+
+```rust
+pub enum DeckError {
+    /// Component not found in registry.
+    #[snafu(display("component '{id}' not found in registry"))]
+    ComponentNotFound {
+        /// The missing component id.
+        id: String,
+    },
+
+    /// Failed to load template file.
+    #[snafu(display("failed to load template for '{id}': {source}"))]
+    TemplateLoad {
+        /// The component id.
+        id: String,
+        /// The underlying IO error.
+        source: std::io::Error,
+    },
+
+    /// Template render error.
+    #[snafu(display("template render error for '{id}': {source}"))]
+    TemplateRender {
+        /// The component id.
+        id: String,
+        /// The underlying minijinja error.
+        source: minijinja::Error,
+    },
+}
+```
+
+## `src/lib.rs`
+
+```rust
+pub struct DeckRenderer {
+    /// Component registry providing templates and schemas.
+    pub registry: ComponentRegistry,
+    /// Resolved slide layout.
+    pub layout: SlideLayout,
+}
+```
+
+```rust
+impl DeckRenderer {
+    pub fn new (registry: ComponentRegistry, aspect: &AspectRatio) -> Self;
+    pub fn render (&self, deck: &Deck, meta: &Meta) -> Result<String, DeckError>;
+}
+```

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-29T22:46:40Z"
+generated_at = "2026-05-29T22:59:40Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -172,6 +172,18 @@ name = "poiesis-core"
 path = "crates/poiesis/core"
 source_hash = "f6cc9b1ce8bf972fea5cd2880c3367bb07f1014695fae10861e37f30fcc31f10"
 l3_token_estimate = 5949
+
+[[crates]]
+name = "poiesis-deck"
+path = "crates/poiesis/deck"
+source_hash = "7e622f4827d5f8d6bb238606aab91f7ee36b1637b21a796c93a6e67f163309b6"
+l3_token_estimate = 346
+
+[[crates]]
+name = "poiesis-deck-layout"
+path = "crates/poiesis/deck-layout"
+source_hash = "64440495a3c6ad133050935773377e4eae3889e7ef437f21d5d752d38dbc5ec0"
+l3_token_estimate = 396
 
 [[crates]]
 name = "poiesis-diff"

--- a/crates/poiesis/deck-layout/Cargo.toml
+++ b/crates/poiesis/deck-layout/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "poiesis-deck-layout"
+version.workspace = true
+description = "Slide layout solver for deck rendering — shared by HTML/CSS and PPTX backends"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+poiesis-core = { path = "../core" }
+serde = { workspace = true }

--- a/crates/poiesis/deck-layout/src/css.rs
+++ b/crates/poiesis/deck-layout/src/css.rs
@@ -1,0 +1,22 @@
+use crate::{Canvas, Zone};
+
+#[expect(
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    reason = "zone coords are normalized [0,1] × canvas ≤ 1280, well within i64"
+)]
+fn f64_to_px(v: f64, canvas_px: u32) -> i64 {
+    (v * f64::from(canvas_px)).round() as i64
+}
+
+/// Convert a normalized zone to absolute CSS pixel coordinates.
+///
+/// Returns a string like `"left: 64px; top: 36px; width: 1152px; height: 108px;"`.
+#[must_use]
+pub fn zone_to_css(zone: &Zone, canvas: &Canvas) -> String {
+    let left = f64_to_px(zone.x, canvas.width_px);
+    let top = f64_to_px(zone.y, canvas.height_px);
+    let width = f64_to_px(zone.w, canvas.width_px);
+    let height = f64_to_px(zone.h, canvas.height_px);
+    format!("left: {left}px; top: {top}px; width: {width}px; height: {height}px;")
+}

--- a/crates/poiesis/deck-layout/src/emu.rs
+++ b/crates/poiesis/deck-layout/src/emu.rs
@@ -1,0 +1,25 @@
+use crate::{Canvas, Zone};
+
+/// One pixel in EMU (English Metric Units).
+const PX_TO_EMU: f64 = 9144.0;
+
+#[expect(
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    reason = "zone coords are normalized [0,1] × canvas × 9144 ≤ 9e6, well within i64"
+)]
+fn f64_to_emu(v: f64, canvas_px: u32) -> i64 {
+    (v * f64::from(canvas_px) * PX_TO_EMU).round() as i64
+}
+
+/// Convert a normalized zone to OOXML EMU coordinates.
+///
+/// Returns `(x_emu, y_emu, cx_emu, cy_emu)`.
+#[must_use]
+pub fn zone_to_emu(zone: &Zone, canvas: &Canvas) -> (i64, i64, i64, i64) {
+    let x = f64_to_emu(zone.x, canvas.width_px);
+    let y = f64_to_emu(zone.y, canvas.height_px);
+    let cx = f64_to_emu(zone.w, canvas.width_px);
+    let cy = f64_to_emu(zone.h, canvas.height_px);
+    (x, y, cx, cy)
+}

--- a/crates/poiesis/deck-layout/src/lib.rs
+++ b/crates/poiesis/deck-layout/src/lib.rs
@@ -1,0 +1,11 @@
+//! Slide layout solver for deck rendering — shared by HTML/CSS and PPTX backends.
+
+pub mod css;
+pub mod emu;
+pub mod solver;
+pub mod zone;
+
+pub use css::zone_to_css;
+pub use emu::zone_to_emu;
+pub use solver::resolve_layout;
+pub use zone::{Canvas, SlideLayout, Zone, ZoneName};

--- a/crates/poiesis/deck-layout/src/solver.rs
+++ b/crates/poiesis/deck-layout/src/solver.rs
@@ -1,0 +1,94 @@
+use poiesis_core::scalar::AspectRatio;
+
+use crate::{Canvas, SlideLayout, Zone, ZoneName};
+
+/// Resolve the default slide layout for a given aspect ratio.
+///
+/// Builds a canvas and inserts all 9 predefined zones.
+#[must_use]
+pub fn resolve_layout(aspect: &AspectRatio) -> SlideLayout {
+    let canvas = Canvas::from_aspect(aspect);
+    let mut zones = std::collections::BTreeMap::new();
+    zones.insert(
+        ZoneName::Full,
+        Zone {
+            x: 0.00,
+            y: 0.00,
+            w: 1.00,
+            h: 1.00,
+        },
+    );
+    zones.insert(
+        ZoneName::Header,
+        Zone {
+            x: 0.05,
+            y: 0.05,
+            w: 0.90,
+            h: 0.15,
+        },
+    );
+    zones.insert(
+        ZoneName::SubHeader,
+        Zone {
+            x: 0.05,
+            y: 0.22,
+            w: 0.90,
+            h: 0.10,
+        },
+    );
+    zones.insert(
+        ZoneName::Body,
+        Zone {
+            x: 0.05,
+            y: 0.22,
+            w: 0.90,
+            h: 0.70,
+        },
+    );
+    zones.insert(
+        ZoneName::Content,
+        Zone {
+            x: 0.05,
+            y: 0.35,
+            w: 0.90,
+            h: 0.57,
+        },
+    );
+    zones.insert(
+        ZoneName::Footer,
+        Zone {
+            x: 0.00,
+            y: 0.90,
+            w: 1.00,
+            h: 0.10,
+        },
+    );
+    zones.insert(
+        ZoneName::LeftHalf,
+        Zone {
+            x: 0.05,
+            y: 0.22,
+            w: 0.44,
+            h: 0.70,
+        },
+    );
+    zones.insert(
+        ZoneName::RightHalf,
+        Zone {
+            x: 0.51,
+            y: 0.22,
+            w: 0.44,
+            h: 0.70,
+        },
+    );
+    zones.insert(
+        ZoneName::CenterKpi,
+        Zone {
+            x: 0.25,
+            y: 0.30,
+            w: 0.50,
+            h: 0.40,
+        },
+    );
+    SlideLayout { canvas, zones }
+}

--- a/crates/poiesis/deck-layout/src/zone.rs
+++ b/crates/poiesis/deck-layout/src/zone.rs
@@ -1,0 +1,101 @@
+use std::collections::BTreeMap;
+
+use poiesis_core::scalar::AspectRatio;
+use serde::{Deserialize, Serialize};
+
+/// Normalized zone coordinates in [0, 1].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Zone {
+    /// Normalized x position.
+    pub x: f64,
+    /// Normalized y position.
+    pub y: f64,
+    /// Normalized width.
+    pub w: f64,
+    /// Normalized height.
+    pub h: f64,
+}
+
+/// Named zone on a slide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ZoneName {
+    /// Full slide.
+    Full,
+    /// Top header area.
+    Header,
+    /// Sub-header below header.
+    SubHeader,
+    /// Main body area.
+    Body,
+    /// Content area.
+    Content,
+    /// Bottom footer.
+    Footer,
+    /// Left half split.
+    LeftHalf,
+    /// Right half split.
+    RightHalf,
+    /// Center KPI card.
+    CenterKpi,
+}
+
+impl ZoneName {
+    /// CSS class for this zone.
+    #[must_use]
+    pub fn css_class(self) -> &'static str {
+        match self {
+            Self::Full => "zone-full",
+            Self::Header => "zone-header",
+            Self::SubHeader => "zone-subheader",
+            Self::Body => "zone-body",
+            Self::Content => "zone-content",
+            Self::Footer => "zone-footer",
+            Self::LeftHalf => "zone-left-half",
+            Self::RightHalf => "zone-right-half",
+            Self::CenterKpi => "zone-center-kpi",
+        }
+    }
+}
+
+/// Canvas dimensions in pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Canvas {
+    /// Width in pixels.
+    pub width_px: u32,
+    /// Height in pixels.
+    pub height_px: u32,
+}
+
+impl Canvas {
+    /// Build a canvas from an aspect ratio.
+    ///
+    /// - 16:9 → 1280×720
+    /// - 4:3 → 1024×768
+    #[must_use]
+    pub fn from_aspect(aspect: &AspectRatio) -> Self {
+        match (aspect.width(), aspect.height()) {
+            (16, 9) => Self {
+                width_px: 1280,
+                height_px: 720,
+            },
+            (4, 3) => Self {
+                width_px: 1024,
+                height_px: 768,
+            },
+            _ => Self {
+                width_px: u32::from(aspect.width()) * 80,
+                height_px: u32::from(aspect.height()) * 80,
+            },
+        }
+    }
+}
+
+/// The complete layout of one slide.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SlideLayout {
+    /// Canvas dimensions.
+    pub canvas: Canvas,
+    /// Named zones in display order.
+    pub zones: BTreeMap<ZoneName, Zone>,
+}

--- a/crates/poiesis/deck/Cargo.toml
+++ b/crates/poiesis/deck/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "poiesis-deck"
+version.workspace = true
+description = "HTML/CSS deck renderer — three-layer CSS compositor and minijinja slide engine"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+poiesis-core = { path = "../core" }
+poiesis-deck-layout = { path = "../deck-layout" }
+minijinja = "2"
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tracing = { workspace = true }

--- a/crates/poiesis/deck/src/css.rs
+++ b/crates/poiesis/deck/src/css.rs
@@ -1,0 +1,41 @@
+use std::fmt::Write;
+
+use poiesis_deck_layout::zone_to_css;
+
+use crate::SlideLayout;
+
+/// Generate the three-layer CSS stylesheet for a deck.
+#[must_use]
+pub(crate) fn three_layer_css(layout: &SlideLayout) -> String {
+    let mut css = String::new();
+
+    // Layer 1: box-sizing reset + deck/slide structure
+    css.push_str("*, *::before, *::after { box-sizing: border-box; }\n");
+    css.push_str(".deck { display: flex; flex-direction: column; }\n");
+    let w = layout.canvas.width_px;
+    let h = layout.canvas.height_px;
+    let _ = writeln!(
+        css,
+        ".slide {{ position: relative; overflow: hidden; page-break-after: always; width: {w}px; height: {h}px; }}"
+    );
+
+    // Layer 2: CSS variables
+    css.push_str(":root {\n");
+    css.push_str("  --theme-primary: #1a56db;\n");
+    css.push_str("  --theme-secondary: #f3f4f6;\n");
+    css.push_str("  --theme-text: #111827;\n");
+    css.push_str("  --theme-accent: #059669;\n");
+    css.push_str("  --theme-bg: #ffffff;\n");
+    css.push_str("  --font-heading: 'Inter', sans-serif;\n");
+    css.push_str("  --font-body: 'Inter', sans-serif;\n");
+    css.push_str("}\n");
+
+    // Layer 3: zone positioning
+    for (name, zone) in &layout.zones {
+        let class = name.css_class();
+        let style = zone_to_css(zone, &layout.canvas);
+        let _ = writeln!(css, ".{class} {{ position: absolute; {style} }}");
+    }
+
+    css
+}

--- a/crates/poiesis/deck/src/error.rs
+++ b/crates/poiesis/deck/src/error.rs
@@ -1,0 +1,31 @@
+use snafu::Snafu;
+
+/// Errors that can occur during deck rendering.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum DeckError {
+    /// Component not found in registry.
+    #[snafu(display("component '{id}' not found in registry"))]
+    ComponentNotFound {
+        /// The missing component id.
+        id: String,
+    },
+
+    /// Failed to load template file.
+    #[snafu(display("failed to load template for '{id}': {source}"))]
+    TemplateLoad {
+        /// The component id.
+        id: String,
+        /// The underlying IO error.
+        source: std::io::Error,
+    },
+
+    /// Template render error.
+    #[snafu(display("template render error for '{id}': {source}"))]
+    TemplateRender {
+        /// The component id.
+        id: String,
+        /// The underlying minijinja error.
+        source: minijinja::Error,
+    },
+}

--- a/crates/poiesis/deck/src/lib.rs
+++ b/crates/poiesis/deck/src/lib.rs
@@ -1,0 +1,42 @@
+//! HTML/CSS deck renderer — three-layer CSS compositor and minijinja slide engine.
+
+pub mod error;
+
+mod css;
+mod render;
+
+use poiesis_core::bodies::Deck;
+use poiesis_core::components::ComponentRegistry;
+use poiesis_core::envelope::Meta;
+use poiesis_core::scalar::AspectRatio;
+use poiesis_deck_layout::SlideLayout;
+
+pub use error::DeckError;
+
+/// The deck renderer.
+#[derive(Debug, Clone)]
+pub struct DeckRenderer {
+    /// Component registry providing templates and schemas.
+    pub registry: ComponentRegistry,
+    /// Resolved slide layout.
+    pub layout: SlideLayout,
+}
+
+impl DeckRenderer {
+    /// Create a new renderer from a registry and aspect ratio.
+    #[must_use]
+    pub fn new(registry: ComponentRegistry, aspect: &AspectRatio) -> Self {
+        let layout = poiesis_deck_layout::resolve_layout(aspect);
+        Self { registry, layout }
+    }
+
+    /// Render a deck to a standalone HTML string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DeckError`] if a component is missing, a template fails to load,
+    /// or minijinja reports a render error.
+    pub fn render(&self, deck: &Deck, meta: &Meta) -> Result<String, DeckError> {
+        render::render_deck(&self.registry, &self.layout, deck, meta)
+    }
+}

--- a/crates/poiesis/deck/src/render.rs
+++ b/crates/poiesis/deck/src/render.rs
@@ -1,0 +1,113 @@
+use std::collections::HashMap;
+
+use poiesis_core::bodies::{Deck, Slide};
+use poiesis_core::components::ComponentRegistry;
+use poiesis_core::envelope::Meta;
+use poiesis_core::scalar::AspectRatio;
+use poiesis_deck_layout::SlideLayout;
+use serde_json::Value;
+use snafu::ResultExt;
+
+use crate::css::three_layer_css;
+use crate::error::{ComponentNotFoundSnafu, DeckError, TemplateLoadSnafu, TemplateRenderSnafu};
+
+/// Minimal HTML-escape for text content.
+fn html_escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Render a complete deck to a standalone HTML string.
+pub(crate) fn render_deck(
+    registry: &ComponentRegistry,
+    layout: &SlideLayout,
+    deck: &Deck,
+    meta: &Meta,
+) -> Result<String, DeckError> {
+    let css = three_layer_css(layout);
+    let title_escaped = html_escape(&meta.title);
+    let deck_class = if deck.aspect == AspectRatio::WIDESCREEN_16_9 {
+        "deck deck--16-9"
+    } else {
+        "deck deck--4-3"
+    };
+
+    let mut slides_html = String::new();
+    let total = deck.slides.len();
+
+    for (idx, slide) in deck.slides.iter().enumerate() {
+        let slide_markup = render_slide(registry, slide, idx, total, meta)?;
+        slides_html.push_str(&slide_markup);
+    }
+
+    Ok(format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=1280">
+  <title>{title_escaped}</title>
+  <style>{css}</style>
+</head>
+<body>
+<div class="{deck_class}">
+{slides_html}</div>
+</body>
+</html>"#
+    ))
+}
+
+/// Render a single slide to HTML.
+fn render_slide(
+    registry: &ComponentRegistry,
+    slide: &Slide,
+    idx: usize,
+    total: usize,
+    meta: &Meta,
+) -> Result<String, DeckError> {
+    let id = &slide.component;
+    let def = registry.get(id).ok_or_else(|| {
+        ComponentNotFoundSnafu {
+            id: id.as_str().to_owned(),
+        }
+        .build()
+    })?;
+
+    let template_source = std::fs::read_to_string(&def.html).context(TemplateLoadSnafu {
+        id: id.as_str().to_owned(),
+    })?;
+
+    let mut env = minijinja::Environment::new();
+    env.set_auto_escape_callback(|_| minijinja::AutoEscape::Html);
+    let template = env
+        .template_from_str(&template_source)
+        .context(TemplateRenderSnafu {
+            id: id.as_str().to_owned(),
+        })?;
+
+    let mut ctx = HashMap::<&str, Value>::new();
+    ctx.insert("fields", slide.fields.clone());
+    ctx.insert("slide_idx", Value::from(idx));
+    ctx.insert("total", Value::from(total));
+    ctx.insert(
+        "meta",
+        serde_json::json!({
+            "title": meta.title,
+            "author": meta.author,
+        }),
+    );
+
+    let inner = template.render(ctx).context(TemplateRenderSnafu {
+        id: id.as_str().to_owned(),
+    })?;
+
+    let component_id = id.as_str();
+    Ok(format!(
+        r#"  <div class="slide slide--{component_id}" data-slide="{idx}">
+    {inner}
+  </div>
+"#,
+    ))
+}


### PR DESCRIPTION
B-003 deck rendering pipeline — two new crates:

- `poiesis-deck-layout`: slide layout solver with normalized zone coordinates, pixel CSS output, and OOXML EMU output (shared by B-003 HTML/CSS and B-004 PPTX backends).
- `poiesis-deck`: three-layer CSS compositor + minijinja slide renderer producing a standalone HTML string.

Workspace wiring: root `Cargo.toml` members, `minijinja` workspace dependency, and `CRATE-INDEX.toml` entries included.