### PR TITLE
feat(poiesis): LaTeX content-trigger routing + system-engine probe (B-006 D)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7094,6 +7094,7 @@ dependencies = [
 name = "poiesis-lint"
 version = "0.30.0"
 dependencies = [
+ "poiesis-core",
  "serde",
  "serde_json",
  "snafu",

--- a/_llm/L3-api-index/poiesis-doc.md
+++ b/_llm/L3-api-index/poiesis-doc.md
@@ -44,6 +44,13 @@ pub enum Error {
         detail: String,
     },
 
+    /// PDF rendering needed a system `LaTeX` engine but none was available.
+    #[snafu(display("pdf LaTeX engine unavailable: {source}"))]
+    PdfLatexEngineUnavailable {
+        /// Detailed probing error from the Pandoc `LaTeX` route.
+        source: crate::pandoc::PandocError,
+    },
+
     /// ODT rendering via the clean-room backend failed.
     #[snafu(display("odt render failed: {detail}"))]
     OdtRenderFailed {
@@ -58,6 +65,48 @@ pub enum Error {
     PandocRequired {
         /// The requested format name (e.g. "docx").
         format: String,
+    },
+}
+```
+
+## `src/latex_probe.rs`
+
+```rust
+pub enum LatexProbe {
+    /// A usable system engine was found.
+    Present {
+        /// Selected PDF engine.
+        engine: PdfEngine,
+        /// Absolute path to the chosen binary.
+        path: PathBuf,
+        /// First line reported by `--version`.
+        version: String,
+    },
+    /// Neither `xelatex` nor `lualatex` could be used.
+    Missing {
+        /// Candidate paths that were searched.
+        searched: Vec<PathBuf>,
+    },
+}
+```
+
+```rust
+impl LatexProbe {
+    pub fn check () -> Self;
+    pub fn engine (self) -> Result<PdfEngine, LatexProbeError>;
+}
+```
+
+```rust
+pub enum LatexProbeError {
+    /// Neither `xelatex` nor `lualatex` was usable on PATH.
+    #[snafu(display(
+        "latex engine not found (searched: {}). Install xelatex or lualatex via a TeX distribution such as TeX Live or MacTeX; on NixOS run `nix develop`",
+        format_paths(searched)
+    ))]
+    NotInstalled {
+        /// Candidate paths that were searched.
+        searched: Vec<PathBuf>,
     },
 }
 ```
@@ -173,6 +222,16 @@ pub enum PandocError {
         found_patch: u32,
     },
 
+    /// A LaTeX-backed PDF export needed `xelatex` or `lualatex`, but neither was usable.
+    #[snafu(display(
+        "latex engine not found (searched: {}). Install xelatex or lualatex via a TeX distribution such as TeX Live or MacTeX; on NixOS run `nix develop`",
+        searched.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
+    ))]
+    LatexEngineNotInstalled {
+        /// Candidate paths that were searched.
+        searched: Vec<PathBuf>,
+    },
+
     /// The Pandoc writer returned a non-zero exit code.
     #[snafu(display("pandoc writer failed for format {fmt}: {stderr}"))]
     WriterFailed {
@@ -258,7 +317,7 @@ pub enum OutputFormat {
     Docx,
     /// `OpenDocument` text (.odt).
     Odt,
-    /// PDF — routed to Typst fast-lane by default; `LaTeX` when overridden.
+    /// PDF — routed to Typst fast-lane by default; `LaTeX` when overridden or content-triggered.
     Pdf,
     /// GitHub-Flavoured Markdown.
     Markdown,

--- a/_llm/L3-api-index/poiesis-lint.md
+++ b/_llm/L3-api-index/poiesis-lint.md
@@ -64,6 +64,8 @@ pub enum FindingKind {
     RequiredSectionMissing,
     /// A heading exceeds the allowed length.
     HeaderLength,
+    /// Raw `LaTeX` was found in a document exported to a non-`LaTeX` target.
+    RawLatexNonPortable,
 }
 ```
 
