### PR TITLE
feat(poiesis-theme): Typst template sink (B-002-C)

### DIFF
--- a/_llm/L3-api-index/poiesis-theme.md
+++ b/_llm/L3-api-index/poiesis-theme.md
@@ -419,6 +419,40 @@ pub fn emit_theme_xml (theme: &ResolvedTheme) -> Result<String, ThemeError>
 pub fn emit_base_pptx (theme: &ResolvedTheme) -> Result<Vec<u8>, ThemeError>
 ```
 
+## `src/sinks/typst.rs`
+
+> Emit the theme as Typst `#let` variable declarations.
+> 
+> Downstream Typst templates `#import` or `#include` this file to access
+> brand colors, typography, spacing, grid, and chart palette.
+> 
+> Variable naming:
+> 
+> ```text
+> color-<role>    rgb("#RRGGBB")          (one per [color.role])
+> tone-<name>     rgb("#RRGGBB")          (one per [color.tone])
+> surface-<name>  rgb("#RRGGBB")          (one per [color.surface])
+> type-family-<name>  ("Geist", ...)      (one per [type.family])
+> type-scale-<name>   <px>                (one per [type.scale])
+> space-<name>    <px>                    (one per [space])
+> grid-<slot>     <value>                 (one per present [grid] field)
+> chart-series    (rgb("#..."), ...)      (resolved palette tuple)
+> ```
+> 
+> The output is deterministic: every map is emitted in declaration order
+> (preserved by [`indexmap::IndexMap`]); colors use the canonical uppercase
+> `#RRGGBB` form; integer values carry no fractional digits. The same
+> [`ResolvedTheme`] always produces byte-identical output.
+> 
+> # Errors
+> 
+> Returns [`ThemeError::Sink`] only if the underlying [`std::fmt::Write`]
+> implementation fails. For `String` this is structurally unreachable; the
+> variant exists for composition with non-allocating sinks.
+```rust
+pub fn emit_typst_template (theme: &ResolvedTheme) -> Result<String, ThemeError>
+```
+
 ## `src/tokens.rs`
 
 ```rust

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-30T01:46:54Z"
+generated_at = "2026-05-30T01:56:32Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -248,8 +248,8 @@ l3_token_estimate = 547
 [[crates]]
 name = "poiesis-theme"
 path = "crates/poiesis/theme"
-source_hash = "ed292e661eea154c476df4fd4ab42ba2876fd177da3203d6dde1d43e9e752571"
-l3_token_estimate = 4575
+source_hash = "6f1779be8fb0112487d9c578df35986991eec0e3c86fed306f0588bb3cb1ea3a"
+l3_token_estimate = 4923
 
 [[crates]]
 name = "poiesis-typst"

--- a/crates/poiesis/theme/src/sinks/typst.rs
+++ b/crates/poiesis/theme/src/sinks/typst.rs
@@ -1,0 +1,210 @@
+use std::fmt::Write;
+
+use snafu::ResultExt;
+
+use crate::error::{SinkSnafu, ThemeError};
+use crate::resolved::ResolvedTheme;
+
+/// Emit the theme as Typst `#let` variable declarations.
+///
+/// Downstream Typst templates `#import` or `#include` this file to access
+/// brand colors, typography, spacing, grid, and chart palette.
+///
+/// Variable naming:
+///
+/// ```text
+/// color-<role>    rgb("#RRGGBB")          (one per [color.role])
+/// tone-<name>     rgb("#RRGGBB")          (one per [color.tone])
+/// surface-<name>  rgb("#RRGGBB")          (one per [color.surface])
+/// type-family-<name>  ("Geist", ...)      (one per [type.family])
+/// type-scale-<name>   <px>                (one per [type.scale])
+/// space-<name>    <px>                    (one per [space])
+/// grid-<slot>     <value>                 (one per present [grid] field)
+/// chart-series    (rgb("#..."), ...)      (resolved palette tuple)
+/// ```
+///
+/// The output is deterministic: every map is emitted in declaration order
+/// (preserved by [`indexmap::IndexMap`]); colors use the canonical uppercase
+/// `#RRGGBB` form; integer values carry no fractional digits. The same
+/// [`ResolvedTheme`] always produces byte-identical output.
+///
+/// # Errors
+///
+/// Returns [`ThemeError::Sink`] only if the underlying [`std::fmt::Write`]
+/// implementation fails. For `String` this is structurally unreachable; the
+/// variant exists for composition with non-allocating sinks.
+pub fn emit_typst_template(theme: &ResolvedTheme) -> Result<String, ThemeError> {
+    let mut out = String::new();
+    write_typst(&mut out, theme).context(SinkSnafu {
+        sink: "typst".to_owned(),
+    })?;
+    Ok(out)
+}
+
+fn write_typst(out: &mut String, theme: &ResolvedTheme) -> std::fmt::Result {
+    writeln!(out, "// poiesis-theme: {}", theme.id)?;
+    writeln!(out, "// Generated — do not edit.")?;
+
+    // Colors — roles
+    if !theme.role.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "// Colors — roles")?;
+        for (name, color) in &theme.role {
+            writeln!(out, "#let color-{name} = rgb(\"{}\")", color.as_str())?;
+        }
+    }
+
+    // Colors — tones
+    if !theme.tone.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "// Colors — tones")?;
+        for (name, color) in &theme.tone {
+            writeln!(out, "#let tone-{name} = rgb(\"{}\")", color.as_str())?;
+        }
+    }
+
+    // Colors — surfaces
+    if !theme.surface.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "// Colors — surfaces")?;
+        for (name, color) in &theme.surface {
+            writeln!(out, "#let surface-{name} = rgb(\"{}\")", color.as_str())?;
+        }
+    }
+
+    // Typography — families
+    if !theme.r#type.family.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "// Typography — families")?;
+        for (name, stack) in &theme.r#type.family {
+            write!(out, "#let type-family-{name} = (")?;
+            for (i, s) in stack.iter().enumerate() {
+                if i > 0 {
+                    write!(out, ", ")?;
+                }
+                write!(out, "\"{s}\"")?;
+            }
+            writeln!(out, ")")?;
+        }
+    }
+
+    // Typography — scale (px)
+    if !theme.r#type.scale.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "// Typography — scale (px)")?;
+        for (name, px) in &theme.r#type.scale {
+            writeln!(out, "#let type-scale-{name} = {px}")?;
+        }
+    }
+
+    // Space (px)
+    if !theme.space.slots.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "// Space (px)")?;
+        for (name, px) in &theme.space.slots {
+            writeln!(out, "#let space-{name} = {px}")?;
+        }
+    }
+
+    // Grid
+    let has_grid = theme.grid.base_canvas.is_some()
+        || theme.grid.columns.is_some()
+        || theme.grid.gutter.is_some()
+        || theme.grid.margin.is_some();
+    if has_grid {
+        writeln!(out)?;
+        writeln!(out, "// Grid")?;
+        if let Some([w, h]) = theme.grid.base_canvas {
+            writeln!(out, "#let grid-canvas-w = {w}")?;
+            writeln!(out, "#let grid-canvas-h = {h}")?;
+        }
+        if let Some(columns) = theme.grid.columns {
+            writeln!(out, "#let grid-columns = {columns}")?;
+        }
+        if let Some(gutter) = theme.grid.gutter {
+            writeln!(out, "#let grid-gutter = {gutter}")?;
+        }
+        if let Some(margin) = theme.grid.margin {
+            writeln!(out, "#let grid-margin = {margin}")?;
+        }
+    }
+
+    // Chart series
+    if !theme.chart.series.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "// Chart series")?;
+        write!(out, "#let chart-series = (")?;
+        let mut first = true;
+        for series_ref in &theme.chart.series {
+            if let Some(color) = theme.lookup_color(series_ref) {
+                if !first {
+                    write!(out, ", ")?;
+                }
+                write!(out, "rgb(\"{}\")", color.as_str())?;
+                first = false;
+            }
+        }
+        writeln!(out, ")")?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn summus() -> ResolvedTheme {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("themes");
+        let registry = crate::registry::Registry::load_dir(&dir).expect("load");
+        registry
+            .resolve(&crate::registry::parse_theme_id("summus").expect("id"))
+            .expect("resolve")
+    }
+
+    #[test]
+    fn typst_starts_with_header_comment() {
+        let typst = emit_typst_template(&summus()).expect("emit summus typst");
+        assert!(
+            typst.starts_with("// poiesis-theme: summus"),
+            "output must start with theme header comment; got:\n{typst}"
+        );
+    }
+
+    #[test]
+    fn typst_emits_navy_role() {
+        let typst = emit_typst_template(&summus()).expect("emit summus typst");
+        assert!(
+            typst.contains("#let color-navy = rgb(\"#232E54\")"),
+            "navy role must appear verbatim; got:\n{typst}"
+        );
+    }
+
+    #[test]
+    fn typst_emits_positive_tone() {
+        let typst = emit_typst_template(&summus()).expect("emit summus typst");
+        assert!(
+            typst.contains("#let tone-positive = rgb(\"#318891\")"),
+            "positive tone must appear with resolved teal hex; got:\n{typst}"
+        );
+    }
+
+    #[test]
+    fn typst_family_is_array_literal() {
+        let typst = emit_typst_template(&summus()).expect("emit summus typst");
+        assert!(
+            typst.contains("(\"Geist\""),
+            "sans family must open as a Typst array literal; got:\n{typst}"
+        );
+    }
+
+    #[test]
+    fn typst_byte_stable_across_runs() {
+        let a = emit_typst_template(&summus()).expect("first emit");
+        let b = emit_typst_template(&summus()).expect("second emit");
+        assert_eq!(a, b, "two emissions must match byte-for-byte");
+    }
+}


### PR DESCRIPTION
Implements `emit_typst_template` for the poiesis-theme B-002-C deliverable.

Emits `#let` variable declarations for all brand tokens (colors, typography, space, grid, chart series) so downstream Typst templates can import the theme from a single generated file.