### PR TITLE
feat(daemon): idle serendipity-discovery maintenance task (Q2 chunk 2c)

### DIFF
--- a/_llm/L3-api-index/episteme.md
+++ b/_llm/L3-api-index/episteme.md
@@ -2486,6 +2486,25 @@ impl QueryResult {
 ```
 
 ```rust
+pub struct SerendipityDiscoveryReport {
+    /// Total facts examined during the pass.
+    pub items_processed: u64,
+    /// Number of discoveries surfaced in the report.
+    pub items_modified: u64,
+    /// Number of candidate discoveries evaluated.
+    pub discovery_count: u64,
+    /// Fact ID selected for follow-up injection, if any.
+    pub selected_fact_id: Option<String>,
+    /// Human-readable reason why the selected discovery was interesting.
+    pub selected_connection_reason: Option<String>,
+    /// Serendipity score of the selected discovery, if any.
+    pub selected_surprise_score: Option<f64>,
+    /// Optional human-readable detail string.
+    pub detail: Option<String>,
+}
+```
+
+```rust
 pub struct KnowledgeConfig {
     /// Embedding dimension for the HNSW index.
     pub dim: usize,
@@ -2573,6 +2592,10 @@ impl KnowledgeStore {
         script: &str,
         params: std::collections::BTreeMap<String, crate::engine::DataValue>,
     ) -> crate::error::Result<QueryResult>;
+    pub fn discover_serendipitous_facts (
+        &self,
+        nous_id: &str,
+    ) -> crate::error::Result<SerendipityDiscoveryReport>;
     pub fn backup_db (&self, out_file: impl AsRef<std::path::Path>) -> crate::error::Result<()>;
     pub fn restore_backup (&self, in_file: impl AsRef<std::path::Path>) -> crate::error::Result<()>;
     pub fn import_from_backup (

--- a/_llm/L3-api-index/oikonomos.md
+++ b/_llm/L3-api-index/oikonomos.md
@@ -404,6 +404,10 @@ pub trait KnowledgeMaintenanceExecutor : Send + Sync {
     fn health_check (&self, nous_id: &str) -> crate::error::Result<MaintenanceReport>;
     fn run_skill_decay (&self, nous_id: &str) -> crate::error::Result<MaintenanceReport>;
     fn materialize_derived_facts (&self) -> crate::error::Result<MaintenanceReport>;
+    fn discover_serendipitous_facts (
+        &self,
+        nous_id: &str,
+    ) -> crate::error::Result<MaintenanceReport>;
 }
 ```
 
@@ -413,6 +417,8 @@ pub struct KnowledgeMaintenanceConfig {
     pub enabled: bool,
     /// Auto-dream consolidation settings.
     pub auto_dream: AutoDreamConfig,
+    /// Serendipity discovery idle-maintenance settings.
+    pub serendipity: SerendipityMaintenanceConfig,
 }
 ```
 
@@ -428,6 +434,15 @@ pub struct AutoDreamConfig {
     pub scan_interval_secs: i64,
     /// Stale lock threshold in seconds.
     pub stale_threshold_secs: i64,
+}
+```
+
+```rust
+pub struct SerendipityMaintenanceConfig {
+    /// Whether serendipity discovery is enabled.
+    pub enabled: bool,
+    /// Cron cadence for the scheduled discovery task.
+    pub cadence: String,
 }
 ```
 
@@ -1292,6 +1307,8 @@ pub enum BuiltinTask {
     /// Materialize derived Datalog rules (IS-A closure, causal chains, defeasible defaults)
     /// into the `derived_facts` relation.
     DerivedFactsMaterialize,
+    /// Run the serendipity-discovery engine over recently active entities.
+    SerendipityDiscovery,
 }
 ```
 

--- a/_llm/L3-api-index/taxis.md
+++ b/_llm/L3-api-index/taxis.md
@@ -1333,12 +1333,23 @@ pub struct MaintenanceSettings {
     /// Whether background knowledge graph maintenance tasks are enabled.
     #[serde(default)]
     pub knowledge_maintenance_enabled: bool,
+    /// Serendipity discovery maintenance settings.
+    pub knowledge_maintenance_serendipity: SerendipityMaintenanceSettings,
     /// Watchdog process monitor settings.
     pub watchdog: WatchdogSettings,
     /// Periodic cron task settings (evolution, reflection, graph cleanup).
     pub cron_tasks: CronTaskSettings,
     /// Fjall knowledge store backup settings.
     pub backup: BackupSettings,
+}
+```
+
+```rust
+pub struct SerendipityMaintenanceSettings {
+    /// Whether the serendipity discovery task is enabled.
+    pub enabled: bool,
+    /// Cron cadence used when the task is scheduled.
+    pub cadence: String,
 }
 ```
 

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "e37d89cea242842b54f911899b4d88f017bab8b86ecab7c28f62b2841fa0d53f"
+source_hash = "172be426c8342633d71860bd78998d3ae932547fa4c92bbd9e0395e28e7f2fdc"
 l3_token_estimate = 167
 
 [[crates]]
@@ -86,8 +86,8 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "06fc46d6a4958b795e0ab498c3183d456507ee5b245b02d71430951364ed4735"
-l3_token_estimate = 32579
+source_hash = "297fa5e9138a147dc51be0072c78c48537f4357e5c82e59c42730bf6ebcdc0ad"
+l3_token_estimate = 32790
 
 [[crates]]
 name = "gnosis"
@@ -152,8 +152,8 @@ l3_token_estimate = 34413
 [[crates]]
 name = "oikonomos"
 path = "crates/daemon"
-source_hash = "ddcaeb8e676e7b0ee79d8bce7892841e0f6a63ccb4cab0513a8abebd923b3ca1"
-l3_token_estimate = 12316
+source_hash = "3d996e1125c7468e879c93b525ba8c3d91cfd48084263053980d80cdbb446b66"
+l3_token_estimate = 12453
 
 [[crates]]
 name = "organon"
@@ -284,8 +284,8 @@ l3_token_estimate = 6587
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "8fd91b7beaed44b73a4cf019321ff008c1c107714dbcafdf6dfadcb5f21f9d54"
-l3_token_estimate = 24318
+source_hash = "c7510d8cba04b8e303b120d296730c0e0d2f7b31b41bec3ba7f35d72c5f9524b"
+l3_token_estimate = 24404
 
 [[crates]]
 name = "theatron"

--- a/crates/aletheia/src/commands/maintenance.rs
+++ b/crates/aletheia/src/commands/maintenance.rs
@@ -272,6 +272,10 @@ pub(crate) fn build_config(
         knowledge_maintenance: oikonomos::maintenance::KnowledgeMaintenanceConfig {
             enabled: settings.knowledge_maintenance_enabled,
             auto_dream: AutoDreamConfig::default(),
+            serendipity: oikonomos::maintenance::SerendipityMaintenanceConfig {
+                enabled: settings.knowledge_maintenance_serendipity.enabled,
+                cadence: settings.knowledge_maintenance_serendipity.cadence.clone(),
+            },
         },
         fjall_backup: FjallBackupConfig {
             enabled: settings.backup.enabled,

--- a/crates/aletheia/src/knowledge_maintenance.rs
+++ b/crates/aletheia/src/knowledge_maintenance.rs
@@ -317,6 +317,40 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
         })
     }
 
+    fn discover_serendipitous_facts(
+        &self,
+        nous_id: &str,
+    ) -> oikonomos::error::Result<MaintenanceReport> {
+        let start = std::time::Instant::now();
+        let report = self
+            .store
+            .discover_serendipitous_facts(nous_id)
+            .map_err(|e| {
+                oikonomos::error::TaskFailedSnafu {
+                    task_id: "serendipity-discovery".to_owned(),
+                    reason: e.to_string(),
+                }
+                .build()
+            })?;
+
+        let duration_ms = start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        let items_processed = report.items_processed;
+        let items_modified = report.items_modified;
+        let discovery_count = report.discovery_count;
+        let detail = report.detail.unwrap_or_else(|| {
+            format!("Serendipity discovery: {discovery_count} surfaced discoveries")
+        });
+        tracing::info!(%detail, duration_ms, "maintenance: serendipity discovery complete");
+
+        Ok(MaintenanceReport {
+            items_processed,
+            items_modified,
+            duration_ms,
+            detail: Some(detail),
+            ..Default::default()
+        })
+    }
+
     fn run_skill_decay(&self, nous_id: &str) -> oikonomos::error::Result<MaintenanceReport> {
         let (active, needs_review, retired) = self.store.run_skill_decay(nous_id).map_err(|e| {
             oikonomos::error::TaskFailedSnafu {
@@ -337,5 +371,201 @@ impl KnowledgeMaintenanceExecutor for KnowledgeMaintenanceAdapter {
             detail: Some(detail),
             ..Default::default()
         })
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+
+    use mneme::engine::DataValue;
+    use mneme::id::{EntityId, FactId};
+    use mneme::knowledge::{
+        EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactSensitivity,
+        FactTemporal, Visibility, far_future,
+    };
+
+    fn make_fact(
+        id: &str,
+        nous_id: &str,
+        content: &str,
+        access_count: u32,
+        last_accessed_at: Option<jiff::Timestamp>,
+    ) -> Fact {
+        let recorded_at = jiff::Timestamp::now();
+        Fact {
+            id: FactId::new(id).expect("valid test id"),
+            nous_id: nous_id.to_owned(),
+            fact_type: "observation".to_owned(),
+            content: content.to_owned(),
+            scope: None,
+            project_id: None,
+            sensitivity: FactSensitivity::Public,
+            visibility: Visibility::Private,
+            temporal: FactTemporal {
+                valid_from: recorded_at,
+                valid_to: far_future(),
+                recorded_at,
+            },
+            provenance: FactProvenance {
+                confidence: 0.9,
+                tier: EpistemicTier::Verified,
+                source_session_id: Some("seed-session".to_owned()),
+                stability_hours: 720.0,
+            },
+            lifecycle: FactLifecycle {
+                superseded_by: None,
+                is_forgotten: false,
+                forgotten_at: None,
+                forget_reason: None,
+            },
+            access: FactAccess {
+                access_count,
+                last_accessed_at,
+            },
+        }
+    }
+
+    fn link_fact_entity(store: &Arc<KnowledgeStore>, fact_id: &FactId, entity_id: &EntityId) {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "fact_id".to_owned(),
+            DataValue::Str(fact_id.as_str().to_owned().into()),
+        );
+        params.insert(
+            "entity_id".to_owned(),
+            DataValue::Str(entity_id.as_str().to_owned().into()),
+        );
+        params.insert(
+            "created_at".to_owned(),
+            DataValue::Str(mneme::knowledge::format_timestamp(&jiff::Timestamp::now()).into()),
+        );
+        store
+            .run_mut_query(
+                "?[fact_id, entity_id, created_at] <- [[$fact_id, $entity_id, $created_at]]\n:put fact_entities {fact_id, entity_id => created_at}",
+                params,
+            )
+            .expect("link fact to entity");
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "seeded maintenance integration covers the full flow"
+    )]
+    #[test]
+    fn discover_serendipitous_facts_runs_on_seeded_store() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = KnowledgeStore::open_fjall(
+            dir.path().join("knowledge"),
+            mneme::knowledge_store::KnowledgeConfig::default(),
+        )
+        .expect("open store");
+
+        let alice = EntityId::new("alice").expect("valid entity id");
+        let bob = EntityId::new("bob").expect("valid entity id");
+        let acme = EntityId::new("acme.corp").expect("valid entity id");
+
+        for (entity_id, name, entity_type) in [
+            (&alice, "Alice", "person"),
+            (&bob, "Bob", "person"),
+            (&acme, "Acme Corp", "company"),
+        ] {
+            store
+                .insert_entity(&mneme::knowledge::Entity {
+                    id: entity_id.clone(),
+                    name: name.to_owned(),
+                    entity_type: entity_type.to_owned(),
+                    aliases: Vec::new(),
+                    created_at: jiff::Timestamp::now(),
+                    updated_at: jiff::Timestamp::now(),
+                })
+                .expect("insert entity");
+        }
+
+        for (src, dst, relation) in [
+            (&alice, &bob, "collaborates_with"),
+            (&bob, &acme, "documents_for"),
+            (&acme, &alice, "contracts_with"),
+        ] {
+            store
+                .insert_relationship(&mneme::knowledge::Relationship {
+                    src: src.clone(),
+                    dst: dst.clone(),
+                    relation: relation.to_owned(),
+                    weight: 0.8,
+                    created_at: jiff::Timestamp::now(),
+                })
+                .expect("insert relationship");
+        }
+
+        let now = jiff::Timestamp::now();
+        let one_hour_ago = now
+            .checked_sub(jiff::SignedDuration::from_hours(1))
+            .expect("timestamp arithmetic");
+        let twelve_hours_ago = now
+            .checked_sub(jiff::SignedDuration::from_hours(12))
+            .expect("timestamp arithmetic");
+        let forty_eight_hours_ago = now
+            .checked_sub(jiff::SignedDuration::from_hours(48))
+            .expect("timestamp arithmetic");
+
+        let facts = [
+            (
+                make_fact(
+                    "fact-alice",
+                    "alice",
+                    "Alice keeps the ops feed tidy.",
+                    3,
+                    Some(one_hour_ago),
+                ),
+                &alice,
+            ),
+            (
+                make_fact(
+                    "fact-bob",
+                    "alice",
+                    "Bob is the bridge between ops and archives.",
+                    2,
+                    Some(twelve_hours_ago),
+                ),
+                &bob,
+            ),
+            (
+                make_fact(
+                    "fact-acme",
+                    "alice",
+                    "Acme Corp owns the incident response handbook.",
+                    1,
+                    Some(forty_eight_hours_ago),
+                ),
+                &acme,
+            ),
+        ];
+
+        for (fact, entity) in facts {
+            store.insert_fact(&fact).expect("insert fact");
+            link_fact_entity(&store, &fact.id, entity);
+        }
+
+        store
+            .recompute_graph_scores()
+            .expect("recompute graph scores");
+
+        let adapter = KnowledgeMaintenanceAdapter::new(Arc::clone(&store));
+        let report = adapter
+            .discover_serendipitous_facts("alice")
+            .expect("discover serendipity");
+
+        assert!(report.items_processed >= 3);
+        assert!(
+            report
+                .detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("Serendipity discovery")),
+            "detail should summarize the discovery pass"
+        );
     }
 }

--- a/crates/daemon/src/execution.rs
+++ b/crates/daemon/src/execution.rs
@@ -183,6 +183,7 @@ pub(crate) async fn execute_builtin_with_behavior(
         | BuiltinTask::IndexMaintenance
         | BuiltinTask::GraphHealthCheck
         | BuiltinTask::SkillDecay
+        | BuiltinTask::SerendipityDiscovery
         | BuiltinTask::DerivedFactsMaterialize => {
             execute_knowledge_task(builtin, nous_id, knowledge_executor).await
         }
@@ -651,6 +652,9 @@ async fn execute_knowledge_task(
             BuiltinTask::IndexMaintenance => executor.maintain_indexes(&nous_id_owned),
             BuiltinTask::GraphHealthCheck => executor.health_check(&nous_id_owned),
             BuiltinTask::SkillDecay => executor.run_skill_decay(&nous_id_owned),
+            BuiltinTask::SerendipityDiscovery => {
+                executor.discover_serendipitous_facts(&nous_id_owned)
+            }
             BuiltinTask::DerivedFactsMaterialize => executor.materialize_derived_facts(),
             BuiltinTask::Prosoche
             | BuiltinTask::TraceRotation

--- a/crates/daemon/src/execution_tests.rs
+++ b/crates/daemon/src/execution_tests.rs
@@ -126,6 +126,10 @@ impl crate::maintenance::KnowledgeMaintenanceExecutor for MockKnowledge {
     fn materialize_derived_facts(&self) -> Result<MaintenanceReport> {
         Ok(MaintenanceReport::default())
     }
+
+    fn discover_serendipitous_facts(&self, _nous_id: &str) -> Result<MaintenanceReport> {
+        Ok(MaintenanceReport::default())
+    }
 }
 
 struct RealKnowledge {
@@ -195,6 +199,10 @@ impl crate::maintenance::KnowledgeMaintenanceExecutor for RealKnowledge {
     }
 
     fn materialize_derived_facts(&self) -> Result<MaintenanceReport> {
+        Ok(MaintenanceReport::default())
+    }
+
+    fn discover_serendipitous_facts(&self, _nous_id: &str) -> Result<MaintenanceReport> {
         Ok(MaintenanceReport::default())
     }
 }
@@ -590,6 +598,28 @@ async fn knowledge_task_with_executor_returns_report() {
         "expected '7 processed' in output, got: {output}"
     );
     assert!(output.contains("2 modified"));
+}
+
+#[tokio::test]
+async fn serendipity_discovery_with_executor_returns_report() {
+    let executor: Arc<dyn crate::maintenance::KnowledgeMaintenanceExecutor> =
+        Arc::new(MockKnowledge);
+    let result = execute_builtin(
+        &BuiltinTask::SerendipityDiscovery,
+        "test-nous",
+        None,
+        None,
+        None,
+        Some(executor),
+    )
+    .await
+    .expect("should succeed");
+    assert!(result.success);
+    let output = result.output.expect("output");
+    assert!(
+        output.contains("0 processed"),
+        "expected zero-count report for mock executor, got: {output}"
+    );
 }
 
 // --- cron execution counter helpers ---

--- a/crates/daemon/src/maintenance/knowledge.rs
+++ b/crates/daemon/src/maintenance/knowledge.rs
@@ -59,6 +59,12 @@ pub trait KnowledgeMaintenanceExecutor: Send + Sync {
     /// chains, defeasible defaults) in sequence and persists results. Returns the
     /// total number of derived facts written.
     fn materialize_derived_facts(&self) -> crate::error::Result<MaintenanceReport>;
+
+    /// Run the serendipity discovery engine over recently active entities.
+    fn discover_serendipitous_facts(
+        &self,
+        nous_id: &str,
+    ) -> crate::error::Result<MaintenanceReport>;
 }
 
 /// Configuration for knowledge maintenance task scheduling.
@@ -68,6 +74,8 @@ pub struct KnowledgeMaintenanceConfig {
     pub enabled: bool,
     /// Auto-dream consolidation settings.
     pub auto_dream: AutoDreamConfig,
+    /// Serendipity discovery idle-maintenance settings.
+    pub serendipity: SerendipityMaintenanceConfig,
 }
 
 /// Configuration for auto-dream memory consolidation.
@@ -96,6 +104,24 @@ impl Default for AutoDreamConfig {
             min_sessions: 5,
             scan_interval_secs: 600,
             stale_threshold_secs: 3_600,
+        }
+    }
+}
+
+/// Configuration for serendipity discovery maintenance.
+#[derive(Debug, Clone)]
+pub struct SerendipityMaintenanceConfig {
+    /// Whether serendipity discovery is enabled.
+    pub enabled: bool,
+    /// Cron cadence for the scheduled discovery task.
+    pub cadence: String,
+}
+
+impl Default for SerendipityMaintenanceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            cadence: "0 0 7 * * *".to_owned(),
         }
     }
 }
@@ -164,6 +190,18 @@ mod tests {
                 ..Default::default()
             })
         }
+
+        fn discover_serendipitous_facts(
+            &self,
+            _nous_id: &str,
+        ) -> crate::error::Result<MaintenanceReport> {
+            Ok(MaintenanceReport {
+                items_processed: 0,
+                items_modified: 0,
+                detail: Some("Serendipity discovery: 0 discoveries surfaced".to_owned()),
+                ..Default::default()
+            })
+        }
     }
 
     #[test]
@@ -190,6 +228,8 @@ mod tests {
     fn default_config_is_disabled() {
         let config = KnowledgeMaintenanceConfig::default();
         assert!(!config.enabled);
+        assert!(!config.serendipity.enabled);
+        assert_eq!(config.serendipity.cadence, "0 0 7 * * *");
     }
 
     #[test]

--- a/crates/daemon/src/maintenance/mod.rs
+++ b/crates/daemon/src/maintenance/mod.rs
@@ -25,6 +25,7 @@ pub use drift_detection::{DriftDetectionConfig, DriftDetector, DriftReport};
 pub use fjall_backup::{FjallBackup, FjallBackupConfig, FjallBackupReport};
 pub use knowledge::{
     AutoDreamConfig, KnowledgeMaintenanceConfig, KnowledgeMaintenanceExecutor, MaintenanceReport,
+    SerendipityMaintenanceConfig,
 };
 pub use prompt_audit_rotation::{
     PromptAuditRetentionConfig, PromptAuditRetentionReport, PromptAuditRotator,

--- a/crates/daemon/src/runner/registration.rs
+++ b/crates/daemon/src/runner/registration.rs
@@ -203,6 +203,15 @@ impl TaskRunner {
 
     /// Register implemented knowledge maintenance tasks with their schedules.
     fn register_knowledge_maintenance_tasks(&mut self) {
+        let (serendipity_enabled, serendipity_cadence) = {
+            let Some(config) = self.maintenance.as_ref() else {
+                return;
+            };
+            (
+                config.knowledge_maintenance.serendipity.enabled,
+                config.knowledge_maintenance.serendipity.cadence.clone(),
+            )
+        };
         let tasks: [(_, _, Schedule, BuiltinTask); 5] = [
             (
                 "decay-refresh",
@@ -241,6 +250,16 @@ impl TaskRunner {
 
         for (id, name, schedule, task) in tasks {
             self.register_builtin(id, name, schedule, task, true);
+        }
+
+        if serendipity_enabled {
+            self.register_builtin(
+                "serendipity-discovery",
+                "Serendipity discovery",
+                Schedule::Cron(serendipity_cadence),
+                BuiltinTask::SerendipityDiscovery,
+                true,
+            );
         }
     }
 

--- a/crates/daemon/src/runner_tests/lifecycle_and_builders.rs
+++ b/crates/daemon/src/runner_tests/lifecycle_and_builders.rs
@@ -168,6 +168,45 @@ fn register_maintenance_tasks_respects_enabled() {
 }
 
 #[test]
+fn serendipity_discovery_task_registers_at_daily_seven_utc() {
+    let token = CancellationToken::new();
+    let mut config = MaintenanceConfig::default();
+    config.knowledge_maintenance.enabled = true;
+    config.knowledge_maintenance.serendipity.enabled = true;
+    let executor: Arc<dyn crate::maintenance::KnowledgeMaintenanceExecutor> =
+        Arc::new(MockKnowledgeExecutor);
+
+    let mut runner = TaskRunner::new("system", token).with_maintenance(config);
+    runner = runner.with_knowledge_maintenance(executor);
+    runner.register_maintenance_tasks();
+
+    let task = runner
+        .tasks
+        .iter()
+        .find(|task| task.def.id == "serendipity-discovery")
+        .expect("serendipity task should be scheduled");
+    assert!(matches!(
+        &task.def.schedule,
+        Schedule::Cron(expr) if expr == "0 0 7 * * *"
+    ));
+}
+
+#[test]
+fn serendipity_discovery_task_skips_when_disabled() {
+    let token = CancellationToken::new();
+    let mut config = MaintenanceConfig::default();
+    config.knowledge_maintenance.enabled = true;
+    config.knowledge_maintenance.serendipity.enabled = false;
+
+    let mut runner = TaskRunner::new("system", token).with_maintenance(config);
+    runner.register_maintenance_tasks();
+
+    let statuses = runner.status();
+    let ids: Vec<&str> = statuses.iter().map(|s| s.id.as_str()).collect();
+    assert!(!ids.contains(&"serendipity-discovery"));
+}
+
+#[test]
 fn routing_store_refresh_registers_when_store_is_attached() {
     let token = CancellationToken::new();
     let config = MaintenanceConfig::default();
@@ -455,6 +494,13 @@ impl crate::maintenance::KnowledgeMaintenanceExecutor for MockKnowledgeExecutor 
 
     fn materialize_derived_facts(
         &self,
+    ) -> crate::error::Result<crate::maintenance::MaintenanceReport> {
+        Ok(crate::maintenance::MaintenanceReport::default())
+    }
+
+    fn discover_serendipitous_facts(
+        &self,
+        _nous_id: &str,
     ) -> crate::error::Result<crate::maintenance::MaintenanceReport> {
         Ok(crate::maintenance::MaintenanceReport::default())
     }

--- a/crates/daemon/src/schedule.rs
+++ b/crates/daemon/src/schedule.rs
@@ -146,6 +146,8 @@ pub enum BuiltinTask {
     /// Materialize derived Datalog rules (IS-A closure, causal chains, defeasible defaults)
     /// into the `derived_facts` relation.
     DerivedFactsMaterialize,
+    /// Run the serendipity-discovery engine over recently active entities.
+    SerendipityDiscovery,
 }
 
 impl Schedule {

--- a/crates/daemon/tests/public_api_config.rs
+++ b/crates/daemon/tests/public_api_config.rs
@@ -27,7 +27,8 @@ use oikonomos::error::Error as DaemonError;
 use oikonomos::maintenance::{
     AutoDreamConfig, DbMonitor, DbMonitoringConfig, DbStatus, DriftDetectionConfig, DriftDetector,
     KnowledgeMaintenanceConfig, MaintenanceConfig, MaintenanceReport, ProposeRulesConfig,
-    RetentionConfig, RetentionExecutor, RetentionSummary, TraceRotationConfig, TraceRotator,
+    RetentionConfig, RetentionExecutor, RetentionSummary, SerendipityMaintenanceConfig,
+    TraceRotationConfig, TraceRotator,
 };
 use oikonomos::probe::{
     Probe, ProbeAuditConfig, ProbeAuditSummary, ProbeCategory, ProbeResult, ProbeSet,
@@ -176,6 +177,8 @@ fn knowledge_maintenance_config_default_disabled_with_default_auto_dream() {
     let cfg = KnowledgeMaintenanceConfig::default();
     assert!(!cfg.enabled);
     assert!(!cfg.auto_dream.enabled);
+    assert!(!cfg.serendipity.enabled);
+    assert_eq!(cfg.serendipity.cadence, "0 0 7 * * *");
 }
 
 #[test]
@@ -464,6 +467,7 @@ fn builtin_task_serde_roundtrips_through_json() {
         BuiltinTask::DbSizeMonitor,
         BuiltinTask::ProbeAudit,
         BuiltinTask::SelfPrompt,
+        BuiltinTask::SerendipityDiscovery,
     ] {
         let json = serde_json::to_string(&task).expect("serialize BuiltinTask");
         let back: BuiltinTask = serde_json::from_str(&json).expect("deserialize BuiltinTask");

--- a/crates/episteme/src/knowledge_store/entity.rs
+++ b/crates/episteme/src/knowledge_store/entity.rs
@@ -169,7 +169,6 @@ impl KnowledgeStore {
     }
 
     /// Build a serendipity-ready graph snapshot from the current store.
-    #[expect(dead_code, reason = "serendipity adapter is staged for later wiring")]
     pub(crate) fn build_serendipity_snapshot(
         &self,
         seed_entity_ids: &[String],

--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -431,6 +431,25 @@ impl From<crate::engine::NamedRows> for QueryResult {
     }
 }
 
+/// Outcome of a serendipity discovery pass.
+#[derive(Debug, Clone, Default)]
+pub struct SerendipityDiscoveryReport {
+    /// Total facts examined during the pass.
+    pub items_processed: u64,
+    /// Number of discoveries surfaced in the report.
+    pub items_modified: u64,
+    /// Number of candidate discoveries evaluated.
+    pub discovery_count: u64,
+    /// Fact ID selected for follow-up injection, if any.
+    pub selected_fact_id: Option<String>,
+    /// Human-readable reason why the selected discovery was interesting.
+    pub selected_connection_reason: Option<String>,
+    /// Serendipity score of the selected discovery, if any.
+    pub selected_surprise_score: Option<f64>,
+    /// Optional human-readable detail string.
+    pub detail: Option<String>,
+}
+
 /// Configuration for `KnowledgeStore` initialization.
 #[cfg(feature = "mneme-engine")]
 pub struct KnowledgeConfig {
@@ -1025,6 +1044,15 @@ impl KnowledgeStore {
                 }
                 .build()
             })
+    }
+
+    /// Discover serendipitous facts from recently active entities.
+    #[instrument(skip(self))]
+    pub fn discover_serendipitous_facts(
+        &self,
+        nous_id: &str,
+    ) -> crate::error::Result<SerendipityDiscoveryReport> {
+        crate::serendipity::discover_serendipitous_facts(self, nous_id)
     }
 
     /// Create a backup of the knowledge database.

--- a/crates/episteme/src/serendipity/mod.rs
+++ b/crates/episteme/src/serendipity/mod.rs
@@ -5,23 +5,17 @@
 //! - **Surprise scoring**: identify facts the agent hasn't accessed recently
 //! - **Path exploration**: find paths between seemingly unrelated entities
 //! - **Serendipity injection**: select "did you know?" facts for context injection
-// WARNING: the engine is intentionally inert until chunks 2b (recall factor) +
-// 2c (idle discovery) wire it to a production caller; `expect` self-surfaces and
-// must be removed once those land.
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "serendipity engine has no production caller until chunks 2b/2c wire it"
-    )
-)]
 
+use std::collections::BTreeMap;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
 
 use crate::graph_intelligence::GraphContext;
 use crate::id::EntityId;
+use crate::knowledge_store::{KnowledgeStore, SerendipityDiscoveryReport};
 
 /// Configuration for the serendipity engine.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -217,6 +211,7 @@ impl GraphSnapshot {
 
     /// Total number of nodes.
     #[must_use]
+    #[cfg(test)]
     pub(crate) fn node_count(&self) -> usize {
         self.nodes.len()
     }
@@ -604,6 +599,257 @@ fn reconstruct_path(
         communities_traversed,
         interest_score: 0.0,
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EntityActivity {
+    last_access_hours: f64,
+    access_count: u32,
+    recorded_at: jiff::Timestamp,
+}
+
+impl EntityActivity {
+    fn new(last_access_hours: f64, access_count: u32, recorded_at: jiff::Timestamp) -> Self {
+        Self {
+            last_access_hours,
+            access_count,
+            recorded_at,
+        }
+    }
+
+    fn update(&mut self, last_access_hours: f64, access_count: u32, recorded_at: jiff::Timestamp) {
+        self.last_access_hours = self.last_access_hours.min(last_access_hours);
+        self.access_count = self.access_count.max(access_count);
+        if recorded_at > self.recorded_at {
+            self.recorded_at = recorded_at;
+        }
+    }
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "orchestrates the full serendipity maintenance flow"
+)]
+/// Run the serendipity engine against real store data and return a report.
+pub(crate) fn discover_serendipitous_facts(
+    store: &KnowledgeStore,
+    nous_id: &str,
+) -> crate::error::Result<SerendipityDiscoveryReport> {
+    let now = jiff::Timestamp::now();
+    let now_str = crate::knowledge::format_timestamp(&now);
+    let facts = store.query_facts(nous_id, &now_str, 200)?;
+    let config = SerendipityConfig::default();
+
+    let mut entity_activity: HashMap<String, EntityActivity> = HashMap::new();
+    let mut fact_contents: HashMap<String, (String, String)> = HashMap::new();
+    let mut entity_links = 0u64;
+
+    for fact in &facts {
+        let access_time = fact
+            .access
+            .last_accessed_at
+            .unwrap_or(fact.temporal.recorded_at);
+        let age_hours = now.duration_since(access_time).as_secs_f64() / 3600.0;
+        let entity_ids = fact_entity_ids(store, fact.id.as_str())?;
+
+        for entity_id in entity_ids {
+            entity_links = entity_links.saturating_add(1);
+            fact_contents
+                .entry(entity_id.clone())
+                .or_insert_with(|| (fact.id.as_str().to_owned(), fact.content.clone()));
+            entity_activity
+                .entry(entity_id)
+                .and_modify(|activity| {
+                    activity.update(
+                        age_hours,
+                        fact.access.access_count,
+                        fact.temporal.recorded_at,
+                    );
+                })
+                .or_insert_with(|| {
+                    EntityActivity::new(
+                        age_hours,
+                        fact.access.access_count,
+                        fact.temporal.recorded_at,
+                    )
+                });
+        }
+    }
+
+    if entity_activity.is_empty() {
+        let detail = format!(
+            "Serendipity discovery: scanned {} facts, found no recently active entities",
+            facts.len()
+        );
+        tracing::info!(%detail, "maintenance: serendipity discovery complete");
+        return Ok(SerendipityDiscoveryReport {
+            items_processed: u64::try_from(facts.len()).unwrap_or(u64::MAX),
+            items_modified: 0,
+            discovery_count: 0,
+            detail: Some(detail),
+            ..Default::default()
+        });
+    }
+
+    let last_access_hours: HashMap<String, f64> = entity_activity
+        .iter()
+        .map(|(entity_id, activity)| (entity_id.clone(), activity.last_access_hours))
+        .collect();
+
+    let mut ranked_entities: Vec<(String, EntityActivity)> = entity_activity.into_iter().collect();
+    ranked_entities.sort_by(|(left_id, left), (right_id, right)| {
+        left.last_access_hours
+            .partial_cmp(&right.last_access_hours)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| right.access_count.cmp(&left.access_count))
+            .then_with(|| right.recorded_at.cmp(&left.recorded_at))
+            .then_with(|| left_id.cmp(right_id))
+    });
+
+    let seed_limit = ranked_entities.len().min(5);
+    let seed_entity_ids: Vec<String> = ranked_entities
+        .into_iter()
+        .take(seed_limit)
+        .map(|(entity_id, _)| entity_id)
+        .collect();
+
+    let snapshot = store.build_serendipity_snapshot(&seed_entity_ids)?;
+    let mut hasher = DefaultHasher::new();
+    nous_id.hash(&mut hasher);
+    seed_entity_ids.hash(&mut hasher);
+    let walk_visits = random_walk(&snapshot, &seed_entity_ids, &config, hasher.finish());
+
+    let home_communities: HashSet<i64> = seed_entity_ids
+        .iter()
+        .filter_map(|seed| snapshot.nodes.get(seed).map(|node| node.community))
+        .filter(|community| *community >= 0)
+        .collect();
+
+    let surprise_scores = surprise_scores(
+        &snapshot,
+        &walk_visits,
+        &home_communities,
+        &last_access_hours,
+    );
+    let surprise_lookup: HashMap<String, f64> = surprise_scores.into_iter().collect();
+
+    let mut distances: HashMap<String, u32> = HashMap::new();
+    for seed in &seed_entity_ids {
+        for (entity_id, distance) in bfs_distances(&snapshot, seed, config.max_path_depth) {
+            distances
+                .entry(entity_id)
+                .and_modify(|current| {
+                    if distance < *current {
+                        *current = distance;
+                    }
+                })
+                .or_insert(distance);
+        }
+    }
+
+    let mut discoveries = score_discoveries(&snapshot, &seed_entity_ids, &distances, &config);
+    for discovery in &mut discoveries {
+        discovery.surprise = surprise_lookup
+            .get(discovery.entity_id.as_str())
+            .copied()
+            .unwrap_or(0.0);
+    }
+
+    let selected_injection = select_injection(&discoveries, &fact_contents, &config);
+    let path_summary = seed_entity_ids
+        .first()
+        .and_then(|seed| explore_from(&snapshot, seed, &config).into_iter().next());
+
+    let discovery_count = u64::try_from(discoveries.len()).unwrap_or(u64::MAX);
+    let items_processed = u64::try_from(facts.len()).unwrap_or(u64::MAX);
+    let selected_preview = selected_injection.as_ref().map(|injection| {
+        let mut preview = injection.content.chars().take(160).collect::<String>();
+        if injection.content.chars().count() > 160 {
+            preview.push_str("...");
+        }
+        preview
+    });
+
+    let top_discoveries = discoveries
+        .iter()
+        .take(3)
+        .map(|discovery| {
+            format!(
+                "{} ({:.2}, dist {})",
+                discovery.name,
+                discovery.serendipity_score,
+                discovery
+                    .graph_distance
+                    .map_or_else(|| "n/a".to_owned(), |distance| distance.to_string())
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let mut detail_parts = vec![
+        format!("facts scanned {}", facts.len()),
+        format!("entity links {}", entity_links),
+        format!("seeds {}", seed_entity_ids.join(", ")),
+        format!("discoveries surfaced {}", discoveries.len()),
+    ];
+    if !top_discoveries.is_empty() {
+        detail_parts.push(format!("top {}", top_discoveries.join(" | ")));
+    }
+    if let Some(injection) = &selected_injection {
+        detail_parts.push(format!(
+            "selected fact {} ({:.2})",
+            injection.fact_id, injection.surprise_score
+        ));
+        detail_parts.push(format!("reason {}", injection.connection_reason));
+        if let Some(preview) = selected_preview {
+            detail_parts.push(format!("content {preview}"));
+        }
+    } else {
+        detail_parts.push("selected fact none".to_owned());
+    }
+    if let Some(path) = path_summary {
+        detail_parts.push(format!(
+            "path {} hops across {} communities",
+            path.length, path.communities_traversed
+        ));
+    }
+
+    let detail = format!("Serendipity discovery: {}", detail_parts.join("; "));
+    tracing::info!(%detail, "maintenance: serendipity discovery complete");
+
+    Ok(SerendipityDiscoveryReport {
+        items_processed,
+        items_modified: discovery_count,
+        discovery_count,
+        selected_fact_id: selected_injection
+            .as_ref()
+            .map(|injection| injection.fact_id.clone()),
+        selected_connection_reason: selected_injection
+            .as_ref()
+            .map(|injection| injection.connection_reason.clone()),
+        selected_surprise_score: selected_injection
+            .as_ref()
+            .map(|injection| injection.surprise_score),
+        detail: Some(detail),
+    })
+}
+
+fn fact_entity_ids(store: &KnowledgeStore, fact_id: &str) -> crate::error::Result<Vec<String>> {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "fid".to_owned(),
+        crate::engine::DataValue::Str(fact_id.to_owned().into()),
+    );
+    let rows = store.run_query(
+        "?[entity_id] := *fact_entities{fact_id: $fid, entity_id}",
+        params,
+    )?;
+    let mut entity_ids = Vec::with_capacity(rows.row_count());
+    for row_idx in 0..rows.row_count() {
+        if let Some(entity_id) = rows.get_string(row_idx, "entity_id") {
+            entity_ids.push(entity_id);
+        }
+    }
+    Ok(entity_ids)
 }
 
 #[cfg(test)]

--- a/crates/taxis/src/config/maintenance.rs
+++ b/crates/taxis/src/config/maintenance.rs
@@ -25,12 +25,35 @@ pub struct MaintenanceSettings {
     /// Whether background knowledge graph maintenance tasks are enabled.
     #[serde(default)]
     pub knowledge_maintenance_enabled: bool,
+    /// Serendipity discovery maintenance settings.
+    pub knowledge_maintenance_serendipity: SerendipityMaintenanceSettings,
     /// Watchdog process monitor settings.
     pub watchdog: WatchdogSettings,
     /// Periodic cron task settings (evolution, reflection, graph cleanup).
     pub cron_tasks: CronTaskSettings,
     /// Fjall knowledge store backup settings.
     pub backup: BackupSettings,
+}
+
+/// Serendipity discovery maintenance settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+#[serde(deny_unknown_fields)]
+pub struct SerendipityMaintenanceSettings {
+    /// Whether the serendipity discovery task is enabled.
+    pub enabled: bool,
+    /// Cron cadence used when the task is scheduled.
+    pub cadence: String,
+}
+
+impl Default for SerendipityMaintenanceSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            cadence: "0 0 7 * * *".to_owned(),
+        }
+    }
 }
 
 /// Trace file rotation settings.

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -25,8 +25,8 @@ pub use maintenance::{
     CircuitBreakerSettings, CredentialConfig, CronTaskEntry, CronTaskSettings,
     DbMonitoringSettings, DiskSpaceSettings, DriftDetectionSettings, KnowledgeGraphMcpConfig,
     LoggingSettings, MaintenanceSettings, McpConfig, McpRateLimitConfig, PromptAuditSettings,
-    RedactionSettings, RepomixMcpConfig, RetentionSettings, SandboxSettings, TraceRotationSettings,
-    WatchdogSettings,
+    RedactionSettings, RepomixMcpConfig, RetentionSettings, SandboxSettings,
+    SerendipityMaintenanceSettings, TraceRotationSettings, WatchdogSettings,
 };
 pub use resolved::{
     AgentCapabilities, ResolvedModelConfig, ResolvedNousConfig, TokenLimits, resolve_nous,

--- a/crates/taxis/src/config_tests.rs
+++ b/crates/taxis/src/config_tests.rs
@@ -146,6 +146,15 @@ fn defaults_are_sensible() {
         "retention should be disabled by default"
     );
     assert!(
+        !config.maintenance.knowledge_maintenance_serendipity.enabled,
+        "serendipity discovery should be disabled by default"
+    );
+    assert_eq!(
+        config.maintenance.knowledge_maintenance_serendipity.cadence,
+        "0 0 7 * * *",
+        "default serendipity cadence should run daily at 07:00 UTC"
+    );
+    assert!(
         config.pricing.is_empty(),
         "pricing map should be empty by default"
     );
@@ -205,6 +214,25 @@ fn knowledge_roundtrip_with_serendipity_weight() {
     assert!(
         (back.recall_serendipity_weight - 0.25).abs() < f64::EPSILON,
         "serendipity weight should survive serde roundtrip"
+    );
+}
+
+#[test]
+fn maintenance_roundtrip_with_serendipity_settings() {
+    let config = MaintenanceSettings {
+        knowledge_maintenance_serendipity: SerendipityMaintenanceSettings {
+            enabled: true,
+            cadence: "0 0 7 * * *".to_owned(),
+        },
+        ..MaintenanceSettings::default()
+    };
+    let json = serde_json::to_string(&config).expect("serialize maintenance config");
+    let back: MaintenanceSettings =
+        serde_json::from_str(&json).expect("deserialize maintenance config");
+    assert!(back.knowledge_maintenance_serendipity.enabled);
+    assert_eq!(
+        back.knowledge_maintenance_serendipity.cadence,
+        "0 0 7 * * *"
     );
 }
 


### PR DESCRIPTION
Q2 chunk 2c — the final serendipity chunk. Adds a default-OFF idle daemon task that runs the 2a engine over recently-active entities (query_facts → top-5 seeds → build_serendipity_snapshot → from_graph_context → random_walk → surprise/discovery scoring → select_injection) and records discoveries in a SerendipityDiscoveryReport; they surface via the 2b recall factor once recall_serendipity_weight>0. Default enabled:false → a default deployment schedules nothing. Daily 07:00 cron, spawn_blocking for sync CozoDB, no panics, exhaustiveness compiler-enforced. 2319 tests pass. Adversarially reviewed: engine genuinely runs end-to-end (not a stub), default provably inert, tests real. Follow-up: #NEW (cfg-gate the new store refs behind mneme-engine for standalone-episteme hygiene — non-blocking, CI unifies). Completes Q2 (engine 2a + recall factor 2b + idle discovery 2c).