### PR TITLE
fix(episteme,oikonomos): prosoche test fields + cfg-gate serendipity store (#4444)

### DIFF
--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -86,7 +86,7 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "297fa5e9138a147dc51be0072c78c48537f4357e5c82e59c42730bf6ebcdc0ad"
+source_hash = "68d1c9813ec230fdbe386e184d4ceab2fd4ffbe52a3fb8f4accb360d3a93b131"
 l3_token_estimate = 32790
 
 [[crates]]
@@ -152,7 +152,7 @@ l3_token_estimate = 34413
 [[crates]]
 name = "oikonomos"
 path = "crates/daemon"
-source_hash = "3d996e1125c7468e879c93b525ba8c3d91cfd48084263053980d80cdbb446b66"
+source_hash = "92854cf1497308ab4932ccf570fdb82a2fc0da93b5b8768cb2a9af8dc5de967b"
 l3_token_estimate = 12453
 
 [[crates]]

--- a/crates/daemon/src/prosoche_tests.rs
+++ b/crates/daemon/src/prosoche_tests.rs
@@ -238,6 +238,7 @@ mod knowledge_store_tests {
             fact_type: "observation".to_owned(),
             content: content.to_owned(),
             scope: None,
+            project_id: None,
             temporal: episteme::knowledge::FactTemporal {
                 valid_from: jiff::Timestamp::now(),
                 valid_to: jiff::Timestamp::from_second(253_402_207_200).expect("far future"),
@@ -260,6 +261,7 @@ mod knowledge_store_tests {
                 last_accessed_at: None,
             },
             sensitivity: episteme::knowledge::FactSensitivity::Public,
+            visibility: episteme::knowledge::Visibility::Private,
         }
     }
 

--- a/crates/episteme/src/serendipity/mod.rs
+++ b/crates/episteme/src/serendipity/mod.rs
@@ -5,17 +5,28 @@
 //! - **Surprise scoring**: identify facts the agent hasn't accessed recently
 //! - **Path exploration**: find paths between seemingly unrelated entities
 //! - **Serendipity injection**: select "did you know?" facts for context injection
+#![cfg_attr(
+    all(not(test), not(feature = "mneme-engine")),
+    expect(
+        dead_code,
+        reason = "serendipity engine helpers are used by gated callers"
+    )
+)]
 
-use std::collections::BTreeMap;
-use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
-use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
 
 use crate::graph_intelligence::GraphContext;
 use crate::id::EntityId;
+#[cfg(feature = "mneme-engine")]
 use crate::knowledge_store::{KnowledgeStore, SerendipityDiscoveryReport};
+#[cfg(feature = "mneme-engine")]
+use std::collections::BTreeMap;
+#[cfg(feature = "mneme-engine")]
+use std::collections::hash_map::DefaultHasher;
+#[cfg(feature = "mneme-engine")]
+use std::hash::{Hash, Hasher};
 
 /// Configuration for the serendipity engine.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -601,6 +612,7 @@ fn reconstruct_path(
     }
 }
 
+#[cfg(feature = "mneme-engine")]
 #[derive(Debug, Clone, Copy)]
 struct EntityActivity {
     last_access_hours: f64,
@@ -608,6 +620,7 @@ struct EntityActivity {
     recorded_at: jiff::Timestamp,
 }
 
+#[cfg(feature = "mneme-engine")]
 impl EntityActivity {
     fn new(last_access_hours: f64, access_count: u32, recorded_at: jiff::Timestamp) -> Self {
         Self {
@@ -626,6 +639,7 @@ impl EntityActivity {
     }
 }
 
+#[cfg(feature = "mneme-engine")]
 #[expect(
     clippy::too_many_lines,
     reason = "orchestrates the full serendipity maintenance flow"
@@ -833,6 +847,7 @@ pub(crate) fn discover_serendipitous_facts(
     })
 }
 
+#[cfg(feature = "mneme-engine")]
 fn fact_entity_ids(store: &KnowledgeStore, fact_id: &str) -> crate::error::Result<Vec<String>> {
     let mut params = BTreeMap::new();
     params.insert(


### PR DESCRIPTION
Two feature-gate fixes, prereq for Q8 (#4414). (1) oikonomos/daemon prosoche Fact test helper E0063 — adds project_id/visibility (a --all-features error CI never built). (2) Closes #4444: the Q2-2c serendipity store-discovery code referenced the mneme-engine-gated KnowledgeStore unconditionally, breaking `cargo check -p episteme` (default features); now cfg-gated behind mneme-engine (import + discover_serendipitous_facts + fact_entity_ids + EntityActivity), engine algorithms left ungated. Verified BOTH `cargo check -p episteme` and `--features mneme-engine` compile clean; 1697 tests pass. NOTE: the audit's third item (reranker unwrap) is moot — zero .unwrap() in reranker on current main. The --all-features gate addition itself follows as a separate CI-iterated step.