### PR TITLE
feat(poiesis): wire the 9 orphaned chart-kind SVG emitters

### DIFF
--- a/_llm/L3-api-index/poiesis-charts.md
+++ b/_llm/L3-api-index/poiesis-charts.md
@@ -671,8 +671,6 @@ pub fn emit (
 >   fallback and `charts-vega` is disabled.
 > - [`crate::Error::BadSeriesShape`]  -  series count violates the per-kind
 >   contract.
-> - [`crate::Error::EmitterStub`]  -  pure-Rust arm for this kind is not yet
->   implemented (stub list above).
 > - [`crate::Error::UnresolvedTone`]  -  a series references a tone the
 >   theme does not provide.
 ```rust

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -164,8 +164,8 @@ l3_token_estimate = 11827
 [[crates]]
 name = "poiesis-charts"
 path = "crates/poiesis/charts"
-source_hash = "7c3c6b37c8d800f4a57df8f523d08f08e06320e9facdafa19d1a17f750d7d500"
-l3_token_estimate = 4605
+source_hash = "0a0c6849477e74604443beeb8e63df4475a152f27017ed2bb3f753d40e0b99b3"
+l3_token_estimate = 4577
 
 [[crates]]
 name = "poiesis-core"

--- a/crates/poiesis/charts/CLAUDE.md
+++ b/crates/poiesis/charts/CLAUDE.md
@@ -13,7 +13,7 @@ Typed chart model + deterministic SVG emitter. Implements B-005 (poiesis chart s
 1. `src/lib.rs` — module map + determinism contract.
 2. `src/model.rs` — `Chart`, `Series`, `Axes`, `FactCite`, `ChartKind::render_path`.
 3. `src/render.rs` — `render_chart` entry point + per-kind dispatch.
-4. `src/render/kinds/combo.rs` — the only fully implemented arm today; the B-005 acceptance gate.
+4. `src/render/kinds/combo.rs` — the multi-axis acceptance gate and the reference multi-series arm.
 5. `src/scale.rs` — linear `Scale` + `nice()` + `ticks()` (consumed by every arm).
 6. `src/format.rs` — fixed-precision number formatting (the only path from `f64` to `<text>`).
 
@@ -27,21 +27,21 @@ Three rules, all enforced in code:
 | Element order | Per-kind arms write groups in a fixed source order (`gridlines → axes → bars → line → labels → x-labels`). No map iteration into output. |
 | IDs | Content-derived or index-based. No UUIDs, no `rand`. |
 
-The combo arm has a re-emit-must-be-byte-identical test (`output_is_deterministic_across_two_renders`). Per-kind golden snapshots via `insta` land with each follow-up arm.
+The combo arm has a re-emit-must-be-byte-identical test (`output_is_deterministic_across_two_renders`). The other wired arms have direct render assertions that check the root SVG plus their expected structural markers.
 
 ## Per-kind emitter status
 
 | Kind | Status |
 |---|---|
-| combo | **Implemented** — covers the B-005 acceptance gate |
-| bar | Stub (`Error::EmitterStub`) — design doc in PR body |
-| column | Stub — column arm shares ~70 % with combo's column primitives; extract during follow-up |
-| line | Stub — line arm shares with combo's line primitives |
-| area | Stub — line + closed polygon |
-| scatter | Stub — Cartesian-x scale + circles only |
-| pie | Stub — angle accumulator + arc emitter |
-| doughnut | Stub — pie with inner-radius cut |
-| stat | Stub — single big number + sparkline |
+| combo | **Implemented / wired** — covers the B-005 acceptance gate |
+| bar | **Implemented / wired** — horizontal grouped bars |
+| column | **Implemented / wired** — vertical grouped bars |
+| line | **Implemented / wired** — polyline + markers |
+| area | **Implemented / wired** — filled polygon + top edge |
+| scatter | **Implemented / wired** — Cartesian-x scale + circles |
+| pie | **Implemented / wired** — arc sectors |
+| doughnut | **Implemented / wired** — pie with inner-radius cut |
+| stat | **Implemented / wired** — single big number |
 
 Follow-up arms reuse `Scale` + `format` + `Canvas`; only the per-arm geometry differs.
 

--- a/crates/poiesis/charts/src/render.rs
+++ b/crates/poiesis/charts/src/render.rs
@@ -12,20 +12,19 @@
 //!
 //! | Kind     | Status                          | Owner       |
 //! |----------|---------------------------------|-------------|
-//! | bar      | stub (`Error::EmitterStub`)     | follow-up   |
-//! | column   | stub (`Error::EmitterStub`)     | follow-up   |
-//! | line     | stub (`Error::EmitterStub`)     | follow-up   |
-//! | area     | stub (`Error::EmitterStub`)     | follow-up   |
-//! | combo    | scaffolded (`emit_combo`)       | this PR     |
-//! | scatter  | stub (`Error::EmitterStub`)     | follow-up   |
-//! | pie      | stub (`Error::EmitterStub`)     | follow-up   |
-//! | doughnut | stub (`Error::EmitterStub`)     | follow-up   |
-//! | stat     | stub (`Error::EmitterStub`)     | follow-up   |
+//! | bar      | implemented / wired             | this PR     |
+//! | column   | implemented / wired             | this PR     |
+//! | line     | implemented / wired             | this PR     |
+//! | area     | implemented / wired             | this PR     |
+//! | combo    | implemented / wired             | B-005 gate  |
+//! | scatter  | implemented / wired             | this PR     |
+//! | pie      | implemented / wired             | this PR     |
+//! | doughnut | implemented / wired             | this PR     |
+//! | stat     | implemented / wired             | this PR     |
 //!
-//! The `combo` arm is scaffolded first because the B-005 acceptance gate
-//! reproduces the offsite slide-3 chart, which is a combo. The other arms
-//! follow the same module shape (one file each under `kinds/`); the design
-//! fan-out is tracked in the PR body.
+//! The pure-Rust emitter now covers `bar`, `column`, `line`, `area`,
+//! `combo`, `scatter`, `pie`, `doughnut`, and `stat`. The remaining chart
+//! kinds route to Vega-Lite behind the `charts-vega` feature.
 
 mod canvas;
 mod kinds;
@@ -53,8 +52,6 @@ pub use crate::theme::ColorMode;
 ///   fallback and `charts-vega` is disabled.
 /// - [`crate::Error::BadSeriesShape`] — series count violates the per-kind
 ///   contract.
-/// - [`crate::Error::EmitterStub`] — pure-Rust arm for this kind is not yet
-///   implemented (stub list above).
 /// - [`crate::Error::UnresolvedTone`] — a series references a tone the
 ///   theme does not provide.
 pub fn render_chart(
@@ -66,17 +63,15 @@ pub fn render_chart(
     chart.validate()?;
 
     match chart.kind {
+        ChartKind::Bar => kinds::bar::emit(chart, theme, canvas, mode),
+        ChartKind::Column => kinds::column::emit(chart, theme, canvas, mode),
+        ChartKind::Line => kinds::line::emit(chart, theme, canvas, mode),
+        ChartKind::Area => kinds::area::emit(chart, theme, canvas, mode),
         ChartKind::Combo => kinds::combo::emit(chart, theme, canvas, mode),
-        ChartKind::Bar
-        | ChartKind::Column
-        | ChartKind::Line
-        | ChartKind::Area
-        | ChartKind::Scatter
-        | ChartKind::Pie
-        | ChartKind::Doughnut
-        | ChartKind::Stat => Err(crate::Error::EmitterStub {
-            kind: chart.kind.name().to_owned(),
-        }),
+        ChartKind::Scatter => kinds::scatter::emit(chart, theme, canvas, mode),
+        ChartKind::Pie => kinds::pie::emit(chart, theme, canvas, mode),
+        ChartKind::Doughnut => kinds::doughnut::emit(chart, theme, canvas, mode),
+        ChartKind::Stat => kinds::stat::emit(chart, theme, canvas, mode),
         ChartKind::Heatmap | ChartKind::Boxplot | ChartKind::Sankey | ChartKind::Candlestick => {
             #[cfg(feature = "charts-vega")]
             {
@@ -99,9 +94,10 @@ pub fn render_chart(
 mod tests {
     use super::*;
     use crate::model::{
-        Axes, AxisSide, Chart, ChartKind, CiteOrText, FactCite, FactId, LegendSpec, Point, Series,
-        SeriesStyle, ToneRef, Unit,
+        Axes, AxisSide, Chart, ChartKind, CiteOrScalar, CiteOrText, FactCite, FactId, LegendSpec,
+        Point, Series, SeriesStyle, ToneRef, Unit,
     };
+    use crate::render::canvas::DeckCanvas;
 
     fn combo_spec() -> Chart {
         let cite = |id: &str, v: f64| FactCite {
@@ -164,17 +160,208 @@ mod tests {
     }
 
     #[test]
-    fn stub_kinds_return_emitter_stub_error() {
-        let mut spec = combo_spec();
-        spec.kind = ChartKind::Line;
-        spec.series.truncate(1);
-        let theme = ResolvedTheme::summus_stub();
-        let r = render_chart(
+    fn bar_renders() {
+        let spec = chart_spec(
+            ChartKind::Bar,
+            vec![series(
+                "Revenue",
+                0,
+                SeriesStyle::Default,
+                AxisSide::Left,
+                vec![point("MAR", 18.0), point("APR", 22.0)],
+            )],
+            true,
+        );
+        assert_kind_svg(&spec, &["<svg", "<g class=\"bars\">", "<rect"]);
+    }
+
+    #[test]
+    fn column_renders() {
+        let spec = chart_spec(
+            ChartKind::Column,
+            vec![series(
+                "Revenue",
+                0,
+                SeriesStyle::Default,
+                AxisSide::Left,
+                vec![point("MAR", 18.0), point("APR", 22.0)],
+            )],
+            true,
+        );
+        assert_kind_svg(&spec, &["<svg", "<g class=\"bars\">", "<rect"]);
+    }
+
+    #[test]
+    fn line_renders() {
+        let spec = chart_spec(
+            ChartKind::Line,
+            vec![series(
+                "Revenue",
+                0,
+                SeriesStyle::Default,
+                AxisSide::Left,
+                vec![point("MAR", 18.0), point("APR", 22.0)],
+            )],
+            true,
+        );
+        assert_kind_svg(
             &spec,
+            &["<svg", "<g class=\"lines\">", "<polyline", "<circle"],
+        );
+    }
+
+    #[test]
+    fn area_renders() {
+        let spec = chart_spec(
+            ChartKind::Area,
+            vec![series(
+                "Revenue",
+                0,
+                SeriesStyle::Default,
+                AxisSide::Left,
+                vec![point("MAR", 18.0), point("APR", 22.0)],
+            )],
+            true,
+        );
+        assert_kind_svg(
+            &spec,
+            &["<svg", "<g class=\"areas\">", "<polygon", "<polyline"],
+        );
+    }
+
+    #[test]
+    fn scatter_renders() {
+        let spec = chart_spec(
+            ChartKind::Scatter,
+            vec![series(
+                "Revenue",
+                0,
+                SeriesStyle::Default,
+                AxisSide::Left,
+                vec![scatter_point(1.0, 18.0), scatter_point(2.0, 22.0)],
+            )],
+            true,
+        );
+        assert_kind_svg(&spec, &["<svg", "<g class=\"dots\">", "<circle"]);
+    }
+
+    #[test]
+    fn pie_renders() {
+        let spec = chart_spec(
+            ChartKind::Pie,
+            vec![series(
+                "Revenue",
+                0,
+                SeriesStyle::Default,
+                AxisSide::Left,
+                vec![point("MAR", 30.0), point("APR", 70.0)],
+            )],
+            true,
+        );
+        assert_kind_svg(&spec, &["<svg", "<g class=\"sectors\">", "<path"]);
+    }
+
+    #[test]
+    fn doughnut_renders() {
+        let spec = chart_spec(
+            ChartKind::Doughnut,
+            vec![series(
+                "Revenue",
+                0,
+                SeriesStyle::Default,
+                AxisSide::Left,
+                vec![point("MAR", 30.0), point("APR", 70.0)],
+            )],
+            true,
+        );
+        assert_kind_svg(&spec, &["<svg", "<g class=\"sectors\">", "<path"]);
+    }
+
+    #[test]
+    fn stat_renders() {
+        let spec = chart_spec(
+            ChartKind::Stat,
+            vec![series(
+                "Users",
+                0,
+                SeriesStyle::Default,
+                AxisSide::Left,
+                vec![point("MAR", 42.0)],
+            )],
+            false,
+        );
+        assert_kind_svg(&spec, &["<svg", "<g class=\"stat\">", "42"]);
+    }
+
+    fn chart_spec(kind: ChartKind, series: Vec<Series>, data_labels: bool) -> Chart {
+        Chart {
+            kind,
+            title: None,
+            series,
+            axes: Axes::default(),
+            legend: LegendSpec::Auto,
+            data_labels,
+            caption: None,
+        }
+    }
+
+    fn series(
+        name: &str,
+        tone: usize,
+        style: SeriesStyle,
+        axis: AxisSide,
+        points: Vec<Point>,
+    ) -> Series {
+        Series {
+            name: CiteOrText::Text(name.to_owned()),
+            points,
+            tone: ToneRef::Indexed(tone),
+            axis,
+            style,
+        }
+    }
+
+    fn point(label: &str, value: f64) -> Point {
+        Point {
+            label: Some(CiteOrText::Text(label.to_owned())),
+            x: None,
+            y: cite(value),
+        }
+    }
+
+    fn scatter_point(x: f64, y: f64) -> Point {
+        Point {
+            label: None,
+            x: Some(CiteOrScalar::Scalar(x)),
+            y: cite(y),
+        }
+    }
+
+    fn cite(value: f64) -> FactCite {
+        FactCite {
+            id: FactId(format!("fact-{value}")),
+            value,
+            unit: Unit::Number,
+        }
+    }
+
+    fn assert_kind_svg(spec: &Chart, markers: &[&str]) {
+        let theme = ResolvedTheme::summus_stub();
+        let svg = render_chart(
+            spec,
             &theme,
             &Canvas::Deck(DeckCanvas::default()),
             ColorMode::Resolved,
-        );
-        assert!(matches!(r, Err(crate::Error::EmitterStub { kind }) if kind == "line"));
+        )
+        .expect("kind emits");
+        assert!(!svg.is_empty());
+        assert!(svg.starts_with("<svg"));
+        for marker in markers {
+            assert!(
+                svg.contains(marker),
+                "expected {} SVG to contain {marker}, got {svg}",
+                spec.kind.name()
+            );
+        }
     }
 }

--- a/crates/poiesis/charts/src/render/kinds.rs
+++ b/crates/poiesis/charts/src/render/kinds.rs
@@ -5,16 +5,21 @@
 //! each arm emits its primitive group in a fixed source order, so the
 //! whole-chart SVG is byte-deterministic.
 //!
-//! The `combo` arm is the only one with a working emitter today (the B-005
-//! acceptance gate is a combo chart); the rest return
-//! [`Error::EmitterStub`](crate::Error::EmitterStub). Per-kind designs are
-//! fanned out as separate follow-up work — the design notes for each kind
-//! live in this module's source comments and in the PR body.
+//! The pure-Rust render path is wired here for `bar`, `column`, `line`,
+//! `area`, `combo`, `scatter`, `pie`, `doughnut`, and `stat`. The remaining
+//! chart kinds continue to route to Vega-Lite behind `charts-vega`.
 //!
 //! [`Chart`]: crate::model::Chart
 //! [`ResolvedTheme`]: crate::theme::ResolvedTheme
 //! [`Canvas`]: super::canvas::Canvas
 //! [`ColorMode`]: crate::theme::ColorMode
 
-/// Combo: columns + line on dual y-axes. The B-005 acceptance gate.
+pub mod area;
+pub mod bar;
+pub mod column;
 pub mod combo;
+pub mod doughnut;
+pub mod line;
+pub mod pie;
+pub mod scatter;
+pub mod stat;

--- a/crates/poiesis/charts/src/render/kinds/area.rs
+++ b/crates/poiesis/charts/src/render/kinds/area.rs
@@ -312,11 +312,7 @@ const fn idx_to_f64(i: usize) -> f64 {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions"
-)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::model::{

--- a/crates/poiesis/charts/src/render/kinds/bar.rs
+++ b/crates/poiesis/charts/src/render/kinds/bar.rs
@@ -35,7 +35,12 @@ pub fn emit(
     mode: ColorMode,
 ) -> Result<String> {
     let plot = canvas.plot_box();
-    let n_cats = chart.series.iter().map(|s| s.points.len()).max().unwrap_or(0);
+    let n_cats = chart
+        .series
+        .iter()
+        .map(|s| s.points.len())
+        .max()
+        .unwrap_or(0);
     if n_cats == 0 {
         return Err(crate::Error::BadSeriesShape {
             kind: "bar".to_owned(),
@@ -70,9 +75,13 @@ pub fn emit(
     emit_svg_open(&mut out, chart, canvas);
     emit_gridlines(&mut out, lo, hi, &x_scale, &plot);
     emit_axes(&mut out, chart, lo, hi, &x_scale, &plot, band_h, theme);
-    emit_bars(&mut out, chart, &x_scale, &plot, band_h, sub_h, bar_h, &fills);
+    emit_bars(
+        &mut out, chart, &x_scale, &plot, band_h, sub_h, bar_h, &fills,
+    );
     if chart.data_labels {
-        emit_labels(&mut out, chart, &x_scale, &plot, band_h, sub_h, theme, &fills);
+        emit_labels(
+            &mut out, chart, &x_scale, &plot, band_h, sub_h, theme, &fills,
+        );
     }
     out.push_str("</svg>");
     Ok(out)
@@ -137,22 +146,23 @@ fn emit_axes(
     }
 
     // y-category labels
-    let first_series = &chart.series[0];
-    for (j, point) in first_series.points.iter().enumerate() {
-        let cy = plot.y0 + band_h * idx_to_f64(j) + band_h * 0.5;
-        let label = match &point.label {
-            Some(CiteOrText::Text(t)) => t.clone(),
-            Some(CiteOrText::Cite(id)) => id.0.clone(),
-            None => String::new(),
-        };
-        let _ = write!(
-            out,
-            "<text x=\"{x}\" y=\"{y}\" text-anchor=\"end\" dominant-baseline=\"middle\" font-family=\"{font}\">{label}</text>",
-            x = coord(plot.x0 - 8.0),
-            y = coord(cy),
-            font = theme.font_sans,
-            label = escape_xml(&label),
-        );
+    if let Some(first_series) = chart.series.first() {
+        for (j, point) in first_series.points.iter().enumerate() {
+            let cy = plot.y0 + band_h * idx_to_f64(j) + band_h * 0.5;
+            let label = match &point.label {
+                Some(CiteOrText::Text(t)) => t.clone(),
+                Some(CiteOrText::Cite(id)) => id.0.clone(),
+                None => String::new(),
+            };
+            let _ = write!(
+                out,
+                "<text x=\"{x}\" y=\"{y}\" text-anchor=\"end\" dominant-baseline=\"middle\" font-family=\"{font}\">{label}</text>",
+                x = coord(plot.x0 - 8.0),
+                y = coord(cy),
+                font = theme.font_sans,
+                label = escape_xml(&label),
+            );
+        }
     }
 
     out.push_str("</g>");
@@ -169,8 +179,7 @@ fn emit_bars(
     fills: &[String],
 ) {
     out.push_str("<g class=\"bars\">");
-    for (i, series) in chart.series.iter().enumerate() {
-        let fill = &fills[i];
+    for (i, (series, fill)) in chart.series.iter().zip(fills.iter()).enumerate() {
         for (j, point) in series.points.iter().enumerate() {
             let x = plot.x0;
             let y = plot.y0 + band_h * idx_to_f64(j) + sub_h * idx_to_f64(i) + sub_h * 0.1;
@@ -201,8 +210,7 @@ fn emit_labels(
     fills: &[String],
 ) {
     out.push_str("<g class=\"labels\">");
-    for (i, series) in chart.series.iter().enumerate() {
-        let fill = &fills[i];
+    for (i, (series, fill)) in chart.series.iter().zip(fills.iter()).enumerate() {
         for (j, point) in series.points.iter().enumerate() {
             let label_x = x_scale.map(point.y.value) + 6.0;
             let label_y = plot.y0 + band_h * idx_to_f64(j) + sub_h * idx_to_f64(i) + sub_h * 0.5;
@@ -265,11 +273,7 @@ fn escape_xml(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions"
-)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::model::{
@@ -407,6 +411,9 @@ mod tests {
         )
         .expect("emit");
         let rect_count = svg.matches("<rect").count();
-        assert!(rect_count >= 6, "expected at least 6 rects, got {rect_count}");
+        assert!(
+            rect_count >= 6,
+            "expected at least 6 rects, got {rect_count}"
+        );
     }
 }

--- a/crates/poiesis/charts/src/render/kinds/column.rs
+++ b/crates/poiesis/charts/src/render/kinds/column.rs
@@ -35,7 +35,12 @@ pub fn emit(
     mode: ColorMode,
 ) -> Result<String> {
     let plot = canvas.plot_box();
-    let n_cats = chart.series.iter().map(|s| s.points.len()).max().unwrap_or(0);
+    let n_cats = chart
+        .series
+        .iter()
+        .map(|s| s.points.len())
+        .max()
+        .unwrap_or(0);
     if n_cats == 0 {
         return Err(crate::Error::BadSeriesShape {
             kind: "column".to_owned(),
@@ -70,9 +75,13 @@ pub fn emit(
     emit_svg_open(&mut out, chart, canvas);
     emit_gridlines(&mut out, lo, hi, &y_scale, &plot);
     emit_axes(&mut out, chart, lo, hi, &y_scale, &plot, band_w, theme);
-    emit_bars(&mut out, chart, &y_scale, &plot, band_w, sub_w, bar_w, &fills);
+    emit_bars(
+        &mut out, chart, &y_scale, &plot, band_w, sub_w, bar_w, &fills,
+    );
     if chart.data_labels {
-        emit_labels(&mut out, chart, &y_scale, &plot, band_w, sub_w, theme, &fills);
+        emit_labels(
+            &mut out, chart, &y_scale, &plot, band_w, sub_w, theme, &fills,
+        );
     }
     out.push_str("</svg>");
     Ok(out)
@@ -137,22 +146,23 @@ fn emit_axes(
     }
 
     // x-category labels
-    let first_series = &chart.series[0];
-    for (j, point) in first_series.points.iter().enumerate() {
-        let cx = plot.x0 + band_w * idx_to_f64(j) + band_w * 0.5;
-        let label = match &point.label {
-            Some(CiteOrText::Text(t)) => t.clone(),
-            Some(CiteOrText::Cite(id)) => id.0.clone(),
-            None => String::new(),
-        };
-        let _ = write!(
-            out,
-            "<text x=\"{x}\" y=\"{y}\" text-anchor=\"middle\" font-family=\"{font}\">{label}</text>",
-            x = coord(cx),
-            y = coord(plot.y1 + 24.0),
-            font = theme.font_sans,
-            label = escape_xml(&label),
-        );
+    if let Some(first_series) = chart.series.first() {
+        for (j, point) in first_series.points.iter().enumerate() {
+            let cx = plot.x0 + band_w * idx_to_f64(j) + band_w * 0.5;
+            let label = match &point.label {
+                Some(CiteOrText::Text(t)) => t.clone(),
+                Some(CiteOrText::Cite(id)) => id.0.clone(),
+                None => String::new(),
+            };
+            let _ = write!(
+                out,
+                "<text x=\"{x}\" y=\"{y}\" text-anchor=\"middle\" font-family=\"{font}\">{label}</text>",
+                x = coord(cx),
+                y = coord(plot.y1 + 24.0),
+                font = theme.font_sans,
+                label = escape_xml(&label),
+            );
+        }
     }
 
     out.push_str("</g>");
@@ -169,8 +179,7 @@ fn emit_bars(
     fills: &[String],
 ) {
     out.push_str("<g class=\"bars\">");
-    for (i, series) in chart.series.iter().enumerate() {
-        let fill = &fills[i];
+    for (i, (series, fill)) in chart.series.iter().zip(fills.iter()).enumerate() {
         for (j, point) in series.points.iter().enumerate() {
             let x = plot.x0 + band_w * idx_to_f64(j) + sub_w * idx_to_f64(i) + sub_w * 0.1;
             let y = y_scale.map(point.y.value);
@@ -200,8 +209,7 @@ fn emit_labels(
     fills: &[String],
 ) {
     out.push_str("<g class=\"labels\">");
-    for (i, series) in chart.series.iter().enumerate() {
-        let fill = &fills[i];
+    for (i, (series, fill)) in chart.series.iter().zip(fills.iter()).enumerate() {
         for (j, point) in series.points.iter().enumerate() {
             let cx = plot.x0 + band_w * idx_to_f64(j) + sub_w * idx_to_f64(i) + sub_w * 0.5;
             let label_y = y_scale.map(point.y.value) - 6.0;
@@ -264,11 +272,7 @@ fn escape_xml(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions"
-)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::model::{
@@ -406,6 +410,9 @@ mod tests {
         )
         .expect("emit");
         let rect_count = svg.matches("<rect").count();
-        assert!(rect_count >= 6, "expected at least 6 rects, got {rect_count}");
+        assert!(
+            rect_count >= 6,
+            "expected at least 6 rects, got {rect_count}"
+        );
     }
 }

--- a/crates/poiesis/charts/src/render/kinds/doughnut.rs
+++ b/crates/poiesis/charts/src/render/kinds/doughnut.rs
@@ -33,14 +33,20 @@ const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
 /// - `chart.kind == ChartKind::Doughnut`
 /// - `series.len() == 1`
 /// - `points.len() >= 1`
-#[expect(clippy::too_many_lines, reason = "single emit function per kind pattern")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "single emit function per kind pattern"
+)]
 pub fn emit(
     chart: &Chart,
     theme: &ResolvedTheme,
     canvas: &Canvas,
     mode: ColorMode,
 ) -> Result<String> {
-    #[expect(clippy::indexing_slicing, reason = "caller invariant: exactly 1 series")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "caller invariant: exactly 1 series"
+    )]
     let series = &chart.series[0];
     let plot = canvas.plot_box();
 
@@ -107,7 +113,11 @@ pub fn emit(
             let (x1o, y1o) = polar_to_xy(cx, cy, r, end_angle);
             let (x0i, y0i) = polar_to_xy(cx, cy, r_inner, start_angle);
             let (x1i, y1i) = polar_to_xy(cx, cy, r_inner, end_angle);
-            let large_arc = if sweep >= std::f64::consts::PI { "1" } else { "0" };
+            let large_arc = if sweep >= std::f64::consts::PI {
+                "1"
+            } else {
+                "0"
+            };
             let mut d = String::new();
             let _ = write!(
                 d,
@@ -200,11 +210,7 @@ fn escape_xml(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions"
-)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::model::{

--- a/crates/poiesis/charts/src/render/kinds/line.rs
+++ b/crates/poiesis/charts/src/render/kinds/line.rs
@@ -275,11 +275,7 @@ const fn idx_to_f64(i: usize) -> f64 {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions"
-)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::model::{

--- a/crates/poiesis/charts/src/render/kinds/pie.rs
+++ b/crates/poiesis/charts/src/render/kinds/pie.rs
@@ -39,7 +39,10 @@ pub fn emit(
     canvas: &Canvas,
     mode: ColorMode,
 ) -> Result<String> {
-    #[expect(clippy::indexing_slicing, reason = "caller invariant: exactly 1 series")]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "caller invariant: exactly 1 series"
+    )]
     let series = &chart.series[0];
     let plot = canvas.plot_box();
 
@@ -94,7 +97,11 @@ pub fn emit(
         } else {
             let (x0, y0) = polar_to_xy(cx, cy, r, start_angle);
             let (x1, y1) = polar_to_xy(cx, cy, r, end_angle);
-            let large_arc = if sweep >= std::f64::consts::PI { "1" } else { "0" };
+            let large_arc = if sweep >= std::f64::consts::PI {
+                "1"
+            } else {
+                "0"
+            };
             let mut d = String::new();
             let _ = write!(
                 d,
@@ -182,11 +189,7 @@ fn escape_xml(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions"
-)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::model::{

--- a/crates/poiesis/charts/src/render/kinds/scatter.rs
+++ b/crates/poiesis/charts/src/render/kinds/scatter.rs
@@ -69,7 +69,9 @@ pub fn emit(
     let mut out = String::new();
     emit_svg_open(&mut out, chart, canvas);
     emit_gridlines(&mut out, &plot, &y_scale, &y_ticks);
-    emit_axes(&mut out, &plot, &x_scale, &y_scale, &x_ticks, &y_ticks, theme, chart);
+    emit_axes(
+        &mut out, &plot, &x_scale, &y_scale, &x_ticks, &y_ticks, theme, chart,
+    );
     emit_dots(&mut out, chart, &x_scale, &y_scale, theme, mode)?;
     if chart.data_labels {
         emit_labels(&mut out, chart, &x_scale, &y_scale, theme, mode)?;
@@ -101,12 +103,7 @@ fn emit_svg_open(out: &mut String, chart: &Chart, canvas: &Canvas) {
     );
 }
 
-fn emit_gridlines(
-    out: &mut String,
-    plot: &PlotBox,
-    y_scale: &Scale,
-    y_ticks: &[f64],
-) {
+fn emit_gridlines(out: &mut String, plot: &PlotBox, y_scale: &Scale, y_ticks: &[f64]) {
     out.push_str("<g class=\"gridlines\">");
     for tick in y_ticks {
         let y = y_scale.map(*tick);
@@ -255,11 +252,7 @@ fn escape_xml(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions"
-)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::model::{
@@ -359,10 +352,7 @@ mod tests {
         let mut chart = scatter_chart();
         chart.series.push(Series {
             name: CiteOrText::Text("Series B".to_owned()),
-            points: vec![
-                pt_xy(1.5, cite("y4", 12.0)),
-                pt_xy(2.5, cite("y5", 18.0)),
-            ],
+            points: vec![pt_xy(1.5, cite("y4", 12.0)), pt_xy(2.5, cite("y5", 18.0))],
             tone: ToneRef::Indexed(1),
             axis: AxisSide::Left,
             style: SeriesStyle::Default,

--- a/crates/poiesis/charts/src/render/kinds/stat.rs
+++ b/crates/poiesis/charts/src/render/kinds/stat.rs
@@ -81,7 +81,11 @@ pub fn emit(
     let aria = if series_name.is_empty() {
         escape_xml(&number_text)
     } else {
-        format!("{} — {}", escape_xml(&number_text), escape_xml(&series_name))
+        format!(
+            "{} — {}",
+            escape_xml(&number_text),
+            escape_xml(&series_name)
+        )
     };
 
     let mut out = String::new();
@@ -153,11 +157,7 @@ fn escape_xml(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions"
-)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::model::{


### PR DESCRIPTION
Closes #4431. Recovers ~3000 lines of complete-but-unreachable work surfaced by the 10-day audit: the 8 chart-kind emitters (bar/column/line/area/scatter/pie/doughnut/stat) were never declared as modules, so rustc never compiled them and render.rs routed them to EmitterStub. This declares the 8 mods in kinds.rs, routes render.rs to the real `kinds::<kind>::emit(...)` per kind, and corrects the doc-table + crate CLAUDE.md from 'stub' to 'implemented/wired'. Verification: 69 poiesis-charts tests pass; pre-push gate (fmt + _llm + scoped clippy) clean.