### PR TITLE
feat(aletheia): implement dispatch.cron_tasks executor (#3940)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "agora",
  "aletheia-routing",
@@ -179,11 +179,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.29.0"
+version = "0.30.0"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "jiff",
  "koina",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "futures",
  "jiff",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "jiff",
  "koina",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "eidos",
  "jiff",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "jiff",
  "koina",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-routing",
  "compact_str",
@@ -3134,7 +3134,7 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "episteme"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "cargo_metadata",
  "fjall",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -4187,7 +4187,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "arboard",
  "clap",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "fjall",
@@ -5286,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5904,7 +5904,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6954,7 +6954,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-charts"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "insta",
  "poiesis-core",
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "jiff",
@@ -6978,7 +6978,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-deck"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "minijinja",
  "poiesis-core",
@@ -6990,7 +6990,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-deck-layout"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "poiesis-core",
  "serde",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "docx-rs",
  "poiesis-core",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -7055,7 +7055,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7064,7 +7064,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-printer-chromium"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "chromiumoxide",
  "futures",
@@ -7077,7 +7077,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -7089,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -7103,7 +7103,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -7116,7 +7116,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-theme"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "jiff",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "comemo",
  "jiff",
@@ -7147,7 +7147,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7557,7 +7557,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -9027,7 +9027,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -9384,7 +9384,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9503,7 +9503,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -9615,14 +9615,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/_llm/L3-api-index/energeia.md
+++ b/_llm/L3-api-index/energeia.md
@@ -211,6 +211,19 @@ impl CostLedger {
 ## `src/cron.rs`
 
 ```rust
+/// Policy for handling overlap between scheduled fires of the same task.
+pub enum OverlapPolicy {
+    /// Allow a new scheduled fire even while a previous callback is still in
+    /// flight. The default — matches the historical scheduler behavior where a
+    /// slow callback does not block later cron ticks.
+    Allow,
+    /// Skip a scheduled fire when the previous callback for the same task has
+    /// not yet returned.
+    SkipIfInFlight,
+}
+```
+
+```rust
 pub struct CronTask {
     /// Unique task identifier.
     pub name: CompactString,
@@ -258,12 +271,15 @@ impl CronLockStore {
 pub struct CronScheduler {
     tasks: Vec<CronTask>,
     lock_store: Arc<CronLockStore>,
+    overlap_policy: OverlapPolicy,
+    in_flight: Arc<parking_lot::Mutex<HashSet<CompactString>>>,
 }
 ```
 
 ```rust
 impl CronScheduler {
     pub fn new (tasks: Vec<CronTask>, lock_store: Arc<CronLockStore>) -> Self;
+    pub fn with_overlap_policy (self, policy: OverlapPolicy) -> Self;
     pub fn next_fire_after (&self, task: &CronTask, now: Zoned) -> Option<Zoned>;
     pub async fn run <F, Fut> (&self, cancel: CancellationToken, on_fire: F) -> Result<()> where
         F: Fn(CronTask) -> Fut + Clone + Send + Sync + 'static,

--- a/_llm/L3-api-index/energeia.md
+++ b/_llm/L3-api-index/energeia.md
@@ -211,14 +211,16 @@ impl CostLedger {
 ## `src/cron.rs`
 
 ```rust
-/// Policy for handling overlap between scheduled fires of the same task.
 pub enum OverlapPolicy {
     /// Allow a new scheduled fire even while a previous callback is still in
     /// flight. The default — matches the historical scheduler behavior where a
     /// slow callback does not block later cron ticks.
+    #[default]
     Allow,
     /// Skip a scheduled fire when the previous callback for the same task has
-    /// not yet returned.
+    /// not yet returned. Used by callers that want serialized recurring work
+    /// (e.g. recurring dispatch where overlapping runs would compete for the
+    /// same project worktree).
     SkipIfInFlight,
 }
 ```
@@ -279,7 +281,7 @@ pub struct CronScheduler {
 ```rust
 impl CronScheduler {
     pub fn new (tasks: Vec<CronTask>, lock_store: Arc<CronLockStore>) -> Self;
-    pub fn with_overlap_policy (self, policy: OverlapPolicy) -> Self;
+    pub fn with_overlap_policy (mut self, policy: OverlapPolicy) -> Self;
     pub fn next_fire_after (&self, task: &CronTask, now: Zoned) -> Option<Zoned>;
     pub async fn run <F, Fut> (&self, cancel: CancellationToken, on_fire: F) -> Result<()> where
         F: Fn(CronTask) -> Fut + Clone + Send + Sync + 'static,

--- a/_llm/L3-api-index/poiesis-charts.md
+++ b/_llm/L3-api-index/poiesis-charts.md
@@ -94,6 +94,13 @@ pub enum Error {
         /// The chart kind whose emitter arm is still a stub.
         kind: String,
     },
+
+    /// Vega-Lite shell-out failed (npx not found, non-zero exit, etc.).
+    #[snafu(display("vega-lite shell-out failed: {message}"))]
+    VegaShellout {
+        /// Error detail.
+        message: String,
+    },
 }
 ```
 
@@ -618,20 +625,35 @@ pub fn emit (
 ) -> Result<String>
 ```
 
+## `src/render/kinds/stat.rs`
+
+```rust
+pub fn emit (
+    chart: &Chart,
+    theme: &ResolvedTheme,
+    canvas: &Canvas,
+    mode: ColorMode,
+) -> Result<String>
+```
+
 ## `src/render/vega.rs`
 
 > Emit a Vega-Lite-rendered chart.
 > 
+> Builds a Vega-Lite 5.x JSON spec from the [`Chart`] model, then shells out
+> to `npx --yes vega-lite@5.20.1 --vl2svg` to produce SVG.
+> 
 > # Errors
 > 
-> Returns [`crate::Error::EmitterStub`] until the shell-out path lands.
+> Returns [`crate::Error::VegaShellout`] if the npx subprocess fails or the
+> spec cannot be serialised.
 ```rust
 pub fn emit (
     chart: &Chart,
-    _theme: &ResolvedTheme,
-    _canvas: &Canvas,
+    theme: &ResolvedTheme,
+    canvas: &Canvas,
     _mode: ColorMode,
-) -> Result<String>
+) -> crate::Result<String>
 ```
 
 ## `src/render.rs`

--- a/_llm/L3-api-index/taxis.md
+++ b/_llm/L3-api-index/taxis.md
@@ -628,6 +628,11 @@ pub struct CronTaskConfig {
     pub schedule: String,
     /// Jitter in seconds (+/-).
     pub jitter_secs: u64,
+    /// Whether this task is registered with the scheduler. Defaults to `true`
+    /// so that defining a task in config implies the operator wants it run;
+    /// set `enabled = false` to leave the task in the config without firing.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
     /// What to dispatch.
     pub dispatch_spec: DispatchSpecConfig,
 }

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-30T03:55:26Z"
+generated_at = "2026-05-30T12:15:02Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -20,7 +20,7 @@ l3_token_estimate = 4901
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "7a738108e9c5183928bc6b0928718c35c9618d32544bbb55b3c68fa52bd427d2"
+source_hash = "567e7c6d9fb5eb27681d1f7a7ff9adc64606e5cf1ad11d5a3e4552d377db2ce2"
 l3_token_estimate = 167
 
 [[crates]]
@@ -80,8 +80,8 @@ l3_token_estimate = 13271
 [[crates]]
 name = "energeia"
 path = "crates/energeia"
-source_hash = "48c7434f7ffef83e67597526618154502afa6ed9736f1feea7f14f246f0fa483"
-l3_token_estimate = 19912
+source_hash = "69c453700319a16743e5a1542fb3b98181a4ad8f8a5781b4941526ada207a59c"
+l3_token_estimate = 20097
 
 [[crates]]
 name = "episteme"
@@ -164,8 +164,8 @@ l3_token_estimate = 11827
 [[crates]]
 name = "poiesis-charts"
 path = "crates/poiesis/charts"
-source_hash = "87524c1ed768d4913faa9ff170126dc2ed523a27e50739b18308bef225718b97"
-l3_token_estimate = 4466
+source_hash = "7c3c6b37c8d800f4a57df8f523d08f08e06320e9facdafa19d1a17f750d7d500"
+l3_token_estimate = 4605
 
 [[crates]]
 name = "poiesis-core"
@@ -278,8 +278,8 @@ l3_token_estimate = 6587
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "3e2e8149c1e6066d1829ff62f069e71ccdfaec3325ad208e29386256cd2b17f5"
-l3_token_estimate = 23358
+source_hash = "df4acdaabad25e90c4e8def379e0552961a9536e2e675410f82eef5ef7bb842a"
+l3_token_estimate = 23433
 
 [[crates]]
 name = "theatron"

--- a/crates/aletheia/src/runtime/cron_executor.rs
+++ b/crates/aletheia/src/runtime/cron_executor.rs
@@ -1,0 +1,185 @@
+//! Wire the `dispatch.cron_tasks` config to the real energeia cron scheduler.
+//!
+//! Replaces the legacy "configured but not started" warning with an actual
+//! scheduler that loads prompts from the project queue and invokes the
+//! orchestrator on each scheduled fire.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use snafu::ResultExt as _;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use tracing::{Instrument, info, warn};
+
+use energeia::cron::{CronLockStore, CronScheduler, CronTask, OverlapPolicy};
+use energeia::orchestrator::Orchestrator;
+use energeia::prompt;
+use energeia::types::DispatchSpec;
+use taxis::config::{CronTaskConfig, DispatchSpecConfig};
+use taxis::oikos::Oikos;
+
+use crate::error::Result;
+
+const LOCK_DB_DIR: &str = "cron-locks.fjall";
+const LOCK_PARTITION: &str = "cron_locks";
+
+/// Start the cron executor: open the lock store, build `CronTask`s from the
+/// enabled config entries, and spawn the scheduler loop on `task_tracker`.
+///
+/// Returns `Ok(())` and logs at info level when no enabled tasks are present
+/// — the daemon should remain healthy without any cron configuration.
+pub(super) fn start(
+    tasks: &[CronTaskConfig],
+    orchestrator: Arc<Orchestrator>,
+    oikos: &Oikos,
+    task_tracker: &TaskTracker,
+    shutdown_token: &CancellationToken,
+) -> Result<()> {
+    let enabled: Vec<&CronTaskConfig> = tasks.iter().filter(|t| t.enabled).collect();
+    if enabled.is_empty() {
+        info!(
+            configured = tasks.len(),
+            "dispatch cron executor: no enabled tasks; skipping scheduler startup"
+        );
+        return Ok(());
+    }
+
+    let mut cron_tasks: Vec<CronTask> = Vec::with_capacity(enabled.len());
+    for cfg in &enabled {
+        match build_cron_task(cfg) {
+            Ok(task) => cron_tasks.push(task),
+            Err(e) => warn!(
+                task = %cfg.name,
+                schedule = %cfg.schedule,
+                error = %e,
+                "dispatch cron executor: invalid task — skipping"
+            ),
+        }
+    }
+    if cron_tasks.is_empty() {
+        warn!(
+            configured = tasks.len(),
+            "dispatch cron executor: all enabled tasks failed to parse — scheduler not started"
+        );
+        return Ok(());
+    }
+
+    let lock_db_path = oikos.data().join(LOCK_DB_DIR);
+    if let Some(parent) = lock_db_path.parent() {
+        std::fs::create_dir_all(parent).with_whatever_context(|_| {
+            format!("failed to CREATE cron lock dir {}", parent.display())
+        })?;
+    }
+    let fjall_db = koina::fjall::FjallDb::open(&lock_db_path, &[LOCK_PARTITION])
+        .with_whatever_context(|_| {
+            format!("failed to open cron lock db at {}", lock_db_path.display())
+        })?;
+    let lock_store = Arc::new(
+        CronLockStore::open(Arc::new(fjall_db.db))
+            .whatever_context("failed to open cron lock store")?,
+    );
+
+    let theke = oikos.theke();
+    let tasks_started = cron_tasks.len();
+    let scheduler = CronScheduler::new(cron_tasks, lock_store)
+        .with_overlap_policy(OverlapPolicy::SkipIfInFlight);
+    let cancel = shutdown_token.child_token();
+
+    info!(
+        tasks = tasks_started,
+        "dispatch cron executor started; recurring dispatch enabled"
+    );
+
+    task_tracker.spawn(
+        async move {
+            let result = scheduler
+                .run(cancel, move |task| {
+                    let orchestrator = Arc::clone(&orchestrator);
+                    let theke = theke.clone();
+                    async move {
+                        fire_task(task, orchestrator, theke).await;
+                    }
+                })
+                .await;
+            if let Err(e) = result {
+                warn!(error = %e, "dispatch cron executor exited with error");
+            }
+        }
+        .instrument(tracing::info_span!("cron_executor")),
+    );
+
+    Ok(())
+}
+
+fn build_cron_task(cfg: &CronTaskConfig) -> energeia::error::Result<CronTask> {
+    let spec = dispatch_spec_from_config(&cfg.dispatch_spec);
+    CronTask::new(
+        cfg.name.as_str(),
+        cfg.schedule.as_str(),
+        Duration::from_secs(cfg.jitter_secs),
+        spec,
+    )
+}
+
+fn dispatch_spec_from_config(cfg: &DispatchSpecConfig) -> DispatchSpec {
+    let mut spec = DispatchSpec::new(cfg.project.clone(), cfg.prompt_numbers.clone());
+    spec.dag_ref = cfg.dag_ref.clone();
+    spec.max_parallel = cfg.max_parallel;
+    spec.max_turns = cfg.max_turns;
+    spec
+}
+
+async fn fire_task(task: CronTask, orchestrator: Arc<Orchestrator>, theke: std::path::PathBuf) {
+    let queue_dir = theke
+        .join("projects")
+        .join(&task.dispatch_spec.project)
+        .join("prompts")
+        .join("queue");
+    let prompts = match prompt::load_queue(&queue_dir) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                task = %task.name,
+                project = %task.dispatch_spec.project,
+                queue = %queue_dir.display(),
+                error = %e,
+                "cron task: failed to load prompt queue"
+            );
+            return;
+        }
+    };
+
+    let wanted: std::collections::HashSet<u32> =
+        task.dispatch_spec.prompt_numbers.iter().copied().collect();
+    let selected: Vec<prompt::PromptSpec> = prompts
+        .into_iter()
+        .filter(|p| wanted.is_empty() || wanted.contains(&p.number))
+        .collect();
+    if selected.is_empty() {
+        warn!(
+            task = %task.name,
+            project = %task.dispatch_spec.project,
+            queue = %queue_dir.display(),
+            "cron task: no prompts matched dispatch spec"
+        );
+        return;
+    }
+
+    match orchestrator
+        .dispatch(task.dispatch_spec.clone(), &selected)
+        .await
+    {
+        Ok(_result) => info!(
+            task = %task.name,
+            project = %task.dispatch_spec.project,
+            "cron dispatch completed"
+        ),
+        Err(e) => warn!(
+            task = %task.name,
+            project = %task.dispatch_spec.project,
+            error = %e,
+            "cron dispatch failed"
+        ),
+    }
+}

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -287,13 +287,22 @@ impl RuntimeBuilder {
 
         // Tool registry
         let after_action_log_dir = self.oikos.logs().join("after-actions");
+        #[cfg(feature = "energeia")]
+        let mut energeia_services: Option<
+            Arc<organon::builtins::energeia::EnergeiaServices>,
+        > = None;
         let mut tool_registry = if self.credentials {
-            build_tool_registry(
+            let built = build_tool_registry(
                 &self.config,
                 &self.oikos,
                 &shutdown_token,
                 Some(after_action_log_dir.clone()),
-            )?
+            )?;
+            #[cfg(feature = "energeia")]
+            {
+                energeia_services = built.energeia_services;
+            }
+            built.registry
         } else {
             ToolRegistry::new()
         };
@@ -637,10 +646,28 @@ impl RuntimeBuilder {
                 daemon_runner = daemon_runner.with_knowledge_maintenance(km_executor);
             }
 
+            #[cfg(feature = "energeia")]
+            if !self.config.dispatch.cron_tasks.is_empty() {
+                if let Some(services) = energeia_services.as_ref() {
+                    cron_executor::start(
+                        &self.config.dispatch.cron_tasks,
+                        Arc::clone(&services.orchestrator),
+                        &self.oikos,
+                        &task_tracker,
+                        &shutdown_token,
+                    )?;
+                } else {
+                    warn!(
+                        cron_tasks = self.config.dispatch.cron_tasks.len(),
+                        "dispatch cron tasks configured but energeia services unavailable; recurring dispatch not started"
+                    );
+                }
+            }
+            #[cfg(not(feature = "energeia"))]
             if !self.config.dispatch.cron_tasks.is_empty() {
                 warn!(
                     cron_tasks = self.config.dispatch.cron_tasks.len(),
-                    "dispatch cron tasks configured but not started; recurring energeia dispatch is disabled until the daemon can execute real dispatch actions"
+                    "dispatch cron tasks configured but the energeia feature is not built; recurring dispatch not started"
                 );
             }
 
@@ -833,6 +860,9 @@ use nous_config::build_nous_runtime_config;
 
 mod setup;
 mod tool_adapters;
+
+#[cfg(feature = "energeia")]
+mod cron_executor;
 
 #[cfg(feature = "recall")]
 use setup::open_knowledge_stores;

--- a/crates/aletheia/src/runtime/setup/setup_energeia_tests.rs
+++ b/crates/aletheia/src/runtime/setup/setup_energeia_tests.rs
@@ -45,8 +45,9 @@ async fn energeia_feature_registers_service_backed_runtime_tools() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let oikos = Oikos::from_root(tmp.path());
     let config = AletheiaConfig::default();
-    let registry = build_tool_registry(&config, &oikos, &CancellationToken::new(), None)
+    let built = build_tool_registry(&config, &oikos, &CancellationToken::new(), None)
         .expect("tool registry with energeia services");
+    let registry = built.registry;
     let names: HashSet<String> = registry
         .definitions()
         .iter()

--- a/crates/aletheia/src/runtime/setup/tool_registry.rs
+++ b/crates/aletheia/src/runtime/setup/tool_registry.rs
@@ -41,12 +41,20 @@ impl energeia::qa::QaGate for MechanicalQaGate {
     }
 }
 
