### PR TITLE
docs(deps): accept chrono/aws-lc-sys/rustls-pemfile as post-1.0 residue (crit 11)

### DIFF
--- a/DEPENDENCIES-AUDIT.md
+++ b/DEPENDENCIES-AUDIT.md
@@ -1,9 +1,27 @@
 # Dependency Ownership Audit
 
-Last checked: 2026-05-29 on `chore/05d-ring-to-p256`.
+Last checked: 2026-05-29 on `chore/05d-ring-to-p256`. `chrono` + `aws-lc-sys`
+provenance re-verified 2026-06-03 for the v1.0.0 cut-line (criterion 11).
 
 This document records the live dependency graph. It is not a Phase 05d target
 statement.
+
+## v1.0.0 Disposition (cut-line criterion 11)
+
+Criterion 11 requires dependency purity to be either closed or
+**documented-as-post-1.0**. The following native/unmaintained residue is
+**accepted for v1.0.0** — each is transitive, none sits in the "no C++ in the
+brain" knowledge/ML core (that path is candle + fjall, pure Rust), and none has
+a clean pure-Rust replacement that ships in the 1.0 window:
+
+| Dependency | Why it stays | Removal trigger |
+|-----------|--------------|-----------------|
+| `aws-lc-sys` (C) | Crypto backend for `rustls`'s `aws-lc-rs` provider (rustls 0.23 default), used by the workspace's TLS. The only pure-Rust rustls provider (`rustls-rustcrypto`) is experimental; switching to `ring` trades one C lib for another. | rustls ships a production pure-Rust provider, or operator accepts `rustls-rustcrypto`. |
+| `chrono` (pure Rust) | Non-optional dep of `rmcp`, `lopdf` (via `pdf-extract`), and `spreadsheet-ods`. Pure Rust, so no C-FFI concern; the only issue is duplication with `jiff` (the workspace time crate). | upstreams drop chrono, or the doc/MCP crates are replaced. |
+| `rustls-pemfile` (unmaintained, RUSTSEC-2025-0134) | Unmaintained-only (not a vulnerability). Transitive via `qdrant-client → tonic`. Deny-ignored with rationale (`deny.toml`). | `qdrant-client`/`tonic` migrate to `rustls-pki-types` `PemObject` (#4389). |
+
+These are tracked below; the disposition is "accept + track upstream," not
+"unresolved blocker."
 
 ## Current C / Native Footprint
 
@@ -28,21 +46,21 @@ statement.
   - `crates/aletheia-sessions-migrate`, the legacy SQLite-to-fjall session
     migration tool.
 
-## aws-lc-sys Status (Blocked)
+## aws-lc-sys Status (accepted post-1.0 — see Disposition)
 
-`aws-lc-sys` appears in `Cargo.lock` as a transitive dep of `aws-lc-rs`, which
-is pulled in by `ureq v3.3.0` via its `[dev-dependencies]`:
+`aws-lc-sys` (C) enters the **normal** build graph as the crypto backend of
+`rustls`'s `aws-lc-rs` provider — the default for rustls 0.23. The workspace's
+TLS-using crates (`aletheia`, `episteme`, and their consumers) depend on
+`rustls v0.23` directly, so the path is
+`aws-lc-sys ← aws-lc-rs ← rustls v0.23 ← {aletheia, episteme, ...}`
+(verified 2026-06-03 via `cargo tree --workspace --locked -i aws-lc-sys`).
 
-```
-[dev-dependencies]
-rustls = { version = "0.23", features = ["aws-lc-rs"] }
-```
-
-With Cargo resolver v2, dev-dependency *features* of external crates still
-bleed into `Cargo.lock` even though they are not used in normal builds.
-`hf-hub` (used by mneme/embed-candle) depends on `ureq 3.3.0`. Eliminating
-`aws-lc-sys` requires either: (a) switching `hf-hub` from `ureq` to its
-`tokio` feature; or (b) patching `ureq` locally. Both are design decisions.
+This corrects an earlier note that attributed `aws-lc-sys` only to a `ureq`
+dev-dependency feature bleed — it is in fact in the primary TLS path, not a
+dev-only artifact. Eliminating it requires a different rustls crypto provider:
+`ring` (still C) or `rustls-rustcrypto` (pure Rust, currently experimental).
+Neither is a clean v1.0.0 move, so it is accepted as post-1.0 residue (see the
+v1.0.0 Disposition table above).
 
 ## Storage Status
 
@@ -80,11 +98,14 @@ path. A follow-on decision is needed before migrating gnosis storage.
 | `ring` (direct dep of `crates/aletheia`) | this branch | Migrated `tls_self_signed.rs` to `p256` (RustCrypto) |
 | `ring` direct dep in `crates/symbolon` | prior to 2026-05-08 | Migrated to p256/hmac/sha2/rand |
 
-## Remaining (Blocked on Design Decisions)
+## Remaining (accepted post-1.0 — see v1.0.0 Disposition)
 
-| Dependency | Blocker | Tracking |
-|-----------|---------|---------|
-| `aws-lc-sys` | `ureq 3.3.0` dev-dep feature bleed; hf-hub feature switch needed | W-04 / REQ-05d-01..03 |
+These are no longer "blockers" for the release: the v1.0.0 Disposition (top of
+this doc) accepts them as tracked post-1.0 residue.
+
+| Dependency | Removal blocker | Tracking |
+|-----------|-----------------|---------|
+| `aws-lc-sys` | needs a production pure-Rust rustls crypto provider | W-04 / REQ-05d-01..03 |
 | `chrono` | rmcp, lopdf, spreadsheet-ods have non-optional chrono deps | REQ-05d-06 |
 
 ## Commands Used


### PR DESCRIPTION
## What

Satisfy v1.0.0 cut-line **criterion 11** (dependency purity) for the residue that does not close in the 1.0 window. Criterion 11 permits residue when **documented as post-1.0**.

## Changes

- **New "v1.0.0 Disposition" table** in `DEPENDENCIES-AUDIT.md` explicitly accepting, with rationale + removal trigger:
  - `aws-lc-sys` (C) — rustls `aws-lc-rs` crypto backend (rustls 0.23 default).
  - `chrono` (pure Rust) — non-optional dep of rmcp / lopdf / spreadsheet-ods.
  - `rustls-pemfile` (unmaintained-only, RUSTSEC-2025-0134) — transitive via qdrant-client→tonic, deny-ignored, tracked in #4389.
  - Rationale: each is transitive, none sits in the "no C++ in the brain" knowledge/ML core (candle + fjall, pure Rust), and none has a clean pure-Rust replacement that ships in 1.0.
- **Doc-truth fix**: corrected the `aws-lc-sys` provenance. It enters the **primary TLS path** via `rustls`'s `aws-lc-rs` provider — not the `ureq` dev-dependency feature bleed the doc claimed. Verified 2026-06-03 with `cargo tree --workspace --locked -i aws-lc-sys`.
- Reframed the "Remaining (Blocked)" table as "accepted post-1.0" to match the disposition.

## Note

This does **not** close #4389 — the rustls-pemfile *migration* remains tracked upstream (qdrant-client/tonic → rustls-pki-types). It documents the criterion-11 disposition. Docs-only change.
