### PR TITLE
feat(hermeneus): warn when seat-bridged providers drop tool defs + provider capability matrix

### DIFF
--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -104,7 +104,7 @@ l3_token_estimate = 5222
 [[crates]]
 name = "hermeneus"
 path = "crates/hermeneus"
-source_hash = "1c3372fe881b0812ac402f3ecdc852b50f7bf50fafd261b84a6762c2e7b169a5"
+source_hash = "e4e4891319a8d19a81e0cc17b1c4aebad4ab26787e06b5ff3855e93e04e814ad"
 l3_token_estimate = 13362
 
 [[crates]]

--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -11,10 +11,11 @@
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use koina::system::{Environment, RealSystem};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
@@ -151,9 +152,34 @@ impl CcProvider {
         parts.join("\n\n")
     }
 
+    fn warn_dropped_tools(dropped_tools: usize) -> bool {
+        // WHY: Seat-bridged subprocess providers run their own CLI-side agentic loop, so
+        // aletheia's tools are intentionally not translated through this adapter.
+        static WARNED: AtomicBool = AtomicBool::new(false);
+
+        if dropped_tools == 0 {
+            return false;
+        }
+
+        let warned = WARNED
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+
+        if warned {
+            warn!(
+                provider = "cc",
+                dropped_tools,
+                "cc dropped {dropped_tools} tool definitions; this seat-bridged CLI runs its own agentic loop so aletheia's tools are not invoked. Use a native API provider for aletheia's tool-loop"
+            );
+        }
+
+        warned
+    }
+
     /// Execute a non-streaming completion via CC subprocess.
     async fn execute(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
         let model = self.resolve_model(&request.model);
+        Self::warn_dropped_tools(request.tools.len());
         let prompt = Self::format_prompt(request);
         let system = request.system.as_deref();
 
@@ -183,6 +209,7 @@ impl CcProvider {
         on_event: &mut (dyn FnMut(StreamEvent) + Send),
     ) -> Result<CompletionResponse> {
         let model = self.resolve_model(&request.model);
+        Self::warn_dropped_tools(request.tools.len());
         let prompt = Self::format_prompt(request);
         let system = request.system.as_deref();
 
@@ -455,5 +482,12 @@ mod tests {
         );
         assert_eq!(provider.subprocess_timeout(), Duration::from_mins(5));
         assert_eq!(provider.cli_product_name(), "claude");
+    }
+
+    #[test]
+    fn warns_once_for_dropped_tools() {
+        assert!(!CcProvider::warn_dropped_tools(0));
+        assert!(CcProvider::warn_dropped_tools(1));
+        assert!(!CcProvider::warn_dropped_tools(2));
     }
 }

--- a/crates/hermeneus/src/codex/provider.rs
+++ b/crates/hermeneus/src/codex/provider.rs
@@ -7,10 +7,11 @@
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use koina::system::{Environment, RealSystem};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
@@ -135,8 +136,33 @@ impl CodexProvider {
         parts.join("\n\n")
     }
 
