### PR TITLE
feat(poiesis): add chromium CDP printer for HTML-to-PDF conversion

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,4 +18,6 @@ ignore = [
     "RUSTSEC-2025-0134",
     # rand 0.8 unsound only with custom logger using rand::rng() — not our usage. Transitive via qdrant-client → tonic 0.12 + spreadsheet-ods + phf
     "RUSTSEC-2026-0097",
+    # async-std unmaintained — transitive via chromiumoxide 0.7.0; no upgrade path while pinned to 0.7
+    "RUSTSEC-2025-0052",
 ]

--- a/CRATE-INDEX.toml
+++ b/CRATE-INDEX.toml
@@ -332,6 +332,16 @@ used_by = []
 [crates.poiesis-deck.features]
 default = ""
 
+[crates.poiesis-printer-chromium]
+path = "crates/poiesis/printer-chromium"
+layer = "tool"
+purpose = "Chromium CDP wrapper — converts HTML strings to PDF bytes via headless browser"
+depends_on = ["poiesis-core"]
+used_by = []
+
+[crates.poiesis-printer-chromium.features]
+chromium = "Enable headless Chromium PDF printing via CDP (requires system Chromium)"
+
 [crates.poiesis-theme]
 path = "crates/poiesis/theme"
 layer = "types"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +480,128 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -472,6 +627,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +641,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5359381fd414fbdb272c48f2111c16cb0bb3447bfacd59311ff3736da9f6664"
+dependencies = [
+ "async-std",
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tokio",
+ "tungstenite 0.23.0",
 ]
 
 [[package]]
@@ -837,6 +1013,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1137,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "byteview"
@@ -1184,6 +1376,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b52a9840ffff5d4d0058ae529fa066a75e794e3125546acfc61c23ad755e49"
 
 [[package]]
