### PR TITLE
feat(poiesis): wire B-002 theme-sinks + B-005 charts to a real consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6496,6 +6496,7 @@ dependencies = [
  "jiff",
  "koina",
  "landlock",
+ "poiesis-charts",
  "poiesis-core",
  "poiesis-diff",
  "poiesis-doc",
@@ -6505,6 +6506,7 @@ dependencies = [
  "poiesis-scaffold",
  "poiesis-sheet",
  "poiesis-slides",
+ "poiesis-theme",
  "poiesis-typst",
  "poiesis-verify",
  "prometheus-client",
@@ -6524,6 +6526,7 @@ dependencies = [
  "tokio",
  "tracing",
  "z3",
+ "zip 8.5.1",
 ]
 
 [[package]]
@@ -6988,6 +6991,7 @@ version = "0.30.0"
 dependencies = [
  "insta",
  "poiesis-core",
+ "poiesis-theme",
  "serde",
  "serde_json",
  "snafu",

--- a/_llm/L3-api-index/poiesis-charts.md
+++ b/_llm/L3-api-index/poiesis-charts.md
@@ -755,6 +755,7 @@ pub struct NamedTone {
 
 ```rust
 impl ResolvedTheme {
+    pub fn from_poiesis_theme (t: &poiesis_theme::ResolvedTheme) -> Self;
     pub fn summus_stub () -> Self;
     pub fn fill_for (
         &self,

--- a/_llm/L3-api-index/poiesis-theme.md
+++ b/_llm/L3-api-index/poiesis-theme.md
@@ -250,6 +250,10 @@ impl Registry {
 }
 ```
 
+```rust
+pub fn summus () -> ResolvedTheme
+```
+
 > Parse a candidate string into a [`ThemeId`], lifting the parse error into
 > the crate's top-level [`ThemeError`].
 > 
@@ -374,7 +378,7 @@ pub fn emit_docvars_yaml (theme: &ResolvedTheme) -> Result<String, ThemeError>
 
 ## `src/sinks/latex.rs`
 
-> Emit a LaTeX preamble fragment with `\definecolor` and `\newcommand`
+> Emit a `LaTeX` preamble fragment with `\definecolor` and `\newcommand`
 > declarations for every brand token in the [`ResolvedTheme`].
 > 
 > Downstream `.tex` files `\input` or `\include` this file to access brand

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -158,14 +158,14 @@ l3_token_estimate = 12316
 [[crates]]
 name = "organon"
 path = "crates/organon"
-source_hash = "7d8dd9d9ba07830464a5b48e877649148796c2e70353ff94ab611944d54e7623"
+source_hash = "5cf7e46774253b74a5eba1a24fdbe5d9056005b94bb5138ce9a32db5514c10b9"
 l3_token_estimate = 11827
 
 [[crates]]
 name = "poiesis-charts"
 path = "crates/poiesis/charts"
-source_hash = "0a0c6849477e74604443beeb8e63df4475a152f27017ed2bb3f753d40e0b99b3"
-l3_token_estimate = 4577
+source_hash = "de23b269feadc812001046054a0aef35383cdb47e141bf4e1f17b0b1eca19a7e"
+l3_token_estimate = 4596
 
 [[crates]]
 name = "poiesis-core"
@@ -248,8 +248,8 @@ l3_token_estimate = 508
 [[crates]]
 name = "poiesis-theme"
 path = "crates/poiesis/theme"
-source_hash = "dc0f8de581ecc18aa81f68fe6a1eb0d45ab6aabb31c2e238326472fd7c7a18d9"
-l3_token_estimate = 5242
+source_hash = "f469fd5868ffbf56de8509a5bd5abbb49c7ba51637f62a5fb163505a216f3fd5"
+l3_token_estimate = 5254
 
 [[crates]]
 name = "poiesis-typst"

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -63,6 +63,8 @@ poiesis-scaffold = { path = "../poiesis/scaffold" }
 poiesis-verify = { path = "../poiesis/verify" }
 poiesis-intake = { path = "../poiesis/intake" }
 poiesis-doc = { path = "../poiesis/doc" }
+poiesis-charts = { path = "../poiesis/charts", features = ["theme-bridge"] }
+poiesis-theme = { path = "../poiesis/theme" }
 poiesis-diff = { path = "../poiesis/diff" }
 poiesis-inspect = { path = "../poiesis/inspect" }
 koina = { path = "../koina" }
@@ -82,6 +84,7 @@ sha2 = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+zip = { version = "=8.5.1", default-features = false, features = ["deflate"] }
 z3 = { version = "0.20", optional = true, features = ["bundled"] }
 
 [dependencies.rustls]

--- a/crates/organon/src/builtins/poiesis.rs
+++ b/crates/organon/src/builtins/poiesis.rs
@@ -8,15 +8,23 @@
 //! - `qa_gate`              — run prose lint and optional factbase validation, returning a structured QA report
 
 use std::future::Future;
+use std::io::{Cursor, Read as _, Write as _};
 use std::pin::Pin;
 
 use hermeneus::types::{DocumentSource, ToolResultBlock};
 use indexmap::IndexMap;
+use poiesis_charts::render::{Canvas, DocCanvas};
+use poiesis_charts::{
+    Chart, ColorMode as ChartColorMode, ResolvedTheme as ChartResolvedTheme, render_chart,
+};
 use poiesis_core::{
     Block, Document, Factbase, Metadata, QaIssue, QaIssueKind, QaReport, Renderer, RichText, Span,
 };
 use poiesis_lint::{LintConfig, Linter};
+use poiesis_theme::{sinks::emit_typst_template, summus};
 use poiesis_verify::Verifier;
+use zip::write::SimpleFileOptions;
+use zip::{ZipArchive, ZipWriter};
 
 use crate::builtins::workspace::validate_path;
 use crate::error::Result;
@@ -43,6 +51,96 @@ fn extract_str<'a>(
     args.get(key)
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| ToolResult::error(format!("missing required argument: {key}")))
+}
+
+const DEFAULT_TYPST_TEMPLATE: &str = include_str!("../../../poiesis/typst/templates/default.typ");
+const TYPST_CHART_APPENDIX: &str = r#"
+#if "chart_svg" in data [
+  #v(16pt)
+  #align(center)[
+    #image(bytes(data.chart_svg), format: "svg", width: 100%)
+  ]
+]
+"#;
+
+fn render_chart_svg(data: &serde_json::Value) -> std::result::Result<Option<String>, String> {
+    let Some(chart_value) = data.get("chart") else {
+        return Ok(None);
+    };
+
+    let chart: Chart = serde_json::from_value(chart_value.clone())
+        .map_err(|e| format!("chart must be valid JSON: {e}"))?;
+    let theme = ChartResolvedTheme::from_poiesis_theme(&summus());
+    let svg = render_chart(
+        &chart,
+        &theme,
+        &Canvas::Doc(DocCanvas::default()),
+        ChartColorMode::Resolved,
+    )
+    .map_err(|e| format!("chart render failed: {e}"))?;
+    Ok(Some(svg))
+}
+
+pub(crate) fn extract_zip_entry(
+    zip_bytes: &[u8],
+    name: &str,
+) -> std::result::Result<Vec<u8>, String> {
+    let cursor = Cursor::new(zip_bytes);
+    let mut archive = ZipArchive::new(cursor).map_err(|e| format!("failed to open zip: {e}"))?;
+    let mut file = archive
+        .by_name(name)
+        .map_err(|e| format!("missing zip entry {name}: {e}"))?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|e| format!("failed to read zip entry {name}: {e}"))?;
+    Ok(bytes)
+}
+
+pub(crate) fn rewrite_zip(
+    original: &[u8],
+    replacements: &[(&str, &[u8])],
+) -> std::result::Result<Vec<u8>, String> {
+    let cursor = Cursor::new(original);
+    let mut archive = ZipArchive::new(cursor).map_err(|e| format!("failed to open zip: {e}"))?;
+    let mut output = ZipWriter::new(Cursor::new(Vec::new()));
+    let mut remaining = std::collections::BTreeMap::new();
+    for (name, bytes) in replacements {
+        remaining.insert(*name, *bytes);
+    }
+
+    for idx in 0..archive.len() {
+        let mut file = archive
+            .by_index(idx)
+            .map_err(|e| format!("failed to read zip entry #{idx}: {e}"))?;
+        let name = file.name().to_owned();
+        if name.ends_with('/') {
+            continue;
+        }
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)
+            .map_err(|e| format!("failed to read zip entry {name}: {e}"))?;
+        let payload = remaining.remove(name.as_str()).unwrap_or(bytes.as_slice());
+        output
+            .start_file(&name, SimpleFileOptions::default())
+            .map_err(|e| format!("failed to write zip entry {name}: {e}"))?;
+        output
+            .write_all(payload)
+            .map_err(|e| format!("failed to write zip entry {name}: {e}"))?;
+    }
+
+    for (name, bytes) in remaining {
+        output
+            .start_file(name, SimpleFileOptions::default())
+            .map_err(|e| format!("failed to write zip entry {name}: {e}"))?;
+        output
+            .write_all(bytes)
+            .map_err(|e| format!("failed to write zip entry {name}: {e}"))?;
+    }
+
+    let cursor = output
+        .finish()
+        .map_err(|e| format!("failed to finish zip: {e}"))?;
+    Ok(cursor.into_inner())
 }
 
 // ── generate_document ─────────────────────────────────────────────────────────
