### PR TITLE
feat(episteme): wire rl reward surface to benchmark evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "diaporeia",
  "dokimion",
  "energeia",
+ "episteme",
  "fjall",
  "hermeneus",
  "indexmap 2.14.0",

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "46fcc3ff8e1fb4773a7d0486897e92a109372fe011aa4329031f539e033138b5"
+source_hash = "afdc0436cd05a268317662ca46c4c7e6709d82927b7f6ee30a760d47b3a14c59"
 l3_token_estimate = 167
 
 [[crates]]
@@ -86,7 +86,7 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "568a6c32927cb89bb77c17ee8652145de836055210937477759b6501094184d8"
+source_hash = "a750f008427b2d961ccf8e0947b286b9dc78114e5f05113d2c9e119bf5817301"
 l3_token_estimate = 32393
 
 [[crates]]

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -69,6 +69,7 @@ symbolon = { path = "../symbolon" }
 pylon = { path = "../pylon" }
 agora = { path = "../agora" }
 dokimion = { path = "../eval" }
+episteme = { path = "../episteme" }
 thesauros = { path = "../thesauros" }
 koilon = { path = "../theatron/koilon", optional = true }
 # WHY: direct deps needed to wire per-crate metric registration at startup.

--- a/crates/aletheia/src/commands/benchmark.rs
+++ b/crates/aletheia/src/commands/benchmark.rs
@@ -1,7 +1,7 @@
 //! `aletheia benchmark`: run memory benchmarks (`LongMemEval`, `LoCoMo`) against a
 //! live instance.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use clap::{Args, Subcommand};
@@ -13,6 +13,7 @@ use dokimion::benchmarks::{
     BenchmarkMetadata, BenchmarkReport, BenchmarkRunner, BenchmarkRunnerConfig, EvalClient,
     MemoryBenchmark,
 };
+use episteme::rl::{LongMemEvalReward, MemoryOutcome, RewardFn};
 
 use crate::error::Result;
 
@@ -64,6 +65,9 @@ pub(crate) struct RunArgs {
     /// Write a compact baseline summary for training reward loaders
     #[arg(long)]
     pub baseline_out: Option<PathBuf>,
+    /// Compare the run against a saved compact baseline summary and surface the reward
+    #[arg(long)]
+    pub baseline_in: Option<PathBuf>,
     /// Query the knowledge store after ingestion and compute Recall@k / NDCG@k
     #[arg(long)]
     pub retrieval_k: Option<usize>,
@@ -193,10 +197,16 @@ async fn run_benchmark(benchmark: &dyn MemoryBenchmark, args: &RunArgs) -> Resul
         println!("Baseline summary written to {}", path.display());
     }
 
+    let reward_surface = if let Some(ref path) = args.baseline_in {
+        Some(load_reward_surface(&report, path)?)
+    } else {
+        None
+    };
+
     if args.json {
         print_report_json(&report).whatever_context("failed to serialize report")?;
     } else {
-        print_report_human(&report);
+        print_report_human(&report, reward_surface.as_ref());
     }
 
     Ok(())
