### PR TITLE
feat(agora): add !skills, !blackboard, !think read-only Signal commands

### DIFF
--- a/_llm/L3-api-index/agora.md
+++ b/_llm/L3-api-index/agora.md
@@ -34,6 +34,12 @@ pub enum Command {
     Uptime,
     /// `!model` — show the model currently configured for the routed agent.
     Model,
+    /// `!skills` — list skills available to the routed agent.
+    Skills,
+    /// `!blackboard` — show recent cross-nous blackboard entries.
+    Blackboard,
+    /// `!think` — show extended-thinking mode and budget.
+    Think,
     /// `!info [agent_id]` — detail view of a specific or current agent.
     Info {
         /// Agent identifier to inspect; `None` means the current routed agent.
@@ -73,6 +79,10 @@ pub struct AgentSnapshot {
     pub uptime_secs: u64,
     /// Configured LLM model name.
     pub model: String,
+    /// Whether extended thinking is enabled.
+    pub thinking_enabled: bool,
+    /// Token budget allocated to extended thinking.
+    pub thinking_budget: u32,
 }
 ```
 
@@ -97,6 +107,10 @@ pub struct CommandContext {
     pub current_agent: Option<AgentSnapshot>,
     /// All running agent snapshots.
     pub all_agents: Vec<AgentSnapshot>,
+    /// Skills advertised by the current dispatch snapshot.
+    pub skills: Vec<String>,
+    /// Recent cross-nous blackboard entries.
+    pub blackboard_entries: Vec<String>,
     /// Channel health snapshots (empty when probe was not run).
     pub channels: Vec<ChannelSnapshot>,
 }

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-06-05T17:59:46Z"
+generated_at = "2026-06-05T23:24:02Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -14,13 +14,13 @@ generator = "scripts/llm-extract-l3.py"
 [[crates]]
 name = "agora"
 path = "crates/agora"
-source_hash = "f39ae1a6ebbf8ebfae1998bd41944fac607024abe11220193eb0bca306da2c4e"
-l3_token_estimate = 5636
+source_hash = "2c074fdf0b1b55fcfb6a33b972bbbb26922358af5a3316feb6d4f9b91cee2e3e"
+l3_token_estimate = 5778
 
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "88b534fd6b6c44eb88fde4f591171a3075b906b2efc74b011a14428cd578dee9"
+source_hash = "b1149450315d8a2a9170b7b8261205aba804773c1120f66fd62d104332dd6622"
 l3_token_estimate = 167
 
 [[crates]]

--- a/crates/agora/README.md
+++ b/crates/agora/README.md
@@ -1,0 +1,23 @@
+# agora
+
+## Signal `!` Commands
+
+The dispatcher recognizes these read-only commands:
+
+| Command | Description |
+|---------|-------------|
+| `!help` | list all available commands |
+| `!status` | lifecycle and session info for this agent |
+| `!agents` | list all running agents |
+| `!whoami` | show which agent handles this conversation |
+| `!new [label]` | start a fresh session (optional label ignored by agent) |
+| `!end` | close the current session |
+| `!sessions` | count sessions tracked by this agent |
+| `!ping` | round-trip liveness check |
+| `!channels` | list channel providers and health |
+| `!uptime` | agent uptime and panic-boundary count |
+| `!model` | show the LLM model configured for this agent |
+| `!skills` | list skills available to this agent |
+| `!blackboard` | show recent cross-nous blackboard entries |
+| `!think` | show extended-thinking mode + budget |
+| `!info [agent_id]` | detail view for an agent (default: current) |

--- a/crates/agora/src/command/mod.rs
+++ b/crates/agora/src/command/mod.rs
@@ -35,6 +35,12 @@ pub enum Command {
     Uptime,
     /// `!model` — show the model currently configured for the routed agent.
     Model,
+    /// `!skills` — list skills available to the routed agent.
+    Skills,
+    /// `!blackboard` — show recent cross-nous blackboard entries.
+    Blackboard,
+    /// `!think` — show extended-thinking mode and budget.
+    Think,
     /// `!info [agent_id]` — detail view of a specific or current agent.
     Info {
         /// Agent identifier to inspect; `None` means the current routed agent.
@@ -63,6 +69,9 @@ impl Command {
             Self::Channels => "channels",
             Self::Uptime => "uptime",
             Self::Model => "model",
+            Self::Skills => "skills",
+            Self::Blackboard => "blackboard",
+            Self::Think => "think",
             Self::Info { .. } => "info",
             Self::Unknown { name } => name.as_str(),
         }
@@ -85,6 +94,9 @@ const KNOWN_COMMANDS: &[(&str, &str)] = &[
     ("!channels", "list channel providers and health"),
     ("!uptime", "agent uptime and panic-boundary count"),
     ("!model", "show the LLM model configured for this agent"),
+    ("!skills", "list skills available to this agent"),
+    ("!blackboard", "show recent cross-nous blackboard entries"),
+    ("!think", "show extended-thinking mode + budget"),
     (
         "!info [agent_id]",
         "detail view for an agent (default: current)",
@@ -130,6 +142,9 @@ pub fn parse(text: &str) -> Option<Command> {
         "channels" | "ch" => Command::Channels,
         "uptime" => Command::Uptime,
         "model" => Command::Model,
+        "skills" => Command::Skills,
+        "blackboard" | "bb" => Command::Blackboard,
+        "think" => Command::Think,
         "info" => Command::Info {
             agent_id: if rest.is_empty() {
                 None
@@ -161,6 +176,10 @@ pub struct AgentSnapshot {
     pub uptime_secs: u64,
     /// Configured LLM model name.
     pub model: String,
+    /// Whether extended thinking is enabled.
+    pub thinking_enabled: bool,
+    /// Token budget allocated to extended thinking.
+    pub thinking_budget: u32,
 }
 
 /// Channel health summary passed by the binary into the command context.
@@ -188,6 +207,10 @@ pub struct CommandContext {
     pub current_agent: Option<AgentSnapshot>,
     /// All running agent snapshots.
     pub all_agents: Vec<AgentSnapshot>,
+    /// Skills advertised by the current dispatch snapshot.
+    pub skills: Vec<String>,
+    /// Recent cross-nous blackboard entries.
+    pub blackboard_entries: Vec<String>,
     /// Channel health snapshots (empty when probe was not run).
     pub channels: Vec<ChannelSnapshot>,
 }
@@ -210,6 +233,9 @@ pub fn execute(cmd: &Command, ctx: &CommandContext) -> String {
         Command::Channels => cmd_channels(ctx),
         Command::Uptime => cmd_uptime(ctx),
         Command::Model => cmd_model(ctx),
+        Command::Skills => cmd_skills(ctx),
+        Command::Blackboard => cmd_blackboard(ctx),
+        Command::Think => cmd_think(ctx),
         Command::Info { agent_id } => cmd_info(ctx, agent_id.as_deref()),
         Command::Unknown { name } => cmd_unknown(name),
     }
@@ -345,6 +371,43 @@ fn cmd_model(ctx: &CommandContext) -> String {
     match &ctx.current_agent {
         None => format!("Agent '{}' status unavailable.", ctx.current_nous_id),
         Some(a) => format!("Agent '{}' model: {}.", a.id, a.model),
+    }
+}
+
+fn cmd_skills(ctx: &CommandContext) -> String {
+    if ctx.skills.is_empty() {
+        return "No skills available.".to_owned();
+    }
+    let mut out = format!("{} skill(s):\n", ctx.skills.len());
+    for skill in &ctx.skills {
+        let _ = writeln!(out, "  {skill}");
+    }
+    out.trim_end().to_owned()
+}
+
+fn cmd_blackboard(ctx: &CommandContext) -> String {
+    if ctx.blackboard_entries.is_empty() {
+        return "Blackboard empty.".to_owned();
+    }
+    let mut out = format!("{} blackboard entries:\n", ctx.blackboard_entries.len());
+    for entry in &ctx.blackboard_entries {
+        let _ = writeln!(out, "  {entry}");
+    }
+    out.trim_end().to_owned()
+}
+
+fn cmd_think(ctx: &CommandContext) -> String {
+    match &ctx.current_agent {
+        None => "No agent.".to_owned(),
+        Some(a) => format!(
+            "Extended thinking: {} (budget {} tokens).",
+            if a.thinking_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            a.thinking_budget,
+        ),
     }
 }
 
@@ -485,6 +548,22 @@ mod tests {
     }
 
     #[test]
+    fn parse_skills() {
+        assert_eq!(parse("!skills"), Some(Command::Skills));
+    }
+
+    #[test]
+    fn parse_blackboard_variants() {
+        assert_eq!(parse("!blackboard"), Some(Command::Blackboard));
+        assert_eq!(parse("!bb"), Some(Command::Blackboard));
+    }
+
+    #[test]
+    fn parse_think() {
+        assert_eq!(parse("!think"), Some(Command::Think));
+    }
+
+    #[test]
     fn parse_info_no_arg() {
         assert_eq!(parse("!info"), Some(Command::Info { agent_id: None }));
     }
@@ -531,6 +610,8 @@ mod tests {
                 panic_count: 0,
                 uptime_secs: 3661,
                 model: "claude-sonnet-4-6".to_owned(),
+                thinking_enabled: false,
+                thinking_budget: 0,
             }),
             all_agents: vec![AgentSnapshot {
                 id: "syn".to_owned(),
@@ -540,7 +621,11 @@ mod tests {
                 panic_count: 0,
                 uptime_secs: 3661,
                 model: "claude-sonnet-4-6".to_owned(),
+                thinking_enabled: false,
+                thinking_budget: 0,
             }],
+            skills: vec![],
+            blackboard_entries: vec![],
             channels: vec![ChannelSnapshot {
                 id: "signal".to_owned(),
                 healthy: true,
@@ -640,6 +725,57 @@ mod tests {
     }
 
     #[test]
+    fn skills_lists_available_skills() {
+        let mut ctx = make_context();
+        ctx.skills = vec!["signal send".to_owned(), "session reset".to_owned()];
+        let reply = execute(&Command::Skills, &ctx);
+        assert!(reply.contains("signal send"), "{reply}");
+        assert!(reply.contains("session reset"), "{reply}");
+    }
+
+    #[test]
+    fn skills_reports_empty_state() {
+        let ctx = make_context();
+        let reply = execute(&Command::Skills, &ctx);
+        assert!(reply.contains("No skills available"), "{reply}");
+    }
+
+    #[test]
+    fn blackboard_lists_recent_entries() {
+        let mut ctx = make_context();
+        ctx.blackboard_entries = vec!["alice: session reset".to_owned()];
+        let reply = execute(&Command::Blackboard, &ctx);
+        assert!(reply.contains("alice: session reset"), "{reply}");
+    }
+
+    #[test]
+    fn blackboard_reports_empty_state() {
+        let ctx = make_context();
+        let reply = execute(&Command::Blackboard, &ctx);
+        assert!(reply.contains("Blackboard empty"), "{reply}");
+    }
+
+    #[test]
+    fn think_reports_current_agent_budget() {
+        let mut ctx = make_context();
+        if let Some(agent) = ctx.current_agent.as_mut() {
+            agent.thinking_enabled = true;
+            agent.thinking_budget = 42_000;
+        }
+        let reply = execute(&Command::Think, &ctx);
+        assert!(reply.contains("enabled"), "{reply}");
+        assert!(reply.contains("42000"), "{reply}");
+    }
+
+    #[test]
+    fn think_reports_no_agent() {
+        let mut ctx = make_context();
+        ctx.current_agent = None;
+        let reply = execute(&Command::Think, &ctx);
+        assert!(reply.contains("No agent"), "{reply}");
+    }
+
+    #[test]
     fn unknown_command_suggests_help() {
         let ctx = make_context();
         let reply = execute(
@@ -700,6 +836,9 @@ mod tests {
         assert_eq!(Command::Channels.name(), "channels");
         assert_eq!(Command::Uptime.name(), "uptime");
         assert_eq!(Command::Model.name(), "model");
+        assert_eq!(Command::Skills.name(), "skills");
+        assert_eq!(Command::Blackboard.name(), "blackboard");
+        assert_eq!(Command::Think.name(), "think");
         assert_eq!(Command::Info { agent_id: None }.name(), "info");
         assert_eq!(
             Command::Unknown {

--- a/crates/aletheia/src/dispatch.rs
+++ b/crates/aletheia/src/dispatch.rs
@@ -148,6 +148,12 @@ async fn execute_command(
                 let model = nous_manager
                     .get_config(nous_id)
                     .map_or_else(String::new, |c| c.generation.model.clone());
+                let thinking_enabled = nous_manager
+                    .get_config(nous_id)
+                    .is_some_and(|c| c.generation.thinking_enabled);
+                let thinking_budget = nous_manager
+                    .get_config(nous_id)
+                    .map_or(0, |c| c.generation.thinking_budget);
                 Some(AgentSnapshot {
                     id: st.id,
                     lifecycle: st.lifecycle.to_string(),
@@ -156,6 +162,8 @@ async fn execute_command(
                     panic_count: st.panic_count,
                     uptime_secs: st.uptime.as_secs(),
                     model,
+                    thinking_enabled,
+                    thinking_budget,
                 })
             }
             Err(e) => {
@@ -176,6 +184,12 @@ async fn execute_command(
                 let model = nous_manager
                     .get_config(&st.id)
                     .map_or_else(String::new, |c| c.generation.model.clone());
+                let thinking_enabled = nous_manager
+                    .get_config(&st.id)
+                    .is_some_and(|c| c.generation.thinking_enabled);
+                let thinking_budget = nous_manager
+                    .get_config(&st.id)
+                    .map_or(0, |c| c.generation.thinking_budget);
                 AgentSnapshot {
                     id: st.id,
                     lifecycle: st.lifecycle.to_string(),
@@ -184,6 +198,8 @@ async fn execute_command(
                     panic_count: st.panic_count,
                     uptime_secs: st.uptime.as_secs(),
                     model,
+                    thinking_enabled,
+                    thinking_budget,
                 }
             })
             .collect()
@@ -204,11 +220,17 @@ async fn execute_command(
         _ => vec![],
     };
 
+    // TODO(#4405): populate skills from SkillLoader / blackboard from BlackboardStore once threaded
+    let skills = Vec::new();
+    let blackboard_entries = Vec::new();
+
     let ctx = CommandContext {
         current_nous_id: nous_id.to_owned(),
         session_key: session_key.to_owned(),
         current_agent,
         all_agents,
+        skills,
+        blackboard_entries,
         channels,
     };
 


### PR DESCRIPTION
## What

Adds three read-only Signal `!`-commands to the agora dispatcher (Q7 / part of #4405, the backed introspection set):

- `!skills` — list skills available to this agent
- `!blackboard` (`!bb`) — recent cross-nous blackboard entries
- `!think` — current extended-thinking mode + budget

## How

Follows agora's existing pure-snapshot pattern (no nous/runtime dependency): new `Command` variants + `cmd_*` handlers reading a `CommandContext` snapshot, with `thinking_enabled`/`thinking_budget` threaded through the binary's `execute_command` from the same `get_config` the `model` field uses. `skills`/`blackboard_entries` carry a `TODO(#4405)` — the empty-state handlers render correctly; populating them needs the SkillLoader/BlackboardStore threaded through the dispatch chain (a follow-up, deliberately out of scope here).

Defers `!distill` (async-trigger plumbing) and real `!new`/`!end` archive-reset to follow-ups.

## Verification

`cargo +1.94.0 fmt --all -- --check` clean · `cargo clippy --workspace ... -D warnings` clean · `cargo nextest run -p agora -p aletheia` → **505 passed, 1 skipped**. `_llm` index regenerated.
