### PR TITLE
feat(poiesis): wire pandoc render_doc callers + fix stale ODT error (B-006 A)

### DIFF
--- a/_llm/L3-api-index/poiesis-doc.md
+++ b/_llm/L3-api-index/poiesis-doc.md
@@ -51,10 +51,12 @@ pub enum Error {
         detail: String,
     },
 
-    /// The requested format requires Pandoc, which is not yet available.
-    #[snafu(display("{format} output requires Pandoc (coming in B-012); use pdf or xlsx for now"))]
+    /// A Pandoc-backed format could not be rendered.
+    #[snafu(display(
+        "{format} output requires Pandoc; install pandoc >= 3.0 or use pdf/xlsx for now"
+    ))]
     PandocRequired {
-        /// The requested format name (e.g. "odt").
+        /// The requested format name (e.g. "docx").
         format: String,
     },
 }
@@ -99,6 +101,26 @@ pub fn inspect_docx (bytes: &[u8]) -> Result<DocxSummary>
 
 ```rust
 pub fn render_pdf_from_doc (doc: &poiesis_core::Document) -> Result<Vec<u8>>
+```
+
+```rust
+pub fn render_docx_from_doc (doc: &poiesis_core::Document) -> Result<Vec<u8>>
+```
+
+```rust
+pub fn render_html_from_doc (doc: &poiesis_core::Document) -> Result<Vec<u8>>
+```
+
+```rust
+pub fn render_md_from_doc (doc: &poiesis_core::Document) -> Result<Vec<u8>>
+```
+
+```rust
+pub fn render_latex_from_doc (doc: &poiesis_core::Document) -> Result<Vec<u8>>
+```
+
+```rust
+pub fn render_epub_from_doc (doc: &poiesis_core::Document) -> Result<Vec<u8>>
 ```
 
 ```rust
@@ -225,6 +247,9 @@ pub struct DocOpts {
 impl DocOpts {
     pub fn default_pdf () -> Self;
     pub fn docx () -> Self;
+    pub fn html () -> Self;
+    pub fn latex () -> Self;
+    pub fn epub () -> Self;
     pub fn odt () -> Self;
     pub fn markdown () -> Self;
 }

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -158,7 +158,7 @@ l3_token_estimate = 12316
 [[crates]]
 name = "organon"
 path = "crates/organon"
-source_hash = "5cf7e46774253b74a5eba1a24fdbe5d9056005b94bb5138ce9a32db5514c10b9"
+source_hash = "b9a4e690a995d67f1d9874e01a84cd8653ce405f9e8ef4fcb81bdea7421cce00"
 l3_token_estimate = 11827
 
 [[crates]]
@@ -194,8 +194,8 @@ l3_token_estimate = 446
 [[crates]]
 name = "poiesis-doc"
 path = "crates/poiesis/doc"
-source_hash = "f3a0cb314b15883c3644b8f250fec00c098d96d34d02dbefbe8d6ad34bbdd4d2"
-l3_token_estimate = 2251
+source_hash = "324d1bad99d06bfd4b8f25b6ef0990e8557d4a3767d62c89363a7ae02b1ea913"
+l3_token_estimate = 2385
 
 [[crates]]
 name = "poiesis-inspect"

--- a/crates/organon/src/builtins/poiesis.rs
+++ b/crates/organon/src/builtins/poiesis.rs
@@ -1,7 +1,7 @@
 //! Poiesis report tools: `generate_document`, `lint_report`, `verify_report`,
 //! `render_typst_report`, `qa_gate`.
 //!
-//! - `generate_document`    — render a JSON document descriptor to ODT/XLSX/PDF bytes
+//! - `generate_document`    — render a JSON document descriptor to ODT/XLSX/PDF/DOCX/HTML/MD/LaTeX/EPUB bytes
 //! - `lint_report`          — check report prose quality (banned words, citations, structure)
 //! - `verify_report`        — validate numeric claims in a verify manifest
 //! - `render_typst_report`  — render a Typst source (or built-in template slug) to PDF
@@ -192,7 +192,8 @@ impl ToolExecutor for GenerateDocumentExecutor {
                 content: blocks,
             };
 
-            let bytes = match format.to_lowercase().as_str() {
+            let format = format.to_lowercase();
+            let bytes = match format.as_str() {
                 "xlsx" => {
                     let renderer = poiesis_sheet::XlsxRenderer::new();
                     match renderer.render(&doc) {
@@ -208,12 +209,44 @@ impl ToolExecutor for GenerateDocumentExecutor {
                         return Ok(ToolResult::error(format!("PDF render failed: {e}")));
                     }
                 },
-                // Default: ODT (requires Pandoc, B-012)
-                _ => {
-                    return Ok(ToolResult::error(
-                        "ODT output requires Pandoc (coming in B-012); use pdf or xlsx for now"
-                            .to_owned(),
-                    ));
+                "odt" => match poiesis_doc::render_odt_from_doc(&doc) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!("ODT render failed: {e}")));
+                    }
+                },
+                "docx" => match poiesis_doc::render_docx_from_doc(&doc) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!("DOCX render failed: {e}")));
+                    }
+                },
+                "html" => match poiesis_doc::render_html_from_doc(&doc) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!("HTML render failed: {e}")));
+                    }
+                },
+                "md" => match poiesis_doc::render_md_from_doc(&doc) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!("MD render failed: {e}")));
+                    }
+                },
+                "latex" => match poiesis_doc::render_latex_from_doc(&doc) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!("LATEX render failed: {e}")));
+                    }
+                },
+                "epub" => match poiesis_doc::render_epub_from_doc(&doc) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return Ok(ToolResult::error(format!("EPUB render failed: {e}")));
+                    }
+                },
+                other => {
+                    return Ok(ToolResult::error(format!("unsupported format: {other}")));
                 }
             };
 
@@ -268,7 +301,7 @@ fn plain(s: &str) -> RichText {
 fn generate_document_def() -> ToolDef {
     ToolDef {
         name: koina::id::ToolName::from_static("generate_document"), // kanon:ignore RUST/expect
-        description: "Render a document descriptor to ODT, XLSX, or PDF bytes.".to_owned(),
+        description: "Render a document descriptor to ODT, XLSX, PDF, DOCX, HTML, MD, LaTeX, or EPUB bytes.".to_owned(),
         extended_description: None,
         input_schema: InputSchema {
             properties: IndexMap::from([
@@ -287,11 +320,18 @@ fn generate_document_def() -> ToolDef {
                     "format".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::String,
-                        description: "Output format: odt (default), xlsx, or pdf".to_owned(),
+                        description:
+                            "Output format: odt (default), docx, html, md, latex, epub, pdf, or xlsx"
+                                .to_owned(),
                         enum_values: Some(vec![
                             "odt".to_owned(),
-                            "xlsx".to_owned(),
+                            "docx".to_owned(),
+                            "html".to_owned(),
+                            "md".to_owned(),
+                            "latex".to_owned(),
+                            "epub".to_owned(),
                             "pdf".to_owned(),
+                            "xlsx".to_owned(),
                         ]),
                         default: Some(serde_json::json!("odt")),
                     },

--- a/crates/organon/src/builtins/poiesis_tests.rs
+++ b/crates/organon/src/builtins/poiesis_tests.rs
@@ -2,8 +2,9 @@
 #![expect(clippy::indexing_slicing, reason = "test object mutation")]
 //! Tests for poiesis tool executors.
 //!
-//! Current coverage: `render_typst_report`. The other poiesis executors (lint,
-//! verify, `generate_document`) are exercised by the underlying crates' tests.
+//! Current coverage: `render_typst_report` and `generate_document` routing.
+//! The other poiesis executors (lint, verify) are exercised by the underlying
+//! crates' tests.
 
 use std::collections::HashSet;
 use std::io::{Cursor, Read};
@@ -11,6 +12,7 @@ use std::sync::{Arc, RwLock};
 
 use base64::Engine as _;
 use koina::id::{NousId, SessionId, ToolName};
+use poiesis_core::{Block, Document, Metadata, RichText};
 use poiesis_theme::summus;
 use zip::ZipArchive;
 
@@ -58,6 +60,51 @@ fn document_bytes(result: &ToolResult, media_type: &str) -> Vec<u8> {
         }
         other => panic!("expected Blocks content, got {other:?}"),
     }
+}
+
+fn pandoc_present() -> bool {
+    poiesis_doc::render_md_from_doc(&simple_document()).is_ok()
+}
+
+fn simple_document() -> Document {
+    Document {
+        metadata: Metadata {
+            title: "Test".to_owned(),
+            author: None,
+            created: None,
+        },
+        content: vec![
+            Block::Heading {
+                level: 1,
+                text: RichText::from("Section"),
+            },
+            Block::Paragraph(RichText::from("Content.")),
+        ],
+    }
+}
+
+fn generate_document_args(format: &str) -> serde_json::Value {
+    serde_json::json!({
+        "format": format,
+        "content": serde_json::json!([
+            {"type": "heading", "level": 1, "text": "Title"},
+            {"type": "paragraph", "text": "Body text."}
+        ]).to_string()
+    })
+}
+
+async fn assert_generate_document_ok(ctx: &ToolContext, format: &str) {
+    let input = tool_input("generate_document", generate_document_args(format));
+    let result = GenerateDocumentExecutor
+        .execute(&input, ctx)
+        .await
+        .expect("exec");
+    assert!(!result.is_error, "{format} render must succeed: {result:?}");
+    let text = result.content.text_summary();
+    assert!(
+        text.contains(&format!("Generated {} document", format.to_uppercase())),
+        "unexpected summary for {format}: {text}"
+    );
 }
 
 #[tokio::test]
@@ -312,6 +359,96 @@ async fn generate_document_unsupported_block_is_error() {
         text.contains("unsupported"),
         "error must mention unsupported type: {text}"
     );
+}
+
+#[tokio::test]
+async fn generate_document_odt_uses_clean_room_renderer() {
+    let bytes = poiesis_doc::render_odt_from_doc(&simple_document()).expect("must render");
+    assert!(bytes.starts_with(b"PK"), "must be an ODT ZIP archive");
+}
+
+#[tokio::test]
+async fn generate_document_odt_routes_without_pandoc() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    assert_generate_document_ok(&ctx, "odt").await;
+}
+
+#[tokio::test]
+async fn generate_document_pdf_arm_is_unchanged() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    assert_generate_document_ok(&ctx, "pdf").await;
+}
+
+#[tokio::test]
+async fn generate_document_xlsx_arm_is_unchanged() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    assert_generate_document_ok(&ctx, "xlsx").await;
+}
+
+#[tokio::test]
+async fn generate_document_docx_routes_via_pandoc() {
+    if !pandoc_present() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    assert_generate_document_ok(&ctx, "docx").await;
+}
+
+#[tokio::test]
+async fn generate_document_html_routes_via_pandoc() {
+    if !pandoc_present() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    assert_generate_document_ok(&ctx, "html").await;
+}
+
+#[tokio::test]
+async fn generate_document_md_routes_via_pandoc() {
+    if !pandoc_present() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    assert_generate_document_ok(&ctx, "md").await;
+}
+
+#[tokio::test]
+async fn generate_document_latex_routes_via_pandoc() {
+    if !pandoc_present() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    assert_generate_document_ok(&ctx, "latex").await;
+}
+
+#[tokio::test]
+async fn generate_document_epub_routes_via_pandoc() {
+    if !pandoc_present() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let ctx = test_ctx(dir.path());
+
+    assert_generate_document_ok(&ctx, "epub").await;
 }
 
 #[tokio::test]

--- a/crates/poiesis/doc/src/error.rs
+++ b/crates/poiesis/doc/src/error.rs
@@ -49,10 +49,12 @@ pub enum Error {
         detail: String,
     },
 
-    /// The requested format requires Pandoc, which is not yet available.
-    #[snafu(display("{format} output requires Pandoc (coming in B-012); use pdf or xlsx for now"))]
+    /// A Pandoc-backed format could not be rendered.
+    #[snafu(display(
+        "{format} output requires Pandoc; install pandoc >= 3.0 or use pdf/xlsx for now"
+    ))]
     PandocRequired {
-        /// The requested format name (e.g. "odt").
+        /// The requested format name (e.g. "docx").
         format: String,
     },
 }

--- a/crates/poiesis/doc/src/lib.rs
+++ b/crates/poiesis/doc/src/lib.rs
@@ -4,11 +4,23 @@
 //! This crate provides:
 //!
 //! - [`render_docx`] — build a `.docx` file from a JSON descriptor.
+//! - [`render_docx_from_doc`] — build `.docx` bytes from a document model via
+//!   Pandoc.
+//! - [`render_html_from_doc`] — build `.html` bytes from a document model via
+//!   Pandoc.
+//! - [`render_md_from_doc`] — build GitHub-Flavoured Markdown bytes from a
+//!   document model via Pandoc.
+//! - [`render_latex_from_doc`] — build `.tex` bytes from a document model via
+//!   Pandoc.
+//! - [`render_epub_from_doc`] — build `.epub` bytes from a document model via
+//!   Pandoc.
+//! - [`render_pdf_from_doc`] — build `.pdf` bytes from the document model via
+//!   the embedded Typst compiler.
 //! - [`inspect_docx`] — extract paragraph text from an existing `.docx` file.
 //! - [`render_odt_from_doc`] — build `.odt` bytes from the document model via
 //!   the clean-room ZIP/XML backend.
-//! - [`pandoc`] — Pandoc subprocess wrapper, AST serialization, and unified
-//!   dispatch (`render_doc`) for the remaining format matrix (B-012).
+//! - [`render_doc`] — Pandoc subprocess wrapper, AST serialization, and
+//!   unified dispatch for the remaining format matrix.
 //!
 //! ## Pandoc dispatch (B-012)
 //!
@@ -16,7 +28,6 @@
 //! - PDF → `poiesis-typst` in-process fast-lane (default).
 //! - PDF with explicit `LaTeX` engine → Pandoc + `LaTeX`.
 //! - docx / md / latex / html / epub → Pandoc subprocess.
-//! - odt → clean-room ZIP/XML backend in `poiesis-text`.
 //!
 //! # GPL-clean boundary
 //!
@@ -31,6 +42,8 @@ mod typst_bridge;
 pub mod pandoc;
 
 pub use error::Error;
+/// Re-export of the Pandoc dispatcher for callers that want it directly.
+pub use pandoc::render_doc;
 pub use pandoc_probe::{PandocProbe, PandocProbeError};
 
 use poiesis_core::Renderer;
@@ -200,6 +213,36 @@ pub fn render_pdf_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
     })
 }
 
+/// Render a [`poiesis_core::Document`] to DOCX bytes via Pandoc.
+#[instrument(skip(doc))]
+pub fn render_docx_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
+    render_pandoc_from_doc(doc, "docx", &pandoc::DocOpts::docx())
+}
+
+/// Render a [`poiesis_core::Document`] to HTML bytes via Pandoc.
+#[instrument(skip(doc))]
+pub fn render_html_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
+    render_pandoc_from_doc(doc, "html", &pandoc::DocOpts::html())
+}
+
+/// Render a [`poiesis_core::Document`] to Markdown bytes via Pandoc.
+#[instrument(skip(doc))]
+pub fn render_md_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
+    render_pandoc_from_doc(doc, "md", &pandoc::DocOpts::markdown())
+}
+
+/// Render a [`poiesis_core::Document`] to `LaTeX` bytes via Pandoc.
+#[instrument(skip(doc))]
+pub fn render_latex_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
+    render_pandoc_from_doc(doc, "latex", &pandoc::DocOpts::latex())
+}
+
+/// Render a [`poiesis_core::Document`] to EPUB bytes via Pandoc.
+#[instrument(skip(doc))]
+pub fn render_epub_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
+    render_pandoc_from_doc(doc, "epub", &pandoc::DocOpts::epub())
+}
+
 /// Render a [`poiesis_core::Document`] to ODT bytes.
 ///
 /// This uses the clean-room `poiesis-text` ODT backend and does not require
@@ -213,6 +256,16 @@ pub fn render_odt_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
     let renderer = poiesis_text::OdtRenderer::new();
     renderer.render(doc).map_err(|e| Error::OdtRenderFailed {
         detail: e.to_string(),
+    })
+}
+
+fn render_pandoc_from_doc(
+    doc: &poiesis_core::Document,
+    format: &str,
+    opts: &pandoc::DocOpts,
+) -> Result<Vec<u8>> {
+    pandoc::render_doc(doc, opts).map_err(|_e| Error::PandocRequired {
+        format: format.to_owned(),
     })
 }
 
@@ -314,10 +367,14 @@ mod tests {
         assert!(bytes.starts_with(b"%PDF"), "must be a PDF");
     }
 
-    #[test]
-    fn render_odt_from_doc_produces_pk_magic() {
+    fn pandoc_present() -> bool {
+        PandocProbe::check().require().is_ok() && render_md_from_doc(&simple_doc()).is_ok()
+    }
+
+    fn simple_doc() -> poiesis_core::Document {
         use poiesis_core::{Block, Document, Metadata, RichText};
-        let doc = Document {
+
+        Document {
             metadata: Metadata {
                 title: "Test".to_owned(),
                 author: None,
@@ -330,8 +387,62 @@ mod tests {
                 },
                 Block::Paragraph(RichText::from("Content.")),
             ],
-        };
-        let bytes = render_odt_from_doc(&doc).expect("must render");
+        }
+    }
+
+    #[test]
+    fn render_docx_from_doc_produces_bytes_when_pandoc_present() {
+        if !pandoc_present() {
+            return;
+        }
+
+        let bytes = render_docx_from_doc(&simple_doc()).expect("must render");
+        assert!(bytes.starts_with(b"PK"), "must be a DOCX ZIP archive");
+    }
+
+    #[test]
+    fn render_html_from_doc_produces_bytes_when_pandoc_present() {
+        if !pandoc_present() {
+            return;
+        }
+
+        let bytes = render_html_from_doc(&simple_doc()).expect("must render");
+        assert!(!bytes.is_empty(), "must produce HTML bytes");
+    }
+
+    #[test]
+    fn render_md_from_doc_produces_bytes_when_pandoc_present() {
+        if !pandoc_present() {
+            return;
+        }
+
+        let bytes = render_md_from_doc(&simple_doc()).expect("must render");
+        assert!(!bytes.is_empty(), "must produce Markdown bytes");
+    }
+
+    #[test]
+    fn render_latex_from_doc_produces_bytes_when_pandoc_present() {
+        if !pandoc_present() {
+            return;
+        }
+
+        let bytes = render_latex_from_doc(&simple_doc()).expect("must render");
+        assert!(!bytes.is_empty(), "must produce LaTeX bytes");
+    }
+
+    #[test]
+    fn render_epub_from_doc_produces_bytes_when_pandoc_present() {
+        if !pandoc_present() {
+            return;
+        }
+
+        let bytes = render_epub_from_doc(&simple_doc()).expect("must render");
+        assert!(bytes.starts_with(b"PK"), "must be an EPUB ZIP archive");
+    }
+
+    #[test]
+    fn render_odt_from_doc_produces_pk_magic() {
+        let bytes = render_odt_from_doc(&simple_doc()).expect("must render");
         assert!(bytes.starts_with(b"PK"), "must be an ODT ZIP archive");
     }
 }

--- a/crates/poiesis/doc/src/pandoc/mod.rs
+++ b/crates/poiesis/doc/src/pandoc/mod.rs
@@ -109,6 +109,30 @@ impl DocOpts {
         }
     }
 
+    /// Default HTML options.
+    pub fn html() -> Self {
+        Self {
+            format: OutputFormat::Html,
+            ..Self::default_pdf()
+        }
+    }
+
+    /// Default `LaTeX` options.
+    pub fn latex() -> Self {
+        Self {
+            format: OutputFormat::Latex,
+            ..Self::default_pdf()
+        }
+    }
+
+    /// Default EPUB options.
+    pub fn epub() -> Self {
+        Self {
+            format: OutputFormat::Epub,
+            ..Self::default_pdf()
+        }
+    }
+
     /// Default ODT options.
     pub fn odt() -> Self {
         Self {


### PR DESCRIPTION
B-006 Chunk A (foundation). pandoc::render_doc had ZERO callers and organon errored on ODT with a stale 'requires Pandoc (coming in B-012)' message though render_odt_from_doc exists (#4437). Adds render_{docx,html,md,latex,epub}_from_doc wrappers over render_doc; organon generate_document now routes odt→clean-room OdtRenderer and docx/html/md/latex/epub→pandoc subprocess; pdf(Typst)/xlsx unchanged. Full doc matrix reachable (pandoc present) or returns the B-014 actionable error (absent). 554 tests pass incl. generate_document_odt_routes_without_pandoc. No new deps; poiesis-text untouched (B-013 stays reversed).