### PR TITLE
feat(poiesis): chart figure embedding via resvg SVG→PNG (B-006 C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7047,10 +7047,12 @@ name = "poiesis-doc"
 version = "0.30.0"
 dependencies = [
  "docx-rs",
+ "poiesis-charts",
  "poiesis-core",
  "poiesis-text",
  "poiesis-typst",
  "quick-xml 0.39.2",
+ "resvg",
  "serde",
  "serde_json",
  "snafu",

--- a/_llm/L3-api-index/poiesis-doc.md
+++ b/_llm/L3-api-index/poiesis-doc.md
@@ -195,6 +195,58 @@ pub enum PandocError {
         /// Underlying I/O error.
         source: std::io::Error,
     },
+
+    /// A chart figure could not be rendered into SVG.
+    #[snafu(display("failed to render figure {figure_id}: {source}"))]
+    FigureRenderFailed {
+        /// Stable figure identifier.
+        figure_id: String,
+        /// Underlying figure rendering error.
+        source: super::figure::FigureError,
+    },
+
+    /// A chart figure SVG could not be rasterized into PNG.
+    #[snafu(display("failed to rasterize figure {figure_id}: {source}"))]
+    FigureRasterizeFailed {
+        /// Stable figure identifier.
+        figure_id: String,
+        /// Underlying SVG rasterization error.
+        source: crate::raster::RasterError,
+    },
+}
+```
+
+## `src/pandoc/figure.rs`
+
+```rust
+pub enum FigureError {
+    /// The embedded figure bytes were not valid UTF-8.
+    #[snafu(display("figure SVG is not valid UTF-8: {source}"))]
+    Utf8 {
+        /// Underlying UTF-8 error.
+        source: std::str::Utf8Error,
+    },
+
+    /// The embedded figure bytes were not valid JSON.
+    #[snafu(display("figure chart JSON is invalid: {source}"))]
+    Json {
+        /// Underlying JSON parse error.
+        source: serde_json::Error,
+    },
+
+    /// The figure MIME type is not supported by the chart path.
+    #[snafu(display("unsupported figure MIME type: {mime}"))]
+    UnsupportedMime {
+        /// Observed MIME type.
+        mime: String,
+    },
+
+    /// Chart rendering failed.
+    #[snafu(display("chart render failed: {source}"))]
+    ChartRender {
+        /// Underlying chart renderer error.
+        source: poiesis_charts::Error,
+    },
 }
 ```
 
@@ -355,6 +407,35 @@ pub enum PandocProbeError {
         found: PandocVersion,
         /// Minimum version required.
         required: PandocVersion,
+    },
+}
+```
+
+## `src/raster.rs`
+
+```rust
+pub enum RasterError {
+    /// SVG parsing failed.
+    #[snafu(display("invalid SVG: {source}"))]
+    ParseSvg {
+        /// Underlying SVG parse error.
+        source: usvg::Error,
+    },
+
+    /// Pixmap allocation failed for the rendered size.
+    #[snafu(display("failed to allocate pixmap {width}x{height}"))]
+    PixmapAlloc {
+        /// Output width in pixels.
+        width: u32,
+        /// Output height in pixels.
+        height: u32,
+    },
+
+    /// PNG encoding failed after rendering.
+    #[snafu(display("PNG encoding failed: {message}"))]
+    EncodePng {
+        /// Human-readable PNG encoding error.
+        message: String,
     },
 }
 ```

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -194,8 +194,8 @@ l3_token_estimate = 446
 [[crates]]
 name = "poiesis-doc"
 path = "crates/poiesis/doc"
-source_hash = "984834d60af142062e7c373b5ca4faac7532ee1563fb52f16bd6166ab5e35bcb"
-l3_token_estimate = 2403
+source_hash = "7c845a7e3c3bb8108e8da690076821a51fadbfd9073c9fad20da20409f36f33a"
+l3_token_estimate = 2960
 
 [[crates]]
 name = "poiesis-inspect"

--- a/crates/poiesis/doc/Cargo.toml
+++ b/crates/poiesis/doc/Cargo.toml
@@ -25,8 +25,12 @@ quick-xml = "0.39"
 poiesis-text = { path = "../text", default-features = false, features = ["odt"] }
 
 # Document model + Typst fast-lane (B-012/B-013)
+poiesis-charts = { path = "../charts" }
 poiesis-core = { path = "../core" }
 poiesis-typst = { path = "../typst" }
+
+# Pure-Rust SVG rasterizer for chart figures.
+resvg = "0.45.1"
 
 # Pandoc binary discovery for the availability probe
 which = "8"

--- a/crates/poiesis/doc/src/lib.rs
+++ b/crates/poiesis/doc/src/lib.rs
@@ -36,6 +36,7 @@
 
 mod error;
 mod pandoc_probe;
+mod raster;
 mod typst_bridge;
 
 /// Pandoc subprocess wrapper, AST serialization, and format dispatch (B-012).

--- a/crates/poiesis/doc/src/pandoc/ast.rs
+++ b/crates/poiesis/doc/src/pandoc/ast.rs
@@ -4,7 +4,7 @@
 //! (`pandoc -f json`). The mapping is near-identity per B-006 § 1, with the
 //! typed note/cite/math/raw-block forms carried directly into the AST.
 
-use poiesis_core::{Block, Document, NoteKind, RichText, Span};
+use poiesis_core::{Block, Document, Image as DocImage, NoteKind, RichText, Span};
 use serde_json::{Value, json};
 
 /// Serialize a `Document` to Pandoc JSON AST bytes.
@@ -12,7 +12,12 @@ use serde_json::{Value, json};
 /// The emitted JSON matches Pandoc's `--from json` input format.
 /// `pandoc-api-version` is pinned to `[1, 23, 1, 1]` for Pandoc 3.7.x.
 pub fn document_to_pandoc_json(doc: &Document) -> Vec<u8> {
-    let blocks: Vec<Value> = doc.content.iter().map(block_to_pandoc).collect();
+    let mut figure_index = 0usize;
+    let blocks: Vec<Value> = doc
+        .content
+        .iter()
+        .map(|block| block_to_pandoc(block, &mut figure_index))
+        .collect();
 
     let ast = json!({
         "pandoc-api-version": [1, 23, 1, 1],
@@ -47,7 +52,7 @@ fn build_meta(doc: &Document) -> Value {
     Value::Object(meta)
 }
 
-fn block_to_pandoc(block: &Block) -> Value {
+fn block_to_pandoc(block: &Block, figure_index: &mut usize) -> Value {
     match block {
         Block::Heading { level, text } => {
             let level_val = u64::from((*level).clamp(1, 6));
@@ -146,15 +151,48 @@ fn block_to_pandoc(block: &Block) -> Value {
                 json!({ "t": "BulletList", "c": inlines })
             }
         }
-        Block::Image(_) => {
-            // Images not yet supported — emit a placeholder Para.
-            // TODO(B-005/B-012): wire apx-figure.lua chart emitter.
-            json!({
-                "t": "Para",
-                "c": [{"t": "Str", "c": "[image placeholder]"}]
-            })
-        }
+        Block::Image(image) => image_to_pandoc(image, figure_index),
     }
+}
+
+fn image_to_pandoc(image: &DocImage, figure_index: &mut usize) -> Value {
+    let figure_id = super::figure::figure_id(*figure_index);
+    *figure_index += 1;
+
+    let caption = inline_text(&image.alt);
+    let figure_src = format!("apx-figure://{figure_id}");
+    let figure_id_attr = figure_id.clone();
+    let attr = json!([
+        figure_id_attr,
+        ["apx-figure"],
+        [["data-figure-id", figure_id]]
+    ]);
+
+    json!({
+        "t": "Para",
+        "c": [{
+            "t": "Image",
+            "c": [
+                attr,
+                caption,
+                [figure_src, ""]
+            ]
+        }]
+    })
+}
+
+fn inline_text(text: &str) -> Vec<Value> {
+    let mut inlines = Vec::new();
+    for (idx, word) in text.split_whitespace().enumerate() {
+        if idx > 0 {
+            inlines.push(json!({"t": "Space"}));
+        }
+        inlines.push(json!({"t": "Str", "c": word}));
+    }
+    if inlines.is_empty() {
+        inlines.push(json!({"t": "Str", "c": "Figure"}));
+    }
+    inlines
 }
 
 fn pandoc_cell(content: &Value) -> Value {

--- a/crates/poiesis/doc/src/pandoc/error.rs
+++ b/crates/poiesis/doc/src/pandoc/error.rs
@@ -60,4 +60,22 @@ pub enum PandocError {
         /// Underlying I/O error.
         source: std::io::Error,
     },
+
+    /// A chart figure could not be rendered into SVG.
+    #[snafu(display("failed to render figure {figure_id}: {source}"))]
+    FigureRenderFailed {
+        /// Stable figure identifier.
+        figure_id: String,
+        /// Underlying figure rendering error.
+        source: super::figure::FigureError,
+    },
+
+    /// A chart figure SVG could not be rasterized into PNG.
+    #[snafu(display("failed to rasterize figure {figure_id}: {source}"))]
+    FigureRasterizeFailed {
+        /// Stable figure identifier.
+        figure_id: String,
+        /// Underlying SVG rasterization error.
+        source: crate::raster::RasterError,
+    },
 }

--- a/crates/poiesis/doc/src/pandoc/figure.rs
+++ b/crates/poiesis/doc/src/pandoc/figure.rs
@@ -1,0 +1,87 @@
+//! Figure helpers for Pandoc document export.
+
+use poiesis_charts::render::{Canvas, DocCanvas};
+use poiesis_charts::{
+    Chart, ColorMode as ChartColorMode, ResolvedTheme as ChartResolvedTheme, render_chart,
+};
+use poiesis_core::Image;
+use snafu::ResultExt;
+use snafu::Snafu;
+
+/// Stable figure identifier prefix.
+pub(crate) fn figure_id(index: usize) -> String {
+    format!("apx-figure-{index}")
+}
+
+/// Figure payload parsing and chart rendering errors.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum FigureError {
+    /// The embedded figure bytes were not valid UTF-8.
+    #[snafu(display("figure SVG is not valid UTF-8: {source}"))]
+    Utf8 {
+        /// Underlying UTF-8 error.
+        source: std::str::Utf8Error,
+    },
+
+    /// The embedded figure bytes were not valid JSON.
+    #[snafu(display("figure chart JSON is invalid: {source}"))]
+    Json {
+        /// Underlying JSON parse error.
+        source: serde_json::Error,
+    },
+
+    /// The figure MIME type is not supported by the chart path.
+    #[snafu(display("unsupported figure MIME type: {mime}"))]
+    UnsupportedMime {
+        /// Observed MIME type.
+        mime: String,
+    },
+
+    /// Chart rendering failed.
+    #[snafu(display("chart render failed: {source}"))]
+    ChartRender {
+        /// Underlying chart renderer error.
+        source: poiesis_charts::Error,
+    },
+}
+
+/// Turn a document image payload into SVG bytes.
+///
+/// Supported figure payloads:
+/// - `image/svg+xml` or raw `<svg ...>` bytes: treated as pre-rendered SVG.
+/// - `application/json` or `application/vnd.poiesis.chart+json`: parsed as a
+///   `poiesis_charts::Chart` and rendered to SVG with the resolved `summus`
+///   palette.
+///
+/// # Errors
+///
+/// Returns [`FigureError`] if the payload is malformed or unsupported.
+pub(crate) fn svg_from_image(image: &Image) -> Result<String, FigureError> {
+    let mime = image.mime.trim();
+    let is_svg = mime == "image/svg+xml" || mime.contains("svg");
+    if is_svg || image.data.starts_with(b"<svg") {
+        return std::str::from_utf8(&image.data)
+            .map(std::borrow::ToOwned::to_owned)
+            .context(Utf8Snafu);
+    }
+
+    let is_chart_json =
+        mime.contains("json") || mime.contains("chart") || image.data.starts_with(b"{");
+    if is_chart_json {
+        let chart: Chart = serde_json::from_slice(&image.data).context(JsonSnafu)?;
+        let theme = ChartResolvedTheme::summus_stub();
+        return render_chart(
+            &chart,
+            &theme,
+            &Canvas::Doc(DocCanvas::default()),
+            ChartColorMode::Resolved,
+        )
+        .context(ChartRenderSnafu);
+    }
+
+    UnsupportedMimeSnafu {
+        mime: mime.to_owned(),
+    }
+    .fail()
+}

--- a/crates/poiesis/doc/src/pandoc/mod.rs
+++ b/crates/poiesis/doc/src/pandoc/mod.rs
@@ -21,12 +21,14 @@
 pub mod ast;
 /// Error types for the Pandoc subprocess wrapper.
 pub mod error;
+/// Figure helpers and chart rendering for `Image` payloads.
+pub(crate) mod figure;
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::raster;
 use poiesis_core::Document;
-use serde::Serialize;
 use tracing::instrument;
 
 pub use error::PandocError;
@@ -250,8 +252,7 @@ impl PandocRunner {
             .arg("-f")
             .arg("json")
             .arg("-t")
-            .arg(fmt)
-            .arg(tmp_path);
+            .arg(fmt);
 
         for (key, value) in extra_env {
             cmd.env(key, value);
@@ -274,6 +275,8 @@ impl PandocRunner {
             }
             _ => {}
         }
+
+        cmd.arg(tmp_path);
 
         let output = cmd.output().map_err(|e| PandocError::Spawn { source: e })?;
 
@@ -332,14 +335,21 @@ pub fn render_doc(doc: &Document, opts: &DocOpts) -> Result<Vec<u8>, PandocError
     let mut render_opts = opts.clone();
     render_opts.lua_filters.extend(default_lua_filters());
     let facts_sidecar = write_apx_facts_sidecar(doc)?;
-    let extra_env = vec![(
-        "APX_FACTS".to_owned(),
-        facts_sidecar.path().display().to_string(),
-    )];
+    let figures_sidecar = write_apx_figures_sidecar(doc)?;
+    let extra_env = vec![
+        (
+            "APX_FACTS".to_owned(),
+            facts_sidecar.path().display().to_string(),
+        ),
+        (
+            "APX_FIGURES".to_owned(),
+            figures_sidecar.sidecar.path().display().to_string(),
+        ),
+    ];
     runner.render(&ast_json, &render_opts, &extra_env)
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, serde::Serialize)]
 struct ApxFactSidecarEntry {
     display: String,
     source_footnote: Option<String>,
@@ -347,7 +357,16 @@ struct ApxFactSidecarEntry {
 
 fn default_lua_filters() -> Vec<PathBuf> {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../filters");
-    vec![root.join("apx-cite.lua"), root.join("apx-theme.lua")]
+    vec![
+        root.join("apx-cite.lua"),
+        root.join("apx-theme.lua"),
+        root.join("apx-figure.lua"),
+    ]
+}
+
+struct FigureSidecarArtifacts {
+    sidecar: tempfile::NamedTempFile,
+    _png_files: Vec<tempfile::NamedTempFile>,
 }
 
 fn write_apx_facts_sidecar(doc: &Document) -> Result<tempfile::NamedTempFile, PandocError> {
@@ -383,6 +402,91 @@ fn write_apx_facts_sidecar(doc: &Document) -> Result<tempfile::NamedTempFile, Pa
     tmp.write_all(&serialized)
         .map_err(|source| PandocError::TempFile { source })?;
     Ok(tmp)
+}
+
+fn write_apx_figures_sidecar(doc: &Document) -> Result<FigureSidecarArtifacts, PandocError> {
+    use std::io::Write;
+
+    let mut sidecar = String::from("return {\n");
+    let mut png_files = Vec::new();
+    let mut figure_index = 0usize;
+
+    for block in &doc.content {
+        let poiesis_core::Block::Image(image) = block else {
+            continue;
+        };
+
+        let figure_id = figure::figure_id(figure_index);
+        let svg =
+            figure::svg_from_image(image).map_err(|source| PandocError::FigureRenderFailed {
+                figure_id: figure_id.clone(),
+                source,
+            })?;
+        let png = raster::svg_to_png(&svg, raster::DEFAULT_DPI).map_err(|source| {
+            PandocError::FigureRasterizeFailed {
+                figure_id: figure_id.clone(),
+                source,
+            }
+        })?;
+
+        let mut png_file = tempfile::Builder::new()
+            .suffix(".png")
+            .tempfile()
+            .map_err(|source| PandocError::TempFile { source })?;
+        png_file
+            .write_all(&png)
+            .map_err(|source| PandocError::TempFile { source })?;
+
+        sidecar.push_str("  [");
+        sidecar.push_str(&lua_string_literal(&figure_id));
+        sidecar.push_str("] = {\n");
+        sidecar.push_str("    svg = ");
+        sidecar.push_str(&lua_string_literal(&svg));
+        sidecar.push_str(",\n");
+        sidecar.push_str("    png_path = ");
+        sidecar.push_str(&lua_string_literal(&png_file.path().display().to_string()));
+        sidecar.push_str(",\n");
+        sidecar.push_str("  },\n");
+        png_files.push(png_file);
+        figure_index += 1;
+    }
+
+    sidecar.push_str("}\n");
+
+    let mut tmp = tempfile::Builder::new()
+        .suffix(".lua")
+        .tempfile()
+        .map_err(|source| PandocError::TempFile { source })?;
+    tmp.write_all(sidecar.as_bytes())
+        .map_err(|source| PandocError::TempFile { source })?;
+
+    Ok(FigureSidecarArtifacts {
+        sidecar: tmp,
+        _png_files: png_files,
+    })
+}
+
+fn lua_string_literal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{0008}' => escaped.push_str("\\b"),
+            '\u{000C}' => escaped.push_str("\\f"),
+            ch if ch.is_control() => {
+                use std::fmt::Write as _;
+                let _ = write!(escaped, "\\x{:02X}", u32::from(ch));
+            }
+            ch => escaped.push(ch),
+        }
+    }
+    escaped.push('"');
+    escaped
 }
 
 fn collect_fact_ids_from_block(
@@ -673,6 +777,116 @@ mod tests {
         assert!(
             latex.contains("Mind the gap."),
             "latex output must include the note body"
+        );
+    }
+
+    fn chart_doc() -> Document {
+        use poiesis_charts::model::{
+            AxisSide, Chart, ChartKind, FactCite, FactId, LegendSpec, Point, Series, SeriesStyle,
+            ToneRef, Unit,
+        };
+        use poiesis_core::Image;
+
+        let chart = Chart {
+            kind: ChartKind::Line,
+            title: None,
+            series: vec![Series {
+                name: poiesis_charts::CiteOrText::Text("Revenue".to_owned()),
+                points: vec![
+                    Point {
+                        label: Some(poiesis_charts::CiteOrText::Text("JAN".to_owned())),
+                        x: None,
+                        y: FactCite {
+                            id: FactId("rev-1".to_owned()),
+                            value: 1.0,
+                            unit: Unit::Number,
+                        },
+                    },
+                    Point {
+                        label: Some(poiesis_charts::CiteOrText::Text("FEB".to_owned())),
+                        x: None,
+                        y: FactCite {
+                            id: FactId("rev-2".to_owned()),
+                            value: 2.0,
+                            unit: Unit::Number,
+                        },
+                    },
+                ],
+                tone: ToneRef::Indexed(0),
+                axis: AxisSide::Left,
+                style: SeriesStyle::Default,
+            }],
+            axes: poiesis_charts::Axes::default(),
+            legend: LegendSpec::Auto,
+            data_labels: false,
+            caption: None,
+        };
+
+        let data = serde_json::to_vec(&chart).expect("chart json");
+
+        Document {
+            metadata: Metadata {
+                title: "Chart Figure".to_owned(),
+                author: None,
+                created: None,
+            },
+            content: vec![Block::Image(Image {
+                data,
+                mime: "application/vnd.poiesis.chart+json".to_owned(),
+                alt: "Revenue trend".to_owned(),
+            })],
+        }
+    }
+
+    fn docx_media_entries(bytes: &[u8]) -> Vec<String> {
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor).expect("docx zip");
+        let mut names = Vec::new();
+
+        for idx in 0..archive.len() {
+            let file = archive.by_index(idx).expect("zip entry");
+            let name = file.name().to_owned();
+            if name.contains("media/") {
+                names.push(name);
+            }
+        }
+
+        names
+    }
+
+    #[test]
+    fn chart_figure_renders_png_in_docx() {
+        if !pandoc_available() {
+            return;
+        }
+
+        let bytes = render_docx_from_doc(&chart_doc()).expect("docx must render");
+        let media = docx_media_entries(&bytes);
+        assert!(
+            media.iter().any(|name| {
+                std::path::Path::new(name)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("png"))
+            }),
+            "docx must embed a PNG media entry, got: {media:?}"
+        );
+    }
+
+    #[test]
+    fn chart_figure_renders_svg_in_html() {
+        if !pandoc_available() {
+            return;
+        }
+
+        let html = String::from_utf8(render_html_from_doc(&chart_doc()).expect("html must render"))
+            .expect("html must be utf-8");
+        assert!(
+            html.contains("<svg"),
+            "html output must include inline SVG, got: {html}"
+        );
+        assert!(
+            !html.contains(".png"),
+            "html output must not reference raster PNG assets, got: {html}"
         );
     }
 }

