### PR TITLE
docs: correct tool/crate counts and remove unbacked Signal-command claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ The tarball contains `instance.example/` with the reference config layout. See [
 - **Persistent memory.** Conversations carry forward. The agent builds a knowledge graph of facts, entities, and relationships that persists across sessions and grows over time.
 - **Working-memory continuity.** Each turn can inject agent-curated `<key_info>` from the prior working checkpoint before recall and history are assembled.
 - **Multiple agents.** Each agent has its own character (SOUL.md), goals, memory, and workspace. They can coordinate, delegate, and specialize.
-- **Tools.** 49 built-in tools: file I/O, shell execution, web search, memory search, planning, agent coordination, plus external MCP tools bridged through the organon tool plane.
+- **Tools.** 67 built-in tools (default build): file I/O, shell execution, web search, memory search, planning, agent coordination, plus external MCP tools bridged through the organon tool plane. Feature-gated additions bring the total to 76 (energeia) or 80 (all features: energeia + bookkeeper + computer-use + z3).
 - **Runtime guardrails.** Tool calls carry HMAC-SHA256 receipts, loop detection combines ping-pong, no-progress, and doom-loop signals, and per-stage timeouts bound long-running turns.
 - **Terminal dashboard.** Rich TUI with markdown rendering, session management, and real-time streaming.
-- **Signal messaging.** Talk to your agents over Signal with 15 built-in commands.
+- **Signal messaging.** Talk to your agents over Signal. Messages arrive as plain conversational turns routed to the configured agent.
 - **Privacy.** No telemetry, no analytics, no phone-home. Only outbound connections are to services you configure.
 
 ---
 
 ## Architecture
 
-44 Rust workspace crates plus the excluded desktop shell. Single binary deployment. The substrate includes persistent sessions, Datalog-backed memory, working-memory injection, HTTP/SSE, MCP, Signal, dispatch, and a 15-scenario substrate canary suite. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and trait boundaries.
+47 Rust workspace crates plus the excluded desktop shell. Single binary deployment. The substrate includes persistent sessions, Datalog-backed memory, working-memory injection, HTTP/SSE, MCP, Signal, dispatch, and a 15-scenario substrate canary suite. See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full dependency graph and trait boundaries.
 
 ---
 
@@ -60,7 +60,7 @@ Each agent has a workspace under `nous/` with character, operations, and memory 
 ## Interfaces
 
 - **TUI** - Terminal dashboard. Rich markdown rendering, session management.
-- **Signal** - 15 `!` commands. `!help` for the list.
+- **Signal** - Inbound messages are delivered as plain conversational turns to the configured agent.
 - **CLI** - `aletheia help` for the full command reference.
 - **API** - REST on port 18789. See [ARCHITECTURE.md](docs/ARCHITECTURE.md).
 

--- a/_llm/L1-workspace.md
+++ b/_llm/L1-workspace.md
@@ -1,6 +1,6 @@
 # L1 - Workspace Overview
 
-Aletheia is a single-binary Rust agent runtime with 44 workspace crates plus the excluded `proskenion` desktop shell. Imports flow from leaf/foundation crates upward into memory, tools, runtime, gateways, and finally the `aletheia` binary. Lower layers must not depend on higher layers; facade crates (`mneme`, `theatron`) exist to stabilize downstream imports, not to hide arbitrary logic.
+Aletheia is a single-binary Rust agent runtime with 47 workspace crates plus the excluded `proskenion` desktop shell. Imports flow from leaf/foundation crates upward into memory, tools, runtime, gateways, and finally the `aletheia` binary. Lower layers must not depend on higher layers; facade crates (`mneme`, `theatron`) exist to stabilize downstream imports, not to hide arbitrary logic.
 
 ## Crate list
 
@@ -35,16 +35,20 @@ Aletheia is a single-binary Rust agent runtime with 44 workspace crates plus the
 | `theatron` | `crates/theatron` | Thin facade re-exporting skene types for external consumers. |
 | `skene` | `crates/theatron/skene` | Shared API client, types, SSE, and streaming infrastructure for Aletheia UIs. |
 | `koilon` | `crates/theatron/koilon` | Terminal dashboard for the Aletheia distributed cognition system. |
+| `poiesis-charts` | `crates/poiesis/charts` | Chart rendering support for poiesis. |
 | `poiesis-core` | `crates/poiesis/core` | Format-agnostic document model and Renderer trait for poiesis. |
-| `poiesis-text` | `crates/poiesis/text` | PDF and ODT document rendering backends for poiesis. |
 | `poiesis-sheet` | `crates/poiesis/sheet` | XLSX and ODS spreadsheet rendering backends for poiesis. |
 | `poiesis-slides` | `crates/poiesis/slides` | PPTX presentation rendering backend for poiesis. |
 | `poiesis-lint` | `crates/poiesis/lint` | Report prose linting: banned words, citation checks, structure checks. |
+| `poiesis-theme` | `crates/poiesis/theme` | Shared theming and styling for poiesis renderers. |
 | `poiesis-scaffold` | `crates/poiesis/scaffold` | Project-template scaffolder for poiesis report projects. |
 | `poiesis-typst` | `crates/poiesis/typst` | Typst-based PDF rendering backend for poiesis: embeddable compiler, JSON data injection, template assets. |
 | `poiesis-verify` | `crates/poiesis/verify` | Report claim verification: arithmetic evaluation and source resolution. |
 | `poiesis-intake` | `crates/poiesis/intake` | Parse Slack-style request text into a structured report scaffold. |
+| `poiesis-deck` | `crates/poiesis/deck` | Slide deck authoring model for poiesis. |
+| `poiesis-deck-layout` | `crates/poiesis/deck-layout` | Layout engine for poiesis slide decks. |
 | `poiesis-doc` | `crates/poiesis/doc` | DOCX write and inspect backend for poiesis. |
+| `poiesis-printer-chromium` | `crates/poiesis/printer-chromium` | Chromium-based headless print backend for poiesis. |
 | `poiesis-diff` | `crates/poiesis/diff` | Cell-level diff for XLSX and PPTX documents. |
 | `poiesis-inspect` | `crates/poiesis/inspect` | Text extraction from PDF, XLSX, and PPTX documents. |
 | `gnosis` | `crates/gnosis` | Machine-derived code-graph index for symbol-level cross-crate queries. |
@@ -65,7 +69,7 @@ Aletheia is a single-binary Rust agent runtime with 44 workspace crates plus the
 
 **CLI and operators.** Binary wiring, migrations, evals, and integration canaries: `aletheia`, `aletheia-sessions-migrate`, `dokimion`, `integration-tests`.
 
-**Poiesis document stack.** Report model, renderers, diff/inspect/intake/scaffold helpers: `poiesis-core`, `poiesis-text`, `poiesis-sheet`, `poiesis-slides`, `poiesis-lint`, `poiesis-verify`, `poiesis-typst`, `poiesis-intake`, `poiesis-doc`, `poiesis-diff`, `poiesis-inspect`, `poiesis-scaffold`.
+**Poiesis document stack.** Report model, renderers, diff/inspect/intake/scaffold helpers: `poiesis-core`, `poiesis-charts`, `poiesis-theme`, `poiesis-sheet`, `poiesis-slides`, `poiesis-deck`, `poiesis-deck-layout`, `poiesis-lint`, `poiesis-verify`, `poiesis-typst`, `poiesis-intake`, `poiesis-doc`, `poiesis-printer-chromium`, `poiesis-diff`, `poiesis-inspect`, `poiesis-scaffold`.
 
 **Presentation.** Shared UI client, TUI, facade, and excluded desktop shell: `skene`, `koilon`, `theatron`, `proskenion`.
 

--- a/docs/ARCHITECTURE-QUICK.md
+++ b/docs/ARCHITECTURE-QUICK.md
@@ -12,7 +12,7 @@
 
 ## Runtime
 - **hermeneus** - LLM client: streaming, retries, health tracking
-- **organon** - tool registry, sandbox, HMAC receipts, 49 built-in tools
+- **organon** - tool registry, sandbox, HMAC receipts, 67 built-in tools (default)
 - **melete** - context distillation / summarization
 - **thesauros** - domain pack loader
 - **nous** - agent runtime: actor model, working memory, turn pipeline, per-stage timeouts

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ Module and crate names use Greek terms reflecting their essential nature (nous =
 
 ## Current substrate shape
 
-The current runtime is a 44-crate workspace plus the excluded `proskenion`
+The current runtime is a 47-crate workspace plus the excluded `proskenion`
 desktop shell. The compact generated inventory lives in
 [`_llm/L1-workspace.md`](../_llm/L1-workspace.md); this document describes the
 human architecture and invariants.
@@ -55,7 +55,7 @@ aletheia
 │   ├── episteme   -  knowledge pipeline: extraction, recall, consolidation, embeddings
 │   └── krites     -  embedded Datalog engine + HNSW vectors (mneme-engine feature gate)
 ├── hermeneus      -  LLM provider registry, fallback chains, loop guard, credentials
-├── organon        -  tool registry + 49 built-in tools + receipt ledger
+├── organon        -  tool registry + 67 built-in tools (default) + receipt ledger
 ├── nous           -  agent pipeline, bootstrap, recall, finalize, actor model
 ├── dianoia        -  planning / project orchestration
 ├── pylon          -  Axum HTTP gateway, SSE streaming, auth enforcement
@@ -134,7 +134,7 @@ The oikos hierarchy is described in [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Rust crate workspace
 
-44 crates in the workspace, with `proskenion` excluded and built via its own
+47 crates in the workspace, with `proskenion` excluded and built via its own
 manifest. The table below calls out the primary architecture crates; the full
 generated inventory is `_llm/L1-workspace.md`.
 
@@ -150,7 +150,7 @@ generated inventory is `_llm/L1-workspace.md`.
 | `krites` | `crates/krites` | Embedded Datalog and graph query engine with HNSW support | eidos |
 | `mneme` | `crates/mneme` | Thin facade re-exporting eidos, graphe, episteme, krites | eidos, graphe, episteme, krites |
 | `hermeneus` | `crates/hermeneus` | LLM provider registry, fallback chains, token redaction, provider trait, loop guard | koina, taxis |
-| `organon` | `crates/organon` | Tool registry, tool definitions, tags, HMAC receipts, 49 built-in tools, sandbox | koina, hermeneus |
+| `organon` | `crates/organon` | Tool registry, tool definitions, tags, HMAC receipts, 67 built-in tools (default), sandbox | koina, hermeneus |
 | `symbolon` | `crates/symbolon` | JWT tokens, password hashing, admin auth facade, RBAC policies | koina |
 | `melete` | `crates/melete` | Context distillation, compression strategies, token budget management | hermeneus |
 | `agora` | `crates/agora` | Channel registry, ChannelProvider trait, Signal JSON-RPC client | koina, taxis |

--- a/docs/FEATURE-FLAGS.md
+++ b/docs/FEATURE-FLAGS.md
@@ -117,9 +117,7 @@ Every feature flag defined in the workspace, how flags interact across crates, a
 | **poiesis-sheet** | `ods` | no | ODS backend | `dep:spreadsheet-ods` |
 | **poiesis-slides** | `default` | **yes** | `pptx` | - |
 | **poiesis-slides** | `pptx` | no | PPTX backend | `dep:ppt-rs` |
-| **poiesis-text** | `default` | **yes** | `pdf`, `odt` | - |
-| **poiesis-text** | `pdf` | no | PDF backend | `dep:krilla` |
-| **poiesis-text** | `odt` | no | ODT backend | `dep:zip` |
+
 
 ## Cross-crate feature interactions
 

--- a/docs/GRACEFUL-DEGRADATION.md
+++ b/docs/GRACEFUL-DEGRADATION.md
@@ -21,7 +21,7 @@ The actor run loop (`crates/nous/src/actor/mod.rs:270`) processes messages seque
 
 ### Cross-nous message handling
 
-**Gap:** `handle_cross_message` (`mod.rs:410-427`) calls `execute_turn` **inline** - it does **not** use `execute_turn_with_panic_boundary`. A pipeline panic on this path crashes the actor task. The `NousManager` health poller will eventually detect the dead actor and restart it (`manager.rs:432-434`), but all in-memory session state for that actor is lost.
+**Resolved:** `handle_cross_message` (`mod.rs:459`) now calls `execute_turn_with_panic_boundary` (`mod.rs:470`). Cross-nous pipeline panics are caught as `JoinError` on the same boundary as normal turns; the actor continues processing subsequent messages.
 
 ### Background tasks
 
@@ -81,7 +81,7 @@ The `ProviderRegistry` (`hermeneus/src/provider.rs:280`) holds a `Vec<ProviderEn
 - **Per-provider health:** `record_success` / `record_error` update state machine (`Up → Degraded → Down`). A single provider failure does not affect other providers.
 - **Mutex poisoning handled gracefully:** `health.rs:103-107` uses `unwrap_or_else(PoisonError::into_inner)` to recover stale state.
 
-**Gap:** The `ConcurrencyLimiter` (`hermeneus/src/concurrency.rs`) uses `.expect()` on `std::sync::Mutex` locking (`concurrency.rs:165`, `179`, `193`, `225`, `254`). If any thread panics while holding this lock, **all subsequent LLM requests across all actors will panic** because the limiter is shared globally via `Arc`. This is a single-failure-to-global-crash vector.
+**Resolved:** The `ConcurrencyLimiter` (`hermeneus/src/concurrency.rs`) now uses `parking_lot::Mutex` (`concurrency.rs:24`), which does not poison on panic. The `.expect()` calls on mutex locking are eliminated; a panic while holding the lock no longer crashes subsequent LLM requests.
 
 ## Tool Executors
 
@@ -96,24 +96,22 @@ See [Daemon Workers](#daemon-workers). Maintenance tasks inherit the same isolat
 The following components can turn a local failure into a process-wide crash:
 
 1. **Krites Datalog engine** - `panic!` on internal invariant violations during query planning and JSON serialization.
-2. **Hermeneus concurrency limiter** - `.expect()` on mutex poisoning; one poisoned lock kills all LLM traffic.
-3. **Pylon signal handler setup** - `.expect()` on signal installation; startup crash in restricted environments.
-4. **Nous actor cross-nous messages** - bypasses the panic boundary; a single bad cross-message kills the actor (process survives, but actor state is lost).
-5. **Nous manager health poller** - fire-and-forget task; if `health_cycle()` panics, health checks stop forever for all actors.
+2. **Pylon signal handler setup** - `.expect()` on signal installation; startup crash in restricted environments.
+3. **Nous manager health poller** - fire-and-forget task; if `health_cycle()` panics, health checks stop forever for all actors.
 
 ## Summary Table
 
 | Component | Failure Mode | Blast Radius | Ideal Behavior | Current Gap |
 |---|---|---|---|---|
 | Nous actor - normal turn | Pipeline panic caught as `JoinError` | Request | Actor continues, enter degraded mode if repeated | ✅ None |
-| Nous actor - cross-nous message | `execute_turn` inline, no panic boundary | Actor | Same panic boundary as normal turns | `actor/mod.rs:420` calls `execute_turn` directly |
+| Nous actor - cross-nous message | Pipeline panic caught as `JoinError` via `execute_turn_with_panic_boundary` | Request | Actor continues, enter degraded mode if repeated | ✅ None (resolved: `actor/mod.rs:470`) |
 | Nous manager health poller | `health_cycle()` panic kills spawned task silently | All actors managed | Supervisor restarts poller on failure | `manager.rs:547` fire-and-forget, no monitoring |
 | Daemon task runner | `JoinError` caught per-task in `check_in_flight` | Task | Task disabled after 3 failures | ✅ None |
 | Daemon maintenance tasks | `spawn_blocking` panics caught as `JoinError` | Task | Same isolation as async tasks | ✅ None |
 | Session store | `tokio::sync::Mutex` - no poisoning | Request | Errors returned to caller | ✅ None |
 | Knowledge store | `fjall` internal concurrency, errors returned | Request | Errors returned to caller | ✅ None |
 | Provider registry | Per-provider health tracker | Provider | Failed provider marked Down, others unaffected | ✅ None |
-| Hermeneus concurrency limiter | `.expect()` on `Mutex` poisoning | Process (all LLM calls) | Use `parking_lot::Mutex` or recover gracefully | `concurrency.rs:165`, `179`, `193`, `225`, `254` |
+| Hermeneus concurrency limiter | `parking_lot::Mutex` - no poisoning | Process | No-poison mutex; limiter survives panics | ✅ None (resolved: `concurrency.rs:24`) |
 | Hermeneus health tracker | `unwrap_or_else(PoisonError::into_inner)` | Component | Recovers stale state, continues | ✅ None |
 | Tool executors | Errors returned; sandbox no-op on non-Linux | Request | Isolate and return errors | ✅ None |
 | Pylon signal handlers | `.expect()` on signal installation failure | Process | Log warning, continue without signals | `server.rs:365`, `413`, `419` |
@@ -132,14 +130,10 @@ The following components can turn a local failure into a process-wide crash:
 - `crates/krites/src/storage/fjall_backend.rs:194` - `unreachable!("INVARIANT: tx is always Some while FjallWriteTx is live")`.
 
 ### Hermeneus
-- `crates/hermeneus/src/concurrency.rs:165` - `.expect("mutex poisoning: thread panicked, no Result to propagate")`.
-- `crates/hermeneus/src/concurrency.rs:179` - Same `.expect()` pattern.
-- `crates/hermeneus/src/concurrency.rs:193` - Same `.expect()` pattern.
-- `crates/hermeneus/src/concurrency.rs:225` - Same `.expect()` pattern inside `acquire()`.
-- `crates/hermeneus/src/concurrency.rs:254` - Same `.expect()` pattern inside `release()`.
+- `crates/hermeneus/src/concurrency.rs:24` - `parking_lot::Mutex` (resolved: replaces `std::sync::Mutex`; no poisoning on panic).
 
 ### Nous
-- `crates/nous/src/actor/mod.rs:420` - `handle_cross_message` calls `execute_turn` inline without panic boundary.
+- `crates/nous/src/actor/mod.rs:470` - `handle_cross_message` calls `execute_turn_with_panic_boundary` (resolved: previously called `execute_turn` inline).
 - `crates/nous/src/manager.rs:547` - `start_health_poller` spawns health task with no restart supervision.
 
 ### Pylon

--- a/docs/MCP-SERVERS.md
+++ b/docs/MCP-SERVERS.md
@@ -1,6 +1,6 @@
 # External MCP Servers
 
-Operator-side MCP servers that extend an agent's capabilities without modifying the aletheia binary. Aletheia is a 44-crate Rust workspace plus the excluded desktop shell. Coding agents (Claude Code, Cursor, etc.) that only have grep and file reads burn tokens re-discovering structure that a Language Server could answer in one request. The servers below close that gap.
+Operator-side MCP servers that extend an agent's capabilities without modifying the aletheia binary. Aletheia is a 47-crate Rust workspace plus the excluded desktop shell. Coding agents (Claude Code, Cursor, etc.) that only have grep and file reads burn tokens re-discovering structure that a Language Server could answer in one request. The servers below close that gap.
 
 These servers run as **operator-side tooling**, not as part of the aletheia binary. They are registered in the agent's client config (e.g. `~/.claude.json`, `.mcp.json`, or Cursor's `mcp.json`). No aletheia crate depends on them, and they are not wired into the `diaporeia` tool bus. See [Why external, not vendored](#why-external-not-vendored) below.
 

--- a/docs/OBSERVABILITY-AUDIT.md
+++ b/docs/OBSERVABILITY-AUDIT.md
@@ -15,7 +15,7 @@
 | **pylon** | sessions (create, get, list, delete, update, restore, send, streaming), config (get/set/reload), knowledge bulk_import | `nous.rs` handlers (list, get_status, tools, recover) have **no span** - gap |
 | **nous** | actor run loop, pipeline stages, finalize, recall, execute (both paths), instinct (tool dispatch), cross-router | Good coverage across the hot path |
 | **hermeneus** | anthropic client complete + complete_streaming, cc process (two fns), stream accumulator, error classifier, fallback | Core LLM call paths all instrumented |
-| **organon** | triage tool only | `ToolRegistry::execute` dispatch loop has **no span** - all 49 tools execute without a per-invocation parent span |
+| **organon** | triage tool only | `ToolRegistry::execute` dispatch loop has **no span** - all 67 tools (default) execute without a per-invocation parent span |
 | daemon | execution, watchdog, cron jobs, prosoche, self_prompt, lifecycle hooks | Good coverage |
 | episteme | consolidation engine, embedding, knowledge store ops | Good coverage |
 | agora | semeion client | Covered |
@@ -27,7 +27,7 @@
 
 **GAP-SPAN-1 (pylon/nous.rs):** `list`, `get_status`, `tools`, `recover` handlers have no `#[instrument]`. These are user-facing nous management endpoints - missing spans means no distributed trace context for nous listing/recovery operations.
 
-**GAP-SPAN-2 (organon/ToolRegistry):** The central `execute` dispatch path has no span. All 49 built-in tools therefore execute without a common parent span. Traces jump from the nous pipeline span directly to individual tool calls (where they exist). Tool-level `#[instrument]` exists only in `triage/mod.rs`.
+**GAP-SPAN-2 (organon/ToolRegistry):** The central `execute` dispatch path has no span. All 67 built-in tools (default) therefore execute without a common parent span. Traces jump from the nous pipeline span directly to individual tool calls (where they exist). Tool-level `#[instrument]` exists only in `triage/mod.rs`.
 
 ---
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -31,7 +31,7 @@ Planning and milestones are tracked in the internal project roadmap.
 | Interface | Status | Notes |
 |-----------|--------|-------|
 | TUI | Active | Terminal dashboard, rich markdown, session management |
-| Signal | Active | 15 `!` commands, always-on ambient messaging |
+| Signal | Active | Always-on ambient messaging; inbound messages delivered as plain conversational turns |
 | HTTP API | Active | REST on port 18789, SSE streaming |
 | Desktop app | In progress | Dioxus 0.7 desktop; scaffold with streaming architecture, not feature-complete |
 

--- a/docs/paper/draft.md
+++ b/docs/paper/draft.md
@@ -21,7 +21,7 @@ Long-term memory is the central problem in agent architecture. Without it, every
 
 The research community has produced several memory systems. Zep [1] pairs property graphs with vector search. MemGPT [2] uses hierarchical memory with explicit management operations. Hindsight [3] provides an upper bound by showing the full conversation at query time. Mem0 [4] layers a memory store over existing LLM APIs. These systems advance the state of the art, but each leaves a gap: none uses Datalog for the knowledge substrate, none integrates kernel-level sandboxing into the agent loop, and none combines more than three signals for recall scoring.
 
-Aletheia closes these gaps. It is a production agent runtime built in Rust with 24 crates and a single-binary deployment model. Its memory subsystem (mneme) embeds a Datalog engine (krites) with HNSW vector indexes, full-text search, and graph algorithms. Tool execution (organon) runs built-in and external tools inside a Landlock + seccomp + netns sandbox. Recall (episteme) fuses six scoring signals through operator-tunable weights.
+Aletheia closes these gaps. It is a production agent runtime built in Rust with 47 workspace crates and a single-binary deployment model. Its memory subsystem (mneme) embeds a Datalog engine (krites) with HNSW vector indexes, full-text search, and graph algorithms. Tool execution (organon) runs built-in and external tools inside a Landlock + seccomp + netns sandbox. Recall (episteme) fuses six scoring signals through operator-tunable weights.
 
 This paper makes four contributions:
 
@@ -66,13 +66,13 @@ Datalog has been used in program analysis, network configuration, and security p
 
 ### 3.1 System overview
 
-Aletheia is a Rust workspace with 24 crates. A single binary (`aletheia`) embeds all subsystems. HTTP traffic arrives at `pylon`, an Axum API with SSE streaming. Agent turns flow through `nous`, a Tokio actor that processes bootstrap, recall, execution, and finalize stages. The memory subsystem (`mneme`) is a thin facade over four sub-crates: `eidos` (types), `graphe` (fjall session store), `episteme` (knowledge pipeline), and `krites` (Datalog engine).
+Aletheia is a Rust workspace with 47 crates. A single binary (`aletheia`) embeds all subsystems. HTTP traffic arrives at `pylon`, an Axum API with SSE streaming. Agent turns flow through `nous`, a Tokio actor that processes bootstrap, recall, execution, and finalize stages. The memory subsystem (`mneme`) is a thin facade over four sub-crates: `eidos` (types), `graphe` (fjall session store), `episteme` (knowledge pipeline), and `krites` (Datalog engine).
 
 ```text
 aletheia binary
 ├── pylon        HTTP gateway, SSE, auth middleware
 ├── nous         Agent pipeline (bootstrap → recall → execute → finalize)
-├── organon      Tool registry (49 built-ins) + sandbox
+├── organon      Tool registry (67 built-ins, default) + sandbox
 ├── mneme        Memory facade
 │   ├── eidos    Shared knowledge types
 │   ├── graphe   fjall session store


### PR DESCRIPTION
## Summary

- **Built-in tool count** (README, ARCHITECTURE, ARCHITECTURE-QUICK, OBSERVABILITY-AUDIT, paper/draft): 49 → 67 (default build). Counting method: `grep -c 'registry\.register(' crates/organon/src/builtins/<module>` for each module in `register_domain_tools` + phase-2 `tool_schema`. Feature-gated totals: 76 (energeia), 80 (all features).
- **Workspace crate count** (README, ARCHITECTURE, MCP-SERVERS, L1-workspace, paper/draft): 44 → 47. Counting method: count lines in `[workspace] members` in root `Cargo.toml`.
- **Signal "15 ! commands"** (README x2, PROJECT.md): removed. No `!`-command dispatcher exists in `crates/agora/src/semeion/`; inbound Signal messages are delivered as plain conversational turns. False claim struck; accurate description substituted.
- **L1-workspace.md poiesis crate list**: replaced nonexistent `poiesis-text` (`crates/poiesis/text` does not exist) with the 5 missing real workspace members (`poiesis-charts`, `poiesis-theme`, `poiesis-deck`, `poiesis-deck-layout`, `poiesis-printer-chromium`); updated layer grouping and count line.
- **GRACEFUL-DEGRADATION.md** two resolved gaps:
  - Cross-nous panic boundary: `handle_cross_message` now calls `execute_turn_with_panic_boundary` (`actor/mod.rs:470`); Gap → Resolved.
  - Concurrency limiter: `ConcurrencyLimiter` uses `parking_lot::Mutex` (`concurrency.rs:24`); no poisoning possible; Gap → Resolved. Surface list, summary table, and citation index updated.
- **FEATURE-FLAGS.md**: removed 3 rows for `poiesis-text` (crate does not exist in workspace).

## Test plan

- [ ] `rg -n '49 built-in|49 tool|44-crate|44 crate|15 Signal|24 crates|poiesis-text' README.md docs/ _llm/L1-workspace.md` returns no matches
- [ ] All changed files are Markdown only — no `.rs` or `Cargo.toml` touched
- [ ] L1-workspace.md crate table row count equals 47 active crates + 1 excluded proskenion row