### PR TITLE
fix(pylon): un-ignore metrics-exposure test by recording traffic first

### DIFF
--- a/crates/pylon/src/tests/health.rs
+++ b/crates/pylon/src/tests/health.rs
@@ -114,9 +114,23 @@ async fn metrics_no_auth_required() {
 }
 
 #[tokio::test]
-#[ignore = "metrics registration broken by FromRef migration — fix in followup"]
 async fn metrics_contains_aletheia_prefixed_families() {
     let (app, _dir) = app().await;
+
+    // WHY: `aletheia_http_requests` is a labeled counter Family — it emits no
+    // `_total` series until at least one request is recorded, so asserting the
+    // data line against a fresh registry always fails (this is what made the
+    // test flaky-looking and got it ignored; registration itself is fine — see
+    // `metrics_counters_increment_after_request`). Record one request through
+    // the metrics middleware first so the exposition exercises the full
+    // record -> shared registry -> handler path.
+    let recorded = app
+        .clone()
+        .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(recorded.status(), StatusCode::OK);
+
     let resp = app
         .oneshot(Request::get("/metrics").body(Body::empty()).unwrap())
         .await
@@ -125,19 +139,19 @@ async fn metrics_contains_aletheia_prefixed_families() {
     let body = body_string(resp).await;
     assert!(
         body.contains("aletheia_http_requests_total"),
-        "should contain HTTP request counter"
+        "should expose the HTTP request counter family; got: {body}"
     );
     assert!(
         body.contains("aletheia_uptime_seconds"),
-        "should contain uptime gauge"
+        "should expose the uptime gauge; got: {body}"
     );
     assert!(
-        body.contains("# HELP"),
-        "should contain Prometheus HELP comments"
+        body.contains("/api/health"),
+        "recorded request path should appear as a counter label; got: {body}"
     );
     assert!(
-        body.contains("# TYPE"),
-        "should contain Prometheus TYPE comments"
+        body.contains("# HELP") && body.contains("# TYPE"),
+        "should contain Prometheus HELP/TYPE metadata; got: {body}"
     );
 }
 


### PR DESCRIPTION
## What

Un-ignore `metrics_contains_aletheia_prefixed_families` (v1.0.0 cut-line criterion 14, #4390).

## Diagnosis

The ignore reason claimed a "registration bug from the FromRef migration." **It is not a registration bug.** Registration, the `FromRef` registry clone (`MetricsState`), and global-`Family` sharing all work correctly — proven by the passing sibling `metrics_counters_increment_after_request`, which records a request and then sees its `/api/health` label in `/metrics`.

The real cause: `aletheia_http_requests` is a **labeled counter `Family`** — it emits no `_total` data line until at least one request is recorded. The ignored test asserted `aletheia_http_requests_total` against a registry with no recorded traffic, so the data line was always absent.

## Fix

Record one request (`GET /api/health`, captured by the metrics middleware) before scraping `/metrics`, so the test exercises the full **record → shared registry → handler** path. Also assert the recorded request's path appears as a counter label.

## Verification

- `metrics_contains_aletheia_prefixed_families` now passes (un-ignored); all 12 pylon metrics tests green.
- `cargo fmt --check` + `cargo clippy -p pylon --all-targets -- -D warnings` clean.

Closes #4390.
