### PR TITLE
fix(hermeneus): route prefixed codex/kimi models, parse codex token usage, omit invalid kimi --model

### DIFF
--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -104,7 +104,7 @@ l3_token_estimate = 5222
 [[crates]]
 name = "hermeneus"
 path = "crates/hermeneus"
-source_hash = "e4e4891319a8d19a81e0cc17b1c4aebad4ab26787e06b5ff3855e93e04e814ad"
+source_hash = "78921499777a967cd716d113b895d177980d21b6dd5b0a5c6e078b5f69117ce4"
 l3_token_estimate = 13362
 
 [[crates]]

--- a/crates/hermeneus/src/codex/parse.rs
+++ b/crates/hermeneus/src/codex/parse.rs
@@ -1,26 +1,102 @@
-//! Parse Codex CLI plain-text output.
+//! Parse Codex CLI `--json` output.
 //!
-//! `codex exec` emits plain text on stdout for headless invocations. The
-//! adapter buffers that output and maps it into Hermeneus' Anthropic-native
-//! response shape.
+//! `codex exec --json` emits newline-delimited JSON events on stdout.
+//! The adapter collects assistant text from `item.completed` events and
+//! final usage from the last `turn.completed` event.
+
+use serde_json::Value;
+use tracing::warn;
 
 use crate::error::{self, Result};
 use crate::types::{CompletionResponse, ContentBlock, StopReason, Usage};
 
