### PR TITLE
test(poiesis): B-011 export-matrix tests + fix Table pandoc-AST (B-006 F)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7047,6 +7047,7 @@ name = "poiesis-doc"
 version = "0.30.0"
 dependencies = [
  "docx-rs",
+ "insta",
  "poiesis-charts",
  "poiesis-core",
  "poiesis-text",

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -194,7 +194,7 @@ l3_token_estimate = 446
 [[crates]]
 name = "poiesis-doc"
 path = "crates/poiesis/doc"
-source_hash = "5188bf5ab869ddd8d7de51e34760b92fb0c139ba7109b862772af0d005cf8588"
+source_hash = "893d982f0631ff2873f9329d4d05644002ad4cda03853fbe7d5bbbad19ecb30e"
 l3_token_estimate = 3417
 
 [[crates]]

--- a/crates/poiesis/doc/Cargo.toml
+++ b/crates/poiesis/doc/Cargo.toml
@@ -44,4 +44,5 @@ tracing = { workspace = true }
 tempfile = "3"
 
 [dev-dependencies]
+insta = "1"
 serde_json = { workspace = true }

--- a/crates/poiesis/doc/src/pandoc/ast.rs
+++ b/crates/poiesis/doc/src/pandoc/ast.rs
@@ -98,7 +98,9 @@ fn block_to_pandoc(block: &Block, figure_index: &mut usize) -> Value {
             json!({ "t": "HorizontalRule" })
         }
         Block::Table(table) => {
-            // Simple table: header row + data rows, one column per header.
+            // WHY: Pandoc 1.23 Table AST shapes — Caption is a bare
+            // [shortcaption, [Block]] array (not a tagged node), a Row is
+            // [Attr, [Cell]], and a TableBody is [Attr, RowHeadColumns, [Row], [Row]].
             let col_count = table.headers.len();
             let col_spec: Vec<Value> = (0..col_count)
                 .map(|_| json!([{"t": "AlignDefault"}, {"t": "ColWidthDefault"}]))
@@ -109,6 +111,7 @@ fn block_to_pandoc(block: &Block, figure_index: &mut usize) -> Value {
                 .iter()
                 .map(|h| pandoc_cell(&json!([{"t": "Para", "c": [{"t": "Str", "c": h}]}])))
                 .collect();
+            let head_row = json!([["", [], []], header_cells]);
 
             let data_rows: Vec<Value> = table
                 .rows
@@ -120,7 +123,7 @@ fn block_to_pandoc(block: &Block, figure_index: &mut usize) -> Value {
                             pandoc_cell(&json!([{"t": "Para", "c": inlines_to_pandoc(cell)}]))
                         })
                         .collect();
-                    json!([[], cells])
+                    json!([["", [], []], cells])
                 })
                 .collect();
 
@@ -128,10 +131,10 @@ fn block_to_pandoc(block: &Block, figure_index: &mut usize) -> Value {
                 "t": "Table",
                 "c": [
                     ["", [], []],
-                    {"t": "Caption", "c": [null, []]},
+                    [null, []],
                     col_spec,
-                    [["", [], []], [header_cells]],
-                    [["", [], []], data_rows],
+                    [["", [], []], [head_row]],
+                    [[["", [], []], 0, [], data_rows]],
                     [["", [], []], []]
                 ]
             })
