### PR TITLE
feat(poiesis): add stat, quote, chart, table, image-full component packs

### DIFF
--- a/crates/poiesis/components/chart/recipe.toml
+++ b/crates/poiesis/components/chart/recipe.toml
@@ -1,0 +1,10 @@
+[slide]
+layout = "blank"
+
+[[shapes]]
+type = "text"
+zone = "header"
+text_field = "title"
+style = "title"
+font_size = 28
+bold = true

--- a/crates/poiesis/components/chart/schema.json
+++ b/crates/poiesis/components/chart/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "chart_type": { "type": "string", "description": "e.g. 'bar', 'line', 'pie'" },
+    "caption": { "type": "string" },
+    "data_note": { "type": "string", "description": "Data source or description note" }
+  }
+}

--- a/crates/poiesis/components/chart/template.html.j2
+++ b/crates/poiesis/components/chart/template.html.j2
@@ -1,0 +1,17 @@
+<div class="zone-header">
+  <h2 style="font-family:var(--font-heading);font-size:1.75rem;font-weight:700;color:var(--theme-text);">{{ fields.title }}</h2>
+  {% if fields.chart_type %}
+  <span style="font-family:var(--font-body);font-size:0.75rem;color:var(--theme-primary);text-transform:uppercase;letter-spacing:0.05em;font-weight:600;">{{ fields.chart_type }} chart</span>
+  {% endif %}
+</div>
+<div class="zone-content" style="display:flex;flex-direction:column;align-items:center;justify-content:center;gap:0.5rem;">
+  <div style="width:90%;height:65%;background:var(--theme-secondary);border:2px dashed var(--theme-primary);border-radius:4px;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+    <span style="font-family:var(--font-body);font-size:1.25rem;color:var(--theme-text);">[ chart ]</span>
+  </div>
+  {% if fields.data_note %}
+  <p style="font-family:var(--font-body);font-size:0.75rem;color:var(--theme-text);opacity:0.5;text-align:center;">{{ fields.data_note }}</p>
+  {% endif %}
+  {% if fields.caption %}
+  <p style="font-family:var(--font-body);font-size:0.875rem;color:var(--theme-text);opacity:0.65;text-align:center;font-style:italic;">{{ fields.caption }}</p>
+  {% endif %}
+</div>

--- a/crates/poiesis/components/chart/tokens.toml
+++ b/crates/poiesis/components/chart/tokens.toml
@@ -1,0 +1,1 @@
+tokens = ["--theme-primary", "--theme-secondary", "--theme-text", "--font-heading", "--font-body"]

--- a/crates/poiesis/components/image-full/recipe.toml
+++ b/crates/poiesis/components/image-full/recipe.toml
@@ -1,0 +1,7 @@
+[slide]
+layout = "blank"
+
+[[shapes]]
+type = "image"
+zone = "full"
+image_field = "src"

--- a/crates/poiesis/components/image-full/schema.json
+++ b/crates/poiesis/components/image-full/schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["src", "alt"],
+  "properties": {
+    "src": { "type": "string", "minLength": 1, "description": "Image URL or relative path" },
+    "alt": { "type": "string", "minLength": 1 },
+    "caption": { "type": "string" }
+  }
+}

--- a/crates/poiesis/components/image-full/template.html.j2
+++ b/crates/poiesis/components/image-full/template.html.j2
@@ -1,0 +1,8 @@
+<div class="zone-full" style="position:relative;overflow:hidden;">
+  <img src="{{ fields.src }}" alt="{{ fields.alt }}" style="width:100%;height:100%;object-fit:cover;display:block;">
+  {% if fields.caption %}
+  <div style="position:absolute;bottom:0;left:0;right:0;padding:0.75rem 1rem;background:linear-gradient(transparent,rgba(0,0,0,0.6));">
+    <p style="font-family:var(--font-body);font-size:0.875rem;color:#fff;margin:0;">{{ fields.caption }}</p>
+  </div>
+  {% endif %}
+</div>

--- a/crates/poiesis/components/image-full/tokens.toml
+++ b/crates/poiesis/components/image-full/tokens.toml
@@ -1,0 +1,1 @@
+tokens = ["--font-body"]

--- a/crates/poiesis/components/quote/recipe.toml
+++ b/crates/poiesis/components/quote/recipe.toml
@@ -1,0 +1,9 @@
+[slide]
+layout = "blank"
+
+[[shapes]]
+type = "text"
+zone = "body"
+text_field = "quote"
+style = "quote"
+font_size = 28

--- a/crates/poiesis/components/quote/schema.json
+++ b/crates/poiesis/components/quote/schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["quote", "attribution"],
+  "properties": {
+    "quote": { "type": "string", "minLength": 1 },
+    "attribution": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "description": "Role or organisation of the quoted person" }
+  }
+}

--- a/crates/poiesis/components/quote/template.html.j2
+++ b/crates/poiesis/components/quote/template.html.j2
@@ -1,0 +1,11 @@
+<div class="zone-full" style="display:flex;flex-direction:column;align-items:center;justify-content:center;padding:3rem;">
+  <blockquote style="font-family:var(--font-heading);font-size:2rem;font-weight:400;color:var(--theme-text);font-style:italic;text-align:center;max-width:80%;line-height:1.4;margin:0;">
+    &#8220;{{ fields.quote }}&#8221;
+  </blockquote>
+  <div style="margin-top:2rem;text-align:center;">
+    <span style="font-family:var(--font-body);font-size:1rem;font-weight:600;color:var(--theme-primary);">{{ fields.attribution }}</span>
+    {% if fields.title %}
+    <span style="font-family:var(--font-body);font-size:0.875rem;color:var(--theme-text);opacity:0.6;display:block;margin-top:0.25rem;">{{ fields.title }}</span>
+    {% endif %}
+  </div>
+</div>