+    fn warn_dropped_tools(dropped_tools: usize) -> bool {
+        // WHY: Seat-bridged subprocess providers run their own CLI-side agentic loop, so
+        // aletheia's tools are intentionally not translated through this adapter.
+        static WARNED: AtomicBool = AtomicBool::new(false);
+
+        if dropped_tools == 0 {
+            return false;
+        }
+
+        let warned = WARNED
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+
+        if warned {
+            warn!(
+                provider = "codex",
+                dropped_tools,
+                "codex dropped {dropped_tools} tool definitions; this seat-bridged CLI runs its own agentic loop so aletheia's tools are not invoked. Use a native API provider for aletheia's tool-loop"
+            );
+        }
+
+        warned
+    }
+
     async fn execute(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
         let model = self.resolve_model(&request.model);
+        Self::warn_dropped_tools(request.tools.len());
         let prompt = Self::format_prompt(request);
 
         let output = Box::pin(process::run_completion(
@@ -164,6 +190,7 @@ impl CodexProvider {
         on_event: &mut (dyn FnMut(StreamEvent) + Send),
     ) -> Result<CompletionResponse> {
         let model = self.resolve_model(&request.model);
+        Self::warn_dropped_tools(request.tools.len());
         let prompt = Self::format_prompt(request);
 
         let output = Box::pin(process::run_completion(
@@ -517,5 +544,12 @@ mod tests {
         );
         assert_eq!(provider.subprocess_timeout(), Duration::from_secs(300));
         assert_eq!(provider.cli_product_name(), "codex");
+    }
+
+    #[test]
+    fn warns_once_for_dropped_tools() {
+        assert!(!CodexProvider::warn_dropped_tools(0));
+        assert!(CodexProvider::warn_dropped_tools(1));
+        assert!(!CodexProvider::warn_dropped_tools(2));
     }
 }

--- a/crates/hermeneus/src/kimi/provider.rs
+++ b/crates/hermeneus/src/kimi/provider.rs
@@ -12,10 +12,11 @@
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use koina::system::{Environment, RealSystem};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
@@ -167,8 +168,33 @@ impl KimiProvider {
         parts.join("\n\n")
     }
 
+    fn warn_dropped_tools(dropped_tools: usize) -> bool {
+        // WHY: Seat-bridged subprocess providers run their own CLI-side agentic loop, so
+        // aletheia's tools are intentionally not translated through this adapter.
+        static WARNED: AtomicBool = AtomicBool::new(false);
+
+        if dropped_tools == 0 {
+            return false;
+        }
+
+        let warned = WARNED
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+
+        if warned {
+            warn!(
+                provider = "kimi",
+                dropped_tools,
+                "kimi dropped {dropped_tools} tool definitions; this seat-bridged CLI runs its own agentic loop so aletheia's tools are not invoked. Use a native API provider for aletheia's tool-loop"
+            );
+        }
+
+        warned
+    }
+
     async fn execute(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
         let model = self.resolve_model(&request.model);
+        Self::warn_dropped_tools(request.tools.len());
         let prompt = Self::format_prompt(request);
         let system = request.system.as_deref();
         let process_config = process::KimiProcessConfig {
@@ -195,6 +221,7 @@ impl KimiProvider {
         on_event: &mut (dyn FnMut(StreamEvent) + Send),
     ) -> Result<CompletionResponse> {
         let model = self.resolve_model(&request.model);
+        Self::warn_dropped_tools(request.tools.len());
         let prompt = Self::format_prompt(request);
         let system = request.system.as_deref();
         let process_config = process::KimiProcessConfig {
@@ -293,6 +320,18 @@ impl LlmProvider for KimiProvider {
         on_event: &'a mut (dyn FnMut(StreamEvent) + Send),
     ) -> Pin<Box<dyn Future<Output = Result<CompletionResponse>> + Send + 'a>> {
         Box::pin(self.execute_streaming(request, on_event))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warns_once_for_dropped_tools() {
+        assert!(!KimiProvider::warn_dropped_tools(0));
+        assert!(KimiProvider::warn_dropped_tools(1));
+        assert!(!KimiProvider::warn_dropped_tools(2));
     }
 }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -36,6 +36,7 @@ Runtime configuration uses the three-layer TOML cascade above. Agent bootstrap f
 - [bindings](#bindings)
 - [embedding](#embedding)
 - [credential](#credential)
+- [provider capability matrix](#provider-capability-matrix)
 - [data](#data)
 - [nous_behavior](#nous_behavior)
 - [daemon_behavior](#daemon_behavior)
@@ -337,6 +338,19 @@ Controls how the server discovers LLM API credentials. The `source` field select
 source = "auto"
 claude_code_credentials = "~/.claude/.credentials.json"
 ```
+
+---
+
+## provider capability matrix
+
+Aletheia can route completions through either the native Anthropic provider or seat-bridged CLI providers. The seat-bridged providers run the CLI's own agentic loop, so `request.tools` are not translated into Aletheia tool execution.
+
+| Provider path | Credential source | Simple chat + recall | Aletheia organon tool-loop | Notes |
+|---|---|---|---|---|
+| Native Anthropic provider | `ANTHROPIC_API_KEY` | yes | yes | Serializes `request.tools` and parses `ToolUse` blocks. |
+| Claude Code subprocess (`cc`) | Local Claude Code OAuth seat; no API key | yes | no | Runs `claude -p`; tools stay inside the CLI's own loop. |
+| Codex subprocess (`codex`) | Local Codex seat; no API key | yes | no | Runs `codex exec`; tools stay inside the CLI's own loop. |
+| Kimi subprocess (`kimi`) | Local Kimi seat; no API key | yes | no | Runs `kimi`; tools stay inside the CLI's own loop. |
 
 ---
 


### PR DESCRIPTION
From the 2026-06-09 metis e2e (#4463). The seat-bridged subprocess providers (cc/codex/kimi) ignore `request.tools` and run their CLI's own agentic loop, so aletheia's organon tool-loop never fires through them — previously SILENT (zero diagnostics). This adds a once-per-process WARN per provider naming the provider + dropped-tool count + the native-API remedy, and documents the provider→capability matrix in docs/CONFIGURATION.md. By-design behavior made observable + documented (operator-approved accept+document+guardrail for v1.0); does NOT wire tools through the CLIs. 402 hermeneus tests pass.