### PR TITLE
fix(hermeneus): declarative Anthropic-protocol providers — registration, instance identity, SSE framing

### DIFF
--- a/_llm/L3-api-index/hermeneus.md
+++ b/_llm/L3-api-index/hermeneus.md
@@ -111,6 +111,17 @@ pub struct AnthropicProvider {
     /// markers are scrubbed before the wire request is built so operator
     /// content never enters Anthropic's prompt cache.
     prompt_cache_mode: PromptCacheMode,
+    /// Instance name for logs, health tracking, and registry diagnostics.
+    /// `"anthropic"` for the first-party endpoint; operator-declared
+    /// compatible endpoints carry their config name (e.g. `"kimi-coding"`).
+    instance_name: String,
+    /// Model IDs this instance claims for registry routing. The first-party
+    /// catalog by default; an operator-declared compatible endpoint claims
+    /// exactly its configured model list instead.
+    model_refs: &'static [&'static str],
+    /// Where this instance's traffic terminates, for the recall
+    /// sensitivity filter (#3404, #3413).
+    deployment_target: DeploymentTarget,
 }
 ```
 
@@ -1283,6 +1294,19 @@ pub struct ProviderConfig {
     /// unconfigured provider speaks to an external service.
     #[serde(default)]
     pub deployment_target: DeploymentTarget,
+    /// Instance name for logs, health tracking, and registry diagnostics.
+    /// `None` uses the implementation's static name (e.g. `"anthropic"`).
+    /// Set when declaring multiple instances of one provider type so each
+    /// is distinguishable (e.g. first-party Anthropic plus a compatible
+    /// third-party endpoint).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Model identifiers this instance claims for registry routing. Empty
+    /// uses the implementation's built-in catalog. Set when the endpoint
+    /// serves models outside that catalog (e.g. an Anthropic-protocol
+    /// endpoint hosting non-Anthropic models).
+    #[serde(default)]
+    pub models: Vec<String>,
 }
 ```
 

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "0c89c38a3c02ac051eb03ce9c2d87c259607deca7e73fcc2b8accb6cbaa4ff4c"
+source_hash = "4b0670282da3d7f08ffcd97ca366ecb08228e5805ef35214300454b09df70452"
 l3_token_estimate = 167
 
 [[crates]]
@@ -104,8 +104,8 @@ l3_token_estimate = 5222
 [[crates]]
 name = "hermeneus"
 path = "crates/hermeneus"
-source_hash = "78921499777a967cd716d113b895d177980d21b6dd5b0a5c6e078b5f69117ce4"
-l3_token_estimate = 13362
+source_hash = "98a9438d0e836e2db7b3cbc292b14fe8a21e44dcef66ef67ce4689593eb53ecd"
+l3_token_estimate = 13698
 
 [[crates]]
 name = "integration-tests"

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -104,7 +104,7 @@ l3_token_estimate = 5222
 [[crates]]
 name = "hermeneus"
 path = "crates/hermeneus"
-source_hash = "98a9438d0e836e2db7b3cbc292b14fe8a21e44dcef66ef67ce4689593eb53ecd"
+source_hash = "6438ff4c4173ef4fa0b9ee5bd431ea74874cba2c1da356d908a824e63e5e97a0"
 l3_token_estimate = 13698
 
 [[crates]]

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -362,11 +362,7 @@ fn register_declared_providers(registry: &mut ProviderRegistry, config: &Alethei
                 }
             }
             ProviderKind::Anthropic => {
-                // Already registered via the credential-chain path above.
-                tracing::debug!(
-                    provider = %entry.name,
-                    "declarative Anthropic entry skipped — provider already registered via credential chain"
-                );
+                register_declared_anthropic(registry, entry);
             }
             ProviderKind::ClaudeCode => {
                 // WHY: declarative registration of the CC adapter would
@@ -399,6 +395,63 @@ fn register_declared_providers(registry: &mut ProviderRegistry, config: &Alethei
                 );
             }
         }