@@ -454,6 +552,10 @@ fn verify_report_def() -> ToolDef {
 struct RenderTypstReportExecutor;
 
 impl ToolExecutor for RenderTypstReportExecutor {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "tool executor wires the full report render path"
+    )]
     fn execute<'a>(
         &'a self,
         input: &'a ToolInput,
@@ -462,23 +564,69 @@ impl ToolExecutor for RenderTypstReportExecutor {
         Box::pin(async move {
             let args = &input.arguments;
 
-            // Optional inline JSON data; defaults to empty object.
-            let data: serde_json::Value = if let Some(raw) = extract_opt_str(args, "data") {
-                match serde_json::from_str(raw) {
+            // NOTE: Optional inline JSON data; accepts either a structured object or a JSON string.
+            let mut data: serde_json::Value = match args.get("data") {
+                None => serde_json::json!({}),
+                Some(serde_json::Value::Object(_)) => match args.get("data").cloned() {
+                    Some(value) => value,
+                    None => {
+                        return Ok(ToolResult::error(
+                            "data object must be present after lookup".to_owned(),
+                        ));
+                    }
+                },
+                Some(serde_json::Value::String(raw)) => match serde_json::from_str(raw) {
                     Ok(v) => v,
                     Err(e) => {
                         return Ok(ToolResult::error(format!("data must be valid JSON: {e}")));
                     }
+                },
+                Some(_) => {
+                    return Ok(ToolResult::error(
+                        "data must be a JSON object or JSON string".to_owned(),
+                    ));
                 }
-            } else {
-                serde_json::json!({})
             };
 
-            // Choose source: inline `source` wins over `template` slug.
+            if let Some(chart_svg) = match render_chart_svg(&data) {
+                Ok(svg) => svg,
+                Err(e) => return Ok(ToolResult::error(e)),
+            } && let Some(obj) = data.as_object_mut()
+            {
+                obj.insert("chart_svg".to_owned(), serde_json::Value::String(chart_svg));
+            }
+
+            let theme = summus();
+            let theme_source = match emit_typst_template(&theme) {
+                Ok(source) => source,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("theme typst sink failed: {e}")));
+                }
+            };
+
+            // NOTE: Inline `source` wins over the `template` slug.
             let pdf_result = if let Some(source) = extract_opt_str(args, "source") {
-                poiesis_typst::render_typst(source, &data)
+                let mut source_text = String::with_capacity(theme_source.len() + source.len() + 2);
+                source_text.push_str(&theme_source);
+                source_text.push_str("\n\n");
+                source_text.push_str(source);
+                poiesis_typst::render_typst(&source_text, &data)
             } else if let Some(slug) = extract_opt_str(args, "template") {
-                poiesis_typst::render_template(slug, &data)
+                match slug {
+                    "default" => {
+                        let mut source_text = String::with_capacity(
+                            theme_source.len() + DEFAULT_TYPST_TEMPLATE.len() + 64,
+                        );
+                        source_text.push_str(&theme_source);
+                        source_text.push_str("\n\n");
+                        source_text.push_str(DEFAULT_TYPST_TEMPLATE);
+                        if data.get("chart_svg").is_some() {
+                            source_text.push_str(TYPST_CHART_APPENDIX);
+                        }
+                        poiesis_typst::render_typst(&source_text, &data)
+                    }
+                    other => poiesis_typst::render_template(other, &data),
+                }
             } else {
                 return Ok(ToolResult::error(
                     "render_typst_report requires 'source' (inline Typst) or 'template' (slug)"
@@ -493,7 +641,7 @@ impl ToolExecutor for RenderTypstReportExecutor {
                 }
             };
 
-            // Optional: write to a caller-provided path in addition to returning bytes.
+            // NOTE: Write to a caller-provided path in addition to returning bytes.
             if let Some(out_path) = extract_opt_str(args, "out_path") {
                 let validated = match validate_path(out_path, ctx, &input.name) {
                     Ok(path) => path,
@@ -532,14 +680,16 @@ fn render_typst_report_def() -> ToolDef {
     ToolDef {
         name: koina::id::ToolName::from_static("render_typst_report"), // kanon:ignore RUST/expect
         description: "Render a Typst source string (or built-in template slug) to a PDF, \
-                      with optional JSON data injected at the virtual path `data.json`."
+                      with optional JSON data injected at the virtual path `data.json` and \
+                      an embedded chart payload when present."
             .to_owned(),
         extended_description: Some(
             "Pass either `source` (inline Typst markup) or `template` (one of the built-in \
              slugs, currently: `default`). The JSON blob passed as `data` is exposed to the \
-             Typst document as a virtual file read via `json(\"data.json\")`. The result \
-             contains a text summary plus a base64-encoded PDF document block; optionally \
-             also writes the PDF to `out_path` on the filesystem."
+             Typst document as a virtual file read via `json(\"data.json\")`. When `data.chart` \
+             is present, the executor renders it through poiesis-charts and appends the SVG to \
+             the default template. The result contains a text summary plus a base64-encoded PDF \
+             document block; optionally also writes the PDF to `out_path` on the filesystem."
                 .to_owned(),
         ),
         input_schema: InputSchema {

--- a/crates/organon/src/builtins/poiesis_tests.rs
+++ b/crates/organon/src/builtins/poiesis_tests.rs
@@ -6,9 +6,13 @@
 //! verify, `generate_document`) are exercised by the underlying crates' tests.
 
 use std::collections::HashSet;
+use std::io::{Cursor, Read};
 use std::sync::{Arc, RwLock};
 
+use base64::Engine as _;
 use koina::id::{NousId, SessionId, ToolName};
+use poiesis_theme::summus;
+use zip::ZipArchive;
 
 use super::*;
 use crate::builtins::render_docx_report::RenderDocxReportExecutor;
@@ -33,6 +37,26 @@ fn tool_input(name: &str, args: serde_json::Value) -> ToolInput {
         name: ToolName::new(name).expect("valid"),
         tool_use_id: "toolu_test".to_owned(),
         arguments: args,
+    }
+}
+
+fn document_bytes(result: &ToolResult, media_type: &str) -> Vec<u8> {
+    match &result.content {
+        crate::types::ToolResultContent::Blocks(blocks) => {
+            let source = blocks
+                .iter()
+                .find_map(|block| match block {
+                    ToolResultBlock::Document { source } if source.media_type == media_type => {
+                        Some(&source.data)
+                    }
+                    _ => None,
+                })
+                .expect("document block must exist");
+            base64::engine::general_purpose::STANDARD
+                .decode(source)
+                .expect("document block must decode")
+        }
+        other => panic!("expected Blocks content, got {other:?}"),
     }
 }
 
@@ -192,6 +216,76 @@ async fn render_typst_report_malformed_typst_is_error() {
 }
 
 #[tokio::test]
+async fn render_typst_report_renders_chart_payload() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    let input = tool_input(
+        "render_typst_report",
+        serde_json::json!({
+            "template": "default",
+            "data": {
+                "title": "Chart Report",
+                "body": ["This report carries a chart."],
+                "chart": {
+                    "kind": "bar",
+                    "series": [
+                        {
+                            "name": "Revenue",
+                            "tone": 0,
+                            "points": [
+                                {
+                                    "label": "Q1",
+                                    "y": { "id": "f1", "value": 12.0, "unit": "number" }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }),
+    );
+    let result = RenderTypstReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+    assert!(!result.is_error, "chart render must succeed: {result:?}");
+
+    let bytes = document_bytes(&result, "application/pdf");
+    assert!(bytes.starts_with(b"%PDF-"), "rendered document must be PDF");
+    assert!(bytes.len() > 200, "rendered PDF must not be empty");
+}
+
+#[tokio::test]
+async fn render_typst_report_bad_chart_is_error() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    let input = tool_input(
+        "render_typst_report",
+        serde_json::json!({
+            "template": "default",
+            "data": {
+                "chart": "not a chart"
+            }
+        }),
+    );
+    let result = RenderTypstReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+    assert!(result.is_error, "bad chart must fail");
+    assert!(
+        result
+            .content
+            .text_summary()
+            .contains("chart must be valid JSON"),
+        "unexpected error text: {:?}",
+        result.content
+    );
+}
+
+#[tokio::test]
 async fn generate_document_unsupported_block_is_error() {
     let dir = tempfile::tempdir().expect("tmpdir");
     let ctx = test_ctx(dir.path());
@@ -257,6 +351,117 @@ async fn render_xlsx_report_missing_data_is_error() {
         .await
         .expect("exec");
     assert!(result.is_error, "missing data must error");
+}
+
+#[tokio::test]
+async fn render_pptx_report_applies_summus_theme() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    let input = tool_input(
+        "render_pptx_report",
+        serde_json::json!({
+            "data": {
+                "slides": [
+                    {
+                        "title": "Theme Check",
+                        "content": [
+                            { "text": "Hello, alice." }
+                        ]
+                    }
+                ]
+            }
+        }),
+    );
+    let result = RenderPptxReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+    assert!(!result.is_error, "pptx render must succeed: {result:?}");
+
+    let bytes = document_bytes(
+        &result,
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    );
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).expect("valid zip");
+    let mut theme_xml = String::new();
+    archive
+        .by_name("ppt/theme/theme1.xml")
+        .expect("theme1.xml must exist")
+        .read_to_string(&mut theme_xml)
+        .expect("read theme1.xml");
+    assert!(
+        theme_xml.contains("232E54"),
+        "theme1.xml must carry the summus navy color: {theme_xml}"
+    );
+}
+
+#[tokio::test]
+async fn render_docx_report_applies_summus_reference() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    let input = tool_input(
+        "render_docx_report",
+        serde_json::json!({
+            "data": {
+                "title": "Docx Check",
+                "paragraphs": [
+                    { "text": "Hello, bob." }
+                ]
+            }
+        }),
+    );
+    let result = RenderDocxReportExecutor
+        .execute(&input, &ctx)
+        .await
+        .expect("exec");
+    assert!(!result.is_error, "docx render must succeed: {result:?}");
+
+    let bytes = document_bytes(
+        &result,
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    );
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).expect("valid zip");
+    let mut styles_xml = String::new();
+    archive
+        .by_name("word/styles.xml")
+        .expect("styles.xml must exist")
+        .read_to_string(&mut styles_xml)
+        .expect("read styles.xml");
+    assert!(
+        styles_xml.contains("Geist"),
+        "styles.xml must carry the summus sans family: {styles_xml}"
+    );
+}
+
+#[test]
+fn chart_theme_adapter_maps_summus() {
+    let theme = summus();
+    let chart_theme = poiesis_charts::ResolvedTheme::from_poiesis_theme(&theme);
+    assert_eq!(chart_theme.theme_name, "summus");
+    assert_eq!(
+        chart_theme.series[0].hex,
+        theme
+            .lookup_color(&theme.chart.series[0])
+            .expect("series[0]")
+            .as_str()
+    );
+    assert_eq!(
+        chart_theme.series[1].hex,
+        theme
+            .lookup_color(&theme.chart.series[1])
+            .expect("series[1]")
+            .as_str()
+    );
+    assert!(
+        chart_theme.font_sans.contains("Geist"),
+        "sans family must come from the theme"
+    );
+    assert!(
+        chart_theme.font_mono.contains("Geist Mono"),
+        "mono family must come from the theme"
+    );
 }
 
 #[tokio::test]

--- a/crates/organon/src/builtins/render_docx_report.rs
+++ b/crates/organon/src/builtins/render_docx_report.rs
@@ -5,7 +5,9 @@ use std::pin::Pin;
 
 use hermeneus::types::{DocumentSource, ToolResultBlock};
 use indexmap::IndexMap;
+use poiesis_theme::{sinks::emit_reference_docx, summus};
 
+use crate::builtins::poiesis::{extract_zip_entry, rewrite_zip};
 use crate::builtins::workspace::validate_path;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
@@ -52,6 +54,31 @@ impl ToolExecutor for RenderDocxReportExecutor {
                 Err(e) => {
                     return Ok(ToolResult::error(format!("docx render failed: {e}")));
                 }
+            };
+
+            let reference_docx = match emit_reference_docx(&summus()) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("theme docx sink failed: {e}")));
+                }
+            };
+            let styles_xml = match extract_zip_entry(&reference_docx, "word/styles.xml") {
+                Ok(bytes) => bytes,
+                Err(e) => return Ok(ToolResult::error(e)),
+            };
+            let theme_xml = match extract_zip_entry(&reference_docx, "word/theme/theme1.xml") {
+                Ok(bytes) => bytes,
+                Err(e) => return Ok(ToolResult::error(e)),
+            };
+            let docx_bytes = match rewrite_zip(
+                &docx_bytes,
+                &[
+                    ("word/styles.xml", styles_xml.as_slice()),
+                    ("word/theme/theme1.xml", theme_xml.as_slice()),
+                ],
+            ) {
+                Ok(bytes) => bytes,
+                Err(e) => return Ok(ToolResult::error(e)),
             };
 
             // Optional: write to a caller-provided path in addition to returning bytes.

--- a/crates/organon/src/builtins/render_pptx_report.rs
+++ b/crates/organon/src/builtins/render_pptx_report.rs
@@ -8,7 +8,9 @@ use std::pin::Pin;
 
 use hermeneus::types::{DocumentSource, ToolResultBlock};
 use indexmap::IndexMap;
+use poiesis_theme::{sinks::emit_base_pptx, summus};
 
+use crate::builtins::poiesis::{extract_zip_entry, rewrite_zip};
 use crate::builtins::workspace::validate_path;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
@@ -55,6 +57,24 @@ impl ToolExecutor for RenderPptxReportExecutor {
                 Err(e) => {
                     return Ok(ToolResult::error(format!("pptx render failed: {e}")));
                 }
+            };
+
+            let base_pptx = match emit_base_pptx(&summus()) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("theme pptx sink failed: {e}")));
+                }
+            };
+            let theme_xml = match extract_zip_entry(&base_pptx, "ppt/theme/theme1.xml") {
+                Ok(bytes) => bytes,
+                Err(e) => return Ok(ToolResult::error(e)),
+            };
+            let pptx_bytes = match rewrite_zip(
+                &pptx_bytes,
+                &[("ppt/theme/theme1.xml", theme_xml.as_slice())],
+            ) {
+                Ok(bytes) => bytes,
+                Err(e) => return Ok(ToolResult::error(e)),
             };
 
             // Optional: write to a caller-provided path in addition to returning bytes.

--- a/crates/poiesis/charts/Cargo.toml
+++ b/crates/poiesis/charts/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 poiesis-core = { path = "../core" }
+poiesis-theme = { path = "../theme", optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
@@ -23,6 +24,7 @@ insta = { version = "1", features = ["yaml"] }
 
 [features]
 default = []
+theme-bridge = ["dep:poiesis-theme"]
 # Vega-Lite fallback for kinds the pure-Rust emitter does not own
 # (heatmap, boxplot, sankey, candlestick, faceted, regression, log/time scales).
 # Off by default: a chart spec that requires Vega-Lite while this feature is

--- a/crates/poiesis/charts/src/theme.rs
+++ b/crates/poiesis/charts/src/theme.rs
@@ -67,6 +67,32 @@ pub struct NamedTone {
 }
 
 impl ResolvedTheme {
+    /// Convert a `poiesis-theme` resolved theme into the chart-local palette.
+    #[cfg(feature = "theme-bridge")]
+    #[must_use]
+    pub fn from_poiesis_theme(t: &poiesis_theme::ResolvedTheme) -> Self {
+        Self {
+            series: t
+                .chart
+                .series
+                .iter()
+                .enumerate()
+                .map(|(i, reference)| Tone {
+                    css_var: format!("series-{i}"),
+                    hex: t
+                        .lookup_color(reference)
+                        .map_or_else(|| "#000000".to_owned(), |color| color.as_str().to_owned()),
+                })
+                .collect(),
+            named: Vec::new(),
+            theme_name: t.id.as_str().to_owned(),
+            font_sans: family_stack(t.lookup_family("sans"))
+                .unwrap_or_else(|| "Inter, system-ui, sans-serif".to_owned()),
+            font_mono: family_stack(t.lookup_family("mono"))
+                .unwrap_or_else(|| "JetBrains Mono, monospace".to_owned()),
+        }
+    }
+
     /// Minimal `summus` theme stand-in.
     ///
     /// This mirrors the offsite-deck palette so the slide-3 golden can be
@@ -145,6 +171,11 @@ impl ResolvedTheme {
             }
         }
     }
+}
+
+#[cfg(feature = "theme-bridge")]
+fn family_stack(family: Option<&[String]>) -> Option<String> {
+    family.map(|stack| stack.join(", "))
 }
 
 #[cfg(test)]

