### PR TITLE
fix(init): quote pricing table key so provider-namespaced model ids produce valid TOML

### DIFF
--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "426706fe25514a605ba7397e546983de87630343d0587b95d4999d12257352ff"
+source_hash = "0c89c38a3c02ac051eb03ce9c2d87c259607deca7e73fcc2b8accb6cbaa4ff4c"
 l3_token_estimate = 167
 
 [[crates]]

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -112,6 +112,7 @@ toml_edit = "0.25"
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+hermeneus = { path = "../hermeneus", features = ["test-support"] }
 mneme = { path = "../mneme", features = ["test-support"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -195,6 +195,7 @@ pub(super) fn render_config(a: &Answers) -> String {
     // works regardless of where the instance directory is placed on disk.
     // Oikos::validate_workspace_path resolves relative paths against the root.
     let workspace = format!("nous/{}", a.agent_id);
+    let pricing_key = toml_edit::Key::new(&a.model).to_string();
     let mut config = format!(
         r#"# Aletheia Instance Configuration
 # Config cascade: compiled defaults -> this file -> ALETHEIA_* env vars
@@ -275,7 +276,7 @@ workspace = "{workspace}"
 # warn_threshold_mb = 100
 
 # --- Cost tracking ---
-[pricing.{model}]
+[pricing.{pricing_key}]
 inputCostPerMtok = 3.0
 outputCostPerMtok = 15.0
 
@@ -286,6 +287,7 @@ source = "{credential_source}"
         bind = a.bind,
         auth_mode = a.auth_mode,
         model = a.model,
+        pricing_key = pricing_key,
         timezone = a.timezone,
         agent_id = a.agent_id,
         agent_name = a.agent_name,
@@ -317,7 +319,9 @@ extraExecPaths = ["~"]
 
 #[cfg(test)]
 mod tests {
-    use super::pronoea_template;
+    use std::path::PathBuf;
+
+    use super::{Answers, pronoea_template, render_config};
 
     const TEMPLATE_PROSOCHE: &str =
         include_str!("../../../../instance.example/nous/_template/PROSOCHE.md");
@@ -355,6 +359,33 @@ mod tests {
             assert!(
                 numbered_check_count(content) <= 5,
                 "{name} must fit within the 5-tool-call heartbeat budget"
+            );
+        }
+    }
+
+    #[test]
+    fn render_config_emits_valid_toml_for_any_model_id() {
+        for model in [
+            "codex/gpt-5-codex",
+            "kimi/kimi-k2-thinking",
+            "claude-sonnet-4-6",
+        ] {
+            let answers = Answers {
+                root: PathBuf::from("/tmp/aletheia-init"),
+                api_key: None,
+                api_provider: "anthropic".to_owned(),
+                model: model.to_owned(),
+                agent_id: "alice".to_owned(),
+                agent_name: "Alice".to_owned(),
+                bind: "localhost".to_owned(),
+                auth_mode: "none".to_owned(),
+                timezone: "America/Chicago".to_owned(),
+                credential_source: "auto".to_owned(),
+            };
+
+            assert!(
+                toml::from_str::<toml::Value>(&render_config(&answers)).is_ok(),
+                "rendered config must parse for model id {model}"
             );
         }
     }


### PR DESCRIPTION
Fixes #4459. `aletheia init --model codex/gpt-5-codex` (or kimi/kimi-k2-thinking) wrote `[pricing.<model>]` as a bare TOML key — the `/` is illegal, so the generated config failed to parse and check-config/server-start aborted. Now quotes the key via toml_edit so any model id is valid TOML; added a round-trip regression test (codex/kimi prefixed + the bare default). Reader unchanged (taxis pricing HashMap deserializes the quoted key identically). 306 tests pass.