+    }
+}
+
+/// Register a declarative Anthropic-protocol provider entry.
+///
+/// WHY: the first-party Anthropic provider is registered by the
+/// credential-chain path in [`build_provider_registry`], so a declarative
+/// entry without its own credential would double-register it. An entry
+/// naming its own `apiKeyEnv` is a distinct Anthropic-protocol endpoint
+/// (proxy, self-hosted, or a compatible third-party host) and registers
+/// independently with its configured base URL and model claims.
+fn register_declared_anthropic(
+    registry: &mut ProviderRegistry,
+    entry: &taxis::config::LlmProviderConfig,
+) {
+    let Some(env_name) = entry.api_key_env.as_deref() else {
+        tracing::debug!(
+            provider = %entry.name,
+            "declarative Anthropic entry without apiKeyEnv skipped — first-party provider is registered via the credential chain"
+        );
+        return;
+    };
+    let key = match std::env::var(env_name) {
+        Ok(v) if !v.is_empty() => SecretString::from(v),
+        _ => {
+            warn!(
+                provider = %entry.name,
+                env = env_name,
+                "apiKeyEnv unset or empty for declarative Anthropic provider — skipping"
+            );
+            return;
+        }
+    };
+    let cfg = ProviderConfig {
+        api_key: Some(key),
+        base_url: entry.base_url.clone(),
+        name: Some(entry.name.clone()),
+        models: entry.models.clone(),
+        deployment_target: map_deployment_target(entry.deployment_target),
+        ..ProviderConfig::default()
+    };
+    match AnthropicProvider::from_config(&cfg) {
+        Ok(provider) => {
+            info!(
+                provider = %entry.name,
+                target = ?entry.deployment_target,
+                base_url = ?entry.base_url,
+                models = ?entry.models,
+                "Anthropic-protocol provider registered"
+            );
+            registry.register(Box::new(provider));
+        }
+        Err(e) => warn!(
+            provider = %entry.name,
+            error = %e,
+            "failed to init declarative Anthropic provider"
+        ),
     }
 }
 
@@ -883,6 +936,60 @@ mod tests {
         assert_eq!(
             configured_openai_api_family(&entry),
             HermeneusOpenAiApiFamily::ChatCompletions
+        );
+    }
+    #[expect(
+        unsafe_code,
+        reason = "std::env::set_var requires unsafe in edition 2024; nextest isolates each test in its own process"
+    )]
+    #[test]
+    fn declarative_anthropic_with_own_key_registers() {
+        use taxis::config::{DeploymentTarget, LlmProviderConfig, ProviderKind};
+
+        // SAFETY: nextest runs this test in its own process; no other
+        // thread reads or mutates the environment concurrently.
+        unsafe { std::env::set_var("TEST_DECL_ANTHROPIC_KEY", "sk-test-123") };
+        let mut config = AletheiaConfig::default();
+        config.providers.push(LlmProviderConfig {
+            name: "kimi-coding".to_owned(),
+            kind: ProviderKind::Anthropic,
+            base_url: Some("https://compat.api.example.com".to_owned()),
+            api_key_env: Some("TEST_DECL_ANTHROPIC_KEY".to_owned()),
+            api_family: None,
+            deployment_target: DeploymentTarget::Cloud,
+            models: vec!["kimi-for-coding".to_owned()],
+        });
+        let mut registry = ProviderRegistry::new();
+        register_declared_providers(&mut registry, &config);
+        assert!(
+            registry.find_provider("kimi-for-coding").is_some(),
+            "declarative Anthropic-protocol entry with its own key must register and claim its models"
+        );
+        assert!(
+            registry.find_provider("claude-opus-4-6").is_none(),
+            "custom-model instance must not claim first-party models"
+        );
+    }
+
+    #[test]
+    fn declarative_anthropic_without_key_env_is_skipped() {
+        use taxis::config::{DeploymentTarget, LlmProviderConfig, ProviderKind};
+
+        let mut config = AletheiaConfig::default();
+        config.providers.push(LlmProviderConfig {
+            name: "anthropic-cloud".to_owned(),
+            kind: ProviderKind::Anthropic,
+            base_url: None,
+            api_key_env: None,
+            api_family: None,
+            deployment_target: DeploymentTarget::Cloud,
+            models: Vec::new(),
+        });
+        let mut registry = ProviderRegistry::new();
+        register_declared_providers(&mut registry, &config);
+        assert!(
+            registry.find_provider("claude-opus-4-6").is_none(),
+            "entry without apiKeyEnv defers to the credential-chain registration"
         );
     }
 }

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -16,7 +16,9 @@ use koina::secret::SecretString;
 
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};
-use crate::provider::{LlmProvider, ModelPricing, PromptCacheMode, ProviderConfig};
+use crate::provider::{
+    DeploymentTarget, LlmProvider, ModelPricing, PromptCacheMode, ProviderConfig, leak_models,
+};
 use crate::types::{CompletionRequest, CompletionResponse};
 
 use super::stream::{StreamAccumulator, StreamEvent, parse_sse_response};