--- a/crates/poiesis/theme/src/lib.rs
+++ b/crates/poiesis/theme/src/lib.rs
@@ -3,11 +3,15 @@
 //!
 //! Every poiesis render path consumes a [`ResolvedTheme`]; the `theme` crate is
 //! the single home for the tokens that every backend reads from and for the
-//! sinks that pre-bake brand assets for the three rendering families:
+//! sinks that pre-bake brand assets for the seven rendering families:
 //!
 //! - CSS custom properties for the HTML/PDF deck path (see [`sinks::css`]),
 //! - OOXML `clrScheme` / `fontScheme` for the PPTX path (see [`sinks::ooxml`]),
-//! - flat doc-vars map for the Pandoc document path (see [`sinks::docvars`]).
+//! - flat doc-vars map for the Pandoc document path (see [`sinks::docvars`]),
+//! - `LaTeX` prelude for document emission (see [`sinks::latex`]),
+//! - packed base PPTX template for slide baking (see [`sinks::pptx`]),
+//! - packed `reference.docx` for Pandoc DOCX (see [`sinks::reference_docx`]),
+//! - Typst prelude for the PDF report path (see [`sinks::typst`]).
 //!
 //! Components reference tokens (e.g. `color.tone.positive`, `type.role.title`),
 //! never literal hex or typeface strings. Swapping `theme: summus → ardent`
