### PR TITLE
chore(ci): pre-push hook (fmt/clippy/_llm) + regenerate stale _llm index

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,4 @@
 use flake .#desktop
+
+# Install in-tree git hooks (fmt/clippy/_llm pre-push + instance-guard pre-commit).
+git config core.hooksPath scripts/githooks 2>/dev/null || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ Cross-tool guide for AI coding agents (Claude Code, Cursor, Windsurf, Copilot, e
 ## Build / Test / Lint
 
 ```bash
+scripts/install-hooks.sh               # one-time: install fmt/clippy/_llm pre-push hook (auto via .envrc)
+cargo +1.94.0 fmt --all -- --check     # REQUIRED CI check, runs first in gate-attestation
 cargo check -p <crate>                 # fast compile check
 cargo test -p <crate>                  # single crate tests
 cargo clippy --workspace               # lint (zero warnings)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,11 +93,15 @@ for the release-time substance-audit gate that calls this tool via
 
 ## Before submitting
 
-1. `cargo test -p <affected-crate>` passes
-2. `cargo clippy --workspace`: zero warnings
-3. No `unwrap()` in library code
-4. New errors use snafu with context
-5. All lint suppressions use `#[expect]` with reason, not `#[allow]`
+Install the in-tree hooks once per clone: `scripts/install-hooks.sh` (auto-run by `.envrc`/direnv). The `pre-push` hook runs CI-exact fmt + `_llm` freshness + clippy so they never first-fail in CI; deliberate bypass is `git push --no-verify`.
+
+1. `cargo +1.94.0 fmt --all -- --check` clean — **fmt is a required CI check** and runs *first* in gate-attestation, so a fmt-only miss aborts the whole gate
+2. `cargo test -p <affected-crate>` passes
+3. `cargo clippy --workspace`: zero warnings (CI-exact: `--all-targets --exclude theatron --exclude skene --exclude koilon -- -D warnings`)
+4. `_llm` index fresh on crate changes: `uv run scripts/llm-extract-l3.py && git add _llm/`
+5. No `unwrap()` in library code
+6. New errors use snafu with context
+7. All lint suppressions use `#[expect]` with reason, not `#[allow]`
 
 ## Test data & instance boundary
 

--- a/_llm/L3-api-index/agora.md
+++ b/_llm/L3-api-index/agora.md
@@ -5,6 +5,107 @@ Crate path: `crates/agora`
 Public API signatures extracted from source. Each signature is preceded by its doc comment.
 For implementation context, read the source directly (`L4`).
 
+## `src/command/mod.rs`
+
+```rust
+pub enum Command {
+    /// `!help` — list all available commands.
+    Help,
+    /// `!status` — lifecycle + session info for the routed nous agent.
+    Status,
+    /// `!agents` — list all running agents.
+    Agents,
+    /// `!whoami` — report which agent will receive this conversation.
+    WhoAmI,
+    /// `!new [session_name]` — start a fresh session (optional label).
+    New {
+        /// Optional human-readable label for the new session.
+        label: Option<String>,
+    },
+    /// `!end` — close the current session for this conversation thread.
+    End,
+    /// `!sessions` — list sessions tracked by the routed nous agent.
+    Sessions,
+    /// `!ping` — liveness check (no agent turn, just a round-trip ack).
+    Ping,
+    /// `!channels` — report registered channel providers and their health.
+    Channels,
+    /// `!uptime` — agent uptime and panic-boundary count.
+    Uptime,
+    /// `!model` — show the model currently configured for the routed agent.
+    Model,
+    /// `!info [agent_id]` — detail view of a specific or current agent.
+    Info {
+        /// Agent identifier to inspect; `None` means the current routed agent.
+        agent_id: Option<String>,
+    },
+    /// Unknown command: carries the unrecognised name for the error reply.
+    Unknown {
+        /// The unrecognised command name (without `!`).
+        name: String,
+    },
+}
+```
+
+```rust
+impl Command {
+    pub fn name (&self) -> &str;
+}
+```
+
+```rust
+pub fn parse (text: &str) -> Option<Command>
+```
+
+```rust
+pub struct AgentSnapshot {
+    /// Agent identifier.
+    pub id: String,
+    /// Lifecycle state as a display string (e.g., "idle", "active").
+    pub lifecycle: String,
+    /// Number of in-memory sessions tracked.
+    pub session_count: usize,
+    /// Currently active session key, if any.
+    pub active_session: Option<String>,
+    /// Panic-boundary hit count since last restart.
+    pub panic_count: u32,
+    /// Uptime in seconds.
+    pub uptime_secs: u64,
+    /// Configured LLM model name.
+    pub model: String,
+}
+```
+
+```rust
+pub struct ChannelSnapshot {
+    /// Channel identifier (e.g., "signal").
+    pub id: String,
+    /// Whether the last probe succeeded.
+    pub healthy: bool,
+    /// Round-trip latency in milliseconds from the last probe, if measured.
+    pub latency_ms: Option<u64>,
+}
+```
+
+```rust
+pub struct CommandContext {
+    /// The nous agent that would normally handle this conversation.
+    pub current_nous_id: String,
+    /// Session key identifying this conversation thread.
+    pub session_key: String,
+    /// Status snapshot for the current agent (if available).
+    pub current_agent: Option<AgentSnapshot>,
+    /// All running agent snapshots.
+    pub all_agents: Vec<AgentSnapshot>,
+    /// Channel health snapshots (empty when probe was not run).
+    pub channels: Vec<ChannelSnapshot>,
+}
+```
+
+```rust
+pub fn execute (cmd: &Command, ctx: &CommandContext) -> String
+```
+
 ## `src/error.rs`
 
 ```rust

--- a/_llm/L3-api-index/eidos.md
+++ b/_llm/L3-api-index/eidos.md
@@ -475,6 +475,12 @@ pub struct RecallResult {
     pub source_type: String,
     /// Source ID.
     pub source_id: String, // kanon:ignore RUST/primitive-for-domain-id — polymorphic source reference string, not a single domain ID type
+    /// Owning nous identifier carried from the storage layer so the recall
+    /// pipeline can apply cohort-visibility filtering (#208).  Empty string
+    /// for non-fact sources or results from pre-208 storage that has not yet
+    /// been hydrated.
+    #[serde(default)]
+    pub nous_id: String,
     /// Data-sovereignty classification for the underlying fact, carried
     /// from [`Fact::sensitivity`] so the recall pipeline can filter results
     /// by the active provider's deployment target (#3404, #3413). Defaults
@@ -515,6 +521,14 @@ pub struct RecallResult {
     /// [`Visibility::Private`]: super::fact::Visibility::Private
     #[serde(default)]
     pub visibility: super::fact::Visibility,
+    /// Consolidated-fact source count from the `fact_multiplicity` side-index,
+    /// carried so the recall pipeline can score the convergence factor (#4415).
+    ///
+    /// `0` for legacy / non-consolidated facts (no multiplicity record) and for
+    /// non-fact sources; populated by the knowledge store only when the
+    /// convergence recall weight is active.
+    #[serde(default)]
+    pub source_count: u32,
 }
 ```
 

--- a/_llm/L3-api-index/energeia.md
+++ b/_llm/L3-api-index/energeia.md
@@ -211,14 +211,16 @@ impl CostLedger {
 ## `src/cron.rs`
 
 ```rust
-/// Policy for handling overlap between scheduled fires of the same task.
 pub enum OverlapPolicy {
     /// Allow a new scheduled fire even while a previous callback is still in
     /// flight. The default — matches the historical scheduler behavior where a
     /// slow callback does not block later cron ticks.
+    #[default]
     Allow,
     /// Skip a scheduled fire when the previous callback for the same task has
-    /// not yet returned.
+    /// not yet returned. Used by callers that want serialized recurring work
+    /// (e.g. recurring dispatch where overlapping runs would compete for the
+    /// same project worktree).
     SkipIfInFlight,
 }
 ```
@@ -279,7 +281,7 @@ pub struct CronScheduler {
 ```rust
 impl CronScheduler {
     pub fn new (tasks: Vec<CronTask>, lock_store: Arc<CronLockStore>) -> Self;
-    pub fn with_overlap_policy (self, policy: OverlapPolicy) -> Self;
+    pub fn with_overlap_policy (mut self, policy: OverlapPolicy) -> Self;
     pub fn next_fire_after (&self, task: &CronTask, now: Zoned) -> Option<Zoned>;
     pub async fn run <F, Fut> (&self, cancel: CancellationToken, on_fire: F) -> Result<()> where
         F: Fn(CronTask) -> Fut + Clone + Send + Sync + 'static,

--- a/_llm/L3-api-index/episteme.md
+++ b/_llm/L3-api-index/episteme.md
@@ -189,7 +189,7 @@ pub struct NuExtractProviderConfig {
 > front. Schema-constrained JSON is generated at inference time with a
 > greedy decode (temperature=0 equivalent). Entity and relationship fields
 > from the returned JSON are lifted into `Extraction`; the LLM fallback is
-> not used because NuExtract is designed for full-coverage extraction rather
+> not used because `NuExtract` is designed for full-coverage extraction rather
 > than NER-only span tagging.
 ```rust
 pub struct NuExtractProvider {
@@ -2526,6 +2526,16 @@ pub struct KnowledgeStore {
     dim: usize,
     /// Serializes read-modify-write access counter increments to prevent races.
     access_lock: std::sync::Mutex<()>,
+    /// Serializes admission-check + insert so concurrent writers for the same
+    /// fact cannot both pass the admission gate and write independently.
+    ///
+    /// WHY: `should_admit` reads store state (or inspects the fact) and then
+    /// `run_mut` writes. Without this lock a second concurrent insert of the
+    /// same fact could pass `should_admit` before the first write lands.
+    /// The `:put` upsert means the end-state is still correct (one row), but
+    /// the admission gate would have fired twice — potentially consuming policy
+    /// budget (e.g. rate counters) or triggering side effects on both paths.
+    insert_lock: std::sync::Mutex<()>,
     /// Admission policy gate: checked before every fact insertion.
     admission_policy: Box<dyn crate::admission::AdmissionPolicy>,
 }
@@ -3087,6 +3097,26 @@ pub struct RecallWeights {
     /// Weight for graph `PageRank` importance (hub entities boosted).
     /// Default: 0.10
     pub graph_importance: f64,
+    /// Weight for Bayesian surprise (topic-shift signal from EM-LLM).
+    ///
+    /// Non-zero values blend in a per-candidate surprise score produced by
+    /// `SurpriseCalculator`. Default: 0.0 (inert — existing behaviour
+    /// preserved). Enable by setting a positive weight in config.
+    pub surprise: f64,
+    /// Weight for evidence-gap coverage (`MemR3` iterative retrieval).
+    ///
+    /// Non-zero values blend in how well a candidate's fact ID appears in the
+    /// evidence-gap tracker's answered set. Default: 0.0 (inert). Enable by
+    /// setting a positive weight in config.
+    pub evidence_coverage: f64,
+    /// Weight for consolidated-fact convergence (multiplicity / source count).
+    ///
+    /// Non-zero values blend in `log(1 + source_count)` (from the
+    /// `fact_multiplicity` side-index) so facts assembled from more independent
+    /// converging observations rank higher. Default: 0.0 (inert). Legacy /
+    /// non-consolidated facts have `source_count` 0 and score 0 here, so enabling
+    /// the weight never regresses them.
+    pub convergence: f64,
 }
 ```
 
@@ -3106,6 +3136,25 @@ pub struct FactorScores {
     pub access_frequency: f64,
     /// `PageRank` graph importance score [0.0, 1.0] (1.0 = highest hub).
     pub graph_importance: f64,
+    /// Bayesian surprise contribution [0.0, 1.0].
+    ///
+    /// Normalised inverse of the KL-divergence score from `SurpriseCalculator`.
+    /// Default: 0.0 — inert unless `RecallWeights::surprise > 0`.
+    pub surprise: f64,
+    /// Evidence-coverage score [0.0, 1.0].
+    ///
+    /// 1.0 when the candidate's `source_id` appears in the `EvidenceGapTracker`
+    /// answered set with high confidence; 0.0 when absent. Supplied by callers
+    /// running iterative retrieval. Default: 0.0 — inert unless
+    /// `RecallWeights::evidence_coverage > 0`.
+    pub evidence_coverage: f64,
+    /// Convergence score [0.0, 1.0] from consolidated-fact multiplicity.
+    ///
+    /// `log(1 + source_count)` normalised against a saturation point, so facts
+    /// built from more independent observations score higher. 0.0 for legacy /
+    /// non-consolidated facts (`source_count` 0). Default: 0.0 — inert unless
+    /// `RecallWeights::convergence > 0`.
+    pub convergence: f64,
 }
 ```
 
@@ -3192,6 +3241,13 @@ impl RecallEngine {
     ) -> Vec<ScoredResult>;
     pub fn rank (&self, mut candidates: Vec<ScoredResult>) -> Vec<ScoredResult>;
     pub fn score_graph_importance (&self, importance: f64) -> f64;
+    pub fn score_surprise (&self, surprise_nats: f64, midpoint_nats: f64) -> f64;
+    pub fn score_evidence_coverage (
+        &self,
+        source_id: &str,
+        answered_ids: &std::collections::HashMap<String, f64>,
+    ) -> f64;
+    pub fn score_convergence (&self, source_count: u32) -> f64;
 }
 ```
 
@@ -4137,6 +4193,7 @@ impl SurpriseCalculator {
     pub fn new () -> Self;
     pub fn with_alpha (ema_alpha: f64) -> Self;
     pub fn compute_surprise (&mut self, text: &str) -> f64;
+    pub fn surprise_of (&self, text: &str) -> f64;
 }
 ```
 

--- a/_llm/L3-api-index/hermeneus.md
+++ b/_llm/L3-api-index/hermeneus.md
@@ -1167,6 +1167,19 @@ impl OpenAiProvider {
 
 ## `src/provider.rs`
 
+```rust
+pub enum MatchKind {
+    // WHY: lower numeric value = lower specificity; `find_provider` keeps
+    // the maximum. Ord derives compare numerically so CatchAll < Prefix < Exact.
+    /// Broad family-pattern match; lowest specificity.
+    CatchAll = 0,
+    /// Namespaced-prefix match (e.g. `cc/`, `codex/`); medium specificity.
+    Prefix = 1,
+    /// Exact model-ID match; highest specificity.
+    Exact = 2,
+}
+```
+
 > Trait for LLM providers.
 > 
 > Implementations handle authentication, request formatting, response parsing,
@@ -1183,6 +1196,7 @@ pub trait LlmProvider : Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>>;
     fn supported_models (&self) -> &[&str];
     fn supports_model (&self, model: &str) -> bool; // default impl
+    fn match_specificity (&self, model: &str) -> Option<MatchKind>; // default impl
     fn name (&self) -> &str;
     fn deployment_target (&self) -> DeploymentTarget; // default impl
     fn supports_streaming (&self) -> bool; // default impl
@@ -1412,6 +1426,8 @@ pub struct MockProvider {
     models: &'static [&'static str],
     provider_name: &'static str,
     requests: Mutex<Vec<CompletionRequest>>,
+    /// Override for `match_specificity`. `None` = use the default exact-match logic.
+    match_kind_override: Option<MatchKind>,
 }
 ```
 
@@ -1422,6 +1438,7 @@ impl MockProvider {
     pub fn error (message: &str) -> Self;
     pub fn models (mut self, models: &'static [&'static str]) -> Self;
     pub fn named (mut self, name: &'static str) -> Self;
+    pub fn with_match_kind (mut self, kind: MatchKind) -> Self;
     pub fn captured_requests (&self) -> Vec<CompletionRequest>;
 }
 ```

--- a/_llm/L3-api-index/integration-tests.md
+++ b/_llm/L3-api-index/integration-tests.md
@@ -47,6 +47,10 @@ impl TestHarness {
         register_tools: bool,
     ) -> Self;
     pub async fn build_with_provider_and_knowledge_store (provider: Box<dyn LlmProvider>) -> Self;
+    pub async fn build_with_provider_and_registry (
+        provider: Box<dyn LlmProvider>,
+        registry: ToolRegistry,
+    ) -> Self;
     pub fn knowledge_store (&self) -> Arc<KnowledgeStore>;
     pub fn embedding_provider (&self) -> Arc<dyn EmbeddingProvider>;
     pub fn auth_token (&self) -> String;

--- a/_llm/L3-api-index/nous.md
+++ b/_llm/L3-api-index/nous.md
@@ -2681,10 +2681,10 @@ pub struct RecallFilteredFact {
 pub struct RecallStage {
     engine: RecallEngine,
     config: RecallConfig,
-    /// Optional side-query selected IDs for pre-filtering before 6-factor scoring.
+    /// Optional side-query selected IDs for pre-filtering before factor scoring.
     side_query_ids: Option<HashSet<String>>,
     /// Production side-query selector used to turn the raw recall manifest into
-    /// a prefilter for 6-factor scoring.
+    /// a prefilter for factor scoring.
     side_query_selector: mneme::side_query::SideQuerySelector,
     /// Data-sovereignty target: gates which facts may leave the instance
     /// through this recall pass (#3404, #3413). Defaults to
@@ -2704,12 +2704,21 @@ pub struct RecallStage {
     project_scope: mneme::recall::ProjectRecallScope,
     /// Optional URL for an HTTP cross-encoder reranker.
     reranker_url: Option<String>,
+    /// Session-scoped surprise scorer snapshot for the current turn.
+    ///
+    /// Present only when `surprise_weight > 0`: a clone of the session's
+    /// running `SurpriseCalculator` whose prior was advanced (actor-side) by
+    /// the current turn before the pipeline spawned. Used read-only in
+    /// `build_candidates` to score each candidate's topic-shift surprise
+    /// against the frozen session prior. `None` leaves `surprise` inert.
+    surprise_calculator: Option<SurpriseCalculator>,
 }
 ```
 
 ```rust
 impl RecallStage {
     pub fn new (config: RecallConfig) -> Self;
+    pub fn with_surprise_calculator (mut self, calc: Option<SurpriseCalculator>) -> Self;
     pub fn with_side_query_ids (mut self, ids: HashSet<String>) -> Self;
     pub fn with_deployment_target (mut self, target: DeploymentTarget) -> Self;
     pub fn with_pinned_facts (mut self, facts: &[FactId]) -> Self;
@@ -2774,6 +2783,43 @@ pub struct RecallConfig {
     /// Per-factor scoring weights applied when building candidates.
     #[serde(default)]
     pub weights: RecallWeights,
+    /// Recall-engine weight for the Bayesian-surprise factor. Default 0.0 (inert).
+    ///
+    /// Sourced from `knowledge.recall_surprise_weight`; threaded into
+    /// [`mneme::recall::RecallWeights::surprise`] at engine construction so a
+    /// non-zero value blends the session `SurpriseCalculator` signal into recall
+    /// scoring.
+    #[serde(default)]
+    pub surprise_weight: f64,
+    /// Recall-engine weight for the evidence-coverage factor. Default 0.0 (inert).
+    ///
+    /// Sourced from `knowledge.recall_evidence_coverage_weight`; threaded into
+    /// [`mneme::recall::RecallWeights::evidence_coverage`] at engine construction
+    /// so a non-zero value boosts candidates that answer an evidence gap in the
+    /// iterative-retrieval path.
+    #[serde(default)]
+    pub evidence_coverage_weight: f64,
+    /// Sigmoid midpoint (in nats) for surprise scoring. Default 2.0.
+    ///
+    /// Sourced from `knowledge.surprise_threshold`; passed to
+    /// [`mneme::recall::RecallEngine::score_surprise`] as the neutral boundary
+    /// above which a candidate counts as a topic shift.
+    #[serde(default = "default_surprise_threshold")]
+    pub surprise_threshold: f64,
+    /// EMA decay factor for the session `SurpriseCalculator`. Default 0.3.
+    ///
+    /// Sourced from `knowledge.surprise_ema_alpha`; controls how fast the
+    /// running topic distribution forgets older turns.
+    #[serde(default = "default_surprise_ema_alpha")]
+    pub surprise_ema_alpha: f64,
+    /// Recall-engine weight for the convergence (fact-multiplicity) factor.
+    /// Default 0.0 (inert).
+    ///
+    /// Sourced from `knowledge.recall_convergence_weight`; threaded into
+    /// [`mneme::recall::RecallWeights::convergence`] at engine construction so a
+    /// non-zero value boosts facts consolidated from more converging sources.
+    #[serde(default)]
+    pub convergence_weight: f64,
     /// Inject factor metadata into recalled knowledge prompts.
     ///
     /// When enabled, each recalled fact includes its factor scores so the
@@ -3287,6 +3333,14 @@ pub struct SessionState {
     /// WHY: persisted per-session so patterns are tracked across turns.
     /// Reset on operator intervention via `reset_on_user_message`.
     pub loop_guard: hermeneus::loop_detector::LoopGuard,
+    /// Running Bayesian-surprise distribution for this session.
+    ///
+    /// WHY: surprise is episodic — the prior must accumulate across turns to
+    /// detect topic shifts. Advanced once per turn (actor-side, before the
+    /// pipeline spawns) with the user content, then read in recall scoring to
+    /// rank candidates by how much they diverge from the session topic. Inert
+    /// unless `recall.surprise_weight > 0`.
+    pub surprise_calculator: mneme::surprise::SurpriseCalculator,
 }
 ```
 

--- a/_llm/L3-api-index/oikonomos.md
+++ b/_llm/L3-api-index/oikonomos.md
@@ -403,6 +403,7 @@ pub trait KnowledgeMaintenanceExecutor : Send + Sync {
     fn maintain_indexes (&self, nous_id: &str) -> crate::error::Result<MaintenanceReport>;
     fn health_check (&self, nous_id: &str) -> crate::error::Result<MaintenanceReport>;
     fn run_skill_decay (&self, nous_id: &str) -> crate::error::Result<MaintenanceReport>;
+    fn materialize_derived_facts (&self) -> crate::error::Result<MaintenanceReport>;
 }
 ```
 
@@ -1288,6 +1289,9 @@ pub enum BuiltinTask {
     PromptAuditRotation,
     /// Refresh empirical after-action routing statistics from JSONL logs.
     RoutingStoreRefresh,
+    /// Materialize derived Datalog rules (IS-A closure, causal chains, defeasible defaults)
+    /// into the `derived_facts` relation.
+    DerivedFactsMaterialize,
 }
 ```
 

--- a/_llm/L3-api-index/poiesis-core.md
+++ b/_llm/L3-api-index/poiesis-core.md
@@ -692,6 +692,8 @@ impl Factbase {
         &self,
         adapters: &DataSourceRegistry,
     ) -> Result<BTreeMap<FactId, ResolvedFact>, FactbaseError>;
+    pub fn walk_citation_chain (&self, root: &FactId) -> Vec<FactId>;
+    pub fn claim_citation_chain (&self, claim_id: &ClaimId) -> Option<Vec<FactId>>;
 }
 ```
 
@@ -742,6 +744,53 @@ pub struct Metadata {
 ```rust
 impl Metadata {
     pub fn titled (title: impl Into<String>) -> Self;
+}
+```
+
+## `src/qa.rs`
+
+```rust
+pub enum QaIssueKind {
+    /// A citation could not be resolved to a fact.
+    CitationUnresolvable,
+    /// A claim does not match the fact it cites.
+    ClaimMismatch,
+    /// Prose violated a style or structural rule.
+    ProseViolation,
+    /// A required section is absent from the document.
+    MissingSection,
+}
+```
+
+```rust
+pub struct QaIssue {
+    /// The classification of the issue.
+    pub kind: QaIssueKind,
+    /// Optional source location (e.g. a JSON pointer or line reference).
+    pub location: Option<String>,
+    /// Human-readable description of the issue.
+    pub message: String,
+}
+```
+
+```rust
+pub struct QaReport {
+    /// Whether any issues were found.
+    pub has_issues: bool,
+    /// Number of issues in this report.
+    pub issue_count: usize,
+    /// The individual issues comprising this report.
+    pub issues: Vec<QaIssue>,
+}
+```
+
+```rust
+impl QaReport {
+    pub fn pass () -> Self;
+    pub fn new (issues: Vec<QaIssue>) -> Self;
+    pub fn merge (reports: impl IntoIterator<Item = QaReport>) -> Self;
+    pub fn is_clean (&self) -> bool;
+    pub fn to_json (&self) -> Result<String, serde_json::Error>;
 }
 ```
 

--- a/_llm/L3-api-index/poiesis-doc.md
+++ b/_llm/L3-api-index/poiesis-doc.md
@@ -253,37 +253,79 @@ pub fn render_doc (doc: &Document, opts: &DocOpts) -> Result<Vec<u8>, PandocErro
 
 ## `src/pandoc_probe.rs`
 
+> Minimum Pandoc version required by `poiesis-doc`.
 ```rust
-pub struct PandocProbe {
-    /// Absolute path to the `pandoc` binary.
-    pub path: PathBuf,
-    /// Version string reported by `pandoc --version`, e.g. `"3.1.13"`.
-    pub version: String,
+pub const REQUIRED_PANDOC_VERSION: PandocVersion = (3, 0, 0);
+```
+
+> Semantic version triple used by the probe.
+```rust
+pub type PandocVersion = (u32, u32, u32);
+```
+
+```rust
+pub enum PandocProbe {
+    /// `pandoc` was found and meets the minimum version requirement.
+    Present {
+        /// Absolute path to the binary that was selected.
+        path: PathBuf,
+        /// Version reported by `pandoc --version`.
+        version: PandocVersion,
+    },
+    /// `pandoc` could not be found on PATH.
+    Missing {
+        /// Candidate paths that were searched.
+        searched: Vec<PathBuf>,
+    },
+    /// `pandoc` was found but is too old for this crate.
+    TooOld {
+        /// Absolute path to the binary that was selected.
+        path: PathBuf,
+        /// Version reported by `pandoc --version`.
+        found: PandocVersion,
+        /// Minimum version required by the crate.
+        required: PandocVersion,
+    },
 }
 ```
 
 ```rust
 impl PandocProbe {
-    pub fn check () -> Result<Self, PandocProbeError>;
+    pub fn check () -> Self;
+    pub fn require (self) -> Result<(), PandocProbeError>;
 }
 ```
 
 ```rust
 pub enum PandocProbeError {
-    /// `pandoc` binary not found on `PATH`.
+    /// `pandoc` binary not found on PATH.
     #[snafu(display(
-        "pandoc not found on PATH — install via `nix develop` \
-         (pandoc is pinned in flake.nix), or use the `pdf` format which needs no pandoc"
+        "pandoc not found (searched: {}). Install pandoc >= 3.0.0; on NixOS run `nix develop`, on Ubuntu/Debian run `apt install pandoc`, on macOS run `brew install pandoc`, or download from https://pandoc.org/installing.html",
+        searched
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
     ))]
-    NotFound,
+    NotInstalled {
+        /// Candidate paths that were searched.
+        searched: Vec<PathBuf>,
+    },
 
-    /// `pandoc --version` found the binary but the command failed.
-    #[snafu(display("pandoc found at {} but `pandoc --version` failed: {detail}", path.display()))]
-    VersionCheckFailed {
-        /// Path where pandoc was found.
+    /// `pandoc` was found but the version is below the minimum requirement.
+    #[snafu(display(
+        "pandoc at {} is version {}, but >= {} is required. Upgrade via https://pandoc.org/installing.html or `nix develop`",
+        path.display(),
+        format_version(found),
+        format_version(required)
+    ))]
+    VersionTooOld {
+        /// Path to the too-old binary.
         path: PathBuf,
-        /// Human-readable failure reason.
-        detail: String,
+        /// Found version.
+        found: PandocVersion,
+        /// Minimum version required.
+        required: PandocVersion,
     },
 }
 ```

--- a/_llm/L3-api-index/taxis.md
+++ b/_llm/L3-api-index/taxis.md
@@ -745,6 +745,39 @@ pub struct KnowledgeConfig {
     /// EMA alpha for surprise baseline adaptation. Default: 0.3.
     /// Mirrors `episteme::surprise::DEFAULT_EMA_ALPHA`.
     pub surprise_ema_alpha: f64,
+    /// Recall weight for Bayesian surprise contribution. Default: 0.0 (inert).
+    ///
+    /// Non-zero values blend the session `SurpriseCalculator`'s KL-divergence
+    /// signal (via `RecallEngine::score_surprise`) into recall scoring, so
+    /// candidates whose content diverges from the running session topic rank
+    /// higher. Threaded into `RecallWeights::surprise` at engine construction
+    /// (`aletheia::runtime::nous_config` → `RecallConfig::surprise_weight`).
+    ///
+    /// WARNING: this is a novelty/serendipity signal, not a relevance booster —
+    /// it surfaces cross-topic memories (high topic-shift surprise), trading
+    /// relevance for diversity. Keep it small relative to `vector_similarity`.
+    pub recall_surprise_weight: f64,
+    /// Recall weight for evidence-gap coverage. Default: 0.0 (inert).
+    ///
+    /// Non-zero values boost candidates whose `source_id` answers a decomposed
+    /// query gap (via `RecallEngine::score_evidence_coverage`) during the
+    /// iterative-retrieval path. Threaded into `RecallWeights::evidence_coverage`
+    /// at engine construction.
+    pub recall_evidence_coverage_weight: f64,
+    /// Recall weight for consolidated-fact convergence. Default: 0.0 (inert).
+    ///
+    /// Non-zero values boost facts assembled from more independent converging
+    /// observations, scored as `log(1 + source_count)` from the
+    /// `fact_multiplicity` side-index (via `RecallEngine::score_convergence`).
+    /// Threaded into `RecallWeights::convergence` at engine construction.
+    pub recall_convergence_weight: f64,
+    /// Admission policy applied to every `insert_fact` call. Default: `default` (admit-all).
+    ///
+    /// Set to `structured` to activate the five-factor A-MAC gate
+    /// (`StructuredAdmissionPolicy`). Operators can tune the threshold and
+    /// min-confidence via `episteme::admission::StructuredAdmissionConfig`
+    /// defaults; those knobs are not yet surfaced in the TOML cascade.
+    pub admission_policy: AdmissionPolicyKind,
 }
 ```
 
@@ -762,6 +795,22 @@ pub enum BookkeepingProviderKind {
     Llm,
     /// `GLiNER` ONNX entity adapter with LLM fallback.
     Gliner,
+}
+```
+
+```rust
+pub enum AdmissionPolicyKind {
+    /// Admit-all policy: every fact that passes basic validation is stored.
+    ///
+    /// This is the pre-admission-control behavior. Use this when the
+    /// extraction pipeline is already well-filtered or when behavioral
+    /// compatibility with existing deployments is required.
+    #[default]
+    Default,
+    /// Five-factor A-MAC policy (arxiv 2603.04549): utility, confidence,
+    /// novelty, recency, and content-type prior. Facts whose combined
+    /// weighted score falls below the configured threshold are rejected.
+    Structured,
 }
 ```
 

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-05-30T12:20:49Z"
+generated_at = "2026-06-05T17:59:46Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -14,13 +14,13 @@ generator = "scripts/llm-extract-l3.py"
 [[crates]]
 name = "agora"
 path = "crates/agora"
-source_hash = "445a22f50b974c5bd11d9c2d40ff722f64ba0797d639d1590560953c3186509d"
-l3_token_estimate = 4901
+source_hash = "f39ae1a6ebbf8ebfae1998bd41944fac607024abe11220193eb0bca306da2c4e"
+l3_token_estimate = 5636
 
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "44459ef29a6ba3b79f04bb575b25ddcc71dcdd93057e74cc68471a46a03e8ddc"
+source_hash = "88b534fd6b6c44eb88fde4f591171a3075b906b2efc74b011a14428cd578dee9"
 l3_token_estimate = 167
 
 [[crates]]
@@ -74,20 +74,20 @@ l3_token_estimate = 8198
 [[crates]]
 name = "eidos"
 path = "crates/eidos"
-source_hash = "7771ca71d4227236486ef10555dd1b05d8b376946975be38293d0632c899753a"
-l3_token_estimate = 13271
+source_hash = "1404454c2879c915436790243e3ee6c7e3214024ae3c8db84cc12ee62b2755b7"
+l3_token_estimate = 13450
 
 [[crates]]
 name = "energeia"
 path = "crates/energeia"
-source_hash = "48c7434f7ffef83e67597526618154502afa6ed9736f1feea7f14f246f0fa483"
-l3_token_estimate = 19912
+source_hash = "b6269ada58c4a21eb2b80d8eaefe0c1ba70350611033ec4c02e43a0606cf2903"
+l3_token_estimate = 20097
 
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "3ac97e8a225ab406fbd95aaef49ee665e2ec27e0db3877ad0f90e1bd24228a39"
-l3_token_estimate = 31579
+source_hash = "2fa904c98ede4e057802f3fd1677c097bb69b472dd684160522c81112670357d"
+l3_token_estimate = 32351
 
 [[crates]]
 name = "gnosis"
@@ -104,19 +104,19 @@ l3_token_estimate = 5222
 [[crates]]
 name = "hermeneus"
 path = "crates/hermeneus"
-source_hash = "0b354fb749d56c843359e7b28b06e99216a7936734b8e03c1865f171231f63eb"
-l3_token_estimate = 13187
+source_hash = "1c3372fe881b0812ac402f3ecdc852b50f7bf50fafd261b84a6762c2e7b169a5"
+l3_token_estimate = 13362
 
 [[crates]]
 name = "integration-tests"
 path = "crates/integration-tests"
-source_hash = "bed726fd38f545be5e2ded2dc4ce3ef5621360b5f05f146cd3c0030c37e63dbb"
-l3_token_estimate = 1135
+source_hash = "6f9eb80574f54a9d0b3dc34080ac0d1f6b0957a042896d63119b87ccea4a6c0f"
+l3_token_estimate = 1170
 
 [[crates]]
 name = "koilon"
 path = "crates/theatron/koilon"
-source_hash = "4d6df542619629bb83bc4fd664685aef515ff804a86d159c228aaad59a55e03f"
+source_hash = "e4df5f3664a681dbde3cf88c7c82729182cc198b08fe155a184a8cde262c19fb"
 l3_token_estimate = 11570
 
 [[crates]]
@@ -128,7 +128,7 @@ l3_token_estimate = 7394
 [[crates]]
 name = "krites"
 path = "crates/krites"
-source_hash = "05eb5e79c6d0c404382fc07bfa76dfc2ba10d494403a4242e4003251d757d1cb"
+source_hash = "50fe968a79e7515cffcf18b7855cc7ca54af4ec1b61300a3f72ef7f103f3e30e"
 l3_token_estimate = 9904
 
 [[crates]]
@@ -140,25 +140,25 @@ l3_token_estimate = 4097
 [[crates]]
 name = "mneme"
 path = "crates/mneme"
-source_hash = "9de5fe56be5ef42af68ac326faca262d3ef20e587fd072dc67518c426125083d"
+source_hash = "650f54ef28416f9038c87dcfaefc28139a9c07635f30d9c1ecb49cdb9dac5082"
 l3_token_estimate = 51
 
 [[crates]]
 name = "nous"
 path = "crates/nous"
-source_hash = "6bdeb97edcd691d54b88414e9aa396a31ad3e25281710ef5a4c58127ea4a3df8"
-l3_token_estimate = 33544
+source_hash = "1653716a8bc42279e63ee80a1c39cb5e5a53c4c3454d240f09a8b300cfb8371b"
+l3_token_estimate = 34289
 
 [[crates]]
 name = "oikonomos"
 path = "crates/daemon"
-source_hash = "df2ef95efc5e98a785048724daf7127c1a74f1829e2206d00cec4f4a82cc23d5"
-l3_token_estimate = 12254
+source_hash = "ddcaeb8e676e7b0ee79d8bce7892841e0f6a63ccb4cab0513a8abebd923b3ca1"
+l3_token_estimate = 12316
 
 [[crates]]
 name = "organon"
 path = "crates/organon"
-source_hash = "5f076ceefcd98f701e87d5095f522f3fd3dad99f46c3d2966304c4445b2759b8"
+source_hash = "7d8dd9d9ba07830464a5b48e877649148796c2e70353ff94ab611944d54e7623"
 l3_token_estimate = 11827
 
 [[crates]]
@@ -170,8 +170,8 @@ l3_token_estimate = 4605
 [[crates]]
 name = "poiesis-core"
 path = "crates/poiesis/core"
-source_hash = "f6cc9b1ce8bf972fea5cd2880c3367bb07f1014695fae10861e37f30fcc31f10"
-l3_token_estimate = 5949
+source_hash = "74497ac7201cd1a3c2204be8b4c056cdc283951cbe9837c94eca180aebde4176"
+l3_token_estimate = 6280
 
 [[crates]]
 name = "poiesis-deck"
@@ -194,8 +194,8 @@ l3_token_estimate = 446
 [[crates]]
 name = "poiesis-doc"
 path = "crates/poiesis/doc"
-source_hash = "55001d53c526272f9d6b8cb99f5f63e4218b9e1db33f3fe1b1136af55f76bd0d"
-l3_token_estimate = 1935
+source_hash = "ab21f3dde2c2244bcfd27306c1c7ffd06e8fb16998011a91667234e36a728b92"
+l3_token_estimate = 2269
 
 [[crates]]
 name = "poiesis-inspect"
@@ -260,7 +260,7 @@ l3_token_estimate = 1354
 [[crates]]
 name = "pylon"
 path = "crates/pylon"
-source_hash = "1a47611c81ff6aa5fcd55adc7d1db3e76362c162da409355938c44e5bbfa5c29"
+source_hash = "9514b9c83a5cc9fb5e45182a9d290e9e898ca9fbb905c17271c5ae6df2e4c5e2"
 l3_token_estimate = 15500
 
 [[crates]]
@@ -278,13 +278,13 @@ l3_token_estimate = 6587
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "3e2e8149c1e6066d1829ff62f069e71ccdfaec3325ad208e29386256cd2b17f5"
-l3_token_estimate = 23358
+source_hash = "32e4a92bf745a3bf87cdfe16cff83f4349895221a80c569c2f52820688877899"
+l3_token_estimate = 24088
 
 [[crates]]
 name = "theatron"
 path = "crates/theatron"
-source_hash = "e1212ba25811767b4e7b774b5aa4263593013d52c07d11340044a35276028a5d"
+source_hash = "9b1e020b438d58ed06b60b21f5aada64196ad610c755da5bca435d67fc194fdc"
 l3_token_estimate = 22042
 
 [[crates]]

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Pre-commit hook: reject any staged files under instance/
+# Install: cp scripts/pre-commit-instance-guard .git/hooks/pre-commit
+
+INSTANCE_FILES=$(git diff --cached --name-only | grep "^instance/" || true)  # NOTE: failure is non-fatal here
+
+if [[ -n "$INSTANCE_FILES" ]]; then
+    echo "ERROR: Attempting to commit instance/ files:"
+    echo "$INSTANCE_FILES"
+    echo ""
+    echo "instance/ is private deployment state and must not be tracked."
+    echo "If you need to update the scaffold, edit instance.example/ instead."
+    exit 1
+fi

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Pre-push hook: catch the CI-required checks that reliably slip to CI — cargo
+# fmt, _llm index freshness, and clippy — at the push->PR boundary instead.
+#
+# Install: `git config core.hooksPath scripts/githooks` (auto-set by .envrc, or
+# run `scripts/install-hooks.sh`). Deliberate bypass: `git push --no-verify`.
+#
+# Speed: fmt (~4s) + _llm (~3s) always run (cheap, and fmt is the check that
+# first-failed CI on formatting alone). Clippy runs on AFFECTED crates by
+# default; set PREPUSH_FULL=1 for the bit-exact workspace clippy CI runs, or
+# PREPUSH_NO_CLIPPY=1 to skip it (CI gate-attestation is the backstop).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+fail() { echo "" >&2; echo "❌ pre-push: $1" >&2; echo "   (bypass with: git push --no-verify)" >&2; exit 1; }
+
+echo "pre-push: cargo fmt --check ..."
+cargo +1.94.0 fmt --all -- --check \
+  || fail "formatting — run 'cargo +1.94.0 fmt --all' then re-push"
+
+# WHY: range vs the upstream the push targets; fall back to origin/main.
+range="origin/main...HEAD"
+git rev-parse --verify --quiet "@{push}" >/dev/null 2>&1 && range="@{push}..HEAD"
+changed="$(git diff --name-only "$range" 2>/dev/null || true)"
+
+# _llm L3 index freshness — paths-gated to what the CI workflow watches.
+if printf '%s\n' "$changed" | grep -qE '^crates/.*\.rs$|(^|/)Cargo\.toml$|^scripts/llm-extract-l3\.py$'; then
+  echo "pre-push: regenerating _llm L3 index ..."
+  uv run scripts/llm-extract-l3.py >/dev/null 2>&1 || fail "_llm extractor failed to run"
+  if ! git diff --quiet _llm/; then
+    git diff --stat _llm/ >&2
+    fail "_llm index stale — run 'uv run scripts/llm-extract-l3.py && git add _llm/' and commit"
+  fi
+fi
+
+if [ "${PREPUSH_NO_CLIPPY:-0}" = "1" ]; then
+  echo "pre-push: clippy skipped (PREPUSH_NO_CLIPPY=1); CI gate-attestation is the backstop"
+elif [ "${PREPUSH_FULL:-0}" = "1" ]; then
+  echo "pre-push: cargo clippy (CI-exact workspace) ..."
+  cargo +1.94.0 clippy --workspace --all-targets \
+    --exclude theatron --exclude skene --exclude koilon -- -D warnings \
+    || fail "clippy (workspace) — fix the warnings above"
+else
+  pkgs="$(printf '%s\n' "$changed" | python3 scripts/affected-crates.py 2>/dev/null || true)"
+  if [ -n "$pkgs" ]; then
+    echo "pre-push: cargo clippy on affected crates ($(echo "$pkgs" | tr '\n' ' '))..."
+    args=()
+    while IFS= read -r p; do [ -n "$p" ] && args+=("-p" "$p"); done <<< "$pkgs"
+    # WHY: affected-crate clippy is a fast 95% pre-filter; CI runs the bit-exact
+    # --workspace pass. Use PREPUSH_FULL=1 for parity.
+    cargo +1.94.0 clippy "${args[@]}" --all-targets -- -D warnings \
+      || fail "clippy (affected crates) — fix the warnings above"
+  fi
+fi
+
+echo "✅ pre-push checks passed"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Install the in-tree git hooks (one-time per clone; idempotent).
+#
+# Points git at scripts/githooks/ (version-controlled, so every clone gets the
+# same fmt/clippy/_llm pre-push + instance-guard pre-commit). Auto-run by .envrc
+# on direnv load; run manually if you don't use direnv.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+git config core.hooksPath scripts/githooks
+chmod +x scripts/githooks/* 2>/dev/null || true
+echo "git hooks installed: core.hooksPath=scripts/githooks (pre-push, pre-commit)"


### PR DESCRIPTION
## What

Harden the PR pipeline against two recurring CI friction classes (build-systems-not-patches), per operator decision 2026-06-04.

## Changes

**1. Pre-push hook (`scripts/githooks/pre-push`)** — catches the CI-required checks that slip to CI, at the push→PR boundary:
- `cargo +1.94.0 fmt --all -- --check` (CI-exact; **fmt runs first in gate-attestation**, so a fmt-only miss aborts the whole gate — it cost a CI round this session).
- `_llm` freshness regen-check (paths-gated to `crates/**/*.rs`, `Cargo.toml`, the extractor — same paths the CI workflow watches).
- clippy on affected crates (`scripts/affected-crates.py`); `PREPUSH_FULL=1` for the bit-exact `--workspace` pass, `PREPUSH_NO_CLIPPY=1` to skip. CI `gate-attestation` is the backstop.
- Deliberate bypass: `git push --no-verify`.

**2. Fix stale `_llm` index** — the L3 API extractor produced a 12-file diff on a clean main checkout, so every crate-touching PR inherited drift. Regenerated (`uv run scripts/llm-extract-l3.py`).

**3. Install + docs** — `scripts/install-hooks.sh` sets `core.hooksPath=scripts/githooks` (auto-run by `.envrc`/direnv); the existing instance-guard pre-commit is preserved under the new path. `CLAUDE.md` "Before submitting" + `AGENTS.md` now list fmt + the hook step.

## Why not CI auto-regen-and-commit for `_llm`

The operator's first instinct was CI auto-regen, but research found **#4143 already removed exactly that**: `GITHUB_TOKEN`-pushed commits don't trigger the required checks that gate auto-merge → structurally-unmergeable auto-PRs. The pre-push regen-check + the existing CI freshness backstop achieve freshness without that failure mode and without a standing PAT/App-token secret. A true zero-author-friction CI version remains possible later via a provisioned PAT — flagged for a follow-up decision.

## Verification
- Pre-push hook self-tested (passed); exercised live on this push.
- fmt clean; this PR touches no `crates/**/*.rs` so the `_llm` change is the drift fix only.