@@ -196,7 +199,9 @@ fn inline_text(text: &str) -> Vec<Value> {
 }
 
 fn pandoc_cell(content: &Value) -> Value {
-    json!([["", [], []], {"t": "AlignDefault"}, 1, 1, [content]])
+    // WHY: Pandoc Cell = [Attr, Alignment, RowSpan, ColSpan, [Block]]; `content`
+    // is already the [Block] list, so embed it directly (no extra wrapping).
+    json!([["", [], []], {"t": "AlignDefault"}, 1, 1, content])
 }
 
 fn inlines_to_pandoc(rt: &RichText) -> Vec<Value> {

--- a/crates/poiesis/doc/tests/export_matrix.rs
+++ b/crates/poiesis/doc/tests/export_matrix.rs
@@ -1,0 +1,322 @@
+//! export-matrix integration tests for poiesis-doc.
+
+#![expect(
+    clippy::indexing_slicing,
+    clippy::string_slice,
+    clippy::default_trait_access,
+    reason = "integration test: assertions index known-shape JSON and parse ASCII citation markers"
+)]
+
+use std::env;
+use std::error::Error;
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use poiesis_charts::model::{
+    AxisSide, Chart, ChartKind, FactCite, FactId, LegendSpec, Point, Series, SeriesStyle, ToneRef,
+    Unit,
+};
+use poiesis_core::{Block, Document, Image, Metadata, RichText, Span, Table};
+use poiesis_doc::{
+    PandocProbe, inspect_docx, pandoc::DocOpts, pandoc::PandocRunner,
+    pandoc::ast::document_to_pandoc_json, pandoc::render_doc, render_odt_from_doc,
+    render_pdf_from_doc,
+};
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+const MISSING_PANDOC_DIR: &str = "/tmp/poiesis-doc-export-matrix-missing-pandoc";
+const TOO_OLD_PANDOC_DIR: &str = "/tmp/poiesis-doc-export-matrix-too-old-pandoc";
+
+#[test]
+fn export_matrix() -> Result<(), Box<dyn Error>> {
+    let document = canonical_document();
+    let math_document = math_document();
+
+    let ast = serde_json::from_slice::<Value>(&document_to_pandoc_json(&document))?;
+    assert_eq!(ast["pandoc-api-version"], json!([1, 23, 1, 1]));
+    insta::assert_snapshot!("canonical_ast", serde_json::to_string_pretty(&ast)?);
+
+    let missing_probe_error = {
+        let _guard = PathGuard::set(OsStr::new(MISSING_PANDOC_DIR));
+        match PandocProbe::check().require() {
+            Ok(()) => return Err("missing pandoc probe unexpectedly succeeded".into()),
+            Err(err) => err.to_string(),
+        }
+    };
+    insta::assert_snapshot!("pandoc_probe_missing", missing_probe_error);
+
+    let too_old_probe_error = {
+        let probe_dir = PathBuf::from(TOO_OLD_PANDOC_DIR);
+        fs::create_dir_all(&probe_dir)?;
+        let fake_pandoc = probe_dir.join("pandoc");
+        fs::write(
+            &fake_pandoc,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'pandoc 2.19.2\\n'\n  exit 0\nfi\nprintf 'old pandoc\\n'\n",
+        )?;
+        make_executable(&fake_pandoc)?;
+
+        let _guard = PathGuard::set(OsStr::new(TOO_OLD_PANDOC_DIR));
+        match PandocProbe::check().require() {
+            Ok(()) => return Err("too-old pandoc probe unexpectedly succeeded".into()),
+            Err(err) => err.to_string(),
+        }
+    };
+    insta::assert_snapshot!("pandoc_probe_too_old", too_old_probe_error);
+
+    let fake_pandoc_dir = tempdir()?;
+    let fake_pandoc = fake_pandoc_dir.path().join("pandoc");
+    let fake_pandoc_log = fake_pandoc_dir.path().join("pandoc.log");
+    fs::write(
+        &fake_pandoc,
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'pandoc 3.7.0.2\\n'\n  exit 0\nfi\nif [ -n \"${PANDOC_RUN_LOG:-}\" ]; then\n  printf '%s\\n' \"$*\" >> \"$PANDOC_RUN_LOG\"\nfi\nprintf 'subprocess-ok'\n",
+    )?;
+    make_executable(&fake_pandoc)?;
+
+    let runner = PandocRunner::probe(Some(&fake_pandoc))?;
+    let rendered = runner.render(
+        &document_to_pandoc_json(&document),
+        &DocOpts::markdown(),
+        &[(
+            "PANDOC_RUN_LOG".to_owned(),
+            fake_pandoc_log.display().to_string(),
+        )],
+    )?;
+    assert_eq!(rendered, b"subprocess-ok");
+    let log = fs::read_to_string(&fake_pandoc_log)?;
+    assert!(log.contains("-f json -t gfm"), "pandoc must be spawned");
+
+    if !pandoc_present() {
+        return Ok(());
+    }
+
+    let docx = render_doc(&document, &DocOpts::docx())?;
+    assert_pk_magic(&docx);
+    let docx_text = inspect_docx(&docx)?.paragraphs.join("\n");
+
+    let odt = render_odt_from_doc(&document)?;
+    assert_pk_magic(&odt);
+
+    let typst_pdf = render_pdf_from_doc(&document)?;
+    assert_pdf_magic(&typst_pdf);
+
+    let html = String::from_utf8(render_doc(&document, &DocOpts::html())?)?;
+    assert!(!html.is_empty(), "HTML output must not be empty");
+
+    let md = String::from_utf8(render_doc(&document, &DocOpts::markdown())?)?;
+    assert!(!md.is_empty(), "Markdown output must not be empty");
+
+    let latex = String::from_utf8(render_doc(&document, &DocOpts::latex())?)?;
+    assert!(!latex.is_empty(), "LaTeX output must not be empty");
+
+    let epub = render_doc(&document, &DocOpts::epub())?;
+    assert_pk_magic(&epub);
+
+    let docx_cite = citation_marker(&docx_text)
+        .ok_or_else(|| std::io::Error::other("DOCX output missing citation number"))?;
+    let html_cite = citation_marker(&html)
+        .ok_or_else(|| std::io::Error::other("HTML output missing citation number"))?;
+    let md_cite = citation_marker(&md)
+        .ok_or_else(|| std::io::Error::other("Markdown output missing citation number"))?;
+    assert_eq!(docx_cite, html_cite);
+    assert_eq!(html_cite, md_cite);
+
+    if which::which("xelatex").is_ok() || which::which("lualatex").is_ok() {
+        let math_pdf = render_pdf_from_doc(&math_document)?;
+        assert_pdf_magic(&math_pdf);
+
+        let math_latex = String::from_utf8(render_doc(&math_document, &DocOpts::latex())?)?;
+        assert!(math_latex.contains("\\begin{document}"));
+        assert!(math_latex.contains("x^2 + y^2 = z^2"));
+    }
+
+    Ok(())
+}
+
+fn canonical_document() -> Document {
+    let chart = Chart {
+        kind: ChartKind::Line,
+        title: None,
+        series: vec![Series {
+            name: poiesis_charts::CiteOrText::Text("Revenue".to_owned()),
+            points: vec![
+                Point {
+                    label: Some(poiesis_charts::CiteOrText::Text("JAN".to_owned())),
+                    x: None,
+                    y: FactCite {
+                        id: FactId("rev-1".to_owned()),
+                        value: 10.0,
+                        unit: Unit::Number,
+                    },
+                },
+                Point {
+                    label: Some(poiesis_charts::CiteOrText::Text("FEB".to_owned())),
+                    x: None,
+                    y: FactCite {
+                        id: FactId("rev-2".to_owned()),
+                        value: 12.0,
+                        unit: Unit::Number,
+                    },
+                },
+            ],
+            tone: ToneRef::Indexed(0),
+            axis: AxisSide::Left,
+            style: SeriesStyle::Default,
+        }],
+        axes: Default::default(),
+        legend: LegendSpec::Auto,
+        data_labels: false,
+        caption: None,
+    };
+
+    let chart_bytes = serde_json::to_vec(&chart).unwrap_or_else(|e| panic!("chart json: {e}"));
+
+    Document {
+        metadata: Metadata {
+            title: "Export Matrix".to_owned(),
+            author: Some("alice".to_owned()),
+            created: None,
+        },
+        content: vec![
+            Block::Heading {
+                level: 1,
+                text: RichText::from("Export Matrix"),
+            },
+            Block::Paragraph(RichText {
+                spans: vec![
+                    Span::Plain("See ".to_owned()),
+                    Span::Cite("fact-42".to_owned()),
+                    Span::Plain(" for details.".to_owned()),
+                ],
+            }),
+            Block::Table(Table {
+                headers: vec!["Quarter".to_owned(), "Value".to_owned()],
+                rows: vec![vec![RichText::from("North"), RichText::from("10")]],
+            }),
+            Block::Image(Image {
+                data: chart_bytes,
+                mime: "application/vnd.poiesis.chart+json".to_owned(),
+                alt: "Revenue trend".to_owned(),
+            }),
+        ],
+    }
+}
+
+fn math_document() -> Document {
+    // Math-only (no chart figure): this exercises the DisplayMath -> LaTeX-engine
+    // routing. A chart SVG on the LaTeX-PDF path would need rsvg-convert + svg.sty
+    // (external TeX tooling); figure embedding is covered by the docx/html exports.
+    Document {
+        metadata: Metadata {
+            title: "Math".to_owned(),
+            author: Some("alice".to_owned()),
+            created: None,
+        },
+        content: vec![
+            Block::Heading {
+                level: 1,
+                text: RichText::from("Math"),
+            },
+            Block::Paragraph(RichText::from("The Pythagorean identity:")),
+            Block::DisplayMath("x^2 + y^2 = z^2".to_owned()),
+        ],
+    }
+}
+
+fn pandoc_present() -> bool {
+    which::which("pandoc").is_ok()
+}
+
+fn assert_pk_magic(bytes: &[u8]) {
+    assert!(
+        bytes.starts_with(b"PK"),
+        "archive output must start with PK"
+    );
+}
+
+fn assert_pdf_magic(bytes: &[u8]) {
+    assert!(
+        bytes.starts_with(b"%PDF"),
+        "PDF output must start with %PDF"
+    );
+}
+
+fn citation_marker(text: &str) -> Option<String> {
+    for (start, _) in text.match_indices('[') {
+        // Markdown escapes display brackets as "\[1\]" and footnote refs as "[^N]";
+        // rich formats use "[N]". All carry the same citation NUMBER — normalise to "[N]".
+        let mut after = start + 1;
+        if text[after..].starts_with('^') {
+            after += 1;
+        }
+        let digits: String = text[after..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if digits.is_empty() {
+            continue;
+        }
+        let end = after + digits.len();
+        if text[end..].starts_with(']') || text[end..].starts_with("\\]") {
+            return Some(format!("[{digits}]"));
+        }
+    }
+    None
+}
+
+fn make_executable(path: &Path) -> Result<(), Box<dyn Error>> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+    }
+
+    Ok(())
+}
+
+struct PathGuard {
+    original: Option<OsString>,
+}
+
+impl PathGuard {
+    fn set(value: &OsStr) -> Self {
+        let original = env::var_os("PATH");
+        #[expect(
+            unsafe_code,
+            reason = "test-only PATH mutation is serialised by the single integration test"
+        )]
+        unsafe {
+            env::set_var("PATH", value);
+        }
+        Self { original }
+    }
+}
+
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(value) => {
+                #[expect(
+                    unsafe_code,
+                    reason = "test-only PATH restoration follows the same guarded mutation"
+                )]
+                unsafe {
+                    env::set_var("PATH", value);
+                }
+            }
+            None => {
+                #[expect(
+                    unsafe_code,
+                    reason = "test-only PATH restoration follows the same guarded mutation"
+                )]
+                unsafe {
+                    env::remove_var("PATH");
+                }
+            }
+        }
+    }
+}