@@ -22,7 +26,9 @@
 //! This crate ships the locked surface from `planning/poiesis-evolution/B-002`:
 //! [`ThemeId`], the [`Theme`] TOML shape, [`ResolvedTheme`], a discoverable
 //! [`Registry`], the seed `summus` brand, the CSS sink, the OOXML `theme1.xml`
-//! emitter, the doc-vars emitter, and the three `THEME/*` lint rule shapes.
+//! emitter, the doc-vars emitter, the `LaTeX` sink, the base PPTX sink, the
+//! `reference.docx` sink, the Typst sink, and the three `THEME/*` lint rule
+//! shapes.
 //! Per-crate downstream wiring (a packed `<name>-base.pptx` for B-004, the
 //! [B-001] `Renderer` parameter, the [B-008] lint-engine registration, and the
 //! `theme` CLI verbs from [B-010]) is the next phase; the per-sink modules
@@ -50,6 +56,6 @@ pub mod tokens;
 
 pub use error::ThemeError;
 pub use id::ThemeId;
-pub use registry::Registry;
+pub use registry::{Registry, summus};
 pub use resolved::ResolvedTheme;
 pub use tokens::Theme;

--- a/crates/poiesis/theme/src/registry.rs
+++ b/crates/poiesis/theme/src/registry.rs
@@ -169,6 +169,24 @@ impl Registry {
     }
 }
 
