### PR TITLE
feat(nous): wire CompactionStrategy into full compaction

### DIFF
--- a/_llm/L3-api-index/nous.md
+++ b/_llm/L3-api-index/nous.md
@@ -647,6 +647,8 @@ pub struct CompactConfig {
     pub full_compact_threshold: f64,
     /// Number of most-recent turns to preserve after full compaction.
     pub preserve_turns: usize,
+    /// Preserved-tail strategy applied during full compaction.
+    pub strategy: CompactionStrategy,
     /// Maximum number of critical files to re-inject after full compaction.
     pub max_critical_files: usize,
     /// Number of recent turns to scan for critical file identification.
@@ -674,6 +676,7 @@ pub fn select_prompt (reason: CompactReason) -> &'static str
 ```rust
 pub enum CompactionStrategy {
     /// Uniform tail truncation (current default).
+    #[default]
     UniformTail,
     /// Step-positional: last 2 steps full, earlier i < n-2 notes-only.
     StepPositional,

--- a/_llm/L3-api-index/taxis.md
+++ b/_llm/L3-api-index/taxis.md
@@ -469,6 +469,9 @@ pub struct AgentBehaviorDefaults { // kanon:ignore RUST/struct-too-many-fields
     pub knowledge_dedup_embed_threshold: f64,
     /// Bookkeeping provider selected for extraction. Default: `llm`.
     pub knowledge_extraction_provider: BookkeepingProviderKind,
+    // --- Compaction ---
+    /// Preserved-tail compaction strategy used during full context compaction.
+    pub compaction_strategy: CompactionStrategyKind,
 
     // --- Fact lifecycle ---
     /// Confidence above which a fact is considered Active. Default: 0.7.
@@ -795,6 +798,16 @@ pub enum BookkeepingProviderKind {
     Llm,
     /// `GLiNER` ONNX entity adapter with LLM fallback.
     Gliner,
+}
+```
+
+```rust
+pub enum CompactionStrategyKind {
+    /// Keep the preserved tail as whole messages.
+    #[default]
+    UniformTail,
+    /// Keep the last two steps full and compact earlier preserved steps.
+    StepPositional,
 }
 ```
 
@@ -2297,6 +2310,8 @@ pub enum ParameterValue {
     Float(f64),
     /// Boolean toggle.
     Bool(bool),
+    /// String-valued parameter.
+    Str(&'static str),
     /// Duration in the unit described by the parameter key (seconds, milliseconds, etc.).
     Duration(u64),
 }

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-06-05T17:59:46Z"
+generated_at = "2026-06-06T00:05:35Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -146,8 +146,8 @@ l3_token_estimate = 51
 [[crates]]
 name = "nous"
 path = "crates/nous"
-source_hash = "1653716a8bc42279e63ee80a1c39cb5e5a53c4c3454d240f09a8b300cfb8371b"
-l3_token_estimate = 34289
+source_hash = "d97734a4b64c7dd00b53f731dcf11be0823f313080caab6a59400c06e767ee81"
+l3_token_estimate = 34318
 
 [[crates]]
 name = "oikonomos"
@@ -278,8 +278,8 @@ l3_token_estimate = 6587
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "32e4a92bf745a3bf87cdfe16cff83f4349895221a80c569c2f52820688877899"
-l3_token_estimate = 24088
+source_hash = "1c8abe44a615565fd95bff6c38d9348665211ea18ba050c03ce2d315223cdb6c"
+l3_token_estimate = 24198
 
 [[crates]]
 name = "theatron"

--- a/crates/nous/src/compact/full.rs
+++ b/crates/nous/src/compact/full.rs
@@ -8,9 +8,10 @@
 use tracing::debug;
 
 use crate::budget::CompactionMetrics;
+use crate::memory::step::Step;
 use crate::pipeline::PipelineMessage;
 
-use super::{CompactConfig, CriticalFile};
+use super::{CompactConfig, CompactionStrategy, CriticalFile};
 
 /// Result of a full compaction pass.
 #[derive(Debug, Clone)]
@@ -65,6 +66,18 @@ pub(crate) fn build_summary_request(
 
     let to_summarize = messages.get(..split_point).unwrap_or(&[]);
     let to_preserve = messages.get(split_point..).unwrap_or(&[]).to_vec();
+    let preserved = match config.strategy {
+        CompactionStrategy::UniformTail => to_preserve,
+        CompactionStrategy::StepPositional => {
+            let steps = crate::pipeline::assemble_steps(&to_preserve);
+            let budget = steps
+                .iter()
+                .map(Step::token_estimate)
+                .fold(0usize, usize::saturating_add);
+            let compacted = config.strategy.apply(&steps, budget);
+            render_steps(&compacted)
+        }
+    };
 
     let mut history_text = String::new();
     for msg in to_summarize {
@@ -75,7 +88,30 @@ pub(crate) fn build_summary_request(
     }
 
     let request = format!("{prompt}\n\n---\n\n{history_text}");
-    (request, to_preserve)
+    (request, preserved)
+}
+
+#[must_use]
+pub(crate) fn render_steps(steps: &[Step]) -> Vec<PipelineMessage> {
+    steps
+        .iter()
+        .flat_map(|step| {
+            let mut messages = Vec::with_capacity(1 + step.observations.len());
+            messages.push(PipelineMessage {
+                role: "assistant".to_owned(),
+                content: step.self_note.clone(),
+                token_estimate: i64::try_from(step.self_note.len().div_ceil(4)).unwrap_or(i64::MAX),
+                cache_breakpoint: false,
+            });
+            messages.extend(step.observations.iter().map(|observation| PipelineMessage {
+                role: "user".to_owned(),
+                content: observation.body.clone(),
+                token_estimate: i64::try_from(observation.token_estimate).unwrap_or(i64::MAX),
+                cache_breakpoint: false,
+            }));
+            messages
+        })
+        .collect()
 }
 
 /// Apply full compaction: replace history with summary + preserved tail.
@@ -254,6 +290,7 @@ fn extract_file_content(content: &str) -> String {
 mod tests {
     use super::*;
     use crate::compact::micro::format_tool_result;
+    use crate::memory::step::{Observation, Step};
 
     fn make_text_msg(role: &str, content: &str, tokens: i64) -> PipelineMessage {
         PipelineMessage {
@@ -262,6 +299,30 @@ mod tests {
             token_estimate: tokens,
             cache_breakpoint: false,
         }
+    }
+
+    fn make_step(index: usize, self_note: &str, observation_body: &str) -> Step {
+        Step {
+            self_note: self_note.to_owned(),
+            observations: vec![Observation::new("shell", observation_body)],
+            summary: None,
+            index,
+            started_at: jiff::Timestamp::UNIX_EPOCH,
+        }
+    }
+
+    fn message_signature(messages: &[PipelineMessage]) -> Vec<(String, String, i64, bool)> {
+        messages
+            .iter()
+            .map(|message| {
+                (
+                    message.role.clone(),
+                    message.content.clone(),
+                    message.token_estimate,
+                    message.cache_breakpoint,
+                )
+            })
+            .collect()
     }
 
     fn make_tool_msg(tool_name: &str, content: &str, tokens: i64) -> PipelineMessage {
@@ -343,6 +404,122 @@ mod tests {
         assert!(
             !request.contains("recent message"),
             "summarization request should not contain preserved messages"
+        );
+    }
+
+    #[test]
+    fn render_steps_round_trips_self_notes_and_tool_prefixes() {
+        let steps = vec![
+            make_step(
+                0,
+                "note 0",
+                &format_tool_result("shell", jiff::Timestamp::UNIX_EPOCH, "obs 0"),
+            ),
+            make_step(
+                1,
+                "note 1",
+                &format_tool_result("shell", jiff::Timestamp::UNIX_EPOCH, "obs 1"),
+            ),
+        ];
+
+        let rendered = render_steps(&steps);
+        assert!(
+            rendered
+                .iter()
+                .any(|message| message.role == "user" && message.content.starts_with("[tool:")),
+            "rendered observations should keep the [tool:] prefix"
+        );
+
+        let round_tripped = crate::pipeline::assemble_steps(&rendered);
+        assert_eq!(
+            round_tripped.len(),
+            steps.len(),
+            "rendered steps should round-trip through assemble_steps"
+        );
+        for (expected, actual) in steps.iter().zip(round_tripped.iter()) {
+            assert_eq!(
+                actual.self_note, expected.self_note,
+                "self_note should survive the render/assemble round-trip"
+            );
+        }
+        assert_eq!(
+            round_tripped[0].observations[0].body, steps[0].observations[0].body,
+            "observation body should round-trip"
+        );
+    }
+
+    #[test]
+    fn build_summary_request_step_positional_changes_preserved_tail() {
+        let messages: Vec<PipelineMessage> = (0..6)
+            .flat_map(|step_index| {
+                let note = format!("note {step_index}");
+                let observation_body = format!("observation {step_index} {}", "x".repeat(256));
+                let observation =
+                    format_tool_result("shell", jiff::Timestamp::UNIX_EPOCH, &observation_body);
+                vec![
+                    make_text_msg("assistant", &note, 10),
+                    make_text_msg("user", &observation, 90),
+                ]
+            })
+            .collect();
+
+        let uniform_config = CompactConfig {
+            preserve_turns: 6,
+            strategy: CompactionStrategy::UniformTail,
+            ..CompactConfig::default()
+        };
+        let positional_config = CompactConfig {
+            preserve_turns: 6,
+            strategy: CompactionStrategy::StepPositional,
+            ..CompactConfig::default()
+        };
+
+        let (_uniform_request, uniform_tail) =
+            build_summary_request(&messages, &uniform_config, "test prompt");
+        let (_positional_request, positional_tail) =
+            build_summary_request(&messages, &positional_config, "test prompt");
+
+        assert_eq!(
+            message_signature(&uniform_tail),
+            message_signature(&messages[6..]),
+            "UniformTail should keep the exact current whole-message tail"
+        );
+        assert_ne!(
+            message_signature(&positional_tail),
+            message_signature(&uniform_tail),
+            "StepPositional should change the preserved tail"
+        );
+
+        let positional_steps = crate::pipeline::assemble_steps(&positional_tail);
+        assert_eq!(
+            positional_steps.len(),
+            3,
+            "three preserved steps should remain visible after StepPositional compaction"
+        );
+        assert_eq!(positional_steps[0].self_note, "note 3");
+        assert!(
+            positional_steps[0].observations.is_empty(),
+            "older preserved step should lose observations under StepPositional"
+        );
+        assert!(
+            !positional_steps[1].observations.is_empty(),
+            "the last two preserved steps should keep their observations"
+        );
+        assert!(
+            !positional_steps[2].observations.is_empty(),
+            "the last two preserved steps should keep their observations"
+        );
+        assert!(
+            uniform_tail
+                .iter()
+                .any(|message| message.content.contains("observation 3")),
+            "UniformTail should keep the older observation body byte-for-byte"
+        );
+        assert!(
+            !positional_tail
+                .iter()
+                .any(|message| message.content.contains("observation 3")),
+            "StepPositional should strip the older observation body from the preserved tail"
         );
     }
 

--- a/crates/nous/src/compact/mod.rs
+++ b/crates/nous/src/compact/mod.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use jiff::SignedDuration;
 
 use hermeneus::types::ToolResultType;
+use taxis::config::CompactionStrategyKind;
 
 pub(crate) mod full;
 pub(crate) mod micro;
@@ -37,6 +38,8 @@ pub struct CompactConfig {
     pub full_compact_threshold: f64,
     /// Number of most-recent turns to preserve after full compaction.
     pub preserve_turns: usize,
+    /// Preserved-tail strategy applied during full compaction.
+    pub strategy: CompactionStrategy,
     /// Maximum number of critical files to re-inject after full compaction.
     pub max_critical_files: usize,
     /// Number of recent turns to scan for critical file identification.
@@ -60,6 +63,7 @@ impl Default for CompactConfig {
             keep_last_n: 2,
             full_compact_threshold: 0.80,
             preserve_turns: 3,
+            strategy: CompactionStrategy::UniformTail,
             max_critical_files: 5,
             critical_file_lookback: 3,
         }
@@ -116,29 +120,16 @@ pub fn select_prompt(reason: CompactReason) -> &'static str {
 use crate::memory::step::Step;
 
 /// Strategy for applying context compaction to a sequence of steps.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "#193 will wire CompactionStrategy into the pipeline"
-    )
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum CompactionStrategy {
     /// Uniform tail truncation (current default).
+    #[default]
     UniformTail,
     /// Step-positional: last 2 steps full, earlier i < n-2 notes-only.
     StepPositional,
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "#193 will wire CompactionStrategy into the pipeline"
-    )
-)]
 impl CompactionStrategy {
     /// Apply the strategy to a step sequence under a token budget.
     ///
@@ -208,6 +199,20 @@ impl CompactionStrategy {
         result.reverse();
         result
     }
+}
+
+/// Map the configured taxis strategy kind to the internal compaction strategy.
+#[must_use]
+pub(crate) fn map_strategy(strategy: CompactionStrategyKind) -> CompactionStrategy {
+    match strategy {
+        CompactionStrategyKind::UniformTail => CompactionStrategy::UniformTail,
+        CompactionStrategyKind::StepPositional => CompactionStrategy::StepPositional,
+        _ => default_compaction_strategy(),
+    }
+}
+
+fn default_compaction_strategy() -> CompactionStrategy {
+    CompactionStrategy::UniformTail
 }
 
 #[cfg(test)]
@@ -284,6 +289,23 @@ mod tests {
         assert_eq!(
             config.max_critical_files, 5,
             "max_critical_files should default to 5"
+        );
+        assert_eq!(
+            config.strategy,
+            CompactionStrategy::UniformTail,
+            "strategy should default to UniformTail"
+        );
+    }
+
+    #[test]
+    fn strategy_kind_maps_to_internal_strategy() {
+        assert_eq!(
+            map_strategy(CompactionStrategyKind::UniformTail),
+            CompactionStrategy::UniformTail
+        );
+        assert_eq!(
+            map_strategy(CompactionStrategyKind::StepPositional),
+            CompactionStrategy::StepPositional
         );
     }
 

--- a/crates/nous/src/pipeline/stages.rs
+++ b/crates/nous/src/pipeline/stages.rs
@@ -18,7 +18,7 @@ use organon::types::ToolContext;
 use taxis::oikos::Oikos;
 
 use crate::bootstrap::{BootstrapFileCache, BootstrapSection, LlmRecipe, TaskHint};
-use crate::compact::{CompactConfig, CompactReason, select_prompt};
+use crate::compact::{CompactConfig, CompactReason, map_strategy, select_prompt};
 use crate::config::{NousConfig, PipelineConfig};
 use crate::error;
 use crate::history::{self, HistoryConfig};
@@ -420,7 +420,10 @@ pub(super) async fn run_full_compact_stage(
     let _guard = span.enter();
     let start = Instant::now();
 
-    let compact_config = CompactConfig::default();
+    let compact_config = CompactConfig {
+        strategy: map_strategy(config.behavior.compaction_strategy),
+        ..CompactConfig::default()
+    };
     let context_window = u64::from(config.generation.context_window);
 
     // NOTE: estimate consumed tokens from messages in context

--- a/crates/nous/src/tuning/mod.rs
+++ b/crates/nous/src/tuning/mod.rs
@@ -323,7 +323,7 @@ fn derive_proposed_value(spec: &ParameterSpec, delta: f64) -> ParameterValue {
             ParameterValue::Int(v)
         }
         ParameterValue::Float(_) => ParameterValue::Float(proposed_f64),
-        ParameterValue::Bool(_) => spec.default.clone(), // bools are not nudged
+        ParameterValue::Bool(_) | ParameterValue::Str(_) => spec.default.clone(),
         ParameterValue::Duration(_) => {
             // WHY: proposed_f64 is derived from u64 * 1.1 or u64 * 0.9, which is
             // non-negative and safely within u64 range for any config duration.
@@ -356,6 +356,7 @@ fn parameter_value_to_f64(value: &ParameterValue) -> f64 {
                 0.0
             }
         }
+        ParameterValue::Str(_) => 0.0,
         ParameterValue::Duration(v) => *v as f64, // kanon:ignore RUST/as-cast
     }
 }
@@ -370,10 +371,13 @@ pub fn build_override_fact_content(
     set_by: &str,
     evidence_summary: &str,
 ) -> String {
-    // WHY: serde_json is not used here to avoid adding a dependency for a
-    // simple 4-field JSON object. The values are pre-validated.
+    let value_json = match value {
+        ParameterValue::Str(v) => serde_json::to_string(v).unwrap_or_else(|_| format!("\"{v}\"")),
+        _ => value.to_string(),
+    };
+
     format!(
-        r#"{{"key":"{key}","value":{value},"set_by":"{set_by}","evidence":"{}"}}"#,
+        r#"{{"key":"{key}","value":{value_json},"set_by":"{set_by}","evidence":"{}"}}"#,
         evidence_summary.replace('"', "'"),
     )
 }
@@ -534,6 +538,17 @@ mod tests {
         assert!(content.contains(r#""value":95000"#));
         assert!(content.contains(r#""set_by":"syn""#));
         assert!(content.contains(r#""evidence":"32 turns, quality +12%""#));
+    }
+
+    #[test]
+    fn override_fact_content_quotes_string_values() {
+        let content = build_override_fact_content(
+            "behavior.compactionStrategy",
+            &ParameterValue::Str("uniform_tail"),
+            "ops",
+            "default path",
+        );
+        assert!(content.contains(r#""value":"uniform_tail""#));
     }
 
     #[test]

--- a/crates/taxis/src/config/agents.rs
+++ b/crates/taxis/src/config/agents.rs
@@ -6,7 +6,7 @@ use eidos::id::FactId;
 use eidos::knowledge::MemoryScope;
 use serde::{Deserialize, Serialize};
 
-use super::{AgencyLevel, BookkeepingProviderKind};
+use super::{AgencyLevel, BookkeepingProviderKind, CompactionStrategyKind};
 
 /// Agent configuration: shared defaults and per-agent definitions.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -519,6 +519,9 @@ pub struct AgentBehaviorDefaults { // kanon:ignore RUST/struct-too-many-fields
     pub knowledge_dedup_embed_threshold: f64,
     /// Bookkeeping provider selected for extraction. Default: `llm`.
     pub knowledge_extraction_provider: BookkeepingProviderKind,
+    // --- Compaction ---
+    /// Preserved-tail compaction strategy used during full context compaction.
+    pub compaction_strategy: CompactionStrategyKind,
 
     // --- Fact lifecycle ---
     /// Confidence above which a fact is considered Active. Default: 0.7.
@@ -663,6 +666,7 @@ impl Default for AgentBehaviorDefaults {
             knowledge_dedup_jw_threshold: 0.85,
             knowledge_dedup_embed_threshold: 0.80,
             knowledge_extraction_provider: BookkeepingProviderKind::Llm,
+            compaction_strategy: CompactionStrategyKind::UniformTail,
             // Fact lifecycle
             fact_active_threshold: 0.7,
             fact_fading_threshold: 0.3,

--- a/crates/taxis/src/config/behavior/knowledge.rs
+++ b/crates/taxis/src/config/behavior/knowledge.rs
@@ -186,6 +186,18 @@ pub enum BookkeepingProviderKind {
     Gliner,
 }
 
+/// Preserved-tail compaction strategy for full context compaction.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CompactionStrategyKind {
+    /// Keep the preserved tail as whole messages.
+    #[default]
+    UniformTail,
+    /// Keep the last two steps full and compact earlier preserved steps.
+    StepPositional,
+}
+
 /// Which admission policy the knowledge store uses for fact insertion.
 ///
 /// Default is `Default` (admit-all), preserving existing behavior unless

--- a/crates/taxis/src/config/behavior/mod.rs
+++ b/crates/taxis/src/config/behavior/mod.rs
@@ -17,7 +17,8 @@ pub use daemon::DaemonBehaviorConfig;
 pub use dispatch::{CronTaskConfig, DispatchConfig, DispatchSpecConfig};
 pub use jwt::JwtSettings;
 pub use knowledge::{
-    AdmissionPolicyKind, BookkeepingProviderKind, ExtractionConfig, KnowledgeConfig,
+    AdmissionPolicyKind, BookkeepingProviderKind, CompactionStrategyKind, ExtractionConfig,
+    KnowledgeConfig,
 };
 pub use messaging::MessagingConfig;
 pub use nous::NousBehaviorConfig;

--- a/crates/taxis/src/config/config_tests/resolve_nous.rs
+++ b/crates/taxis/src/config/config_tests/resolve_nous.rs
@@ -39,6 +39,11 @@ fn resolve_nous_uses_defaults_when_no_override() {
         resolved.behavior.distillation_context_token_trigger, 120_000,
         "default behavior should be used when no per-agent override is set"
     );
+    assert_eq!(
+        resolved.behavior.compaction_strategy,
+        CompactionStrategyKind::UniformTail,
+        "default behavior should preserve the uniform-tail compaction strategy"
+    );
     assert!(
         (resolved.behavior.competence_correction_penalty - 0.05).abs() < f64::EPSILON,
         "default competence_correction_penalty must come from AgentBehaviorDefaults"
@@ -63,6 +68,7 @@ fn resolve_nous_per_agent_override_wins() {
         recall: None,
         recall_profile: None,
         behavior: Some(AgentBehaviorDefaults {
+            compaction_strategy: CompactionStrategyKind::StepPositional,
             competence_correction_penalty: 0.10,
             ..Default::default()
         }),
@@ -71,6 +77,11 @@ fn resolve_nous_per_agent_override_wins() {
     assert!(
         (resolved.behavior.competence_correction_penalty - 0.10).abs() < f64::EPSILON,
         "per-agent behavior override must win over defaults"
+    );
+    assert_eq!(
+        resolved.behavior.compaction_strategy,
+        CompactionStrategyKind::StepPositional,
+        "per-agent compaction strategy override must win over defaults"
     );
     // All other fields should remain at default
     assert_eq!(
@@ -102,6 +113,11 @@ fn resolve_nous_non_overriding_agent_uses_defaults() {
     assert_eq!(
         resolved.behavior.corrections_max_corrections, 50,
         "agent without behavior override should use shared defaults"
+    );
+    assert_eq!(
+        resolved.behavior.compaction_strategy,
+        CompactionStrategyKind::UniformTail,
+        "agent without behavior override should use the default compaction strategy"
     );
 }
 
@@ -222,6 +238,7 @@ fn agent_behavior_defaults_survive_serde_roundtrip() {
         .defaults
         .behavior
         .competence_correction_penalty = 0.08;
+    config.agents.defaults.behavior.compaction_strategy = CompactionStrategyKind::StepPositional;
 
     let json = serde_json::to_string(&config).expect("serialize");
     let back: AletheiaConfig = serde_json::from_str(&json).expect("deserialize");
@@ -237,6 +254,11 @@ fn agent_behavior_defaults_survive_serde_roundtrip() {
     assert!(
         (back.agents.defaults.behavior.competence_correction_penalty - 0.08).abs() < f64::EPSILON,
         "competence_correction_penalty survives serde roundtrip"
+    );
+    assert_eq!(
+        back.agents.defaults.behavior.compaction_strategy,
+        CompactionStrategyKind::StepPositional,
+        "compaction_strategy survives serde roundtrip"
     );
 }
 
@@ -258,6 +280,11 @@ fn new_deployment_sections_are_absent_in_default_toml() {
     assert_eq!(
         config.messaging.poll_interval_ms, 2_000,
         "omitted messaging section should use defaults"
+    );
+    assert_eq!(
+        config.agents.defaults.behavior.compaction_strategy,
+        CompactionStrategyKind::UniformTail,
+        "omitted compaction strategy should use the uniform-tail default"
     );
 }
 

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -12,10 +12,10 @@ pub use agents::{
 };
 pub use behavior::{
     AdmissionPolicyKind, AnthropicConfig, ApiLimitsConfig, BookkeepingProviderKind, CapacityConfig,
-    CronTaskConfig, DaemonBehaviorConfig, DeploymentTarget, DispatchConfig, DispatchSpecConfig,
-    ExtractionConfig, JwtSettings, KnowledgeConfig, LlmProviderConfig, MessagingConfig,
-    NousBehaviorConfig, OpenAiApiFamily, PromptCacheMode, ProviderBehaviorConfig, ProviderKind,
-    RetrySettings, TimeoutsConfig, ToolLimitsConfig, TuningConfig,
+    CompactionStrategyKind, CronTaskConfig, DaemonBehaviorConfig, DeploymentTarget, DispatchConfig,
+    DispatchSpecConfig, ExtractionConfig, JwtSettings, KnowledgeConfig, LlmProviderConfig,
+    MessagingConfig, NousBehaviorConfig, OpenAiApiFamily, PromptCacheMode, ProviderBehaviorConfig,
+    ProviderKind, RetrySettings, TimeoutsConfig, ToolLimitsConfig, TuningConfig,
 };
 pub use gateway::{
     BodyLimitConfig, CorsConfig, CsrfConfig, GatewayAuthConfig, GatewayConfig,

--- a/crates/taxis/src/registry.rs
+++ b/crates/taxis/src/registry.rs
@@ -62,6 +62,8 @@ pub enum ParameterValue {
     Float(f64),
     /// Boolean toggle.
     Bool(bool),
+    /// String-valued parameter.
+    Str(&'static str),
     /// Duration in the unit described by the parameter key (seconds, milliseconds, etc.).
     Duration(u64),
 }
@@ -72,6 +74,7 @@ impl std::fmt::Display for ParameterValue {
             Self::Int(v) => write!(f, "{v}"),
             Self::Float(v) => write!(f, "{v}"),
             Self::Bool(v) => write!(f, "{v}"),
+            Self::Str(v) => write!(f, "{v}"),
             Self::Duration(v) => write!(f, "{v}"),
         }
     }
@@ -847,6 +850,22 @@ fn build_registry() -> Vec<ParameterSpec> {
             affects: "safety_cost_control",
             outcome_signal: "session_cost_distribution",
             evidence_required: "Session token usage distribution",
+            direction_hint: TuningDirection::Contextual,
+        },
+        // ===================================================================
+        // Compaction
+        // ===================================================================
+        ParameterSpec {
+            key: "agents.defaults.behavior.compactionStrategy",
+            section: "agents.defaults.behavior",
+            tier: ParameterTier::PerAgent,
+            default: ParameterValue::Str("uniform_tail"),
+            bounds: None,
+            hot_reloadable: true,
+            description: "Context compaction preserved-tail strategy: uniform_tail | step_positional",
+            affects: "compaction_quality",
+            outcome_signal: "post_compaction_turn_quality",
+            evidence_required: "A/B comparison of decision retention across strategies",
             direction_hint: TuningDirection::Contextual,
         },
         // ===================================================================

--- a/crates/taxis/src/registry_tests.rs
+++ b/crates/taxis/src/registry_tests.rs
@@ -37,6 +37,15 @@ fn spec_by_key_finds_known_parameter() {
 }
 
 #[test]
+fn spec_by_key_finds_compaction_strategy() {
+    let spec = spec_by_key("agents.defaults.behavior.compactionStrategy");
+    assert!(spec.is_some(), "expected to find compaction strategy spec");
+    let spec = spec.unwrap();
+    assert_eq!(spec.tier, ParameterTier::PerAgent);
+    assert_eq!(spec.default.to_string(), "uniform_tail");
+}
+
+#[test]
 fn spec_by_key_returns_none_for_unknown() {
     assert!(spec_by_key("nonexistent.key").is_none());
 }
@@ -175,6 +184,7 @@ fn registry_exposes_validated_behavior_fields() {
         "daemonBehavior.prosocheAnomalySampleSize",
         "daemonBehavior.runnerOutputBriefHeadLines",
         "daemonBehavior.runnerOutputBriefTailLines",
+        "agents.defaults.behavior.compactionStrategy",
     ];
 
     for key in VALIDATED_FIELDS {


### PR DESCRIPTION
## What

Wires the previously dead-coded `CompactionStrategy` enum (`UniformTail` | `StepPositional`) into the nous full-compaction path, making `StepPositional` a real, config-selectable, model-visible behavior. Resolves the long-standing dead-code island in `crates/nous/src/compact/` (the in-code `#193` reference was stale — #193 is an unrelated dianoia issue; **this PR does not close it**).

## How

- **taxis**: `CompactionStrategyKind` (snake_case serde, `#[default] UniformTail`) + `AgentBehaviorDefaults.compaction_strategy` + registry `ParameterSpec`.
- **nous**: removed the `#[expect(dead_code)]` suppressions; added `CompactConfig.strategy` + `map_strategy`; added `render_steps` (inverse of `assemble_steps`, round-trip-stable via `[tool:...]` framing); `build_summary_request` builds the preserved tail via `assemble_steps → strategy.apply → render_steps` when `StepPositional`, and keeps the **exact** current whole-message path when `UniformTail`.
- Fires only above `full_compact_threshold` (0.80); the every-turn hot path is untouched.

## Verification

`fmt` clean · `clippy --workspace ... -D warnings` clean · `nextest`: **1398 passed, 0 skipped**. Adversarially reviewed: default `UniformTail` is byte-identical (test-locked); a pipeline-level test proves `StepPositional` yields a different preserved tail; `render_steps` round-trip tested.
