### PR TITLE
feat(nous,episteme): wire surprise + evidence-coverage recall factors

### DIFF
--- a/crates/aletheia/src/runtime/nous_config.rs
+++ b/crates/aletheia/src/runtime/nous_config.rs
@@ -89,7 +89,7 @@ pub(super) fn build_nous_runtime_config(
 
     let workspace = resolve_config_path(oikos, &resolved.workspace);
     let project_id = detect_project_id(&workspace);
-    let nous_config = NousConfig {
+    let mut nous_config = NousConfig {
         id: resolved.id,
         name: resolved.name,
         generation: nous::config::NousGenerationConfig {
@@ -136,6 +136,15 @@ pub(super) fn build_nous_runtime_config(
         hooks: nous::config::HookConfig::default(),
         behavior: resolved.behavior,
     };
+    // WHY: thread the knowledge-config surprise/evidence recall knobs into the
+    // recall engine. The From<RecallSettings> conversion cannot carry these —
+    // they live on KnowledgeConfig, not RecallSettings — so they are applied
+    // here where the global config is in scope. Defaults keep recall inert.
+    nous_config.recall.surprise_weight = config.knowledge.recall_surprise_weight;
+    nous_config.recall.evidence_coverage_weight = config.knowledge.recall_evidence_coverage_weight;
+    nous_config.recall.surprise_threshold = config.knowledge.surprise_threshold;
+    nous_config.recall.surprise_ema_alpha = config.knowledge.surprise_ema_alpha;
+
     let mut extraction_cfg = mneme::extract::ExtractionConfig::default();
     if let Some(model) = nous_config.generation.extraction_model.as_deref() {
         model.clone_into(&mut extraction_cfg.model);

--- a/crates/episteme/src/recall/mod.rs
+++ b/crates/episteme/src/recall/mod.rs
@@ -1,4 +1,4 @@
-//! Recall engine: 6-factor scoring for knowledge retrieval.
+//! Recall engine: 9-factor scoring for knowledge retrieval.
 //!
 //! Combines multiple signals to rank recall results:
 //!
@@ -8,9 +8,13 @@
 //! 4. **Epistemic tier**: verified > inferred > assumed
 //! 5. **Relationship proximity**: graph distance from query context entities
 //! 6. **Access frequency**: memories accessed more often are more salient
+//! 7. **Graph importance**: `PageRank` hub entities rank higher
+//! 8. **Surprise**: Bayesian topic-shift signal (`EM-LLM`); default weight 0.0
+//! 9. **Evidence coverage**: `MemR3` gap-answering boost; default weight 0.0
 //!
 //! Each factor produces a score in [0.0, 1.0]. The final score is a weighted
-//! combination, configurable per-nous via oikos cascade.
+//! combination, configurable per-nous via oikos cascade. Factors 8 and 9 are
+//! inert unless their weight is set positive in knowledge config.
 
 use std::collections::HashSet;
 use std::hash::BuildHasher;
@@ -81,7 +85,7 @@ impl RecallWeights {
     ///
     /// # Complexity
     ///
-    /// O(1) - constant time sum of 7 fields.
+    /// O(1) - constant time sum of 9 fields.
     #[must_use]
     #[instrument(skip(self))]
     pub(crate) fn total(&self) -> f64 {
@@ -488,7 +492,7 @@ impl RecallEngine {
     ///
     /// # Complexity
     ///
-    /// O(1) - constant time weighted sum of 7 factors.
+    /// O(1) - constant time weighted sum of 9 factors.
     #[instrument(skip(self, factors))]
     #[must_use]
     pub(crate) fn compute_score(&self, factors: &FactorScores) -> f64 {
@@ -513,7 +517,7 @@ impl RecallEngine {
 
     /// Pre-filter candidates via side-query selection, then score and rank.
     ///
-    /// WHY: runs `pre_filter_by_side_query` before 6-factor scoring so the
+    /// WHY: runs `pre_filter_by_side_query` before factor scoring so the
     /// expensive `compute_score` loop operates on a narrower candidate set.
     /// When `selected_ids` is empty, all candidates pass through unfiltered.
     ///
@@ -654,10 +658,10 @@ impl RecallEngine {
     /// score using a sigmoid mapping so that high-surprise candidates rank
     /// higher when `RecallWeights::surprise > 0`.
     ///
-    /// `surprise_nats = 0.0` → score 0.5 (neutral, mid-range boost).
-    /// High values approach 1.0; the neutral midpoint is configurable via
-    /// `midpoint_nats` (pass `DEFAULT_THRESHOLD` from `crate::surprise` for
-    /// the standard 2.0-nat boundary).
+    /// `surprise_nats = midpoint_nats` → score 0.5 (neutral); values below the
+    /// midpoint score toward 0.0 and above toward 1.0. At the default 2.0-nat
+    /// midpoint, zero-divergence content scores ≈0.12 (`sigmoid(-2)`). Pass
+    /// `DEFAULT_THRESHOLD` from `crate::surprise` for the standard boundary.
     ///
     /// Returns 0.0 when `RecallWeights::surprise` is effectively zero so
     /// callers can skip the `SurpriseCalculator` entirely in the common case.
@@ -770,7 +774,7 @@ pub(crate) fn refresh_stability_hours(fact_type: &str, tier: &str, access_count:
 /// Pre-filter recall candidates using side-query selections.
 ///
 /// Retains only candidates whose `source_id` appears in `selected_ids`.
-/// Designed to run between vector search retrieval and 6-factor scoring
+/// Designed to run between vector search retrieval and factor scoring
 /// to reduce the candidate set before the more expensive scoring runs.
 ///
 /// # Arguments

--- a/crates/episteme/src/surprise.rs
+++ b/crates/episteme/src/surprise.rs
@@ -139,6 +139,30 @@ impl SurpriseCalculator {
         surprise
     }
 
+    /// Compute the Bayesian surprise of `text` against the current prior
+    /// WITHOUT advancing the running distribution.
+    ///
+    /// Unlike [`compute_surprise`](Self::compute_surprise), this is a read-only
+    /// probe: the EMA prior is left untouched. It is the variant recall scoring
+    /// needs — every candidate in a turn is scored against the same fixed
+    /// session prior, so per-candidate calls must not mutate (and thereby
+    /// corrupt) the running distribution.
+    ///
+    /// Returns the KL divergence `D_KL(observed || prior)` in nats, or 0.0 for
+    /// empty text or an empty prior (no distribution to diverge from yet).
+    ///
+    /// # Complexity
+    ///
+    /// O(n) where n = `text.len()`.
+    #[must_use]
+    pub fn surprise_of(&self, text: &str) -> f64 {
+        let observed = bigram_frequencies(text);
+        if observed.is_empty() || self.prior.is_empty() {
+            return 0.0;
+        }
+        kl_divergence(&observed, &self.prior)
+    }
+
     /// Update the running prior via exponential moving average.
     fn update_prior(&mut self, observed: &HashMap<[u8; NGRAM_SIZE], f64>) {
         let retain = 1.0 - self.ema_alpha;
@@ -409,6 +433,53 @@ mod tests {
         assert!(
             previous < first * 0.5,
             "adapted surprise {previous} should be < 50% of initial {first}"
+        );
+    }
+
+    /// `surprise_of` must return 0.0 on an empty prior and must NOT advance it.
+    #[test]
+    fn surprise_of_is_non_mutating() {
+        let mut calc = SurpriseCalculator::new();
+
+        // Empty prior -> 0.0, and probing must not bootstrap the prior.
+        assert_eq!(calc.surprise_of("the weather is sunny"), 0.0);
+
+        // Establish a prior around cooking.
+        for _ in 0..5 {
+            calc.compute_surprise("chop the onions and garlic then saute in olive oil");
+        }
+
+        // Probing the same divergent text repeatedly must yield the same score
+        // every time, because the prior never moves. (Tolerance absorbs the
+        // tiny float-summation noise from HashMap iteration order.)
+        let probe = "the schwarzschild radius is proportional to mass";
+        let first = calc.surprise_of(probe);
+        let second = calc.surprise_of(probe);
+        assert!(first > 0.0, "divergent text should be surprising: {first}");
+        assert!(
+            (first - second).abs() < 1e-9,
+            "surprise_of must be stable across calls (no EMA update): {first} vs {second}"
+        );
+
+        // Contrast: compute_surprise DOES advance the prior, so repeated calls
+        // on the same divergent probe drift downward as the prior adapts.
+        let mut mutating_calc = calc.clone();
+        let m1 = mutating_calc.compute_surprise(probe);
+        let m2 = mutating_calc.compute_surprise(probe);
+        // The first mutating call equals surprise_of (same prior, KL component).
+        assert!(
+            (m1 - first).abs() < 1e-9,
+            "compute_surprise's KL must match surprise_of on the same prior: {m1} vs {first}"
+        );
+        // The second mutating call is strictly lower — proof the prior moved.
+        assert!(
+            m2 < m1,
+            "compute_surprise must adapt the prior (m2 {m2} < m1 {m1})"
+        );
+        // surprise_of on the original is unchanged — proof it never mutated.
+        assert!(
+            (calc.surprise_of(probe) - first).abs() < 1e-9,
+            "surprise_of must leave the original prior untouched"
         );
     }
 

--- a/crates/mneme/src/lib.rs
+++ b/crates/mneme/src/lib.rs
@@ -352,6 +352,27 @@ pub mod recall {
     }
 }
 
+/// Bayesian-surprise calculator (`EM-LLM`) for topic-shift detection.
+///
+/// # Facade surface
+///
+/// [`SurpriseCalculator`](surprise::SurpriseCalculator) — the session-scoped
+/// running-distribution scorer threaded into recall surprise scoring.
+pub mod surprise {
+    pub use episteme::surprise::{DEFAULT_EMA_ALPHA, DEFAULT_THRESHOLD, SurpriseCalculator};
+}
+
+/// Evidence-gap tracking (`MemR3`) for iterative retrieval.
+///
+/// # Facade surface
+///
+/// [`EvidenceGapTracker`](evidence_gap::EvidenceGapTracker),
+/// [`EvidenceQuery`](evidence_gap::EvidenceQuery),
+/// [`AnsweredQuestion`](evidence_gap::AnsweredQuestion)
+pub mod evidence_gap {
+    pub use episteme::evidence_gap::{AnsweredQuestion, EvidenceGapTracker, EvidenceQuery};
+}
+
 /// Side-query memory relevance selector.
 pub mod side_query {
     pub use episteme::side_query::{

--- a/crates/nous/src/actor/turn.rs
+++ b/crates/nous/src/actor/turn.rs
@@ -515,6 +515,15 @@ impl NousActor {
 
         session.next_turn();
 
+        // WHY: surprise is episodic — advance the running session prior with
+        // this turn's content here, on the authoritative SessionState, so the
+        // EMA persists across turns. The pipeline below scores candidates
+        // read-only against the clone (mutations inside the spawned task are
+        // discarded). Skipped entirely when surprise scoring is inert.
+        if self.config.recall.surprise_weight > f64::EPSILON {
+            session.surprise_calculator.compute_surprise(content);
+        }
+
         // Persist session to store BEFORE spawning the pipeline task.
         if let Some(ref store) = self.stores.session_store {
             let guard = store.lock().await;

--- a/crates/nous/src/pipeline/mod.rs
+++ b/crates/nous/src/pipeline/mod.rs
@@ -1017,6 +1017,12 @@ pub(crate) async fn run_pipeline(
                 text_search,
                 providers,
                 emitter,
+                // WHY: pass the session surprise prior (already advanced by this
+                // turn, actor-side) for read-only per-candidate scoring. None
+                // when surprise scoring is inert, so no clone cost in the common
+                // case.
+                (config.recall.surprise_weight > f64::EPSILON)
+                    .then(|| input.session.surprise_calculator.clone()),
             ),
         )
         .await?;

--- a/crates/nous/src/pipeline/stages.rs
+++ b/crates/nous/src/pipeline/stages.rs
@@ -178,6 +178,7 @@ pub(super) async fn run_recall_stage(
     text_search: Option<&dyn crate::recall::TextSearch>,
     providers: &ProviderRegistry,
     emitter: &EventEmitter,
+    surprise_calc: Option<mneme::surprise::SurpriseCalculator>,
 ) -> error::Result<()> {
     // WHY (#3404, #3413): resolve the active provider's deployment target
     // so the sovereignty filter in `finalize_results` can drop facts whose
@@ -223,7 +224,8 @@ pub(super) async fn run_recall_stage(
             );
             let recall_stage = crate::recall::RecallStage::new(config.recall.clone())
                 .with_deployment_target(deployment_target)
-                .with_project_scope(project_recall_scope(pipeline_config));
+                .with_project_scope(project_recall_scope(pipeline_config))
+                .with_surprise_calculator(surprise_calc.clone());
             let result = recall_stage.run_bm25(content, &config.id, ts, budget);
             apply_recall_result(result, ctx, &span, config.recall.late_inject_anchor);
         } else {
@@ -237,7 +239,8 @@ pub(super) async fn run_recall_stage(
     } else if let (Some(ep), Some(vs)) = (embedding_provider, vector_search) {
         let recall_stage = crate::recall::RecallStage::new(config.recall.clone())
             .with_deployment_target(deployment_target)
-            .with_project_scope(project_recall_scope(pipeline_config));
+            .with_project_scope(project_recall_scope(pipeline_config))
+            .with_surprise_calculator(surprise_calc);
         let recall_bridge = ProviderRecallBridge {
             providers,
             model: &config.generation.model,

--- a/crates/nous/src/recall/mod.rs
+++ b/crates/nous/src/recall/mod.rs
@@ -15,6 +15,7 @@ use hermeneus::provider::DeploymentTarget;
 use mneme::embedding::EmbeddingProvider;
 use mneme::knowledge::{FactSensitivity, RecallResult as KnowledgeRecallResult};
 use mneme::recall::{FactorScores, RecallEngine, ScoredResult};
+use mneme::surprise::SurpriseCalculator;
 
 use crate::error;
 
@@ -29,7 +30,7 @@ pub use search::VectorSearch;
 
 #[cfg(test)]
 use reranking::is_stopword;
-use reranking::{detect_gaps, discover_terminology};
+use reranking::{build_evidence_map, detect_gaps, discover_terminology};
 #[cfg(feature = "knowledge-store")]
 use search::vector_search_tiered;
 use search::{embed, vector_search};
@@ -119,6 +120,14 @@ pub struct RecallStage {
     project_scope: mneme::recall::ProjectRecallScope,
     /// Optional URL for an HTTP cross-encoder reranker.
     reranker_url: Option<String>,
+    /// Session-scoped surprise scorer snapshot for the current turn.
+    ///
+    /// Present only when `surprise_weight > 0`: a clone of the session's
+    /// running `SurpriseCalculator` whose prior was advanced (actor-side) by
+    /// the current turn before the pipeline spawned. Used read-only in
+    /// `build_candidates` to score each candidate's topic-shift surprise
+    /// against the frozen session prior. `None` leaves `surprise` inert.
+    surprise_calculator: Option<SurpriseCalculator>,
 }
 
 impl RecallStage {
@@ -130,7 +139,8 @@ impl RecallStage {
     /// source of truth rather than mirroring the struct in taxis.
     #[must_use]
     pub fn new(config: RecallConfig) -> Self {
-        let engine = Self::engine_with_reranker_url(config.reranker_url.as_deref());
+        let engine =
+            Self::engine_with_reranker_url(config.reranker_url.as_deref(), Self::engine_weights(&config));
 
         let pinned_facts: HashSet<String> = config
             .pinned_facts
@@ -154,7 +164,34 @@ impl RecallStage {
             scope_quotas,
             project_scope: mneme::recall::ProjectRecallScope::Global,
             reranker_url,
+            surprise_calculator: None,
         }
+    }
+
+    /// Build the episteme recall-engine weights for `config`.
+    ///
+    /// WHY: the seven base factors keep their episteme defaults (the single
+    /// source of truth) so existing scoring math is unchanged; only the two
+    /// speculative weights — surprise and evidence-coverage — are threaded from
+    /// the knowledge config. Both default 0.0, so recall is inert until an
+    /// operator enables them.
+    fn engine_weights(config: &RecallConfig) -> mneme::recall::RecallWeights {
+        mneme::recall::RecallWeights {
+            surprise: config.surprise_weight,
+            evidence_coverage: config.evidence_coverage_weight,
+            ..mneme::recall::RecallWeights::default()
+        }
+    }
+
+    /// Attach the session-scoped surprise calculator for the current turn.
+    ///
+    /// Pass `Some(calc)` only when `surprise_weight > 0`; the calculator's prior
+    /// must already reflect the current turn (advanced actor-side before the
+    /// pipeline spawned). `None` leaves surprise scoring inert.
+    #[must_use]
+    pub fn with_surprise_calculator(mut self, calc: Option<SurpriseCalculator>) -> Self {
+        self.surprise_calculator = calc;
+        self
     }
 
     /// Set side-query selected IDs for pre-filtering before 6-factor scoring.
@@ -214,14 +251,14 @@ impl RecallStage {
     /// Set the URL for an HTTP cross-encoder reranker.
     #[must_use]
     pub fn with_reranker_url(mut self, url: Option<String>) -> Self {
-        self.engine = Self::engine_with_reranker_url(url.as_deref());
+        self.engine = Self::engine_with_reranker_url(url.as_deref(), Self::engine_weights(&self.config));
         self.reranker_url = url;
         self
     }
 
     #[cfg(feature = "reranker")]
-    fn engine_with_reranker_url(url: Option<&str>) -> RecallEngine {
-        let engine = RecallEngine::with_weights(mneme::recall::RecallWeights::default());
+    fn engine_with_reranker_url(url: Option<&str>, weights: mneme::recall::RecallWeights) -> RecallEngine {
+        let engine = RecallEngine::with_weights(weights);
         // WHY: Wire reranker only when the episteme reranker feature is present.
         // A configured URL uses the HTTP cross-encoder; otherwise NaiveReranker
         // preserves an in-process fallback for feature-enabled deployments.
@@ -237,8 +274,8 @@ impl RecallStage {
     }
 
     #[cfg(not(feature = "reranker"))]
-    fn engine_with_reranker_url(_url: Option<&str>) -> RecallEngine {
-        RecallEngine::with_weights(mneme::recall::RecallWeights::default())
+    fn engine_with_reranker_url(_url: Option<&str>, weights: mneme::recall::RecallWeights) -> RecallEngine {
+        RecallEngine::with_weights(weights)
     }
 
     /// Rank candidates, applying side-query pre-filter when configured.
@@ -291,7 +328,7 @@ impl RecallStage {
             return Ok(RecallStageResult::empty());
         }
 
-        let candidates = self.build_candidates(raw, nous_id);
+        let candidates = self.build_candidates(raw, nous_id, None);
         let ranked = self.rank_candidates(candidates);
         Ok(self.finalize_results(ranked, remaining_budget, nous_id))
     }
@@ -413,7 +450,7 @@ impl RecallStage {
         }
 
         let side_ids = side_ranker.and_then(|ranker| self.side_query_ids(query, &raw, ranker));
-        let candidates = self.build_candidates(raw, nous_id);
+        let candidates = self.build_candidates(raw, nous_id, None);
         let ranked = self.rank_candidates_with_side_ids(
             candidates,
             self.side_query_ids.as_ref().or(side_ids.as_ref()),
@@ -454,7 +491,7 @@ impl RecallStage {
             return Ok(RecallStageResult::empty());
         }
 
-        let candidates_c1 = self.build_candidates(raw_cycle1.clone(), nous_id);
+        let candidates_c1 = self.build_candidates(raw_cycle1.clone(), nous_id, None);
         let side_ids_c1 =
             side_ranker.and_then(|ranker| self.side_query_ids(query, &raw_cycle1, ranker));
         let ranked_c1 = self.rank_candidates_with_side_ids(candidates_c1, side_ids_c1.as_ref());
@@ -505,7 +542,22 @@ impl RecallStage {
             "merged results from 2 cycles"
         );
 
-        let candidates = self.build_candidates(merged, nous_id);
+        // WHY: when evidence-coverage scoring is enabled, decompose the query
+        // into gaps and credit every merged fact (from either cycle) that
+        // answers one; the map boosts gap-answering facts in the final ranking.
+        // Skipped entirely (inert) when the weight is zero.
+        let answered_ids: Option<HashMap<String, f64>> = (self.config.evidence_coverage_weight
+            > f64::EPSILON)
+            .then(|| {
+                build_evidence_map(
+                    query,
+                    merged
+                        .iter()
+                        .map(|r| (r.content.as_str(), r.source_id.as_str())),
+                )
+            });
+
+        let candidates = self.build_candidates(merged, nous_id, answered_ids.as_ref());
         let ranked = self.rank_candidates(candidates);
         Ok(self.finalize_results(ranked, remaining_budget, nous_id))
     }
@@ -739,17 +791,16 @@ impl RecallStage {
         &self,
         raw: Vec<KnowledgeRecallResult>,
         _nous_id: &str,
+        answered_ids: Option<&HashMap<String, f64>>,
     ) -> Vec<ScoredResult> {
         let w = &self.config.weights;
         raw.into_iter()
             .map(|r| ScoredResult {
-                content: r.content,
-                source_type: r.source_type,
-                source_id: r.source_id,
-                // WHY (#208): propagate the stored fact's owning nous so
-                // `filter_by_cohort_visibility` can compare it against the
-                // recalling nous in `finalize_results`.
-                nous_id: r.nous_id,
+                // WHY: surprise scores the candidate's content against the
+                // frozen session topic prior; evidence-coverage looks up the
+                // candidate's `source_id` in the answered-gap map. Both stay
+                // 0.0 unless their engine weight is enabled (the scorers
+                // short-circuit), so default recall is unchanged.
                 factors: FactorScores {
                     vector_similarity: self.engine.score_vector_similarity(r.distance),
                     decay: w.decay,
@@ -757,12 +808,17 @@ impl RecallStage {
                     epistemic_tier: w.epistemic_tier,
                     relationship_proximity: w.relationship_proximity,
                     access_frequency: w.access_frequency,
-                    // WHY: nous recall does not compute the episteme-recall
-                    // speculative signals; they stay inert (0.0) here.
-                    surprise: 0.0,
-                    evidence_coverage: 0.0,
+                    surprise: self.score_candidate_surprise(&r.content),
+                    evidence_coverage: self.score_candidate_evidence(&r.source_id, answered_ids),
                     graph_importance: self.engine.score_graph_importance(r.graph_importance),
                 },
+                content: r.content,
+                source_type: r.source_type,
+                source_id: r.source_id,
+                // WHY (#208): propagate the stored fact's owning nous so
+                // `filter_by_cohort_visibility` can compare it against the
+                // recalling nous in `finalize_results`.
+                nous_id: r.nous_id,
                 score: 0.0,
                 // WHY (#3404, #3413): propagate sensitivity from the search
                 // layer so the sovereignty filter in `finalize_results` sees
@@ -773,6 +829,35 @@ impl RecallStage {
                 visibility: r.visibility,
             })
             .collect()
+    }
+
+    /// Score a candidate's topic-shift surprise against the session prior.
+    ///
+    /// Returns 0.0 when no calculator is attached (surprise weight unset) — the
+    /// engine `score_surprise` also short-circuits on a zero weight, so this is
+    /// inert by default.
+    fn score_candidate_surprise(&self, content: &str) -> f64 {
+        match &self.surprise_calculator {
+            Some(calc) => self
+                .engine
+                .score_surprise(calc.surprise_of(content), self.config.surprise_threshold),
+            None => 0.0,
+        }
+    }
+
+    /// Score a candidate's evidence coverage from the answered-gap map.
+    ///
+    /// Returns 0.0 when no answered map is supplied (non-iterative paths) — the
+    /// engine `score_evidence_coverage` also short-circuits on a zero weight.
+    fn score_candidate_evidence(
+        &self,
+        source_id: &str,
+        answered_ids: Option<&HashMap<String, f64>>,
+    ) -> f64 {
+        match answered_ids {
+            Some(ids) => self.engine.score_evidence_coverage(source_id, ids),
+            None => 0.0,
+        }
     }
 
     /// Filter candidates by minimum score and take top results.

--- a/crates/nous/src/recall/mod.rs
+++ b/crates/nous/src/recall/mod.rs
@@ -97,10 +97,10 @@ struct SensitivityFilterResult {
 pub struct RecallStage {
     engine: RecallEngine,
     config: RecallConfig,
-    /// Optional side-query selected IDs for pre-filtering before 6-factor scoring.
+    /// Optional side-query selected IDs for pre-filtering before factor scoring.
     side_query_ids: Option<HashSet<String>>,
     /// Production side-query selector used to turn the raw recall manifest into
-    /// a prefilter for 6-factor scoring.
+    /// a prefilter for factor scoring.
     side_query_selector: mneme::side_query::SideQuerySelector,
     /// Data-sovereignty target: gates which facts may leave the instance
     /// through this recall pass (#3404, #3413). Defaults to
@@ -139,8 +139,10 @@ impl RecallStage {
     /// source of truth rather than mirroring the struct in taxis.
     #[must_use]
     pub fn new(config: RecallConfig) -> Self {
-        let engine =
-            Self::engine_with_reranker_url(config.reranker_url.as_deref(), Self::engine_weights(&config));
+        let engine = Self::engine_with_reranker_url(
+            config.reranker_url.as_deref(),
+            Self::engine_weights(&config),
+        );
 
         let pinned_facts: HashSet<String> = config
             .pinned_facts
@@ -194,11 +196,11 @@ impl RecallStage {
         self
     }
 
-    /// Set side-query selected IDs for pre-filtering before 6-factor scoring.
+    /// Set side-query selected IDs for pre-filtering before factor scoring.
     ///
     /// // WHY: Side-queries (e.g., from tool results or explicit references) can
     /// // identify relevant knowledge IDs directly, bypassing vector search.
-    /// // Pre-filtering avoids expensive 6-factor scoring on irrelevant candidates.
+    /// // Pre-filtering avoids expensive factor scoring on irrelevant candidates.
     #[must_use]
     pub fn with_side_query_ids(mut self, ids: HashSet<String>) -> Self {
         self.side_query_ids = Some(ids);
@@ -251,13 +253,17 @@ impl RecallStage {
     /// Set the URL for an HTTP cross-encoder reranker.
     #[must_use]
     pub fn with_reranker_url(mut self, url: Option<String>) -> Self {
-        self.engine = Self::engine_with_reranker_url(url.as_deref(), Self::engine_weights(&self.config));
+        self.engine =
+            Self::engine_with_reranker_url(url.as_deref(), Self::engine_weights(&self.config));
         self.reranker_url = url;
         self
     }
 
     #[cfg(feature = "reranker")]
-    fn engine_with_reranker_url(url: Option<&str>, weights: mneme::recall::RecallWeights) -> RecallEngine {
+    fn engine_with_reranker_url(
+        url: Option<&str>,
+        weights: mneme::recall::RecallWeights,
+    ) -> RecallEngine {
         let engine = RecallEngine::with_weights(weights);
         // WHY: Wire reranker only when the episteme reranker feature is present.
         // A configured URL uses the HTTP cross-encoder; otherwise NaiveReranker
@@ -274,7 +280,10 @@ impl RecallStage {
     }
 
     #[cfg(not(feature = "reranker"))]
-    fn engine_with_reranker_url(_url: Option<&str>, weights: mneme::recall::RecallWeights) -> RecallEngine {
+    fn engine_with_reranker_url(
+        _url: Option<&str>,
+        weights: mneme::recall::RecallWeights,
+    ) -> RecallEngine {
         RecallEngine::with_weights(weights)
     }
 
@@ -546,9 +555,8 @@ impl RecallStage {
         // into gaps and credit every merged fact (from either cycle) that
         // answers one; the map boosts gap-answering facts in the final ranking.
         // Skipped entirely (inert) when the weight is zero.
-        let answered_ids: Option<HashMap<String, f64>> = (self.config.evidence_coverage_weight
-            > f64::EPSILON)
-            .then(|| {
+        let answered_ids: Option<HashMap<String, f64>> =
+            (self.config.evidence_coverage_weight > f64::EPSILON).then(|| {
                 build_evidence_map(
                     query,
                     merged

--- a/crates/nous/src/recall/reranking.rs
+++ b/crates/nous/src/recall/reranking.rs
@@ -11,6 +11,86 @@ pub(super) fn is_stopword(word: &str) -> bool {
     aletheia_lexica::stopwords::ENGLISH_STOPWORDS.contains(&word)
 }
 
+/// Minimum fraction of a sub-question's content words a candidate must contain
+/// to count as evidence answering that gap.
+pub(super) const EVIDENCE_MATCH_THRESHOLD: f64 = 0.5;
+
+/// Tokenize text into lowercased alphanumeric content words.
+///
+/// Matches [`discover_terminology`]'s filter: trims non-alphanumerics, keeps
+/// words longer than three characters that are not stopwords.
+fn content_tokens(text: &str) -> Vec<String> {
+    text.split_whitespace()
+        .map(|w| {
+            w.trim_matches(|c: char| !c.is_alphanumeric())
+                .to_lowercase()
+        })
+        .filter(|w| w.len() > 3 && !is_stopword(w))
+        .collect()
+}
+
+/// Build the answered-evidence map for iterative (`MemR3`) retrieval.
+///
+/// Decomposes `query` into sub-questions via [`EvidenceGapTracker`], records
+/// every `(content, source_id)` candidate whose content lexically covers a
+/// sub-question's content words at or above [`EVIDENCE_MATCH_THRESHOLD`] as
+/// evidence (confidence = coverage ratio), then flattens the tracker's answered
+/// set into a `source_id -> confidence` map for
+/// [`RecallEngine::score_evidence_coverage`](mneme::recall::RecallEngine::score_evidence_coverage).
+///
+/// Built from the merged candidate set so gap-answering facts surfaced in
+/// either retrieval cycle are credited.
+///
+/// WHY: the heuristic decomposition + lexical coverage match the no-LLM design
+/// of `EvidenceGapTracker` itself, so the same query produces a stable gap map
+/// without an extra model round-trip.
+pub(super) fn build_evidence_map<'a, I>(query: &str, candidates: I) -> HashMap<String, f64>
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    let mut tracker = mneme::evidence_gap::EvidenceGapTracker::new(query);
+    let sub_questions: Vec<String> = tracker.query().sub_questions.clone();
+
+    // Pre-tokenize candidates once (token set + source_id) to avoid re-tokenizing
+    // per sub-question.
+    let tokenized: Vec<(HashSet<String>, &str)> = candidates
+        .into_iter()
+        .map(|(content, source_id)| (content_tokens(content).into_iter().collect(), source_id))
+        .collect();
+
+    for (idx, sub_q) in sub_questions.iter().enumerate() {
+        let sq_tokens = content_tokens(sub_q);
+        let sq_set: HashSet<&str> = sq_tokens.iter().map(String::as_str).collect();
+        // WHY: a sub-question carrying fewer than two content words is too vague
+        // to match meaningfully — any candidate mentioning that single word would
+        // clear the coverage threshold and falsely answer the gap. Require at
+        // least two content words before recording evidence.
+        if sq_set.len() < 2 {
+            continue;
+        }
+        let total = u32::try_from(sq_set.len()).unwrap_or(u32::MAX);
+
+        for (cand_tokens, source_id) in &tokenized {
+            let hits = u32::try_from(sq_set.iter().filter(|t| cand_tokens.contains(**t)).count())
+                .unwrap_or(u32::MAX);
+            let coverage = f64::from(hits) / f64::from(total);
+            if coverage >= EVIDENCE_MATCH_THRESHOLD {
+                tracker.record_evidence(idx, source_id, coverage);
+            }
+        }
+    }
+
+    let mut map: HashMap<String, f64> = HashMap::new();
+    for aq in &tracker.query().answered {
+        for id in &aq.evidence_ids {
+            map.entry(id.clone())
+                .and_modify(|c| *c = c.max(aq.confidence))
+                .or_insert(aq.confidence);
+        }
+    }
+    map
+}
+
 /// Extract domain-specific terms from first-pass results not present in the original query.
 ///
 /// Splits result content on whitespace, filters stopwords and short words,
@@ -105,4 +185,98 @@ fn extract_quoted_strings(text: &str) -> Vec<String> {
         .filter(|(i, part)| i % 2 == 1 && !part.is_empty() && part.len() < 100)
         .map(|(_, part)| (*part).to_owned())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scored(content: &str, source_id: &str) -> ScoredResult {
+        ScoredResult {
+            content: content.to_owned(),
+            source_type: "fact".to_owned(),
+            source_id: source_id.to_owned(),
+            nous_id: "syn".to_owned(),
+            factors: mneme::recall::FactorScores::default(),
+            score: 0.0,
+            sensitivity: mneme::knowledge::FactSensitivity::Public,
+            visibility: mneme::knowledge::Visibility::Private,
+            scope: None,
+            project_id: None,
+        }
+    }
+
+    #[test]
+    fn evidence_map_credits_gap_answering_facts() {
+        // A compound query decomposes into two sub-questions on " and ".
+        let query =
+            "what is the capital of France and what is the population of France";
+        let ranked = [
+            scored(
+                "The capital of France is Paris, a major European city.",
+                "fact-capital",
+            ),
+            scored(
+                "The population of France is roughly 68 million people.",
+                "fact-population",
+            ),
+            scored("Bananas are an excellent source of potassium.", "fact-banana"),
+        ];
+
+        let map = build_evidence_map(
+            query,
+            ranked.iter().map(|s| (s.content.as_str(), s.source_id.as_str())),
+        );
+
+        assert!(
+            map.contains_key("fact-capital"),
+            "capital fact should answer a gap: {map:?}"
+        );
+        assert!(
+            map.contains_key("fact-population"),
+            "population fact should answer a gap: {map:?}"
+        );
+        assert!(
+            !map.contains_key("fact-banana"),
+            "unrelated fact must not be credited: {map:?}"
+        );
+        for confidence in map.values() {
+            assert!(
+                *confidence > 0.0 && *confidence <= 1.0,
+                "confidence {confidence} should be in (0, 1]"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_map_empty_without_lexical_overlap() {
+        let ranked = [scored("The weather today is sunny and mild.", "fact-weather")];
+        let map = build_evidence_map(
+            "quantum chromodynamics lattice gauge theory",
+            ranked.iter().map(|s| (s.content.as_str(), s.source_id.as_str())),
+        );
+        assert!(
+            map.is_empty(),
+            "no lexical overlap should yield no evidence: {map:?}"
+        );
+    }
+
+    #[test]
+    fn evidence_map_skips_single_token_subquestions() {
+        // A query that decomposes to one content word ("population") must not
+        // credit a candidate merely mentioning that word — a single-token gap is
+        // too vague to count as answered.
+        let ranked = [scored(
+            "The population census was conducted across the region in 2020",
+            "fact-census",
+        )];
+        let map = build_evidence_map(
+            "population",
+            ranked.iter().map(|s| (s.content.as_str(), s.source_id.as_str())),
+        );
+        assert!(
+            map.is_empty(),
+            "single-content-word sub-question must not credit tangential facts: {map:?}"
+        );
+    }
 }

--- a/crates/nous/src/recall/reranking.rs
+++ b/crates/nous/src/recall/reranking.rs
@@ -209,8 +209,7 @@ mod tests {
     #[test]
     fn evidence_map_credits_gap_answering_facts() {
         // A compound query decomposes into two sub-questions on " and ".
-        let query =
-            "what is the capital of France and what is the population of France";
+        let query = "what is the capital of France and what is the population of France";
         let ranked = [
             scored(
                 "The capital of France is Paris, a major European city.",
@@ -220,12 +219,17 @@ mod tests {
                 "The population of France is roughly 68 million people.",
                 "fact-population",
             ),
-            scored("Bananas are an excellent source of potassium.", "fact-banana"),
+            scored(
+                "Bananas are an excellent source of potassium.",
+                "fact-banana",
+            ),
         ];
 
         let map = build_evidence_map(
             query,
-            ranked.iter().map(|s| (s.content.as_str(), s.source_id.as_str())),
+            ranked
+                .iter()
+                .map(|s| (s.content.as_str(), s.source_id.as_str())),
         );
 
         assert!(
@@ -250,10 +254,15 @@ mod tests {
 
     #[test]
     fn evidence_map_empty_without_lexical_overlap() {
-        let ranked = [scored("The weather today is sunny and mild.", "fact-weather")];
+        let ranked = [scored(
+            "The weather today is sunny and mild.",
+            "fact-weather",
+        )];
         let map = build_evidence_map(
             "quantum chromodynamics lattice gauge theory",
-            ranked.iter().map(|s| (s.content.as_str(), s.source_id.as_str())),
+            ranked
+                .iter()
+                .map(|s| (s.content.as_str(), s.source_id.as_str())),
         );
         assert!(
             map.is_empty(),
@@ -272,7 +281,9 @@ mod tests {
         )];
         let map = build_evidence_map(
             "population",
-            ranked.iter().map(|s| (s.content.as_str(), s.source_id.as_str())),
+            ranked
+                .iter()
+                .map(|s| (s.content.as_str(), s.source_id.as_str())),
         );
         assert!(
             map.is_empty(),

--- a/crates/nous/src/recall/scoring.rs
+++ b/crates/nous/src/recall/scoring.rs
@@ -67,6 +67,35 @@ pub struct RecallConfig {
     /// Per-factor scoring weights applied when building candidates.
     #[serde(default)]
     pub weights: RecallWeights,
+    /// Recall-engine weight for the Bayesian-surprise factor. Default 0.0 (inert).
+    ///
+    /// Sourced from `knowledge.recall_surprise_weight`; threaded into
+    /// [`mneme::recall::RecallWeights::surprise`] at engine construction so a
+    /// non-zero value blends the session `SurpriseCalculator` signal into recall
+    /// scoring.
+    #[serde(default)]
+    pub surprise_weight: f64,
+    /// Recall-engine weight for the evidence-coverage factor. Default 0.0 (inert).
+    ///
+    /// Sourced from `knowledge.recall_evidence_coverage_weight`; threaded into
+    /// [`mneme::recall::RecallWeights::evidence_coverage`] at engine construction
+    /// so a non-zero value boosts candidates that answer an evidence gap in the
+    /// iterative-retrieval path.
+    #[serde(default)]
+    pub evidence_coverage_weight: f64,
+    /// Sigmoid midpoint (in nats) for surprise scoring. Default 2.0.
+    ///
+    /// Sourced from `knowledge.surprise_threshold`; passed to
+    /// [`mneme::recall::RecallEngine::score_surprise`] as the neutral boundary
+    /// above which a candidate counts as a topic shift.
+    #[serde(default = "default_surprise_threshold")]
+    pub surprise_threshold: f64,
+    /// EMA decay factor for the session `SurpriseCalculator`. Default 0.3.
+    ///
+    /// Sourced from `knowledge.surprise_ema_alpha`; controls how fast the
+    /// running topic distribution forgets older turns.
+    #[serde(default = "default_surprise_ema_alpha")]
+    pub surprise_ema_alpha: f64,
     /// Inject factor metadata into recalled knowledge prompts.
     ///
     /// When enabled, each recalled fact includes its factor scores so the
@@ -101,6 +130,16 @@ pub(super) fn default_chars_per_token() -> u64 {
     4
 }
 
+fn default_surprise_threshold() -> f64 {
+    // WHY: single source of truth — the episteme surprise default, so the
+    // assembly override and this From-path default cannot drift.
+    mneme::surprise::DEFAULT_THRESHOLD
+}
+
+fn default_surprise_ema_alpha() -> f64 {
+    mneme::surprise::DEFAULT_EMA_ALPHA
+}
+
 impl Default for RecallConfig {
     fn default() -> Self {
         Self {
@@ -111,6 +150,10 @@ impl Default for RecallConfig {
             iterative: false,
             max_cycles: 2,
             weights: RecallWeights::default(),
+            surprise_weight: 0.0,
+            evidence_coverage_weight: 0.0,
+            surprise_threshold: default_surprise_threshold(),
+            surprise_ema_alpha: default_surprise_ema_alpha(),
             inject_metadata: false,
             pinned_facts: Vec::new(),
             late_inject_anchor: false,
@@ -139,6 +182,15 @@ impl From<taxis::config::RecallSettings> for RecallConfig {
                 access_frequency: s.weights.access_frequency,
                 graph_importance: s.weights.graph_importance,
             },
+            // NOTE: the surprise/evidence engine weights + tunables are not
+            //       carried by RecallSettings; they are sourced from the
+            //       knowledge behavior config at NousConfig assembly (see
+            //       aletheia::runtime::nous_config). Default here keeps them
+            //       inert when that override is absent (tests, direct From use).
+            surprise_weight: 0.0,
+            evidence_coverage_weight: 0.0,
+            surprise_threshold: default_surprise_threshold(),
+            surprise_ema_alpha: default_surprise_ema_alpha(),
             inject_metadata: s.inject_metadata,
             pinned_facts: s.pinned_facts,
             late_inject_anchor: s.late_inject_anchor,

--- a/crates/nous/src/recall_tests/mod.rs
+++ b/crates/nous/src/recall_tests/mod.rs
@@ -137,4 +137,5 @@ fn make_scored(content: &str, score: f64) -> ScoredResult {
 #[cfg(feature = "knowledge-store")]
 mod knowledge_bridge;
 mod recall_core;
+mod speculative_recall;
 mod terminology_discovery;

--- a/crates/nous/src/recall_tests/speculative_recall.rs
+++ b/crates/nous/src/recall_tests/speculative_recall.rs
@@ -1,0 +1,154 @@
+//! End-to-end recall tests for the speculative surprise + evidence factors (Q1).
+//!
+//! Verifies that, once their knowledge-config weights are enabled, the surprise
+//! and evidence-coverage factors genuinely affect ranking — and stay inert by
+//! default.
+
+#![expect(clippy::expect_used, reason = "test assertions may panic on failure")]
+
+use super::super::*;
+use super::*;
+
+/// With a positive surprise weight and a session prior primed on one topic, a
+/// topically-divergent candidate outranks a same-topic one at equal vector
+/// distance.
+#[test]
+fn surprise_weight_boosts_divergent_candidate() {
+    let mut calc = mneme::surprise::SurpriseCalculator::new();
+    for _ in 0..6 {
+        calc.compute_surprise(
+            "chop the onions and garlic then saute them in olive oil until golden",
+        );
+    }
+
+    let config = RecallConfig {
+        surprise_weight: 12.0,
+        surprise_threshold: 0.0,
+        min_score: 0.0,
+        max_results: 5,
+        ..Default::default()
+    };
+    let stage = RecallStage::new(config).with_surprise_calculator(Some(calc));
+
+    // Identical vector distance — only topic-shift surprise differs.
+    let similar =
+        make_knowledge_result_with_id("saute the garlic and onions in olive oil", 0.5, "fact-cook");
+    let divergent = make_knowledge_result_with_id(
+        "the schwarzschild radius of a black hole scales linearly with its mass",
+        0.5,
+        "fact-physics",
+    );
+
+    let result = stage
+        .run(
+            "what should i cook for dinner",
+            "syn",
+            &mock_embed(),
+            &MockVectorSearch::new(vec![similar, divergent]),
+            100_000,
+        )
+        .expect("recall runs");
+
+    let section = result.recall_section.expect("recall section present");
+    let physics_idx = section
+        .find("schwarzschild")
+        .expect("physics candidate present");
+    let cooking_idx = section.find("saute").expect("cooking candidate present");
+    assert!(
+        physics_idx < cooking_idx,
+        "the surprising (divergent) candidate should rank first:\n{section}"
+    );
+}
+
+/// With surprise inert (default weight 0, no calculator), ranking follows vector
+/// distance only — the closer candidate wins regardless of topic.
+#[test]
+fn surprise_inert_by_default() {
+    let config = RecallConfig {
+        min_score: 0.0,
+        max_results: 5,
+        ..Default::default()
+    };
+    let stage = RecallStage::new(config);
+
+    let near = make_knowledge_result_with_id("alpha gardening tomatoes outdoors", 0.1, "fact-near");
+    let far = make_knowledge_result_with_id(
+        "the schwarzschild radius scales with black hole mass",
+        0.9,
+        "fact-far",
+    );
+
+    let result = stage
+        .run(
+            "anything",
+            "syn",
+            &mock_embed(),
+            &MockVectorSearch::new(vec![near, far]),
+            100_000,
+        )
+        .expect("recall runs");
+
+    let section = result.recall_section.expect("recall section present");
+    let near_idx = section.find("alpha gardening").expect("near present");
+    let far_idx = section.find("schwarzschild").expect("far present");
+    assert!(
+        near_idx < far_idx,
+        "closer candidate should rank first when surprise is inert:\n{section}"
+    );
+}
+
+/// With a positive evidence-coverage weight in the iterative path, facts that
+/// lexically answer a decomposed query gap outrank an off-topic filler.
+#[test]
+fn evidence_weight_boosts_gap_answering_candidates() {
+    let config = RecallConfig {
+        evidence_coverage_weight: 15.0,
+        iterative: true,
+        max_cycles: 2,
+        min_score: 0.0,
+        max_results: 5,
+        ..Default::default()
+    };
+    let stage = RecallStage::new(config);
+
+    let query = "what is the capital of France and the population of France";
+
+    // Cycle 1: a gap-answering fact + off-topic filler (novel terms trigger cycle 2).
+    let cycle1 = vec![
+        make_knowledge_result_with_id(
+            "The capital of France is Paris in western Europe",
+            0.5,
+            "fact-capital",
+        ),
+        make_knowledge_result_with_id(
+            "Unrelated note about gardening tomatoes and zucchini outdoors",
+            0.5,
+            "fact-filler",
+        ),
+    ];
+    // Cycle 2: the second gap-answering fact.
+    let cycle2 = vec![make_knowledge_result_with_id(
+        "The population of France numbers about 68 million residents",
+        0.5,
+        "fact-pop",
+    )];
+    let vs = CycledMockSearch::new(vec![cycle1, cycle2]);
+
+    let result = stage
+        .run(query, "syn", &mock_embed(), &vs, 100_000)
+        .expect("recall runs");
+
+    assert!(vs.call_count() >= 2, "cycle 2 should have run");
+
+    let section = result.recall_section.expect("recall section present");
+    let filler_idx = section
+        .find("gardening tomatoes")
+        .expect("filler candidate present");
+    let capital_idx = section
+        .find("capital of France")
+        .expect("capital candidate present");
+    assert!(
+        capital_idx < filler_idx,
+        "gap-answering candidate should outrank the off-topic filler:\n{section}"
+    );
+}

--- a/crates/nous/src/session.rs
+++ b/crates/nous/src/session.rs
@@ -53,6 +53,14 @@ pub struct SessionState {
     /// WHY: persisted per-session so patterns are tracked across turns.
     /// Reset on operator intervention via `reset_on_user_message`.
     pub loop_guard: hermeneus::loop_detector::LoopGuard,
+    /// Running Bayesian-surprise distribution for this session.
+    ///
+    /// WHY: surprise is episodic — the prior must accumulate across turns to
+    /// detect topic shifts. Advanced once per turn (actor-side, before the
+    /// pipeline spawns) with the user content, then read in recall scoring to
+    /// rank candidates by how much they diverge from the session topic. Inert
+    /// unless `recall.surprise_weight > 0`.
+    pub surprise_calculator: mneme::surprise::SurpriseCalculator,
 }
 
 impl SessionState {
@@ -79,6 +87,9 @@ impl SessionState {
             receipt_signer: ReceiptSigner::new_session(),
             receipt_ledger: Arc::new(Mutex::new(ReceiptLedger::default())),
             loop_guard: hermeneus::loop_detector::LoopGuard::new(),
+            surprise_calculator: mneme::surprise::SurpriseCalculator::with_alpha(
+                config.recall.surprise_ema_alpha,
+            ),
         }
     }
 

--- a/crates/taxis/src/config/behavior/knowledge.rs
+++ b/crates/taxis/src/config/behavior/knowledge.rs
@@ -86,15 +86,22 @@ pub struct KnowledgeConfig {
     pub surprise_ema_alpha: f64,
     /// Recall weight for Bayesian surprise contribution. Default: 0.0 (inert).
     ///
-    /// Non-zero values cause `RecallEngine::score_surprise` to blend the
-    /// KL-divergence signal from `SurpriseCalculator` into the final recall
-    /// score. Wired through `RecallWeights::surprise` at engine construction.
+    /// Non-zero values blend the session `SurpriseCalculator`'s KL-divergence
+    /// signal (via `RecallEngine::score_surprise`) into recall scoring, so
+    /// candidates whose content diverges from the running session topic rank
+    /// higher. Threaded into `RecallWeights::surprise` at engine construction
+    /// (`aletheia::runtime::nous_config` → `RecallConfig::surprise_weight`).
+    ///
+    /// WARNING: this is a novelty/serendipity signal, not a relevance booster —
+    /// it surfaces cross-topic memories (high topic-shift surprise), trading
+    /// relevance for diversity. Keep it small relative to `vector_similarity`.
     pub recall_surprise_weight: f64,
     /// Recall weight for evidence-gap coverage. Default: 0.0 (inert).
     ///
-    /// Non-zero values cause `RecallEngine::score_evidence_coverage` to boost
-    /// candidates whose `source_id` appears in the `EvidenceGapTracker`
-    /// answered set. Wired through `RecallWeights::evidence_coverage`.
+    /// Non-zero values boost candidates whose `source_id` answers a decomposed
+    /// query gap (via `RecallEngine::score_evidence_coverage`) during the
+    /// iterative-retrieval path. Threaded into `RecallWeights::evidence_coverage`
+    /// at engine construction.
     pub recall_evidence_coverage_weight: f64,
     /// Admission policy applied to every `insert_fact` call. Default: `default` (admit-all).
     ///


### PR DESCRIPTION
## What

Genuinely wire the two dormant episteme recall factors — Bayesian **surprise** (EM-LLM) and **evidence-coverage** (MemR3) — into the nous recall pipeline. Both were fully scaffolded but inert (hardcoded `0.0` in `build_candidates`, no config thread, a false "wired" taxis doc claim). v1.0.0 cut-line: dormant surfaces genuinely wired (Q1).

## How

Gated behind knowledge-config weights (default `0.0` → **default recall byte-for-byte unchanged**):

**Surprise** (novelty / serendipity signal — boosts cross-topic memories, not relevance)
- Session-scoped `SurpriseCalculator` on `SessionState`, advanced once per turn **actor-side** (before the pipeline spawn) so the EMA prior survives the `tokio::spawn` clone boundary.
- New non-mutating `surprise_of()` scores each candidate read-only against the frozen session prior — no EMA pollution from per-candidate calls.
- Engine surprise weight + threshold + ema threaded from `knowledge` config at nous-config assembly.

**Evidence-coverage** (iterative-retrieval gap answering)
- `EvidenceGapTracker` built per `run_iterative` call from the **merged** candidate set; credits facts that lexically answer a decomposed query gap (≥2 content words required); the answered map drives `score_evidence_coverage`.

**Truth-up**
- Fix the false taxis doc claims to describe the real wiring path.
- Correct the stale "6/7-factor" counts in episteme recall (it is 9 factors).
- Add a `mneme` facade for `surprise` + `evidence_gap`.

## Verification

- CI-exact clippy gate green: `cargo +1.94.0 clippy --workspace --all-targets --exclude theatron --exclude skene --exclude koilon -- -D warnings`.
- New tests: `surprise_of` non-mutation; evidence-map gap crediting + single-token guard; end-to-end recall ranking with surprise / evidence enabled; inert-by-default. All recall + episteme surprise tests green.
- 4-lens adversarial review: core wiring (session-prior persistence across the spawn boundary, non-mutating scoring, genuine ranking effect) un-refutable; backwards-compat sound; 5 minor/nit findings all addressed.