+name = "chromiumoxide"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8380ce7721cc895fe8a184c49d615fe755b0c9a3d7986355cee847439fff907f"
+dependencies = [
+ "async-std",
+ "async-tungstenite",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chromiumoxide_cdp",
+ "chromiumoxide_types",
+ "dunce",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+ "which 6.0.3",
+ "winreg",
+]
+
+[[package]]
+name = "chromiumoxide_cdp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadbfb52fa0aeca43626f6c42ca04184b108b786f8e45198dc41a42aedcf2e50"
+dependencies = [
+ "chromiumoxide_pdl",
+ "chromiumoxide_types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_pdl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c197aeb42872c5d4c923e7d8ad46d99a58fd0fec37f6491554ff677a6791d3c9"
+dependencies = [
+ "chromiumoxide_types",
+ "either",
+ "heck 0.4.1",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923486888790528d55ac37ec2f7483ed19eb8ccbb44701878e5856d1ceadf5d8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,7 +1542,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1458,6 +1718,15 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console"
@@ -1758,7 +2027,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2311,7 +2580,7 @@ dependencies = [
  "subsecond",
  "thiserror 2.0.18",
  "tracing",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -2778,7 +3047,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2856,6 +3125,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "episteme"
@@ -2936,6 +3211,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3287,6 +3589,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3308,6 +3623,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -3507,7 +3828,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link",
 ]
 
@@ -3854,6 +4175,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -3935,6 +4262,15 @@ name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -4843,7 +5179,7 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "regex",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "snafu",
@@ -5007,7 +5343,7 @@ dependencies = [
  "rmp-serde",
  "rust-stemmers",
  "rustc-hash 2.1.2",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -5042,6 +5378,15 @@ dependencies = [
  "arrayvec",
  "euclid 0.22.14",
  "smallvec",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -5144,6 +5489,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -5193,6 +5544,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "longest-increasing-subsequence"
@@ -5468,7 +5822,7 @@ dependencies = [
  "koina",
  "libc",
  "prometheus-client",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "snafu",
@@ -5489,7 +5843,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -6026,7 +6380,7 @@ dependencies = [
  "koina",
  "notify",
  "prometheus-client",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "snafu",
@@ -6158,7 +6512,7 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "reqwest 0.13.2",
- "rustix",
+ "rustix 1.1.4",
  "rustls",
  "seccompiler",
  "serde",
@@ -6247,6 +6601,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -6551,6 +6911,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6712,6 +7089,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "poiesis-printer-chromium"
+version = "0.29.0"
+dependencies = [
+ "chromiumoxide",
+ "futures",
+ "poiesis-core",
+ "snafu",
+ "tokio",
+ "tracing",
+ "which 7.0.3",
+]
+
+[[package]]
 name = "poiesis-scaffold"
 version = "0.29.0"
 dependencies = [
@@ -6797,6 +7187,20 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8074,6 +8478,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -8081,7 +8498,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -8747,7 +9164,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8929,7 +9346,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9016,7 +9433,7 @@ dependencies = [
  "prometheus-client",
  "rand 0.10.1",
  "reqwest 0.13.2",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -9147,7 +9564,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -9871,6 +10288,24 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -10108,7 +10543,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141cbd1027129fbf6bda1013f52a264df7befc7388cc8f47767d65e803fd3a59"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10570,6 +11005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
 name = "varint-rs"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10949,6 +11390,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.1.4",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11091,6 +11556,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -11138,6 +11612,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -11190,6 +11679,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -11208,6 +11703,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -11223,6 +11724,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11256,6 +11763,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -11271,6 +11784,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11292,6 +11811,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -11307,6 +11832,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11337,6 +11868,22 @@ checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"
@@ -11377,7 +11924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -11388,7 +11935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
@@ -11490,7 +12037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "crates/poiesis/deck",
     "crates/poiesis/deck-layout",
     "crates/poiesis/doc",
+    "crates/poiesis/printer-chromium",
     "crates/poiesis/diff",
     "crates/poiesis/inspect",
     "crates/gnosis",

--- a/_llm/L3-api-index/poiesis-printer-chromium.md
+++ b/_llm/L3-api-index/poiesis-printer-chromium.md
@@ -1,0 +1,63 @@
+# L3 API Index: poiesis-printer-chromium
+
+Crate path: `crates/poiesis/printer-chromium`
+
+Public API signatures extracted from source. Each signature is preceded by its doc comment.
+For implementation context, read the source directly (`L4`).
+
+## `src/error.rs`
+
+```rust
+pub enum PrinterError {
+    #[snafu(display("Chromium binary not found; install chromium or set CHROMIUM_PATH env var"))]
+    ChromiumNotFound,
+    #[snafu(display("Browser launch failed: {source}"))]
+    BrowserLaunch {
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[snafu(display("Page error: {source}"))]
+    PageError {
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[snafu(display("PDF generation failed: {source}"))]
+    PdfError {
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+```
+
+## `src/lib.rs`
+
+```rust
+pub struct PrintOptions {
+    /// Paper width in mm.
+    pub paper_width_mm: f64,
+    /// Paper height in mm.
+    pub paper_height_mm: f64,
+    /// Top margin in mm (0.0 = no margin).
+    pub margin_top_mm: f64,
+    /// Bottom margin in mm.
+    pub margin_bottom_mm: f64,
+    /// Left margin in mm.
+    pub margin_left_mm: f64,
+    /// Right margin in mm.
+    pub margin_right_mm: f64,
+    /// Page scale factor (1.0 = 100%).
+    pub scale: f64,
+}
+```
+
+```rust
+impl PrintOptions {
+    pub fn widescreen_16_9 () -> Self;
+    pub fn standard_4_3 () -> Self;
+    pub fn from_aspect (aspect: &poiesis_core::scalar::AspectRatio) -> Self;
+}
+```
+
+```rust
+pub async fn print_to_pdf (html: &str, opts: &PrintOptions) -> Result<Vec<u8>, PrinterError>
+```

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -216,6 +216,12 @@ source_hash = "de719b792a5a6a7cb254fb0fa998e67a70b54f5b6bec2171d388763fcebaf180"
 l3_token_estimate = 841
 
 [[crates]]
+name = "poiesis-printer-chromium"
+path = "crates/poiesis/printer-chromium"
+source_hash = "070e9b6a13d051f9ab8f8495ad03e9ca4f7e756bb910efac9abac5405aa31662"
+l3_token_estimate = 459
+
+[[crates]]
 name = "poiesis-scaffold"
 path = "crates/poiesis/scaffold"
 source_hash = "c92b30fca6288086833ee78ab733eb27d3395629ec3b5e95325ccf46a0084b9f"

--- a/crates/poiesis/printer-chromium/Cargo.toml
+++ b/crates/poiesis/printer-chromium/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "poiesis-printer-chromium"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[features]
+default = ["chromium"]
+chromium = ["dep:chromiumoxide", "dep:tokio", "dep:which", "dep:futures"]
+
+[dependencies]
+poiesis-core = { path = "../core" }
+chromiumoxide = { version = "=0.7.0", optional = true, features = ["tokio-runtime"] }
+tokio = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+which = { version = "=7.0.3", optional = true }
+snafu = { workspace = true }
+tracing = { workspace = true }

--- a/crates/poiesis/printer-chromium/src/chromium_impl.rs
+++ b/crates/poiesis/printer-chromium/src/chromium_impl.rs
@@ -1,0 +1,92 @@
+use std::path::PathBuf;
+
+use chromiumoxide::{Browser, BrowserConfig};
+use futures::StreamExt as _;
+use tracing::debug;
+
+use crate::{PrintOptions, PrinterError};
+
+pub(crate) async fn print_to_pdf_inner(
+    html: &str,
+    opts: &PrintOptions,
+) -> Result<Vec<u8>, PrinterError> {
+    let exe = find_chromium().ok_or(PrinterError::ChromiumNotFound)?;
+    debug!(path = %exe.display(), "launching Chromium");
+
+    let config = BrowserConfig::builder()
+        .chrome_executable(exe)
+        .arg("--no-sandbox")
+        .arg("--disable-gpu")
+        .arg("--disable-dev-shm-usage")
+        .build()
+        .map_err(|e| PrinterError::BrowserLaunch {
+            source: Box::from(e),
+        })?;
+
+    let (mut browser, mut handler) =
+        Browser::launch(config)
+            .await
+            .map_err(|e| PrinterError::BrowserLaunch {
+                source: Box::from(e),
+            })?;
+
+    let _handle = tokio::spawn(async move { while let Some(_ev) = handler.next().await {} });
+
+    let page = browser
+        .new_page("about:blank")
+        .await
+        .map_err(|e| PrinterError::PageError {
+            source: Box::from(e),
+        })?;
+
+    page.set_content(html)
+        .await
+        .map_err(|e| PrinterError::PageError {
+            source: Box::from(e),
+        })?;
+
+    // Convert mm to inches for CDP (1 in = 25.4 mm)
+    let mm_to_in = |mm: f64| mm / 25.4;
+
+    let pdf_params = chromiumoxide::cdp::browser_protocol::page::PrintToPdfParams::builder()
+        .paper_width(mm_to_in(opts.paper_width_mm))
+        .paper_height(mm_to_in(opts.paper_height_mm))
+        .margin_top(mm_to_in(opts.margin_top_mm))
+        .margin_bottom(mm_to_in(opts.margin_bottom_mm))
+        .margin_left(mm_to_in(opts.margin_left_mm))
+        .margin_right(mm_to_in(opts.margin_right_mm))
+        .scale(opts.scale)
+        .print_background(true)
+        .build();
+
+    let pdf_bytes = page
+        .pdf(pdf_params)
+        .await
+        .map_err(|e| PrinterError::PdfError {
+            source: Box::from(e),
+        })?;
+
+    browser.close().await.ok();
+
+    Ok(pdf_bytes)
+}
+
+fn find_chromium() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CHROMIUM_PATH") {
+        let pb = PathBuf::from(&path);
+        if pb.exists() {
+            return Some(pb);
+        }
+    }
+    for candidate in &[
+        "chromium",
+        "chromium-browser",
+        "google-chrome",
+        "google-chrome-stable",
+    ] {
+        if let Ok(path) = which::which(candidate) {
+            return Some(path);
+        }
+    }
+    None
+}

--- a/crates/poiesis/printer-chromium/src/error.rs
+++ b/crates/poiesis/printer-chromium/src/error.rs
@@ -1,0 +1,23 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum PrinterError {
+    #[snafu(display("Chromium binary not found; install chromium or set CHROMIUM_PATH env var"))]
+    ChromiumNotFound,
+    #[snafu(display("Browser launch failed: {source}"))]
+    BrowserLaunch {
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[snafu(display("Page error: {source}"))]
+    PageError {
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[snafu(display("PDF generation failed: {source}"))]
+    PdfError {
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}

--- a/crates/poiesis/printer-chromium/src/lib.rs
+++ b/crates/poiesis/printer-chromium/src/lib.rs
@@ -1,0 +1,95 @@
+//! Chromium CDP wrapper for HTML-to-PDF conversion.
+//!
+//! # Soft dependency
+//!
+//! The `chromium` feature (enabled by default) requires a system Chromium browser.
+//!
+//! **Install:**
+//! - Debian/Ubuntu: `apt install chromium`
+//! - macOS: `brew install --cask chromium`
+//!
+//! **Override binary path:** set the `CHROMIUM_PATH` environment variable.
+
+pub mod error;
+pub use error::PrinterError;
+
+/// PDF print options controlling paper size and margins.
+#[derive(Debug, Clone)]
+pub struct PrintOptions {
+    /// Paper width in mm.
+    pub paper_width_mm: f64,
+    /// Paper height in mm.
+    pub paper_height_mm: f64,
+    /// Top margin in mm (0.0 = no margin).
+    pub margin_top_mm: f64,
+    /// Bottom margin in mm.
+    pub margin_bottom_mm: f64,
+    /// Left margin in mm.
+    pub margin_left_mm: f64,
+    /// Right margin in mm.
+    pub margin_right_mm: f64,
+    /// Page scale factor (1.0 = 100%).
+    pub scale: f64,
+}
+
+impl Default for PrintOptions {
+    fn default() -> Self {
+        Self::widescreen_16_9()
+    }
+}
+
+impl PrintOptions {
+    /// 16:9 widescreen — 254 mm × 142.875 mm, no margins.
+    #[must_use]
+    pub fn widescreen_16_9() -> Self {
+        Self {
+            paper_width_mm: 254.0,
+            paper_height_mm: 142.875,
+            margin_top_mm: 0.0,
+            margin_bottom_mm: 0.0,
+            margin_left_mm: 0.0,
+            margin_right_mm: 0.0,
+            scale: 1.0,
+        }
+    }
+
+    /// 4:3 standard — 254 mm × 190.5 mm, no margins.
+    #[must_use]
+    pub fn standard_4_3() -> Self {
+        Self {
+            paper_width_mm: 254.0,
+            paper_height_mm: 190.5,
+            margin_top_mm: 0.0,
+            margin_bottom_mm: 0.0,
+            margin_left_mm: 0.0,
+            margin_right_mm: 0.0,
+            scale: 1.0,
+        }
+    }
+
+    /// Select options based on a `poiesis_core` aspect ratio.
+    #[must_use]
+    pub fn from_aspect(aspect: &poiesis_core::scalar::AspectRatio) -> Self {
+        if aspect == &poiesis_core::scalar::AspectRatio::WIDESCREEN_16_9 {
+            Self::widescreen_16_9()
+        } else {
+            Self::standard_4_3()
+        }
+    }
+}
+
+#[cfg(feature = "chromium")]
+mod chromium_impl;
+
+/// Convert an HTML string to PDF bytes using a headless Chromium browser.
+///
+/// # Errors
+///
+/// - [`PrinterError::ChromiumNotFound`] — no Chromium binary is available
+/// - [`PrinterError::BrowserLaunch`] — CDP browser failed to start
+/// - [`PrinterError::PageError`] — page navigation or content error
+/// - [`PrinterError::PdfError`] — PDF generation failed
+#[cfg(feature = "chromium")]
+pub async fn print_to_pdf(html: &str, opts: &PrintOptions) -> Result<Vec<u8>, PrinterError> {
+    chromium_impl::print_to_pdf_inner(html, opts).await
+}

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,10 @@ reason = "paste unmaintained, transitive via tokenizers; no safe upgrade"
 id = "RUSTSEC-2025-0134"
 reason = "rustls-pemfile 2.x unmaintained — transitive via qdrant-client → tonic 0.12. Blocked until qdrant-client upgrades tonic to 0.13+"
 
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0052"
+reason = "async-std unmaintained — transitive via chromiumoxide 0.7.0; no upgrade path while pinned to 0.7"
+
 [licenses]
 # WHY: `version = 2` enables modern SPDX 3.x parsing so "AGPL-3.0-or-later" /
 # "LGPL-3.0-or-later" are accepted as bare license identifiers. Without this,


### PR DESCRIPTION
New `poiesis-printer-chromium` crate — headless Chromium bridge via CDP for HTML→PDF rendering (B-003).

## Changes

- `print_to_pdf(html, opts) -> Result<Vec<u8>>` converts an HTML string to PDF bytes via chromiumoxide 0.7
- `PrintOptions` with `widescreen_16_9()` (254×142.875 mm), `standard_4_3()` (254×190.5 mm), and `from_aspect()` routing on `AspectRatio`
- Binary discovery: `CHROMIUM_PATH` env → `which()` for chromium/chromium-browser/google-chrome/google-chrome-stable
- `chromium` feature (default-on) gates all CDP deps; compiles clean with `--no-default-features`
- Soft dep: requires system Chromium (`apt install chromium` / `brew install --cask chromium`)
- RUSTSEC-2025-0052 (async-std unmaintained via chromiumoxide 0.7) suppressed in audit.toml and deny.toml

## Gate

Gate-Passed: kanon 0.1.3