@@ -56,6 +58,17 @@ pub struct AnthropicProvider {
     /// markers are scrubbed before the wire request is built so operator
     /// content never enters Anthropic's prompt cache.
     prompt_cache_mode: PromptCacheMode,
+    /// Instance name for logs, health tracking, and registry diagnostics.
+    /// `"anthropic"` for the first-party endpoint; operator-declared
+    /// compatible endpoints carry their config name (e.g. `"kimi-coding"`).
+    instance_name: String,
+    /// Model IDs this instance claims for registry routing. The first-party
+    /// catalog by default; an operator-declared compatible endpoint claims
+    /// exactly its configured model list instead.
+    model_refs: &'static [&'static str],
+    /// Where this instance's traffic terminates, for the recall
+    /// sensitivity filter (#3404, #3413).
+    deployment_target: DeploymentTarget,
 }
 
 /// Static credential provider for backward-compatible `from_config()`.
@@ -77,6 +90,25 @@ impl CredentialProvider for StaticCredentialProvider {
     )]
     fn name(&self) -> &str {
         "static"
+    }
+}
+
+/// Resolve the instance name from config: operator-declared name, or the
+/// first-party default.
+fn instance_name(config: &ProviderConfig) -> String {
+    config
+        .name
+        .clone()
+        .unwrap_or_else(|| "anthropic".to_owned())
+}
+
+/// Resolve the routing model claims from config: the operator-declared list
+/// for compatible endpoints, or the first-party catalog when unset.
+fn model_refs(config: &ProviderConfig) -> &'static [&'static str] {
+    if config.models.is_empty() {
+        SUPPORTED_MODELS
+    } else {
+        leak_models(&config.models)
     }
 }
 
