### PR TITLE
docs(readme): bump install example to v0.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ One binary. No containers. No external databases. Beyond your LLM provider, ther
 Download the tarball from [releases](https://github.com/forkwright/aletheia/releases), extract, and run `init`:
 
 ```bash
-VERSION=v0.27.0
+VERSION=v0.30.0
 curl -L "https://github.com/forkwright/aletheia/releases/download/${VERSION}/aletheia-linux-x86_64-${VERSION}.tar.gz" \
   -o aletheia.tar.gz
 tar xzf aletheia.tar.gz


### PR DESCRIPTION
README install example pinned a stale VERSION=v0.27.0; current release is v0.30.0. Docs-only (no Rust change). Closes the README staleness item from the v1.0.0 readiness audit.