### PR TITLE
ci(release): scope GITHUB_TOKEN permissions to job level (S7028)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,6 @@ on:
   push:
     tags: ["v*"]
 
-permissions:
-  attestations: write
-  contents: write
-  id-token: write
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
@@ -17,6 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -45,6 +42,8 @@ jobs:
     # enables them locally. See standards/RUST.md "Feature Flags" section.
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -89,6 +88,10 @@ jobs:
 
   build:
     needs: [test]
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -273,6 +276,8 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
Follow-up to #4344 (auto-merged before this hardening landed).

#4344's `release.yml` grants `attestations`/`contents`/`id-token: write` at the workflow level (every job). SonarCloud S7028 flags this; scope each job to least privilege:
- `test`, `feature-check`: `contents: read`
- `build`: `contents` + `attestations` + `id-token: write` (release upload + provenance/SBOM attestation)
- `sbom`: `contents: write` (release upload only)

No behavioural change at tag time. `release.yml` runs only on `push: tags: v*`, so it has no PR-CI coverage — permissions mapped by inspection against each job's steps.