+/// Built tool registry plus optional energeia services that the rest of the
+/// runtime needs to reach (e.g. the cron-driven dispatch executor).
+pub(in crate::runtime) struct BuiltToolRegistry {
+    pub registry: ToolRegistry,
+    #[cfg(feature = "energeia")]
+    pub energeia_services: Option<Arc<organon::builtins::energeia::EnergeiaServices>>,
+}
+
 pub(in crate::runtime) fn build_tool_registry(
     config: &AletheiaConfig,
     oikos: &Oikos,
     shutdown_token: &CancellationToken,
     after_action_log_dir: Option<std::path::PathBuf>,
-) -> Result<ToolRegistry> {
+) -> Result<BuiltToolRegistry> {
     let mut registry = ToolRegistry::new();
     let sandbox_settings = &config.sandbox;
     let sandbox = organon::sandbox::SandboxConfig {
@@ -69,6 +77,16 @@ pub(in crate::runtime) fn build_tool_registry(
         egress_allowlist: sandbox_settings.egress_allowlist.clone(),
         nproc_limit: sandbox_settings.nproc_limit,
     };
+    #[cfg(feature = "energeia")]
+    let energeia_services = register_builtin_tools(
+        &mut registry,
+        sandbox,
+        config,
+        oikos,
+        shutdown_token.child_token(),
+        after_action_log_dir,
+    )?;
+    #[cfg(not(feature = "energeia"))]
     register_builtin_tools(
         &mut registry,
         sandbox,
@@ -78,9 +96,29 @@ pub(in crate::runtime) fn build_tool_registry(
         after_action_log_dir,
     )?;
     info!(count = registry.definitions().len(), "tools registered");
-    Ok(registry)
+    Ok(BuiltToolRegistry {
+        registry,
+        #[cfg(feature = "energeia")]
+        energeia_services,
+    })
 }
 
+#[cfg(feature = "energeia")]
+fn register_builtin_tools(
+    registry: &mut ToolRegistry,
+    sandbox: organon::sandbox::SandboxConfig,
+    config: &AletheiaConfig,
+    oikos: &Oikos,
+    cancel_token: CancellationToken,
+    after_action_log_dir: Option<std::path::PathBuf>,
+) -> Result<Option<Arc<organon::builtins::energeia::EnergeiaServices>>> {
+    let services = build_energeia_services(config, oikos, cancel_token, after_action_log_dir)?;
+    builtins::register_all_with_sandbox_and_energeia_services(registry, sandbox, services.as_ref())
+        .whatever_context("failed to register builtin tools")?;
+    Ok(Some(services))
+}
+
+#[cfg(not(feature = "energeia"))]
 fn register_builtin_tools(
     registry: &mut ToolRegistry,
     sandbox: organon::sandbox::SandboxConfig,
@@ -89,23 +127,9 @@ fn register_builtin_tools(
     cancel_token: CancellationToken,
     after_action_log_dir: Option<std::path::PathBuf>,
 ) -> Result<()> {
-    #[cfg(feature = "energeia")]
-    {
-        let services = build_energeia_services(config, oikos, cancel_token, after_action_log_dir)?;
-        builtins::register_all_with_sandbox_and_energeia_services(
-            registry,
-            sandbox,
-            services.as_ref(),
-        )
+    let _ = (config, oikos, cancel_token, after_action_log_dir);
+    builtins::register_all_with_sandbox(registry, sandbox)
         .whatever_context("failed to register builtin tools")
-    }
-
-    #[cfg(not(feature = "energeia"))]
-    {
-        let _ = (config, oikos, cancel_token, after_action_log_dir);
-        builtins::register_all_with_sandbox(registry, sandbox)
-            .whatever_context("failed to register builtin tools")
-    }
 }
 
 #[cfg(feature = "energeia")]

--- a/crates/energeia/CLAUDE.md
+++ b/crates/energeia/CLAUDE.md
@@ -31,6 +31,7 @@ Dispatch orchestration: actualization of plans into execution. Absorbs kanon's p
 | `DispatchEngine` | `engine.rs` | Trait: spawn/resume sessions against Agent SDK |
 | `SessionHandle` | `engine.rs` | Trait: event stream, wait, abort for a running session |
 | `QaGate` | `qa.rs` | Trait: evaluate PR quality, mechanical checks |
+| `CronTask` / `CronScheduler` | `cron.rs` | Recurring dispatch driven by `jiff-cron`; fjall-backed cross-restart lock and per-task overlap policy. Feature: `storage-fjall`. |
 
 ## Patterns
 

--- a/crates/energeia/src/cron.rs
+++ b/crates/energeia/src/cron.rs
@@ -14,6 +14,7 @@
 //! | `cron.sleep` | info | `task_name`, `next`, `sleep_ms` | Scheduler computed next wake time |
 //! | `cron.shutdown` | info | | Cancellation token triggered |
 
+use std::collections::HashSet;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,6 +29,21 @@ use tracing::Instrument;
 
 use crate::error::{self, Result};
 use crate::types::DispatchSpec;
+
+/// Policy for handling overlap between scheduled fires of the same task.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OverlapPolicy {
+    /// Allow a new scheduled fire even while a previous callback is still in
+    /// flight. The default — matches the historical scheduler behavior where a
+    /// slow callback does not block later cron ticks.
+    #[default]
+    Allow,
+    /// Skip a scheduled fire when the previous callback for the same task has
+    /// not yet returned. Used by callers that want serialized recurring work
+    /// (e.g. recurring dispatch where overlapping runs would compete for the
+    /// same project worktree).
+    SkipIfInFlight,
+}
 
 // ---------------------------------------------------------------------------
 // CronTask
@@ -180,13 +196,29 @@ impl CronLockStore {
 pub struct CronScheduler {
     tasks: Vec<CronTask>,
     lock_store: Arc<CronLockStore>,
+    overlap_policy: OverlapPolicy,
+    in_flight: Arc<parking_lot::Mutex<HashSet<CompactString>>>,
 }
 
 impl CronScheduler {
-    /// Create a new scheduler.
+    /// Create a new scheduler with the default ([`OverlapPolicy::Allow`])
+    /// overlap policy.
     #[must_use]
     pub fn new(tasks: Vec<CronTask>, lock_store: Arc<CronLockStore>) -> Self {
-        Self { tasks, lock_store }
+        Self {
+            tasks,
+            lock_store,
+            overlap_policy: OverlapPolicy::default(),
+            in_flight: Arc::new(parking_lot::Mutex::new(HashSet::new())),
+        }
+    }
+
+    /// Set the overlap policy applied when a previous callback for the same
+    /// task is still running.
+    #[must_use]
+    pub fn with_overlap_policy(mut self, policy: OverlapPolicy) -> Self {
+        self.overlap_policy = policy;
+        self
     }
 
     /// Compute the next fire time for a task after `now`.
@@ -262,39 +294,78 @@ impl CronScheduler {
                 continue;
             }
 
-            match self
+            self.try_fire(task, base_scheduled, &on_fire);
+        }
+    }
+
+    fn try_fire<F, Fut>(&self, task: &CronTask, base_scheduled: Timestamp, on_fire: &F)
+    where
+        F: Fn(CronTask) -> Fut + Clone + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        if self.overlap_policy == OverlapPolicy::SkipIfInFlight
+            && self.in_flight.lock().contains(task.name.as_str())
+        {
+            tracing::warn!(
+                task = %task.name,
+                scheduled = %base_scheduled,
+                "cron task skipped — previous run still in flight"
+            );
+            // WHY: claim the lock so the next loop iteration computes a fresh
+            // future tick and we don't spin retrying the same scheduled time.
+            if let Err(e) = self
                 .lock_store
                 .try_acquire(task.name.as_str(), base_scheduled)
             {
-                Ok(true) => {
-                    tracing::info!(
-                        task = %task.name,
-                        scheduled = %base_scheduled,
-                        "cron task fired"
-                    );
-                    let span = tracing::info_span!("cron_fire", task = %task.name);
-                    let callback = on_fire.clone();
-                    let task = task.clone();
-                    tokio::spawn(async move {
-                        callback(task).instrument(span).await;
-                    });
-                }
-                Ok(false) => {
-                    tracing::debug!(
-                        task = %task.name,
-                        scheduled = %base_scheduled,
-                        "cron task skipped — lock held"
-                    );
-                }
-                Err(e) => {
-                    tracing::error!(
-                        task = %task.name,
-                        error = %e,
-                        "cron lock acquisition failed"
-                    );
-                }
+                tracing::error!(
+                    task = %task.name,
+                    error = %e,
+                    "cron lock acquisition failed during overlap skip"
+                );
             }
+            return;
         }
+        match self
+            .lock_store
+            .try_acquire(task.name.as_str(), base_scheduled)
+        {
+            Ok(true) => self.spawn_fire(task.clone(), base_scheduled, on_fire.clone()),
+            Ok(false) => tracing::debug!(
+                task = %task.name,
+                scheduled = %base_scheduled,
+                "cron task skipped — lock held"
+            ),
+            Err(e) => tracing::error!(
+                task = %task.name,
+                error = %e,
+                "cron lock acquisition failed"
+            ),
+        }
+    }
+
+    fn spawn_fire<F, Fut>(&self, task: CronTask, base_scheduled: Timestamp, on_fire: F)
+    where
+        F: Fn(CronTask) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        tracing::info!(
+            task = %task.name,
+            scheduled = %base_scheduled,
+            "cron task fired"
+        );
+        let span = tracing::info_span!("cron_fire", task = %task.name);
+        let in_flight = Arc::clone(&self.in_flight);
+        let track_overlap = self.overlap_policy == OverlapPolicy::SkipIfInFlight;
+        if track_overlap {
+            in_flight.lock().insert(task.name.clone());
+        }
+        let task_for_callback = task.clone();
+        tokio::spawn(async move {
+            on_fire(task_for_callback).instrument(span).await;
+            if track_overlap {
+                in_flight.lock().remove(task.name.as_str());
+            }
+        });
     }
 }
 
