### PR TITLE
feat(energeia): wire AgentSdkEngine MCP servers into build_args

### DIFF
--- a/.codex.log
+++ b/.codex.log
@@ -1,0 +1,8055 @@
+Reading prompt from stdin...
+OpenAI Codex v0.123.0 (research preview)
+--------
+workdir: /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+model: gpt-5.4-mini
+provider: openai
+approval: never
+sandbox: danger-full-access
+reasoning effort: high
+reasoning summaries: none
+session id: 019e8b6d-c2bf-71b0-a2fb-ab90f70a79c5
+--------
+user
+# Task: WIRE AgentSdkEngine.mcp_servers into build_args (energeia)
+
+You are in an aletheia worktree (Rust). The operator's directive is to ACTIVATE built-but-unwired capability (not remove it).
+
+## The dormant code
+`crates/energeia/src/agent_sdk.rs` — `AgentSdkEngine` has a field `mcp_servers` (~line 31) that is populated but NEVER included when the engine assembles its invocation arguments in `build_args()` (~line 130). So configured MCP servers are silently dropped for AgentSdk-engine dispatches.
+
+## The fix (WIRE it)
+1. Read `agent_sdk.rs` fully + how `build_args()` constructs the args + how the underlying agent CLI accepts MCP servers (look at how the sibling `HttpEngine` or the codex/kimi/claude CLIs accept `--mcp-server` / mcp config, and how `mcp_servers` is shaped — a Vec of what type?).
+2. Wire `mcp_servers` into `build_args()` so each configured MCP server is passed to the spawned agent (the correct CLI flag/format for the target agent runtime). Match the existing arg-building idiom.
+3. If the agent CLI expects MCP config via a file or env rather than a flag, do that correctly instead.
+
+## Test
+Add/extend a unit test asserting `build_args()` includes the MCP servers when `mcp_servers` is non-empty (and omits them when empty). Match existing test patterns in the crate.
+
+## Constraints
+- Only edit `crates/energeia/`. Minimal, idiomatic (snafu, existing patterns). No unrelated changes, no reformatting untouched code.
+- Must compile + keep clippy `-D warnings` clean.
+- If `mcp_servers` turns out to have NO correct wiring target (the AgentSdk runtime genuinely can't accept MCP servers), STOP and report that — do NOT fake it.
+- Zero AI indicators. When done, STOP (do not commit/push) — leave changes in the working tree.
+
+codex
+I’m inspecting `crates/energeia` to trace how `AgentSdkEngine` builds its command line, what shape `mcp_servers` has, and which runtime flag or config path the sibling engines use so I can wire it in without inventing behavior.
+exec
+/bin/bash -lc "sed -n '1,260p' crates/energeia/src/agent_sdk.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+//! Experimental Claude CLI subprocess engine with OAuth token injection.
+//!
+//! WHY: This engine uses the `claude` CLI transport while preserving the
+//! dispatch-engine boundary for future native SDK integration. It is not a
+//! native HTTP/SSE Agent SDK client yet.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::process::Stdio;
+
+use tokio::process::Command;
+
+use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+use crate::error::{self, Result};
+use crate::http::session::ProcessSessionHandle;
+use crate::http::stream::EventStream;
+
+/// Configuration for the experimental Claude CLI bridge.
+#[derive(Clone)]
+pub struct AgentSdkConfig {
+    /// Default model identifier (e.g., "claude-opus-4", "claude-sonnet-4").
+    pub default_model: String,
+    /// Skip permission checks during dispatch.
+    pub skip_permissions: bool,
+    /// Disable MCP plugin loading.
+    pub disable_plugins: bool,
+    /// Optional `OAuth` token for API authentication.
+    pub oauth_token: Option<String>,
+    /// Optional MCP server configurations.
+    pub mcp_servers: Vec<McpServerConfig>,
+}
+
+impl Default for AgentSdkConfig {
+    fn default() -> Self {
+        Self {
+            default_model: "claude-sonnet-4".to_string(),
+            skip_permissions: false,
+            disable_plugins: false,
+            oauth_token: None,
+            mcp_servers: Vec::new(),
+        }
+    }
+}
+
+impl std::fmt::Debug for AgentSdkConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentSdkConfig")
+            .field("default_model", &self.default_model)
+            .field("skip_permissions", &self.skip_permissions)
+            .field("disable_plugins", &self.disable_plugins)
+            .field("has_oauth", &self.oauth_token.is_some())
+            .field("mcp_server_count", &self.mcp_servers.len())
+            .finish()
+    }
+}
+
+/// MCP server configuration.
+#[derive(Debug, Clone)]
+pub struct McpServerConfig {
+    /// Server name/identifier.
+    pub name: String,
+    /// Server command to execute.
+    pub command: String,
+    /// Arguments for the server command.
+    pub args: Vec<String>,
+    /// Environment variables.
+    pub env: HashMap<String, String>,
+}
+
+/// Experimental Claude CLI dispatch engine.
+///
+/// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+/// permissions, and MCP configuration fields while the native SDK path remains
+/// unwired. The public type name is kept for compatibility with existing
+/// configuration code, but the current transport is a `claude` CLI subprocess,
+/// not a native Agent SDK client.
+pub struct AgentSdkEngine {
+    config: AgentSdkConfig,
+    binary: String,
+}
+
+impl AgentSdkEngine {
+    /// Create a new experimental Claude CLI bridge with the given configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the engine cannot be initialized.
+    ///
+    /// Current validation is intentionally narrow: only the default model ID is
+    /// checked here. `OAuth` token validation, MCP plugin wiring, permission
+    /// enforcement, and native SDK availability checks remain future work.
+    pub fn new(config: AgentSdkConfig) -> Result<Self> {
+        // WHY: Verify the model identifier is valid during construction.
+        if config.default_model.is_empty() {
+            return error::InvalidModelSnafu {
+                model: "(empty)".to_string(),
+            }
+            .fail();
+        }
+
+        // Future-work: validate OAuth token, init MCP plugin system, set up
+        // permission system, and replace the CLI subprocess with a native SDK
+        // transport when that integration exists.
+        Ok(Self {
+            config,
+            binary: "claude".to_owned(),
+        })
+    }
+
+    /// Get the configured default model.
+    #[must_use]
+    pub fn default_model(&self) -> &str {
+        &self.config.default_model
+    }
+
+    /// Check if permissions are enabled.
+    #[must_use]
+    pub fn permissions_enabled(&self) -> bool {
+        !self.config.skip_permissions
+    }
+
+    /// Check if plugins are enabled.
+    #[must_use]
+    pub fn plugins_enabled(&self) -> bool {
+        !self.config.disable_plugins
+    }
+
+    /// Build the CLI argument vector for a session.
+    fn build_args(&self, options: &AgentOptions) -> Vec<String> {
+        let mut args = Vec::new();
+
+        args.extend(["--output-format".to_owned(), "stream-json".to_owned()]);
+        args.push("--verbose".to_owned());
+
+        let model = options
+            .model
+            .as_deref()
+            .unwrap_or(&self.config.default_model);
+        args.extend(["--model".to_owned(), model.to_owned()]);
+
+        // WHY: Apply permission mode based on config (if not skipped).
+        if !self.config.skip_permissions
+            && let Some(ref mode) = options.permission_mode
+        {
+            args.extend(["--permission-mode".to_owned(), mode.clone()]);
+        }
+
+        if let Some(ref prompt) = options.system_prompt {
+            args.extend(["--system-prompt".to_owned(), prompt.clone()]);
+        }
+
+        if let Some(turns) = options.max_turns {
+            args.extend(["--max-turns".to_owned(), turns.to_string()]);
+        }
+
+        for dir in &options.additional_dirs {
+            args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+        }
+
+        args
+    }
+
+    /// Spawn a subprocess and return a session handle.
+    fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        // INVARIANT: kill_on_drop ensures cleanup if the handle is dropped
+        // without explicit wait/abort.
+        cmd.kill_on_drop(true);
+
+        let mut child = cmd.spawn().map_err(|e| {
+            error::EngineSnafu {
+                detail: format!("failed to spawn claude CLI subprocess: {e}"),
+            }
+            .build()
+        })?;
+
+        let stdout = child.stdout.take().ok_or_else(|| {
+            error::EngineSnafu {
+                detail: "stdout not captured from subprocess",
+            }
+            .build()
+        })?;
+
+        let stream = EventStream::new(stdout);
+        Ok(ProcessSessionHandle::new(child, stream, String::new()))
+    }
+}
+
+// WHY: manual Debug impl rather than `#[derive]` because the config holds an
+// `oauth_token: Option<String>` we must never log. The summary form shows
+// `has_oauth: bool` and `mcp_server_count: usize` instead of the raw values.
+impl std::fmt::Debug for AgentSdkEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentSdkEngine")
+            .field("binary", &self.binary)
+            .field("default_model", &self.config.default_model)
+            .field("skip_permissions", &self.config.skip_permissions)
+            .field("disable_plugins", &self.config.disable_plugins)
+            .field("has_oauth", &self.config.oauth_token.is_some())
+            .field("mcp_server_count", &self.config.mcp_servers.len())
+            .finish()
+    }
+}
+
+impl DispatchEngine for AgentSdkEngine {
+    fn spawn_session<'a>(
+        &'a self,
+        spec: &'a SessionSpec,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut cmd = Command::new(&self.binary);
+            cmd.args(["-p", &spec.prompt]);
+            cmd.args(self.build_args(options));
+
+            // WHY: cwd is set on the Command, not as a CLI flag.
+            let cwd = spec.cwd.as_ref().or(options.cwd.as_ref());
+            if let Some(dir) = cwd {
+                cmd.current_dir(dir);
+            }
+
+            // When prompt_components is present, the static prefix is already
+            // in system_prompt and the dynamic suffix is already in prompt.
+            if let Some(ref sys) = spec.system_prompt
+                && options.system_prompt.is_none()
+            {
+                cmd.args(["--system-prompt", sys]);
+            }
+
+            // WHY: Inject OAuth token if configured.
+            if let Some(ref token) = self.config.oauth_token {
+                cmd.env("CLAUDE_API_TOKEN", token);
+            }
+
+            tracing::debug!(
+                prompt_len = spec.prompt.len(),
+                model = options
+                    .model
+                    .as_deref()
+                    .unwrap_or(&self.config.default_model),
+                "spawning claude CLI subprocess session"
+            );
+
+            let handle = Self::launch(cmd)?;
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+
+    fn resume_session<'a>(
+        &'a self,
+        session_id: &'a str,
+        prompt: &'a str,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut cmd = Command::new(&self.binary);
+            cmd.args(["--resume", session_id, "-p", prompt]);
+
+exec
+/bin/bash -lc "rg -n \"struct AgentSdkEngine|build_args\\(|mcp_servers|HttpEngine|mcp-server|MCP\" crates/energeia/src -S" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+crates/energeia/src/engine.rs:4://! Implementations: `HttpEngine` (production), `MockEngine` (tests).
+crates/energeia/src/agent_sdk.rs:26:    /// Disable MCP plugin loading.
+crates/energeia/src/agent_sdk.rs:30:    /// Optional MCP server configurations.
+crates/energeia/src/agent_sdk.rs:31:    pub mcp_servers: Vec<McpServerConfig>,
+crates/energeia/src/agent_sdk.rs:41:            mcp_servers: Vec::new(),
+crates/energeia/src/agent_sdk.rs:53:            .field("mcp_server_count", &self.mcp_servers.len())
+crates/energeia/src/agent_sdk.rs:58:/// MCP server configuration.
+crates/energeia/src/agent_sdk.rs:74:/// permissions, and MCP configuration fields while the native SDK path remains
+crates/energeia/src/agent_sdk.rs:78:pub struct AgentSdkEngine {
+crates/energeia/src/agent_sdk.rs:91:    /// checked here. `OAuth` token validation, MCP plugin wiring, permission
+crates/energeia/src/agent_sdk.rs:102:        // Future-work: validate OAuth token, init MCP plugin system, set up
+crates/energeia/src/agent_sdk.rs:130:    fn build_args(&self, options: &AgentOptions) -> Vec<String> {
+crates/energeia/src/agent_sdk.rs:202:            .field("mcp_server_count", &self.config.mcp_servers.len())
+crates/energeia/src/agent_sdk.rs:216:            cmd.args(self.build_args(options));
+crates/energeia/src/agent_sdk.rs:261:            cmd.args(self.build_args(options));
+crates/energeia/src/http/mod.rs:11://! - [`client`] — `HttpEngine` implementing `DispatchEngine`
+crates/energeia/src/http/mod.rs:21:pub use client::HttpEngine;
+crates/energeia/src/http/client.rs:1://! `HttpEngine`: subprocess-based implementation of [`DispatchEngine`].
+crates/energeia/src/http/client.rs:3://! Named `HttpEngine` because the trait targets the Anthropic Agent SDK HTTP/SSE
+crates/energeia/src/http/client.rs:22:// HttpEngine
+crates/energeia/src/http/client.rs:30:pub struct HttpEngine {
+crates/energeia/src/http/client.rs:37:impl HttpEngine {
+crates/energeia/src/http/client.rs:56:    fn build_args(&self, options: &AgentOptions) -> Vec<String> {
+crates/energeia/src/http/client.rs:150:impl DispatchEngine for HttpEngine {
+crates/energeia/src/http/client.rs:207:            cmd.args(self.build_args(options));
+crates/energeia/src/http/client.rs:242:            cmd.args(self.build_args(options));
+crates/energeia/src/http/client.rs:276:        let engine = HttpEngine::new("claude-sonnet-4-20250514");
+crates/energeia/src/http/client.rs:278:        let args = engine.build_args(&options);
+crates/energeia/src/http/client.rs:288:        let engine = HttpEngine::new("default-model");
+crates/energeia/src/http/client.rs:294:        let args = engine.build_args(&options);
+crates/energeia/src/http/client.rs:307:        let engine = HttpEngine::new("m");
+crates/energeia/src/http/client.rs:309:        let args = engine.build_args(&options);
+crates/energeia/src/http/client.rs:353:    fn mock_engine(dir: &std::path::Path) -> HttpEngine {
+crates/energeia/src/http/client.rs:354:        HttpEngine::new("test-model").binary(dir.join("claude").display().to_string())
+crates/energeia/src/http/client.rs:505:        let engine = HttpEngine::new("test-model").binary(script_path.display().to_string());
+crates/energeia/src/http/client.rs:518:            assert::<HttpEngine>();
+
+exec
+/bin/bash -lc "sed -n '1,260p' crates/energeia/src/http.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ exited 2 in 0ms:
+sed: can't read crates/energeia/src/http.rs: No such file or directory
+
+codex
+I found `AgentSdkEngine` is currently just a `claude` subprocess wrapper, so the wiring target is the CLI flag surface, not a native SDK API. I’m reading the sibling HTTP engine tests plus the rest of `agent_sdk.rs` to match the existing arg-building style and see how MCP server configs are represented end-to-end.
+exec
+/bin/bash -lc "sed -n '260,520p' crates/energeia/src/agent_sdk.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+            cmd.args(["--resume", session_id, "-p", prompt]);
+            cmd.args(self.build_args(options));
+
+            // WHY: Inject OAuth token if configured.
+            if let Some(ref token) = self.config.oauth_token {
+                cmd.env("CLAUDE_API_TOKEN", token);
+            }
+
+            tracing::debug!(session_id, "resuming claude CLI session");
+
+            let handle = Self::launch(cmd)?;
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+}
+
+exec
+/bin/bash -lc "sed -n '1,420p' crates/energeia/src/http/client.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+//! `HttpEngine`: subprocess-based implementation of [`DispatchEngine`].
+//!
+//! Named `HttpEngine` because the trait targets the Anthropic Agent SDK HTTP/SSE
+//! API. The current implementation uses the Claude CLI subprocess as a transport
+//! (matching phronesis's approach) because the Agent SDK HTTP endpoints are not
+//! yet publicly documented. The [`DispatchEngine`] trait boundary insulates
+//! callers from this implementation detail.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::process::Stdio;
+use std::time::Instant;
+
+use tokio::process::Command;
+
+use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+use crate::error::{self, Result};
+use crate::http::session::ProcessSessionHandle;
+use crate::http::stream::EventStream;
+
+// ---------------------------------------------------------------------------
+// HttpEngine
+// ---------------------------------------------------------------------------
+
+/// Subprocess-based dispatch engine targeting the Claude CLI.
+///
+/// Spawns `claude --output-format stream-json` subprocesses and streams NDJSON
+/// events. Will be replaced by a direct HTTP/SSE client when the Anthropic
+/// Agent SDK HTTP endpoints are publicly available.
+pub struct HttpEngine {
+    /// Default model identifier (e.g., "claude-sonnet-4-20250514").
+    default_model: String,
+    /// Path to the claude CLI binary.
+    binary: String,
+}
+
+impl HttpEngine {
+    /// Create a new engine with the given default model.
+    #[must_use]
+    pub fn new(default_model: impl Into<String>) -> Self {
+        Self {
+            default_model: default_model.into(),
+            binary: "claude".to_owned(),
+        }
+    }
+
+    /// Override the CLI binary path (for testing with mock scripts).
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn binary(mut self, path: impl Into<String>) -> Self {
+        self.binary = path.into();
+        self
+    }
+
+    /// Build the CLI argument vector for a session.
+    fn build_args(&self, options: &AgentOptions) -> Vec<String> {
+        let mut args = Vec::new();
+
+        args.extend(["--output-format".to_owned(), "stream-json".to_owned()]);
+        args.push("--verbose".to_owned());
+
+        let model = options.model.as_deref().unwrap_or(&self.default_model);
+        args.extend(["--model".to_owned(), model.to_owned()]);
+
+        if let Some(ref mode) = options.permission_mode {
+            args.extend(["--permission-mode".to_owned(), mode.clone()]);
+        }
+
+        if let Some(ref prompt) = options.system_prompt {
+            args.extend(["--system-prompt".to_owned(), prompt.clone()]);
+        }
+
+        if let Some(turns) = options.max_turns {
+            args.extend(["--max-turns".to_owned(), turns.to_string()]);
+        }
+
+        for dir in &options.additional_dirs {
+            args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+        }
+
+        args
+    }
+
+    /// Spawn a subprocess and return a session handle.
+    ///
+    /// WHY: includes a tiny ETXTBSY retry loop. On Linux, `exec()` can return
+    /// ETXTBSY ("Text file busy") if the kernel's still cleaning up a
+    /// concurrent writer's handle on the binary, even when the writer has
+    /// closed the fd. This is benign in production (claude binary is
+    /// stable) but flaky in tests where mock scripts are written milliseconds
+    /// before exec. Retry up to 3 times with 5ms backoff. See #2990.
+    fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        // INVARIANT: kill_on_drop ensures cleanup if the handle is dropped
+        // without explicit wait/abort.
+        cmd.kill_on_drop(true);
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) if e.raw_os_error() == Some(26) => {
+                // ETXTBSY = 26 on Linux. Retry up to 3 times.
+                let mut last_err = e;
+                let mut attempt = 0;
+                loop {
+                    attempt += 1;
+                    if attempt > 3 {
+                        return Err(error::EngineSnafu {
+                            detail: format!(
+                                "failed to spawn claude subprocess after {attempt} ETXTBSY retries: {last_err}"
+                            ),
+                        }
+                        .build());
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(5 * attempt));
+                    match cmd.spawn() {
+                        Ok(c) => break c,
+                        Err(e2) if e2.raw_os_error() == Some(26) => {
+                            last_err = e2;
+                        }
+                        Err(e2) => {
+                            return Err(error::EngineSnafu {
+                                detail: format!("failed to spawn claude subprocess: {e2}"),
+                            }
+                            .build());
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(error::EngineSnafu {
+                    detail: format!("failed to spawn claude subprocess: {e}"),
+                }
+                .build());
+            }
+        };
+
+        let stdout = child.stdout.take().ok_or_else(|| {
+            error::EngineSnafu {
+                detail: "stdout not captured from subprocess",
+            }
+            .build()
+        })?;
+
+        let stream = EventStream::new(stdout);
+        Ok(ProcessSessionHandle::new(child, stream, String::new()))
+    }
+}
+
+impl DispatchEngine for HttpEngine {
+    fn probe_health<'a>(
+        &'a self,
+        timeout: std::time::Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<u64>>> + Send + 'a>> {
+        Box::pin(async move {
+            let t0 = Instant::now();
+            let mut cmd = Command::new(&self.binary);
+            cmd.arg("--version")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            cmd.kill_on_drop(true);
+
+            let mut child = cmd.spawn().map_err(|e| {
+                error::EngineSnafu {
+                    detail: format!("failed to spawn claude health probe: {e}"),
+                }
+                .build()
+            })?;
+
+            let status = match tokio::time::timeout(timeout, child.wait()).await {
+                Ok(Ok(status)) => status,
+                Ok(Err(e)) => {
+                    return Err(error::EngineSnafu {
+                        detail: format!("claude health probe failed while waiting: {e}"),
+                    }
+                    .build());
+                }
+                Err(_) => {
+                    let _ = child.start_kill();
+                    return Err(error::EngineSnafu {
+                        detail: format!("claude health probe timed out after {timeout:?}"),
+                    }
+                    .build());
+                }
+            };
+
+            if status.success() {
+                let latency_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);
+                Ok(Some(latency_ms))
+            } else {
+                Err(error::EngineSnafu {
+                    detail: format!("claude health probe exited with status {status}"),
+                }
+                .build())
+            }
+        })
+    }
+
+    fn spawn_session<'a>(
+        &'a self,
+        spec: &'a SessionSpec,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut cmd = Command::new(&self.binary);
+            cmd.args(["-p", &spec.prompt]);
+            cmd.args(self.build_args(options));
+
+            // WHY: cwd is set on the Command, not as a CLI flag.
+            let cwd = spec.cwd.as_ref().or(options.cwd.as_ref());
+            if let Some(dir) = cwd {
+                cmd.current_dir(dir);
+            }
+
+            if let Some(ref sys) = spec.system_prompt
+                && options.system_prompt.is_none()
+            {
+                cmd.args(["--system-prompt", sys]);
+            }
+
+            tracing::debug!(
+                prompt_len = spec.prompt.len(),
+                model = options.model.as_deref().unwrap_or(&self.default_model),
+                "spawning session"
+            );
+
+            let handle = Self::launch(cmd)?;
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+
+    fn resume_session<'a>(
+        &'a self,
+        session_id: &'a str,
+        prompt: &'a str,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut cmd = Command::new(&self.binary);
+            cmd.args(["--resume", session_id, "-p", prompt]);
+            cmd.args(self.build_args(options));
+
+            if let Some(ref dir) = options.cwd {
+                cmd.current_dir(dir);
+            }
+
+            tracing::debug!(session_id, prompt_len = prompt.len(), "resuming session");
+
+            let handle = Self::launch(cmd)?;
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test assertions and helpers"
+)]
+mod tests {
+    use std::fmt::Write;
+
+    use super::*;
+    use crate::engine::SessionEvent;
+
+    #[test]
+    fn build_args_default_model() {
+        let engine = HttpEngine::new("claude-sonnet-4-20250514");
+        let options = AgentOptions::new();
+        let args = engine.build_args(&options);
+
+        assert!(args.contains(&"--output-format".to_owned()));
+        assert!(args.contains(&"stream-json".to_owned()));
+        assert!(args.contains(&"--model".to_owned()));
+        assert!(args.contains(&"claude-sonnet-4-20250514".to_owned()));
+    }
+
+    #[test]
+    fn build_args_option_overrides() {
+        let engine = HttpEngine::new("default-model");
+        let options = AgentOptions::new()
+            .model("claude-opus-4-6")
+            .max_turns(50)
+            .permission_mode("bypassPermissions")
+            .add_dir("/tmp/shared");
+        let args = engine.build_args(&options);
+
+        assert!(args.contains(&"claude-opus-4-6".to_owned()));
+        assert!(args.contains(&"--max-turns".to_owned()));
+        assert!(args.contains(&"50".to_owned()));
+        assert!(args.contains(&"--permission-mode".to_owned()));
+        assert!(args.contains(&"bypassPermissions".to_owned()));
+        assert!(args.contains(&"--add-dir".to_owned()));
+        assert!(args.contains(&"/tmp/shared".to_owned()));
+    }
+
+    #[test]
+    fn build_args_omits_unset_options() {
+        let engine = HttpEngine::new("m");
+        let options = AgentOptions::new();
+        let args = engine.build_args(&options);
+
+        assert!(!args.contains(&"--system-prompt".to_owned()));
+        assert!(!args.contains(&"--max-turns".to_owned()));
+        assert!(!args.contains(&"--permission-mode".to_owned()));
+    }
+
+    /// Helper: create a mock script that emits NDJSON lines and exits.
+    ///
+    /// WHY: uses `File::open + sync_all` to flush metadata before returning.
+    /// Without the explicit fsync, parallel tests in the same runner can hit
+    /// `ETXTBSY` ("Text file busy") when one thread tries to exec the script
+    /// while another thread's recent write is still in the kernel buffer
+    /// (#2990). The sync forces the inode metadata to disk so the exec sees
+    /// a fully-flushed, no-writers-attached file.
+    fn create_mock_script(
+        dir: &std::path::Path,
+        stdout_lines: &[&str],
+        exit_code: i32,
+    ) -> std::path::PathBuf {
+        let script_path = dir.join("claude");
+        let mut content = String::from("#!/bin/sh\n");
+        for line in stdout_lines {
+            let _ = writeln!(content, "echo '{line}'");
+        }
+        let _ = writeln!(content, "exit {exit_code}");
+        std::fs::write(&script_path, &content).expect("mock script should be writable");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+                .expect("mock script should be chmod-able");
+        }
+
+        // WHY: explicit sync_all forces metadata and content to disk so a
+        // subsequent exec doesn't race with a still-in-flight write.
+        let f = std::fs::File::open(&script_path).expect("open for sync");
+        f.sync_all().expect("sync_all");
+        drop(f);
+
+        script_path
+    }
+
+    fn mock_engine(dir: &std::path::Path) -> HttpEngine {
+        HttpEngine::new("test-model").binary(dir.join("claude").display().to_string())
+    }
+
+    fn sample_session_spec(prompt: &str) -> SessionSpec {
+        SessionSpec {
+            prompt: prompt.to_owned(),
+            system_prompt: None,
+            cwd: None,
+            prompt_components: None,
+            output_format: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_session_successful() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lines = &[
+            r#"{"type":"system","subtype":"init","session_id":"sess-001"}"#,
+            r#"{"type":"assistant","content":[{"type":"text","text":"Hello"}]}"#,
+            r#"{"type":"result","session_id":"sess-001","subtype":"success","is_error":false,"total_cost_usd":0.10,"num_turns":3,"duration_ms":5000,"result":"Done"}"#,
+        ];
+        create_mock_script(tmp.path(), lines, 0);
+
+        let engine = mock_engine(tmp.path());
+        let handle = engine
+            .spawn_session(&sample_session_spec("test prompt"), &AgentOptions::new())
+            .await
+            .unwrap();
+        let result = handle.wait().await.unwrap();
+
+        assert_eq!(result.session_id, "sess-001");
+        assert!(result.success);
+        assert_eq!(result.num_turns, 3);
+        assert!((result.cost_usd - 0.10).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn spawn_session_error_result() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lines = &[
+            r#"{"type":"system","subtype":"init","session_id":"sess-err"}"#,
+            r#"{"type":"result","session_id":"sess-err","subtype":"error_during_execution","is_error":true,"num_turns":1,"duration_ms":500}"#,
+        ];
+        create_mock_script(tmp.path(), lines, 1);
+
+        let engine = mock_engine(tmp.path());
+        let handle = engine
+            .spawn_session(&sample_session_spec("bad prompt"), &AgentOptions::new())
+            .await
+            .unwrap();
+        let result = handle.wait().await.unwrap();
+
+        assert!(!result.success);
+    }
+
+    #[tokio::test]
+    async fn resume_session_works() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lines = &[
+            r#"{"type":"system","subtype":"init","session_id":"sess-resume"}"#,
+            r#"{"type":"result","session_id":"sess-resume","subtype":"success","is_error":false,"num_turns":5,"duration_ms":3000}"#,
+        ];
+        create_mock_script(tmp.path(), lines, 0);
+
+        let engine = mock_engine(tmp.path());
+        let handle = engine
+            .resume_session("sess-resume", "continue working", &AgentOptions::new())
+
+exec
+/bin/bash -lc 'rg -n "--mcp-server|mcp_servers|McpServerConfig|mcp config|mcp-server" -S .' in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ exited 2 in 0ms:
+rg: unrecognized flag --mcp-server|mcp_servers|McpServerConfig|mcp config|mcp-server
+
+codex
+The first pass confirms `mcp_servers` is a `Vec<McpServerConfig>`, and `AgentSdkEngine::build_args()` currently ignores it. I’m now checking the rest of the tests and then I’ll verify the exact Claude CLI MCP flag syntax so the wiring matches the runtime instead of guessing.
+exec
+/bin/bash -lc "sed -n '520,760p' crates/energeia/src/http/client.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+exec
+/bin/bash -lc "sed -n '1,260p' crates/energeia/src/engine.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+    }
+}
+
+ succeeded in 0ms:
+//! Dispatch engine trait: abstraction over session execution backends.
+//!
+//! The [`DispatchEngine`] trait targets the Anthropic Agent SDK HTTP/SSE API.
+//! Implementations: `HttpEngine` (production), `MockEngine` (tests).
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+// ---------------------------------------------------------------------------
+// DispatchEngine trait
+// ---------------------------------------------------------------------------
+
+/// Core abstraction over session execution backends.
+///
+/// Targets the Anthropic Agent SDK HTTP/SSE API. Production implementations
+/// use HTTP+SSE streaming; test implementations return canned responses.
+#[expect(
+    clippy::type_complexity,
+    reason = "async trait methods returning boxed trait objects require nested generics"
+)]
+pub trait DispatchEngine: Send + Sync {
+    /// Probe backend readiness before dispatch execution.
+    ///
+    /// Returning `Ok(Some(latency_ms))` records a successful probe. Returning
+    /// `Ok(None)` means this engine has no lightweight readiness probe.
+    fn probe_health<'a>(
+        &'a self,
+        _timeout: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<u64>>> + Send + 'a>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    /// Spawn a new agent session for the given spec and options.
+    fn spawn_session<'a>(
+        &'a self,
+        spec: &'a SessionSpec,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>>;
+
+    /// Resume an existing session with a new prompt.
+    fn resume_session<'a>(
+        &'a self,
+        session_id: &'a str,
+        prompt: &'a str,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>>;
+}
+
+// ---------------------------------------------------------------------------
+// SessionHandle trait
+// ---------------------------------------------------------------------------
+
+/// Handle to a running or completed agent session.
+///
+/// Provides an event stream for observing session progress, plus control
+/// methods for waiting on completion or aborting.
+pub trait SessionHandle: Send {
+    /// The Agent SDK session identifier.
+    fn session_id(&self) -> &str;
+
+    /// Receive the next event from the session's SSE stream.
+    ///
+    /// Returns `None` when the stream is exhausted (session complete or errored).
+    fn next_event<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Option<SessionEvent>> + Send + 'a>>;
+
+    /// Wait for the session to complete and return the final result.
+    fn wait(self: Box<Self>) -> Pin<Box<dyn Future<Output = Result<SessionResult>> + Send>>;
+
+    /// Request the session to abort.
+    fn abort<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+}
+
+// ---------------------------------------------------------------------------
+// Session types
+// ---------------------------------------------------------------------------
+
+/// Specification for spawning a new agent session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SessionSpec {
+    /// The prompt or task description to send to the agent.
+    pub prompt: String,
+    /// System prompt to prepend to the session.
+    pub system_prompt: Option<String>,
+    /// Working directory for the agent session.
+    pub cwd: Option<String>,
+    /// Optional prompt cache components. When present, engines that support
+    /// prompt caching should use `static_prefix` as the cached system prompt
+    /// and `dynamic_suffix` as the user message.
+    pub prompt_components: Option<crate::prompt_cache::PromptComponents>,
+    /// Optional structured output contract for the session response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_format: Option<hermeneus::types::OutputFormat>,
+}
+
+/// Configuration options for an agent session.
+///
+/// Built incrementally via the builder methods.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, from = "AgentOptionsRaw")]
+#[non_exhaustive]
+pub struct AgentOptions {
+    /// LLM model identifier (e.g., "claude-sonnet-4-20250514").
+    pub model: Option<String>,
+    /// System prompt override.
+    pub system_prompt: Option<String>,
+    /// Working directory for the agent.
+    pub cwd: Option<String>,
+    /// Maximum LLM turns before the session is stopped.
+    pub max_turns: Option<u32>,
+    /// Permission mode for tool execution (e.g., "plan", "auto").
+    pub permission_mode: Option<String>,
+    /// Additional directories the agent can access.
+    pub additional_dirs: Vec<PathBuf>,
+}
+
+/// Raw deserialization type for [`AgentOptions`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AgentOptionsRaw {
+    model: Option<String>,
+    system_prompt: Option<String>,
+    cwd: Option<String>,
+    max_turns: Option<u32>,
+    permission_mode: Option<String>,
+    #[serde(default)]
+    additional_dirs: Vec<PathBuf>,
+}
+
+impl From<AgentOptionsRaw> for AgentOptions {
+    fn from(raw: AgentOptionsRaw) -> Self {
+        Self {
+            model: raw.model,
+            system_prompt: raw.system_prompt,
+            cwd: raw.cwd,
+            max_turns: raw.max_turns,
+            permission_mode: raw.permission_mode,
+            additional_dirs: raw.additional_dirs,
+        }
+    }
+}
+
+impl AgentOptions {
+    /// Create empty options with all fields unset.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            model: None,
+            system_prompt: None,
+            cwd: None,
+            max_turns: None,
+            permission_mode: None,
+            additional_dirs: Vec::new(),
+        }
+    }
+
+    /// Set the model identifier.
+    #[must_use]
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the system prompt.
+    #[must_use]
+    pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(prompt.into());
+        self
+    }
+
+    /// Set the working directory.
+    #[must_use]
+    pub fn cwd(mut self, cwd: impl Into<String>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    /// Set the maximum turn count.
+    #[must_use]
+    pub fn max_turns(mut self, turns: u32) -> Self {
+        self.max_turns = Some(turns);
+        self
+    }
+
+    /// Set the permission mode.
+    #[must_use]
+    pub fn permission_mode(mut self, mode: impl Into<String>) -> Self {
+        self.permission_mode = Some(mode.into());
+        self
+    }
+
+    /// Add an additional accessible directory.
+    #[must_use]
+    pub fn add_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.additional_dirs.push(dir.into());
+        self
+    }
+}
+
+impl Default for AgentOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// An event from a running agent session's SSE stream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum SessionEvent {
+    /// Agent produced a text output chunk.
+    TextDelta {
+        /// The text content.
+        text: String,
+    },
+    /// Agent invoked a tool.
+    ToolUse {
+        /// Tool name.
+        name: String,
+        /// Tool input as JSON.
+        input: serde_json::Value,
+    },
+    /// Tool execution completed.
+    ToolResult {
+        /// Tool name.
+        name: String,
+        /// Whether the tool succeeded.
+        success: bool,
+    },
+    /// Session turn completed.
+    TurnComplete {
+        /// Turn number within the session.
+        turn: u32,
+    },
+    /// Session encountered an error.
+    Error {
+        /// Error description.
+        message: String,
+    },
+}
+
+/// Final result of a completed session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "SessionResultRaw")]
+#[non_exhaustive]
+pub struct SessionResult {
+    /// The Agent SDK session identifier.
+    // kanon:ignore RUST/primitive-for-domain-id — wire-protocol/deserialization type; changing to newtype would be a breaking API change across crates
+    pub session_id: String,
+    /// Total cost in USD.
+    pub cost_usd: f64,
+    /// Total turns consumed.
+    pub num_turns: u32,
+
+exec
+/bin/bash -lc 'cargo run --quiet -p energeia --bin claude -- --help' in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ exited 101 in 280ms:
+error: no bin target named `claude` in `energeia` package
+
+codex
+`energeia` doesn’t ship a `claude` binary, so the local-help shortcut is a dead end. I’m searching the workspace for any existing MCP CLI wiring or docs, and if that comes up empty I’ll verify the flag syntax from the upstream Claude CLI docs before editing.
+exec
+/bin/bash -lc 'rg -n -- "mcp_servers|mcp-server|--mcp|McpServerConfig|mcp config|MCP" crates docs .agents -S' in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ exited 2 in 0ms:
+rg: .agents: No such file or directory (os error 2)
+rg: -S: No such file or directory (os error 2)
+docs/lexicon.md:76:| **Diaporeia** | διαπορεία | "mcp-server" | Passage through, transit between worlds. MCP server bridge for external AI agents. |
+docs/glossary.md:69:**In this codebase.** The Model Context Protocol (MCP) server bridge. Exposes Aletheia tools
+docs/glossary.md:70:and knowledge to external AI agents via the MCP protocol, bridging the internal system to the
+docs/TECHNOLOGY.md:43:| MCP | rmcp 1.2.0 pinned exact | @modelcontextprotocol/sdk | MCP SDK for external AI agent integration via diaporeia. Pre-1.0 - pin exact, wrap in trait. |
+docs/OBSERVABILITY-AUDIT.md:77:| RBAC denial (diaporeia) | `warn` | Resource RBAC denied (no role resolved), MCP RBAC denied |
+docs/MCP-SERVERS.md:1:# External MCP Servers
+docs/MCP-SERVERS.md:3:Operator-side MCP servers that extend an agent's capabilities without modifying the aletheia binary. Aletheia is a 47-crate Rust workspace plus the excluded desktop shell. Coding agents (Claude Code, Cursor, etc.) that only have grep and file reads burn tokens re-discovering structure that a Language Server could answer in one request. The servers below close that gap.
+docs/MCP-SERVERS.md:15:[Serena](https://github.com/oraios/serena) wraps `rust-analyzer` (and 40+ other language servers) as MCP tools. For aletheia, this means an agent can ask:
+docs/MCP-SERVERS.md:23:This is the same navigation an IDE user has, exposed as MCP.
+docs/MCP-SERVERS.md:46:claude mcp add serena -- serena start-mcp-server \
+docs/MCP-SERVERS.md:56:claude mcp add --scope user serena -- serena start-mcp-server \
+docs/MCP-SERVERS.md:69:This foregrounds a stdio MCP server rooted at the aletheia workspace. Useful for:
+docs/MCP-SERVERS.md:72:- Registering with Cursor, Windsurf, or any other MCP-capable client that expects a raw command.
+docs/MCP-SERVERS.md:110:An earlier draft of the integrating issue (#3355) proposed wiring Serena into the `diaporeia` tool bus as a vendored MCP client. We chose the external route instead:
+docs/MCP-SERVERS.md:114:- **Agents already have an MCP client.** Claude Code, Cursor, and Windsurf all speak MCP natively. Aletheia's internal `diaporeia` bus is for tools inside the aletheia process (e.g. things the `nous` pipeline calls), not for operator-side coding helpers.
+docs/MCP-SERVERS.md:115:- **Sovereignty path preserved.** If the upstream trajectory diverges from our needs, a Rust-native MCP server wrapping `rust-analyzer` directly can be added under `crates/` later. This is tracked as a follow-up (see PR body for #3355).
+docs/HUBS.md:41:- Facts carry `Visibility` and optional `MemoryScope`; recall and MCP/API surfaces must preserve those filters
+docs/HUBS.md:133:- `diaporeia::tools` - MCP tools: `nous_list`, `nous_status`, `nous_tools`
+docs/HOT-RELOAD.md:20:| MCP | 3 | 0 |
+docs/HOT-RELOAD.md:211:### MCP (`mcp`)
+docs/HOT-RELOAD.md:215:| `mcp.rateLimit.enabled` | Hot | Rate limit toggle read per-MCP-request |
+docs/HOT-RELOAD.md:216:| `mcp.rateLimit.messageRequestsPerMinute` | Hot | Limit read per-MCP-request |
+docs/HOT-RELOAD.md:217:| `mcp.rateLimit.readRequestsPerMinute` | Hot | Limit read per-MCP-request |
+docs/HOT-RELOAD.md:281:- **Rate limiting**: All gateway and MCP rate limit settings
+docs/GROUNDS.md:14:| Tool        | 3        | Organon builtins, Thesauros packs, External tools config | Multi-grounded (diaporeia MCP is **not** equivalent) |
+docs/GROUNDS.md:33:4. **Diaporeia MCP `session_message` tool** - `crates/diaporeia/src/tools/mod.rs:154-169`
+docs/GROUNDS.md:34:   The MCP server calls `find_or_create_session` as a side-effect of the `session_message` tool. This is API-adjacent (MCP transport instead of HTTP) but still request-driven, not programmatic or declarative.
+docs/GROUNDS.md:91:4. **Diaporeia MCP tools** - `crates/diaporeia/src/tools/mod.rs:149`
+docs/GROUNDS.md:149:4. **Tools (diaporeia)** - decide whether diaporeia MCP tools should be bridged into `organon::ToolRegistry` or documented as an intentionally separate tool plane.
+docs/FEATURE-FLAGS.md:256:### "I want to run the MCP server"
+docs/ARCHITECTURE.md:33:- **External tool plane:** `diaporeia` can bridge external MCP servers into the
+docs/ARCHITECTURE.md:40:  through facts, Datalog schema, recall filtering, and MCP/API surfaces.
+docs/ARCHITECTURE.md:62:├── diaporeia      -  MCP server interface and external tool-plane bridge
+docs/ARCHITECTURE.md:162:| `diaporeia` | `crates/diaporeia` | MCP server interface and stdio/external tool bridge for external AI agents | koina, taxis, nous, organon, mneme, symbolon |
+docs/ARCHITECTURE.md:277:- **High**: `nous` (multiple mid+low deps), `pylon` (multiple deps including nous), `diaporeia` (MCP server, multiple deps including nous)
+docs/ARCHITECTURE-QUICK.md:23:- **diaporeia** - MCP server and external tool-plane bridge
+crates/hermeneus/src/lib.rs:42:/// Doom-loop detection for multi-tool MCP dispatch (Phase 7).
+crates/eidos/src/knowledge/architecture_fact.rs:399:            claim: "All built-in MCP tools are registered via `builtins::register_all` in \
+crates/eidos/CLAUDE.md:44:- `Fact` carries `visibility` and optional `scope`; downstream Datalog, recall, API, and MCP code must preserve them.
+crates/gnosis/src/query.rs:5://! JSON for MCP tool output.
+crates/gnosis/src/query.rs:85:/// Corresponds to the `symbol_rdeps` MCP operation.
+crates/diaporeia/tests/public_api_transport.rs:244:    // Without an `Accept: text/event-stream` header, the downstream MCP
+crates/diaporeia/tests/public_api_transport.rs:261:        "auth_mode=none must pass the request through to the MCP service, \
+crates/diaporeia/tests/public_api_transport.rs:313:        "DELETE without session id must be rejected by the MCP service"
+crates/diaporeia/tests/public_api_transport.rs:346:    // reach the downstream MCP service. The service then rejects with 400
+crates/diaporeia/tests/public_api_transport.rs:368:        "valid Bearer token must clear auth and reach the MCP service, \
+crates/diaporeia/tests/public_api_transport.rs:460:         MCP service (which returns 400 for GET without Accept: text/event-stream)"
+crates/gnosis/src/lib.rs:29://!   [`CodeGraph::rebuild`] calls or via the `code_graph_query` MCP tool.
+crates/gnosis/src/lib.rs:38://! Today: manual, via [`CodeGraph::rebuild`] or the MCP tool `op=rebuild`.
+crates/diaporeia/tests/public_api_repomix.rs:41:// Split: Repomix MCP tool end-to-end tests.
+crates/diaporeia/tests/public_api_repomix.rs:43:// Section 6: Repomix MCP tools — end-to-end via socket
+crates/gnosis/README.md:49:**Today (v1):** Manual. Call `CodeGraph::rebuild()` or use the MCP tool:
+crates/gnosis/README.md:67:## Example queries (MCP tool)
+crates/gnosis/README.md:100:- **`crates/organon/src/builtins/code_graph_query.rs`** - MCP tool executor.
+crates/taxis/src/config/mod.rs:90:    /// MCP server configuration.
+crates/diaporeia/src/transport.rs:15:/// Build an Axum Router that serves MCP over streamable HTTP.
+crates/diaporeia/src/transport.rs:17:/// Mount this into the main application router to expose MCP at `/mcp`.
+crates/diaporeia/src/transport.rs:39:/// `ERROR` when the bind address is not loopback, because the MCP server
+crates/diaporeia/src/transport.rs:64:                "MCP authentication disabled — all connections have {} access",
+crates/diaporeia/src/transport.rs:70:                "MCP exposed on network with no authentication — all connections have {} access",
+crates/diaporeia/src/transport.rs:90:/// Run MCP over stdio (blocking: intended for `aletheia mcp` subcommand).
+crates/taxis/src/config/maintenance.rs:1://! Maintenance, monitoring, sandbox, logging, and MCP configuration types.
+crates/taxis/src/config/maintenance.rs:539:/// MCP server configuration.
+crates/taxis/src/config/maintenance.rs:545:    /// Per-session rate limiting for MCP tool calls.
+crates/taxis/src/config/maintenance.rs:547:    /// Knowledge graph MCP surface configuration.
+crates/taxis/src/config/maintenance.rs:549:    /// Repomix MCP surface configuration.
+crates/taxis/src/config/maintenance.rs:553:/// Configuration for the knowledge graph MCP surface.
+crates/taxis/src/config/maintenance.rs:555:/// When enabled, the MCP server exposes `knowledge.*` tools for querying
+crates/taxis/src/config/maintenance.rs:563:    /// Whether the knowledge graph MCP tools are enabled.
+crates/taxis/src/config/maintenance.rs:587:/// Configuration for the repomix MCP surface.
+crates/taxis/src/config/maintenance.rs:589:/// When enabled, the MCP server exposes `repomix.*` tools for packing
+crates/taxis/src/config/maintenance.rs:599:    /// Whether the repomix MCP tools are enabled.
+crates/taxis/src/config/maintenance.rs:624:/// Per-session rate limiting configuration for MCP requests.
+crates/taxis/src/config/maintenance.rs:628:/// read/status operations. Limits are enforced per MCP session.
+crates/taxis/src/config/maintenance.rs:634:    /// Whether MCP rate limiting is active.
+crates/diaporeia/src/tools/params.rs:1://! Parameter structs for MCP tools.
+crates/diaporeia/src/tools/params.rs:12:    pub nous_id: String, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:21:    pub nous_id: Option<String>, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:28:    pub nous_id: String, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:39:    pub session_id: String, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:48:    pub nous_id: String, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:57:    pub nous_id: Option<String>, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:70:    pub nous_id: Option<String>, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:83:    pub nous_id: String, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:94:    pub fact_id: String, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:106:    pub fact_id: String, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/params.rs:113:    pub entity_id: String, // kanon:ignore RUST/primitive-for-domain-id -- WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/diaporeia/src/tools/mod.rs:2://! MCP tool implementations for diaporeia.
+crates/diaporeia/src/tools/mod.rs:75:    // on direct MCP connections that bypass the gateway.
+crates/diaporeia/src/tools/mod.rs:123:/// Require at least the given role, returning an MCP error if insufficient.
+crates/diaporeia/src/tools/mod.rs:141:                "MCP RBAC denied",
+crates/diaporeia/src/tools/mod.rs:150:            tracing::warn!(operation, "MCP RBAC denied: no role resolved");
+crates/diaporeia/src/tools/mod.rs:160:/// Check that the knowledge graph MCP surface is enabled.
+crates/diaporeia/src/tools/mod.rs:181:/// Check that the repomix MCP surface is enabled.
+crates/diaporeia/src/tools/mod.rs:440:    /// The MCP protocol's `tools/call` is a request-response RPC: the client
+crates/diaporeia/src/tools/mod.rs:441:    /// sends one request and receives one response. There is no MCP-level
+crates/diaporeia/src/tools/mod.rs:446:    /// stream events are drained and discarded because MCP has no server-push
+crates/diaporeia/src/tools/mod.rs:482:        // the actor. MCP doesn't support server-push, so events are discarded.
+crates/diaporeia/src/tools/mod.rs:737:    /// access, requires `Agent` role or above. When the knowledge graph MCP
+crates/diaporeia/src/tools/mod.rs:883:            // of MCP-inserted facts identifiable during audits.
+crates/diaporeia/src/tools/mod.rs:2137:            test_entity("e4", "MCP", "protocol"),
+crates/diaporeia/src/state.rs:1://! Shared state for the diaporeia MCP server.
+crates/diaporeia/src/state.rs:22:/// Shared state for the diaporeia MCP server.
+crates/diaporeia/src/state.rs:49:    /// Shared knowledge store for the knowledge graph MCP surface.
+crates/diaporeia/src/server.rs:1://! `DiaporeiaServer`: MCP server implementation.
+crates/diaporeia/src/server.rs:23:/// The MCP server for Aletheia.
+crates/diaporeia/src/server.rs:26:/// MCP requests over stdio or streamable HTTP.
+crates/diaporeia/src/server.rs:73:                    "MCP resource RBAC denied",
+crates/diaporeia/src/server.rs:82:                tracing::warn!(operation, "MCP resource RBAC denied: no role resolved");
+crates/diaporeia/src/server.rs:197:        // WHY(#3337): all MCP resources expose internal state (agent workspace
+crates/diaporeia/src/sanitize.rs:1://! Error message sanitization for MCP responses.
+crates/diaporeia/src/resources/nous.rs:3://! Exposes agent workspace files (SOUL.md, IDENTITY.md, etc.) as MCP resources.
+crates/diaporeia/src/resources/mod.rs:1://! MCP resource handlers for diaporeia.
+crates/diaporeia/src/rate_limit.rs:1://! Per-session token bucket rate limiter for MCP requests.
+crates/diaporeia/src/rate_limit.rs:36:    /// Returns `Ok(())` when permitted, or an MCP error when the bucket is
+crates/diaporeia/src/lib.rs:3://! Diaporeia: MCP server interface for Aletheia.
+crates/diaporeia/src/lib.rs:19:/// Bearer token authentication middleware for MCP transport.
+crates/diaporeia/src/lib.rs:21:/// MCP client helpers for external server integration.
+crates/diaporeia/src/lib.rs:29:/// MCP server implementation with tool, resource, and prompt capabilities.
+crates/diaporeia/src/lib.rs:31:/// Shared application state for the MCP server.
+crates/diaporeia/src/lib.rs:34:/// Transport bindings for streamable HTTP and stdio MCP transports.
+crates/diaporeia/src/error.rs:5:/// Errors from diaporeia MCP operations.
+crates/diaporeia/src/error.rs:79:    /// The knowledge graph MCP surface is disabled or not configured.
+crates/diaporeia/src/error.rs:81:        "knowledge graph MCP surface is disabled; \
+crates/diaporeia/src/error.rs:113:    /// The session notes MCP surface is disabled or not configured.
+crates/diaporeia/src/error.rs:120:    /// The shared blackboard MCP surface is disabled or not configured.
+crates/diaporeia/src/error.rs:143:    /// The repomix MCP surface is disabled or not configured.
+crates/diaporeia/src/error.rs:145:        "repomix MCP surface is disabled; set mcp.repomix.enabled = true in aletheia.toml"
+crates/diaporeia/src/error.rs:174:/// Maps each variant to the appropriate MCP error code and strips server-side
+crates/diaporeia/src/client.rs:1://! MCP client helpers for connecting Aletheia to external MCP servers.
+crates/diaporeia/src/client.rs:3://! The server side of diaporeia exposes Aletheia over MCP. This module is the
+crates/diaporeia/src/client.rs:4://! inverse path: it lets Aletheia act as an MCP client for operator-configured
+crates/diaporeia/src/client.rs:21:/// Stdio child-process MCP server configuration.
+crates/diaporeia/src/client.rs:23:pub struct StdioMcpServerConfig {
+crates/diaporeia/src/client.rs:34:impl StdioMcpServerConfig {
+crates/diaporeia/src/client.rs:35:    /// Create a new stdio MCP server config.
+crates/diaporeia/src/client.rs:47:/// Running external MCP client connection.
+crates/diaporeia/src/client.rs:54:    /// Spawn a stdio MCP server and complete the MCP client handshake.
+crates/diaporeia/src/client.rs:59:    /// be spawned or the MCP handshake fails.
+crates/diaporeia/src/client.rs:60:    pub async fn connect_stdio(config: &StdioMcpServerConfig) -> Result<Self> {
+crates/diaporeia/src/client.rs:76:                message: format!("failed to spawn stdio MCP server '{command}': {e}"),
+crates/diaporeia/src/client.rs:87:                message: format!("failed to initialize stdio MCP server '{command}': {e}"),
+crates/diaporeia/src/client.rs:97:    /// Connect to a streamable HTTP MCP server and complete the MCP client handshake.
+crates/diaporeia/src/client.rs:101:    /// Returns [`crate::error::Error::Transport`] when the MCP handshake fails.
+crates/diaporeia/src/client.rs:111:                    "failed to initialize streamable HTTP MCP server '{endpoint}': {e}"
+crates/diaporeia/src/client.rs:122:    /// List all tools exposed by the connected MCP server.
+crates/diaporeia/src/client.rs:126:    /// Returns [`crate::error::Error::Transport`] when the MCP request fails.
+crates/diaporeia/src/client.rs:134:                message: format!("MCP tools/list failed: {e}"),
+crates/diaporeia/src/client.rs:140:    /// Call a tool on the connected MCP server.
+crates/diaporeia/src/client.rs:144:    /// Returns [`crate::error::Error::Transport`] when the MCP request fails.
+crates/diaporeia/src/client.rs:158:                    message: format!("MCP tools/call '{name}' failed: {e}"),
+crates/diaporeia/src/client.rs:174:                message: format!("failed to close MCP client: {e}"),
+crates/diaporeia/src/client.rs:191:    fn fake_mcp_server() -> (TempDir, StdioMcpServerConfig) {
+crates/diaporeia/src/client.rs:220:        let config = StdioMcpServerConfig::new(script.display().to_string());
+crates/diaporeia/src/auth.rs:1://! Bearer token authentication middleware for MCP transport.
+crates/diaporeia/src/auth.rs:19:/// Axum middleware that validates Bearer JWT tokens on MCP requests.
+crates/diaporeia/src/auth.rs:23:/// - `"none"`: permits anonymous requests and lets MCP handlers resolve
+crates/diaporeia/src/auth.rs:45:        warn!("MCP request rejected: missing or malformed Authorization header");
+crates/diaporeia/src/auth.rs:53:        warn!("MCP request rejected: jwt_manager unavailable despite auth_mode != \"none\"");
+crates/diaporeia/src/auth.rs:61:            warn!("MCP request rejected: invalid Bearer token"); // kanon:ignore SECURITY/credential-logging -- logs rejection event, not the token
+crates/diaporeia/clippy.toml:1:# diaporeia: MCP server — high-level interface layer alongside pylon.
+crates/diaporeia/Cargo.toml:4:description = "MCP server interface — the passage through for external AI agents"
+crates/diaporeia/Cargo.toml:26:# MCP SDK — pin exact per TECHNOLOGY.md policy
+crates/diaporeia/CLAUDE.md:5:MCP server interface for external AI agents. Depends on koina, taxis, nous, and mneme. Entry point: `src/lib.rs` (DiaporeiaServer, DiaporeiaState).
+crates/diaporeia/CLAUDE.md:9:MCP server interface for external AI agents via the Model Context Protocol. 1.5K lines.
+crates/diaporeia/CLAUDE.md:16:4. `src/tools/mod.rs`: MCP tool implementations (session, nous, knowledge, config, health)
+crates/diaporeia/CLAUDE.md:23:| `DiaporeiaServer` | `server.rs` | MCP server: implements `ServerHandler`, holds state + rate limiter + tool router |
+crates/diaporeia/CLAUDE.md:28:## MCP tools (21)
+crates/diaporeia/CLAUDE.md:60:- **Path sanitization**: `sanitize::strip_paths()` removes server file paths before errors reach MCP clients.
+crates/diaporeia/CLAUDE.md:66:- Diaporeia owns both streamable HTTP MCP and stdio/external MCP bridging into organon.
+crates/diaporeia/CLAUDE.md:74:| Add MCP tool | `src/tools/mod.rs` (new `#[tool]` method on DiaporeiaServer) + `src/tools/params.rs` (param struct) |
+crates/diaporeia/CLAUDE.md:75:| Add MCP resource | `src/resources/` (new module) + `src/server.rs` (list/read handlers) |
+crates/pylon/src/router.rs:39:/// Extra routes (e.g. diaporeia's MCP router) are merged BEFORE middleware
+crates/organon/src/types/mod.rs:35:    /// MCP tool invocation and external API calls (`web_fetch`, `http_request`, ...).
+crates/organon/src/types/mod.rs:74:    /// External data retrieval (HTTP, MCP, web search, etc.).
+crates/aletheia/src/cli.rs:69:    /// Serve Aletheia MCP over stdio
+crates/aletheia/src/recall_sources/mod.rs:4://! queryable through the recall pipeline, not just via ad-hoc MCP tools.
+crates/aletheia/src/recall_sources/academic.rs:5://! MCP tools in CC sessions.
+crates/aletheia/Cargo.toml:24:# MCP server (Model Context Protocol). Disabled by default: adds context-window
+crates/aletheia/src/external_tools.rs:1:// kanon:ignore RUST/file-too-long — cohesive tool registry: config parsing, MCP client, HTTP proxy, and schema conversion are interdependent
+crates/aletheia/src/external_tools.rs:6://! MCP entries are server registrations: Aletheia connects to the external MCP
+crates/aletheia/src/external_tools.rs:10://! WHY: Different deployments have different MCP servers available.  A menos
+crates/aletheia/src/external_tools.rs:21:use diaporeia::client::{ExternalMcpClient, StdioMcpServerConfig};
+crates/aletheia/src/external_tools.rs:57:    /// Stdio MCP server command. For `type = "mcp"`, defaults to the config key.
+crates/aletheia/src/external_tools.rs:60:    /// Stdio MCP server command arguments.
+crates/aletheia/src/external_tools.rs:63:    /// Stdio MCP server working directory.
+crates/aletheia/src/external_tools.rs:66:    /// Extra environment for stdio MCP server processes.
+crates/aletheia/src/external_tools.rs:316:            warn!(server = server_name, error = %e, "failed to connect MCP server");
+crates/aletheia/src/external_tools.rs:329:            warn!(server = server_name, error = %e, "failed to list MCP server tools");
+crates/aletheia/src/external_tools.rs:341:        warn!(server = server_name, "MCP server exposed no tools");
+crates/aletheia/src/external_tools.rs:358:                "invalid MCP tool name after normalization"
+crates/aletheia/src/external_tools.rs:373:            .unwrap_or_else(|| format!("External MCP tool {remote_name} from {server_name}"));
+crates/aletheia/src/external_tools.rs:378:                "External MCP tool '{remote_name}' served by '{server_name}'."
+crates/aletheia/src/external_tools.rs:398:                    "external MCP tool registered"
+crates/aletheia/src/external_tools.rs:412:                    "failed to register external MCP tool"
+crates/aletheia/src/external_tools.rs:440:    let config = StdioMcpServerConfig {
+crates/aletheia/src/external_tools.rs:459:        "MCP external tools require rebuilding aletheia with the `mcp` feature"
+crates/aletheia/src/external_tools.rs:551:        .unwrap_or("External MCP tool parameter")
+crates/aletheia/src/external_tools.rs:713:                    "External MCP tool '{tool}' expected object arguments",
+crates/aletheia/src/external_tools.rs:722:                    "External MCP tool '{tool}' on server '{server}' failed: {e}",
+crates/aletheia/src/external_tools.rs:743:        serde_json::to_string(&result).unwrap_or_else(|e| format!("unrenderable MCP result: {e}"))
+crates/aletheia/src/external_tools.rs:945:printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo","description":"Echo through MCP","inputSchema":{"type":"object","properties":{"message":{"type":"string","description":"Message"}},"required":["message"]},"annotations":{"readOnlyHint":true}}]}}'
+crates/aletheia/src/external_tools.rs:989:        let mut entry = entry(ExternalToolKind::Mcp, None, Some("Fake MCP"));
+crates/aletheia/src/external_tools.rs:1025:        let mut entry = entry(ExternalToolKind::Mcp, None, Some("Fake MCP"));
+crates/aletheia/src/commands/server/mod.rs:110:            // MCP knowledge tools access the identical in-process instance.
+crates/aletheia/src/commands/server/mod.rs:123:        info!("diaporeia MCP server mounted at /mcp");
+crates/aletheia/src/commands/server/mod.rs:124:        // WHY: merge MCP routes BEFORE pylon's middleware layers so they get
+crates/energeia/src/agent_sdk.rs:26:    /// Disable MCP plugin loading.
+crates/energeia/src/agent_sdk.rs:30:    /// Optional MCP server configurations.
+crates/energeia/src/agent_sdk.rs:31:    pub mcp_servers: Vec<McpServerConfig>,
+crates/energeia/src/agent_sdk.rs:41:            mcp_servers: Vec::new(),
+crates/energeia/src/agent_sdk.rs:53:            .field("mcp_server_count", &self.mcp_servers.len())
+crates/energeia/src/agent_sdk.rs:58:/// MCP server configuration.
+crates/energeia/src/agent_sdk.rs:60:pub struct McpServerConfig {
+crates/energeia/src/agent_sdk.rs:74:/// permissions, and MCP configuration fields while the native SDK path remains
+crates/energeia/src/agent_sdk.rs:91:    /// checked here. `OAuth` token validation, MCP plugin wiring, permission
+crates/energeia/src/agent_sdk.rs:102:        // Future-work: validate OAuth token, init MCP plugin system, set up
+crates/energeia/src/agent_sdk.rs:202:            .field("mcp_server_count", &self.config.mcp_servers.len())
+crates/aletheia/src/commands/mod.rs:86:                anyhow::bail!("MCP stdio not available - rebuild with `--features mcp`")
+crates/organon/src/builtins/tool_schema.rs:1://! MCP meta-tool: `tool_schema` — fetch the full input schema for a named tool.
+crates/aletheia/src/commands/mcp.rs:1://! Stdio MCP server command.
+crates/aletheia/src/commands/mcp.rs:13:/// Run diaporeia over stdio for local MCP clients.
+crates/aletheia/src/commands/mcp.rs:50:        .whatever_context("diaporeia stdio MCP transport failed")
+crates/aletheia-memory-mcp/src/tools.rs:1:// kanon:ignore RUST/file-too-long — MCP tool implementations with inline datalog scripts; splitting would fragment the #[tool_router] impl and break the single-file routing convention.
+crates/aletheia-memory-mcp/src/tools.rs:2://! MCP tool implementations for the memory server.
+crates/aletheia-memory-mcp/src/tools.rs:8://! registered if the `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` environment variable is
+crates/aletheia-memory-mcp/src/tools.rs:45:    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/aletheia-memory-mcp/src/tools.rs:56:    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/aletheia-memory-mcp/src/tools.rs:69:    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/aletheia-memory-mcp/src/tools.rs:72:    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/aletheia-memory-mcp/src/tools.rs:85:    // kanon:ignore RUST/primitive-for-domain-id — WHY: MCP JSON protocol boundary; String required for serde/schemars JsonSchema derivation
+crates/aletheia-memory-mcp/src/tools.rs:675:                // Use "f-mcp-" prefix to mark MCP-inserted facts for audit purposes.
+crates/aletheia-memory-mcp/src/tools.rs:877:                    nous_id: "mcp-server".to_owned(),
+crates/aletheia-memory-mcp/src/error.rs:4://! rmcp::ErrorData`. Server-side paths are not included in MCP messages so
+crates/aletheia-memory-mcp/src/error.rs:9:/// Errors produced by the memory MCP server.
+crates/aletheia-memory-mcp/src/error.rs:52:    /// MCP transport error (stdio read/write or shutdown).
+crates/aletheia-memory-mcp/src/server.rs:1://! `MemoryServer`: stdio MCP server exposing read tools and token-gated writes.
+crates/aletheia-memory-mcp/src/server.rs:7://! tools are registered only when `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` is present.
+crates/aletheia-memory-mcp/src/server.rs:22:/// MCP server surface for Aletheia's memory layer.
+crates/aletheia-memory-mcp/src/server.rs:57:        let write_token = std::env::var("ALETHEIA_MEMORY_MCP_WRITE_TOKEN").ok();
+crates/aletheia-memory-mcp/src/server.rs:70:    /// which reads from `ALETHEIA_MEMORY_MCP_WRITE_TOKEN`.
+crates/aletheia-memory-mcp/src/server.rs:112:    /// Serve MCP over stdio until the peer closes the connection.
+crates/aletheia-memory-mcp/src/server.rs:195:                "MCP surface for Aletheia's nous local knowledge store \
+crates/aletheia-memory-mcp/src/server.rs:200:                 only when ALETHEIA_MEMORY_MCP_WRITE_TOKEN is configured.",
+crates/aletheia-memory-mcp/src/main.rs:1://! `aletheia-memory-mcp` — stdio MCP binary.
+crates/aletheia-memory-mcp/src/main.rs:8://! - `ALETHEIA_MEMORY_MCP_STORE` — override the store path directly.
+crates/aletheia-memory-mcp/src/main.rs:9://! - `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` — enable write tools and authorize each
+crates/aletheia-memory-mcp/src/main.rs:28:    // WHY: tracing must go to stderr because stdout is the MCP JSON-RPC
+crates/aletheia-memory-mcp/src/main.rs:64:    tracing::info!("memory MCP server ready on stdio");
+crates/aletheia-memory-mcp/src/main.rs:72:/// 1. `ALETHEIA_MEMORY_MCP_STORE` — explicit override.
+crates/aletheia-memory-mcp/src/main.rs:75:    if let Ok(explicit) = std::env::var("ALETHEIA_MEMORY_MCP_STORE") {
+crates/aletheia-memory-mcp/README.md:3:Standalone stdio MCP server exposing Aletheia's nous local knowledge store to external agents (Claude Code, Cursor, OpenHands, etc.) without requiring the full Aletheia runtime. This is the session-scoped Aletheia nous store, not kanon mnemosyne's durable corpus.
+crates/aletheia-memory-mcp/README.md:25:- `ALETHEIA_MEMORY_MCP_STORE` - override the store path directly.
+crates/aletheia-memory-mcp/README.md:26:- `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` - capability token for write tools. If unset, write tools are not registered.
+crates/aletheia-memory-mcp/README.md:35:1. **Server Startup**: The spawning process (aletheia daemon or operator) generates a random token and sets it in the child's environment as `ALETHEIA_MEMORY_MCP_WRITE_TOKEN`. If this variable is unset, write tools are not registered or listed by MCP discovery.
+crates/aletheia-memory-mcp/README.md:48:This produces a 64-character hexadecimal string suitable for use as `ALETHEIA_MEMORY_MCP_WRITE_TOKEN`.
+crates/aletheia-memory-mcp/README.md:53:export ALETHEIA_MEMORY_MCP_WRITE_TOKEN=$(openssl rand -hex 32)
+crates/aletheia-memory-mcp/README.md:57:### Example: MCP client call
+crates/aletheia-memory-mcp/README.md:66:    "write_token": "..."  // must match ALETHEIA_MEMORY_MCP_WRITE_TOKEN
+crates/aletheia-memory-mcp/README.md:74:- **No Encryption**: The token is passed in-process via environment variable and in-protocol via MCP calls. It's not encrypted on the wire; use this server only over local IPC or secure channels (SSH, TLS).
+crates/aletheia-memory-mcp/src/lib.rs:2://! aletheia-memory-mcp: standalone stdio MCP server for Aletheia's memory layer.
+crates/aletheia-memory-mcp/src/lib.rs:11://! `diaporeia` is the in-process MCP server that bundles session management,
+crates/aletheia-memory-mcp/src/lib.rs:17://! service use case: any agent that speaks MCP can treat Aletheia's KG as a
+crates/aletheia-memory-mcp/src/lib.rs:32://! Write tools are registered only when `ALETHEIA_MEMORY_MCP_WRITE_TOKEN` is set
+crates/aletheia-memory-mcp/Cargo.toml:4:description = "Standalone stdio MCP server exposing Aletheia's memory and token-gated write tools to external agents"
+crates/aletheia-memory-mcp/Cargo.toml:15:# MCP SDK — pin exact per TECHNOLOGY.md policy (matches diaporeia)
+crates/organon/src/builtins/code_graph_query.rs:1://! MCP tool: `code_graph_query` — symbol-level cross-crate queries.
+crates/organon/src/builtins/architecture_fact.rs:1://! MCP tool: `architecture_fact` — query structured architecture facts.
+crates/organon/src/builtins/architecture_fact.rs:383:                    "claim": "Test claim via MCP.",
+crates/organon/src/builtins/architecture_fact.rs:412:                .contains("Test claim via MCP.")
+crates/nous/src/tasks/types.rs:103:    /// Background monitoring task (e.g. MCP health).
+
+exec
+/bin/bash -lc 'find crates/energeia -maxdepth 2 -type f | sort' in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+crates/energeia/CLAUDE.md
+crates/energeia/Cargo.toml
+crates/energeia/src/agent_sdk.rs
+crates/energeia/src/backend.rs
+crates/energeia/src/budget.rs
+crates/energeia/src/cost_ledger.rs
+crates/energeia/src/cron.rs
+crates/energeia/src/dag.rs
+crates/energeia/src/engine.rs
+crates/energeia/src/error.rs
+crates/energeia/src/frontier.rs
+crates/energeia/src/hermeneus_engine.rs
+crates/energeia/src/lib.rs
+crates/energeia/src/predictive_budget.rs
+crates/energeia/src/prompt.rs
+crates/energeia/src/prompt_cache.rs
+crates/energeia/src/resume.rs
+crates/energeia/src/types.rs
+crates/energeia/tests/public_api_errors_and_bounds.rs
+crates/energeia/tests/public_api_types_and_config.rs
+
+web search: 
+web search: site:docs.anthropic.com Claude CLI MCP server flag --mcp-server
+web search: 
+web search: 'mcp' in https://docs.anthropic.com/en/docs/claude-code/cli-usage
+web search: 
+web search: https://docs.anthropic.com/en/docs/claude-code/sdk/sdk-mcp
+codex
+I’ve confirmed the Claude CLI surface: `--mcp-config` loads one or more JSON config strings/files, and the SDK docs use a top-level `mcpServers` map. I’m checking how `AgentSdkConfig` is constructed elsewhere so I can preserve the intended merge behavior instead of accidentally clobbering other config.
+exec
+/bin/bash -lc "rg -n \"AgentSdkConfig::default\\(|AgentSdkConfig \\{|mcp_servers\" crates/energeia crates -g '"'!target'"'" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+crates/energeia/src/agent_sdk.rs:21:pub struct AgentSdkConfig {
+crates/energeia/src/agent_sdk.rs:31:    pub mcp_servers: Vec<McpServerConfig>,
+crates/energeia/src/agent_sdk.rs:34:impl Default for AgentSdkConfig {
+crates/energeia/src/agent_sdk.rs:41:            mcp_servers: Vec::new(),
+crates/energeia/src/agent_sdk.rs:46:impl std::fmt::Debug for AgentSdkConfig {
+crates/energeia/src/agent_sdk.rs:53:            .field("mcp_server_count", &self.mcp_servers.len())
+crates/energeia/src/agent_sdk.rs:202:            .field("mcp_server_count", &self.config.mcp_servers.len())
+crates/energeia/src/agent_sdk.rs:21:pub struct AgentSdkConfig {
+crates/energeia/src/agent_sdk.rs:31:    pub mcp_servers: Vec<McpServerConfig>,
+crates/energeia/src/agent_sdk.rs:34:impl Default for AgentSdkConfig {
+crates/energeia/src/agent_sdk.rs:41:            mcp_servers: Vec::new(),
+crates/energeia/src/agent_sdk.rs:46:impl std::fmt::Debug for AgentSdkConfig {
+crates/energeia/src/agent_sdk.rs:53:            .field("mcp_server_count", &self.mcp_servers.len())
+crates/energeia/src/agent_sdk.rs:202:            .field("mcp_server_count", &self.config.mcp_servers.len())
+
+exec
+/bin/bash -lc "sed -n '1,220p' crates/energeia/src/lib.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+exec
+/bin/bash -lc "sed -n '1,220p' crates/energeia/tests/public_api_types_and_config.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+//! aletheia-energeia: dispatch orchestration for the Aletheia agent runtime.
+#![deny(missing_docs)]
+//!
+//! Energeia (ἐνέργεια): "actualization" — the process of bringing potential
+//! into reality. This crate orchestrates the dispatch of coding tasks to agent
+//! sessions, tracks budgets and health, evaluates quality, and manages the
+//! lifecycle from prompt to merged PR.
+//!
+//! # Architecture
+//!
+//! - [`engine::DispatchEngine`] — session execution backend (Agent SDK HTTP/SSE)
+//! - [`http`] — subprocess-based `DispatchEngine` implementation and mock engine
+//! - [`session`] — per-prompt session management: spawn, monitor, resume, budget enforce
+//! - [`qa::QaGate`] — quality assurance evaluation (mechanical + LLM)
+//! - [`budget`] — atomic cost/turn/duration tracking for concurrent sessions
+//! - [`resume`] — multi-stage escalation policy for stuck sessions
+//! - [`dag`] — prompt dependency graph with topological frontier computation
+//! - [`prompt`] — YAML frontmatter loading and DAG construction from prompt files
+//! - [`routing`] — static and empirical provider selection (success-rate based)
+//! - [`types`] — dispatch specs, outcomes, QA results
+//! - [`error`] — snafu error types with location tracking
+
+/// Agent SDK engine: OAuth-enabled, permission-aware dispatch backend.
+pub mod agent_sdk;
+/// High-level dispatch backend trait for control plane integration.
+pub mod backend;
+/// Atomic budget tracking for dispatch runs.
+pub mod budget;
+/// Per-blast-radius cost attribution ledger.
+pub mod cost_ledger;
+/// Cron scheduler for recurring dispatch tasks with fjall-backed locking.
+#[cfg(feature = "storage-fjall")]
+pub mod cron;
+/// Prompt dependency DAG and parallel frontier computation.
+pub mod dag;
+/// Dispatch engine trait and session types.
+pub mod engine;
+/// Error types for energeia operations.
+pub mod error;
+/// Friction capture: parse structured observations from PR bodies.
+pub mod friction;
+/// Parallel-execution frontier derivation from a [`dag::PromptDag`].
+pub mod frontier;
+/// Hermeneus-based dispatch engine with prompt caching.
+pub mod hermeneus_engine;
+/// HTTP/SSE dispatch engine: subprocess-based `DispatchEngine` and mock.
+pub mod http;
+/// Metrics and reporting: health signals, cost reports, status dashboard, Prometheus.
+pub mod metrics;
+/// Top-level dispatch orchestrator: DAG execution with concurrency and QA.
+pub mod orchestrator;
+/// 4-stage dispatch pipeline: preparation → execution → post-processing.
+pub(crate) mod pipeline;
+/// Predictive budget allocation from prompt characteristics.
+pub mod predictive_budget;
+/// Prompt loading from YAML frontmatter files.
+pub mod prompt;
+/// Prompt cache optimization: static prefix / dynamic suffix split.
+pub mod prompt_cache;
+/// Quality assurance gate trait.
+pub mod qa;
+/// Multi-stage resume escalation policy.
+pub mod resume;
+/// Provider routing: static config-driven and empirical success-rate-based selection.
+pub(crate) mod routing;
+/// Per-prompt session management: spawn, monitor, resume, budget enforce.
+pub mod session;
+/// Steward CI management pipeline: classify, merge, fix, and manage pull requests.
+pub mod steward;
+/// State persistence layer (fjall key-value store).
+pub mod store;
+/// Core dispatch types: specs, outcomes, QA results.
+pub mod types;
+
+ succeeded in 0ms:
+#![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(clippy::indexing_slicing, reason = "test assertions")]
+
+use std::time::Duration;
+
+use energeia::cost_ledger::CostLedger;
+use energeia::engine::AgentOptions;
+use energeia::orchestrator::OrchestratorConfig;
+use energeia::types::DispatchSpec;
+
+// Split: DispatchSpec + AgentOptions + OrchestratorConfig + CostLedger.
+
+// ============================================================================
+// DispatchSpec serde round-trips
+// ============================================================================
+
+#[test]
+fn dispatch_spec_serde_roundtrip_basic() {
+    let spec = DispatchSpec::new("my-project".to_owned(), vec![1, 2, 3]);
+    let json = serde_json::to_string(&spec).expect("serialize");
+    let deserialized: DispatchSpec = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(deserialized.prompt_numbers, vec![1, 2, 3]);
+    assert_eq!(deserialized.project, "my-project");
+    assert!(deserialized.dag_ref.is_none());
+    assert!(deserialized.max_parallel.is_none());
+    assert!(deserialized.max_turns.is_none());
+}
+
+#[test]
+fn dispatch_spec_serde_with_dag_ref() {
+    // Build using serde deserialization since struct is non_exhaustive
+    let json = r#"{
+        "prompt_numbers": [10, 20, 30],
+        "project": "test-proj",
+        "dag_ref": "dag.yaml",
+        "max_parallel": 8,
+        "max_turns": 12
+    }"#;
+    let spec: DispatchSpec = serde_json::from_str(json).expect("deserialize");
+
+    assert_eq!(spec.prompt_numbers, vec![10, 20, 30]);
+    assert_eq!(spec.project, "test-proj");
+    assert_eq!(spec.dag_ref, Some("dag.yaml".to_owned()));
+    assert_eq!(spec.max_parallel, Some(8));
+    assert_eq!(spec.max_turns, Some(12));
+}
+
+#[test]
+fn dispatch_spec_yaml_roundtrip() {
+    let yaml = r"
+prompt_numbers:
+  - 1
+  - 2
+project: yaml-test
+dag_ref: prompts/dag.yaml
+max_parallel: 4
+max_turns: 9
+";
+    let spec: DispatchSpec = serde_yaml::from_str(yaml).expect("deserialize from yaml");
+
+    assert_eq!(spec.prompt_numbers, vec![1, 2]);
+    assert_eq!(spec.project, "yaml-test");
+    assert_eq!(spec.dag_ref, Some("prompts/dag.yaml".to_owned()));
+    assert_eq!(spec.max_parallel, Some(4));
+    assert_eq!(spec.max_turns, Some(9));
+}
+
+// ============================================================================
+// AgentOptions builder chaining + serde
+// ============================================================================
+
+#[test]
+fn agent_options_builder_chaining() {
+    let opts = AgentOptions::new()
+        .model("claude-sonnet-4-20250514")
+        .system_prompt("You are a helpful coding assistant")
+        .cwd("/tmp/project")
+        .max_turns(100)
+        .permission_mode("plan");
+
+    assert_eq!(opts.model, Some("claude-sonnet-4-20250514".to_owned()));
+    assert_eq!(
+        opts.system_prompt,
+        Some("You are a helpful coding assistant".to_owned())
+    );
+    assert_eq!(opts.cwd, Some("/tmp/project".to_owned()));
+    assert_eq!(opts.max_turns, Some(100));
+    assert_eq!(opts.permission_mode, Some("plan".to_owned()));
+}
+
+#[test]
+fn agent_options_default_is_empty() {
+    let opts = AgentOptions::default();
+    assert!(opts.model.is_none());
+    assert!(opts.system_prompt.is_none());
+    assert!(opts.cwd.is_none());
+    assert!(opts.max_turns.is_none());
+    assert!(opts.permission_mode.is_none());
+}
+
+#[test]
+fn agent_options_serde_roundtrip() {
+    let opts = AgentOptions::new()
+        .model("claude-opus-4-20250514")
+        .max_turns(50);
+
+    let json = serde_json::to_string(&opts).expect("serialize");
+    let deserialized: AgentOptions = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(
+        deserialized.model,
+        Some("claude-opus-4-20250514".to_owned())
+    );
+    assert_eq!(deserialized.max_turns, Some(50));
+    assert!(deserialized.system_prompt.is_none());
+}
+
+#[test]
+fn agent_options_serde_partial() {
+    let json = r#"{"model":"claude-3-haiku","max_turns":25}"#;
+    let opts: AgentOptions = serde_json::from_str(json).expect("deserialize");
+
+    assert_eq!(opts.model, Some("claude-3-haiku".to_owned()));
+    assert_eq!(opts.max_turns, Some(25));
+    assert!(opts.cwd.is_none());
+    assert!(opts.permission_mode.is_none());
+}
+
+#[test]
+fn agent_options_builder_method_chaining_order_independent() {
+    // Verify builder works regardless of order
+    let opts1 = AgentOptions::new()
+        .model("claude-3")
+        .max_turns(50)
+        .cwd("/a");
+
+    let opts2 = AgentOptions::new()
+        .cwd("/a")
+        .model("claude-3")
+        .max_turns(50);
+
+    assert_eq!(opts1.model, opts2.model);
+    assert_eq!(opts1.cwd, opts2.cwd);
+    assert_eq!(opts1.max_turns, opts2.max_turns);
+}
+
+// ============================================================================
+// OrchestratorConfig defaults and builder
+// ============================================================================
+
+#[test]
+fn orchestrator_config_defaults() {
+    let config = OrchestratorConfig::default();
+
+    assert_eq!(config.max_concurrent, 4);
+    assert!(config.default_budget_usd.is_none());
+    assert!(config.default_budget_turns.is_none());
+    assert!(config.max_duration.is_none());
+    assert_eq!(config.session_idle_timeout, Some(Duration::from_mins(10)));
+    assert_eq!(config.max_corrective_retries, 0);
+}
+
+#[test]
+fn orchestrator_config_new_uses_defaults() {
+    let config = OrchestratorConfig::new();
+
+    assert_eq!(config.max_concurrent, 4);
+    assert!(config.default_budget_usd.is_none());
+}
+
+#[test]
+fn orchestrator_config_builder_chaining() {
+    let config = OrchestratorConfig::new()
+        .max_concurrent(8)
+        .default_budget_usd(50.0)
+        .default_budget_turns(1000)
+        .max_duration(Duration::from_hours(1))
+        .session_idle_timeout(Duration::from_mins(5))
+        .max_corrective_retries(3);
+
+    assert_eq!(config.max_concurrent, 8);
+    assert_eq!(config.default_budget_usd, Some(50.0));
+    assert_eq!(config.default_budget_turns, Some(1000));
+    assert_eq!(config.max_duration, Some(Duration::from_hours(1)));
+    assert_eq!(config.session_idle_timeout, Some(Duration::from_mins(5)));
+    assert_eq!(config.max_corrective_retries, 3);
+}
+
+#[test]
+fn orchestrator_config_serde_roundtrip() {
+    let config = OrchestratorConfig::new()
+        .max_concurrent(6)
+        .default_budget_usd(25.0)
+        .max_duration(Duration::from_mins(30));
+
+    let json = serde_json::to_string(&config).expect("serialize");
+    let deserialized: OrchestratorConfig = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(deserialized.max_concurrent, 6);
+    assert_eq!(deserialized.default_budget_usd, Some(25.0));
+    assert_eq!(deserialized.max_duration, Some(Duration::from_mins(30)));
+    assert_eq!(
+        deserialized.session_idle_timeout,
+        Some(Duration::from_mins(10))
+    );
+}
+
+#[test]
+fn orchestrator_config_serde_with_null_durations() {
+    // Use JSON deserialization for non_exhaustive struct
+    let json = r#"{
+        "max_concurrent": 4,
+        "default_budget_usd": null,
+        "default_budget_turns": null,
+        "max_duration": null,
+        "session_idle_timeout": null,
+        "max_corrective_retries": 1
+    }"#;
+    let config: OrchestratorConfig = serde_json::from_str(json).expect("deserialize");
+
+exec
+/bin/bash -lc "sed -n '1,220p' crates/energeia/Cargo.toml" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+exec
+/bin/bash -lc "sed -n '1,220p' crates/energeia/src/error.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+[package]
+name = "energeia"
+version.workspace = true
+description = "Dispatch orchestration — actualization of plans into execution"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+test-core = ["storage-fjall"]
+test-full = []
+storage-fjall = ["dep:fjall", "koina/fjall"]
+
+[dependencies]
+aletheia-routing = { path = "../aletheia-routing" }
+compact_str = { workspace = true }
+koina = { path = "../koina" }
+eidos = { path = "../eidos" }
+hermeneus = { path = "../hermeneus" }
+prometheus-client = { workspace = true }
+rand = { workspace = true }
+regex = { workspace = true }
+fjall = { version = "3", optional = true }
+jiff = { workspace = true, features = ["serde"] }
+jiff-cron = "0.3"
+parking_lot = { version = "0.12", default-features = false }
+reqwest = { workspace = true }
+rmp-serde = "1.2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+sha2 = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true, features = ["process", "io-util"] }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+rustls = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["process", "io-util", "test-util"] }
+wiremock = { workspace = true }
+hermeneus = { path = "../hermeneus", features = ["test-utils"] }
+
+ succeeded in 0ms:
+//! Energeia-specific errors.
+
+use std::path::PathBuf;
+
+use snafu::Snafu;
+
+/// Errors from dispatch orchestration operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[expect(
+    missing_docs,
+    reason = "snafu error variant fields are self-documenting via display format"
+)]
+#[non_exhaustive]
+pub enum Error {
+    /// I/O error reading or listing prompt files.
+    #[snafu(display("I/O error for '{}': {source}", path.display()))]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// YAML frontmatter parse error in a prompt file.
+    #[snafu(display("frontmatter parse error in '{}': {detail}", path.display()))]
+    FrontmatterParse {
+        path: PathBuf,
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Cycle detected in the prompt dependency graph.
+    #[snafu(display("cycle in prompt DAG: {}", cycle.iter().map(|n| format!("#{n}")).collect::<Vec<_>>().join(" -> ")))]
+    DagCycle {
+        /// Prompt numbers forming the cycle.
+        cycle: Vec<u32>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Broken or missing dependency references in the prompt DAG.
+    #[snafu(display("broken prompt dependencies: {detail}"))]
+    DagMissingDeps {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Dispatch was aborted via cancellation.
+    #[snafu(display("dispatch aborted"))]
+    Aborted {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Budget limit exceeded during dispatch.
+    #[snafu(display("budget exceeded: {reason}"))]
+    BudgetExceeded {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Session spawn failed for a specific prompt.
+    #[snafu(display("spawn failed for prompt {prompt_number}: {detail}"))]
+    SpawnFailed {
+        prompt_number: u32,
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Session resume failed.
+    #[snafu(display("resume failed for session '{session_id}': {detail}"))]
+    ResumeFailed {
+        session_id: String,
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// QA evaluation failed.
+    #[snafu(display("QA evaluation failed: {detail}"))]
+    QaFailed {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// LLM provider error during dispatch operations.
+    #[snafu(display("LLM error: {detail}"))]
+    Llm {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Preflight validation failed before dispatch could start.
+    #[snafu(display("preflight failed: {reason}"))]
+    Preflight {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Blast radius overlap detected between concurrent sessions.
+    #[snafu(display("blast radius overlap: {detail}"))]
+    BlastRadiusOverlap {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Task join error from a spawned session task.
+    #[snafu(display("task join failed: {detail}"))]
+    TaskJoin {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Engine-level transport or protocol error.
+    #[snafu(display("engine error: {detail}"))]
+    Engine {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// State store read/write failure.
+    #[snafu(display("store error: {message}"))]
+    Store {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Record serialization or deserialization failure.
+    #[snafu(display("serialization error: {message}"))]
+    Serialization {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Requested record not found.
+    #[snafu(display("not found: {what}"))]
+    NotFound {
+        what: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Invalid cron expression.
+    #[snafu(display("invalid cron expression '{expression}': {source}"))]
+    CronParse {
+        expression: String,
+        source: jiff_cron::error::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Invalid model identifier specified.
+    #[snafu(display("invalid model: {model}"))]
+    InvalidModel {
+        model: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Convenience alias for results with [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn error_display_aborted() {
+        let err = AbortedSnafu.build();
+        assert!(err.to_string().contains("aborted"));
+    }
+
+    #[test]
+    fn error_display_budget_exceeded() {
+        let err = BudgetExceededSnafu {
+            reason: "cost limit $5.00",
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("budget exceeded"));
+        assert!(msg.contains("$5.00"));
+    }
+
+    #[test]
+    fn error_display_spawn_failed() {
+        let err = SpawnFailedSnafu {
+            prompt_number: 3u32,
+            detail: "auth failure",
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("prompt 3"));
+        assert!(msg.contains("auth failure"));
+    }
+
+    #[test]
+    fn error_display_resume_failed() {
+        let err = ResumeFailedSnafu {
+            session_id: "sess-abc",
+            detail: "session expired",
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("sess-abc"));
+
+exec
+/bin/bash -lc "sed -n '1,220p' crates/energeia/CLAUDE.md" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+# energeia
+
+## At a glance
+
+Dispatch orchestration for plan execution. Depends on koina, eidos, and hermeneus. Entry point: `src/lib.rs` (DispatchEngine, QaGate).
+
+## Depth
+
+Dispatch orchestration: actualization of plans into execution. Absorbs kanon's phronesis dispatch system into aletheia.
+
+## Read first
+
+1. `src/types.rs`: DispatchSpec, DispatchResult, SessionOutcome, Budget, ResumePolicy, QA types
+2. `src/engine.rs`: DispatchEngine trait, SessionHandle trait, SessionSpec, AgentOptions
+3. `src/qa.rs`: QaGate trait, PromptSpec
+4. `src/error.rs`: snafu error enum
+
+## Key types
+
+| Type | Path | Purpose |
+|------|------|---------|
+| `DispatchSpec` | `types.rs` | What to dispatch: prompt numbers, DAG reference, project |
+| `DispatchResult` | `types.rs` | Aggregate outcome: dispatch_id, outcomes, cost, duration |
+| `SessionOutcome` | `types.rs` | Per-prompt result: status, cost, turns, duration, PR URL |
+| `SessionStatus` | `types.rs` | Terminal state: Success, Failed, Stuck, Aborted, BudgetExceeded |
+| `Budget` | `types.rs` | Cost/turn/duration limits with record + check |
+| `BudgetStatus` | `types.rs` | Ok, Warning, Exceeded |
+| `ResumePolicy` | `types.rs` | Multi-stage escalation with turn budgets |
+| `QaResult` | `types.rs` | QA evaluation outcome: verdict, criteria, mechanical issues |
+| `QaVerdict` | `types.rs` | Pass, Partial, Fail |
+| `DispatchEngine` | `engine.rs` | Trait: spawn/resume sessions against Agent SDK |
+| `SessionHandle` | `engine.rs` | Trait: event stream, wait, abort for a running session |
+| `QaGate` | `qa.rs` | Trait: evaluate PR quality, mechanical checks |
+
+## Patterns
+
+- **Atomic budget tracking**: Budget uses atomic operations for thread-safe concurrent recording
+- **Health-driven escalation**: ResumePolicy defines stages with escalating urgency
+- **Mechanical pre-screening**: QaGate separates fast structural checks from LLM evaluation
+- **Agent SDK target**: DispatchEngine targets Anthropic Agent SDK HTTP/SSE API
+
+## Common tasks
+
+| Task | Where |
+|------|-------|
+| Add dispatch type | `src/types.rs` |
+| Add error variant | `src/error.rs` |
+| Add engine capability | `src/engine.rs` (DispatchEngine or SessionHandle trait) |
+| Add QA check | `src/qa.rs` (QaGate trait or MechanicalIssueKind) |
+
+## Dependencies
+
+Uses: koina, eidos, hermeneus, jiff, serde, snafu, tokio
+Used by: aletheia (binary, behind `energeia` feature flag)
+
+exec
+/bin/bash -lc "rg -n \"serde_json::to_string\\(|to_string\\(&.*json|json"'!'"\\(\" crates/energeia/src crates/energeia/tests -S" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+crates/energeia/tests/public_api_types_and_config.rs:20:    let json = serde_json::to_string(&spec).expect("serialize");
+crates/energeia/tests/public_api_types_and_config.rs:108:    let json = serde_json::to_string(&opts).expect("serialize");
+crates/energeia/tests/public_api_types_and_config.rs:197:    let json = serde_json::to_string(&config).expect("serialize");
+crates/energeia/src/types.rs:423:        let json = serde_json::to_string(&spec).unwrap();
+crates/energeia/src/types.rs:449:        let json = serde_json::to_string(&outcome).unwrap();
+crates/energeia/src/types.rs:475:        let json = serde_json::to_string(&result).unwrap();
+crates/energeia/tests/public_api_errors_and_bounds.rs:178:    let json = serde_json::to_string(&event).expect("serialize");
+crates/energeia/tests/public_api_errors_and_bounds.rs:184:        input: serde_json::json!({"path": "/tmp/test.rs"}),
+crates/energeia/tests/public_api_errors_and_bounds.rs:186:    let json = serde_json::to_string(&event).expect("serialize");
+crates/energeia/tests/public_api_errors_and_bounds.rs:198:    let json = serde_json::to_string(&event).expect("serialize");
+crates/energeia/tests/public_api_errors_and_bounds.rs:206:    let json = serde_json::to_string(&event).expect("serialize");
+crates/energeia/tests/public_api_errors_and_bounds.rs:217:    let json = serde_json::to_string(&event).expect("serialize");
+crates/energeia/tests/public_api_errors_and_bounds.rs:335:    let json = serde_json::to_string(&policy).expect("serialize");
+crates/energeia/src/store/records.rs:294:        let json = serde_json::to_string(&id).unwrap();
+crates/energeia/src/http/stream.rs:428:                input: serde_json::json!({"cmd": "ls"}),
+crates/energeia/src/http/mock.rs:203:                    input: serde_json::json!({"cmd": "ls"}),
+crates/energeia/src/hermeneus_engine.rs:398:                schema: serde_json::json!({
+crates/energeia/src/store/fjall_store.rs:106:            serde_json::to_string(spec).map_err(|e| ser_err("serialize dispatch spec", e))?;
+crates/energeia/src/store/fjall_store.rs:472:        let content = serde_json::to_string(&outcome_data)
+crates/energeia/src/steward/types.rs:750:        let json = serde_json::to_string(&pr).unwrap();
+crates/energeia/src/steward/types.rs:766:        let json = serde_json::to_string(&issue).unwrap();
+crates/energeia/src/routing/persona.rs:284:        serde_json::json!({
+crates/energeia/src/session/options.rs:230:        let json = serde_json::to_string(&progress).expect("serialize child progress");
+crates/energeia/src/routing/empirical.rs:248:        serde_json::json!({
+crates/energeia/src/session/manager.rs:722:            schema: serde_json::json!({"type": "object"}),
+crates/energeia/src/session/manager.rs:890:            Some(serde_json::json!({"summary": "bounded"}))
+crates/energeia/src/routing/affinity.rs:431:        serde_json::json!({
+crates/energeia/src/engine.rs:372:        let json = serde_json::to_string(&spec).unwrap();
+crates/energeia/src/engine.rs:381:            input: serde_json::json!({"path": "/tmp/test.rs"}),
+crates/energeia/src/engine.rs:383:        let json = serde_json::to_string(&event).unwrap();
+crates/energeia/src/engine.rs:401:        let json = serde_json::to_string(&result).unwrap();
+crates/energeia/src/qa/mod.rs:437:        let json = serde_json::to_string(&spec).unwrap();
+crates/energeia/src/pipeline/post_processing.rs:161:    let line = serde_json::to_string(&record)
+crates/energeia/src/pipeline/health_check.rs:396:            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+crates/energeia/src/pipeline/health_check.rs:438:            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+crates/energeia/src/pipeline/health_check.rs:504:            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+crates/energeia/src/pipeline/execution.rs:849:            schema: serde_json::json!({
+crates/energeia/src/orchestrator/orchestrator_tests.rs:408:    let json = serde_json::to_string(&plan).unwrap();
+crates/energeia/src/orchestrator/config.rs:269:        let json = serde_json::to_string(&config).expect("serialize");
+crates/energeia/src/orchestrator/config.rs:283:        let json = serde_json::to_string(&config).expect("serialize");
+crates/energeia/src/orchestrator/config.rs:300:        let json = serde_json::to_string(&config).expect("serialize");
+crates/energeia/src/resume.rs:223:        let json = serde_json::to_string(&policy).unwrap();
+
+codex
+I’ve pinned the wire format: `claude` wants `--mcp-config` with a JSON config containing `mcpServers`. I’m patching `crates/energeia/src/agent_sdk.rs` to serialize the configured servers into that flag and adding unit tests for both the populated and empty cases.
+apply patch
+patch: completed
+/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/energeia/src/agent_sdk.rs
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+codex
+The wiring is in place. I’m doing a quick source review for compile issues now, then I’ll run the focused tests and clippy to catch any borrow, import, or serialization mistakes before I stop.
+exec
+/bin/bash -lc "sed -n '1,260p' crates/energeia/src/agent_sdk.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+//! Experimental Claude CLI subprocess engine with OAuth token injection.
+//!
+//! WHY: This engine uses the `claude` CLI transport while preserving the
+//! dispatch-engine boundary for future native SDK integration. It is not a
+//! native HTTP/SSE Agent SDK client yet.
+
+use std::collections::{BTreeMap, HashMap};
+use std::future::Future;
+use std::pin::Pin;
+use std::process::Stdio;
+
+use serde::Serialize;
+use tokio::process::Command;
+
+use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+use crate::error::{self, Result};
+use crate::http::session::ProcessSessionHandle;
+use crate::http::stream::EventStream;
+
+/// Configuration for the experimental Claude CLI bridge.
+#[derive(Clone)]
+pub struct AgentSdkConfig {
+    /// Default model identifier (e.g., "claude-opus-4", "claude-sonnet-4").
+    pub default_model: String,
+    /// Skip permission checks during dispatch.
+    pub skip_permissions: bool,
+    /// Disable MCP plugin loading.
+    pub disable_plugins: bool,
+    /// Optional `OAuth` token for API authentication.
+    pub oauth_token: Option<String>,
+    /// Optional MCP server configurations.
+    pub mcp_servers: Vec<McpServerConfig>,
+}
+
+impl Default for AgentSdkConfig {
+    fn default() -> Self {
+        Self {
+            default_model: "claude-sonnet-4".to_string(),
+            skip_permissions: false,
+            disable_plugins: false,
+            oauth_token: None,
+            mcp_servers: Vec::new(),
+        }
+    }
+}
+
+impl std::fmt::Debug for AgentSdkConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentSdkConfig")
+            .field("default_model", &self.default_model)
+            .field("skip_permissions", &self.skip_permissions)
+            .field("disable_plugins", &self.disable_plugins)
+            .field("has_oauth", &self.oauth_token.is_some())
+            .field("mcp_server_count", &self.mcp_servers.len())
+            .finish()
+    }
+}
+
+/// MCP server configuration.
+#[derive(Debug, Clone)]
+pub struct McpServerConfig {
+    /// Server name/identifier.
+    pub name: String,
+    /// Server command to execute.
+    pub command: String,
+    /// Arguments for the server command.
+    pub args: Vec<String>,
+    /// Environment variables.
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+struct McpConfigFile {
+    #[serde(rename = "mcpServers")]
+    mcp_servers: BTreeMap<String, McpServerEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct McpServerEntry {
+    command: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    args: Vec<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    env: BTreeMap<String, String>,
+}
+
+/// Experimental Claude CLI dispatch engine.
+///
+/// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+/// permissions, and MCP configuration fields while the native SDK path remains
+/// unwired. The public type name is kept for compatibility with existing
+/// configuration code, but the current transport is a `claude` CLI subprocess,
+/// not a native Agent SDK client.
+pub struct AgentSdkEngine {
+    config: AgentSdkConfig,
+    binary: String,
+}
+
+impl AgentSdkEngine {
+    /// Create a new experimental Claude CLI bridge with the given configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the engine cannot be initialized.
+    ///
+    /// Current validation is intentionally narrow: only the default model ID is
+    /// checked here. `OAuth` token validation, MCP plugin wiring, permission
+    /// enforcement, and native SDK availability checks remain future work.
+    pub fn new(config: AgentSdkConfig) -> Result<Self> {
+        // WHY: Verify the model identifier is valid during construction.
+        if config.default_model.is_empty() {
+            return error::InvalidModelSnafu {
+                model: "(empty)".to_string(),
+            }
+            .fail();
+        }
+
+        // Future-work: validate OAuth token, init MCP plugin system, set up
+        // permission system, and replace the CLI subprocess with a native SDK
+        // transport when that integration exists.
+        Ok(Self {
+            config,
+            binary: "claude".to_owned(),
+        })
+    }
+
+    /// Get the configured default model.
+    #[must_use]
+    pub fn default_model(&self) -> &str {
+        &self.config.default_model
+    }
+
+    /// Check if permissions are enabled.
+    #[must_use]
+    pub fn permissions_enabled(&self) -> bool {
+        !self.config.skip_permissions
+    }
+
+    /// Check if plugins are enabled.
+    #[must_use]
+    pub fn plugins_enabled(&self) -> bool {
+        !self.config.disable_plugins
+    }
+
+    /// Build the CLI argument vector for a session.
+    fn build_args(&self, options: &AgentOptions) -> Vec<String> {
+        let mut args = Vec::new();
+
+        args.extend(["--output-format".to_owned(), "stream-json".to_owned()]);
+        args.push("--verbose".to_owned());
+
+        let model = options
+            .model
+            .as_deref()
+            .unwrap_or(&self.config.default_model);
+        args.extend(["--model".to_owned(), model.to_owned()]);
+
+        // WHY: Apply permission mode based on config (if not skipped).
+        if !self.config.skip_permissions
+            && let Some(ref mode) = options.permission_mode
+        {
+            args.extend(["--permission-mode".to_owned(), mode.clone()]);
+        }
+
+        if let Some(ref prompt) = options.system_prompt {
+            args.extend(["--system-prompt".to_owned(), prompt.clone()]);
+        }
+
+        if let Some(turns) = options.max_turns {
+            args.extend(["--max-turns".to_owned(), turns.to_string()]);
+        }
+
+        for dir in &options.additional_dirs {
+            args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+        }
+
+        if !self.config.mcp_servers.is_empty() {
+            if let Some(mcp_config) = self.mcp_config_json() {
+                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
+                args.extend(["--mcp-config".to_owned(), mcp_config]);
+            } else {
+                tracing::warn!(
+                    mcp_server_count = self.config.mcp_servers.len(),
+                    "failed to serialize MCP server configuration; skipping --mcp-config"
+                );
+            }
+        }
+
+        args
+    }
+
+    fn mcp_config_json(&self) -> Option<String> {
+        let mcp_servers = self
+            .config
+            .mcp_servers
+            .iter()
+            .map(|server| {
+                let env = server
+                    .env
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect();
+
+                (
+                    server.name.clone(),
+                    McpServerEntry {
+                        command: server.command.clone(),
+                        args: server.args.clone(),
+                        env,
+                    },
+                )
+            })
+            .collect();
+
+        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
+    }
+
+    /// Spawn a subprocess and return a session handle.
+    fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        // INVARIANT: kill_on_drop ensures cleanup if the handle is dropped
+        // without explicit wait/abort.
+        cmd.kill_on_drop(true);
+
+        let mut child = cmd.spawn().map_err(|e| {
+            error::EngineSnafu {
+                detail: format!("failed to spawn claude CLI subprocess: {e}"),
+            }
+            .build()
+        })?;
+
+        let stdout = child.stdout.take().ok_or_else(|| {
+            error::EngineSnafu {
+                detail: "stdout not captured from subprocess",
+            }
+            .build()
+        })?;
+
+        let stream = EventStream::new(stdout);
+        Ok(ProcessSessionHandle::new(child, stream, String::new()))
+    }
+}
+
+// WHY: manual Debug impl rather than `#[derive]` because the config holds an
+// `oauth_token: Option<String>` we must never log. The summary form shows
+// `has_oauth: bool` and `mcp_server_count: usize` instead of the raw values.
+impl std::fmt::Debug for AgentSdkEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentSdkEngine")
+            .field("binary", &self.binary)
+            .field("default_model", &self.config.default_model)
+            .field("skip_permissions", &self.config.skip_permissions)
+            .field("disable_plugins", &self.config.disable_plugins)
+            .field("has_oauth", &self.config.oauth_token.is_some())
+            .field("mcp_server_count", &self.config.mcp_servers.len())
+            .finish()
+    }
+}
+
+
+exec
+/bin/bash -lc "sed -n '260,420p' crates/energeia/src/agent_sdk.rs" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+
+impl DispatchEngine for AgentSdkEngine {
+    fn spawn_session<'a>(
+        &'a self,
+        spec: &'a SessionSpec,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut cmd = Command::new(&self.binary);
+            cmd.args(["-p", &spec.prompt]);
+            cmd.args(self.build_args(options));
+
+            // WHY: cwd is set on the Command, not as a CLI flag.
+            let cwd = spec.cwd.as_ref().or(options.cwd.as_ref());
+            if let Some(dir) = cwd {
+                cmd.current_dir(dir);
+            }
+
+            // When prompt_components is present, the static prefix is already
+            // in system_prompt and the dynamic suffix is already in prompt.
+            if let Some(ref sys) = spec.system_prompt
+                && options.system_prompt.is_none()
+            {
+                cmd.args(["--system-prompt", sys]);
+            }
+
+            // WHY: Inject OAuth token if configured.
+            if let Some(ref token) = self.config.oauth_token {
+                cmd.env("CLAUDE_API_TOKEN", token);
+            }
+
+            tracing::debug!(
+                prompt_len = spec.prompt.len(),
+                model = options
+                    .model
+                    .as_deref()
+                    .unwrap_or(&self.config.default_model),
+                "spawning claude CLI subprocess session"
+            );
+
+            let handle = Self::launch(cmd)?;
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+
+    fn resume_session<'a>(
+        &'a self,
+        session_id: &'a str,
+        prompt: &'a str,
+        options: &'a AgentOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut cmd = Command::new(&self.binary);
+            cmd.args(["--resume", session_id, "-p", prompt]);
+            cmd.args(self.build_args(options));
+
+            // WHY: Inject OAuth token if configured.
+            if let Some(ref token) = self.config.oauth_token {
+                cmd.env("CLAUDE_API_TOKEN", token);
+            }
+
+            tracing::debug!(session_id, "resuming claude CLI session");
+
+            let handle = Self::launch(cmd)?;
+            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+            Ok(boxed)
+        })
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test assertions and helpers"
+)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::engine::AgentOptions;
+
+    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
+        AgentSdkEngine::new(AgentSdkConfig {
+            default_model: "claude-sonnet-4-20250514".to_owned(),
+            skip_permissions: false,
+            disable_plugins: false,
+            oauth_token: None,
+            mcp_servers,
+        })
+        .expect("engine should initialize")
+    }
+
+    #[test]
+    fn build_args_includes_mcp_config() {
+        let mut env = HashMap::new();
+        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
+
+        let engine = test_engine(vec![
+            McpServerConfig {
+                name: "filesystem".to_owned(),
+                command: "npx".to_owned(),
+                args: vec![
+                    "-y".to_owned(),
+                    "@modelcontextprotocol/server-filesystem".to_owned(),
+                    "/Users/me/projects".to_owned(),
+                ],
+                env,
+            },
+            McpServerConfig {
+                name: "docs".to_owned(),
+                command: "python".to_owned(),
+                args: vec!["server.py".to_owned()],
+                env: HashMap::new(),
+            },
+        ]);
+
+        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
+        let mcp_idx = args
+            .iter()
+            .position(|arg| arg == "--mcp-config")
+            .expect("mcp config flag");
+        let config: serde_json::Value =
+            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
+
+        assert_eq!(
+            config,
+            serde_json::json!({
+                "mcpServers": {
+                    "docs": {
+                        "command": "python",
+                        "args": ["server.py"]
+                    },
+                    "filesystem": {
+                        "command": "npx",
+                        "args": [
+                            "-y",
+                            "@modelcontextprotocol/server-filesystem",
+                            "/Users/me/projects"
+                        ],
+                        "env": {
+                            "CACHE_DIR": "/tmp/cache"
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn build_args_omits_mcp_config_when_empty() {
+        let engine = test_engine(Vec::new());
+        let args = engine.build_args(&AgentOptions::new());
+
+        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
+    }
+}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+codex
+I’ve reviewed the patch for logic and shape; the only remaining risk is formatting or a type inference edge. I’m running rustfmt on the touched file, then the targeted energeia tests and a clippy pass for the crate.
+exec
+/bin/bash -lc 'rustfmt crates/energeia/src/agent_sdk.rs' in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+exec
+/bin/bash -lc 'cargo test -p energeia build_args -- --nocapture' in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+exec
+/bin/bash -lc 'cargo clippy -p energeia --all-targets -- -D warnings' in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+codex
+The test and clippy jobs are compiling the crate now. I’m waiting on the first pass to finish so I can address any type or lint fallout immediately rather than guessing.
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+codex
+Compilation is still underway; there’s no failure signal yet. I’m keeping the checks running until both the test filter and clippy either pass or give me a concrete fix target.
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+ succeeded in 189730ms:
+    Blocking waiting for file lock on package cache
+    Blocking waiting for file lock on package cache
+    Blocking waiting for file lock on package cache
+   Compiling proc-macro2 v1.0.106
+   Compiling quote v1.0.45
+   Compiling unicode-ident v1.0.24
+   Compiling libc v0.2.185
+   Compiling memchr v2.8.0
+   Compiling pin-project-lite v0.2.17
+   Compiling cfg-if v1.0.4
+   Compiling itoa v1.0.18
+   Compiling once_cell v1.21.4
+   Compiling bytes v1.11.1
+   Compiling serde_core v1.0.228
+   Compiling futures-core v0.3.32
+   Compiling smallvec v1.15.1
+   Compiling stable_deref_trait v1.2.1
+   Compiling futures-sink v0.3.32
+   Compiling serde v1.0.228
+   Compiling futures-channel v0.3.32
+   Compiling tracing-core v0.1.36
+   Compiling futures-task v0.3.32
+   Compiling futures-io v0.3.32
+   Compiling slab v0.4.12
+   Compiling syn v2.0.117
+   Compiling shlex v1.3.0
+   Compiling errno v0.3.14
+   Compiling signal-hook-registry v1.4.8
+   Compiling mio v1.2.0
+   Compiling socket2 v0.6.3
+   Compiling find-msvc-tools v0.1.9
+   Compiling cc v1.2.59
+   Compiling log v0.4.29
+   Compiling zeroize v1.8.2
+   Compiling zmij v1.0.21
+   Compiling http v1.4.0
+   Compiling writeable v0.6.3
+   Compiling serde_json v1.0.149
+   Compiling litemap v0.8.2
+   Compiling utf8_iter v1.0.4
+   Compiling icu_normalizer_data v2.2.0
+   Compiling equivalent v1.0.2
+   Compiling hashbrown v0.17.0
+   Compiling icu_properties_data v2.2.0
+   Compiling rustls-pki-types v1.14.0
+   Compiling getrandom v0.2.17
+   Compiling http-body v1.0.1
+   Compiling aho-corasick v1.1.4
+   Compiling untrusted v0.9.0
+   Compiling httparse v1.10.1
+   Compiling indexmap v2.14.0
+   Compiling typenum v1.19.0
+   Compiling percent-encoding v2.3.2
+   Compiling synstructure v0.13.2
+   Compiling regex-syntax v0.8.10
+   Compiling fnv v1.0.7
+   Compiling bitflags v2.11.0
+   Compiling tower-service v0.3.3
+   Compiling try-lock v0.2.5
+   Compiling parking_lot_core v0.9.12
+   Compiling rustls v0.23.38
+   Compiling lazy_static v1.5.0
+   Compiling atomic-waker v1.1.2
+   Compiling want v0.3.1
+   Compiling httpdate v1.0.3
+   Compiling regex-automata v0.4.14
+   Compiling scopeguard v1.2.0
+   Compiling cpufeatures v0.3.0
+   Compiling getrandom v0.4.2
+   Compiling subtle v2.6.1
+   Compiling rand_core v0.10.0
+   Compiling heck v0.5.0
+   Compiling rustix v1.1.4
+   Compiling lock_api v0.4.14
+   Compiling hybrid-array v0.4.10
+   Compiling form_urlencoded v1.2.2
+   Compiling jiff v0.2.23
+   Compiling ring v0.17.14
+   Compiling prometheus-client v0.24.1
+   Compiling siphasher v1.0.2
+   Compiling base64 v0.22.1
+   Compiling ryu v1.0.23
+   Compiling linux-raw-sys v0.12.1
+   Compiling ipnet v2.12.0
+   Compiling autocfg v1.5.0
+   Compiling rustls-webpki v0.103.13
+   Compiling num-traits v0.2.19
+   Compiling matchers v0.2.0
+   Compiling regex v1.12.3
+   Compiling phf_shared v0.13.1
+   Compiling parking_lot v0.12.5
+   Compiling chacha20 v0.10.0
+   Compiling sharded-slab v0.1.7
+   Compiling tracing-log v0.2.0
+   Compiling sync_wrapper v1.0.2
+   Compiling thread_local v1.1.9
+   Compiling tower-layer v0.3.3
+   Compiling rustversion v1.0.22
+   Compiling dtoa v1.0.11
+   Compiling fastrand v2.4.1
+   Compiling openssl-probe v0.2.1
+   Compiling nu-ansi-term v0.50.3
+   Compiling rustls-native-certs v0.8.3
+   Compiling phf_generator v0.13.1
+   Compiling rand v0.10.1
+   Compiling block-buffer v0.12.0
+   Compiling crypto-common v0.2.1
+   Compiling http-body-util v0.1.3
+   Compiling iri-string v0.7.12
+   Compiling digest v0.11.2
+   Compiling rustls-platform-verifier v0.6.2
+   Compiling rmp v0.8.15
+   Compiling sha2 v0.11.0
+   Compiling num_cpus v1.17.0
+   Compiling castaway v0.2.4
+   Compiling deadpool-runtime v0.1.4
+   Compiling unsafe-libyaml v0.2.11
+   Compiling zerofrom-derive v0.1.7
+   Compiling tokio-macros v2.7.0
+   Compiling yoke-derive v0.8.2
+   Compiling futures-macro v0.3.32
+   Compiling zerovec-derive v0.11.3
+   Compiling serde_derive v1.0.228
+   Compiling tokio v1.52.1
+   Compiling displaydoc v0.2.5
+   Compiling tracing-attributes v0.1.31
+   Compiling futures-util v0.3.32
+   Compiling snafu-derive v0.8.9
+   Compiling tokio-util v0.7.18
+   Compiling tracing-serde v0.2.0
+   Compiling prometheus-client-derive-encode v0.5.0
+   Compiling zerofrom v0.1.7
+   Compiling futures-executor v0.3.32
+   Compiling yoke v0.8.2
+   Compiling zerovec v0.11.6
+   Compiling zerotrie v0.2.4
+   Compiling tinystr v0.8.3
+   Compiling icu_locale_core v2.2.0
+   Compiling potential_utf v0.1.5
+   Compiling icu_collections v2.2.0
+   Compiling tracing v0.1.44
+   Compiling icu_provider v2.2.0
+   Compiling icu_properties v2.2.0
+   Compiling icu_normalizer v2.2.0
+   Compiling h2 v0.4.13
+   Compiling idna_adapter v1.2.1
+   Compiling idna v1.1.0
+   Compiling tracing-subscriber v0.3.23
+   Compiling tower v0.5.3
+   Compiling url v2.5.8
+   Compiling snafu v0.8.9
+   Compiling hyper v1.9.0
+   Compiling tokio-rustls v0.26.4
+   Compiling tower-http v0.6.8
+   Compiling koina v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/koina)
+   Compiling hyper-util v0.1.20
+   Compiling futures v0.3.32
+   Compiling serde_urlencoded v0.7.1
+   Compiling phf_macros v0.13.1
+   Compiling hyper-rustls v0.27.7
+   Compiling reqwest v0.13.2
+   Compiling static_assertions v1.1.0
+   Compiling winnow v1.0.1
+   Compiling compact_str v0.9.0
+   Compiling hermeneus v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/hermeneus)
+   Compiling aletheia-routing v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/aletheia-routing)
+   Compiling eidos v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/eidos)
+   Compiling rmp-serde v1.3.1
+   Compiling serde_yaml_ng v0.10.0
+   Compiling assert-json-diff v2.0.2
+   Compiling deadpool v0.12.3
+   Compiling tempfile v3.27.0
+   Compiling phf v0.13.1
+   Compiling jiff-cron v0.3.0
+   Compiling wiremock v0.6.5
+   Compiling energeia v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/energeia)
+    Finished `test` profile [optimized + debuginfo] target(s) in 3m 09s
+     Running unittests src/lib.rs (target/debug/deps/energeia-83a33d0ccc62e4b1)
+
+running 5 tests
+test agent_sdk::tests::build_args_omits_mcp_config_when_empty ... ok
+test http::client::tests::build_args_default_model ... ok
+test http::client::tests::build_args_omits_unset_options ... ok
+test agent_sdk::tests::build_args_includes_mcp_config ... ok
+test http::client::tests::build_args_option_overrides ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 510 filtered out; finished in 0.00s
+
+     Running tests/public_api_errors_and_bounds.rs (target/debug/deps/public_api_errors_and_bounds-f0df826bc7d716f0)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 38 filtered out; finished in 0.00s
+
+     Running tests/public_api_types_and_config.rs (target/debug/deps/public_api_types_and_config-1d2cbb8d63ad93c2)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 24 filtered out; finished in 0.00s
+
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+ succeeded in 211399ms:
+    Blocking waiting for file lock on package cache
+    Blocking waiting for file lock on package cache
+    Blocking waiting for file lock on package cache
+    Blocking waiting for file lock on build directory
+    Checking memchr v2.8.0
+    Checking pin-project-lite v0.2.17
+    Checking cfg-if v1.0.4
+    Checking itoa v1.0.18
+    Checking once_cell v1.21.4
+    Checking libc v0.2.185
+    Checking bytes v1.11.1
+    Checking serde_core v1.0.228
+    Checking futures-core v0.3.32
+    Checking zerofrom v0.1.7
+    Checking stable_deref_trait v1.2.1
+    Checking smallvec v1.15.1
+    Checking futures-sink v0.3.32
+    Checking yoke v0.8.2
+    Checking tracing-core v0.1.36
+    Checking futures-channel v0.3.32
+    Checking futures-io v0.3.32
+    Checking slab v0.4.12
+    Checking futures-task v0.3.32
+    Checking zerovec v0.11.6
+    Checking zeroize v1.8.2
+    Checking log v0.4.29
+    Checking futures-util v0.3.32
+    Checking tracing v0.1.44
+    Checking http v1.4.0
+    Checking litemap v0.8.2
+    Checking writeable v0.6.3
+    Checking zmij v1.0.21
+    Checking zerotrie v0.2.4
+    Checking hashbrown v0.17.0
+    Checking utf8_iter v1.0.4
+    Checking errno v0.3.14
+    Checking mio v1.2.0
+    Checking socket2 v0.6.3
+    Checking tinystr v0.8.3
+    Checking signal-hook-registry v1.4.8
+    Checking icu_locale_core v2.2.0
+    Checking potential_utf v0.1.5
+    Checking equivalent v1.0.2
+    Checking icu_collections v2.2.0
+    Checking getrandom v0.2.17
+    Checking indexmap v2.14.0
+    Checking tokio v1.52.1
+    Checking rustls-pki-types v1.14.0
+    Checking http-body v1.0.1
+    Checking aho-corasick v1.1.4
+    Checking percent-encoding v2.3.2
+    Checking regex-syntax v0.8.10
+    Checking untrusted v0.9.0
+    Checking ring v0.17.14
+    Checking icu_normalizer_data v2.2.0
+    Checking icu_properties_data v2.2.0
+    Checking icu_provider v2.2.0
+    Checking tower-service v0.3.3
+    Checking atomic-waker v1.1.2
+    Checking serde v1.0.228
+    Checking serde_json v1.0.149
+    Checking bitflags v2.11.0
+    Checking try-lock v0.2.5
+    Checking lazy_static v1.5.0
+    Checking fnv v1.0.7
+    Checking want v0.3.1
+    Checking icu_properties v2.2.0
+    Checking icu_normalizer v2.2.0
+    Checking typenum v1.19.0
+    Checking httparse v1.10.1
+    Checking cpufeatures v0.3.0
+    Checking subtle v2.6.1
+    Checking httpdate v1.0.3
+    Checking scopeguard v1.2.0
+    Checking rand_core v0.10.0
+    Checking lock_api v0.4.14
+    Checking parking_lot_core v0.9.12
+    Checking jiff v0.2.23
+    Checking rustls-webpki v0.103.13
+    Checking form_urlencoded v1.2.2
+    Checking base64 v0.22.1
+    Checking linux-raw-sys v0.12.1
+    Checking hybrid-array v0.4.10
+    Checking regex-automata v0.4.14
+    Checking ipnet v2.12.0
+    Checking ryu v1.0.23
+    Checking idna_adapter v1.2.1
+    Checking rustls v0.23.38
+    Checking idna v1.1.0
+    Checking rustix v1.1.4
+    Checking parking_lot v0.12.5
+    Checking getrandom v0.4.2
+    Checking chacha20 v0.10.0
+    Checking snafu v0.8.9
+    Checking tracing-serde v0.2.0
+    Checking sharded-slab v0.1.7
+    Checking tracing-log v0.2.0
+    Checking sync_wrapper v1.0.2
+    Checking thread_local v1.1.9
+    Checking tower-layer v0.3.3
+    Checking dtoa v1.0.11
+    Checking openssl-probe v0.2.1
+    Checking nu-ansi-term v0.50.3
+    Checking rustls-native-certs v0.8.3
+    Checking prometheus-client v0.24.1
+    Checking rand v0.10.1
+    Checking url v2.5.8
+    Checking crypto-common v0.2.1
+    Checking block-buffer v0.12.0
+    Checking futures-executor v0.3.32
+    Checking http-body-util v0.1.3
+    Checking iri-string v0.7.12
+    Checking siphasher v1.0.2
+    Checking phf_shared v0.13.1
+    Checking futures v0.3.32
+    Checking digest v0.11.2
+    Checking num-traits v0.2.19
+    Checking tokio-util v0.7.18
+    Checking tower v0.5.3
+    Checking regex v1.12.3
+    Checking matchers v0.2.0
+    Checking serde_urlencoded v0.7.1
+    Checking tracing-subscriber v0.3.23
+    Checking rmp v0.8.15
+    Checking h2 v0.4.13
+    Checking phf v0.13.1
+    Checking castaway v0.2.4
+    Checking sha2 v0.11.0
+    Checking num_cpus v1.17.0
+    Checking winnow v1.0.1
+    Checking static_assertions v1.1.0
+    Checking unsafe-libyaml v0.2.11
+    Checking deadpool-runtime v0.1.4
+    Checking deadpool v0.12.3
+    Checking tower-http v0.6.8
+    Checking compact_str v0.9.0
+    Checking rmp-serde v1.3.1
+    Checking aletheia-routing v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/aletheia-routing)
+    Checking assert-json-diff v2.0.2
+    Checking serde_yaml_ng v0.10.0
+    Checking jiff-cron v0.3.0
+    Checking fastrand v2.4.1
+    Checking koina v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/koina)
+    Checking tokio-rustls v0.26.4
+    Checking rustls-platform-verifier v0.6.2
+    Checking tempfile v3.27.0
+    Checking eidos v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/eidos)
+    Checking hyper v1.9.0
+    Checking hyper-util v0.1.20
+    Checking hyper-rustls v0.27.7
+    Checking wiremock v0.6.5
+    Checking reqwest v0.13.2
+    Checking hermeneus v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/hermeneus)
+    Checking energeia v0.30.0 (/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/energeia)
+    Finished `dev` profile [optimized + debuginfo] target(s) in 3m 31s
+
+codex
+The code and checks are green. I’m grabbing the final line numbers now so I can give you a precise change summary with the affected file references and no extra noise.
+exec
+/bin/bash -lc 'git diff -- crates/energeia/src/agent_sdk.rs' in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b7456..286118c54 100644
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@ pub struct McpServerConfig {
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@ impl AgentSdkEngine {
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@ impl DispatchEngine for AgentSdkEngine {
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+exec
+/bin/bash -lc "nl -ba crates/energeia/src/agent_sdk.rs | sed -n '1,260p'" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+     1	//! Experimental Claude CLI subprocess engine with OAuth token injection.
+     2	//!
+     3	//! WHY: This engine uses the `claude` CLI transport while preserving the
+     4	//! dispatch-engine boundary for future native SDK integration. It is not a
+     5	//! native HTTP/SSE Agent SDK client yet.
+     6	
+     7	use std::collections::{BTreeMap, HashMap};
+     8	use std::future::Future;
+     9	use std::pin::Pin;
+    10	use std::process::Stdio;
+    11	
+    12	use serde::Serialize;
+    13	use tokio::process::Command;
+    14	
+    15	use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+    16	use crate::error::{self, Result};
+    17	use crate::http::session::ProcessSessionHandle;
+    18	use crate::http::stream::EventStream;
+    19	
+    20	/// Configuration for the experimental Claude CLI bridge.
+    21	#[derive(Clone)]
+    22	pub struct AgentSdkConfig {
+    23	    /// Default model identifier (e.g., "claude-opus-4", "claude-sonnet-4").
+    24	    pub default_model: String,
+    25	    /// Skip permission checks during dispatch.
+    26	    pub skip_permissions: bool,
+    27	    /// Disable MCP plugin loading.
+    28	    pub disable_plugins: bool,
+    29	    /// Optional `OAuth` token for API authentication.
+    30	    pub oauth_token: Option<String>,
+    31	    /// Optional MCP server configurations.
+    32	    pub mcp_servers: Vec<McpServerConfig>,
+    33	}
+    34	
+    35	impl Default for AgentSdkConfig {
+    36	    fn default() -> Self {
+    37	        Self {
+    38	            default_model: "claude-sonnet-4".to_string(),
+    39	            skip_permissions: false,
+    40	            disable_plugins: false,
+    41	            oauth_token: None,
+    42	            mcp_servers: Vec::new(),
+    43	        }
+    44	    }
+    45	}
+    46	
+    47	impl std::fmt::Debug for AgentSdkConfig {
+    48	    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    49	        f.debug_struct("AgentSdkConfig")
+    50	            .field("default_model", &self.default_model)
+    51	            .field("skip_permissions", &self.skip_permissions)
+    52	            .field("disable_plugins", &self.disable_plugins)
+    53	            .field("has_oauth", &self.oauth_token.is_some())
+    54	            .field("mcp_server_count", &self.mcp_servers.len())
+    55	            .finish()
+    56	    }
+    57	}
+    58	
+    59	/// MCP server configuration.
+    60	#[derive(Debug, Clone)]
+    61	pub struct McpServerConfig {
+    62	    /// Server name/identifier.
+    63	    pub name: String,
+    64	    /// Server command to execute.
+    65	    pub command: String,
+    66	    /// Arguments for the server command.
+    67	    pub args: Vec<String>,
+    68	    /// Environment variables.
+    69	    pub env: HashMap<String, String>,
+    70	}
+    71	
+    72	#[derive(Debug, Serialize)]
+    73	struct McpConfigFile {
+    74	    #[serde(rename = "mcpServers")]
+    75	    mcp_servers: BTreeMap<String, McpServerEntry>,
+    76	}
+    77	
+    78	#[derive(Debug, Serialize)]
+    79	struct McpServerEntry {
+    80	    command: String,
+    81	    #[serde(skip_serializing_if = "Vec::is_empty")]
+    82	    args: Vec<String>,
+    83	    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    84	    env: BTreeMap<String, String>,
+    85	}
+    86	
+    87	/// Experimental Claude CLI dispatch engine.
+    88	///
+    89	/// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+    90	/// permissions, and MCP configuration fields while the native SDK path remains
+    91	/// unwired. The public type name is kept for compatibility with existing
+    92	/// configuration code, but the current transport is a `claude` CLI subprocess,
+    93	/// not a native Agent SDK client.
+    94	pub struct AgentSdkEngine {
+    95	    config: AgentSdkConfig,
+    96	    binary: String,
+    97	}
+    98	
+    99	impl AgentSdkEngine {
+   100	    /// Create a new experimental Claude CLI bridge with the given configuration.
+   101	    ///
+   102	    /// # Errors
+   103	    ///
+   104	    /// Returns an error if the engine cannot be initialized.
+   105	    ///
+   106	    /// Current validation is intentionally narrow: only the default model ID is
+   107	    /// checked here. `OAuth` token validation, MCP plugin wiring, permission
+   108	    /// enforcement, and native SDK availability checks remain future work.
+   109	    pub fn new(config: AgentSdkConfig) -> Result<Self> {
+   110	        // WHY: Verify the model identifier is valid during construction.
+   111	        if config.default_model.is_empty() {
+   112	            return error::InvalidModelSnafu {
+   113	                model: "(empty)".to_string(),
+   114	            }
+   115	            .fail();
+   116	        }
+   117	
+   118	        // Future-work: validate OAuth token, init MCP plugin system, set up
+   119	        // permission system, and replace the CLI subprocess with a native SDK
+   120	        // transport when that integration exists.
+   121	        Ok(Self {
+   122	            config,
+   123	            binary: "claude".to_owned(),
+   124	        })
+   125	    }
+   126	
+   127	    /// Get the configured default model.
+   128	    #[must_use]
+   129	    pub fn default_model(&self) -> &str {
+   130	        &self.config.default_model
+   131	    }
+   132	
+   133	    /// Check if permissions are enabled.
+   134	    #[must_use]
+   135	    pub fn permissions_enabled(&self) -> bool {
+   136	        !self.config.skip_permissions
+   137	    }
+   138	
+   139	    /// Check if plugins are enabled.
+   140	    #[must_use]
+   141	    pub fn plugins_enabled(&self) -> bool {
+   142	        !self.config.disable_plugins
+   143	    }
+   144	
+   145	    /// Build the CLI argument vector for a session.
+   146	    fn build_args(&self, options: &AgentOptions) -> Vec<String> {
+   147	        let mut args = Vec::new();
+   148	
+   149	        args.extend(["--output-format".to_owned(), "stream-json".to_owned()]);
+   150	        args.push("--verbose".to_owned());
+   151	
+   152	        let model = options
+   153	            .model
+   154	            .as_deref()
+   155	            .unwrap_or(&self.config.default_model);
+   156	        args.extend(["--model".to_owned(), model.to_owned()]);
+   157	
+   158	        // WHY: Apply permission mode based on config (if not skipped).
+   159	        if !self.config.skip_permissions
+   160	            && let Some(ref mode) = options.permission_mode
+   161	        {
+   162	            args.extend(["--permission-mode".to_owned(), mode.clone()]);
+   163	        }
+   164	
+   165	        if let Some(ref prompt) = options.system_prompt {
+   166	            args.extend(["--system-prompt".to_owned(), prompt.clone()]);
+   167	        }
+   168	
+   169	        if let Some(turns) = options.max_turns {
+   170	            args.extend(["--max-turns".to_owned(), turns.to_string()]);
+   171	        }
+   172	
+   173	        for dir in &options.additional_dirs {
+   174	            args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+   175	        }
+   176	
+   177	        if !self.config.mcp_servers.is_empty() {
+   178	            if let Some(mcp_config) = self.mcp_config_json() {
+   179	                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
+   180	                args.extend(["--mcp-config".to_owned(), mcp_config]);
+   181	            } else {
+   182	                tracing::warn!(
+   183	                    mcp_server_count = self.config.mcp_servers.len(),
+   184	                    "failed to serialize MCP server configuration; skipping --mcp-config"
+   185	                );
+   186	            }
+   187	        }
+   188	
+   189	        args
+   190	    }
+   191	
+   192	    fn mcp_config_json(&self) -> Option<String> {
+   193	        let mcp_servers = self
+   194	            .config
+   195	            .mcp_servers
+   196	            .iter()
+   197	            .map(|server| {
+   198	                let env = server
+   199	                    .env
+   200	                    .iter()
+   201	                    .map(|(key, value)| (key.clone(), value.clone()))
+   202	                    .collect();
+   203	
+   204	                (
+   205	                    server.name.clone(),
+   206	                    McpServerEntry {
+   207	                        command: server.command.clone(),
+   208	                        args: server.args.clone(),
+   209	                        env,
+   210	                    },
+   211	                )
+   212	            })
+   213	            .collect();
+   214	
+   215	        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
+   216	    }
+   217	
+   218	    /// Spawn a subprocess and return a session handle.
+   219	    fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+   220	        cmd.stdout(Stdio::piped());
+   221	        cmd.stderr(Stdio::piped());
+   222	        // INVARIANT: kill_on_drop ensures cleanup if the handle is dropped
+   223	        // without explicit wait/abort.
+   224	        cmd.kill_on_drop(true);
+   225	
+   226	        let mut child = cmd.spawn().map_err(|e| {
+   227	            error::EngineSnafu {
+   228	                detail: format!("failed to spawn claude CLI subprocess: {e}"),
+   229	            }
+   230	            .build()
+   231	        })?;
+   232	
+   233	        let stdout = child.stdout.take().ok_or_else(|| {
+   234	            error::EngineSnafu {
+   235	                detail: "stdout not captured from subprocess",
+   236	            }
+   237	            .build()
+   238	        })?;
+   239	
+   240	        let stream = EventStream::new(stdout);
+   241	        Ok(ProcessSessionHandle::new(child, stream, String::new()))
+   242	    }
+   243	}
+   244	
+   245	// WHY: manual Debug impl rather than `#[derive]` because the config holds an
+   246	// `oauth_token: Option<String>` we must never log. The summary form shows
+   247	// `has_oauth: bool` and `mcp_server_count: usize` instead of the raw values.
+   248	impl std::fmt::Debug for AgentSdkEngine {
+   249	    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+   250	        f.debug_struct("AgentSdkEngine")
+   251	            .field("binary", &self.binary)
+   252	            .field("default_model", &self.config.default_model)
+   253	            .field("skip_permissions", &self.config.skip_permissions)
+   254	            .field("disable_plugins", &self.config.disable_plugins)
+   255	            .field("has_oauth", &self.config.oauth_token.is_some())
+   256	            .field("mcp_server_count", &self.config.mcp_servers.len())
+   257	            .finish()
+   258	    }
+   259	}
+   260	
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+exec
+/bin/bash -lc "nl -ba crates/energeia/src/agent_sdk.rs | sed -n '260,420p'" in /home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk
+ succeeded in 0ms:
+   260	
+   261	impl DispatchEngine for AgentSdkEngine {
+   262	    fn spawn_session<'a>(
+   263	        &'a self,
+   264	        spec: &'a SessionSpec,
+   265	        options: &'a AgentOptions,
+   266	    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+   267	        Box::pin(async move {
+   268	            let mut cmd = Command::new(&self.binary);
+   269	            cmd.args(["-p", &spec.prompt]);
+   270	            cmd.args(self.build_args(options));
+   271	
+   272	            // WHY: cwd is set on the Command, not as a CLI flag.
+   273	            let cwd = spec.cwd.as_ref().or(options.cwd.as_ref());
+   274	            if let Some(dir) = cwd {
+   275	                cmd.current_dir(dir);
+   276	            }
+   277	
+   278	            // When prompt_components is present, the static prefix is already
+   279	            // in system_prompt and the dynamic suffix is already in prompt.
+   280	            if let Some(ref sys) = spec.system_prompt
+   281	                && options.system_prompt.is_none()
+   282	            {
+   283	                cmd.args(["--system-prompt", sys]);
+   284	            }
+   285	
+   286	            // WHY: Inject OAuth token if configured.
+   287	            if let Some(ref token) = self.config.oauth_token {
+   288	                cmd.env("CLAUDE_API_TOKEN", token);
+   289	            }
+   290	
+   291	            tracing::debug!(
+   292	                prompt_len = spec.prompt.len(),
+   293	                model = options
+   294	                    .model
+   295	                    .as_deref()
+   296	                    .unwrap_or(&self.config.default_model),
+   297	                "spawning claude CLI subprocess session"
+   298	            );
+   299	
+   300	            let handle = Self::launch(cmd)?;
+   301	            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+   302	            Ok(boxed)
+   303	        })
+   304	    }
+   305	
+   306	    fn resume_session<'a>(
+   307	        &'a self,
+   308	        session_id: &'a str,
+   309	        prompt: &'a str,
+   310	        options: &'a AgentOptions,
+   311	    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn SessionHandle>>> + Send + 'a>> {
+   312	        Box::pin(async move {
+   313	            let mut cmd = Command::new(&self.binary);
+   314	            cmd.args(["--resume", session_id, "-p", prompt]);
+   315	            cmd.args(self.build_args(options));
+   316	
+   317	            // WHY: Inject OAuth token if configured.
+   318	            if let Some(ref token) = self.config.oauth_token {
+   319	                cmd.env("CLAUDE_API_TOKEN", token);
+   320	            }
+   321	
+   322	            tracing::debug!(session_id, "resuming claude CLI session");
+   323	
+   324	            let handle = Self::launch(cmd)?;
+   325	            let boxed: Box<dyn SessionHandle> = Box::new(handle);
+   326	            Ok(boxed)
+   327	        })
+   328	    }
+   329	}
+   330	
+   331	#[cfg(test)]
+   332	#[expect(
+   333	    clippy::expect_used,
+   334	    clippy::indexing_slicing,
+   335	    reason = "test assertions and helpers"
+   336	)]
+   337	mod tests {
+   338	    use std::collections::HashMap;
+   339	
+   340	    use super::*;
+   341	    use crate::engine::AgentOptions;
+   342	
+   343	    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
+   344	        AgentSdkEngine::new(AgentSdkConfig {
+   345	            default_model: "claude-sonnet-4-20250514".to_owned(),
+   346	            skip_permissions: false,
+   347	            disable_plugins: false,
+   348	            oauth_token: None,
+   349	            mcp_servers,
+   350	        })
+   351	        .expect("engine should initialize")
+   352	    }
+   353	
+   354	    #[test]
+   355	    fn build_args_includes_mcp_config() {
+   356	        let mut env = HashMap::new();
+   357	        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
+   358	
+   359	        let engine = test_engine(vec![
+   360	            McpServerConfig {
+   361	                name: "filesystem".to_owned(),
+   362	                command: "npx".to_owned(),
+   363	                args: vec![
+   364	                    "-y".to_owned(),
+   365	                    "@modelcontextprotocol/server-filesystem".to_owned(),
+   366	                    "/Users/me/projects".to_owned(),
+   367	                ],
+   368	                env,
+   369	            },
+   370	            McpServerConfig {
+   371	                name: "docs".to_owned(),
+   372	                command: "python".to_owned(),
+   373	                args: vec!["server.py".to_owned()],
+   374	                env: HashMap::new(),
+   375	            },
+   376	        ]);
+   377	
+   378	        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
+   379	        let mcp_idx = args
+   380	            .iter()
+   381	            .position(|arg| arg == "--mcp-config")
+   382	            .expect("mcp config flag");
+   383	        let config: serde_json::Value =
+   384	            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
+   385	
+   386	        assert_eq!(
+   387	            config,
+   388	            serde_json::json!({
+   389	                "mcpServers": {
+   390	                    "docs": {
+   391	                        "command": "python",
+   392	                        "args": ["server.py"]
+   393	                    },
+   394	                    "filesystem": {
+   395	                        "command": "npx",
+   396	                        "args": [
+   397	                            "-y",
+   398	                            "@modelcontextprotocol/server-filesystem",
+   399	                            "/Users/me/projects"
+   400	                        ],
+   401	                        "env": {
+   402	                            "CACHE_DIR": "/tmp/cache"
+   403	                        }
+   404	                    }
+   405	                }
+   406	            })
+   407	        );
+   408	    }
+   409	
+   410	    #[test]
+   411	    fn build_args_omits_mcp_config_when_empty() {
+   412	        let engine = test_engine(Vec::new());
+   413	        let args = engine.build_args(&AgentOptions::new());
+   414	
+   415	        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
+   416	    }
+   417	}
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+codex
+Wired `AgentSdkConfig.mcp_servers` into `AgentSdkEngine::build_args()` by serializing the configured servers into a Claude CLI `--mcp-config` JSON payload, and it now omits the flag when the list is empty.
+
+Changed in [crates/energeia/src/agent_sdk.rs](/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/energeia/src/agent_sdk.rs#L72):
+- Added a small serializer for Claude’s `mcpServers` config shape.
+- Appended `--mcp-config <json>` in `build_args()` when MCP servers are present.
+- Added unit tests covering:
+  - populated MCP config is included and serializes both servers
+  - empty MCP config omits the flag
+
+Verification:
+- `cargo test -p energeia build_args -- --nocapture`
+- `cargo clippy -p energeia --all-targets -- -D warnings`
+
+
+diff --git a/crates/energeia/src/agent_sdk.rs b/crates/energeia/src/agent_sdk.rs
+index cf22b745601f8912dcc709f77750488a487bac45..286118c54a4e3cf13344173a32eaae533ba5f8dd
+--- a/crates/energeia/src/agent_sdk.rs
++++ b/crates/energeia/src/agent_sdk.rs
+@@ -4,11 +4,12 @@
+ //! dispatch-engine boundary for future native SDK integration. It is not a
+ //! native HTTP/SSE Agent SDK client yet.
+ 
+-use std::collections::HashMap;
++use std::collections::{BTreeMap, HashMap};
+ use std::future::Future;
+ use std::pin::Pin;
+ use std::process::Stdio;
+ 
++use serde::Serialize;
+ use tokio::process::Command;
+ 
+ use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
+@@ -68,6 +69,21 @@
+     pub env: HashMap<String, String>,
+ }
+ 
++#[derive(Debug, Serialize)]
++struct McpConfigFile {
++    #[serde(rename = "mcpServers")]
++    mcp_servers: BTreeMap<String, McpServerEntry>,
++}
++
++#[derive(Debug, Serialize)]
++struct McpServerEntry {
++    command: String,
++    #[serde(skip_serializing_if = "Vec::is_empty")]
++    args: Vec<String>,
++    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
++    env: BTreeMap<String, String>,
++}
++
+ /// Experimental Claude CLI dispatch engine.
+ ///
+ /// WHY: Provides CLI subprocess integration with `OAuth` token injection,
+@@ -158,9 +174,47 @@
+             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
+         }
+ 
++        if !self.config.mcp_servers.is_empty() {
++            if let Some(mcp_config) = self.mcp_config_json() {
++                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
++                args.extend(["--mcp-config".to_owned(), mcp_config]);
++            } else {
++                tracing::warn!(
++                    mcp_server_count = self.config.mcp_servers.len(),
++                    "failed to serialize MCP server configuration; skipping --mcp-config"
++                );
++            }
++        }
++
+         args
+     }
+ 
++    fn mcp_config_json(&self) -> Option<String> {
++        let mcp_servers = self
++            .config
++            .mcp_servers
++            .iter()
++            .map(|server| {
++                let env = server
++                    .env
++                    .iter()
++                    .map(|(key, value)| (key.clone(), value.clone()))
++                    .collect();
++
++                (
++                    server.name.clone(),
++                    McpServerEntry {
++                        command: server.command.clone(),
++                        args: server.args.clone(),
++                        env,
++                    },
++                )
++            })
++            .collect();
++
++        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
++    }
++
+     /// Spawn a subprocess and return a session handle.
+     fn launch(mut cmd: Command) -> Result<ProcessSessionHandle> {
+         cmd.stdout(Stdio::piped());
+@@ -273,3 +327,91 @@
+         })
+     }
+ }
++
++#[cfg(test)]
++#[expect(
++    clippy::expect_used,
++    clippy::indexing_slicing,
++    reason = "test assertions and helpers"
++)]
++mod tests {
++    use std::collections::HashMap;
++
++    use super::*;
++    use crate::engine::AgentOptions;
++
++    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
++        AgentSdkEngine::new(AgentSdkConfig {
++            default_model: "claude-sonnet-4-20250514".to_owned(),
++            skip_permissions: false,
++            disable_plugins: false,
++            oauth_token: None,
++            mcp_servers,
++        })
++        .expect("engine should initialize")
++    }
++
++    #[test]
++    fn build_args_includes_mcp_config() {
++        let mut env = HashMap::new();
++        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
++
++        let engine = test_engine(vec![
++            McpServerConfig {
++                name: "filesystem".to_owned(),
++                command: "npx".to_owned(),
++                args: vec![
++                    "-y".to_owned(),
++                    "@modelcontextprotocol/server-filesystem".to_owned(),
++                    "/Users/me/projects".to_owned(),
++                ],
++                env,
++            },
++            McpServerConfig {
++                name: "docs".to_owned(),
++                command: "python".to_owned(),
++                args: vec!["server.py".to_owned()],
++                env: HashMap::new(),
++            },
++        ]);
++
++        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
++        let mcp_idx = args
++            .iter()
++            .position(|arg| arg == "--mcp-config")
++            .expect("mcp config flag");
++        let config: serde_json::Value =
++            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
++
++        assert_eq!(
++            config,
++            serde_json::json!({
++                "mcpServers": {
++                    "docs": {
++                        "command": "python",
++                        "args": ["server.py"]
++                    },
++                    "filesystem": {
++                        "command": "npx",
++                        "args": [
++                            "-y",
++                            "@modelcontextprotocol/server-filesystem",
++                            "/Users/me/projects"
++                        ],
++                        "env": {
++                            "CACHE_DIR": "/tmp/cache"
++                        }
++                    }
++                }
++            })
++        );
++    }
++
++    #[test]
++    fn build_args_omits_mcp_config_when_empty() {
++        let engine = test_engine(Vec::new());
++        let args = engine.build_args(&AgentOptions::new());
++
++        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
++    }
++}
+
+tokens used
+147,539
+Wired `AgentSdkConfig.mcp_servers` into `AgentSdkEngine::build_args()` by serializing the configured servers into a Claude CLI `--mcp-config` JSON payload, and it now omits the flag when the list is empty.
+
+Changed in [crates/energeia/src/agent_sdk.rs](/home/ck/metis-ops/cargo-target/dispatch-worktrees/wire-agentsdk/crates/energeia/src/agent_sdk.rs#L72):
+- Added a small serializer for Claude’s `mcpServers` config shape.
+- Appended `--mcp-config <json>` in `build_args()` when MCP servers are present.
+- Added unit tests covering:
+  - populated MCP config is included and serializes both servers
+  - empty MCP config omits the flag
+
+Verification:
+- `cargo test -p energeia build_args -- --nocapture`
+- `cargo clippy -p energeia --all-targets -- -D warnings`
+
+

--- a/crates/energeia/src/agent_sdk.rs
+++ b/crates/energeia/src/agent_sdk.rs
@@ -4,11 +4,12 @@
 //! dispatch-engine boundary for future native SDK integration. It is not a
 //! native HTTP/SSE Agent SDK client yet.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::pin::Pin;
 use std::process::Stdio;
 
+use serde::Serialize;
 use tokio::process::Command;
 
 use crate::engine::{AgentOptions, DispatchEngine, SessionHandle, SessionSpec};
@@ -66,6 +67,21 @@ pub struct McpServerConfig {
     pub args: Vec<String>,
     /// Environment variables.
     pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+struct McpConfigFile {
+    #[serde(rename = "mcpServers")]
+    mcp_servers: BTreeMap<String, McpServerEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct McpServerEntry {
+    command: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    args: Vec<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    env: BTreeMap<String, String>,
 }
 
 /// Experimental Claude CLI dispatch engine.
@@ -158,7 +174,45 @@ impl AgentSdkEngine {
             args.extend(["--add-dir".to_owned(), dir.to_string_lossy().into_owned()]);
         }
 
+        if !self.config.mcp_servers.is_empty() {
+            if let Some(mcp_config) = self.mcp_config_json() {
+                // WHY: Claude CLI loads MCP servers from a session-local JSON config string.
+                args.extend(["--mcp-config".to_owned(), mcp_config]);
+            } else {
+                tracing::warn!(
+                    mcp_server_count = self.config.mcp_servers.len(),
+                    "failed to serialize MCP server configuration; skipping --mcp-config"
+                );
+            }
+        }
+
         args
+    }
+
+    fn mcp_config_json(&self) -> Option<String> {
+        let mcp_servers = self
+            .config
+            .mcp_servers
+            .iter()
+            .map(|server| {
+                let env = server
+                    .env
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect();
+
+                (
+                    server.name.clone(),
+                    McpServerEntry {
+                        command: server.command.clone(),
+                        args: server.args.clone(),
+                        env,
+                    },
+                )
+            })
+            .collect();
+
+        serde_json::to_string(&McpConfigFile { mcp_servers }).ok()
     }
 
     /// Spawn a subprocess and return a session handle.
@@ -271,5 +325,93 @@ impl DispatchEngine for AgentSdkEngine {
             let boxed: Box<dyn SessionHandle> = Box::new(handle);
             Ok(boxed)
         })
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test assertions and helpers"
+)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::engine::AgentOptions;
+
+    fn test_engine(mcp_servers: Vec<McpServerConfig>) -> AgentSdkEngine {
+        AgentSdkEngine::new(AgentSdkConfig {
+            default_model: "claude-sonnet-4-20250514".to_owned(),
+            skip_permissions: false,
+            disable_plugins: false,
+            oauth_token: None,
+            mcp_servers,
+        })
+        .expect("engine should initialize")
+    }
+
+    #[test]
+    fn build_args_includes_mcp_config() {
+        let mut env = HashMap::new();
+        env.insert("CACHE_DIR".to_owned(), "/tmp/cache".to_owned());
+
+        let engine = test_engine(vec![
+            McpServerConfig {
+                name: "filesystem".to_owned(),
+                command: "npx".to_owned(),
+                args: vec![
+                    "-y".to_owned(),
+                    "@modelcontextprotocol/server-filesystem".to_owned(),
+                    "/Users/me/projects".to_owned(),
+                ],
+                env,
+            },
+            McpServerConfig {
+                name: "docs".to_owned(),
+                command: "python".to_owned(),
+                args: vec!["server.py".to_owned()],
+                env: HashMap::new(),
+            },
+        ]);
+
+        let args = engine.build_args(&AgentOptions::new().model("claude-opus-4-20250514"));
+        let mcp_idx = args
+            .iter()
+            .position(|arg| arg == "--mcp-config")
+            .expect("mcp config flag");
+        let config: serde_json::Value =
+            serde_json::from_str(&args[mcp_idx + 1]).expect("parse mcp config");
+
+        assert_eq!(
+            config,
+            serde_json::json!({
+                "mcpServers": {
+                    "docs": {
+                        "command": "python",
+                        "args": ["server.py"]
+                    },
+                    "filesystem": {
+                        "command": "npx",
+                        "args": [
+                            "-y",
+                            "@modelcontextprotocol/server-filesystem",
+                            "/Users/me/projects"
+                        ],
+                        "env": {
+                            "CACHE_DIR": "/tmp/cache"
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn build_args_omits_mcp_config_when_empty() {
+        let engine = test_engine(Vec::new());
+        let args = engine.build_args(&AgentOptions::new());
+
+        assert!(!args.iter().any(|arg| arg == "--mcp-config"));
     }
 }


### PR DESCRIPTION
AgentSdkEngine populated `mcp_servers` but `build_args()` never passed them — configured MCP servers were silently dropped for AgentSdk (Claude-CLI) dispatches. Serialize into Claude's `mcpServers` JSON shape + append `--mcp-config`; warn-and-skip on serialization failure. Unit tests cover populated (both servers) + empty (flag omitted). Verified locally: clippy -p energeia clean, nextest -p energeia green.