@@ -176,6 +208,9 @@ impl AnthropicProvider {
             cc_profile: None, // API key mode — no mimicry needed
             non_streaming_timeout: NON_STREAMING_TIMEOUT,
             prompt_cache_mode: config.prompt_cache_mode,
+            instance_name: instance_name(config),
+            model_refs: model_refs(config),
+            deployment_target: config.deployment_target,
         };
         // TODO(#2178): add allow_insecure config field
         if !provider.base_url.starts_with("https://") && !is_loopback_url(&provider.base_url) {
@@ -229,6 +264,9 @@ impl AnthropicProvider {
             cc_profile,
             non_streaming_timeout: NON_STREAMING_TIMEOUT,
             prompt_cache_mode: config.prompt_cache_mode,
+            instance_name: instance_name(config),
+            model_refs: model_refs(config),
+            deployment_target: config.deployment_target,
         };
         // TODO(#2178): add allow_insecure config field
         if !provider.base_url.starts_with("https://") && !is_loopback_url(&provider.base_url) {
@@ -281,7 +319,7 @@ impl AnthropicProvider {
         mut on_event: impl FnMut(StreamEvent) + Send,
     ) -> Result<CompletionResponse> {
         let span = info_span!("llm_call",
-            llm.provider = "anthropic",
+            llm.provider = %self.instance_name,
             llm.model = %request.model,
             llm.duration_ms = tracing::field::Empty,
             llm.tokens_in = tracing::field::Empty,
@@ -436,14 +474,14 @@ impl AnthropicProvider {
                         "LLM call complete"
                     );
                     crate::metrics::record_completion(
-                        "anthropic",
+                        &self.instance_name,
                         resp.usage.input_tokens,
                         resp.usage.output_tokens,
                         cost,
                         true,
                     );
                     crate::metrics::record_cache_tokens(
-                        "anthropic",
+                        &self.instance_name,
                         resp.usage.cache_read_tokens,
                         resp.usage.cache_write_tokens,
                     );
@@ -515,7 +553,7 @@ impl AnthropicProvider {
         tracing::Span::current().record("llm.retries", self.max_retries);
         tracing::Span::current().record("llm.status", "error");
 
-        crate::metrics::record_completion("anthropic", 0, 0, 0.0, false);
+        crate::metrics::record_completion(&self.instance_name, 0, 0, 0.0, false);
         crate::metrics::record_latency(&request.model, "error", start.elapsed().as_secs_f64());
 
         Err(last_error.unwrap_or_else(|| {
@@ -750,7 +788,7 @@ impl AnthropicProvider {
 
     async fn execute_with_retry(&self, request: &CompletionRequest) -> Result<CompletionResponse> {
         let span = info_span!("llm_call",
-            llm.provider = "anthropic",
+            llm.provider = %self.instance_name,
             llm.model = %request.model,
             llm.duration_ms = tracing::field::Empty,
             llm.tokens_in = tracing::field::Empty,
@@ -877,14 +915,14 @@ impl AnthropicProvider {
                         "LLM call complete"
                     );
                     crate::metrics::record_completion(
-                        "anthropic",
+                        &self.instance_name,
                         resp.usage.input_tokens,
                         resp.usage.output_tokens,
                         cost,
                         true,
                     );
                     crate::metrics::record_cache_tokens(
-                        "anthropic",
+                        &self.instance_name,
                         resp.usage.cache_read_tokens,
                         resp.usage.cache_write_tokens,
                     );
@@ -942,7 +980,7 @@ impl AnthropicProvider {
         tracing::Span::current().record("llm.retries", self.max_retries);
         tracing::Span::current().record("llm.status", "error");
 
-        crate::metrics::record_completion("anthropic", 0, 0, 0.0, false);
+        crate::metrics::record_completion(&self.instance_name, 0, 0, 0.0, false);
         crate::metrics::record_latency(&request.model, "error", start.elapsed().as_secs_f64());
 
         Err(last_error.unwrap_or_else(|| {
@@ -963,15 +1001,15 @@ impl LlmProvider for AnthropicProvider {
     }
 
     fn supported_models(&self) -> &[&str] {
-        SUPPORTED_MODELS
+        self.model_refs
     }
 
-    #[expect(
-        clippy::unnecessary_literal_bound,
-        reason = "trait requires &str return, static string is fine"
-    )]
     fn name(&self) -> &str {
-        "anthropic"
+        &self.instance_name
+    }
+
+    fn deployment_target(&self) -> DeploymentTarget {
+        self.deployment_target
     }
 
     fn supports_streaming(&self) -> bool {

--- a/crates/hermeneus/src/anthropic/client_tests.rs
+++ b/crates/hermeneus/src/anthropic/client_tests.rs
@@ -14,7 +14,7 @@ use super::*;
 use crate::anthropic::pricing::{backoff_delay, estimate_cost, model_family};
 use crate::error::Error;
 use crate::models::BACKOFF_MAX_MS;
-use crate::provider::{LlmProvider, ProviderConfig};
+use crate::provider::{DeploymentTarget, LlmProvider, ProviderConfig};
 use crate::types::{CompletionRequest, Content, Message, Role};
 
 fn test_config_with(base_url: &str) -> ProviderConfig {
@@ -28,6 +28,8 @@ fn test_config_with(base_url: &str) -> ProviderConfig {
         cc_mimicry: None,
         prompt_cache_mode: crate::provider::PromptCacheMode::Disabled,
         deployment_target: crate::provider::DeploymentTarget::Cloud,
+        name: None,
+        models: Vec::new(),
     }
 }
 
@@ -102,6 +104,51 @@ fn from_config_valid() {
         debug.contains("custom.api.example.com"),
         "debug should show base_url: {debug}"
     );
+}
+
+#[test]
+fn from_config_custom_models_claim_routing() {
+    let config = ProviderConfig {
+        // NOTE: test-only fixture value, not a real credential
+        api_key: Some(SecretString::from("sk-test-123")),
+        base_url: Some("https://compat.api.example.com".to_owned()),
+        name: Some("kimi-coding".to_owned()),
+        models: vec!["kimi-for-coding".to_owned()],
+        ..ProviderConfig::default()
+    };
+    let provider = AnthropicProvider::from_config(&config).expect("valid config");
+    assert_eq!(provider.name(), "kimi-coding");
+    assert_eq!(provider.supported_models(), ["kimi-for-coding"]);
+    assert!(provider.supports_model("kimi-for-coding"));
+    assert!(
+        !provider.supports_model("claude-opus-4-6"),
+        "custom-model instance must not claim first-party models"
+    );
+}
+
+#[test]
+fn from_config_default_models_and_name_unchanged() {
+    let config = ProviderConfig {
+        // NOTE: test-only fixture value, not a real credential
+        api_key: Some(SecretString::from("sk-test-123")),
+        ..ProviderConfig::default()
+    };
+    let provider = AnthropicProvider::from_config(&config).expect("valid config");
+    assert_eq!(provider.name(), "anthropic");
+    assert!(provider.supports_model("claude-opus-4-6"));
+}
+
+#[test]
+fn from_config_deployment_target_propagates() {
+    let config = ProviderConfig {
+        // NOTE: test-only fixture value, not a real credential
+        api_key: Some(SecretString::from("sk-test-123")),
+        base_url: Some("https://compat.api.example.com".to_owned()),
+        deployment_target: DeploymentTarget::LocalHosted,
+        ..ProviderConfig::default()
+    };
+    let provider = AnthropicProvider::from_config(&config).expect("valid config");
+    assert_eq!(provider.deployment_target(), DeploymentTarget::LocalHosted);
 }
 
 #[tokio::test]

--- a/crates/hermeneus/src/anthropic/stream/mod.rs
+++ b/crates/hermeneus/src/anthropic/stream/mod.rs
@@ -98,9 +98,9 @@ pub(crate) fn parse_sse_stream(
             continue;
         }
 
-        if let Some(event_type) = line.strip_prefix("event: ") {
+        if let Some(event_type) = sse_field_value(line, "event:") {
             event_type.clone_into(&mut current_event_type);
-        } else if let Some(data) = line.strip_prefix("data: ") {
+        } else if let Some(data) = sse_field_value(line, "data:") {
             // WHY: SSE spec requires multiple data: lines to be concatenated with newlines.
             if !current_data.is_empty() {
                 current_data.push('\n');
@@ -111,6 +111,17 @@ pub(crate) fn parse_sse_stream(
     }
 
     Ok(())
+}
+
+/// Extract an SSE field value, tolerating the spec-optional space after `:`.
+///
+/// WHY: WHATWG SSE permits `data:value` and `data: value` equally — the
+/// first-party API emits the space, but compatible Anthropic-protocol
+/// endpoints (e.g. Kimi) emit none, and requiring it silently drops every
+/// stream event from such endpoints.
+fn sse_field_value<'a>(line: &'a str, field: &str) -> Option<&'a str> {
+    let rest = line.strip_prefix(field)?;
+    Some(rest.strip_prefix(' ').unwrap_or(rest))
 }
 
 /// Parse SSE events incrementally from a live HTTP response stream.
@@ -162,9 +173,9 @@ pub(crate) async fn parse_sse_response(
                     }
                     current_event_type.clear();
                     current_data.clear();
-                } else if let Some(et) = line.strip_prefix("event: ") {
+                } else if let Some(et) = sse_field_value(line, "event:") {
                     et.clone_into(&mut current_event_type);
-                } else if let Some(data) = line.strip_prefix("data: ") {
+                } else if let Some(data) = sse_field_value(line, "data:") {
                     // WHY: SSE spec requires multiple data: lines to be concatenated with newlines.
                     if !current_data.is_empty() {
                         current_data.push('\n');
@@ -244,6 +255,47 @@ data: {\"type\":\"message_stop\"}\n\
         assert_eq!(response.content.len(), 1);
         match &response.content[0] {
             ContentBlock::Text { text, .. } => assert_eq!(text, "Hello world"),
+            _ => panic!("expected Text block"),
+        }
+    }
+
+    #[test]
+    fn parses_spaceless_field_framing() {
+        // WHY: WHATWG SSE makes the space after `:` optional; compatible
+        // Anthropic-protocol endpoints (e.g. Kimi) emit `data:{...}` with no
+        // space, which a space-required parser drops silently.
+        let sse = "\
+event:message_start\n\
+data:{\"type\":\"message_start\",\"message\":{\"id\":\"msg_k\",\"model\":\"kimi-for-coding\",\"usage\":{\"input_tokens\":9,\"output_tokens\":0}}}\n\
+\n\
+event:content_block_start\n\
+data:{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\
+\n\
+event:content_block_delta\n\
+data:{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"OK\"}}\n\
+\n\
+event:content_block_stop\n\
+data:{\"type\":\"content_block_stop\",\"index\":0}\n\
+\n\
+event:message_delta\n\
+data:{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\
+\n\
+event:message_stop\n\
+data:{\"type\":\"message_stop\"}\n\
+\n";
+
+        let (events, response) = collect_events(sse);
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, StreamEvent::TextDelta { text } if text == "OK")),
+            "space-less data: lines must still produce deltas"
+        );
+        assert_eq!(response.id, "msg_k");
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+        match &response.content[0] {
+            ContentBlock::Text { text, .. } => assert_eq!(text, "OK"),
             _ => panic!("expected Text block"),
         }
     }

--- a/crates/hermeneus/src/openai/client.rs
+++ b/crates/hermeneus/src/openai/client.rs
@@ -20,7 +20,7 @@ use koina::secret::SecretString;
 use crate::anthropic::StreamEvent;
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};
-use crate::provider::{DeploymentTarget, LlmProvider};
+use crate::provider::{DeploymentTarget, LlmProvider, leak_models};
 use crate::types::{CompletionRequest, CompletionResponse};
 
 use super::error::{map_error_response, map_request_error};
@@ -603,24 +603,6 @@ fn record_stream_success(
         true,
     );
     crate::metrics::record_latency(&request.model, "ok", start.elapsed().as_secs_f64());
-}
-
-/// Leak a `Vec<String>` of model IDs to a `&'static [&'static str]` slice.
-///
-/// Called once at provider construction so [`LlmProvider::supported_models`]
-/// can return a borrowed static slice — the provider outlives every request
-/// in normal operation, and leaking keeps the trait signature (`&[&str]`)
-/// simple without forcing every caller into dynamic storage.
-fn leak_models(models: &[String]) -> &'static [&'static str] {
-    let leaked: Vec<&'static str> = models
-        .iter()
-        .map(|s| {
-            let boxed: Box<str> = s.clone().into_boxed_str();
-            let static_ref: &'static str = Box::leak(boxed);
-            static_ref
-        })
-        .collect();
-    Box::leak(leaked.into_boxed_slice())
 }
 
 impl std::fmt::Debug for OpenAiProvider {

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -240,6 +240,19 @@ pub struct ProviderConfig {
     /// unconfigured provider speaks to an external service.
     #[serde(default)]
     pub deployment_target: DeploymentTarget,
+    /// Instance name for logs, health tracking, and registry diagnostics.
+    /// `None` uses the implementation's static name (e.g. `"anthropic"`).
+    /// Set when declaring multiple instances of one provider type so each
+    /// is distinguishable (e.g. first-party Anthropic plus a compatible
+    /// third-party endpoint).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Model identifiers this instance claims for registry routing. Empty
+    /// uses the implementation's built-in catalog. Set when the endpoint
+    /// serves models outside that catalog (e.g. an Anthropic-protocol
+    /// endpoint hosting non-Anthropic models).
+    #[serde(default)]
+    pub models: Vec<String>,
 }
 
 impl std::fmt::Debug for ProviderConfig {
@@ -253,6 +266,8 @@ impl std::fmt::Debug for ProviderConfig {
             .field("cc_mimicry", &self.cc_mimicry)
             .field("prompt_cache_mode", &self.prompt_cache_mode)
             .field("deployment_target", &self.deployment_target)
+            .field("name", &self.name)
+            .field("models", &self.models)
             .finish_non_exhaustive()
     }
 }
@@ -321,8 +336,28 @@ impl Default for ProviderConfig {
             // `aletheia.toml` so the recall filter lets `Internal` /
             // `Confidential` facts through to the non-cloud boundary.
             deployment_target: DeploymentTarget::Cloud,
+            name: None,
+            models: Vec::new(),
         }
     }
+}
+
+/// Leak a `Vec<String>` of model IDs to a `&'static [&'static str]` slice.
+///
+/// Called once at provider construction so [`LlmProvider::supported_models`]
+/// can return a borrowed static slice — the provider outlives every request
+/// in normal operation, and leaking keeps the trait signature (`&[&str]`)
+/// simple without forcing every caller into dynamic storage.
+pub(crate) fn leak_models(models: &[String]) -> &'static [&'static str] {
+    let leaked: Vec<&'static str> = models
+        .iter()
+        .map(|s| {
+            let boxed: Box<str> = s.clone().into_boxed_str();
+            let static_ref: &'static str = Box::leak(boxed);
+            static_ref
+        })
+        .collect();
+    Box::leak(leaked.into_boxed_slice())
 }
 
 struct ProviderEntry {

--- a/crates/hermeneus/src/types.rs
+++ b/crates/hermeneus/src/types.rs
@@ -676,7 +676,7 @@ impl std::str::FromStr for StopReason {
 }
 
 /// Token usage for a completion.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Usage {
     /// Input tokens consumed.
     pub input_tokens: u64,


### PR DESCRIPTION
## Problem

A `[[providers]]` entry with `providerType = "anthropic"` validated in config but could never serve traffic. Three independent breaks, found live while wiring a Kimi-for-Coding endpoint (`https://api.kimi.com/coding` speaks the Anthropic Messages protocol, including `tool_use` + streaming) against a real migrated instance:

1. **Never registered** — the `ProviderKind::Anthropic` arm in `register_declared_providers` unconditionally skipped declarative entries as credential-chain duplicates, so any custom Anthropic-protocol endpoint (compatible third-party host, proxy, self-hosted) silently failed to route: `no provider for model: kimi-for-coding`.
2. **No instance identity** — `AnthropicProvider` hard-coded `name() = "anthropic"` and the first-party model catalog, so a registered second instance couldn't claim its models or be distinguished in spans/metrics/health.
3. **SSE events dropped** — the stream parser required a space after `data:`/`event:`, but WHATWG SSE makes that space optional. Kimi emits `data:{...}` space-less: streaming turns returned empty content with zero usage while non-streaming calls succeeded.

Plus a latent build break shipped in #4468: `CodexParsedOutput` derives `Eq` over `Usage`, which had no equality derives — `--features codex-provider` did not compile on main (gate-attestation doesn't exercise that feature combination; follow-up issue to be filed).

## Fix

- `ProviderConfig` gains `name` + `models` instance identity; `AnthropicProvider` claims configured models (shared `leak_models`, hoisted from the OpenAI client), labels spans/metrics/health by instance name, and propagates `deployment_target`.
- `register_declared_providers` registers an Anthropic entry that carries its own `apiKeyEnv`; entries without one still defer to the credential chain (no double-registration).
- SSE field values strip one optional leading space per spec; regression test with space-less framing.
- `Usage` derives `PartialEq, Eq`.

## Verification

- 765/765 scoped tests pass (hermeneus + aletheia); clippy `-D warnings` clean; new unit tests for custom-model routing, default-path invariance, deployment-target propagation, declarative registration + skip.
- **Live end-to-end on a real migrated instance**: `[[providers]] kimi-coding` registers (`Anthropic-protocol provider registered`), routes `Exact`, and a real nous (akron) completes agentic turns on `kimi-for-coding` — `tools=1` (memory_search dispatched + result consumed), real usage (`in=30593, out=205`), streamed deltas. This is the first no-Anthropic-API-key path that drives aletheia's full 77-tool loop.

Co-authored-by: Cody Kickertz <cody.kickertz@pm.me>