@@ -116,4 +118,20 @@ impl Linter {
     ) -> Result<Vec<Finding>, LintError>;
     pub fn to_json (findings: &[Finding]) -> Result<String, LintError>;
 }
+```
+
+## `src/raw_latex.rs`
+
+```rust
+pub enum ExportTarget {
+    /// A target that can render raw `LaTeX`, such as `.tex` or `LaTeX`-backed PDF.
+    Latex,
+    /// Any non-`LaTeX` target such as HTML, DOCX, EPUB, or Typst fast-lane PDF.
+    NonLatex,
+}
+```
+
+> Check whether raw `LaTeX` content would be non-portable for the export target.
+```rust
+pub fn check_raw_latex_nonportable (doc: &Document, target: ExportTarget) -> Vec<Finding>
 ```

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -194,8 +194,8 @@ l3_token_estimate = 446
 [[crates]]
 name = "poiesis-doc"
 path = "crates/poiesis/doc"
-source_hash = "7c845a7e3c3bb8108e8da690076821a51fadbfd9073c9fad20da20409f36f33a"
-l3_token_estimate = 2960
+source_hash = "5188bf5ab869ddd8d7de51e34760b92fb0c139ba7109b862772af0d005cf8588"
+l3_token_estimate = 3417
 
 [[crates]]
 name = "poiesis-inspect"
@@ -212,8 +212,8 @@ l3_token_estimate = 456
 [[crates]]
 name = "poiesis-lint"
 path = "crates/poiesis/lint"
-source_hash = "de719b792a5a6a7cb254fb0fa998e67a70b54f5b6bec2171d388763fcebaf180"
-l3_token_estimate = 841
+source_hash = "1a1477a0bd07975e8f80d32ab42fb0d0517f5218a36b21df77a50b81a78c3a8f"
+l3_token_estimate = 976
 
 [[crates]]
 name = "poiesis-printer-chromium"

--- a/crates/poiesis/doc/src/error.rs
+++ b/crates/poiesis/doc/src/error.rs
@@ -42,6 +42,13 @@ pub enum Error {
         detail: String,
     },
 
+    /// PDF rendering needed a system `LaTeX` engine but none was available.
+    #[snafu(display("pdf LaTeX engine unavailable: {source}"))]
+    PdfLatexEngineUnavailable {
+        /// Detailed probing error from the Pandoc `LaTeX` route.
+        source: crate::pandoc::PandocError,
+    },
+
     /// ODT rendering via the clean-room backend failed.
     #[snafu(display("odt render failed: {detail}"))]
     OdtRenderFailed {

--- a/crates/poiesis/doc/src/latex_probe.rs
+++ b/crates/poiesis/doc/src/latex_probe.rs
@@ -1,0 +1,217 @@
+//! System `LaTeX` engine availability probe.
+//!
+//! `LatexProbe::check()` classifies the system `xelatex`/`lualatex` path so
+//! the PDF dispatcher can choose a system engine without bundling `TeX`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use crate::pandoc::PdfEngine;
+use snafu::Snafu;
+
+/// Probe result for a system `LaTeX` engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LatexProbe {
+    /// A usable system engine was found.
+    Present {
+        /// Selected PDF engine.
+        engine: PdfEngine,
+        /// Absolute path to the chosen binary.
+        path: PathBuf,
+        /// First line reported by `--version`.
+        version: String,
+    },
+    /// Neither `xelatex` nor `lualatex` could be used.
+    Missing {
+        /// Candidate paths that were searched.
+        searched: Vec<PathBuf>,
+    },
+}
+
+impl LatexProbe {
+    /// Probe once and cache the first successful result for the process.
+    #[must_use]
+    pub fn check() -> Self {
+        static CACHE: OnceLock<LatexProbe> = OnceLock::new();
+        CACHE
+            .get_or_init(|| Self::check_with(search_latex_candidates, real_version_source))
+            .clone()
+    }
+
+    /// Convert a probe result into the selected engine or an actionable error.
+    pub fn engine(self) -> Result<PdfEngine, LatexProbeError> {
+        match self {
+            Self::Present { engine, .. } => Ok(engine),
+            Self::Missing { searched } => Err(LatexProbeError::NotInstalled { searched }),
+        }
+    }
+
+    /// Probe with injected search and version sources.
+    ///
+    /// This is primarily for tests: callers can provide a synthetic PATH
+    /// search result and a fake `--version` payload without spawning a real
+    /// `LaTeX` binary.
+    #[must_use]
+    pub(crate) fn check_with<Search, Version>(search: Search, version_source: Version) -> Self
+    where
+        Search: FnOnce() -> Vec<(PdfEngine, PathBuf)>,
+        Version: Fn(&Path) -> Result<String, String>,
+    {
+        let mut searched = Vec::new();
+
+        for (engine, path) in search() {
+            searched.push(path.clone());
+
+            let Ok(output) = version_source(&path) else {
+                continue;
+            };
+
+            let version = output.lines().next().unwrap_or_default().trim().to_owned();
+            if version.is_empty() {
+                continue;
+            }
+
+            return Self::Present {
+                engine,
+                path,
+                version,
+            };
+        }
+
+        Self::Missing { searched }
+    }
+}
+
+/// Error returned when the system `LaTeX` engine probe cannot find a usable binary.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum LatexProbeError {
+    /// Neither `xelatex` nor `lualatex` was usable on PATH.
+    #[snafu(display(
+        "latex engine not found (searched: {}). Install xelatex or lualatex via a TeX distribution such as TeX Live or MacTeX; on NixOS run `nix develop`",
+        format_paths(searched)
+    ))]
+    NotInstalled {
+        /// Candidate paths that were searched.
+        searched: Vec<PathBuf>,
+    },
+}
+
+fn search_latex_candidates() -> Vec<(PdfEngine, PathBuf)> {
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return Vec::new();
+    };
+
+    let mut candidates = Vec::new();
+    for dir in std::env::split_paths(&path_var) {
+        let path = dir.join("xelatex");
+        if path.exists() {
+            candidates.push((PdfEngine::XeLaTeX, path));
+        }
+    }
+    for dir in std::env::split_paths(&path_var) {
+        let path = dir.join("lualatex");
+        if path.exists() {
+            candidates.push((PdfEngine::LuaLaTeX, path));
+        }
+    }
+
+    candidates
+}
+
+fn real_version_source(path: &Path) -> Result<String, String> {
+    let output = Command::new(path)
+        .arg("--version")
+        .output()
+        .map_err(|e| e.to_string())?;
+
+    if !output.status.success() {
+        return Err(format!("exit status {}", output.status));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn format_paths(paths: &[PathBuf]) -> String {
+    if paths.is_empty() {
+        return "<none>".to_owned();
+    }
+
+    paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_with_returns_xelatex_when_available() {
+        let probe = LatexProbe::check_with(
+            || vec![(PdfEngine::XeLaTeX, PathBuf::from("/tmp/xelatex"))],
+            |path| {
+                assert_eq!(path, Path::new("/tmp/xelatex"));
+                Ok("XeTeX 3.141592653-2.6-0.999994 (TeX Live 2024)\n".to_owned())
+            },
+        );
+
+        assert_eq!(
+            probe,
+            LatexProbe::Present {
+                engine: PdfEngine::XeLaTeX,
+                path: PathBuf::from("/tmp/xelatex"),
+                version: "XeTeX 3.141592653-2.6-0.999994 (TeX Live 2024)".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn check_with_falls_back_to_lualatex_when_xelatex_fails() {
+        let probe = LatexProbe::check_with(
+            || {
+                vec![
+                    (PdfEngine::XeLaTeX, PathBuf::from("/tmp/xelatex")),
+                    (PdfEngine::LuaLaTeX, PathBuf::from("/tmp/lualatex")),
+                ]
+            },
+            |path| {
+                if path == Path::new("/tmp/xelatex") {
+                    Err("broken xelatex".to_owned())
+                } else {
+                    Ok("LuaHBTeX, Version 1.18.0 (TeX Live 2023)\n".to_owned())
+                }
+            },
+        );
+
+        assert_eq!(
+            probe,
+            LatexProbe::Present {
+                engine: PdfEngine::LuaLaTeX,
+                path: PathBuf::from("/tmp/lualatex"),
+                version: "LuaHBTeX, Version 1.18.0 (TeX Live 2023)".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn engine_maps_missing_probe_to_actionable_error() {
+        let Err(err) = (LatexProbe::Missing {
+            searched: vec![
+                PathBuf::from("/tmp/xelatex"),
+                PathBuf::from("/tmp/lualatex"),
+            ],
+        })
+        .engine() else {
+            panic!("missing probe must become an error")
+        };
+
+        let message = err.to_string();
+        assert!(message.contains("latex engine not found"));
+        assert!(message.contains("xelatex"));
+        assert!(message.contains("lualatex"));
+    }
+}

--- a/crates/poiesis/doc/src/lib.rs
+++ b/crates/poiesis/doc/src/lib.rs
@@ -15,7 +15,8 @@
 //! - [`render_epub_from_doc`] — build `.epub` bytes from a document model via
 //!   Pandoc.
 //! - [`render_pdf_from_doc`] — build `.pdf` bytes from the document model via
-//!   the embedded Typst compiler.
+//!   Typst by default or the system `LaTeX` engine path when the content needs
+//!   it.
 //! - [`inspect_docx`] — extract paragraph text from an existing `.docx` file.
 //! - [`render_odt_from_doc`] — build `.odt` bytes from the document model via
 //!   the clean-room ZIP/XML backend.
@@ -25,8 +26,8 @@
 //! ## Pandoc dispatch (B-012)
 //!
 //! [`pandoc::render_doc`] routes by format:
-//! - PDF → `poiesis-typst` in-process fast-lane (default).
-//! - PDF with explicit `LaTeX` engine → Pandoc + `LaTeX`.
+//! - PDF → `poiesis-typst` in-process fast-lane by default.
+//! - PDF with explicit `LaTeX` engine or math/raw-`LaTeX` content → Pandoc + `LaTeX`.
 //! - docx / md / latex / html / epub → Pandoc subprocess.
 //!
 //! # GPL-clean boundary
@@ -35,14 +36,16 @@
 //! the `pandoc` Rust crate.
 
 mod error;
+mod latex_probe;
 mod pandoc_probe;
 mod raster;
-mod typst_bridge;
 
 /// Pandoc subprocess wrapper, AST serialization, and format dispatch (B-012).
 pub mod pandoc;
 
 pub use error::Error;
+/// Re-export of the system `LaTeX` engine probe.
+pub use latex_probe::{LatexProbe, LatexProbeError};
 /// Re-export of the Pandoc dispatcher for callers that want it directly.
 pub use pandoc::render_doc;
 pub use pandoc_probe::{PandocProbe, PandocProbeError};
@@ -196,22 +199,30 @@ pub fn inspect_docx(bytes: &[u8]) -> Result<DocxSummary> {
     Ok(DocxSummary::new(paragraphs))
 }
 
-/// Render a [`poiesis_core::Document`] to PDF bytes via the embedded Typst compiler.
+/// Render a [`poiesis_core::Document`] to PDF bytes.
 ///
-/// Intermediate replacement for the retired text-format PDF backend.
-/// The Pandoc-backed path (B-012) will supersede this for the full format matrix.
+/// This keeps the Typst fast-lane for common documents, but content that
+/// needs `LaTeX` math or raw `LaTeX` blocks is routed through the system-engine
+/// `LaTeX` path when available.
 ///
 /// # Errors
 ///
-/// Returns [`Error::PdfRenderFailed`] if Typst compilation fails.
+/// Returns [`Error::PdfRenderFailed`] if Typst compilation fails, or
+/// [`Error::PdfLatexEngineUnavailable`] when `LaTeX` content is present but no
+/// system engine could be probed.
 #[instrument(skip(doc))]
 pub fn render_pdf_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
-    let source = typst_bridge::doc_to_typst(doc);
-    poiesis_typst::render_typst(&source, &serde_json::json!({})).map_err(|e| {
-        Error::PdfRenderFailed {
-            detail: e.to_string(),
+    match pandoc::render_doc(doc, &pandoc::DocOpts::default_pdf()) {
+        Ok(bytes) => Ok(bytes),
+        Err(pandoc::PandocError::LatexEngineNotInstalled { searched }) => {
+            Err(Error::PdfLatexEngineUnavailable {
+                source: pandoc::PandocError::LatexEngineNotInstalled { searched },
+            })
         }
-    })
+        Err(e) => Err(Error::PdfRenderFailed {
+            detail: e.to_string(),
+        }),
+    }
 }
 
 /// Render a [`poiesis_core::Document`] to DOCX bytes via Pandoc.
@@ -391,6 +402,19 @@ mod tests {
         }
     }
 
+    fn math_doc() -> poiesis_core::Document {
+        use poiesis_core::{Block, Document, Metadata};
+
+        Document {
+            metadata: Metadata {
+                title: "Math".to_owned(),
+                author: None,
+                created: None,
+            },
+            content: vec![Block::DisplayMath("x^2 + y^2 = z^2".to_owned())],
+        }
+    }
+
     #[test]
     fn render_docx_from_doc_produces_bytes_when_pandoc_present() {
         if !pandoc_present() {
@@ -445,5 +469,48 @@ mod tests {
     fn render_odt_from_doc_produces_pk_magic() {
         let bytes = render_odt_from_doc(&simple_doc()).expect("must render");
         assert!(bytes.starts_with(b"PK"), "must be an ODT ZIP archive");
+    }
+
+    #[test]
+    fn display_math_routes_to_latex_and_html_mathml_without_needing_latex() {
+        if !pandoc_present() {
+            return;
+        }
+
+        let doc = math_doc();
+
+        let latex = String::from_utf8(render_latex_from_doc(&doc).expect("latex must render"))
+            .expect("latex must be utf-8");
+        assert!(
+            latex.contains("\\begin{document}"),
+            "latex output must be standalone"
+        );
+        assert!(
+            latex.contains("x^2 + y^2 = z^2"),
+            "latex output must include the display math expression"
+        );
+
+        let html = String::from_utf8(render_html_from_doc(&doc).expect("html must render"))
+            .expect("html must be utf-8");
+        assert!(
+            html.contains("<math") || html.contains("MathML"),
+            "html output must include MathML math markup"
+        );
+
+        if LatexProbe::check().engine().is_ok() {
+            let bytes = render_pdf_from_doc(&doc).expect("latex-backed pdf must render");
+            assert!(bytes.starts_with(b"%PDF"), "must be a PDF");
+        } else {
+            let err = render_pdf_from_doc(&doc).expect_err("missing latex engine must error");
+            match err {
+                Error::PdfLatexEngineUnavailable { source } => {
+                    assert!(
+                        source.to_string().contains("latex engine not found"),
+                        "missing engine error must be actionable"
+                    );
+                }
+                other => panic!("unexpected pdf error variant: {other:?}"),
+            }
+        }
     }
 }

--- a/crates/poiesis/doc/src/pandoc/error.rs
+++ b/crates/poiesis/doc/src/pandoc/error.rs
@@ -38,6 +38,16 @@ pub enum PandocError {
         found_patch: u32,
     },
 
+    /// A LaTeX-backed PDF export needed `xelatex` or `lualatex`, but neither was usable.
+    #[snafu(display(
+        "latex engine not found (searched: {}). Install xelatex or lualatex via a TeX distribution such as TeX Live or MacTeX; on NixOS run `nix develop`",
+        searched.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
+    ))]
+    LatexEngineNotInstalled {
+        /// Candidate paths that were searched.
+        searched: Vec<PathBuf>,
+    },
+
     /// The Pandoc writer returned a non-zero exit code.
     #[snafu(display("pandoc writer failed for format {fmt}: {stderr}"))]
     WriterFailed {
@@ -78,4 +88,14 @@ pub enum PandocError {
         /// Underlying SVG rasterization error.
         source: crate::raster::RasterError,
     },
+}
+
+impl From<crate::latex_probe::LatexProbeError> for PandocError {
+    fn from(err: crate::latex_probe::LatexProbeError) -> Self {
+        match err {
+            crate::latex_probe::LatexProbeError::NotInstalled { searched } => {
+                Self::LatexEngineNotInstalled { searched }
+            }
+        }
+    }
 }

--- a/crates/poiesis/doc/src/pandoc/mod.rs
+++ b/crates/poiesis/doc/src/pandoc/mod.rs
@@ -4,8 +4,8 @@
 //! [`OutputFormat`] (supported export formats), and [`DocOpts`] (render options).
 //!
 //! The `render_doc` function is the unified dispatch entry point: it routes
-//! PDF to `poiesis-typst` (in-process fast-lane) and all other formats to
-//! the Pandoc subprocess.
+//! PDF to `poiesis-typst` (in-process fast-lane) unless the document content
+//! requires `LaTeX`, in which case it probes a system engine and uses Pandoc.
 //!
 //! # GPL-clean boundary
 //!
@@ -41,7 +41,7 @@ pub enum OutputFormat {
     Docx,
     /// `OpenDocument` text (.odt).
     Odt,
-    /// PDF — routed to Typst fast-lane by default; `LaTeX` when overridden.
+    /// PDF — routed to Typst fast-lane by default; `LaTeX` when overridden or content-triggered.
     Pdf,
     /// GitHub-Flavoured Markdown.
     Markdown,
@@ -78,6 +78,17 @@ pub enum PdfEngine {
     XeLaTeX,
     /// `lualatex` — alternative `LaTeX` engine.
     LuaLaTeX,
+}
+
+impl PdfEngine {
+    /// Return the Pandoc `--pdf-engine` flag value for system engines.
+    fn pandoc_arg(self) -> Option<&'static str> {
+        match self {
+            Self::Typst => None,
+            Self::XeLaTeX => Some("xelatex"),
+            Self::LuaLaTeX => Some("lualatex"),
+        }
+    }
 }
 
 /// Options controlling the render call.
@@ -276,6 +287,17 @@ impl PandocRunner {
             _ => {}
         }
 
+        if matches!(opts.format, OutputFormat::Html) {
+            cmd.arg("--mathml");
+        }
+
+        if matches!(opts.format, OutputFormat::Pdf)
+            && let Some(engine) = opts.pdf_engine
+            && let Some(engine_arg) = engine.pandoc_arg()
+        {
+            cmd.arg("--pdf-engine").arg(engine_arg);
+        }
+
         cmd.arg(tmp_path);
 
         let output = cmd.output().map_err(|e| PandocError::Spawn { source: e })?;
@@ -304,12 +326,12 @@ fn parse_pandoc_version(output: &str) -> Option<(u32, u32, u32)> {
 /// Unified dispatch: render a [`Document`] to bytes using the appropriate backend.
 ///
 /// Routing rules (per B-006 § 3):
-/// 1. `opts.format == Pdf` and no `pdf_engine` override → Typst in-process.
+/// 1. `opts.format == Pdf` and no `pdf_engine` override plus no `LaTeX`-only
+///    content → Typst in-process.
 /// 2. `opts.pdf_engine == Some(Typst)` → Typst in-process.
-/// 3. `opts.pdf_engine == Some(XeLaTeX | LuaLaTeX)` → Pandoc + `LaTeX` engine.
-/// 4. Content-trigger routing (`DisplayMath`/`RawBlock(latex)`) remains a
-///    later routing chunk. See ESCALATION.md Q2.
-/// 5. All other formats → Pandoc via `PandocRunner`.
+/// 3. `opts.pdf_engine == Some(XeLaTeX | LuaLaTeX)` or content-triggered PDF
+///    (`DisplayMath` / `RawBlock(LaTeX)`) → Pandoc + `LaTeX` engine.
+/// 4. All other formats → Pandoc via `PandocRunner`.
 ///
 /// # Errors
 ///
@@ -318,12 +340,8 @@ fn parse_pandoc_version(output: &str) -> Option<(u32, u32, u32)> {
 /// Typst failures.
 #[instrument(skip(doc), fields(fmt = ?opts.format))]
 pub fn render_doc(doc: &Document, opts: &DocOpts) -> Result<Vec<u8>, PandocError> {
-    // Route PDF to Typst fast-lane unless an explicit LaTeX engine is set.
-    let use_typst = matches!(opts.format, OutputFormat::Pdf)
-        && !matches!(
-            opts.pdf_engine,
-            Some(PdfEngine::XeLaTeX | PdfEngine::LuaLaTeX)
-        );
+    let pdf_engine = select_pdf_engine(doc, opts)?;
+    let use_typst = matches!(opts.format, OutputFormat::Pdf) && pdf_engine.is_none();
 
     if use_typst {
         return render_doc_via_typst(doc);
@@ -333,6 +351,9 @@ pub fn render_doc(doc: &Document, opts: &DocOpts) -> Result<Vec<u8>, PandocError
     let runner = PandocRunner::probe(None)?;
     let ast_json = ast::document_to_pandoc_json(doc);
     let mut render_opts = opts.clone();
+    if let Some(engine) = pdf_engine {
+        render_opts.pdf_engine = Some(engine);
+    }
     render_opts.lua_filters.extend(default_lua_filters());
     let facts_sidecar = write_apx_facts_sidecar(doc)?;
     let figures_sidecar = write_apx_figures_sidecar(doc)?;
@@ -347,6 +368,36 @@ pub fn render_doc(doc: &Document, opts: &DocOpts) -> Result<Vec<u8>, PandocError
         ),
     ];
     runner.render(&ast_json, &render_opts, &extra_env)
+}
+
+fn select_pdf_engine(doc: &Document, opts: &DocOpts) -> Result<Option<PdfEngine>, PandocError> {
+    if !matches!(opts.format, OutputFormat::Pdf) {
+        return Ok(None);
+    }
+
+    if let Some(engine @ (PdfEngine::XeLaTeX | PdfEngine::LuaLaTeX)) = opts.pdf_engine {
+        return Ok(Some(engine));
+    }
+
+    if matches!(opts.pdf_engine, Some(PdfEngine::Typst)) {
+        return Ok(None);
+    }
+
+    if opts.pdf_engine.is_none() && document_needs_latex_pdf(doc) {
+        return Ok(Some(crate::LatexProbe::check().engine()?));
+    }
+
+    Ok(None)
+}
+
+fn document_needs_latex_pdf(doc: &Document) -> bool {
+    use poiesis_core::Block;
+
+    doc.content.iter().any(|block| match block {
+        Block::DisplayMath(_) => true,
+        Block::RawBlock { format, .. } => format.eq_ignore_ascii_case("latex"),
+        _ => false,
+    })
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/crates/poiesis/lint/Cargo.toml
+++ b/crates/poiesis/lint/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+poiesis-core = { path = "../core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/poiesis/lint/src/lib.rs
+++ b/crates/poiesis/lint/src/lib.rs
@@ -8,9 +8,14 @@ mod banned_words;
 mod citations;
 /// Error types for the lint pipeline.
 pub mod error;
+mod raw_latex;
 mod structure;
 
 pub use error::LintError;
+/// Export-target selector for document portability linting.
+pub use raw_latex::ExportTarget;
+/// Lint raw `LaTeX` portability against a target export format.
+pub use raw_latex::check_raw_latex_nonportable;
 
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
@@ -47,6 +52,8 @@ pub enum FindingKind {
     RequiredSectionMissing,
     /// A heading exceeds the allowed length.
     HeaderLength,
+    /// Raw `LaTeX` was found in a document exported to a non-`LaTeX` target.
+    RawLatexNonPortable,
 }
 
 /// Data needed to apply an automatic fix for a banned word.

--- a/crates/poiesis/lint/src/raw_latex.rs
+++ b/crates/poiesis/lint/src/raw_latex.rs
@@ -1,0 +1,100 @@
+//! Document portability lint for raw `LaTeX` blocks.
+
+use poiesis_core::{Block, Document};
+
+use crate::{Finding, FindingKind};
+
+/// Export target used by the raw `LaTeX` portability check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExportTarget {
+    /// A target that can render raw `LaTeX`, such as `.tex` or `LaTeX`-backed PDF.
+    Latex,
+    /// Any non-`LaTeX` target such as HTML, DOCX, EPUB, or Typst fast-lane PDF.
+    NonLatex,
+}
+
+/// Check whether raw `LaTeX` content would be non-portable for the export target.
+pub fn check_raw_latex_nonportable(doc: &Document, target: ExportTarget) -> Vec<Finding> {
+    if matches!(target, ExportTarget::Latex) {
+        return Vec::new();
+    }
+
+    if has_raw_latex_block(doc) {
+        vec![Finding {
+            line_start: 1,
+            line_end: 1,
+            message: "document contains RawBlock(latex), which will not render for non-LaTeX export targets".to_owned(),
+            kind: FindingKind::RawLatexNonPortable,
+            fix: None,
+        }]
+    } else {
+        Vec::new()
+    }
+}
+
+fn has_raw_latex_block(doc: &Document) -> bool {
+    doc.content.iter().any(|block| {
+        matches!(
+            block,
+            Block::RawBlock { format, .. } if format.eq_ignore_ascii_case("latex")
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use poiesis_core::{Block, Document, Metadata, RichText};
+
+    fn sample_doc() -> Document {
+        Document {
+            metadata: Metadata {
+                title: "Raw latex".to_owned(),
+                author: None,
+                created: None,
+            },
+            content: vec![
+                Block::Paragraph(RichText::from("Hello.")),
+                Block::RawBlock {
+                    format: "latex".to_owned(),
+                    content: "\\alpha".to_owned(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn non_latex_target_flags_raw_latex() {
+        let findings = check_raw_latex_nonportable(&sample_doc(), ExportTarget::NonLatex);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(
+            findings.first().map(|finding| &finding.kind),
+            Some(&FindingKind::RawLatexNonPortable)
+        );
+    }
+
+    #[test]
+    fn latex_target_allows_raw_latex() {
+        let findings = check_raw_latex_nonportable(&sample_doc(), ExportTarget::Latex);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn non_latex_target_ignores_nonlatex_raw_blocks() {
+        let doc = Document {
+            metadata: Metadata {
+                title: "Other raw".to_owned(),
+                author: None,
+                created: None,
+            },
+            content: vec![Block::RawBlock {
+                format: "html".to_owned(),
+                content: "<span>ok</span>".to_owned(),
+            }],
+        };
+
+        let findings = check_raw_latex_nonportable(&doc, ExportTarget::NonLatex);
+        assert!(findings.is_empty());
+    }
+}


### PR DESCRIPTION
B-006 Chunk D. PDF generation auto-routes to a LaTeX engine when a Document needs it (DisplayMath / RawBlock[latex]) and stays on the Typst fast-lane otherwise. Per operator decision the engine is a runtime probe of system xelatex/lualatex (latex_probe.rs) — NOT bundled tectonic — with an actionable 'install TeX Live/MacTeX' error when absent. Adds the DOC/raw-latex-nonportable lint (poiesis-lint) for raw LaTeX on non-LaTeX targets. select_pdf_engine documents the 3 routing cases. 59 tests (probe detect/fallback/error + content-routing + html-MathML + lint). No heavy build dep.