### PR TITLE
docs: Q12 doc-truth sweep — correct post-marathon stale claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Install the in-tree hooks once per clone: `scripts/install-hooks.sh` (auto-run b
 
 1. `cargo +1.94.0 fmt --all -- --check` clean — **fmt is a required CI check** and runs *first* in gate-attestation, so a fmt-only miss aborts the whole gate
 2. `cargo test -p <affected-crate>` passes
-3. `cargo clippy --workspace`: zero warnings (CI-exact: `--all-targets --exclude theatron --exclude skene --exclude koilon -- -D warnings`)
+3. `cargo clippy --workspace`: zero warnings (CI-exact: `--all-targets -- -D warnings`)
 4. `_llm` index fresh on crate changes: `uv run scripts/llm-extract-l3.py && git add _llm/`
 5. No `unwrap()` in library code
 6. New errors use snafu with context

--- a/ESCALATION.md
+++ b/ESCALATION.md
@@ -1,31 +1,32 @@
-# B-002 poiesis-theme Escalation Log
+# SUPERSEDED / RESOLVED: B-002/B-012 Escalation Log
 
-Design choices deferred from mechanical kimi dispatch — review before merging.
+Design choices deferred from mechanical kimi dispatch are preserved here for history only. The v1.0 marathon landed the real filters and routing that close the loop: `apx-cite` and `apx-figure` are wired now (#4448, #4450), content-trigger LaTeX routing is live (#4451), and B-002/B-005 are on main. Treat every "Default if no answer", "blocked", "stub", "identity filter", and "not yet defined" note below as resolved by that shipped reality.
 
 ## B-002-B: `emit_base_pptx` OOXML design choices
 
 ### PPTX `fmtScheme` in `<a:themeElements>`
 
-ECMA-376 requires `<a:fmtScheme>` inside `<a:themeElements>`. The existing `sinks/ooxml.rs`
-emits a stub `<a:fmtScheme name=""/>`. For a base.pptx, Office consumers need the
+ECMA-376 requires `<a:fmtScheme>` inside `<a:themeElements>`. The scaffold-era `sinks/ooxml.rs`
+emitted a stub `<a:fmtScheme name=""/>`; the shipped implementation now embeds the full
+Office-default format scheme. For a base.pptx, Office consumers need the
 `<a:fillStyleLst>`, `<a:lnStyleLst>`, `<a:effectStyleLst>`, and `<a:bgFillStyleLst>` children
 to be non-empty, otherwise the format scheme is invalid and PowerPoint falls back to Office
-defaults. **Decision needed**: should `emit_base_pptx` embed the full Office-default format scheme
-(copy from slides/pptx.rs `THEME` static) or keep the stub? Recommendation: embed the Office-
-default format scheme so the base.pptx opens cleanly in both PowerPoint and LibreOffice.
+defaults. **RESOLVED:** `emit_base_pptx` embeds the full Office-default format scheme from
+`slides/pptx.rs`, so the base.pptx opens cleanly in both PowerPoint and LibreOffice.
 
 ### Blank slide layout type
 
 The one blank title slide in base.pptx should reference a `slideLayout` of type `"blank"` or
 `"title"`. Using `type="blank"` (no placeholders) is safest for a template/base file; `type="title"`
 creates a title+content placeholder. The existing slides crate uses `type="titleAndContent"` for
-content slides. **Decision**: use `type="blank"` for the base.pptx master slide layout.
+content slides. **RESOLVED:** the base.pptx master slide layout uses `type="blank"`.
 
 ### `<p:sldMaster>` color map
 
 The slideMaster must carry a `<p:clrMap>` mapping scheme slots to DrawingML token names (e.g.
 `bg1="lt1" tx1="dk1"`). This is required for theme colors to propagate through the layout hierarchy.
-The mapping is standard OOXML and does not vary by theme — copy from slides/pptx.rs.
+The mapping is standard OOXML and does not vary by theme — copied from `slides/pptx.rs` in the
+shipped implementation.
 
 ---
 
@@ -42,29 +43,29 @@ needed for functional Pandoc output:
 - `Body Text` (body paragraph)
 - `Default Paragraph Font` (character style)
 
-**Decision**: emit all 9 styles listed above. Styles absent from the reference.docx cause Pandoc
+**RESOLVED:** emit all 9 styles listed above. Styles absent from the reference.docx cause Pandoc
 to fall back to its internal defaults — missing styles do not break output, just theme application.
-Emit a minimal set (Normal + Heading 1–3) for the initial implementation; the remaining styles can
-be added in a follow-up without breaking existing consumers.
+The shipped reference-doc includes the full set; the minimal-set note is historical only.
 
 ### Word XML namespace minimum for styles.xml
 
 `word/styles.xml` needs at minimum `xmlns:w` and `xmlns:r`. The `w:rsid*` attributes are optional
 (Pandoc ignores them). The `w:styleId` must match what Pandoc expects exactly (e.g. `"Normal"`,
 `"Heading1"` — note: Pandoc maps `heading 1` display name to `styleId="Heading1"`). The mapping
-is: `styleId="Heading1"` with `<w:name w:val="heading 1"/>`.
+is: `styleId="Heading1"` with `<w:name w:val="heading 1"/>`. The shipped asset uses that shape.
 
 ### ODT style naming for Pandoc
 
 Pandoc's ODT reader looks for styles by name with underscore normalization: `Heading_1` maps to
-"Heading 1". Use `style:name="Heading_1"` and `style:display-name="Heading 1"`.
+"Heading 1". Use `style:name="Heading_1"` and `style:display-name="Heading 1"`. The shipped ODT
+reference asset follows that convention.
 
 ### Embedded fonts vs. font references
 
 The reference.docx and reference.odt should use **font name references** only (not embedded font
 blobs). LibreOffice and Word will substitute if the named font (Geist, Newsreader) is not installed,
 falling back to system defaults. Embedding fonts requires font license verification and adds binary
-payload — out of scope for B-002.
+payload — out of scope for B-002. The shipped assets keep the font references only.
 
 ---
 
@@ -81,14 +82,13 @@ payload — out of scope for B-002.
 
 **Date:** 2026-05-29
 **Entry:** B-012 — poiesis Pandoc backend module under poiesis-doc
-**Status:** Scaffold committed; Q1 + Q2 resolved by B-001 landing; Q3 + Q4 still need operator answers
+**Status:** Superseded by the v1.0 marathon; Q1-Q4 are resolved in the shipped implementation
 
-> **UPDATE 2026-05-29:** B-001 has landed at `0cb2bd3b` (PR #4350). Q1 and Q2 are resolved —
-> defaults accepted. See notes under each question. Q3 and Q4 remain open.
+> **UPDATE 2026-05-29:** B-001 landed at `0cb2bd3b` (PR #4350), and the later v1.0 marathon closed the remaining gaps. Q1-Q4 are resolved in the current tree; the notes below are historical only.
 
-This PR delivers the mechanical scaffold: `PandocRunner`, `OutputFormat`, `DocOpts`, the dispatch
-routing skeleton, and stub Lua filters. Q3 and Q4 below need operator answers before the full
-implementation (Lua filter logic) can be finalised. Q1 and Q2 are now closed.
+This PR delivered the mechanical scaffold: `PandocRunner`, `OutputFormat`, `DocOpts`, the dispatch
+routing skeleton, and scaffold-era Lua filters. The landed tree now replaces the stubs with the real
+filters and the live dispatch matrix. Q1-Q4 are resolved in the current branch.
 
 ---
 
@@ -117,8 +117,7 @@ will change.
 
 > **RESOLVED (B-001 landed `0cb2bd3b`):** B-001 added `envelope.rs`, `factbase.rs`, `ids.rs`
 > (including `FactId`) to `poiesis-core`, but did NOT add `Span::Cite` to `rich_text.rs`.
-> **Default accepted:** B-012 serializes `poiesis_core::Document`; `Cite` path is a no-op stub;
-> upgrade to `DeliverableSpec` is a tracked follow-on. B-012 does NOT add types to `poiesis-core`.
+> **RESOLVED:** The current tree serializes `poiesis_core::Document` through the landed Pandoc AST path, and the historical `Cite` stub is gone from the filter flow. The `DeliverableSpec` upgrade remains a follow-on, but the scaffold-era "no-op stub" answer is obsolete.
 
 ---
 
@@ -139,10 +138,7 @@ additions). Until B-001 lands, the content trigger cannot fire.
 2. If B-012 adds these variants to `poiesis-core`, it creates a B-001 ordering constraint: B-001
    must not introduce conflicting variants. Is that acceptable?
 
-> **RESOLVED (B-001 landed `0cb2bd3b`):** B-001 did NOT add `Block::DisplayMath` or
-> `Block::RawBlock` to `block.rs` (verified). **Default accepted:** Content-trigger routing stays
-> stubbed; PDF always routes to Typst; `DocOpts::pdf_engine(PdfEngine::Latex)` is the only LaTeX
-> override path. Full content-trigger wires in as a follow-on when Block variants land.
+> **RESOLVED:** Content-trigger routing is wired in the landed tree. PDF now follows the Typst fast-lane by default and switches to the Pandoc/LaTeX path when math/raw-`LaTeX` content or an explicit engine override requires it.
 
 ---
 
@@ -171,9 +167,7 @@ know:
    the writer format from `FORMAT` (pandoc's global) or from a `doc.cite.source_mode` metadata
    key? The spec mentions the latter as a knob but doesn't specify the key name.
 
-**Default if no answer:** `apx-cite.lua` is a stub that passes `Span("apx-cite")` through
-unchanged (identity filter). The sidecar contract is declared as a TODO comment in the stub. Full
-impl unblocked once Q1 (B-001 Cite type) and Q3 schema are answered.
+> **RESOLVED:** `apx-cite.lua` is now a real filter in the landed backend; the identity-filter fallback is obsolete, and the sidecar contract is implemented in the shipped path rather than left as a TODO.
 
 ---
 
@@ -196,14 +190,13 @@ defined.
    { svg: "<svg>...</svg>", png_path: "/tmp/...png" }` before spawning Pandoc. The filter reads
    it and substitutes. Is this the right shape?
 
-**Default if no answer:** `apx-figure.lua` is a stub (identity). The sidecar contract is
-documented as a TODO comment.
+> **RESOLVED:** `apx-figure.lua` is now a real filter wired to the chart emitter; the identity stub is obsolete and the figure sidecar contract is now exercised by the shipped path.
 
 ---
 
-## What this PR ships without escalation answers
+## Historical scaffold snapshot
 
-The scaffold below is correct and final regardless of the above answers:
+The table below is the original scaffold snapshot, preserved for provenance. Every row now maps to shipped code in the v1.0 marathon tree.
 
 | Item | Status |
 |---|---|
@@ -211,19 +204,19 @@ The scaffold below is correct and final regardless of the above answers:
 | `PandocError` enum | Shipped |
 | `OutputFormat` enum (docx, odt, pdf, md, latex, html, epub) | Shipped |
 | `DocOpts` struct (format + optional pdf_engine override) | Shipped |
-| `render_doc()` dispatch skeleton (Typst for PDF, error-stub for others) | Shipped |
-| `crates/poiesis/filters/apx-cite.lua` stub | Shipped |
-| `crates/poiesis/filters/apx-figure.lua` stub | Shipped |
-| `crates/poiesis/filters/apx-theme.lua` stub | Shipped |
+| `render_doc()` dispatch skeleton (Typst for PDF, error-stub for others) | Replaced by the live dispatch matrix |
+| `crates/poiesis/filters/apx-cite.lua` stub | Replaced by the real filter |
+| `crates/poiesis/filters/apx-figure.lua` stub | Replaced by the real filter |
+| `crates/poiesis/filters/apx-theme.lua` stub | Replaced by the real filter |
 | `cargo deny` assertion placeholder comment | Shipped |
 | Unit tests for dispatch routing | Shipped |
 
-Items blocked on answers above (not in this PR):
+Items that were unresolved in the scaffold are now resolved in the shipped tree:
 
-| Item | Blocked on |
+| Item | Resolution |
 |---|---|
-| Full `Document` → Pandoc JSON AST serialization | Q1 (B-001 types) |
-| Content-trigger LaTeX routing | Q2 (B-001 Block variants) |
-| `apx-cite.lua` factbase resolution | Q1 + Q3 |
-| `apx-figure.lua` chart baking | Q4 (B-005 API) |
-| `reference.{docx,odt}` theming assets | B-002 (not yet landed) |
+| Full `Document` → Pandoc JSON AST serialization | The landed `poiesis-doc` Pandoc AST path |
+| Content-trigger LaTeX routing | The shipped Typst/Pandoc/LaTeX route selection |
+| `apx-cite.lua` factbase resolution | The real `apx-cite` filter |
+| `apx-figure.lua` chart baking | The real `apx-figure` filter and chart bridge |
+| `reference.{docx,odt}` theming assets | The landed theme sinks and doc backend |

--- a/crates/poiesis/CLAUDE.md
+++ b/crates/poiesis/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## At a glance
 
-Report tooling family: format-agnostic document model plus rendering backends (Typst→PDF, ODT, XLSX, ODS, PPTX, DOCX) and report-quality checks (prose lint, numeric claim verify). Zero internal dependencies. Entry points: `core/src/lib.rs` (Document, Renderer) and `typst/src/lib.rs` (`render_typst`, `render_template`).
+Report tooling family: format-agnostic document model plus rendering backends (Typst→PDF, ODT, XLSX, ODS, PPTX, DOCX, and Pandoc-backed DOCX/HTML/MD/LaTeX/EPUB) and report-quality checks (prose lint, numeric claim verify). Zero internal dependencies. Entry points: `core/src/lib.rs` (Document, Renderer) and `typst/src/lib.rs` (`render_typst`, `render_template`).
 
 **Typst is the primary renderer.** Prefer `poiesis-typst` for prose-oriented PDF output - it supports templates, math, citations, breakable blocks, cross-references, and JSON data injection, with structured compile diagnostics carrying source locations. The `text/pdf` backend (via `krilla`) remains for the document-model path where no template system or data injection is needed.
 
 ## Depth
 
-Report tooling family: format-agnostic document model, Typst-based PDF primary renderer, format-specific backends (ODT/XLSX/ODS/PPTX/DOCX), and report-quality checks (lint + verify). ~2K lines.
+Report tooling family: format-agnostic document model, Typst-based PDF primary renderer, format-specific backends (ODT/XLSX/ODS/PPTX/DOCX/Pandoc), and report-quality checks (lint + verify). ~2K lines.
 
 ## Read first
 
@@ -24,9 +24,12 @@ Report tooling family: format-agnostic document model, Typst-based PDF primary r
 |------|------|---------|
 | `render_typst` | `typst/src/lib.rs` | Primary PDF path: Typst source + JSON data → PDF bytes |
 | `render_template` | `typst/src/lib.rs` | Resolve a built-in template slug and render |
+| `render_doc` | `doc/src/pandoc/mod.rs` | Unified Pandoc dispatcher: docx/html/md/latex/epub subprocess, PDF Typst fast-lane with LaTeX override |
 | `PoiesisError` | `typst/src/error.rs` | Typst render errors (serialize, compile, PDF export, unknown slug) |
 | `Document` | `core/src/document.rs` | Format-agnostic document: metadata + ordered content blocks |
 | `Renderer` | `core/src/renderer.rs` | Trait: `render(&self, &Document) -> Result<Vec<u8>, Error>` |
+| `DocOpts` | `doc/src/pandoc/mod.rs` | Pandoc render options: format, PDF engine, Lua filters, reference-doc |
+| `OutputFormat` | `doc/src/pandoc/mod.rs` | Pandoc target matrix (docx, odt, pdf, md, latex, html, epub) |
 | `Metadata` | `core/src/metadata.rs` | Title, author, optional creation timestamp |
 | `Block` | `core/src/block.rs` | Block-level element: Heading, Paragraph, Table, List, Image, PageBreak |
 | `RichText` | `core/src/rich_text.rs` | Sequence of styled inline `Span`s |
@@ -37,6 +40,7 @@ Report tooling family: format-agnostic document model, Typst-based PDF primary r
 | `OdsRenderer` | `sheet/src/ods.rs` | ODS backend via `spreadsheet-ods` |
 | `PptxRenderer` | `slides/src/pptx.rs` | PowerPoint backend via hand-rolled ZIP/XML emitter |
 | `render_docx` | `doc/src/lib.rs` | DOCX backend via `docx-rs`: JSON descriptor → DOCX bytes |
+| `render_odt_from_doc` | `doc/src/lib.rs` | Clean-room ODT backend for document-model exports |
 | `inspect_docx` | `doc/src/lib.rs` | Extract paragraph text from DOCX ZIP via `zip` + `quick-xml` |
 | `DocxSummary` | `doc/src/lib.rs` | Text summary of an inspected DOCX file |
 | `Linter` | `lint/src/lib.rs` | Report prose linter (banned words, citations, structure) |
@@ -63,6 +67,7 @@ Current slugs: `default`.
 | `ods` | `poiesis-sheet` | yes | ODS output via `spreadsheet-ods` |
 | `pptx` | `poiesis-slides` | yes | PPTX output via hand-rolled ZIP/XML emitter |
 | `docx` | `poiesis-doc` | yes | DOCX output via `docx-rs` |
+| `pandoc` | `poiesis-doc` | yes | DOCX/HTML/MD/LaTeX/EPUB via Pandoc subprocess; PDF uses Typst unless LaTeX is required |
 
 ## Patterns
 
@@ -71,6 +76,7 @@ Current slugs: `default`.
 - **Trait-based backends**: Each non-Typst subcrate implements `Renderer`; callers pass the same `Document` to any backend.
 - **Feature-gated dependencies**: Every backend is behind a Cargo feature so consumers only compile what they need.
 - **Plain-text fallback**: Non-Typst backends that cannot natively express a feature (images in PDF/spreadsheets, rich text in XLSX) degrade to plain text or alt text instead of failing.
+- **Pandoc dispatch**: `poiesis-doc` owns the `render_*_from_doc` matrix. DOCX/HTML/MD/LaTeX/EPUB route through Pandoc; PDF stays on Typst unless math/raw-`LaTeX` content or an explicit engine override requires the Pandoc/LaTeX path.
 - **ZIP-based packaging**: ODT, XLSX, ODS, and PPTX are all ZIP archives; tests verify the `PK` magic bytes.
 - **In-memory Typst world**: `poiesis-typst` embeds the compiler as a library; source and injected data live in memory (no temp files, no CLI subprocess).
 

--- a/crates/poiesis/charts/CLAUDE.md
+++ b/crates/poiesis/charts/CLAUDE.md
@@ -47,7 +47,7 @@ Follow-up arms reuse `Scale` + `format` + `Canvas`; only the per-arm geometry di
 
 ## Theme seam
 
-`ResolvedTheme` lives in `src/theme.rs` because `poiesis-theme` (B-002) is not yet on `main`. When B-002 lands, this crate switches to `poiesis_theme::summus().resolve()` and deletes `ResolvedTheme::summus_stub`. The stub mirrors the offsite navy + teal pair (`#232E54`, `#318891`) so B-005 acceptance test 2 ("colors come only from `theme: summus`") can be exercised today.
+`ResolvedTheme` lives in `src/theme.rs` as the chart-local theme seam. B-002 has landed, so the crate bridges through `ResolvedTheme::from_poiesis_theme()` when the `theme-bridge` feature is enabled. `ResolvedTheme::summus_stub()` is retained for the offsite acceptance test, not deleted; it still mirrors the navy + teal pair (`#232E54`, `#318891`) so B-005 acceptance test 2 ("colors come only from `theme: summus`") remains reproducible.
 
 ## Patterns
 
@@ -60,4 +60,4 @@ Follow-up arms reuse `Scale` + `format` + `Canvas`; only the per-arm geometry di
 
 Uses: `poiesis-core`, `serde`, `serde_json`, `snafu`, `tracing`. Dev: `insta` for golden snapshots.
 
-Used by: nothing yet (organon adds the wiring when B-003/B-004 land).
+Used by: organon (doc/figure resvg path).

--- a/crates/poiesis/charts/docs/design/README.md
+++ b/crates/poiesis/charts/docs/design/README.md
@@ -2,8 +2,9 @@
 
 Each file in this directory sketches the geometry, fixed source order, and
 shared-primitive reuse for one `ChartKind` emitter arm. The combo arm
-(`src/render/kinds/combo.rs`) is the implemented reference; the others are
-stubs returning `Error::EmitterStub`.
+(`src/render/kinds/combo.rs`) is the implemented reference; the rest are now
+implemented and wired, so these notes describe the shipped emitters rather
+than stubs.
 
 These notes are intentionally short — each one names what's specific to the
 kind and points at the shared primitives the arm reuses. They are the
@@ -38,15 +39,15 @@ The combo arm follows this; new arms keep the order.
 
 | Kind | File |
 |---|---|
-| bar | [bar.md](bar.md) |
-| column | [column.md](column.md) |
-| line | [line.md](line.md) |
-| area | [area.md](area.md) |
-| scatter | [scatter.md](scatter.md) |
-| pie | [pie.md](pie.md) |
-| doughnut | [doughnut.md](doughnut.md) |
-| stat | [stat.md](stat.md) |
-| combo | implemented — see `src/render/kinds/combo.rs` |
+| bar | implemented / wired — see `src/render/kinds/bar.rs` |
+| column | implemented / wired — see `src/render/kinds/column.rs` |
+| line | implemented / wired — see `src/render/kinds/line.rs` |
+| area | implemented / wired — see `src/render/kinds/area.rs` |
+| scatter | implemented / wired — see `src/render/kinds/scatter.rs` |
+| pie | implemented / wired — see `src/render/kinds/pie.rs` |
+| doughnut | implemented / wired — see `src/render/kinds/doughnut.rs` |
+| stat | implemented / wired — see `src/render/kinds/stat.rs` |
+| combo | implemented / wired — see `src/render/kinds/combo.rs` |
 
 Vega-Lite kinds (`heatmap`, `boxplot`, `sankey`, `candlestick`) route through
 `Chart::validate` and emit via the `charts-vega` feature; their design

--- a/crates/poiesis/theme/CLAUDE.md
+++ b/crates/poiesis/theme/CLAUDE.md
@@ -9,8 +9,9 @@ tightens: this crate's conventions narrow the parent only — sink ownership, by
 ## At a glance
 
 Theme registry, token model, and brand-asset sinks for poiesis. One source of
-brand truth (a `themes/<name>.toml` file) → three sinks (CSS custom
-properties, OOXML `theme1.xml`, Pandoc doc-vars). Three `THEME/*` lint rules
+brand truth (a `themes/<name>.toml` file) → seven sinks (CSS custom
+properties, OOXML `theme1.xml`, Pandoc doc-vars, LaTeX, PPTX, reference.docx,
+Typst). Three `THEME/*` lint rules
 mechanically enforce that specs reference tokens, never raw hex or typeface
 literals.
 
@@ -32,7 +33,7 @@ Locks: spec 03 of forkwright/kanon#978 (apodeixis Phase-00 bootstrap).
 
 ## Patterns
 
-- **One source → three sinks.** Each sink owns its serialization. Cross-sink
+- **One source → seven sinks.** Each sink owns its serialization. Cross-sink
   emission shares nothing beyond `ResolvedTheme`. Adding a sink is a new module
   in `src/sinks/`.
 - **TOML order preserved.** `IndexMap` everywhere a brand-author cares about
@@ -62,10 +63,13 @@ Locks: spec 03 of forkwright/kanon#978 (apodeixis Phase-00 bootstrap).
 | CSS sink                  | shipped (`src/sinks/css.rs`)             | regression-byte test against offsite CSS once [B-003] lands |
 | OOXML `theme1.xml`        | shipped (`src/sinks/ooxml.rs`)           | full `assets/<name>-base.pptx` raw OOXML pack belongs to [B-004]; this crate emits the `theme1.xml` body |
 | Pandoc doc-vars           | shipped (`src/sinks/docvars.rs`, JSON + YAML) | generate `reference.docx/odt/template.{typ,latex}` in [B-006] |
+| LaTeX prelude             | shipped (`src/sinks/latex.rs`)           | `\definecolor` / `\newcommand` assets for the doc backend |
+| PPTX pack                 | shipped (`src/sinks/pptx.rs`)            | packed base PPTX template with the theme baked in |
+| reference.docx            | shipped (`src/sinks/reference_docx.rs`)  | Pandoc reference-doc asset for DOCX theming |
+| Typst prelude             | shipped (`src/sinks/typst.rs`)           | Typst prelude for the PDF / report template path |
 | `THEME/*` lint rules      | shipped (`src/lint.rs`) — rule shapes + scan/check APIs | register with the [B-008] basanos engine |
 
 ## Dependencies
 
 Uses: indexmap, jiff, regex, serde, serde_json, snafu, toml.
-Used by: (none yet). The intended consumers are [B-001] core, [B-003] HTML
-deck, [B-004] PPTX, [B-006] doc, and [B-008] QA gate.
+Used by: organon (hard dep); poiesis-charts (optional theme-bridge feature).


### PR DESCRIPTION
Q12 in-repo doc-truth sweep. Corrects agent-guidance docs that no longer described reality after the v1.0 marathon: root CLAUDE.md CI-exact clippy command (drops the removed theatron/skene/koilon excludes, #4429); ESCALATION.md marked SUPERSEDED (its stub/identity-filter/blocked questions all resolved by #4448/#4450/#4451 + B-002/B-005); poiesis-theme CLAUDE.md (three→seven sinks, Used-by organon+charts); poiesis-charts CLAUDE.md (B-002 landed, from_poiesis_theme bridge) + charts/docs/design/README.md (all 9 emitters implemented+wired, not EmitterStub); poiesis CLAUDE.md (pandoc backend noted). Docs-only; _llm/* untouched (auto-generated). Kanon planning-doc refresh handled in the readiness-review phase.