--- a/crates/poiesis/doc/src/raster.rs
+++ b/crates/poiesis/doc/src/raster.rs
@@ -1,0 +1,83 @@
+//! SVG rasterizer for chart figures.
+
+use resvg::tiny_skia;
+use resvg::usvg;
+use snafu::ResultExt;
+use snafu::Snafu;
+
+/// Default rasterization DPI for document figures.
+pub(crate) const DEFAULT_DPI: f32 = 192.0;
+
+/// Rasterization errors.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum RasterError {
+    /// SVG parsing failed.
+    #[snafu(display("invalid SVG: {source}"))]
+    ParseSvg {
+        /// Underlying SVG parse error.
+        source: usvg::Error,
+    },
+
+    /// Pixmap allocation failed for the rendered size.
+    #[snafu(display("failed to allocate pixmap {width}x{height}"))]
+    PixmapAlloc {
+        /// Output width in pixels.
+        width: u32,
+        /// Output height in pixels.
+        height: u32,
+    },
+
+    /// PNG encoding failed after rendering.
+    #[snafu(display("PNG encoding failed: {message}"))]
+    EncodePng {
+        /// Human-readable PNG encoding error.
+        message: String,
+    },
+}
+
+/// Rasterize an SVG string to PNG bytes.
+///
+/// # Errors
+///
+/// Returns [`RasterError`] if the SVG cannot be parsed, rendered, or encoded.
+pub(crate) fn svg_to_png(svg: &str, dpi: f32) -> Result<Vec<u8>, RasterError> {
+    let opt = usvg::Options {
+        dpi,
+        ..usvg::Options::default()
+    };
+
+    let tree = usvg::Tree::from_str(svg, &opt).context(ParseSvgSnafu)?;
+    let size = tree.size().to_int_size();
+    let mut pixmap =
+        tiny_skia::Pixmap::new(size.width(), size.height()).ok_or(RasterError::PixmapAlloc {
+            width: size.width(),
+            height: size.height(),
+        })?;
+
+    let mut pixmap_mut = pixmap.as_mut();
+    resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap_mut);
+    pixmap
+        .encode_png()
+        .map_err(|source| RasterError::EncodePng {
+            message: source.to_string(),
+        })
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rasterizes_svg_to_png() {
+        let png = svg_to_png(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+                 <rect x="0" y="0" width="10" height="10" fill="#232E54"/>
+               </svg>"##,
+            DEFAULT_DPI,
+        )
+        .expect("svg must rasterize");
+        assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
+    }
+}

