### PR TITLE
fix(koilon): sandbox Config::load probe under test, drop gate exclusion

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -1,11 +1,6 @@
 # WHY: Core gate — enforces fmt, clippy, and test coverage on every PR.
 # Replaces the self-hosted `kanon gate` invocation (kanon is a private binary
 # unavailable on GitHub-hosted runners) with equivalent explicit cargo steps.
-# theatron/skene/koilon excluded from clippy and nextest: koilon's Config::load
-# hangs ~120s on ephemeral ubuntu runners (network/dbus/keyring probe at init),
-# matching the established local gate scope. See #4387 and metis CLAUDE.md §
-# metis-local-work era. CI runs the gate directly (fmt/clippy/nextest); the
-# legacy Gate-Passed local-attestation trailer is no longer required.
 name: Gate Attestation
 
 on:
@@ -82,15 +77,11 @@ jobs:
 
       - name: cargo clippy
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'release-please[bot]' }}
-        # WHY: theatron/skene/koilon excluded — koilon Config::load hangs on
-        # ephemeral ubuntu runners (network/dbus/keyring probe timeout ~120s).
-        # Matches the established local gate scope on metis.
-        run: cargo clippy --workspace --all-targets --exclude theatron --exclude skene --exclude koilon -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: cargo nextest run
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'release-please[bot]' }}
-        # WHY: same theatron/skene/koilon exclusion as clippy above.
-        run: cargo nextest run --workspace --exclude theatron --exclude skene --exclude koilon
+        run: cargo nextest run --workspace
 
       - name: Gate summary
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'release-please[bot]' }}

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -116,7 +116,7 @@ l3_token_estimate = 1170
 [[crates]]
 name = "koilon"
 path = "crates/theatron/koilon"
-source_hash = "e4df5f3664a681dbde3cf88c7c82729182cc198b08fe155a184a8cde262c19fb"
+source_hash = "42b63e1cb5084410f1fa58e852f4a5289f9b184921ffb552ad8ecac0d36f3829"
 l3_token_estimate = 11570
 
 [[crates]]
@@ -284,7 +284,7 @@ l3_token_estimate = 24198
 [[crates]]
 name = "theatron"
 path = "crates/theatron"
-source_hash = "9b1e020b438d58ed06b60b21f5aada64196ad610c755da5bca435d67fc194fdc"
+source_hash = "d4dc4328dd3141b8808f6dc7a0fc9673d9ae4c33e1c5d47ba6e80ffcdba2180f"
 l3_token_estimate = 22042
 
 [[crates]]

--- a/crates/theatron/koilon/src/config.rs
+++ b/crates/theatron/koilon/src/config.rs
@@ -175,13 +175,11 @@ impl Config {
         // WHY: When neither CLI flag nor config file provides a URL, attempt
         // auto-discovery before falling back to the compiled default.
         // Discovery runs a blocking runtime because Config::load is sync.
-        // WHY cfg(test) skip: LAN probes block ~120 s per candidate on
-        // workstation test harnesses (TCP timeout, not connection-refused).
-        // `#[cfg(test)]` gates only the koilon crate's own tests — the
-        // binary and integration consumers always run live discovery.
-        // Runtime override via KOILON_NO_DISCOVERY is kept as a belt-and-
-        // suspenders escape for cases where cfg(test) is not sufficient.
-        let skip_discovery = cfg!(test) || RealSystem.var("KOILON_NO_DISCOVERY").is_some();
+        // WHY test skip: test binaries must not pay the live LAN/dbus/keyring
+        // probe cost. `cfg(test)` covers unit tests; nextest sets NEXTEST for
+        // package tests that compile the library as a non-test dependency.
+        // KOILON_SKIP_PROBE remains as an explicit escape hatch for harnesses.
+        let skip_discovery = Self::skip_discovery();
         let url = cli_url.or(file_config.url).unwrap_or_else(|| {
             if skip_discovery {
                 DEFAULT_URL.to_string()
@@ -231,6 +229,14 @@ impl Config {
                 .ok()?;
             rt.block_on(skene::discovery::discover_server_with_config(config))
         }
+    }
+
+    fn skip_discovery() -> bool {
+        cfg!(test)
+            || RealSystem.var("KOILON_NO_DISCOVERY").is_some()
+            || RealSystem.var("KOILON_SKIP_PROBE").is_some()
+            || RealSystem.var("NEXTEST").is_some()
+            || RealSystem.var("NEXTEST_RUN_ID").is_some()
     }
 
     #[expect(


### PR DESCRIPTION
Fixes the koilon Config::load test hang (~120s network/dbus/keyring probe) via a `skip_discovery()` guard (cfg(test) || KOILON_NO_DISCOVERY/KOILON_SKIP_PROBE/NEXTEST env) — **production probe behavior unchanged**, only test/sandboxed builds skip the live probe. Then removes `--exclude theatron --exclude skene --exclude koilon` from gate-attestation so the full workspace is gated honestly. NOTE: the un-excluded full-workspace gate runs for the first time in this PR's CI — if it surfaces latent theatron/skene lints, this PR will need a follow-up (it won't auto-merge unless green).