### PR TITLE
chore(deps): cargo-deny ban on pandoc Rust crates (B-006 E)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -61,8 +61,12 @@ confidence-threshold = 0.8
 multiple-versions = "warn"
 wildcards = "allow"
 # WHY: "pure Rust, no C++" — rustls replaces openssl across the workspace.
+# WHY: pandoc must stay an external subprocess so we keep the GPL-clean
+# boundary and never link a pandoc Rust binding into the binary.
 deny = [
     { crate = "openssl-sys", wrappers = [] },
+    { crate = "pandoc", reason = "Aletheia shells out to pandoc as a subprocess; do not link the pandoc crate into the binary." },
+    { crate = "pandoc_ast", reason = "Pandoc AST bindings must stay outside the build; Aletheia uses pandoc as an external subprocess only." },
 ]
 
 # Skip entries for duplicates caused by upstream constraints we cannot resolve.


### PR DESCRIPTION
B-006 Chunk E (B-012 acceptance #4). Bans the pandoc + pandoc_ast Rust crates via cargo-deny [bans] with WHY reasons, enforcing the GPL-clean subprocess boundary: aletheia invokes the pandoc binary as an external subprocess and must never link a GPL Haskell-FFI binding. cargo deny check bans passes on the current tree (no such crate present) and would fail if one were added. Config-only; audit.toml/osv-scanner.toml left unchanged (they only mirror advisory ignores). No legit deps (resvg/zip/etc.) affected.