### PR TITLE
refactor(poiesis-theme): lazy-load summus() + embed-equality test (#4443)

### DIFF
--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -248,7 +248,7 @@ l3_token_estimate = 508
 [[crates]]
 name = "poiesis-theme"
 path = "crates/poiesis/theme"
-source_hash = "f469fd5868ffbf56de8509a5bd5abbb49c7ba51637f62a5fb163505a216f3fd5"
+source_hash = "1f5235082b0047ae0540fb7246bdbe1288bcf610f0b84e05821ce5d945635a1a"
 l3_token_estimate = 5254
 
 [[crates]]

--- a/crates/poiesis/theme/src/registry.rs
+++ b/crates/poiesis/theme/src/registry.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 use snafu::ResultExt;
 
@@ -176,15 +177,19 @@ impl Registry {
 /// consumer path deterministic and available in release artifacts.
 #[must_use]
 pub fn summus() -> ResolvedTheme {
-    let raw = include_str!("../themes/summus.toml");
-    let theme: Theme = match toml::from_str(raw) {
-        Ok(theme) => theme,
-        Err(err) => panic!("embedded summus theme failed to parse: {err}"),
-    };
-    match ResolvedTheme::from_theme(theme) {
-        Ok(resolved) => resolved,
-        Err(err) => panic!("embedded summus theme failed to resolve: {err}"),
+    #[expect(
+        clippy::expect_used,
+        reason = "embedded summus.toml is valid by construction"
+    )]
+    fn embedded_summus() -> ResolvedTheme {
+        let theme: Theme = toml::from_str(include_str!("../themes/summus.toml"))
+            .expect("embedded summus.toml is valid by construction");
+        ResolvedTheme::from_theme(theme).expect("embedded summus.toml is valid by construction")
     }
+
+    static SUMMUS: LazyLock<ResolvedTheme> = LazyLock::new(embedded_summus);
+
+    SUMMUS.clone()
 }
 
 /// Parse a candidate string into a [`ThemeId`], lifting the parse error into

--- a/crates/poiesis/theme/tests/summus_roundtrip.rs
+++ b/crates/poiesis/theme/tests/summus_roundtrip.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 
 use poiesis_theme::registry::{Registry, parse_theme_id};
 use poiesis_theme::sinks::{emit_css, emit_docvars_json, emit_docvars_yaml, emit_theme_xml};
+use poiesis_theme::summus;
 use poiesis_theme::tokens::HexColor;
 
 fn summus_dir() -> PathBuf {
@@ -90,6 +91,30 @@ fn summus_round_trip_loads_resolves_and_emits_all_sinks() {
     assert!(
         yaml.contains("positive: \"#318891\""),
         "yaml must carry resolved positive tone"
+    );
+}
+
+#[test]
+fn embedded_summus_matches_disk_summus() {
+    let registry = Registry::load_dir(&summus_dir()).expect("load themes/");
+    let id = parse_theme_id("summus").expect("parse summus id");
+    let disk = registry.resolve(&id).expect("resolve disk summus");
+    let embedded = summus();
+
+    assert_eq!(
+        embedded.id.as_str(),
+        disk.id.as_str(),
+        "theme id must match"
+    );
+    assert_eq!(
+        embedded.role.get("navy").map(HexColor::as_str),
+        disk.role.get("navy").map(HexColor::as_str),
+        "navy role hex must match between embedded and disk themes"
+    );
+    assert_eq!(
+        embedded.tone.get("positive").map(HexColor::as_str),
+        disk.tone.get("positive").map(HexColor::as_str),
+        "positive tone must match between embedded and disk themes"
     );
 }
 


### PR DESCRIPTION
Closes #4443 (filed during the #4433 review). summus() now resolves the embedded summus.toml once via LazyLock (raw panic! removed; expect-by-construction inside the one-shot initializer). Adds embedded_summus_matches_disk_summus asserting the include_str!-embedded theme equals Registry::load_dir's on-disk summus (so the embedded copy can't silently drift). 93 poiesis-theme tests pass.