@@ -504,6 +575,87 @@ mod tests {
         assert!(
             fired.load(Ordering::SeqCst) >= 2,
             "slow callback should not block later cron ticks"
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_task_fires_on_scheduled_tick() {
+        let db = koina::fjall::FjallDb::open_temp(&[LOCK_PARTITION]).unwrap();
+        let lock_store = Arc::new(CronLockStore::open(Arc::new(db.db)).unwrap());
+        let task = CronTask {
+            name: CompactString::new("tick-fire"),
+            cron: parse_schedule("* * * * * *"),
+            jitter: Duration::ZERO,
+            dispatch_spec: DispatchSpec::new("test".to_owned(), vec![1, 2]),
+        };
+        let fired = Arc::new(AtomicUsize::new(0));
+        let scheduler = CronScheduler::new(vec![task], lock_store);
+        let cancel = CancellationToken::new();
+        let cancel_for_task = cancel.clone();
+        let fired_for_task = Arc::clone(&fired);
+
+        let handle = tokio::spawn(async move {
+            scheduler
+                .run(cancel_for_task, move |task| {
+                    let fired = Arc::clone(&fired_for_task);
+                    async move {
+                        assert_eq!(task.dispatch_spec.project, "test");
+                        fired.fetch_add(1, Ordering::SeqCst);
+                    }
+                })
+                .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
+        cancel.cancel();
+        handle.await.unwrap().unwrap();
+
+        assert!(
+            fired.load(Ordering::SeqCst) >= 1,
+            "a configured cron_task should fire at least once on its scheduled tick"
+        );
+    }
+
+    #[tokio::test]
+    async fn skip_if_in_flight_policy_serializes_overlapping_fires() {
+        let db = koina::fjall::FjallDb::open_temp(&[LOCK_PARTITION]).unwrap();
+        let lock_store = Arc::new(CronLockStore::open(Arc::new(db.db)).unwrap());
+        let task = CronTask {
+            name: CompactString::new("overlap-test"),
+            cron: parse_schedule("* * * * * *"),
+            jitter: Duration::ZERO,
+            dispatch_spec: DispatchSpec::new("test".to_owned(), vec![]),
+        };
+        let fired = Arc::new(AtomicUsize::new(0));
+        let scheduler = CronScheduler::new(vec![task], lock_store)
+            .with_overlap_policy(OverlapPolicy::SkipIfInFlight);
+        let cancel = CancellationToken::new();
+        let cancel_for_task = cancel.clone();
+        let fired_for_task = Arc::clone(&fired);
+
+        // The callback takes 5 seconds; a fresh tick arrives every second. With
+        // OverlapPolicy::SkipIfInFlight, later ticks must be skipped while the
+        // first run is still executing.
+        let handle = tokio::spawn(async move {
+            scheduler
+                .run(cancel_for_task, move |_task| {
+                    let fired = Arc::clone(&fired_for_task);
+                    async move {
+                        fired.fetch_add(1, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                    }
+                })
+                .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(2_500)).await;
+        cancel.cancel();
+        handle.await.unwrap().unwrap();
+
+        let total = fired.load(Ordering::SeqCst);
+        assert!(
+            total <= 1,
+            "SkipIfInFlight should prevent overlapping fires, got {total}"
         );
     }
 

--- a/crates/taxis/src/config/behavior/dispatch.rs
+++ b/crates/taxis/src/config/behavior/dispatch.rs
@@ -23,8 +23,60 @@ pub struct CronTaskConfig {
     pub schedule: String,
     /// Jitter in seconds (+/-).
     pub jitter_secs: u64,
+    /// Whether this task is registered with the scheduler. Defaults to `true`
+    /// so that defining a task in config implies the operator wants it run;
+    /// set `enabled = false` to leave the task in the config without firing.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
     /// What to dispatch.
     pub dispatch_spec: DispatchSpecConfig,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cron_task_enabled_defaults_to_true_when_omitted() {
+        let toml = r#"
+name = "nightly"
+schedule = "0 2 * * *"
+jitterSecs = 0
+
+[dispatchSpec]
+promptNumbers = [1, 2]
+project = "aletheia"
+"#;
+        let parsed: CronTaskConfig = toml::from_str(toml).expect("valid cron task config");
+        assert!(
+            parsed.enabled,
+            "omitted `enabled` should default to true so configured tasks actually run"
+        );
+    }
+
+    #[test]
+    fn cron_task_disabled_when_enabled_false() {
+        let toml = r#"
+name = "off"
+schedule = "0 2 * * *"
+jitterSecs = 0
+enabled = false
+
+[dispatchSpec]
+promptNumbers = []
+project = "aletheia"
+"#;
+        let parsed: CronTaskConfig = toml::from_str(toml).expect("valid cron task config");
+        assert!(
+            !parsed.enabled,
+            "`enabled = false` should round-trip from config"
+        );
+    }
 }
 
 /// Raw dispatch spec for config deserialization.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -41,6 +41,7 @@ Runtime configuration uses the three-layer TOML cascade above. Agent bootstrap f
 - [daemon_behavior](#daemon_behavior)
 - [tool_limits](#tool_limits)
 - [maintenance](#maintenance)
+- [dispatch](#dispatch)
 - [logging](#logging)
 - [pricing](#pricing)
 - [packs](#packs)
@@ -470,6 +471,59 @@ alert_threshold_mb = 1000
 
 [maintenance.retention]
 enabled = true
+```
+
+---
+
+## dispatch
+
+Recurring energeia dispatches driven by cron expressions. Each task is parsed
+on startup and scheduled by the daemon: at every scheduled tick the executor
+loads the project's prompt queue, filters by `promptNumbers`, and invokes the
+energeia orchestrator. Requires the `energeia` build feature.
+
+### dispatch.cronTasks[]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | _required_ | Unique task identifier; used as the fjall lock key for cross-restart dedup. |
+| `schedule` | string | _required_ | 6-field cron expression (`sec min hour dom mon dow`) parsed by `jiff-cron`. |
+| `jitterSecs` | u64 | `0` | Maximum random offset (±, in seconds) applied to each computed fire time to spread thundering-herd starts. |
+| `enabled` | bool | `true` | Set `false` to leave the task in the config without scheduling it. |
+| `dispatchSpec` | table | _required_ | Spec passed to the orchestrator (see below). |
+
+### dispatch.cronTasks[].dispatchSpec
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `project` | string | _required_ | Project key — resolves to `theke/projects/<project>/prompts/queue/`. |
+| `promptNumbers` | u32[] | _required_ | Prompt numbers to dispatch; empty selects every prompt in the queue. |
+| `dagRef` | string | `null` | Optional DAG reference handed to the orchestrator. |
+| `maxParallel` | u32 | `null` | Override the orchestrator's max-concurrent-sessions budget. |
+| `maxTurns` | u32 | `null` | Override the orchestrator's per-session turn budget. |
+
+**Missed-tick policy.** The scheduler computes the next future occurrence
+after `now` on each loop iteration and sleeps until then; if the daemon was
+offline for several scheduled windows, only the next future tick fires (no
+catch-up storm). The fjall-backed lock store also prevents the same scheduled
+time from firing twice across restarts.
+
+**Overlap policy.** When a task's previous callback is still running at the
+next scheduled tick, the new fire is **skipped** with `cron.task.skipped`
+emitted at warn. This prevents two concurrent dispatches from competing for
+the same project worktree.
+
+```toml
+[[dispatch.cronTasks]]
+name = "nightly-aletheia-sweep"
+schedule = "0 0 2 * * *"   # every day at 02:00:00 UTC
+jitterSecs = 60            # ± up to one minute
+enabled = true
+
+[dispatch.cronTasks.dispatchSpec]
+project = "aletheia"
+promptNumbers = [1, 2, 3]
+maxParallel = 2
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Replace the runtime warn-only path with a real cron executor that wires `dispatch.cron_tasks` through `energeia::cron::CronScheduler` (fjall-backed cross-restart lock, jiff-cron parsing, ±jitter).
- Add a `CronTaskConfig.enabled` field (default `true`) so disabled tasks stay declared in config without firing.
- Default the wiring to `OverlapPolicy::SkipIfInFlight` so a slow dispatch never has a second copy scheduled on top of it; `cron.task.skipped` is emitted at warn for visibility.
- Load the project's prompt queue at fire time and call `Orchestrator::dispatch` with the configured `DispatchSpec`.
- Document `dispatch.cronTasks` in `CONFIGURATION.md` and refresh L3 surfaces for taxis + energeia.

## Test plan
- [x] `cargo test -p taxis --lib config::behavior::dispatch::tests` (default and `enabled = false` round-trip)
- [x] `cargo test -p energeia --features storage-fjall --lib cron::` (added `configured_task_fires_on_scheduled_tick` and `skip_if_in_flight_policy_serializes_overlapping_fires`; existing `slow_on_fire_does_not_block_scheduler_ticks` still passes under the default `Allow` policy)
- [x] `cargo clippy -p energeia -p taxis -p aletheia --all-targets -- -D warnings`
- [x] `kanon gate --tier full --stamp` → PASS (Gate-Passed: kanon 0.1.3)
- [ ] End-to-end smoke: configure a `[[dispatch.cronTasks]]` against a populated `theke/projects/<p>/prompts/queue/` and verify the orchestrator is invoked at the scheduled tick.

## Notes
- Missed-tick policy: the scheduler always computes the next future occurrence after `now`, so a daemon that was offline through several scheduled windows fires only the next future tick (no catch-up storm). The fjall lock store still prevents the same scheduled timestamp from firing twice across restarts.
- The lock store lives at `instance/data/cron-locks.fjall` so it can be inspected/cleared independently of `energeia.fjall`.

Closes #3940.