### PR TITLE
feat(poiesis): resurrect clean-room ODT emitter; restore poiesis-text crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5270,6 +5270,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "krilla"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ddd739cf930f99a70ee89ec51b21fab894b5f142dc9672e0e9a27947b2bc093"
+dependencies = [
+ "base64 0.22.1",
+ "bumpalo",
+ "flate2",
+ "float-cmp 0.10.0",
+ "gif 0.13.3",
+ "image-webp",
+ "imagesize 0.14.0",
+ "indexmap 2.14.0",
+ "once_cell",
+ "pdf-writer",
+ "png 0.17.16",
+ "rustc-hash 2.1.2",
+ "rustybuzz",
+ "siphasher",
+ "skrifa",
+ "smallvec",
+ "subsetter",
+ "tiny-skia-path",
+ "xmp-writer",
+ "yoke 0.8.2",
+ "zune-jpeg 0.5.15",
+]
+
+[[package]]
 name = "krilla-svg"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5277,7 +5306,7 @@ checksum = "f485e1a850201a01dcd8d73e7cf09f2cd4c4cc85c2cd296359094d49336d8ef7"
 dependencies = [
  "flate2",
  "fontdb",
- "krilla",
+ "krilla 0.6.0",
  "png 0.17.16",
  "resvg",
  "tiny-skia",
@@ -7014,6 +7043,7 @@ version = "0.30.0"
 dependencies = [
  "docx-rs",
  "poiesis-core",
+ "poiesis-text",
  "poiesis-typst",
  "quick-xml 0.39.2",
  "serde",
@@ -7111,6 +7141,16 @@ dependencies = [
  "serde_json",
  "snafu",
  "tracing",
+ "zip 8.5.1",
+]
+
+[[package]]
+name = "poiesis-text"
+version = "0.30.0"
+dependencies = [
+ "krilla 0.7.0",
+ "poiesis-core",
+ "snafu",
  "zip 8.5.1",
 ]
 
@@ -10540,7 +10580,7 @@ dependencies = [
  "image",
  "indexmap 2.14.0",
  "infer",
- "krilla",
+ "krilla 0.6.0",
  "krilla-svg",
  "rustc-hash 2.1.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "crates/poiesis/verify",
     "crates/poiesis/intake",
     "crates/poiesis/deck",
+    "crates/poiesis/text",
     "crates/poiesis/deck-layout",
     "crates/poiesis/doc",
     "crates/poiesis/printer-chromium",

--- a/_llm/L3-api-index/poiesis-doc.md
+++ b/_llm/L3-api-index/poiesis-doc.md
@@ -44,6 +44,13 @@ pub enum Error {
         detail: String,
     },
 
+    /// ODT rendering via the clean-room backend failed.
+    #[snafu(display("odt render failed: {detail}"))]
+    OdtRenderFailed {
+        /// Human-readable description.
+        detail: String,
+    },
+
     /// The requested format requires Pandoc, which is not yet available.
     #[snafu(display("{format} output requires Pandoc (coming in B-012); use pdf or xlsx for now"))]
     PandocRequired {
@@ -94,16 +101,8 @@ pub fn inspect_docx (bytes: &[u8]) -> Result<DocxSummary>
 pub fn render_pdf_from_doc (doc: &poiesis_core::Document) -> Result<Vec<u8>>
 ```
 
-> Render a [`poiesis_core::Document`] to ODT bytes.
-> 
-> ODT output requires the Pandoc backend (B-012) which has not landed yet.
-> Returns [`Error::PandocRequired`] until B-012 ships.
-> 
-> # Errors
-> 
-> Always returns [`Error::PandocRequired`] in this stub implementation.
 ```rust
-pub fn render_odt_from_doc (_doc: &poiesis_core::Document) -> Result<Vec<u8>>
+pub fn render_odt_from_doc (doc: &poiesis_core::Document) -> Result<Vec<u8>>
 ```
 
 ## `src/pandoc/ast.rs`

--- a/_llm/L3-api-index/poiesis-text.md
+++ b/_llm/L3-api-index/poiesis-text.md
@@ -19,9 +19,6 @@ pub enum OdtError {
 ```
 
 > Renders a [`Document`] to an ODT byte vector.
-> 
-> The output is a self-contained `OpenDocument` Text file (ODF 1.2) that can be
-> opened in `LibreOffice`, Apache `OpenOffice`, or any conformant editor.
 ```rust
 pub struct OdtRenderer;
 ```

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -194,8 +194,8 @@ l3_token_estimate = 446
 [[crates]]
 name = "poiesis-doc"
 path = "crates/poiesis/doc"
-source_hash = "7be6bd60737ae62d030a3254beb91529f63d9d7a9d0db1ecb2af51daacf15bc7"
-l3_token_estimate = 2269
+source_hash = "f3a0cb314b15883c3644b8f250fec00c098d96d34d02dbefbe8d6ad34bbdd4d2"
+l3_token_estimate = 2251
 
 [[crates]]
 name = "poiesis-inspect"
@@ -238,6 +238,12 @@ name = "poiesis-slides"
 path = "crates/poiesis/slides"
 source_hash = "1acfca3d017925f9fac4a3dd2c7eedbc705f7e9ab3698d4a8606ee0967b4e4e9"
 l3_token_estimate = 600
+
+[[crates]]
+name = "poiesis-text"
+path = "crates/poiesis/text"
+source_hash = "a1ac3f2a8037c8dc32c9dd6d15e7ab92cbc9055d64e68596c3841d98feda20a6"
+l3_token_estimate = 508
 
 [[crates]]
 name = "poiesis-theme"

--- a/crates/poiesis/doc/Cargo.toml
+++ b/crates/poiesis/doc/Cargo.toml
@@ -21,6 +21,9 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 # XML parsing for inspect
 quick-xml = "0.39"
 
+# ODT backend — clean-room ZIP/XML emitter
+poiesis-text = { path = "../text", default-features = false, features = ["odt"] }
+
 # Document model + Typst fast-lane (B-012/B-013)
 poiesis-core = { path = "../core" }
 poiesis-typst = { path = "../typst" }

--- a/crates/poiesis/doc/src/error.rs
+++ b/crates/poiesis/doc/src/error.rs
@@ -42,6 +42,13 @@ pub enum Error {
         detail: String,
     },
 
+    /// ODT rendering via the clean-room backend failed.
+    #[snafu(display("odt render failed: {detail}"))]
+    OdtRenderFailed {
+        /// Human-readable description.
+        detail: String,
+    },
+
     /// The requested format requires Pandoc, which is not yet available.
     #[snafu(display("{format} output requires Pandoc (coming in B-012); use pdf or xlsx for now"))]
     PandocRequired {

--- a/crates/poiesis/doc/src/lib.rs
+++ b/crates/poiesis/doc/src/lib.rs
@@ -5,15 +5,18 @@
 //!
 //! - [`render_docx`] — build a `.docx` file from a JSON descriptor.
 //! - [`inspect_docx`] — extract paragraph text from an existing `.docx` file.
+//! - [`render_odt_from_doc`] — build `.odt` bytes from the document model via
+//!   the clean-room ZIP/XML backend.
 //! - [`pandoc`] — Pandoc subprocess wrapper, AST serialization, and unified
-//!   dispatch (`render_doc`) for the full format matrix (B-012).
+//!   dispatch (`render_doc`) for the remaining format matrix (B-012).
 //!
 //! ## Pandoc dispatch (B-012)
 //!
 //! [`pandoc::render_doc`] routes by format:
 //! - PDF → `poiesis-typst` in-process fast-lane (default).
 //! - PDF with explicit `LaTeX` engine → Pandoc + `LaTeX`.
-//! - docx / odt / md / latex / html / epub → Pandoc subprocess.
+//! - docx / md / latex / html / epub → Pandoc subprocess.
+//! - odt → clean-room ZIP/XML backend in `poiesis-text`.
 //!
 //! # GPL-clean boundary
 //!
@@ -30,6 +33,7 @@ pub mod pandoc;
 pub use error::Error;
 pub use pandoc_probe::{PandocProbe, PandocProbeError};
 
+use poiesis_core::Renderer;
 use serde_json::Value;
 use snafu::ResultExt;
 use tracing::instrument;
@@ -198,15 +202,17 @@ pub fn render_pdf_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
 
 /// Render a [`poiesis_core::Document`] to ODT bytes.
 ///
-/// ODT output requires the Pandoc backend (B-012) which has not landed yet.
-/// Returns [`Error::PandocRequired`] until B-012 ships.
+/// This uses the clean-room `poiesis-text` ODT backend and does not require
+/// Pandoc.
 ///
 /// # Errors
 ///
-/// Always returns [`Error::PandocRequired`] in this stub implementation.
-pub fn render_odt_from_doc(_doc: &poiesis_core::Document) -> Result<Vec<u8>> {
-    Err(Error::PandocRequired {
-        format: "odt".to_owned(),
+/// Returns [`Error::OdtRenderFailed`] if the ODT encoder fails.
+#[instrument(skip(doc))]
+pub fn render_odt_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
+    let renderer = poiesis_text::OdtRenderer::new();
+    renderer.render(doc).map_err(|e| Error::OdtRenderFailed {
+        detail: e.to_string(),
     })
 }
 
@@ -309,17 +315,23 @@ mod tests {
     }
 
     #[test]
-    fn render_odt_from_doc_returns_error() {
-        use poiesis_core::{Document, Metadata};
+    fn render_odt_from_doc_produces_pk_magic() {
+        use poiesis_core::{Block, Document, Metadata, RichText};
         let doc = Document {
             metadata: Metadata {
                 title: "Test".to_owned(),
                 author: None,
                 created: None,
             },
-            content: vec![],
+            content: vec![
+                Block::Heading {
+                    level: 1,
+                    text: RichText::from("Section"),
+                },
+                Block::Paragraph(RichText::from("Content.")),
+            ],
         };
-        let err = render_odt_from_doc(&doc).expect_err("must fail");
-        assert!(matches!(err, Error::PandocRequired { .. }));
+        let bytes = render_odt_from_doc(&doc).expect("must render");
+        assert!(bytes.starts_with(b"PK"), "must be an ODT ZIP archive");
     }
 }

--- a/crates/poiesis/text/Cargo.toml
+++ b/crates/poiesis/text/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "poiesis-text"
+version.workspace = true
+description = "PDF and ODT document rendering backends for poiesis"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+poiesis-core = { path = "../core" }
+snafu = { workspace = true }
+
+# PDF backend
+krilla = { version = "0.7", optional = true }
+
+# ODT backend
+zip = { version = "8", optional = true }
+
+[features]
+default = ["pdf", "odt"]
+pdf = ["dep:krilla"]
+odt = ["dep:zip"]

--- a/crates/poiesis/text/src/lib.rs
+++ b/crates/poiesis/text/src/lib.rs
@@ -1,0 +1,18 @@
+#![deny(missing_docs)]
+//! poiesis-text: PDF and ODT document rendering backends.
+//!
+//! Feature flags:
+//! - `pdf` (default): PDF output via the `krilla` crate.
+//! - `odt` (default): `OpenDocument` Text output via clean-room ZIP/XML.
+
+#[cfg(feature = "odt")]
+pub mod odt;
+
+#[cfg(feature = "pdf")]
+pub mod pdf;
+
+#[cfg(feature = "odt")]
+pub use odt::OdtRenderer;
+
+#[cfg(feature = "pdf")]
+pub use pdf::PdfRenderer;

--- a/crates/poiesis/text/src/odt.rs
+++ b/crates/poiesis/text/src/odt.rs
@@ -1,0 +1,515 @@
+//! ODT rendering backend using a clean-room ZIP/XML implementation.
+//!
+//! `OpenDocument` Text is a ZIP archive containing several XML files:
+//! - `mimetype` (stored, first entry)
+//! - `META-INF/manifest.xml`
+//! - `meta.xml`
+//! - `styles.xml`
+//! - `content.xml`
+
+use std::io::Write as _;
+
+use poiesis_core::{Block, Document, Renderer, RichText, Span};
+use snafu::Snafu;
+use zip::ZipWriter;
+use zip::write::SimpleFileOptions;
+
+/// Errors produced by the ODT renderer.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum OdtError {
+    /// A ZIP I/O error occurred while building the ODT package.
+    #[snafu(display("ODT zip error: {message}"))]
+    Zip {
+        /// Human-readable ZIP error description.
+        message: String,
+    },
+}
+
+/// Renders a [`Document`] to an ODT byte vector.
+pub struct OdtRenderer;
+
+impl OdtRenderer {
+    /// Construct a new `OdtRenderer`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for OdtRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Renderer for OdtRenderer {
+    type Error = OdtError;
+
+    fn format(&self) -> &'static str {
+        "odt"
+    }
+
+    fn render(&self, doc: &Document) -> Result<Vec<u8>, Self::Error> {
+        let cursor = std::io::Cursor::new(Vec::new());
+        let mut zip = ZipWriter::new(cursor);
+
+        zip.start_file(
+            "mimetype",
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored),
+        )
+        .map_err(|e| OdtError::Zip {
+            message: e.to_string(),
+        })?;
+        zip.write_all(b"application/vnd.oasis.opendocument.text")
+            .map_err(|e| OdtError::Zip {
+                message: e.to_string(),
+            })?;
+
+        write_entry(&mut zip, "META-INF/manifest.xml", &build_manifest())?;
+        write_entry(&mut zip, "meta.xml", &build_meta(doc))?;
+        write_entry(&mut zip, "styles.xml", build_styles())?;
+        write_entry(&mut zip, "content.xml", &build_content(doc))?;
+
+        let cursor = zip.finish().map_err(|e| OdtError::Zip {
+            message: e.to_string(),
+        })?;
+        Ok(cursor.into_inner())
+    }
+}
+
+fn write_entry(
+    zip: &mut ZipWriter<std::io::Cursor<Vec<u8>>>,
+    name: &str,
+    content: &str,
+) -> Result<(), OdtError> {
+    zip.start_file(name, SimpleFileOptions::default())
+        .map_err(|e| OdtError::Zip {
+            message: e.to_string(),
+        })?;
+    zip.write_all(content.as_bytes())
+        .map_err(|e| OdtError::Zip {
+            message: e.to_string(),
+        })
+}
+
+fn build_manifest() -> String {
+    concat!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>"#,
+        "\n",
+        r#"<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0" manifest:version="1.2">"#,
+        "\n",
+        r#"  <manifest:file-entry manifest:full-path="/" manifest:media-type="application/vnd.oasis.opendocument.text"/>"#,
+        "\n",
+        r#"  <manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>"#,
+        "\n",
+        r#"  <manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/>"#,
+        "\n",
+        r#"  <manifest:file-entry manifest:full-path="meta.xml" manifest:media-type="text/xml"/>"#,
+        "\n",
+        r#"</manifest:manifest>"#,
+    )
+    .to_owned()
+}
+
+fn build_meta(doc: &Document) -> String {
+    let title = xml_escape(&doc.metadata.title);
+    let author = doc
+        .metadata
+        .author
+        .as_deref()
+        .map(xml_escape)
+        .unwrap_or_default();
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<office:document-meta xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"
+  office:version="1.2">
+  <office:meta>
+    <dc:title>{title}</dc:title>
+    <dc:creator>{author}</dc:creator>
+  </office:meta>
+</office:document-meta>"#
+    )
+}
+
+fn build_styles() -> &'static str {
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<office:document-styles
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"
+  office:version="1.2">
+  <office:styles>
+    <style:style style:name="Heading_1" style:family="paragraph" style:class="text">
+      <style:paragraph-properties fo:margin-top="6pt" fo:margin-bottom="3pt"/>
+      <style:text-properties fo:font-size="20pt" fo:font-weight="bold"/>
+    </style:style>
+    <style:style style:name="Heading_2" style:family="paragraph" style:class="text">
+      <style:paragraph-properties fo:margin-top="5pt" fo:margin-bottom="2pt"/>
+      <style:text-properties fo:font-size="16pt" fo:font-weight="bold"/>
+    </style:style>
+    <style:style style:name="Heading_3" style:family="paragraph" style:class="text">
+      <style:paragraph-properties fo:margin-top="4pt" fo:margin-bottom="2pt"/>
+      <style:text-properties fo:font-size="14pt" fo:font-weight="bold"/>
+    </style:style>
+    <style:style style:name="Text_Body" style:family="paragraph" style:class="text">
+      <style:paragraph-properties fo:margin-bottom="4pt"/>
+      <style:text-properties fo:font-size="11pt"/>
+    </style:style>
+    <style:style style:name="Bold" style:family="text">
+      <style:text-properties fo:font-weight="bold"/>
+    </style:style>
+    <style:style style:name="Italic" style:family="text">
+      <style:text-properties fo:font-style="italic"/>
+    </style:style>
+    <style:style style:name="Code" style:family="text">
+      <style:text-properties fo:font-family="monospace" style:font-name="monospace"/>
+    </style:style>
+  </office:styles>
+</office:document-styles>"#
+}
+
+fn build_content(doc: &Document) -> String {
+    let mut body = String::new();
+    for block in &doc.content {
+        render_block(block, &mut body);
+    }
+
+    let mut content = String::new();
+    push_line(&mut content, r#"<?xml version="1.0" encoding="UTF-8"?>"#);
+    push_line(&mut content, r"<office:document-content");
+    push_line(
+        &mut content,
+        r#"  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0""#,
+    );
+    push_line(
+        &mut content,
+        r#"  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0""#,
+    );
+    push_line(
+        &mut content,
+        r#"  xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0""#,
+    );
+    push_line(
+        &mut content,
+        r#"  xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0""#,
+    );
+    push_line(
+        &mut content,
+        r#"  xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0""#,
+    );
+    push_line(
+        &mut content,
+        r#"  xmlns:xlink="http://www.w3.org/1999/xlink""#,
+    );
+    push_line(&mut content, r#"  office:version="1.2">"#);
+    push_line(&mut content, "  <office:body>");
+    push_line(&mut content, "    <office:text>");
+    content.push_str(&body);
+    push_line(&mut content, "    </office:text>");
+    push_line(&mut content, "  </office:body>");
+    push_line(&mut content, "</office:document-content>");
+    content
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "ODT/XML block mapping is intentionally centralized for readability"
+)]
+fn render_block(block: &Block, out: &mut String) {
+    match block {
+        Block::Heading { level, text } => {
+            let style = heading_style(*level);
+            let outline = (*level).clamp(1, 6);
+            push_line(
+                out,
+                &format!(
+                    "      <text:h text:style-name=\"{style}\" text:outline-level=\"{outline}\">{}</text:h>",
+                    render_rich_text(text)
+                ),
+            );
+        }
+        Block::Paragraph(rt) => {
+            push_line(
+                out,
+                &format!(
+                    "      <text:p text:style-name=\"Text_Body\">{}</text:p>",
+                    render_rich_text(rt)
+                ),
+            );
+        }
+        Block::Note(note) => {
+            let text = format!(
+                "{}: {}",
+                xml_escape(note.kind.label()),
+                render_rich_text(&note.body)
+            );
+            push_line(
+                out,
+                &format!("      <text:p text:style-name=\"Text_Body\">{text}</text:p>"),
+            );
+        }
+        Block::DisplayMath(expr) => {
+            push_line(
+                out,
+                &format!(
+                    "      <text:p text:style-name=\"Text_Body\">{}</text:p>",
+                    xml_escape(expr)
+                ),
+            );
+        }
+        Block::RawBlock { content, .. } => {
+            push_line(
+                out,
+                &format!(
+                    "      <text:p text:style-name=\"Text_Body\">{}</text:p>",
+                    xml_escape(content)
+                ),
+            );
+        }
+        Block::Table(table) => {
+            out.push_str(
+                "      <table:table>\n        <table:table-header-rows>\n          <table:table-row>\n",
+            );
+            for header in &table.headers {
+                push_line(
+                    out,
+                    &format!(
+                        "            <table:table-cell><text:p>{}</text:p></table:table-cell>",
+                        xml_escape(header)
+                    ),
+                );
+            }
+            out.push_str("          </table:table-row>\n        </table:table-header-rows>\n");
+            for row in &table.rows {
+                out.push_str("        <table:table-row>\n");
+                for (col_idx, _) in table.headers.iter().enumerate() {
+                    let cell_text = row.get(col_idx).map(render_rich_text).unwrap_or_default();
+                    push_line(
+                        out,
+                        &format!(
+                            "          <table:table-cell><text:p>{cell_text}</text:p></table:table-cell>"
+                        ),
+                    );
+                }
+                out.push_str("        </table:table-row>\n");
+            }
+            out.push_str("      </table:table>\n");
+        }
+        Block::List { ordered, items } => {
+            let list_style = if *ordered { "OL" } else { "UL" };
+            push_line(
+                out,
+                &format!("      <text:list text:style-name=\"{list_style}\">"),
+            );
+            for item in items {
+                push_line(
+                    out,
+                    &format!(
+                        "        <text:list-item><text:p>{}</text:p></text:list-item>",
+                        render_rich_text(&item.content)
+                    ),
+                );
+            }
+            push_line(out, "      </text:list>");
+        }
+        Block::Image(img) => {
+            push_line(
+                out,
+                &format!(
+                    "      <text:p text:style-name=\"Text_Body\">[Image: {}]</text:p>",
+                    xml_escape(&img.alt)
+                ),
+            );
+        }
+        Block::PageBreak => {
+            push_line(out, "      <text:p><text:page-break/></text:p>");
+        }
+    }
+}
+
+fn render_rich_text(rt: &RichText) -> String {
+    rt.spans.iter().map(render_span).collect()
+}
+
+fn render_span(span: &Span) -> String {
+    match span {
+        Span::Plain(s) | Span::Cite(s) => xml_escape(s),
+        Span::Bold(s) => format!(
+            "<text:span text:style-name=\"Bold\">{}</text:span>",
+            xml_escape(s)
+        ),
+        Span::Italic(s) => format!(
+            "<text:span text:style-name=\"Italic\">{}</text:span>",
+            xml_escape(s)
+        ),
+        Span::Code(s) => format!(
+            "<text:span text:style-name=\"Code\">{}</text:span>",
+            xml_escape(s)
+        ),
+        Span::Link { text, url } => format!(
+            "<text:a xlink:type=\"simple\" xlink:href=\"{}\">{}</text:a>",
+            xml_escape(url),
+            xml_escape(text)
+        ),
+    }
+}
+
+fn heading_style(level: u8) -> &'static str {
+    match level {
+        1 => "Heading_1",
+        2 => "Heading_2",
+        _ => "Heading_3",
+    }
+}
+
+fn push_line(out: &mut String, line: &str) {
+    out.push_str(line);
+    out.push('\n');
+}
+
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use poiesis_core::{Block, Document, Metadata, RichText, Span, block::Table};
+
+    use super::*;
+
+    fn sample_doc() -> Document {
+        Document {
+            metadata: Metadata {
+                title: "ODT Test".to_owned(),
+                author: Some("Bob".to_owned()),
+                created: None,
+            },
+            content: vec![
+                Block::Heading {
+                    level: 1,
+                    text: RichText {
+                        spans: vec![Span::Plain("Section One".to_owned())],
+                    },
+                },
+                Block::Paragraph(RichText {
+                    spans: vec![
+                        Span::Plain("Hello ".to_owned()),
+                        Span::Bold("world".to_owned()),
+                    ],
+                }),
+                Block::Table(Table {
+                    headers: vec!["A".to_owned(), "B".to_owned()],
+                    rows: vec![vec![
+                        RichText {
+                            spans: vec![Span::Plain("x".to_owned())],
+                        },
+                        RichText {
+                            spans: vec![Span::Plain("y".to_owned())],
+                        },
+                    ]],
+                }),
+            ],
+        }
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "test assertion")]
+    fn odt_produces_nonempty_bytes() {
+        let renderer = OdtRenderer::new();
+        let bytes = renderer.render(&sample_doc()).expect("ODT render failed");
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    #[expect(
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        reason = "test assertions on known-good data"
+    )]
+    fn odt_starts_with_pk_magic() {
+        let renderer = OdtRenderer::new();
+        let bytes = renderer.render(&sample_doc()).expect("ODT render failed");
+        assert_eq!(&bytes[..2], b"PK", "output should be a valid ZIP/ODT");
+    }
+
+    #[test]
+    fn xml_escape_handles_all_chars() {
+        assert_eq!(
+            xml_escape("a&b<c>d\"e'f"),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "test assertions")]
+    fn odt_includes_span_styles_and_xlink_ns() {
+        let doc = Document {
+            metadata: Metadata {
+                title: "Styles Test".to_owned(),
+                author: None,
+                created: None,
+            },
+            content: vec![Block::Paragraph(RichText {
+                spans: vec![
+                    Span::Bold("bold text".to_owned()),
+                    Span::Italic("italic text".to_owned()),
+                    Span::Code("code text".to_owned()),
+                    Span::Cite("fact-42".to_owned()),
+                    Span::Link {
+                        text: "link".to_owned(),
+                        url: "https://example.com".to_owned(),
+                    },
+                ],
+            })],
+        };
+        let bytes = OdtRenderer::new().render(&doc).expect("render");
+        let mut archive = zip::ZipArchive::new(std::io::Cursor::new(&bytes)).expect("zip");
+
+        let mut styles_xml = String::new();
+        archive
+            .by_name("styles.xml")
+            .expect("styles.xml")
+            .read_to_string(&mut styles_xml)
+            .expect("read");
+        assert!(
+            styles_xml.contains("style:name=\"Bold\""),
+            "must declare Bold style"
+        );
+        assert!(
+            styles_xml.contains("style:name=\"Italic\""),
+            "must declare Italic style"
+        );
+        assert!(
+            styles_xml.contains("style:name=\"Code\""),
+            "must declare Code style"
+        );
+
+        let mut content_xml = String::new();
+        archive
+            .by_name("content.xml")
+            .expect("content.xml")
+            .read_to_string(&mut content_xml)
+            .expect("read");
+        assert!(
+            content_xml.contains("xmlns:xlink=\"http://www.w3.org/1999/xlink\""),
+            "must declare xlink namespace"
+        );
+    }
+}