-/// Normalize buffered Codex stdout into assistant text.
-pub(crate) fn parse_output(stdout: &str) -> Result<String> {
-    let text = stdout.trim_end_matches(['\r', '\n']).to_owned();
-    if text.trim().is_empty() {
+/// Parsed Codex subprocess output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CodexParsedOutput {
+    pub text: String,
+    pub usage: Usage,
+}
+
+/// Parse Codex JSONL output into assistant text and usage.
+pub(crate) fn parse_output(stdout: &str) -> Result<CodexParsedOutput> {
+    let mut text = String::new();
+    let mut usage = Usage::default();
+
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let value: Value = match serde_json::from_str(trimmed) {
+            Ok(value) => value,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    line = %trimmed,
+                    "failed to parse Codex stream-json event"
+                );
+                continue;
+            }
+        };
+
+        match value.get("type").and_then(Value::as_str) {
+            Some("item.completed") => {
+                if value
+                    .get("item")
+                    .and_then(|item| item.get("type"))
+                    .and_then(Value::as_str)
+                    == Some("agent_message")
+                    && let Some(part) = value
+                        .get("item")
+                        .and_then(|item| item.get("text"))
+                        .and_then(Value::as_str)
+                {
+                    if !part.is_empty() {
+                        text.push_str(part);
+                    }
+                }
+            }
+            Some("turn.completed") => {
+                if let Some(parsed) = parse_usage(value.get("usage")) {
+                    usage = parsed;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if text.is_empty() {
         return Err(error::ApiRequestSnafu {
             message: "Codex subprocess produced no text output".to_owned(),
         }
         .build());
     }
-    Ok(text)
+
+    Ok(CodexParsedOutput { text, usage })
 }
 
-/// Convert Codex plain text into a [`CompletionResponse`].
-pub(crate) fn text_to_response(text: &str, model: &str) -> CompletionResponse {
+fn parse_usage(value: Option<&Value>) -> Option<Usage> {
+    let value = value?;
+    Some(Usage {
+        input_tokens: value
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        output_tokens: value
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        cache_read_tokens: value
+            .get("cached_input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        cache_write_tokens: 0,
+    })
+}
+
+/// Convert parsed Codex text and usage into a `CompletionResponse`.
+pub(crate) fn text_to_response(text: &str, usage: Usage, model: &str) -> CompletionResponse {
     CompletionResponse {
         id: format!("codex_{}", koina::uuid::uuid_v4()),
         model: model.to_owned(),
@@ -29,7 +105,7 @@ pub(crate) fn text_to_response(text: &str, model: &str) -> CompletionResponse {
             text: text.to_owned(),
             citations: None,
         }],
-        usage: Usage::default(),
+        usage,
         cost_usd: None,
         duration_ms: None,
     }
@@ -41,15 +117,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_output_trims_trailing_newlines() {
-        let text = parse_output("hello world\n\n").unwrap();
-        assert_eq!(text, "hello world");
+    fn parse_output_parses_jsonl_text_and_usage() {
+        let output = parse_output(
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"hello "}}
+{"type":"item.completed","item":{"type":"agent_message","text":"world"}}
+{"type":"turn.completed","usage":{"input_tokens":11,"cached_input_tokens":3,"output_tokens":7}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(output.text, "hello world");
+        assert_eq!(output.usage.input_tokens, 11);
+        assert_eq!(output.usage.output_tokens, 7);
+        assert_eq!(output.usage.cache_read_tokens, 3);
+        assert_eq!(output.usage.cache_write_tokens, 0);
     }
 
     #[test]
-    fn parse_output_preserves_internal_whitespace() {
-        let text = parse_output("line one\n\nline two\n").unwrap();
-        assert_eq!(text, "line one\n\nline two");
+    fn parse_output_skips_malformed_lines_and_keeps_later_events() {
+        let output = parse_output(
+            r#"not json
+{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}
+{"type":"turn.completed","usage":{"input_tokens":2,"cached_input_tokens":1,"output_tokens":4}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(output.text, "ok");
+        assert_eq!(output.usage.input_tokens, 2);
+        assert_eq!(output.usage.output_tokens, 4);
+        assert_eq!(output.usage.cache_read_tokens, 1);
     }
 
     #[test]
@@ -60,10 +155,20 @@ mod tests {
 
     #[test]
     fn text_to_response_wraps_text_block() {
-        let response = text_to_response("done", "gpt-5-codex");
+        let response = text_to_response(
+            "done",
+            Usage {
+                input_tokens: 9,
+                output_tokens: 4,
+                cache_read_tokens: 2,
+                cache_write_tokens: 0,
+            },
+            "gpt-5-codex",
+        );
         assert!(response.id.starts_with("codex_"));
         assert_eq!(response.model, "gpt-5-codex");
         assert_eq!(response.stop_reason, StopReason::EndTurn);
         assert_eq!(response.content.len(), 1);
+        assert_eq!(response.usage.input_tokens, 9);
     }
 }

--- a/crates/hermeneus/src/codex/process.rs
+++ b/crates/hermeneus/src/codex/process.rs
@@ -81,6 +81,7 @@ pub(crate) async fn run_completion(
         .arg("--skip-git-repo-check")
         .arg("--color")
         .arg("never")
+        .arg("--json")
         .arg("-")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/hermeneus/src/codex/process_tests.rs
+++ b/crates/hermeneus/src/codex/process_tests.rs
@@ -3,6 +3,8 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt as _;
 
+use crate::codex::parse;
+
 use super::*;
 
 const ETXTBSY: i32 = 26;
@@ -118,7 +120,7 @@ async fn run_completion_spawn_failure_reports_binary_path() {
 }
 
 #[tokio::test]
-async fn run_completion_success_collects_plain_output() {
+async fn run_completion_success_collects_jsonl_output() {
     let script = write_script(
         "completion_ok",
         r#"test "$1" = "exec" || exit 31
@@ -126,19 +128,39 @@ test "$2" = "--dangerously-bypass-approvals-and-sandbox" || exit 32
 test "$3" = "--skip-git-repo-check" || exit 33
 test "$4" = "--color" || exit 34
 test "$5" = "never" || exit 35
-test "$6" = "-" || exit 36
-test -z "${OPENAI_API_KEY+x}" || exit 37
+test "$6" = "--json" || exit 36
+test "$7" = "-" || exit 37
+test -z "${OPENAI_API_KEY+x}" || exit 38
 input="$(cat)"
-test "$input" = "prompt text" || exit 38
-printf 'codex says hello\n'"#,
+test "$input" = "prompt text" || exit 39
+printf '{"type":"item.completed","item":{"type":"agent_message","text":"codex says hello"}}\n'
+printf '{"type":"turn.completed","usage":{"input_tokens":4,"cached_input_tokens":1,"output_tokens":2}}\n'"#,
     );
 
     let output = run_completion(&script, None, "prompt text", Duration::from_secs(10))
         .await
         .unwrap();
 
-    assert_eq!(output.stdout, "codex says hello\n");
+    assert!(output.stdout.contains(r#""type":"item.completed""#));
+    assert!(output.stdout.contains("codex says hello"));
+    assert!(output.stdout.contains(r#""type":"turn.completed""#));
     let _ = fs::remove_file(&script);
+}
+
+#[test]
+fn parse_output_jsonl_fixture_captures_text_and_usage() {
+    let parsed = parse::parse_output(
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"hello "}}
+{"type":"item.completed","item":{"type":"agent_message","text":"world"}}
+{"type":"turn.completed","usage":{"input_tokens":12,"cached_input_tokens":5,"output_tokens":7}}"#,
+    )
+    .unwrap();
+
+    assert_eq!(parsed.text, "hello world");
+    assert_eq!(parsed.usage.input_tokens, 12);
+    assert_eq!(parsed.usage.output_tokens, 7);
+    assert_eq!(parsed.usage.cache_read_tokens, 5);
+    assert_eq!(parsed.usage.cache_write_tokens, 0);
 }
 
 #[tokio::test]

--- a/crates/hermeneus/src/codex/provider.rs
+++ b/crates/hermeneus/src/codex/provider.rs
@@ -15,7 +15,7 @@ use tracing::{debug, info, warn};
 
 use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
-use crate::provider::{DeploymentTarget, LlmProvider};
+use crate::provider::{DeploymentTarget, LlmProvider, MatchKind};
 use crate::seat_bridged::SeatBridgedProvider;
 use crate::types::{CompletionRequest, CompletionResponse, Content, ContentBlock, Role};
 
@@ -172,9 +172,9 @@ impl CodexProvider {
             self.timeout,
         ))
         .await?;
-        let text = parse::parse_output(&output.stdout)?;
+        let parse::CodexParsedOutput { text, usage } = parse::parse_output(&output.stdout)?;
 
-        Ok(parse::text_to_response(&text, model))
+        Ok(parse::text_to_response(&text, usage, model))
     }
 
     /// Execute a streaming completion, emitting `StreamEvent::TextDelta` for each
@@ -200,7 +200,7 @@ impl CodexProvider {
             self.timeout,
         ))
         .await?;
-        let text = parse::parse_output(&output.stdout)?;
+        let parse::CodexParsedOutput { text, usage } = parse::parse_output(&output.stdout)?;
 
         // WHY: Codex's CLI does not support line-by-line streaming; we emit the
         // full response as a single TextDelta so callers that consume
@@ -208,7 +208,7 @@ impl CodexProvider {
         // which seat-bridged provider they're talking to.
         on_event(StreamEvent::TextDelta { text: text.clone() });
 
-        Ok(parse::text_to_response(&text, model))
+        Ok(parse::text_to_response(&text, usage, model))
     }
 }
 
@@ -275,7 +275,17 @@ impl LlmProvider for CodexProvider {
     }
 
     fn supports_model(&self, model: &str) -> bool {
-        model.starts_with(CODEX_MODEL_PREFIX) || SUPPORTED_MODELS.contains(&model)
+        self.match_specificity(model).is_some()
+    }
+
+    fn match_specificity(&self, model: &str) -> Option<MatchKind> {
+        if model.starts_with(CODEX_MODEL_PREFIX) {
+            Some(MatchKind::Prefix)
+        } else if SUPPORTED_MODELS.contains(&model) {
+            Some(MatchKind::Exact)
+        } else {
+            None
+        }
     }
 
     fn name(&self) -> &'static str {
@@ -506,6 +516,24 @@ mod tests {
         assert!(provider.supports_model("codex/gpt-5-codex"));
         assert!(provider.supports_model("gpt-5-codex"));
         assert!(!provider.supports_model("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn match_specificity_prefers_prefix_and_exact() {
+        let provider = CodexProvider {
+            codex_binary: PathBuf::from("codex"),
+            default_model: "codex/gpt-5-codex".to_owned(),
+            timeout: Duration::from_secs(1),
+        };
+        assert_eq!(
+            provider.match_specificity("codex/gpt-5-codex"),
+            Some(MatchKind::Prefix)
+        );
+        assert_eq!(
+            provider.match_specificity("gpt-5-codex"),
+            Some(MatchKind::Exact)
+        );
+        assert_eq!(provider.match_specificity("claude-sonnet-4-6"), None);
     }
 
     #[test]

--- a/crates/hermeneus/src/kimi/process.rs
+++ b/crates/hermeneus/src/kimi/process.rs
@@ -1,7 +1,7 @@
 //! Kimi subprocess management.
 //!
 //! Spawns `kimi --print --output-format stream-json --input-format text --afk --yolo --thinking
-//! -w <cwd> --model <model>` and writes the prompt over stdin.
+//! -w <cwd> [--model <model>]` and writes the prompt over stdin.
 //! manages the child process lifecycle: stdout reading, timeout, and cleanup.
 
 use std::path::Path;
@@ -81,7 +81,7 @@ fn compose_prompt(system_prompt: Option<&str>, prompt: &str) -> Result<String> {
     }
 }
 
-fn build_kimi_command(kimi_binary: &Path, cwd: &Path, model: &str) -> Command {
+fn build_kimi_command(kimi_binary: &Path, cwd: &Path, model: Option<&str>) -> Command {
     let mut cmd = Command::new(kimi_binary);
     cmd.arg("--print")
         .arg("--output-format")
@@ -92,10 +92,11 @@ fn build_kimi_command(kimi_binary: &Path, cwd: &Path, model: &str) -> Command {
         .arg("--yolo")
         .arg("--thinking")
         .arg("-w")
-        .arg(cwd)
-        .arg("--model")
-        .arg(model)
-        .current_dir(cwd)
+        .arg(cwd);
+    if let Some(model) = model {
+        cmd.arg("--model").arg(model);
+    }
+    cmd.current_dir(cwd)
         .kill_on_drop(true)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -128,7 +129,7 @@ pub(crate) struct KimiOutput {
 pub(crate) struct KimiProcessConfig<'a> {
     pub kimi_binary: &'a Path,
     pub cwd: &'a Path,
-    pub model: &'a str,
+    pub model: Option<&'a str>,
     pub timeout: Duration,
 }
 
@@ -295,7 +296,7 @@ pub(crate) async fn run_streaming(
 fn spawn_kimi(
     kimi_binary: &Path,
     cwd: &Path,
-    model: &str,
+    model: Option<&str>,
     log_message: &'static str,
 ) -> Result<Child> {
     debug!(
@@ -407,9 +408,15 @@ where
 
         let trimmed = line.trim();
         if trimmed.starts_with('{') {
-            if let Some(text) = parse_json_message_text(trimmed)? {
-                on_delta(&text);
-                stream_deltas.push(text);
+            match parse_json_message_text(trimmed) {
+                Ok(Some(text)) => {
+                    on_delta(&text);
+                    stream_deltas.push(text);
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    warn!(error = %e, line = %trimmed, "failed to parse Kimi stream-json output");
+                }
             }
             continue;
         }

--- a/crates/hermeneus/src/kimi/process_tests.rs
+++ b/crates/hermeneus/src/kimi/process_tests.rs
@@ -66,7 +66,7 @@ fn process_config<'a>(kimi_binary: &'a Path, cwd: &'a Path) -> KimiProcessConfig
     KimiProcessConfig {
         kimi_binary,
         cwd,
-        model: "kimi-k2-thinking",
+        model: None,
         timeout: Duration::from_secs(10),
     }
 }
@@ -153,7 +153,7 @@ async fn read_stream_with_callback_invokes_for_text_parts() {
 async fn read_stream_parses_stream_json_text_content() {
     let buf = stream_buf(&[
         r#"{"role":"tool","content":"ignored"}"#,
-        r#"{"role":"assistant","content":"hello"}"#,
+        r#"{"role":"assistant","content":[{"type":"think","think":"hidden"},{"type":"text","text":"hello"}]}"#,
         r#"{"role":"assistant","content":[{"type":"think","think":"hidden"},{"type":"text","text":" world"}]}"#,
     ]);
 
@@ -163,10 +163,23 @@ async fn read_stream_parses_stream_json_text_content() {
     assert_eq!(output.stream_deltas, vec!["hello", " world"]);
 }
 
+#[tokio::test]
+async fn read_stream_skips_malformed_json_lines() {
+    let buf = stream_buf(&[
+        "not json",
+        r#"{"role":"assistant","content":[{"type":"think","think":"hidden"},{"type":"text","text":"ok"}]}"#,
+    ]);
+
+    let output = read_stream(buf.as_slice()).await.unwrap();
+
+    assert_eq!(output.result_text, "ok");
+    assert_eq!(output.stream_deltas, vec!["ok"]);
+}
+
 #[test]
 fn build_kimi_command_uses_validated_headless_invocation_and_scrubs_api_key() {
     let cwd = Path::new("/tmp");
-    let mut cmd = build_kimi_command(Path::new("/usr/bin/kimi"), cwd, "kimi-k2-thinking");
+    let mut cmd = build_kimi_command(Path::new("/usr/bin/kimi"), cwd, None);
     cmd.env("MOONSHOT_API_KEY", "raw-api-key");
     scrub_kimi_auth_env(&mut cmd);
 
@@ -175,6 +188,7 @@ fn build_kimi_command_uses_validated_headless_invocation_and_scrubs_api_key() {
         .get_args()
         .map(|arg| arg.to_string_lossy().into_owned())
         .collect();
+    assert!(!args.iter().any(|arg| arg == "--model"));
     assert_eq!(
         args,
         vec![
@@ -188,8 +202,6 @@ fn build_kimi_command_uses_validated_headless_invocation_and_scrubs_api_key() {
             "--thinking",
             "-w",
             "/tmp",
-            "--model",
-            "kimi-k2-thinking",
         ]
     );
 
@@ -214,11 +226,11 @@ async fn run_completion_uses_stub_kimi_shape() {
 [ "$7" = "--yolo" ] || exit 2
 [ "$8" = "--thinking" ] || exit 2
 [ "$9" = "-w" ] || exit 2
-[ "${11}" = "--model" ] || exit 2
-[ "${12}" = "kimi-k2-thinking" ] || exit 2
+[ "$10" = "$(pwd)" ] || exit 2
+test $# -eq 10 || exit 2
 prompt="$(cat)"
 [ "$prompt" = "prompt text" ] || exit 2
-printf '{"role":"assistant","content":"stub ok"}\n'"#,
+printf '{"role":"assistant","content":[{"type":"think","think":"..."},{"type":"text","text":"stub ok"}]}\n'"#,
     );
 
     let cwd = std::env::temp_dir();

--- a/crates/hermeneus/src/kimi/provider.rs
+++ b/crates/hermeneus/src/kimi/provider.rs
@@ -20,7 +20,7 @@ use tracing::{debug, info, warn};
 
 use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
-use crate::provider::LlmProvider;
+use crate::provider::{LlmProvider, MatchKind};
 use crate::types::{CompletionRequest, CompletionResponse, Content, ContentBlock, Role};
 
 use super::parse;
@@ -139,10 +139,6 @@ impl KimiProvider {
         }
     }
 
-    fn cli_model_name(model: &str) -> &str {
-        model.strip_prefix(KIMI_MODEL_PREFIX).unwrap_or(model)
-    }
-
     /// Format message history into a single prompt string for Kimi.
     fn format_prompt(request: &CompletionRequest) -> String {
         if request.messages.len() == 1
@@ -200,7 +196,7 @@ impl KimiProvider {
         let process_config = process::KimiProcessConfig {
             kimi_binary: &self.kimi_binary,
             cwd: &self.working_directory,
-            model: Self::cli_model_name(model),
+            model: None,
             timeout: self.timeout,
         };
 
@@ -227,7 +223,7 @@ impl KimiProvider {
         let process_config = process::KimiProcessConfig {
             kimi_binary: &self.kimi_binary,
             cwd: &self.working_directory,
-            model: Self::cli_model_name(model),
+            model: None,
             timeout: self.timeout,
         };
 
@@ -303,7 +299,20 @@ impl LlmProvider for KimiProvider {
     }
 
     fn supports_model(&self, model: &str) -> bool {
-        model.starts_with(KIMI_MODEL_PREFIX) || SUPPORTED_MODELS.contains(&model)
+        self.match_specificity(model).is_some()
+    }
+
+    fn match_specificity(&self, model: &str) -> Option<MatchKind> {
+        if SUPPORTED_MODELS.contains(&model) {
+            // WHY: Kimi's canonical default model string is namespaced, so
+            // the exact supported-model match should win over the broader
+            // `kimi/` prefix for that one model ID.
+            Some(MatchKind::Exact)
+        } else if model.starts_with(KIMI_MODEL_PREFIX) {
+            Some(MatchKind::Prefix)
+        } else {
+            None
+        }
     }
 
     fn name(&self) -> &'static str {
@@ -332,6 +341,25 @@ mod tests {
         assert!(!KimiProvider::warn_dropped_tools(0));
         assert!(KimiProvider::warn_dropped_tools(1));
         assert!(!KimiProvider::warn_dropped_tools(2));
+    }
+
+    #[test]
+    fn match_specificity_prefers_prefix_and_exact() {
+        let provider = KimiProvider {
+            kimi_binary: PathBuf::from("kimi"),
+            working_directory: PathBuf::from("."),
+            default_model: DEFAULT_MODEL.to_owned(),
+            timeout: Duration::from_secs(1),
+        };
+        assert_eq!(
+            provider.match_specificity("kimi/experimental"),
+            Some(MatchKind::Prefix)
+        );
+        assert_eq!(
+            provider.match_specificity(DEFAULT_MODEL),
+            Some(MatchKind::Exact)
+        );
+        assert_eq!(provider.match_specificity("claude-sonnet-4-6"), None);
     }
 }
 


### PR DESCRIPTION
Fixes #4460, #4462, #4464 (from the metis e2e). (1) #4460 — codex+kimi now override match_specificity (the registry routes by it, not supports_model), so prefixed ids like `codex/gpt-5-codex` route (was 'no provider registered'). (2) #4462 — codex invoked with `--json`; parse.rs parses the JSONL `turn.completed.usage` (input/output/cached_input_tokens) + `agent_message` text, so codex turns report real token usage (was in=0/out=0). (3) #4464 — kimi omits `--model` (kimi-cli rejected the hardcoded id with 'LLM not set'; it uses its config default), parser hardened for the content[] think/text shape. All formats confirmed against the live codex-cli 0.123.0 + kimi-cli 1.41.0. 402 hermeneus tests pass.