### PR TITLE
fix(pylon): scope idempotency cache keys to authenticated principal (#2200)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "agora",
  "aletheia-routing",
@@ -179,11 +179,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.30.0"
+version = "0.29.0"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "jiff",
  "koina",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "futures",
  "jiff",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "jiff",
  "koina",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "eidos",
  "jiff",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "jiff",
  "koina",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "aletheia-routing",
  "compact_str",
@@ -3134,7 +3134,7 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "episteme"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "cargo_metadata",
  "fjall",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -4187,7 +4187,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "arboard",
  "clap",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "criterion",
  "fjall",
@@ -5286,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5904,7 +5904,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6954,7 +6954,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-charts"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "insta",
  "poiesis-core",
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "indexmap 2.14.0",
  "jiff",
@@ -6978,7 +6978,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-deck"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "minijinja",
  "poiesis-core",
@@ -6990,7 +6990,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-deck-layout"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "poiesis-core",
  "serde",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "docx-rs",
  "poiesis-core",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -7055,7 +7055,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7064,7 +7064,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-printer-chromium"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "chromiumoxide",
  "futures",
@@ -7077,7 +7077,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -7089,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -7103,7 +7103,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -7116,7 +7116,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-theme"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "indexmap 2.14.0",
  "jiff",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "comemo",
  "jiff",
@@ -7147,7 +7147,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7557,7 +7557,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -9027,7 +9027,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -9384,7 +9384,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9503,7 +9503,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -9615,14 +9615,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.30.0"
+version = "0.29.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "agora",
  "aletheia-routing",
@@ -179,11 +179,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.29.0"
+version = "0.30.0"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "jiff",
  "koina",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "futures",
  "jiff",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "jiff",
  "koina",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "eidos",
  "jiff",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "jiff",
  "koina",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-routing",
  "compact_str",
@@ -3134,7 +3134,7 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "episteme"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "cargo_metadata",
  "fjall",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -4187,7 +4187,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "arboard",
  "clap",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "fjall",
@@ -5286,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5904,7 +5904,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6954,7 +6954,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-charts"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "insta",
  "poiesis-core",
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "jiff",
@@ -6978,7 +6978,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-deck"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "minijinja",
  "poiesis-core",
@@ -6990,7 +6990,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-deck-layout"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "poiesis-core",
  "serde",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "docx-rs",
  "poiesis-core",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -7055,7 +7055,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7064,7 +7064,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-printer-chromium"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "chromiumoxide",
  "futures",
@@ -7077,7 +7077,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -7089,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -7103,7 +7103,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -7116,7 +7116,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-theme"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "jiff",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "comemo",
  "jiff",
@@ -7147,7 +7147,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7557,7 +7557,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -9027,7 +9027,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -9384,7 +9384,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9503,7 +9503,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -9615,14 +9615,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",

--- a/crates/pylon/src/handlers/sessions/streaming.rs
+++ b/crates/pylon/src/handlers/sessions/streaming.rs
@@ -125,11 +125,10 @@ pub async fn send_message(
     require_role(&claims, Role::Operator)?;
 
     let idempotency_key =
-        extract_idempotency_key(&headers, state.idempotency_cache.max_key_length)?
-            .map(|k| format!("{}:{k}", claims.sub));
+        extract_idempotency_key(&headers, state.idempotency_cache.max_key_length)?;
 
     if let Some(ref key) = idempotency_key {
-        match state.idempotency_cache.check_or_insert(key) {
+        match state.idempotency_cache.check_or_insert(&claims.sub, key) {
             LookupResult::Miss => {}
             LookupResult::Hit { body, .. } => {
                 tracing::info!(idempotency_key = %key, "idempotency cache hit — returning cached completion");
@@ -265,6 +264,7 @@ pub async fn send_message(
     let sid = session_id.clone();
 
     let idem_key = idempotency_key.clone();
+    let idem_principal = claims.sub.clone();
     let idem_cache = Arc::clone(&state.idempotency_cache);
 
     // WHY(#3276): Create a turn buffer for this turn so events survive disconnection.
@@ -349,7 +349,7 @@ pub async fn send_message(
                             "output_tokens": result.usage.output_tokens,
                         })
                         .to_string();
-                        idem_cache.complete(key, axum::http::StatusCode::OK, body);
+                        idem_cache.complete(&idem_principal, key, axum::http::StatusCode::OK, body);
                     }
                 }
                 Err(err) => {
@@ -359,7 +359,7 @@ pub async fn send_message(
 
                     // WHY: Remove idempotency entry on error so the client can retry.
                     if let Some(ref key) = idem_key {
-                        idem_cache.remove(key);
+                        idem_cache.remove(&idem_principal, key);
                     }
 
                     let (err_code, err_message) = turn_error_info(&err);

--- a/crates/pylon/src/idempotency.rs
+++ b/crates/pylon/src/idempotency.rs
@@ -1,8 +1,9 @@
 //! Idempotency-key cache for deduplicating `POST /sessions/{id}/messages`.
 //!
-//! Stores a bounded, TTL-evicting map of `(idempotency_key, state)` pairs so that
-//! retried requests with the same key return the cached response instead of
-//! creating duplicate turns.
+//! Stores a bounded, TTL-evicting map of `(principal, idempotency_key, state)` tuples so that
+//! retried requests with the same key and same authenticated principal return the cached response
+//! instead of creating duplicate turns. Keys are namespaced per principal so one principal cannot
+//! observe or replay another principal's cached response.
 
 use std::collections::{HashMap, VecDeque};
 // WHY: lock not held across await points
@@ -67,6 +68,15 @@ pub(crate) enum LookupResult {
     Conflict,
 }
 
+/// Build a composite cache key that namespaces `key` under `principal`.
+///
+/// Uses a NUL byte separator: NUL cannot appear in valid ASCII HTTP header values,
+/// so `"alice\x00k"` can never collide with a principal of `"alice\x00k"` and a
+/// separate key component.
+fn composite_key(principal: &str, key: &str) -> String {
+    format!("{principal}\x00{key}")
+}
+
 impl Default for IdempotencyCache {
     fn default() -> Self {
         Self::new()
@@ -102,21 +112,23 @@ impl IdempotencyCache {
         })
     }
 
-    /// Look up a key. On miss, atomically inserts it as `InFlight`.
+    /// Look up a (principal, key) pair. On miss, atomically inserts it as `InFlight`.
+    ///
+    /// The cache entry is keyed by `"{principal}\x00{key}"` so that two different
+    /// principals presenting identical `Idempotency-Key` header values never collide.
+    /// The NUL separator cannot appear in valid ASCII header values, ensuring no
+    /// ambiguity between a principal that ends with a substring of another key.
     ///
     /// # Complexity
     ///
     /// O(1) for the `HashMap` lookup. O(k) for eviction of expired entries
     /// where k is the number of expired entries at the front of the LRU queue.
-    pub(crate) fn check_or_insert(&self, key: &str) -> LookupResult {
+    pub(crate) fn check_or_insert(&self, principal: &str, key: &str) -> LookupResult {
+        let composite = composite_key(principal, key);
         let mut inner = self.lock_inner();
         inner.evict_expired();
 
-        // TODO(#2200): Cache keys are not scoped per user. The `sub` claim from
-        // Claims is not available at this layer because the cache operates below
-        // the auth extractor. Callers should prefix the key with the user's `sub`
-        // before calling check_or_insert to prevent cross-user key collisions.
-        if let Some(entry) = inner.entries.get(key) {
+        if let Some(entry) = inner.entries.get(&composite) {
             return match &entry.state {
                 EntryState::InFlight => LookupResult::Conflict,
                 EntryState::Completed { status, body } => LookupResult::Hit {
@@ -135,30 +147,32 @@ impl IdempotencyCache {
         }
 
         inner.entries.insert(
-            key.to_owned(),
+            composite.clone(),
             CacheEntry {
                 state: EntryState::InFlight,
                 created_at: Instant::now(),
             },
         );
-        inner.order.push_back(key.to_owned());
+        inner.order.push_back(composite);
 
         LookupResult::Miss
     }
 
-    /// Mark a key as completed with the given response.
-    pub(crate) fn complete(&self, key: &str, status: StatusCode, body: String) {
+    /// Mark a (principal, key) pair as completed with the given response.
+    pub(crate) fn complete(&self, principal: &str, key: &str, status: StatusCode, body: String) {
+        let composite = composite_key(principal, key);
         let mut inner = self.lock_inner();
-        if let Some(entry) = inner.entries.get_mut(key) {
+        if let Some(entry) = inner.entries.get_mut(&composite) {
             entry.state = EntryState::Completed { status, body };
         }
     }
 
-    /// Remove a key from the cache (e.g. on error, to allow retry).
-    pub(crate) fn remove(&self, key: &str) {
+    /// Remove a (principal, key) pair from the cache (e.g. on error, to allow retry).
+    pub(crate) fn remove(&self, principal: &str, key: &str) {
+        let composite = composite_key(principal, key);
         let mut inner = self.lock_inner();
-        inner.entries.remove(key);
-        inner.order.retain(|k| k != key);
+        inner.entries.remove(&composite);
+        inner.order.retain(|k| k != &composite);
     }
 
     /// Number of entries currently in the cache (for testing).
@@ -202,15 +216,22 @@ mod tests {
     #[test]
     fn miss_then_hit_after_complete() {
         let cache = IdempotencyCache::new();
+        let principal = "alice";
         let key = "test-key-001";
 
-        assert!(matches!(cache.check_or_insert(key), LookupResult::Miss));
+        assert!(matches!(
+            cache.check_or_insert(principal, key),
+            LookupResult::Miss
+        ));
 
-        assert!(matches!(cache.check_or_insert(key), LookupResult::Conflict));
+        assert!(matches!(
+            cache.check_or_insert(principal, key),
+            LookupResult::Conflict
+        ));
 
-        cache.complete(key, StatusCode::OK, r#"{"ok":true}"#.to_owned());
+        cache.complete(principal, key, StatusCode::OK, r#"{"ok":true}"#.to_owned());
 
-        match cache.check_or_insert(key) {
+        match cache.check_or_insert(principal, key) {
             LookupResult::Hit { status, body } => {
                 assert_eq!(status, StatusCode::OK);
                 assert_eq!(body, r#"{"ok":true}"#);
@@ -222,11 +243,18 @@ mod tests {
     #[test]
     fn remove_allows_retry() {
         let cache = IdempotencyCache::new();
+        let principal = "alice";
         let key = "retry-key";
 
-        assert!(matches!(cache.check_or_insert(key), LookupResult::Miss));
-        cache.remove(key);
-        assert!(matches!(cache.check_or_insert(key), LookupResult::Miss));
+        assert!(matches!(
+            cache.check_or_insert(principal, key),
+            LookupResult::Miss
+        ));
+        cache.remove(principal, key);
+        assert!(matches!(
+            cache.check_or_insert(principal, key),
+            LookupResult::Miss
+        ));
     }
 
     #[test]
@@ -241,14 +269,15 @@ mod tests {
             max_key_length: DEFAULT_MAX_KEY_LENGTH,
         };
 
+        let principal = "alice";
         for i in 0..4 {
-            cache.check_or_insert(&format!("key-{i}"));
+            cache.check_or_insert(principal, &format!("key-{i}"));
         }
 
         assert_eq!(cache.len(), 3);
         let inner = cache.inner.lock().unwrap();
-        assert!(!inner.entries.contains_key("key-0"));
-        assert!(inner.entries.contains_key("key-3"));
+        assert!(!inner.entries.contains_key(&composite_key(principal, "key-0")));
+        assert!(inner.entries.contains_key(&composite_key(principal, "key-3")));
     }
 
     #[test]
@@ -263,11 +292,84 @@ mod tests {
             max_key_length: DEFAULT_MAX_KEY_LENGTH,
         };
 
-        cache.check_or_insert("expired-key");
+        cache.check_or_insert("alice", "expired-key");
         assert!(matches!(
-            cache.check_or_insert("expired-key"),
+            cache.check_or_insert("alice", "expired-key"),
             LookupResult::Miss
         ));
+    }
+
+    /// Two principals using the same `Idempotency-Key` value must not share a
+    /// cache entry. Alice's completed response must not be served to Bob, and
+    /// Bob's first use of that key must be a Miss (not a Hit or Conflict).
+    #[test]
+    fn different_principals_same_key_are_isolated() {
+        let cache = IdempotencyCache::new();
+        let key = "shared-key-value";
+
+        // Alice sends a request and it completes.
+        assert!(matches!(
+            cache.check_or_insert("alice", key),
+            LookupResult::Miss
+        ));
+        cache.complete("alice", key, StatusCode::OK, r#"{"user":"alice"}"#.to_owned());
+
+        // Alice's replay returns her own cached response.
+        match cache.check_or_insert("alice", key) {
+            LookupResult::Hit { body, .. } => {
+                assert_eq!(body, r#"{"user":"alice"}"#);
+            }
+            other => panic!("expected Hit for alice, got {other:?}"),
+        }
+
+        // Bob uses the same Idempotency-Key but must see a Miss — not Alice's response.
+        assert!(
+            matches!(cache.check_or_insert("bob", key), LookupResult::Miss),
+            "bob must not see alice's cache entry"
+        );
+
+        // Bob's entry is in-flight until he completes; a second call from Bob is a Conflict.
+        assert!(matches!(
+            cache.check_or_insert("bob", key),
+            LookupResult::Conflict
+        ));
+
+        // Bob completing his entry does not disturb Alice's cached entry.
+        cache.complete("bob", key, StatusCode::OK, r#"{"user":"bob"}"#.to_owned());
+        match cache.check_or_insert("alice", key) {
+            LookupResult::Hit { body, .. } => {
+                assert_eq!(body, r#"{"user":"alice"}"#, "alice's entry must be unchanged");
+            }
+            other => panic!("expected Hit for alice after bob's complete, got {other:?}"),
+        }
+        match cache.check_or_insert("bob", key) {
+            LookupResult::Hit { body, .. } => {
+                assert_eq!(body, r#"{"user":"bob"}"#);
+            }
+            other => panic!("expected Hit for bob, got {other:?}"),
+        }
+    }
+
+    /// Removing a key for one principal must not affect the same key for another.
+    #[test]
+    fn remove_is_principal_scoped() {
+        let cache = IdempotencyCache::new();
+        let key = "shared-removable-key";
+
+        cache.check_or_insert("alice", key);
+        cache.check_or_insert("bob", key);
+
+        // Remove only alice's entry.
+        cache.remove("alice", key);
+
+        assert!(
+            matches!(cache.check_or_insert("alice", key), LookupResult::Miss),
+            "alice's entry should be gone after remove"
+        );
+        assert!(
+            matches!(cache.check_or_insert("bob", key), LookupResult::Conflict),
+            "bob's in-flight entry must be unaffected"
+        );
     }
 
     impl std::fmt::Debug for LookupResult {

--- a/crates/pylon/src/idempotency.rs
+++ b/crates/pylon/src/idempotency.rs
@@ -276,8 +276,16 @@ mod tests {
 
         assert_eq!(cache.len(), 3);
         let inner = cache.inner.lock().unwrap();
-        assert!(!inner.entries.contains_key(&composite_key(principal, "key-0")));
-        assert!(inner.entries.contains_key(&composite_key(principal, "key-3")));
+        assert!(
+            !inner
+                .entries
+                .contains_key(&composite_key(principal, "key-0"))
+        );
+        assert!(
+            inner
+                .entries
+                .contains_key(&composite_key(principal, "key-3"))
+        );
     }
 
     #[test]
@@ -312,7 +320,12 @@ mod tests {
             cache.check_or_insert("alice", key),
             LookupResult::Miss
         ));
-        cache.complete("alice", key, StatusCode::OK, r#"{"user":"alice"}"#.to_owned());
+        cache.complete(
+            "alice",
+            key,
+            StatusCode::OK,
+            r#"{"user":"alice"}"#.to_owned(),
+        );
 
         // Alice's replay returns her own cached response.
         match cache.check_or_insert("alice", key) {
@@ -338,7 +351,10 @@ mod tests {
         cache.complete("bob", key, StatusCode::OK, r#"{"user":"bob"}"#.to_owned());
         match cache.check_or_insert("alice", key) {
             LookupResult::Hit { body, .. } => {
-                assert_eq!(body, r#"{"user":"alice"}"#, "alice's entry must be unchanged");
+                assert_eq!(
+                    body, r#"{"user":"alice"}"#,
+                    "alice's entry must be unchanged"
+                );
             }
             other => panic!("expected Hit for alice after bob's complete, got {other:?}"),
         }

--- a/crates/pylon/src/tests/idempotency.rs
+++ b/crates/pylon/src/tests/idempotency.rs
@@ -102,11 +102,10 @@ async fn idempotency_key_in_flight_returns_409() {
     let created = create_test_session(&router).await;
     let id = created["id"].as_str().unwrap();
 
-    // WHY: The handler prefixes the idempotency key with the JWT sub claim.
-    // We must insert with the same prefix to simulate an in-flight request.
+    // WHY: Pre-seeding the cache with the test principal ("test-user") and the
+    // raw key simulates an in-flight request and triggers the 409 Conflict path.
     let key = "inflight-key-001";
-    let prefixed_key = format!("test-user:{key}");
-    state.idempotency_cache.check_or_insert(&prefixed_key);
+    state.idempotency_cache.check_or_insert("test-user", key);
 
     let req = send_message_req(id, Some(key));
     let resp = router.clone().oneshot(req).await.unwrap();


### PR DESCRIPTION
Idempotency cache keys were global across all sessions/users (TODO #2200): a client that knew another user's `Idempotency-Key` header value could replay or observe that user's cached response. A prior partial fix prefixed the key with `{sub}:` at one call site, but `:` is a valid header-value character, leaving an ambiguity (principal `alice:bob`+key `k` vs `alice`+`bob:k`).

**Fix:** push scoping into the cache API — `check_or_insert`/`complete`/`remove` now take `(principal, key)` and compose the key with a NUL separator (cannot appear in a valid ASCII header value). The authenticated principal is `Claims::sub` (the narrowest correct tenancy boundary — two users can share a session or nous, so those would be too broad).

Tests: `different_principals_same_key_are_isolated` + `remove_is_principal_scoped` (unit), plus the in-flight integration test updated.
Verified locally: `cargo clippy -p pylon --all-targets -- -D warnings` clean; `cargo nextest run -p pylon` 503 pass.