--- a/crates/poiesis/text/src/pdf.rs
+++ b/crates/poiesis/text/src/pdf.rs
@@ -1,0 +1,417 @@
+//! PDF rendering backend using the `krilla` crate.
+//!
+//! `PdfRenderer` traverses the document tree and produces a single PDF byte
+//! payload. Pages are A4 (595 × 842 pt). Text is laid out top-to-bottom with
+//! simple line wrapping. A system font is required; if none is found the
+//! renderer returns [`PdfError::NoFont`].
+
+use krilla::Document as KrillaDocument;
+use krilla::geom::Point;
+use krilla::page::PageSettings;
+use krilla::text::{Font, TextDirection};
+
+use poiesis_core::{Block, Document, Renderer, RichText};
+use snafu::Snafu;
+
+/// A4 page width in PDF points (1 pt = 1/72 inch).
+const PAGE_W: f32 = 595.0;
+/// A4 page height in PDF points.
+const PAGE_H: f32 = 842.0;
+/// Left/right page margin in points.
+const MARGIN_X: f32 = 56.0;
+/// Top/bottom page margin in points.
+const MARGIN_TOP: f32 = 56.0;
+/// Default body font size in points.
+const FONT_SIZE_BODY: f32 = 11.0;
+/// H1 font size in points.
+const FONT_SIZE_H1: f32 = 20.0;
+/// H2 font size in points.
+const FONT_SIZE_H2: f32 = 16.0;
+/// Leading (line height) multiplier applied to font size.
+const LEADING: f32 = 1.4;
+/// Paragraph spacing below a paragraph block in points.
+const PARA_SPACING: f32 = 6.0;
+/// Spacing above/below a heading in points.
+const HEAD_SPACING: f32 = 10.0;
+/// Usable page width between margins.
+const USABLE_W: f32 = PAGE_W - 2.0 * MARGIN_X;
+
+/// Errors produced by the PDF renderer.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum PdfError {
+    /// No usable system font was found. Install a font (e.g. `liberation-sans-fonts`
+    /// or `google-noto-sans-fonts`) and verify it is readable.
+    #[snafu(display("no usable system font found for PDF rendering"))]
+    NoFont,
+
+    /// `krilla` rejected the page dimensions. A4 constants are compile-time
+    /// checked, so this variant is not reachable in practice.
+    #[snafu(display("invalid page dimensions: {width}x{height}"))]
+    InvalidPageSize {
+        /// Attempted width in PDF points.
+        width: f32,
+        /// Attempted height in PDF points.
+        height: f32,
+    },
+
+    /// `krilla` returned an error while producing the PDF.
+    #[snafu(display("krilla PDF error: {message}"))]
+    Krilla {
+        /// Human-readable krilla error description.
+        message: String,
+    },
+}
+
+/// Renders a [`Document`] to a PDF byte vector using the `krilla` crate.
+///
+/// Requires at least one OpenType/TrueType font to be available at the paths
+/// checked by [`PdfRenderer::font_data`]. On Fedora the `liberation-sans-fonts`
+/// or `google-noto-sans-fonts` package satisfies this requirement.
+pub struct PdfRenderer {
+    /// Raw font bytes. Loaded once at construction time.
+    font_data: Vec<u8>,
+}
+
+impl PdfRenderer {
+    /// Try to construct a renderer using a discovered system font.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::NoFont`] if no readable font file is found.
+    pub fn new() -> Result<Self, PdfError> {
+        let data = Self::load_system_font().ok_or(PdfError::NoFont)?;
+        Ok(Self { font_data: data })
+    }
+
+    /// Construct a renderer using caller-supplied raw font bytes.
+    ///
+    /// Use this when you want full control over the font (e.g. in tests).
+    pub fn with_font_data(data: Vec<u8>) -> Self {
+        Self { font_data: data }
+    }
+
+    /// Attempt to load a font from well-known system locations.
+    fn load_system_font() -> Option<Vec<u8>> {
+        let candidates = [
+            "/usr/share/fonts/liberation-sans-fonts/LiberationSans-Regular.ttf",
+            "/usr/share/fonts/google-noto-vf/NotoSans[wght].ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+            "/System/Library/Fonts/Helvetica.ttc",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf",
+        ];
+
+        candidates
+            .iter()
+            .find_map(|path| std::fs::read(path).ok().filter(|data| !data.is_empty()))
+    }
+}
+
+fn a4_page() -> Result<PageSettings, PdfError> {
+    PageSettings::from_wh(PAGE_W, PAGE_H).ok_or(PdfError::InvalidPageSize {
+        width: PAGE_W,
+        height: PAGE_H,
+    })
+}
+
+impl Renderer for PdfRenderer {
+    type Error = PdfError;
+
+    fn format(&self) -> &'static str {
+        "pdf"
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "PDF page layout is inherently sequential; splitting would scatter related rendering logic"
+    )]
+    fn render(&self, doc: &Document) -> Result<Vec<u8>, Self::Error> {
+        let font = Font::new(self.font_data.clone().into(), 0).ok_or(PdfError::NoFont)?;
+
+        let mut krilla_doc = KrillaDocument::new();
+
+        let mut page = krilla_doc.start_page_with(a4_page()?);
+        let mut surface = page.surface();
+
+        let mut y = MARGIN_TOP;
+        let x = MARGIN_X;
+
+        macro_rules! check_page_break {
+            () => {
+                if y > PAGE_H - MARGIN_TOP {
+                    surface.finish();
+                    page.finish();
+                    page = krilla_doc.start_page_with(a4_page()?);
+                    surface = page.surface();
+                    y = MARGIN_TOP;
+                }
+            };
+        }
+
+        let title_text = doc.metadata.title.as_str();
+        if !title_text.is_empty() {
+            check_page_break!();
+            surface.draw_text(
+                Point::from_xy(x, y + FONT_SIZE_H1),
+                font.clone(),
+                FONT_SIZE_H1,
+                title_text,
+                false,
+                TextDirection::Auto,
+            );
+            y += FONT_SIZE_H1 * LEADING + HEAD_SPACING;
+        }
+
+        for block in &doc.content {
+            check_page_break!();
+
+            match block {
+                Block::Heading { level, text } => {
+                    y += HEAD_SPACING;
+                    check_page_break!();
+                    let fs = heading_font_size(*level);
+                    let plain = text.plain_text();
+                    surface.draw_text(
+                        Point::from_xy(x, y + fs),
+                        font.clone(),
+                        fs,
+                        &plain,
+                        false,
+                        TextDirection::Auto,
+                    );
+                    y += fs * LEADING + HEAD_SPACING;
+                }
+                Block::Paragraph(rt) => {
+                    let lines =
+                        wrap_words(&rt.plain_text(), chars_per_line(FONT_SIZE_BODY, USABLE_W));
+                    for line in lines {
+                        check_page_break!();
+                        draw_line(&mut surface, &font, FONT_SIZE_BODY, &line, x, y);
+                        y += FONT_SIZE_BODY * LEADING;
+                    }
+                    y += PARA_SPACING;
+                }
+                Block::Note(note) => {
+                    let text = format!("{}: {}", note.kind.label(), note.body.plain_text());
+                    let lines = wrap_words(&text, chars_per_line(FONT_SIZE_BODY, USABLE_W));
+                    for line in lines {
+                        check_page_break!();
+                        draw_line(&mut surface, &font, FONT_SIZE_BODY, &line, x, y);
+                        y += FONT_SIZE_BODY * LEADING;
+                    }
+                    y += PARA_SPACING;
+                }
+                Block::DisplayMath(expr) | Block::RawBlock { content: expr, .. } => {
+                    let lines = wrap_words(expr, chars_per_line(FONT_SIZE_BODY, USABLE_W));
+                    for line in lines {
+                        check_page_break!();
+                        draw_line(&mut surface, &font, FONT_SIZE_BODY, &line, x, y);
+                        y += FONT_SIZE_BODY * LEADING;
+                    }
+                    y += PARA_SPACING;
+                }
+                Block::Table(table) => {
+                    let header_line = table.headers.join(" | ");
+                    let lines = wrap_words(&header_line, chars_per_line(FONT_SIZE_BODY, USABLE_W));
+                    for line in lines {
+                        check_page_break!();
+                        draw_line(&mut surface, &font, FONT_SIZE_BODY, &line, x, y);
+                        y += FONT_SIZE_BODY * LEADING;
+                    }
+                    y += 4.0;
+                    for row in &table.rows {
+                        let cells: Vec<String> = row.iter().map(RichText::plain_text).collect();
+                        let row_line = cells.join(" | ");
+                        let lines = wrap_words(&row_line, chars_per_line(FONT_SIZE_BODY, USABLE_W));
+                        for line in lines {
+                            check_page_break!();
+                            draw_line(&mut surface, &font, FONT_SIZE_BODY, &line, x, y);
+                            y += FONT_SIZE_BODY * LEADING;
+                        }
+                    }
+                    y += PARA_SPACING;
+                }
+                Block::List { ordered, items } => {
+                    for (i, item) in items.iter().enumerate() {
+                        let bullet = if *ordered {
+                            format!("{}. ", i + 1)
+                        } else {
+                            "\u{2022} ".to_owned()
+                        };
+                        let text = format!("{}{}", bullet, item.content.plain_text());
+                        let lines = wrap_words(&text, chars_per_line(FONT_SIZE_BODY, USABLE_W));
+                        for line in lines {
+                            check_page_break!();
+                            draw_line(&mut surface, &font, FONT_SIZE_BODY, &line, x, y);
+                            y += FONT_SIZE_BODY * LEADING;
+                        }
+                    }
+                    y += PARA_SPACING;
+                }
+                Block::Image(img) => {
+                    let alt = format!("[Image: {}]", img.alt);
+                    let lines = wrap_words(&alt, chars_per_line(FONT_SIZE_BODY, USABLE_W));
+                    for line in lines {
+                        check_page_break!();
+                        draw_line(&mut surface, &font, FONT_SIZE_BODY, &line, x, y);
+                        y += FONT_SIZE_BODY * LEADING;
+                    }
+                    y += PARA_SPACING;
+                }
+                Block::PageBreak => {
+                    surface.finish();
+                    page.finish();
+                    page = krilla_doc.start_page_with(a4_page()?);
+                    surface = page.surface();
+                    y = MARGIN_TOP;
+                }
+            }
+        }
+
+        surface.finish();
+        page.finish();
+
+        krilla_doc.finish().map_err(|e| PdfError::Krilla {
+            message: format!("{e:?}"),
+        })
+    }
+}
+
+fn heading_font_size(level: u8) -> f32 {
+    match level {
+        1 => FONT_SIZE_H1,
+        2 => FONT_SIZE_H2,
+        3 => 14.0,
+        4 => 12.0,
+        _ => FONT_SIZE_BODY,
+    }
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::as_conversions,
+    reason = "max_width and char_w_approx are positive finite f32 from page constants; ratio fits in usize"
+)]
+fn chars_per_line(font_size: f32, max_width: f32) -> usize {
+    let char_w_approx = font_size * 0.55;
+    (max_width / char_w_approx).max(1.0) as usize
+}
+
+fn draw_line(
+    surface: &mut krilla::surface::Surface<'_>,
+    font: &Font,
+    font_size: f32,
+    text: &str,
+    x: f32,
+    y: f32,
+) {
+    surface.draw_text(
+        Point::from_xy(x, y + font_size),
+        font.clone(),
+        font_size,
+        text,
+        false,
+        TextDirection::Auto,
+    );
+}
+
+fn wrap_words(text: &str, max_chars: usize) -> Vec<String> {
+    if text.is_empty() {
+        return vec![String::new()];
+    }
+
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.len() + 1 + word.len() <= max_chars {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(current.clone());
+            current.clear();
+            current.push_str(word);
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use poiesis_core::{Block, Document, Metadata, RichText, Span};
+
+    use super::*;
+
+    fn minimal_doc() -> Document {
+        Document {
+            metadata: Metadata {
+                title: "PDF Test".to_owned(),
+                author: None,
+                created: None,
+            },
+            content: vec![
+                Block::Heading {
+                    level: 1,
+                    text: RichText {
+                        spans: vec![Span::Plain("Introduction".to_owned())],
+                    },
+                },
+                Block::Paragraph(RichText {
+                    spans: vec![Span::Plain(
+                        "This is a short paragraph of body text.".to_owned(),
+                    )],
+                }),
+            ],
+        }
+    }
+
+    #[test]
+    fn wrap_words_short() {
+        let lines = wrap_words("hello world", 20);
+        assert_eq!(lines, vec!["hello world"]);
+    }
+
+    #[test]
+    fn wrap_words_splits() {
+        let lines = wrap_words("one two three four five six", 10);
+        for line in &lines {
+            assert!(
+                line.len() <= 10,
+                "line too long: {line:?} ({} chars)",
+                line.len()
+            );
+        }
+    }
+
+    #[test]
+    #[expect(clippy::indexing_slicing, reason = "test assertion on known-good data")]
+    fn wrap_words_empty() {
+        let lines = wrap_words("", 80);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].is_empty());
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "test assertion")]
+    fn pdf_renderer_produces_nonempty_bytes() {
+        let renderer = match PdfRenderer::new() {
+            Ok(r) => r,
+            Err(PdfError::NoFont) => return,
+            Err(e) => panic!("unexpected error: {e}"),
+        };
+        let doc = minimal_doc();
+        let bytes = renderer.render(&doc).expect("PDF rendering failed");
+        assert!(!bytes.is_empty(), "rendered PDF must not be empty");
+        assert!(
+            bytes.starts_with(b"%PDF-"),
+            "output should start with PDF magic"
+        );
+    }
+}


### PR DESCRIPTION
Closes #4432. The DEFAULT ODT generate_document path errored end-to-end because B-013 (#4354) deleted the entire poiesis-text crate (its ODT + document-model PDF backends) and left render_odt_from_doc a permanent PandocRequired stub. Per operator decision, this resurrects the clean-room backends.

- **Restores the poiesis-text crate** (re-added as a workspace member): OdtRenderer (ZipWriter ODF-1.2, clean-room, zero new deps beyond zip) + PdfRenderer (krilla document-model PDF) — both with their original tests.
- **Wires ODT**: render_odt_from_doc now renders via OdtRenderer (Pandoc-independent); default generate_document(odt) produces valid ODT (PK-magic end-to-end test added). render_pdf_from_doc is UNCHANGED (Typst remains the primary PDF path).
- PdfRenderer (document-model) is restored + tested + public, available as a Pandoc/Typst-independent backend; render_pdf keeps Typst as primary — offering it as an explicit option is a tracked follow-up.

Verification: 27 poiesis-text/doc tests pass; clippy --workspace (scoped) + fmt clean. Does not wire the broader Pandoc matrix (HTML/EPUB/Markdown/LaTeX — separate follow-up).