@@ -222,6 +232,38 @@ impl BenchmarkBaselineSummary {
             judge_accuracy: report.judge_accuracy(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct RewardSurface {
+    outcome: MemoryOutcome,
+    baseline_exact_match_rate: f64,
+    reward: f64,
+}
+
+fn load_reward_surface(report: &BenchmarkReport, baseline_path: &Path) -> Result<RewardSurface> {
+    let reward_fn = LongMemEvalReward::from_json_file(baseline_path)
+        .whatever_context("failed to load baseline summary for reward calculation")?;
+    let outcome = MemoryOutcome {
+        exact_match_rate: report.exact_match_rate(),
+        mean_f1: Some(report.mean_f1()),
+    };
+    let reward = reward_fn.reward(&outcome);
+
+    Ok(RewardSurface {
+        outcome,
+        baseline_exact_match_rate: reward_fn.baseline_exact_match_rate,
+        reward,
+    })
+}
+
+fn format_reward_surface(surface: &RewardSurface) -> String {
+    format!(
+        "Reward vs baseline: {:+.3} (EM {:.1}% vs baseline {:.1}%)",
+        surface.reward,
+        surface.outcome.exact_match_rate * 100.0,
+        surface.baseline_exact_match_rate * 100.0,
+    )
 }
 
 async fn collect_metadata(
@@ -253,7 +295,7 @@ async fn collect_metadata(
 
 /// Print a human-readable benchmark report with per-category breakdown
 /// and peer baseline comparison.
-fn print_report_human(report: &BenchmarkReport) {
+fn print_report_human(report: &BenchmarkReport, reward_surface: Option<&RewardSurface>) {
     let use_color = supports_color::on(supports_color::Stream::Stdout).is_some();
 
     let header = if let Some(ref meta) = report.metadata {
@@ -335,6 +377,10 @@ fn print_report_human(report: &BenchmarkReport) {
         println!("\nLLM-as-judge accuracy: {:.1}%", judge_acc * 100.0);
     }
 
+    if let Some(surface) = reward_surface {
+        println!("\n{}", format_reward_surface(surface));
+    }
+
     // Peer baseline comparison
     print_baselines(report, use_color);
 }
@@ -396,6 +442,8 @@ fn print_report_json(report: &BenchmarkReport) -> std::result::Result<(), serde_
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
     use super::*;
+    use dokimion::benchmarks::{BenchmarkScore, QuestionResult};
+    use std::io::Write as _;
 
     fn base_args() -> RunArgs {
         RunArgs {
@@ -408,6 +456,7 @@ mod tests {
             json: false,
             output: None,
             baseline_out: None,
+            baseline_in: None,
             retrieval_k: None,
             judge_endpoint: None,
             judge_model: "gpt-4o".to_owned(),
@@ -478,5 +527,70 @@ mod tests {
         a.retrieval_k = Some(10);
         a.timeout = 1;
         validate_args(&a).unwrap();
+    }
+
+    fn sample_report() -> BenchmarkReport {
+        BenchmarkReport::new(
+            "LongMemEval",
+            vec![
+                QuestionResult {
+                    id: "q1".to_owned(),
+                    category: "factual".to_owned(),
+                    actual_answer: "blue".to_owned(),
+                    expected_answers: vec!["blue".to_owned()],
+                    score: BenchmarkScore {
+                        exact_match: true,
+                        f1: 1.0,
+                        contains: true,
+                    },
+                    judge_score: None,
+                    retrieved_facts: None,
+                    recall_at_k: None,
+                    ndcg_at_k: None,
+                },
+                QuestionResult {
+                    id: "q2".to_owned(),
+                    category: "factual".to_owned(),
+                    actual_answer: "green".to_owned(),
+                    expected_answers: vec!["red".to_owned()],
+                    score: BenchmarkScore {
+                        exact_match: false,
+                        f1: 0.0,
+                        contains: false,
+                    },
+                    judge_score: None,
+                    retrieved_facts: None,
+                    recall_at_k: None,
+                    ndcg_at_k: None,
+                },
+            ],
+        )
+    }
+
+    #[test]
+    fn reward_surface_uses_real_report_and_baseline_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("baseline.json");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(
+            serde_json::json!({
+                "benchmark": "LongMemEval",
+                "exact_match_rate": 0.35,
+                "mean_f1": 0.40
+            })
+            .to_string()
+            .as_bytes(),
+        )
+        .unwrap();
+
+        let report = sample_report();
+        let surface = load_reward_surface(&report, &path).unwrap();
+
+        assert!((surface.outcome.exact_match_rate - 0.5).abs() < f64::EPSILON);
+        assert!((surface.reward - 0.15).abs() < f64::EPSILON);
+        assert_eq!(
+            format_reward_surface(&surface),
+            "Reward vs baseline: +0.150 (EM 50.0% vs baseline 35.0%)"
+        );
     }
 }

--- a/crates/episteme/src/rl/actions.rs
+++ b/crates/episteme/src/rl/actions.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// The variants mirror the planned policy vocabulary without encoding the
 /// still-missing Phase 05c parameter inventory.
+// TODO(#3969) Phase-06b boundary type: the learned RL policy remains 1.x.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[non_exhaustive]

--- a/crates/episteme/src/rl/mod.rs
+++ b/crates/episteme/src/rl/mod.rs
@@ -1,8 +1,8 @@
 //! Reinforcement-learning readiness types for memory policy experiments.
 //!
-//! This module intentionally defines only stable boundary types. The concrete
-//! environment is deferred until the in-tree memory-policy constants have been
-//! inventoried into a durable state schema.
+//! The benchmark reward surface is wired and evaluated against real benchmark
+//! outcomes, but the learned policy / training loop remains a Phase-06b
+//! boundary.
 
 /// Memory policy action space placeholders.
 pub mod actions;

--- a/crates/episteme/src/rl/reward.rs
+++ b/crates/episteme/src/rl/reward.rs
@@ -91,7 +91,13 @@ fn exact_match_rate_from_questions(value: &serde_json::Value) -> Option<f64> {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
+    use std::fs;
+    use std::io::Write as _;
+
+    use tempfile::tempdir;
+
     use super::{LongMemEvalReward, MemoryOutcome, RewardFn, extract_exact_match_rate};
 
     #[test]
@@ -125,6 +131,31 @@ mod tests {
         let outcome = MemoryOutcome {
             exact_match_rate: 0.50,
             mean_f1: None,
+        };
+
+        assert!((reward.reward(&outcome) - 0.15).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn loads_reward_from_file_and_scores_real_outcome() {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("baseline.json");
+        let mut file = fs::File::create(&path).unwrap();
+        file.write_all(
+            serde_json::json!({
+                "benchmark": "LongMemEval",
+                "exact_match_rate": 0.35,
+                "mean_f1": 0.42
+            })
+            .to_string()
+            .as_bytes(),
+        )
+        .unwrap();
+
+        let reward = LongMemEvalReward::from_json_file(&path).unwrap();
+        let outcome = MemoryOutcome {
+            exact_match_rate: 0.50,
+            mean_f1: Some(0.40),
         };
 
         assert!((reward.reward(&outcome) - 0.15).abs() < f64::EPSILON);

--- a/crates/episteme/src/rl/state.rs
+++ b/crates/episteme/src/rl/state.rs
@@ -11,6 +11,7 @@ use super::Action;
 /// The concrete 66-constant schema referenced by the Phase 06b issue is not
 /// present in this repository. A named feature map keeps the scaffold useful
 /// for reward-loader and harness work without freezing placeholder constants.
+// TODO(#3969) Phase-06b boundary type: the learned RL loop stays 1.x.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct MemoryState {
     /// Stable identifier for the memory item or policy decision point.
@@ -39,6 +40,7 @@ impl MemoryState {
 }
 
 /// A single memory-policy transition emitted by a future training environment.
+// TODO(#3969) Phase-06b boundary type: transition wiring stays out of the 1.x learned policy loop.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MemoryTransition {
     /// State before the action.


### PR DESCRIPTION
Wires the dead-coded `episteme/src/rl` reward surface (RewardFn/LongMemEvalReward/MemoryOutcome/Action) so its exported types have real callers, per cut-line line 53 (wire the existing surface; the RL training loop #3969 stays 1.x). Connects the benchmark baseline-out JSON to LongMemEvalReward and surfaces the scalar reward on real eval outcomes; MemoryState/Transition annotated as Phase-06b boundary types (TODO #3969). Honest: reward surface wired+evaluated, learned recall policy is 1.x (no 'RL-tuned recall' claim). Pre-push hook gated (fmt + _llm + clippy episteme/aletheia).