### PR TITLE
feat(poiesis-doc): pandoc availability probe + flake.nix pin (B-014)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7020,6 +7020,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tracing",
+ "which 8.0.2",
  "zip 8.5.1",
 ]
 
@@ -7091,6 +7092,7 @@ version = "0.29.0"
 dependencies = [
  "calamine",
  "poiesis-core",
+ "poiesis-theme",
  "rust_xlsxwriter",
  "serde_json",
  "snafu",
@@ -11373,6 +11375,15 @@ dependencies = [
  "env_home",
  "rustix 1.1.4",
  "winsafe",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/_llm/L3-api-index/poiesis-doc.md
+++ b/_llm/L3-api-index/poiesis-doc.md
@@ -105,3 +105,40 @@ pub fn render_pdf_from_doc (doc: &poiesis_core::Document) -> Result<Vec<u8>>
 ```rust
 pub fn render_odt_from_doc (_doc: &poiesis_core::Document) -> Result<Vec<u8>>
 ```
+
+## `src/pandoc_probe.rs`
+
+```rust
+pub struct PandocProbe {
+    /// Absolute path to the `pandoc` binary.
+    pub path: PathBuf,
+    /// Version string reported by `pandoc --version`, e.g. `"3.1.13"`.
+    pub version: String,
+}
+```
+
+```rust
+impl PandocProbe {
+    pub fn check () -> Result<Self, PandocProbeError>;
+}
+```
+
+```rust
+pub enum PandocProbeError {
+    /// `pandoc` binary not found on `PATH`.
+    #[snafu(display(
+        "pandoc not found on PATH — install via `nix develop` \
+         (pandoc is pinned in flake.nix), or use the `pdf` format which needs no pandoc"
+    ))]
+    NotFound,
+
+    /// `pandoc --version` found the binary but the command failed.
+    #[snafu(display("pandoc found at {} but `pandoc --version` failed: {detail}", path.display()))]
+    VersionCheckFailed {
+        /// Path where pandoc was found.
+        path: PathBuf,
+        /// Human-readable failure reason.
+        detail: String,
+    },
+}
+```

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-30T02:46:31Z"
+generated_at = "2026-05-30T03:00:47Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -194,8 +194,8 @@ l3_token_estimate = 446
 [[crates]]
 name = "poiesis-doc"
 path = "crates/poiesis/doc"
-source_hash = "de565291bf627ea000ff922b22b821b0bbb006a853b5925f69391e305f6d7cc5"
-l3_token_estimate = 706
+source_hash = "fbb92c8c44141764e4c6b7d7c06364c1e1e79642cba8e032e33078fcec889f8c"
+l3_token_estimate = 940
 
 [[crates]]
 name = "poiesis-inspect"

--- a/crates/poiesis/doc/Cargo.toml
+++ b/crates/poiesis/doc/Cargo.toml
@@ -25,6 +25,9 @@ quick-xml = "0.39"
 poiesis-core = { path = "../core" }
 poiesis-typst = { path = "../typst" }
 
+# Pandoc binary discovery for the availability probe
+which = "8"
+
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/poiesis/doc/src/lib.rs
+++ b/crates/poiesis/doc/src/lib.rs
@@ -23,9 +23,11 @@
 //! `Heading1`, `Heading2`, `Normal`, etc.
 
 mod error;
+mod pandoc_probe;
 mod typst_bridge;
 
 pub use error::Error;
+pub use pandoc_probe::{PandocProbe, PandocProbeError};
 
 use serde_json::Value;
 use snafu::ResultExt;

--- a/crates/poiesis/doc/src/pandoc_probe.rs
+++ b/crates/poiesis/doc/src/pandoc_probe.rs
@@ -1,0 +1,101 @@
+//! Pandoc binary availability probe.
+//!
+//! Call [`PandocProbe::check`] before invoking any Pandoc render path.
+//! If the binary is missing the error message tells the operator exactly
+//! how to fix it (run `nix develop` — pandoc is pinned in `flake.nix`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use snafu::Snafu;
+
+/// Confirmed pandoc installation: binary path and reported version.
+#[derive(Debug, Clone)]
+pub struct PandocProbe {
+    /// Absolute path to the `pandoc` binary.
+    pub path: PathBuf,
+    /// Version string reported by `pandoc --version`, e.g. `"3.1.13"`.
+    pub version: String,
+}
+
+impl PandocProbe {
+    /// Probe for `pandoc` on `PATH`.
+    ///
+    /// Returns the binary path and version on success. Returns an error with
+    /// an actionable message pointing at `nix develop` if pandoc is absent
+    /// or unresponsive.
+    ///
+    /// # Errors
+    ///
+    /// - [`PandocProbeError::NotFound`] when the binary is not on `PATH`.
+    /// - [`PandocProbeError::VersionCheckFailed`] when `pandoc --version` fails.
+    pub fn check() -> Result<Self, PandocProbeError> {
+        let path = which::which("pandoc").map_err(|_e| PandocProbeError::NotFound)?;
+
+        let output = Command::new(&path).arg("--version").output().map_err(|e| {
+            PandocProbeError::VersionCheckFailed {
+                path: path.clone(),
+                detail: e.to_string(),
+            }
+        })?;
+
+        if !output.status.success() {
+            return Err(PandocProbeError::VersionCheckFailed {
+                path,
+                detail: format!("exit status {}", output.status),
+            });
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let version = stdout
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("unknown")
+            .to_owned();
+
+        Ok(Self { path, version })
+    }
+}
+
+/// Error from the pandoc availability check.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum PandocProbeError {
+    /// `pandoc` binary not found on `PATH`.
+    #[snafu(display(
+        "pandoc not found on PATH — install via `nix develop` \
+         (pandoc is pinned in flake.nix), or use the `pdf` format which needs no pandoc"
+    ))]
+    NotFound,
+
+    /// `pandoc --version` found the binary but the command failed.
+    #[snafu(display("pandoc found at {} but `pandoc --version` failed: {detail}", path.display()))]
+    VersionCheckFailed {
+        /// Path where pandoc was found.
+        path: PathBuf,
+        /// Human-readable failure reason.
+        detail: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_check_returns_result() {
+        // Passes whether pandoc is present or absent — must not panic.
+        let _ = PandocProbe::check();
+    }
+
+    #[test]
+    fn probe_error_message_is_actionable() {
+        let msg = PandocProbeError::NotFound.to_string();
+        assert!(
+            msg.contains("nix develop"),
+            "error must mention `nix develop`"
+        );
+        assert!(msg.contains("flake.nix"), "error must mention flake.nix");
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
         pkgs.pkg-config
         pkgs.cmake
         pkgs.rustPlatform.bindgenHook
+        pkgs.pandoc
       ];
 
       # Shared source filter: include Rust sources, Cargo manifests,
@@ -102,6 +103,7 @@
           # Build tooling
           pkgs.cargo-deny
           pkgs.cargo-watch
+          pkgs.pandoc
 
           # Wayland session support
           pkgs.wayland-protocols


### PR DESCRIPTION
## Summary

- Adds `PandocProbe::check()` to `poiesis-doc` — probes for the `pandoc` binary at startup of the doc render path via `which`, runs `pandoc --version` to confirm responsiveness, and emits an **actionable** error pointing at `nix develop` + `flake.nix` if the binary is missing.
- Pins `pkgs.pandoc` in `flake.nix` in both `buildInputs` and the `devShell` package list (fixes the gap identified in B-014 spec — flake did not previously vendor pandoc).
- Adds `which = "8"` as a direct dep of `poiesis-doc` (already in workspace Cargo.lock).

## Acceptance (per planning/poiesis-evolution/B-014)

- [x] `PandocProbe::check()` returns `Ok` if pandoc is present, `Err(PandocProbeError::NotFound)` if absent
- [x] Error message mentions `nix develop` and `flake.nix` — both asserted by `probe_error_message_is_actionable` test
- [x] `flake.nix` adds `pkgs.pandoc` (pinned via nixpkgs-unstable, same lockfile discipline as existing deps)
- [x] Gate-Passed: kanon 0.1.0

## Notes

B-012 (Pandoc backend subprocess invocation) will call `PandocProbe::check()` as its first step before any pandoc render. B-013 (retire poiesis-text) is independent and ships separately.