--- a/crates/poiesis/doc/tests/snapshots/export_matrix__canonical_ast.snap
+++ b/crates/poiesis/doc/tests/snapshots/export_matrix__canonical_ast.snap
@@ -1,0 +1,298 @@
+---
+source: crates/poiesis/doc/tests/export_matrix.rs
+expression: "serde_json::to_string_pretty(&ast)?"
+---
+{
+  "blocks": [
+    {
+      "c": [
+        1,
+        [
+          "",
+          [],
+          []
+        ],
+        [
+          {
+            "c": "Export Matrix",
+            "t": "Str"
+          }
+        ]
+      ],
+      "t": "Header"
+    },
+    {
+      "c": [
+        {
+          "c": "See ",
+          "t": "Str"
+        },
+        {
+          "c": [
+            [
+              "",
+              [
+                "apx-cite"
+              ],
+              [
+                [
+                  "data-factid",
+                  "fact-42"
+                ]
+              ]
+            ],
+            []
+          ],
+          "t": "Span"
+        },
+        {
+          "c": " for details.",
+          "t": "Str"
+        }
+      ],
+      "t": "Para"
+    },
+    {
+      "c": [
+        [
+          "",
+          [],
+          []
+        ],
+        [
+          null,
+          []
+        ],
+        [
+          [
+            {
+              "t": "AlignDefault"
+            },
+            {
+              "t": "ColWidthDefault"
+            }
+          ],
+          [
+            {
+              "t": "AlignDefault"
+            },
+            {
+              "t": "ColWidthDefault"
+            }
+          ]
+        ],
+        [
+          [
+            "",
+            [],
+            []
+          ],
+          [
+            [
+              [
+                "",
+                [],
+                []
+              ],
+              [
+                [
+                  [
+                    "",
+                    [],
+                    []
+                  ],
+                  {
+                    "t": "AlignDefault"
+                  },
+                  1,
+                  1,
+                  [
+                    {
+                      "c": [
+                        {
+                          "c": "Quarter",
+                          "t": "Str"
+                        }
+                      ],
+                      "t": "Para"
+                    }
+                  ]
+                ],
+                [
+                  [
+                    "",
+                    [],
+                    []
+                  ],
+                  {
+                    "t": "AlignDefault"
+                  },
+                  1,
+                  1,
+                  [
+                    {
+                      "c": [
+                        {
+                          "c": "Value",
+                          "t": "Str"
+                        }
+                      ],
+                      "t": "Para"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ],
+        [
+          [
+            [
+              "",
+              [],
+              []
+            ],
+            0,
+            [],
+            [
+              [
+                [
+                  "",
+                  [],
+                  []
+                ],
+                [
+                  [
+                    [
+                      "",
+                      [],
+                      []
+                    ],
+                    {
+                      "t": "AlignDefault"
+                    },
+                    1,
+                    1,
+                    [
+                      {
+                        "c": [
+                          {
+                            "c": "North",
+                            "t": "Str"
+                          }
+                        ],
+                        "t": "Para"
+                      }
+                    ]
+                  ],
+                  [
+                    [
+                      "",
+                      [],
+                      []
+                    ],
+                    {
+                      "t": "AlignDefault"
+                    },
+                    1,
+                    1,
+                    [
+                      {
+                        "c": [
+                          {
+                            "c": "10",
+                            "t": "Str"
+                          }
+                        ],
+                        "t": "Para"
+                      }
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ],
+        [
+          [
+            "",
+            [],
+            []
+          ],
+          []
+        ]
+      ],
+      "t": "Table"
+    },
+    {
+      "c": [
+        {
+          "c": [
+            [
+              "apx-figure-0",
+              [
+                "apx-figure"
+              ],
+              [
+                [
+                  "data-figure-id",
+                  "apx-figure-0"
+                ]
+              ]
+            ],
+            [
+              {
+                "c": "Revenue",
+                "t": "Str"
+              },
+              {
+                "t": "Space"
+              },
+              {
+                "c": "trend",
+                "t": "Str"
+              }
+            ],
+            [
+              "apx-figure://apx-figure-0",
+              ""
+            ]
+          ],
+          "t": "Image"
+        }
+      ],
+      "t": "Para"
+    }
+  ],
+  "meta": {
+    "author": {
+      "c": [
+        {
+          "c": [
+            {
+              "c": "alice",
+              "t": "Str"
+            }
+          ],
+          "t": "MetaInlines"
+        }
+      ],
+      "t": "MetaList"
+    },
+    "title": {
+      "c": [
+        {
+          "c": "Export Matrix",
+          "t": "Str"
+        }
+      ],
+      "t": "MetaInlines"
+    }
+  },
+  "pandoc-api-version": [
+    1,
+    23,
+    1,
+    1
+  ]
+}

--- a/crates/poiesis/doc/tests/snapshots/export_matrix__pandoc_probe_missing.snap
+++ b/crates/poiesis/doc/tests/snapshots/export_matrix__pandoc_probe_missing.snap
@@ -1,0 +1,5 @@
+---
+source: crates/poiesis/doc/tests/export_matrix.rs
+expression: missing_probe_error
+---
+pandoc not found (searched: /tmp/poiesis-doc-export-matrix-missing-pandoc/pandoc). Install pandoc >= 3.0.0; on NixOS run `nix develop`, on Ubuntu/Debian run `apt install pandoc`, on macOS run `brew install pandoc`, or download from https://pandoc.org/installing.html

--- a/crates/poiesis/doc/tests/snapshots/export_matrix__pandoc_probe_too_old.snap
+++ b/crates/poiesis/doc/tests/snapshots/export_matrix__pandoc_probe_too_old.snap
@@ -1,0 +1,5 @@
+---
+source: crates/poiesis/doc/tests/export_matrix.rs
+expression: too_old_probe_error
+---
+pandoc at /tmp/poiesis-doc-export-matrix-too-old-pandoc/pandoc is version 2.19.2, but >= 3.0.0 is required. Upgrade via https://pandoc.org/installing.html or `nix develop`


### PR DESCRIPTION
B-006 Chunk F (final). Adds the B-011 export-matrix integration test: a canonical Document (Cite + Table + chart figure + prose) asserted across docx/odt/pdf-Typst/md/latex/html/epub, an insta-golden of the Pandoc JSON AST, the cross-format cited-number identity, the DisplayMath→LaTeX route, B-014 absent/too-old probe snapshots, and a real GPL-clean subprocess proof (fake-pandoc logs its argv).

VALUE: on its first run the test caught a real bug — document_to_pandoc_json produced INVALID Pandoc 1.23 Table AST (Caption as a tagged node, rows missing Attr wrappers, TableBody wrong arity, pandoc_cell double-wrapping the cell block list), so EVERY Table broke pandoc export (docx/odt/html/md/epub). Fixed all five shapes; the test now renders Tables across the matrix. Exactly what B-011 is for.

The cite-identity check normalizes markdown's escaped \[1\] + footnote [^1] forms to the number. The LaTeX-route test uses a math-only doc (a chart SVG on the LaTeX-PDF path needs rsvg-convert + svg.sty — follow-up #NEW). 34 tests pass; pandoc integration ran for real (pandoc present on the build host). Completes B-006/Q6.