--- a/crates/poiesis/components/quote/tokens.toml
+++ b/crates/poiesis/components/quote/tokens.toml
@@ -1,0 +1,1 @@
+tokens = ["--theme-primary", "--theme-text", "--font-heading", "--font-body"]

--- a/crates/poiesis/components/stat/recipe.toml
+++ b/crates/poiesis/components/stat/recipe.toml
@@ -1,0 +1,17 @@
+[slide]
+layout = "center-kpi"
+
+[[shapes]]
+type = "text"
+zone = "center-kpi"
+text_field = "metric"
+style = "kpi"
+font_size = 72
+bold = true
+
+[[shapes]]
+type = "text"
+zone = "footer"
+text_field = "label"
+style = "label"
+font_size = 20

--- a/crates/poiesis/components/stat/schema.json
+++ b/crates/poiesis/components/stat/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["metric", "label"],
+  "properties": {
+    "metric": { "type": "string", "minLength": 1, "description": "The KPI value, e.g. '94%' or '$2.4M'" },
+    "label": { "type": "string", "minLength": 1, "description": "Short label below the metric" },
+    "description": { "type": "string" },
+    "context": { "type": "string", "description": "Trend, timeframe, or comparison note" }
+  }
+}

--- a/crates/poiesis/components/stat/template.html.j2
+++ b/crates/poiesis/components/stat/template.html.j2
@@ -1,0 +1,12 @@
+<div class="zone-header">
+  <h2 style="font-family:var(--font-heading);font-size:1.25rem;font-weight:600;color:var(--theme-text);opacity:0.7;">{{ fields.label }}</h2>
+</div>
+<div class="zone-center-kpi" style="display:flex;flex-direction:column;align-items:center;justify-content:center;">
+  <div style="font-family:var(--font-heading);font-size:5rem;font-weight:800;color:var(--theme-primary);line-height:1;letter-spacing:-0.02em;">{{ fields.metric }}</div>
+  {% if fields.description %}
+  <p style="font-family:var(--font-body);font-size:1.125rem;color:var(--theme-text);opacity:0.75;margin-top:1rem;text-align:center;">{{ fields.description }}</p>
+  {% endif %}
+  {% if fields.context %}
+  <p style="font-family:var(--font-body);font-size:0.875rem;color:var(--theme-text);opacity:0.5;margin-top:0.5rem;text-align:center;">{{ fields.context }}</p>
+  {% endif %}
+</div>

--- a/crates/poiesis/components/stat/tokens.toml
+++ b/crates/poiesis/components/stat/tokens.toml
@@ -1,0 +1,1 @@
+tokens = ["--theme-primary", "--theme-text", "--font-heading", "--font-body"]

--- a/crates/poiesis/components/table/recipe.toml
+++ b/crates/poiesis/components/table/recipe.toml
@@ -1,0 +1,10 @@
+[slide]
+layout = "blank"
+
+[[shapes]]
+type = "text"
+zone = "header"
+text_field = "title"
+style = "title"
+font_size = 28
+bold = true

--- a/crates/poiesis/components/table/schema.json
+++ b/crates/poiesis/components/table/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["title", "headers", "rows"],
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "headers": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "rows": {
+      "type": "array",
+      "items": { "type": "array", "items": { "type": "string" } },
+      "minItems": 1
+    },
+    "caption": { "type": "string" }
+  }
+}

--- a/crates/poiesis/components/table/template.html.j2
+++ b/crates/poiesis/components/table/template.html.j2
@@ -1,0 +1,26 @@
+<div class="zone-header">
+  <h2 style="font-family:var(--font-heading);font-size:1.75rem;font-weight:700;color:var(--theme-text);">{{ fields.title }}</h2>
+</div>
+<div class="zone-content" style="overflow:auto;">
+  <table style="width:100%;border-collapse:collapse;font-family:var(--font-body);font-size:0.875rem;color:var(--theme-text);">
+    <thead>
+      <tr style="background:var(--theme-primary);color:#fff;">
+        {% for h in fields.headers %}
+        <th style="padding:0.5rem 0.75rem;text-align:left;font-weight:600;">{{ h }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in fields.rows %}
+      <tr{% if loop.index % 2 == 0 %} style="background:var(--theme-secondary);"{% endif %}>
+        {% for cell in row %}
+        <td style="padding:0.5rem 0.75rem;border-bottom:1px solid rgba(0,0,0,0.05);">{{ cell }}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% if fields.caption %}
+  <p style="font-size:0.75rem;color:var(--theme-text);opacity:0.5;margin-top:0.5rem;font-style:italic;">{{ fields.caption }}</p>
+  {% endif %}
+</div>

--- a/crates/poiesis/components/table/tokens.toml
+++ b/crates/poiesis/components/table/tokens.toml
@@ -1,0 +1,1 @@
+tokens = ["--theme-primary", "--theme-secondary", "--theme-text", "--font-heading", "--font-body"]


### PR DESCRIPTION
Adds five new Poiesis component packs:

- `stat` — KPI metric slide with large number, label, optional description and context
- `quote` — Pull-quote slide with attribution and optional title
- `chart` — Chart placeholder slide with labeled box
- `table` — Data table slide with headers, rows, and optional caption
- `image-full` — Full-bleed image slide with optional caption overlay

Pure asset files (schema, recipe, template, tokens) — no Rust code changes.