+/// Return the embedded `summus` theme resolved into renderer-facing tokens.
+///
+/// WHY: deployed binaries should not depend on a filesystem-bound registry
+/// just to obtain the flagship theme. Embedding the seed theme keeps the
+/// consumer path deterministic and available in release artifacts.
+#[must_use]
+pub fn summus() -> ResolvedTheme {
+    let raw = include_str!("../themes/summus.toml");
+    let theme: Theme = match toml::from_str(raw) {
+        Ok(theme) => theme,
+        Err(err) => panic!("embedded summus theme failed to parse: {err}"),
+    };
+    match ResolvedTheme::from_theme(theme) {
+        Ok(resolved) => resolved,
+        Err(err) => panic!("embedded summus theme failed to resolve: {err}"),
+    }
+}
+
 /// Parse a candidate string into a [`ThemeId`], lifting the parse error into
 /// the crate's top-level [`ThemeError`].
 ///

--- a/crates/poiesis/theme/src/sinks/latex.rs
+++ b/crates/poiesis/theme/src/sinks/latex.rs
@@ -5,7 +5,7 @@ use snafu::ResultExt;
 use crate::error::{SinkSnafu, ThemeError};
 use crate::resolved::ResolvedTheme;
 
-/// Emit a LaTeX preamble fragment with `\definecolor` and `\newcommand`
+/// Emit a `LaTeX` preamble fragment with `\definecolor` and `\newcommand`
 /// declarations for every brand token in the [`ResolvedTheme`].
 ///
 /// Downstream `.tex` files `\input` or `\include` this file to access brand
