### PR TITLE
chore(deny): drop stale rustls-pemfile advisory ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -18,10 +18,6 @@ id = "RUSTSEC-2024-0436"
 reason = "paste unmaintained, transitive via tokenizers; no safe upgrade"
 
 [[advisories.ignore]]
-id = "RUSTSEC-2025-0134"
-reason = "rustls-pemfile 2.x unmaintained — transitive via qdrant-client → tonic 0.12. Blocked until qdrant-client upgrades tonic to 0.13+"
-
-[[advisories.ignore]]
 id = "RUSTSEC-2025-0052"
 reason = "async-std unmaintained — transitive via chromiumoxide 0.7.0; no upgrade path while pinned to 0.7"
 


### PR DESCRIPTION
RUSTSEC-2025-0134 (rustls-pemfile unmaintained) no longer applies — the crate is absent from the dependency tree, so cargo-deny emits `advisory-not-detected` for the dead ignore entry. Removed.

**Local verification (metis, verda CI runner offline):**
- `cargo tree -i rustls-pemfile` → no match (crate gone)
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok; exit 0; no advisory-not-detected warning
- `cargo audit` → exit 0

Self-hosted checks (cargo-deny/audit/gate-attestation/no-ai) cannot complete while the verda runner is offline; GitHub-hosted checks (fmt/scan/sonar) pass.