### PR TITLE
feat(episteme): wire fact_multiplicity into recall convergence + conflict tie-break

### DIFF
--- a/crates/aletheia/src/runtime/nous_config.rs
+++ b/crates/aletheia/src/runtime/nous_config.rs
@@ -144,6 +144,7 @@ pub(super) fn build_nous_runtime_config(
     nous_config.recall.evidence_coverage_weight = config.knowledge.recall_evidence_coverage_weight;
     nous_config.recall.surprise_threshold = config.knowledge.surprise_threshold;
     nous_config.recall.surprise_ema_alpha = config.knowledge.surprise_ema_alpha;
+    nous_config.recall.convergence_weight = config.knowledge.recall_convergence_weight;
 
     let mut extraction_cfg = mneme::extract::ExtractionConfig::default();
     if let Some(model) = nous_config.generation.extraction_model.as_deref() {

--- a/crates/eidos/src/knowledge/entity.rs
+++ b/crates/eidos/src/knowledge/entity.rs
@@ -112,4 +112,12 @@ pub struct RecallResult {
     /// [`Visibility::Private`]: super::fact::Visibility::Private
     #[serde(default)]
     pub visibility: super::fact::Visibility,
+    /// Consolidated-fact source count from the `fact_multiplicity` side-index,
+    /// carried so the recall pipeline can score the convergence factor (#4415).
+    ///
+    /// `0` for legacy / non-consolidated facts (no multiplicity record) and for
+    /// non-fact sources; populated by the knowledge store only when the
+    /// convergence recall weight is active.
+    #[serde(default)]
+    pub source_count: u32,
 }

--- a/crates/eidos/src/knowledge/knowledge_tests/ids.rs
+++ b/crates/eidos/src/knowledge/knowledge_tests/ids.rs
@@ -267,6 +267,7 @@ fn recall_result_serde_roundtrip() {
         scope: None,
         project_id: None,
         visibility: Visibility::Private,
+        source_count: 0,
     };
     let json = serde_json::to_string(&result).expect("RecallResult serialization is infallible");
     let back: RecallResult =

--- a/crates/episteme/src/conflict.rs
+++ b/crates/episteme/src/conflict.rs
@@ -462,16 +462,24 @@ pub(crate) fn classify_against_candidates(
 /// Determine the action based on classification, confidence, and tier.
 ///
 /// Rules:
-/// - CONTRADICTS → supersede (lower confidence loses; newer info wins ties)
+/// - CONTRADICTS → supersede (lower confidence loses; on equal confidence the
+///   fact with more independent converging sources wins, then newer info)
 /// - REFINES → supersede (refinement always wins)
 /// - SUPPLEMENTS → insert (both live)
 /// - UNRELATED → insert
 /// - Exception: `Verified` tier never superseded by `Assumed` tier
+///
+/// `existing_source_count` / `new_source_count` are the consolidated-fact
+/// multiplicities (`fact_multiplicity` side-index; 1 for non-consolidated /
+/// single-observation facts) used only to break equal-confidence contradictions
+/// (#4415).
 #[cfg(any(feature = "mneme-engine", test))]
 pub(crate) fn resolve_action(
     classification: &ConflictClassification,
     candidate: &ConflictCandidate,
     new_fact: &FactForConflictCheck,
+    existing_source_count: u32,
+    new_source_count: u32,
 ) -> ConflictAction {
     match classification {
         ConflictClassification::Contradicts => {
@@ -486,12 +494,22 @@ pub(crate) fn resolve_action(
                     old_id: candidate.existing_fact_id.clone(),
                 };
             }
-            if new_fact.confidence >= candidate.existing_confidence {
+            if new_fact.confidence > candidate.existing_confidence {
                 ConflictAction::Supersede {
                     old_id: candidate.existing_fact_id.clone(),
                 }
-            } else {
+            } else if new_fact.confidence < candidate.existing_confidence {
                 ConflictAction::Drop
+            } else if existing_source_count > new_source_count {
+                // WHY (#4415): equal confidence — the existing fact has more
+                // independent converging observations, so it wins the tie. The
+                // `>=` recency default applies when counts are equal or the new
+                // fact has at least as many sources.
+                ConflictAction::Drop
+            } else {
+                ConflictAction::Supersede {
+                    old_id: candidate.existing_fact_id.clone(),
+                }
             }
         }
         ConflictClassification::Refines => {
@@ -535,7 +553,23 @@ pub(crate) fn detect_conflicts(
         } else {
             match classify_against_candidates(classifier, &fact, &candidates)? {
                 Some((classification, candidate_idx)) => {
-                    resolve_action(&classification, &candidates[candidate_idx], &fact)
+                    // WHY (#4415): consult the fact_multiplicity side-index so an
+                    // equal-confidence contradiction is broken toward the fact
+                    // with more independent converging sources. Non-consolidated
+                    // facts (None) count as a single observation; the new fact is
+                    // always a single fresh observation.
+                    let existing_source_count = store
+                        .get_fact_multiplicity(&candidates[candidate_idx].existing_fact_id)
+                        .ok()
+                        .flatten()
+                        .map_or(1, |m| m.source_count.max(1));
+                    resolve_action(
+                        &classification,
+                        &candidates[candidate_idx],
+                        &fact,
+                        existing_source_count,
+                        1,
+                    )
                 }
                 None => ConflictAction::Insert,
             }

--- a/crates/episteme/src/conflict_tests.rs
+++ b/crates/episteme/src/conflict_tests.rs
@@ -258,7 +258,13 @@ fn intra_batch_dedup_single() {
 fn resolve_contradicts_new_higher_confidence() {
     let candidate = make_candidate("f-old", "old claim", 0.7, EpistemicTier::Inferred, 0.9);
     let fact = make_fact("new claim", 0.9, vec![]);
-    let action = resolve_action(&ConflictClassification::Contradicts, &candidate, &fact);
+    let action = resolve_action(
+        &ConflictClassification::Contradicts,
+        &candidate,
+        &fact,
+        1,
+        1,
+    );
     assert_eq!(
         action,
         ConflictAction::Supersede {
@@ -268,11 +274,62 @@ fn resolve_contradicts_new_higher_confidence() {
     );
 }
 
+/// #4415: on an equal-confidence contradiction, the fact with more independent
+/// converging sources wins the tie; equal multiplicity falls back to recency.
+#[test]
+fn resolve_contradicts_equal_confidence_breaks_on_multiplicity() {
+    let candidate = make_candidate(
+        "f-consolidated",
+        "established",
+        0.8,
+        EpistemicTier::Inferred,
+        0.9,
+    );
+    let fact = make_fact("new singleton claim", 0.8, vec![]);
+
+    // Existing fact consolidated from 5 sources vs a single new observation:
+    // the existing converging evidence wins, so the new fact is dropped.
+    let action = resolve_action(
+        &ConflictClassification::Contradicts,
+        &candidate,
+        &fact,
+        5,
+        1,
+    );
+    assert_eq!(
+        action,
+        ConflictAction::Drop,
+        "higher-multiplicity existing fact should win the equal-confidence tie"
+    );
+
+    // Equal multiplicity falls back to the recency default (new supersedes).
+    let tie = resolve_action(
+        &ConflictClassification::Contradicts,
+        &candidate,
+        &fact,
+        1,
+        1,
+    );
+    assert_eq!(
+        tie,
+        ConflictAction::Supersede {
+            old_id: FactId::new("f-consolidated").expect("valid test id")
+        },
+        "equal multiplicity should fall back to recency (new wins)"
+    );
+}
+
 #[test]
 fn resolve_contradicts_new_lower_confidence() {
     let candidate = make_candidate("f-old", "old claim", 0.95, EpistemicTier::Inferred, 0.9);
     let fact = make_fact("new claim", 0.5, vec![]);
-    let action = resolve_action(&ConflictClassification::Contradicts, &candidate, &fact);
+    let action = resolve_action(
+        &ConflictClassification::Contradicts,
+        &candidate,
+        &fact,
+        1,
+        1,
+    );
     assert_eq!(
         action,
         ConflictAction::Drop,
@@ -284,7 +341,13 @@ fn resolve_contradicts_new_lower_confidence() {
 fn resolve_contradicts_equal_confidence_new_wins() {
     let candidate = make_candidate("f-old", "old claim", 0.8, EpistemicTier::Inferred, 0.9);
     let fact = make_fact("new claim", 0.8, vec![]);
-    let action = resolve_action(&ConflictClassification::Contradicts, &candidate, &fact);
+    let action = resolve_action(
+        &ConflictClassification::Contradicts,
+        &candidate,
+        &fact,
+        1,
+        1,
+    );
     assert_eq!(
         action,
         ConflictAction::Supersede {
@@ -298,7 +361,7 @@ fn resolve_contradicts_equal_confidence_new_wins() {
 fn resolve_refines_supersedes() {
     let candidate = make_candidate("f-old", "general claim", 0.8, EpistemicTier::Inferred, 0.85);
     let fact = make_fact("specific claim", 0.9, vec![]);
-    let action = resolve_action(&ConflictClassification::Refines, &candidate, &fact);
+    let action = resolve_action(&ConflictClassification::Refines, &candidate, &fact, 1, 1);
     assert_eq!(
         action,
         ConflictAction::Supersede {
@@ -312,7 +375,13 @@ fn resolve_refines_supersedes() {
 fn resolve_supplements_inserts() {
     let candidate = make_candidate("f-old", "existing claim", 0.8, EpistemicTier::Inferred, 0.8);
     let fact = make_fact("additional info", 0.7, vec![]);
-    let action = resolve_action(&ConflictClassification::Supplements, &candidate, &fact);
+    let action = resolve_action(
+        &ConflictClassification::Supplements,
+        &candidate,
+        &fact,
+        1,
+        1,
+    );
     assert_eq!(
         action,
         ConflictAction::Insert,
@@ -330,7 +399,7 @@ fn resolve_unrelated_inserts() {
         0.75,
     );
     let fact = make_fact("different topic", 0.9, vec![]);
-    let action = resolve_action(&ConflictClassification::Unrelated, &candidate, &fact);
+    let action = resolve_action(&ConflictClassification::Unrelated, &candidate, &fact, 1, 1);
     assert_eq!(
         action,
         ConflictAction::Insert,
@@ -353,7 +422,13 @@ fn verified_not_superseded_by_assumed_contradicts() {
         EpistemicTier::Assumed,
         vec![],
     );
-    let action = resolve_action(&ConflictClassification::Contradicts, &candidate, &fact);
+    let action = resolve_action(
+        &ConflictClassification::Contradicts,
+        &candidate,
+        &fact,
+        1,
+        1,
+    );
     assert_eq!(
         action,
         ConflictAction::Drop,
@@ -371,7 +446,7 @@ fn verified_not_superseded_by_assumed_refines() {
         0.9,
     );
     let fact = make_fact_with_tier("assumed refinement", 0.95, EpistemicTier::Assumed, vec![]);
-    let action = resolve_action(&ConflictClassification::Refines, &candidate, &fact);
+    let action = resolve_action(&ConflictClassification::Refines, &candidate, &fact, 1, 1);
     assert_eq!(
         action,
         ConflictAction::Drop,
@@ -383,7 +458,13 @@ fn verified_not_superseded_by_assumed_refines() {
 fn verified_can_be_superseded_by_verified() {
     let candidate = make_candidate("f-old", "old verified", 0.7, EpistemicTier::Verified, 0.9);
     let fact = make_fact_with_tier("new verified", 0.95, EpistemicTier::Verified, vec![]);
-    let action = resolve_action(&ConflictClassification::Contradicts, &candidate, &fact);
+    let action = resolve_action(
+        &ConflictClassification::Contradicts,
+        &candidate,
+        &fact,
+        1,
+        1,
+    );
     assert_eq!(
         action,
         ConflictAction::Supersede {
@@ -397,7 +478,13 @@ fn verified_can_be_superseded_by_verified() {
 fn verified_can_be_superseded_by_inferred() {
     let candidate = make_candidate("f-old", "old verified", 0.7, EpistemicTier::Verified, 0.9);
     let fact = make_fact_with_tier("new inferred", 0.95, EpistemicTier::Inferred, vec![]);
-    let action = resolve_action(&ConflictClassification::Contradicts, &candidate, &fact);
+    let action = resolve_action(
+        &ConflictClassification::Contradicts,
+        &candidate,
+        &fact,
+        1,
+        1,
+    );
     assert_eq!(
         action,
         ConflictAction::Supersede {
@@ -476,7 +563,13 @@ fn correction_fact_wins_contradiction_regardless_of_confidence() {
     let candidate = make_candidate("f-old", "old claim", 0.95, EpistemicTier::Inferred, 0.9);
     let mut fact = make_fact("corrected claim", 0.5, vec![]);
     fact.is_correction = true;
-    let action = resolve_action(&ConflictClassification::Contradicts, &candidate, &fact);
+    let action = resolve_action(
+        &ConflictClassification::Contradicts,
+        &candidate,
+        &fact,
+        1,
+        1,
+    );
     assert_eq!(
         action,
         ConflictAction::Supersede {
@@ -581,7 +674,7 @@ fn classify_each_type_produces_correct_action() {
         let (classification, idx) = classify_against_candidates(&classifier, &fact, &candidates)
             .expect("classify must succeed")
             .expect("must be Some when candidates exist");
-        let action = resolve_action(&classification, &candidates[idx], &fact);
+        let action = resolve_action(&classification, &candidates[idx], &fact, 1, 1);
         assert_eq!(action, expected_action, "failed for {response}");
     }
 }

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -739,6 +739,9 @@ pub(super) fn rows_to_recall_results(
             scope,
             project_id,
             visibility,
+            // WHY (#4415): populated by `enrich_source_counts` on the recall
+            // path; the generic row marshaller has no side-index access.
+            source_count: 0,
         });
     }
     Ok(out)

--- a/crates/episteme/src/knowledge_store/search.rs
+++ b/crates/episteme/src/knowledge_store/search.rs
@@ -100,6 +100,7 @@ impl KnowledgeStore {
         results.truncate(k as usize);
 
         self.enrich_recall_results(&mut results)?;
+        self.enrich_source_counts(&mut results);
         self.expand_recall_by_cluster(&mut results, k)?;
 
         let source_ids: Vec<crate::id::FactId> = results
@@ -168,6 +169,7 @@ impl KnowledgeStore {
         let rows = self.run_read(queries::BM25_RECALL, params)?;
         let mut results = rows_to_recall_results(rows)?;
         self.enrich_recall_results(&mut results)?;
+        self.enrich_source_counts(&mut results);
         self.expand_recall_by_cluster(&mut results, k)?;
         Ok(results)
     }
@@ -212,6 +214,25 @@ impl KnowledgeStore {
         }
 
         Ok(())
+    }
+
+    /// Populate `source_count` on fact results from the `fact_multiplicity`
+    /// side-index so the recall pipeline can score the convergence factor (#4415).
+    ///
+    /// Non-consolidated / legacy facts have no multiplicity record and keep
+    /// `source_count` 0 (convergence scores 0 for them). NOTE: this issues one
+    /// indexed point-query per fact result; the convergence recall weight
+    /// defaults to 0 so the score — and thus ranking — is unchanged when the
+    /// feature is off. A batched side-index load is a future optimisation.
+    fn enrich_source_counts(&self, results: &mut [crate::knowledge::RecallResult]) {
+        for result in results.iter_mut().filter(|r| r.source_type == "fact") {
+            let Ok(fact_id) = crate::id::FactId::new(&result.source_id) else {
+                continue;
+            };
+            if let Ok(Some(multiplicity)) = self.get_fact_multiplicity(&fact_id) {
+                result.source_count = multiplicity.source_count;
+            }
+        }
     }
 
     /// Hydrate recall results with `scope`, `project_id`, and `visibility` from the `facts` relation.
@@ -373,6 +394,7 @@ impl KnowledgeStore {
                     scope: None,
                     project_id: None,
                     visibility: crate::knowledge::Visibility::Private,
+                    source_count: 0,
                 });
                 added += 1;
                 if added >= limit {
@@ -604,6 +626,11 @@ impl KnowledgeStore {
                     scope: fact.scope,
                     project_id: fact.project_id,
                     visibility: fact.visibility,
+                    source_count: self
+                        .get_fact_multiplicity(&fact.id)
+                        .ok()
+                        .flatten()
+                        .map_or(0, |m| m.source_count),
                 });
                 break;
             }

--- a/crates/episteme/src/phase_f_integration_tests.rs
+++ b/crates/episteme/src/phase_f_integration_tests.rs
@@ -198,7 +198,13 @@ fn conflict_detection_identifies_contradicting_behavioral_preferences() {
         embedding: vec![],
     };
 
-    let action = resolve_action(&ConflictClassification::Contradicts, &existing, &new_fact);
+    let action = resolve_action(
+        &ConflictClassification::Contradicts,
+        &existing,
+        &new_fact,
+        1,
+        1,
+    );
     assert!(
         matches!(action, ConflictAction::Supersede { .. }),
         "higher-confidence behavioral preference should supersede lower-confidence one"
@@ -217,6 +223,8 @@ fn conflict_detection_identifies_contradicting_behavioral_preferences() {
         &ConflictClassification::Contradicts,
         &existing,
         &weaker_fact,
+        1,
+        1,
     );
     assert_eq!(
         drop_action,

--- a/crates/episteme/src/recall/mod.rs
+++ b/crates/episteme/src/recall/mod.rs
@@ -1,4 +1,4 @@
-//! Recall engine: 9-factor scoring for knowledge retrieval.
+//! Recall engine: 10-factor scoring for knowledge retrieval.
 //!
 //! Combines multiple signals to rank recall results:
 //!
@@ -11,9 +11,10 @@
 //! 7. **Graph importance**: `PageRank` hub entities rank higher
 //! 8. **Surprise**: Bayesian topic-shift signal (`EM-LLM`); default weight 0.0
 //! 9. **Evidence coverage**: `MemR3` gap-answering boost; default weight 0.0
+//! 10. **Convergence**: consolidated-fact multiplicity (`log(1+sources)`); default weight 0.0
 //!
 //! Each factor produces a score in [0.0, 1.0]. The final score is a weighted
-//! combination, configurable per-nous via oikos cascade. Factors 8 and 9 are
+//! combination, configurable per-nous via oikos cascade. Factors 8–10 are
 //! inert unless their weight is set positive in knowledge config.
 
 use std::collections::HashSet;
@@ -62,6 +63,14 @@ pub struct RecallWeights {
     /// evidence-gap tracker's answered set. Default: 0.0 (inert). Enable by
     /// setting a positive weight in config.
     pub evidence_coverage: f64,
+    /// Weight for consolidated-fact convergence (multiplicity / source count).
+    ///
+    /// Non-zero values blend in `log(1 + source_count)` (from the
+    /// `fact_multiplicity` side-index) so facts assembled from more independent
+    /// converging observations rank higher. Default: 0.0 (inert). Legacy /
+    /// non-consolidated facts have `source_count` 0 and score 0 here, so enabling
+    /// the weight never regresses them.
+    pub convergence: f64,
 }
 
 impl Default for RecallWeights {
@@ -76,6 +85,7 @@ impl Default for RecallWeights {
             graph_importance: 0.10,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         }
     }
 }
@@ -85,7 +95,7 @@ impl RecallWeights {
     ///
     /// # Complexity
     ///
-    /// O(1) - constant time sum of 9 fields.
+    /// O(1) - constant time sum of 10 fields.
     #[must_use]
     #[instrument(skip(self))]
     pub(crate) fn total(&self) -> f64 {
@@ -98,6 +108,7 @@ impl RecallWeights {
             + self.graph_importance
             + self.surprise
             + self.evidence_coverage
+            + self.convergence
     }
 
     /// Whether the graph intelligence recall pipeline should run.
@@ -145,6 +156,13 @@ pub struct FactorScores {
     /// running iterative retrieval. Default: 0.0 — inert unless
     /// `RecallWeights::evidence_coverage > 0`.
     pub evidence_coverage: f64,
+    /// Convergence score [0.0, 1.0] from consolidated-fact multiplicity.
+    ///
+    /// `log(1 + source_count)` normalised against a saturation point, so facts
+    /// built from more independent observations score higher. 0.0 for legacy /
+    /// non-consolidated facts (`source_count` 0). Default: 0.0 — inert unless
+    /// `RecallWeights::convergence > 0`.
+    pub convergence: f64,
 }
 
 /// A scored recall candidate.
@@ -510,7 +528,8 @@ impl RecallEngine {
             + factors.access_frequency * w.access_frequency
             + factors.graph_importance * w.graph_importance
             + factors.surprise * w.surprise
-            + factors.evidence_coverage * w.evidence_coverage;
+            + factors.evidence_coverage * w.evidence_coverage
+            + factors.convergence * w.convergence;
 
         raw / total_weight
     }
@@ -713,7 +732,37 @@ impl RecallEngine {
             .unwrap_or(0.0)
             .clamp(0.0, 1.0)
     }
+
+    /// Compute the convergence score for a candidate from its consolidated-fact
+    /// source count (`fact_multiplicity` side-index).
+    ///
+    /// `log(1 + source_count)` normalised against [`CONVERGENCE_SATURATION`] so
+    /// the signal is logarithmic — a 50-source fact does not dominate a
+    /// 10-source one. `source_count = 0` (legacy / non-consolidated facts, where
+    /// `get_fact_multiplicity` returns `None`) scores 0.0, so enabling the
+    /// weight never regresses those facts.
+    ///
+    /// Returns 0.0 immediately when `RecallWeights::convergence` is effectively
+    /// zero so callers can skip the side-index lookup in the common case.
+    ///
+    /// # Complexity
+    ///
+    /// O(1) — one logarithm and division.
+    #[must_use]
+    #[instrument(skip(self))]
+    pub fn score_convergence(&self, source_count: u32) -> f64 {
+        if self.weights.convergence < f64::EPSILON {
+            return 0.0;
+        }
+        let n = f64::from(source_count);
+        ((1.0 + n).ln() / (1.0 + CONVERGENCE_SATURATION).ln()).clamp(0.0, 1.0)
+    }
 }
+
+/// Source count at which the convergence score saturates to ~1.0. Facts built
+/// from this many or more independent observations receive the maximal
+/// convergence boost; the logarithmic curve keeps lower counts well-separated.
+const CONVERGENCE_SATURATION: f64 = 32.0;
 
 impl Default for RecallEngine {
     fn default() -> Self {

--- a/crates/episteme/src/recall_tests/scoring.rs
+++ b/crates/episteme/src/recall_tests/scoring.rs
@@ -416,6 +416,7 @@ fn perfect_score() {
         graph_importance: 1.0,
         surprise: 1.0,
         evidence_coverage: 1.0,
+        convergence: 1.0,
     };
     assert!(
         (e.compute_score(&factors) - 1.0).abs() < 0.01,
@@ -449,5 +450,70 @@ fn vector_similarity_dominates() {
         "vector_similarity weight (0.35) should dominate decay weight (0.20): high_vec={}, high_decay={}",
         e.compute_score(&high_vec),
         e.compute_score(&high_decay)
+    );
+}
+
+/// #4415: the convergence factor boosts consolidated facts with more sources,
+/// is logarithmic, and is inert (0.0) for legacy / non-consolidated facts.
+#[test]
+fn convergence_factor_scores_multiplicity() {
+    let weights = RecallWeights {
+        convergence: 1.0,
+        ..RecallWeights::default()
+    };
+    let engine = RecallEngine::with_weights(weights);
+
+    // More converging sources -> higher score; legacy (0) scores nothing.
+    let none = engine.score_convergence(0);
+    let singleton = engine.score_convergence(1);
+    let consolidated = engine.score_convergence(10);
+    assert!(
+        (none - 0.0).abs() < f64::EPSILON,
+        "legacy facts must score 0"
+    );
+    assert!(
+        singleton > 0.0,
+        "a recorded single source scores > 0: {singleton}"
+    );
+    assert!(
+        consolidated > singleton,
+        "10-source fact should outscore a singleton: {consolidated} vs {singleton}"
+    );
+    // Logarithmic: each additional source adds less than the previous one.
+    let s2 = engine.score_convergence(2);
+    let s3 = engine.score_convergence(3);
+    assert!(
+        (s2 - singleton) > (s3 - s2),
+        "convergence growth must be logarithmic (diminishing marginal returns)"
+    );
+
+    // With convergence weighted, an equal-everything-else high-multiplicity
+    // candidate ranks above a singleton.
+    let base = FactorScores {
+        vector_similarity: 0.5,
+        ..FactorScores::default()
+    };
+    let singleton_cand = FactorScores {
+        convergence: engine.score_convergence(1),
+        ..base.clone()
+    };
+    let consolidated_cand = FactorScores {
+        convergence: engine.score_convergence(20),
+        ..base
+    };
+    assert!(
+        engine.compute_score(&consolidated_cand) > engine.compute_score(&singleton_cand),
+        "the higher-multiplicity candidate must rank above an equal-confidence singleton"
+    );
+}
+
+/// #4415: convergence stays inert when its weight is zero (default), so the
+/// factor cannot regress existing recall behaviour.
+#[test]
+fn convergence_inert_when_weight_zero() {
+    let engine = RecallEngine::with_weights(RecallWeights::default());
+    assert!(
+        (engine.score_convergence(50) - 0.0).abs() < f64::EPSILON,
+        "convergence must score 0 when its weight is unset"
     );
 }

--- a/crates/integration-tests/tests/knowledge_recall.rs
+++ b/crates/integration-tests/tests/knowledge_recall.rs
@@ -28,6 +28,7 @@ fn fact_to_scored(fact: &Fact, engine: &RecallEngine, query_nous: &str) -> Score
             graph_importance: 0.0,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
         score: 0.0,
         sensitivity: mneme::knowledge::FactSensitivity::Public,
@@ -148,6 +149,7 @@ fn knowledge_types_all_serialize() {
         scope: None,
         project_id: None,
         visibility: mneme::knowledge::Visibility::Private,
+        source_count: 0,
     };
 
     assert!(serde_json::to_string(&fact).is_ok());

--- a/crates/integration-tests/tests/r722_substrate_canary.rs
+++ b/crates/integration-tests/tests/r722_substrate_canary.rs
@@ -118,6 +118,7 @@ mod fixtures {
                 graph_importance: 0.0,
                 surprise: 0.0,
                 evidence_coverage: 0.0,
+                convergence: 0.0,
             },
             score: result_score,
             sensitivity: FactSensitivity::Public,

--- a/crates/integration-tests/tests/recall_scoring.rs
+++ b/crates/integration-tests/tests/recall_scoring.rs
@@ -39,6 +39,7 @@ fn verified_fact_scores_higher_than_assumed() {
             graph_importance: 0.0,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
     );
     let assumed = make_result(
@@ -54,6 +55,7 @@ fn verified_fact_scores_higher_than_assumed() {
             graph_importance: 0.0,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
     );
 
@@ -78,6 +80,7 @@ fn own_fact_outranks_other_agent() {
             graph_importance: 0.0,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
     );
     let other = make_result(
@@ -93,6 +96,7 @@ fn own_fact_outranks_other_agent() {
             graph_importance: 0.0,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
     );
 
@@ -117,6 +121,7 @@ fn recent_fact_outranks_old() {
             graph_importance: 0.0,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
     );
     let old = make_result(
@@ -132,6 +137,7 @@ fn recent_fact_outranks_old() {
             graph_importance: 0.0,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
     );
 
@@ -152,6 +158,7 @@ fn custom_weights_shift_ranking() {
         graph_importance: 0.0,
         surprise: 0.0,
         evidence_coverage: 0.0,
+        convergence: 0.0,
     };
     let engine = RecallEngine::with_weights(weights);
 
@@ -169,6 +176,7 @@ fn custom_weights_shift_ranking() {
             graph_importance: 0.0,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
     );
     let assumed_self = make_result(
@@ -184,6 +192,7 @@ fn custom_weights_shift_ranking() {
             graph_importance: 0.0,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
     );
 

--- a/crates/nous/src/recall/mod.rs
+++ b/crates/nous/src/recall/mod.rs
@@ -181,6 +181,7 @@ impl RecallStage {
         mneme::recall::RecallWeights {
             surprise: config.surprise_weight,
             evidence_coverage: config.evidence_coverage_weight,
+            convergence: config.convergence_weight,
             ..mneme::recall::RecallWeights::default()
         }
     }
@@ -818,6 +819,10 @@ impl RecallStage {
                     access_frequency: w.access_frequency,
                     surprise: self.score_candidate_surprise(&r.content),
                     evidence_coverage: self.score_candidate_evidence(&r.source_id, answered_ids),
+                    // WHY: convergence scores consolidated-fact multiplicity; the
+                    // engine short-circuits to 0.0 when its weight is unset, so
+                    // legacy/non-consolidated facts (source_count 0) stay inert.
+                    convergence: self.engine.score_convergence(r.source_count),
                     graph_importance: self.engine.score_graph_importance(r.graph_importance),
                 },
                 content: r.content,

--- a/crates/nous/src/recall/scoring.rs
+++ b/crates/nous/src/recall/scoring.rs
@@ -96,6 +96,14 @@ pub struct RecallConfig {
     /// running topic distribution forgets older turns.
     #[serde(default = "default_surprise_ema_alpha")]
     pub surprise_ema_alpha: f64,
+    /// Recall-engine weight for the convergence (fact-multiplicity) factor.
+    /// Default 0.0 (inert).
+    ///
+    /// Sourced from `knowledge.recall_convergence_weight`; threaded into
+    /// [`mneme::recall::RecallWeights::convergence`] at engine construction so a
+    /// non-zero value boosts facts consolidated from more converging sources.
+    #[serde(default)]
+    pub convergence_weight: f64,
     /// Inject factor metadata into recalled knowledge prompts.
     ///
     /// When enabled, each recalled fact includes its factor scores so the
@@ -154,6 +162,7 @@ impl Default for RecallConfig {
             evidence_coverage_weight: 0.0,
             surprise_threshold: default_surprise_threshold(),
             surprise_ema_alpha: default_surprise_ema_alpha(),
+            convergence_weight: 0.0,
             inject_metadata: false,
             pinned_facts: Vec::new(),
             late_inject_anchor: false,
@@ -191,6 +200,7 @@ impl From<taxis::config::RecallSettings> for RecallConfig {
             evidence_coverage_weight: 0.0,
             surprise_threshold: default_surprise_threshold(),
             surprise_ema_alpha: default_surprise_ema_alpha(),
+            convergence_weight: 0.0,
             inject_metadata: s.inject_metadata,
             pinned_facts: s.pinned_facts,
             late_inject_anchor: s.late_inject_anchor,

--- a/crates/nous/src/recall_tests/mod.rs
+++ b/crates/nous/src/recall_tests/mod.rs
@@ -78,6 +78,7 @@ fn make_knowledge_result(content: &str, distance: f64) -> KnowledgeRecallResult 
         scope: None,
         project_id: None,
         visibility: mneme::knowledge::Visibility::Private,
+        source_count: 0,
     }
 }
 
@@ -97,6 +98,7 @@ fn make_knowledge_result_with_id(
         scope: None,
         project_id: None,
         visibility: mneme::knowledge::Visibility::Private,
+        source_count: 0,
     }
 }
 
@@ -116,6 +118,7 @@ fn make_knowledge_result_with_scope(
         scope,
         project_id: None,
         visibility: mneme::knowledge::Visibility::Private,
+        source_count: 0,
     }
 }
 

--- a/crates/nous/src/recall_tests/recall_core.rs
+++ b/crates/nous/src/recall_tests/recall_core.rs
@@ -100,6 +100,7 @@ fn recall_formats_section_with_metadata() {
             graph_importance: 0.5,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
         score: 0.87,
         sensitivity: mneme::knowledge::FactSensitivity::Public,
@@ -122,6 +123,7 @@ fn recall_formats_section_with_metadata() {
             graph_importance: 0.3,
             surprise: 0.0,
             evidence_coverage: 0.0,
+            convergence: 0.0,
         },
         score: 0.72,
         sensitivity: mneme::knowledge::FactSensitivity::Public,
@@ -595,6 +597,7 @@ fn make_knowledge_result_with_nous(
         scope: None,
         project_id: None,
         visibility,
+        source_count: 0,
     }
 }
 

--- a/crates/nous/src/recall_tests/terminology_discovery.rs
+++ b/crates/nous/src/recall_tests/terminology_discovery.rs
@@ -221,6 +221,7 @@ fn make_knowledge_result_sensitive(
         scope: None,
         project_id: None,
         visibility: mneme::knowledge::Visibility::Private,
+        source_count: 0,
     }
 }
 

--- a/crates/taxis/src/config/behavior/knowledge.rs
+++ b/crates/taxis/src/config/behavior/knowledge.rs
@@ -103,6 +103,13 @@ pub struct KnowledgeConfig {
     /// iterative-retrieval path. Threaded into `RecallWeights::evidence_coverage`
     /// at engine construction.
     pub recall_evidence_coverage_weight: f64,
+    /// Recall weight for consolidated-fact convergence. Default: 0.0 (inert).
+    ///
+    /// Non-zero values boost facts assembled from more independent converging
+    /// observations, scored as `log(1 + source_count)` from the
+    /// `fact_multiplicity` side-index (via `RecallEngine::score_convergence`).
+    /// Threaded into `RecallWeights::convergence` at engine construction.
+    pub recall_convergence_weight: f64,
     /// Admission policy applied to every `insert_fact` call. Default: `default` (admit-all).
     ///
     /// Set to `structured` to activate the five-factor A-MAC gate
@@ -143,6 +150,7 @@ impl Default for KnowledgeConfig {
             surprise_ema_alpha: 0.3,
             recall_surprise_weight: 0.0,
             recall_evidence_coverage_weight: 0.0,
+            recall_convergence_weight: 0.0,
             admission_policy: AdmissionPolicyKind::Default,
         }
     }


### PR DESCRIPTION
## What

Wire the `fact_multiplicity` side-index (schema v9, #3692) into recall scoring and conflict resolution (#4415, v1.0.0 "wire built-but-unwired"). `get_fact_multiplicity` was consulted only from tests; this makes the already-paid-for capability live.

## How

Gated to be inert by default (no recall/conflict behaviour change until tuned):

**Recall — a 10th `convergence` factor**
- `RecallWeights` / `FactorScores` gain `convergence`; `score_convergence(source_count)` = `log(1 + n)` normalised against a 32-source saturation point (logarithmic, so a 50-source fact doesn't dominate). Default weight **0.0**.
- `RecallResult` carries `source_count`, populated from the side-index on the recall path (`enrich_source_counts`). Legacy / non-consolidated facts have `source_count` 0 → score 0 → **no regression**.
- Weight threads from `knowledge.recall_convergence_weight` through the nous-config assembly (same path as the surprise/evidence weights).

**Conflict — equal-confidence tie-break**
- On an equal-confidence `CONTRADICTS`, `resolve_action` now tie-breaks toward the fact with more independent converging sources, then falls back to recency. `detect_conflicts` looks up the existing fact's multiplicity.

## Guardrails (per #4415)
- **No schema bump** — the v9 `fact_multiplicity` relation already exists.
- `FactProvenance` unchanged (the explicitly-rejected #3665 design).
- Side-index design preserved; legacy facts return `None` gracefully, no backfill.

## Verification
- CI-exact clippy gate green (`cargo +1.94.0 clippy --workspace --all-targets --exclude theatron --exclude skene --exclude koilon -- -D warnings`).
- 72 episteme conflict + scoring tests green, including new tests: convergence is logarithmic + inert-by-default + ranks high-multiplicity above an equal-confidence singleton; equal-confidence tie-break wins on multiplicity and falls back to recency.

Closes #4415.