--- a/crates/poiesis/filters/apx-figure.lua
+++ b/crates/poiesis/filters/apx-figure.lua
@@ -1,17 +1,102 @@
---[[
-apx-figure.lua — select SVG vs PNG per writer for Figure blocks.
+-- NOTE: apx-figure.lua swaps chart figures to SVG or PNG assets per writer.
 
-STUB: passes through unchanged. Full implementation requires:
-- B-005: poiesis-charts SVG emitter API
-- B-012 ESCALATION.md Q4: APX_FIGURES sidecar JSON schema
-- APX_FIGURES env var: JSON mapping figure_id -> { svg, png_path }
+local figures_cache = nil
 
-Format rules (planned):
-- html / latex / typst-pdf: inline/linked SVG
-- docx / odt / epub: PNG bake via resvg at print density
+local function load_figures()
+  if figures_cache ~= nil then
+    return figures_cache
+  end
 
-See ESCALATION.md Q4.
-]]
+  local path = os.getenv("APX_FIGURES")
+  if path == nil or path == "" then
+    figures_cache = {}
+    return figures_cache
+  end
 
--- Identity filter: return blocks unchanged until wired.
-return {}
+  local loader, err = loadfile(path)
+  if loader == nil then
+    figures_cache = {}
+    return figures_cache
+  end
+
+  local ok, decoded = pcall(loader)
+  if ok and type(decoded) == "table" then
+    figures_cache = decoded
+  else
+    figures_cache = {}
+  end
+
+  return figures_cache
+end
+
+local function is_raster_format()
+  return FORMAT == "docx" or FORMAT == "odt" or FORMAT:match("epub") ~= nil
+end
+
+local function figure_id(img)
+  if type(img.identifier) == "string" and img.identifier:match("^apx%-figure%-%d+$") then
+    return img.identifier
+  end
+
+  local fallback = img.attributes["data-figure-id"]
+  if type(fallback) == "string" and fallback:match("^apx%-figure%-%d+$") then
+    return fallback
+  end
+
+  return nil
+end
+
+local function ensure_svg_file(figure_id_value, svg)
+  local path = os.tmpname() .. "-" .. figure_id_value .. ".svg"
+  local handle = assert(io.open(path, "w"))
+  handle:write(svg)
+  handle:close()
+  return path
+end
+
+local function replace_image(img)
+  local id = figure_id(img)
+  if id == nil then
+    return nil
+  end
+
+  local figure = load_figures()[id]
+  if figure == nil then
+    return pandoc.Str("[missing-figure:" .. id .. "]")
+  end
+
+  if is_raster_format() then
+    local png_path = figure.png_path
+    if type(png_path) ~= "string" or png_path == "" then
+      return pandoc.Str("[missing-figure:" .. id .. "]")
+    end
+    return pandoc.Image(img.caption, png_path, img.title, img.attr)
+  end
+
+  local svg = figure.svg
+  if type(svg) ~= "string" or svg == "" then
+    return pandoc.Str("[missing-figure:" .. id .. "]")
+  end
+
+  if FORMAT:match("html") ~= nil then
+    return pandoc.RawInline("html", svg)
+  end
+
+  local svg_path = figure.svg_path
+  if type(svg_path) ~= "string" or svg_path == "" then
+    svg_path = ensure_svg_file(id, svg)
+    figure.svg_path = svg_path
+  end
+
+  return pandoc.Image(img.caption, svg_path, img.title, img.attr)
+end
+
+function Image(img)
+  return replace_image(img)
+end
+
+function Figure(fig)
+  return fig:walk({
+    Image = replace_image,
+  })
+end


### PR DESCRIPTION
B-006 Chunk C. Charts now embed in pandoc-generated documents end-to-end: a chart Block::Image renders via poiesis_charts::render_chart→SVG, then for raster targets (docx/odt/epub) rasterizes to PNG via the pure-Rust resvg (0.45.1, no z3/system libs) at 192 DPI, and inlines/links SVG for html/latex. New raster.rs (svg_to_png) + figure.rs (figure_id, render, APX_FIGURES sidecar mirroring Chunk B's pattern); apx-figure.lua swaps placeholders to the right asset per writer. Replaces the Block::Image placeholder. Tests: chart_figure_renders_png_in_docx, chart_figure_renders_svg_in_html, rasterizes_svg_to_png. Gate green.