@@ -28,6 +28,7 @@ pub fn emit_latex_template(theme: &ResolvedTheme) -> Result<String, ThemeError> 
     Ok(out)
 }
 
+#[expect(clippy::too_many_lines, reason = "single-pass sink emitter")]
 fn write_latex(out: &mut String, theme: &ResolvedTheme) -> std::fmt::Result {
     writeln!(out, "%% poiesis-theme: {}", theme.id)?;
     writeln!(out, "%% Generated — do not edit.")?;
@@ -190,11 +191,11 @@ fn write_latex(out: &mut String, theme: &ResolvedTheme) -> std::fmt::Result {
 fn px_to_pt(px: u32) -> String {
     let raw = f64::from(px) * 0.75;
     let rounded = (raw * 2.0).round() / 2.0;
-    // Emit without trailing `.0` when the value is a whole number.
+    // NOTE: Emit without trailing `.0` when the value is a whole number.
     if (rounded * 2.0).round().rem_euclid(2.0) == 0.0 {
-        format!("{:.0}pt", rounded)
+        format!("{rounded:.0}pt")
     } else {
-        format!("{:.1}pt", rounded)
+        format!("{rounded:.1}pt")
     }
 }
 

--- a/crates/poiesis/theme/src/sinks/mod.rs
+++ b/crates/poiesis/theme/src/sinks/mod.rs
@@ -1,18 +1,34 @@
 //! Sinks: emit a [`ResolvedTheme`](crate::ResolvedTheme) into a per-target
-//! brand-asset format. One source → three sinks is the rule B-002 names; each
-//! sink is the single owner of one format's serialization.
+//! brand-asset format. One source → seven sinks is the rule B-002 names; each
+//! sink family is the single owner of one format's serialization.
 //!
 //! - [`css`] — CSS custom properties for the HTML / printed-deck path.
 //! - [`ooxml`] — `theme1.xml` `clrScheme` + `fontScheme` for the PPTX path.
 //! - [`docvars`] — flat key/value map for the Pandoc document path.
+//! - [`latex`] — LaTeX preamble for document emission.
+//! - [`pptx`] — packed base PPTX template with the theme baked in.
+//! - [`reference_docx`] — packed `reference.docx` template for Pandoc DOCX.
+//! - [`typst`] — Typst prelude for the PDF report path.
 
 /// CSS custom properties sink for the HTML / printed-deck path.
 pub mod css;
 /// Pandoc-shaped doc-vars sink (JSON + YAML).
 pub mod docvars;
+/// `LaTeX` preamble sink.
+pub mod latex;
 /// OOXML `theme1.xml` (`clrScheme` + `fontScheme`) sink for the PPTX path.
 pub mod ooxml;
+/// Packed base-PPTX sink.
+pub mod pptx;
+/// Pandoc `reference.docx` sink.
+pub mod reference_docx;
+/// Typst prelude sink.
+pub mod typst;
 
 pub use css::emit_css;
 pub use docvars::{emit_docvars_json, emit_docvars_yaml};
+pub use latex::emit_latex_template;
 pub use ooxml::emit_theme_xml;
+pub use pptx::emit_base_pptx;
+pub use reference_docx::emit_reference_docx;
+pub use typst::emit_typst_template;

--- a/crates/poiesis/theme/src/sinks/pptx.rs
+++ b/crates/poiesis/theme/src/sinks/pptx.rs
@@ -65,11 +65,7 @@ pub fn emit_base_pptx(theme: &ResolvedTheme) -> Result<Vec<u8>, ThemeError> {
 
     pack_entry(&mut zip, "[Content_Types].xml", CONTENT_TYPES.as_bytes())?;
     pack_entry(&mut zip, "_rels/.rels", RELS_RELS.as_bytes())?;
-    pack_entry(
-        &mut zip,
-        "ppt/presentation.xml",
-        PRESENTATION.as_bytes(),
-    )?;
+    pack_entry(&mut zip, "ppt/presentation.xml", PRESENTATION.as_bytes())?;
     pack_entry(
         &mut zip,
         "ppt/_rels/presentation.xml.rels",
@@ -338,7 +334,7 @@ mod tests {
         let bytes = emit_base_pptx(&summus()).expect("emit base pptx");
         let cursor = std::io::Cursor::new(bytes);
         let archive = zip::ZipArchive::new(cursor).expect("valid zip archive");
-        assert!(archive.len() > 0, "archive must contain entries");
+        assert!(!archive.is_empty(), "archive must contain entries");
     }
 
     #[test]

--- a/crates/poiesis/theme/src/sinks/reference_docx.rs
+++ b/crates/poiesis/theme/src/sinks/reference_docx.rs
@@ -63,11 +63,7 @@ pub fn emit_reference_docx(theme: &ResolvedTheme) -> Result<Vec<u8>, ThemeError>
         "word/styles.xml",
         build_styles_xml(theme).as_bytes(),
     )?;
-    pack_entry(
-        &mut zip,
-        "word/settings.xml",
-        WORD_SETTINGS.as_bytes(),
-    )?;
+    pack_entry(&mut zip, "word/settings.xml", WORD_SETTINGS.as_bytes())?;
     pack_entry(
         &mut zip,
         "word/theme/theme1.xml",
@@ -93,12 +89,11 @@ fn pack_entry(
             entry: name.into(),
             message: e.to_string(),
         })?;
-    zip.write_all(data)
-        .map_err(|e| ThemeError::ZipWrite {
-            sink: "reference_docx".into(),
-            entry: name.into(),
-            message: e.to_string(),
-        })
+    zip.write_all(data).map_err(|e| ThemeError::ZipWrite {
+        sink: "reference_docx".into(),
+        entry: name.into(),
+        message: e.to_string(),
+    })
 }
 
 fn build_styles_xml(theme: &ResolvedTheme) -> String {
@@ -238,7 +233,11 @@ mod tests {
     #[test]
     fn docx_is_valid_zip() {
         let bytes = emit_reference_docx(&summus()).expect("emit");
-        assert_eq!(&bytes[..2], b"PK", "DOCX output must be a valid ZIP");
+        assert_eq!(
+            bytes.get(..2),
+            Some(b"PK".as_slice()),
+            "DOCX output must be a valid ZIP"
+        );
     }
 
     #[test]
@@ -264,7 +263,11 @@ mod tests {
             .expect("styles.xml entry")
             .read_to_string(&mut styles)
             .expect("read styles");
-        let sans = summus().lookup_family("sans").expect("sans family")[0].clone();
+        let sans = summus()
+            .lookup_family("sans")
+            .and_then(|family| family.first())
+            .cloned()
+            .expect("sans family");
         assert!(
             styles.contains(&format!(r#"w:ascii="{sans}""#)),
             "styles.xml must carry body sans font {sans}: {styles}"


### PR DESCRIPTION
Closes #4433. Recovers the orphaned B-002 theme-sinks + B-005 charts (10-day audit V-3). Declares the 4 never-compiled sinks (latex/pptx/typst/reference_docx), adds an embedded summus() theme (the filesystem Registry was unusable in a deployed binary), a feature-gated theme→charts adapter (the crates have separate ResolvedTheme types), and wires THREE real consumers in organon: render_typst_report (theme source prepended + chart SVG injected), render_pptx_report (themed theme1.xml injected), render_docx_report (themed styles.xml injected). Charts reverse-dep 0→1-reachable. Adversarially reviewed: all wiring CONSUMED (not cosmetic), tests prove live invocation (%PDF-, navy 232E54, Geist font); 682 tests pass. Follow-up: #NEW (panic!→expect in summus(), embed-equality test).