### PR TITLE
chore: sync Cargo.lock workspace versions to 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agora"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "koina",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "agora",
  "aletheia-routing",
@@ -179,11 +179,11 @@ dependencies = [
 
 [[package]]
 name = "aletheia-lexica"
-version = "0.29.0"
+version = "0.30.0"
 
 [[package]]
 name = "aletheia-memory-mcp"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "jiff",
  "koina",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-routing"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "futures",
  "jiff",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "aletheia-sessions-migrate"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "dianoia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "jiff",
  "koina",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "diaporeia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum 0.8.9",
  "hermeneus",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "dokimion"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "eidos",
  "jiff",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "eidos"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "jiff",
  "koina",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "energeia"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-routing",
  "compact_str",
@@ -3134,7 +3134,7 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "episteme"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "cargo_metadata",
  "fjall",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "graphe"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "eidos",
@@ -4187,7 +4187,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermeneus"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum 0.8.9",
  "dokimion",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "koilon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "arboard",
  "clap",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "koina"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "fjall",
@@ -5286,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "krites"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "melete"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-lexica",
  "futures",
@@ -5904,7 +5904,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "eidos",
  "episteme",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "nous"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-classify",
  "aletheia-lexica",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "oikonomos"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-routing",
  "axum 0.8.9",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "organon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "base64 0.22.1",
  "eidos",
@@ -6954,7 +6954,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-charts"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "insta",
  "poiesis-core",
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "jiff",
@@ -6978,7 +6978,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-deck"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "minijinja",
  "poiesis-core",
@@ -6990,7 +6990,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-deck-layout"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "poiesis-core",
  "serde",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-diff"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "poiesis-sheet",
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-doc"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "docx-rs",
  "poiesis-core",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-inspect"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "lopdf",
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-intake"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aletheia-lexica",
  "poiesis-scaffold",
@@ -7055,7 +7055,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-lint"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7064,7 +7064,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-printer-chromium"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "chromiumoxide",
  "futures",
@@ -7077,7 +7077,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-scaffold"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "poiesis-core",
  "poiesis-sheet",
@@ -7089,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-sheet"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "calamine",
  "poiesis-core",
@@ -7103,7 +7103,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-slides"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "poiesis-core",
  "quick-xml 0.39.2",
@@ -7116,7 +7116,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-theme"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "jiff",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-typst"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "comemo",
  "jiff",
@@ -7147,7 +7147,7 @@ dependencies = [
 
 [[package]]
 name = "poiesis-verify"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7557,7 +7557,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pylon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "axum 0.8.9",
  "axum-server",
@@ -9027,7 +9027,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -9384,7 +9384,7 @@ dependencies = [
 
 [[package]]
 name = "symbolon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9503,7 +9503,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "chacha20poly1305",
  "eidos",
@@ -9615,14 +9615,14 @@ dependencies = [
 
 [[package]]
 name = "theatron"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "skene",
 ]
 
 [[package]]
 name = "thesauros"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "futures",
  "indexmap 2.14.0",


### PR DESCRIPTION
The v0.30.0 release bumped crate manifests but left `Cargo.lock` at 0.29.0 workspace versions. Every cargo invocation regenerated the lock, producing spurious churn in unrelated PRs. This syncs the lock to the manifests — 46 workspace version entries `0.29.0`→`0.30.0`, no dependency changes.