### PR TITLE
fix(koina,poiesis): actionable store-lock message + alt-text for Typst image-drop

### DIFF
--- a/_llm/L3-api-index/koina.md
+++ b/_llm/L3-api-index/koina.md
@@ -587,6 +587,12 @@ pub enum FjallOpenError {
     },
     /// Failed to open the fjall database or a partition.
     Open(String),
+    /// The fjall keyspace at `path` is locked by another process holding the
+    /// exclusive file lock (typically a running aletheia server).
+    Locked {
+        /// The locked store path.
+        path: std::path::PathBuf,
+    },
 }
 ```
 

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -122,8 +122,8 @@ l3_token_estimate = 11570
 [[crates]]
 name = "koina"
 path = "crates/koina"
-source_hash = "6671a6250a584e440529584640240d2b9207d18d306c76a941bcab4b8e3d7308"
-l3_token_estimate = 7394
+source_hash = "f2d971d8fb72f6ecbef58b8b250ab47f43c7f5f9da6d216f075ce4af8f1b6aef"
+l3_token_estimate = 7453
 
 [[crates]]
 name = "krites"
@@ -194,7 +194,7 @@ l3_token_estimate = 446
 [[crates]]
 name = "poiesis-doc"
 path = "crates/poiesis/doc"
-source_hash = "4674726dc7bd502665ea510bdd174b0d777bd4cd26fb9af7044f81d776cd42c4"
+source_hash = "587a8e827bf3e7f058231d2306172e96eb20a2d5bf32a9d5b35752e4cd984d33"
 l3_token_estimate = 3417
 
 [[crates]]

--- a/crates/koina/src/fjall.rs
+++ b/crates/koina/src/fjall.rs
@@ -58,9 +58,15 @@ impl FjallDb {
     ///
     /// Returns a `String` error message if the database cannot be opened.
     pub fn open_existing(path: &Path) -> Result<Self, FjallOpenError> {
-        let db = SingleWriterTxDatabase::builder(path)
-            .open()
-            .map_err(|e| FjallOpenError::Open(format!("fjall open: {e}")))?;
+        let db = SingleWriterTxDatabase::builder(path).open().map_err(|e| {
+            if matches!(e, fjall::Error::Locked) {
+                FjallOpenError::Locked {
+                    path: path.to_path_buf(),
+                }
+            } else {
+                FjallOpenError::Open(format!("fjall open: {e}"))
+            }
+        })?;
 
         Ok(Self {
             db,
@@ -83,9 +89,15 @@ impl FjallDb {
             source,
         })?;
 
-        let db = SingleWriterTxDatabase::builder(path)
-            .open()
-            .map_err(|e| FjallOpenError::Open(format!("fjall open: {e}")))?;
+        let db = SingleWriterTxDatabase::builder(path).open().map_err(|e| {
+            if matches!(e, fjall::Error::Locked) {
+                FjallOpenError::Locked {
+                    path: path.to_path_buf(),
+                }
+            } else {
+                FjallOpenError::Open(format!("fjall open: {e}"))
+            }
+        })?;
 
         for name in partitions {
             db.keyspace(name, KeyspaceCreateOptions::default)
@@ -149,6 +161,12 @@ pub enum FjallOpenError {
     },
     /// Failed to open the fjall database or a partition.
     Open(String),
+    /// The fjall keyspace at `path` is locked by another process holding the
+    /// exclusive file lock (typically a running aletheia server).
+    Locked {
+        /// The locked store path.
+        path: std::path::PathBuf,
+    },
 }
 
 impl std::fmt::Display for FjallOpenError {
@@ -159,6 +177,11 @@ impl std::fmt::Display for FjallOpenError {
             }
             Self::TempDir { source } => write!(f, "failed to create temp directory: {source}"),
             Self::Open(msg) => f.write_str(msg),
+            Self::Locked { path } => write!(
+                f,
+                "the aletheia store at {} is locked — a running aletheia server holds it. Stop the server, or use the HTTP API (e.g. `aletheia memory`, `aletheia maintenance`, `aletheia session-export --url ...`) which talks to the running server instead of opening the store directly.",
+                path.display()
+            ),
         }
     }
 }
@@ -167,7 +190,7 @@ impl std::error::Error for FjallOpenError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::CreateDir { source, .. } | Self::TempDir { source } => Some(source),
-            Self::Open(_) => None,
+            Self::Open(_) | Self::Locked { .. } => None,
         }
     }
 }
@@ -208,6 +231,22 @@ mod tests {
             .keyspace("data", KeyspaceCreateOptions::default)
             .unwrap();
         ks.insert("k", b"v").unwrap();
+    }
+
+    #[test]
+    fn locked_error_includes_path() {
+        let path = std::path::PathBuf::from("/tmp/aletheia-store");
+        let err = FjallOpenError::Locked { path: path.clone() };
+        let rendered = err.to_string();
+
+        assert!(
+            rendered.contains("is locked"),
+            "missing lock hint: {rendered}"
+        );
+        assert!(
+            rendered.contains(path.to_string_lossy().as_ref()),
+            "missing path in message: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/poiesis/doc/src/pandoc/mod.rs
+++ b/crates/poiesis/doc/src/pandoc/mod.rs
@@ -660,7 +660,25 @@ fn render_doc_via_typst(doc: &Document) -> Result<Vec<u8>, PandocError> {
                 }
                 src.push_str(")\n\n");
             }
-            Block::Image(_) => {} // skip in stub
+            Block::Image(image) => {
+                // WARNING: the in-process Typst fast-lane cannot embed image bytes
+                // (TypstWorld wires only data.json); emit alt text as a visible
+                // placeholder rather than silently dropping the block.
+                let alt = if image.alt.trim().is_empty() {
+                    "untitled figure"
+                } else {
+                    image.alt.trim()
+                };
+                let alt_escaped = alt
+                    .replace('\\', "\\\\")
+                    .replace('#', "\\#")
+                    .replace('[', "\\[")
+                    .replace(']', "\\]");
+                let _ = write!(
+                    src,
+                    "#figure(rect(width: 100%, stroke: 0.5pt)[#emph[Figure: {alt_escaped}]])\n\n"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #4461 + #4458 (metis e2e). #4461 — koina maps fjall::Error::Locked to a typed FjallOpenError::Locked{path} with an actionable message ('the aletheia store at <path> is locked — a running server holds it; stop it or use the HTTP API') instead of the cryptic 'FjallError: Locked'; propagates through graphe/symbolon unchanged. #4458 — the in-process Typst PDF fast-lane no longer silently drops Block::Image; it emits an alt-text figure placeholder (keeps the B-011 export_matrix test producing a PDF). 305 tests pass.