### PR TITLE
feat(memory): reembed + gc recovery commands; typed krites store-lock error

### DIFF
--- a/_llm/L3-api-index/episteme.md
+++ b/_llm/L3-api-index/episteme.md
@@ -2165,6 +2165,7 @@ impl KnowledgeStore {
         &self,
         rel: &crate::knowledge::Relationship,
     ) -> crate::error::Result<()>;
+    pub fn remove_orphaned_entities (&self) -> crate::error::Result<usize>;
     pub fn list_entities (&self) -> crate::error::Result<Vec<crate::knowledge::Entity>>;
     pub fn list_all_relationships (
         &self,
@@ -2225,6 +2226,7 @@ impl KnowledgeStore {
         provider: Option<&dyn crate::embedding::EmbeddingProvider>,
         tuning: &crate::dedup::DedupTuning,
     ) -> crate::error::Result<Vec<crate::dedup::MergeRecord>>;
+    pub fn orphaned_entity_ids (&self) -> crate::error::Result<Vec<String>>;
 }
 ```
 
@@ -2232,6 +2234,10 @@ impl KnowledgeStore {
 
 ```rust
 impl KnowledgeStore {
+    pub fn reembed_all (
+        &self,
+        provider: &dyn crate::embedding::EmbeddingProvider,
+    ) -> crate::error::Result<usize>;
     pub fn insert_fact (&self, fact: &crate::knowledge::Fact) -> crate::error::Result<()>;
     pub fn backfill_fact_embeddings (
         &self,

--- a/_llm/L3-api-index/krites.md
+++ b/_llm/L3-api-index/krites.md
@@ -1354,6 +1354,23 @@ pub enum StorageError {
         location: snafu::Location,
     },
 
+    /// The on-disk store is locked by another process.
+    ///
+    /// WHY: fjall takes an exclusive lock per keyspace; without a dedicated
+    /// variant the lock surfaces as an opaque "transaction failed: open"
+    /// message. Mirrors `koina::fjall::FjallOpenError::Locked` so every
+    /// store (session, auth, knowledge) reports lock contention the same
+    /// actionable way.
+    #[snafu(display(
+        "the store at {} is locked — a running aletheia server holds it. Stop the server, or use the HTTP API (e.g. `aletheia memory`, `aletheia maintenance`) which talks to the running server instead of opening the store directly.",
+        path.display()
+    ))]
+    Locked {
+        path: std::path::PathBuf,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// Attempted a write operation on a read-only transaction.
     #[snafu(display("write attempted on a read-only transaction"))]
     WriteInReadTransaction {

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "4b0670282da3d7f08ffcd97ca366ecb08228e5805ef35214300454b09df70452"
+source_hash = "ae431122a7468eeefcfe9a08883ed28d5c9ab2e51c1a5920d054d75f4cd50be8"
 l3_token_estimate = 167
 
 [[crates]]
@@ -86,8 +86,8 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "43fa591013c0471deca7f194567ab76de1043923975ca9e271336ed753a94a1d"
-l3_token_estimate = 32790
+source_hash = "770e958f9812d2bd1482b6fcbb9e51775538ad0b3866f98509eb657bed6269cd"
+l3_token_estimate = 32863
 
 [[crates]]
 name = "gnosis"
@@ -128,8 +128,8 @@ l3_token_estimate = 7453
 [[crates]]
 name = "krites"
 path = "crates/krites"
-source_hash = "50fe968a79e7515cffcf18b7855cc7ca54af4ec1b61300a3f72ef7f103f3e30e"
-l3_token_estimate = 9904
+source_hash = "508129f78819572d7c09b9f0c881b30b042d8527a614eee7dc338627495f5466"
+l3_token_estimate = 10102
 
 [[crates]]
 name = "melete"

--- a/crates/aletheia/src/cli_tests.rs
+++ b/crates/aletheia/src/cli_tests.rs
@@ -11,6 +11,7 @@ use super::{
     commands::backup::{BackupAction, BackupArgs},
     commands::credential,
     commands::maintenance,
+    commands::memory,
     commands::session_create::SessionCreateArgs,
     commands::session_export::ExportFormat,
     commands::tls,
@@ -94,6 +95,36 @@ fn status_custom_url_parses() {
         }
         _ => panic!("expected Status command"),
     }
+}
+
+#[test]
+fn memory_reembed_parses() {
+    let cli = Cli::parse_from(["aletheia", "memory", "reembed"]);
+    assert!(
+        matches!(
+            cli.command,
+            Some(Command::Memory {
+                action: memory::Action::Reembed,
+                ..
+            })
+        ),
+        "memory reembed subcommand should parse"
+    );
+}
+
+#[test]
+fn memory_gc_parses() {
+    let cli = Cli::parse_from(["aletheia", "memory", "gc"]);
+    assert!(
+        matches!(
+            cli.command,
+            Some(Command::Memory {
+                action: memory::Action::Gc,
+                ..
+            })
+        ),
+        "memory gc subcommand should parse"
+    );
 }
 
 #[test]

--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -1,7 +1,7 @@
 // kanon:ignore RUST/file-too-long — module contains tightly-coupled memory subcommand implementations; splitting would hurt cohesion
 //! `aletheia memory`: knowledge graph inspection and maintenance.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Subcommand, ValueEnum};
 use snafu::prelude::*;
@@ -96,6 +96,10 @@ pub(crate) enum Action {
         /// Output file path
         output_path: PathBuf,
     },
+    /// Recompute fact embeddings for every store on disk.
+    Reembed,
+    /// Remove orphaned entities with no relationships and no fact links.
+    Gc,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -142,45 +146,78 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
             );
         }
 
-        let config = mneme::knowledge_store::KnowledgeConfig::default();
-        let store = mneme::knowledge_store::KnowledgeStore::open_fjall(&knowledge_path, config)
-            .whatever_context("failed to open knowledge store")?;
-
         // WHY (#4165 D): load the resolved aletheia config so the dedup
         // CLI honours the operator's `knowledge_dedup_*` knobs the same
         // way the scheduled maintenance task does. A missing/invalid
         // config falls back to the historical defaults — the same shape
         // every prior CLI invocation used — so this is strictly additive.
-        #[allow(unused_variables, reason = "consumed only by Dedup branch")]
-        let dedup_tuning = taxis::loader::load_config(&oikos)
+        let loaded_config = if matches!(action, Action::Dedup { .. } | Action::Reembed) {
+            Some(taxis::loader::load_config(&oikos))
+        } else {
+            None
+        };
+        let dedup_tuning = loaded_config
+            .as_ref()
+            .and_then(|result| result.as_ref().ok())
             .map_or(mneme::dedup::DedupTuning::DEFAULT, |cfg| {
                 crate::knowledge_maintenance::tuning_from_behavior(&cfg.agents.defaults.behavior)
             });
+        let recovery_dim = loaded_config
+            .as_ref()
+            .and_then(|result| result.as_ref().ok())
+            .map_or_else(
+                || mneme::knowledge_store::KnowledgeConfig::default().dim,
+                |cfg| cfg.embedding.dimension,
+            );
 
         match action {
-            Action::Check { json } => run_check(&store, json),
-            Action::Sample { count, nous_id } => run_sample(&store, count, nous_id.as_deref()),
+            Action::Check { json } => {
+                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
+                run_check(&store, json)
+            }
+            Action::Sample { count, nous_id } => {
+                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
+                run_sample(&store, count, nous_id.as_deref())
+            }
             Action::Dedup { nous_id, dry_run } => {
+                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
                 run_dedup(&store, &nous_id, dry_run, &dedup_tuning)
             }
-            Action::Patterns { nous_id, limit } => run_patterns(&store, nous_id.as_deref(), limit),
+            Action::Patterns { nous_id, limit } => {
+                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
+                run_patterns(&store, nous_id.as_deref(), limit)
+            }
             Action::ExportGraph {
                 format,
                 nous_id,
                 scope,
                 output_path,
-            } => run_export_graph(&store, format, nous_id.as_deref(), scope, &output_path),
-            Action::DedupPending { nous_id } => run_dedup_pending(&store, &nous_id),
+            } => {
+                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
+                run_export_graph(&store, format, nous_id.as_deref(), scope, &output_path)
+            }
+            Action::DedupPending { nous_id } => {
+                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
+                run_dedup_pending(&store, &nous_id)
+            }
             Action::DedupApprove {
                 nous_id,
                 canonical_id,
                 merged_id,
-            } => run_dedup_approve(&store, &nous_id, &canonical_id, &merged_id),
+            } => {
+                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
+                run_dedup_approve(&store, &nous_id, &canonical_id, &merged_id)
+            }
             Action::DedupReject {
                 nous_id,
                 entity_a,
                 entity_b,
-            } => run_dedup_reject(&store, &nous_id, &entity_a, &entity_b),
+            } => {
+                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
+                run_dedup_reject(&store, &nous_id, &entity_a, &entity_b)
+            }
+            Action::Reembed => run_reembed(&oikos, recovery_dim, loaded_config.as_ref()),
+            Action::Gc => run_gc(&oikos, recovery_dim),
         }
     }
 
@@ -237,6 +274,7 @@ fn validate_action(action: &Action) -> Result<()> {
             }
             Ok(())
         }
+        Action::Reembed | Action::Gc => Ok(()),
         Action::DedupApprove {
             nous_id,
             canonical_id,
@@ -522,6 +560,150 @@ async fn run_check_via_api(url: &str, json: bool) -> Result<()> {
     Ok(())
 }
 
+// --- recovery ---
+
+#[cfg(feature = "recall")]
+fn open_recovery_store(
+    path: &Path,
+    dim: usize,
+) -> Result<std::sync::Arc<mneme::knowledge_store::KnowledgeStore>> {
+    let config = mneme::knowledge_store::KnowledgeConfig {
+        dim,
+        ..Default::default()
+    };
+    mneme::knowledge_store::KnowledgeStore::open_fjall(path, config).map_err(|err| {
+        let message = err.to_string();
+        if is_store_lock_error(&message) {
+            crate::error::Error::msg(format!(
+                "knowledge store at {} is locked by another process. Stop the server first, then rerun this command.",
+                path.display()
+            ))
+        } else {
+            crate::error::Error::msg(format!(
+                "failed to open knowledge store at {}: {message}",
+                path.display()
+            ))
+        }
+    })
+}
+
+#[cfg(feature = "recall")]
+fn is_store_lock_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("lock") || lower.contains("busy") || lower.contains("in use")
+}
+
+#[cfg(feature = "recall")]
+fn recovery_store_paths(oikos: &taxis::oikos::Oikos) -> Result<Vec<PathBuf>> {
+    let root = oikos.knowledge_db();
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut stores = Vec::new();
+    for entry in
+        std::fs::read_dir(&root).whatever_context("failed to enumerate knowledge store cohorts")?
+    {
+        let entry = entry.whatever_context("failed to inspect knowledge store cohort")?;
+        let path = entry.path();
+        if path.is_dir() {
+            stores.push(path);
+        }
+    }
+    stores.sort();
+    Ok(stores)
+}
+
+#[cfg(feature = "recall")]
+fn run_reembed(
+    oikos: &taxis::oikos::Oikos,
+    dim: usize,
+    loaded_config: Option<&std::result::Result<taxis::config::AletheiaConfig, taxis::error::Error>>,
+) -> Result<()> {
+    let config = match loaded_config {
+        Some(Ok(cfg)) => cfg,
+        Some(Err(err)) => {
+            whatever!("failed to load instance config for memory reembed: {err}");
+        }
+        None => {
+            whatever!(
+                "failed to load instance config for memory reembed; the configured embedding provider is required"
+            );
+        }
+    };
+    let embedding_config = mneme::embedding::EmbeddingConfig {
+        provider: config.embedding.provider.clone(),
+        model: config.embedding.model.clone(),
+        dimension: Some(config.embedding.dimension),
+        api_key: None,
+        base_url: None,
+    };
+    let provider = mneme::embedding::create_provider(&embedding_config)
+        .whatever_context("failed to create configured embedding provider")?;
+
+    let stores = recovery_store_paths(oikos)?;
+    if stores.is_empty() {
+        whatever!(
+            "no knowledge stores found under {}\n  \
+             Start the server or run a migration/import first.",
+            oikos.knowledge_db().display()
+        );
+    }
+
+    let store_count = stores.len();
+    let mut total = 0usize;
+    for store_path in stores {
+        let store = open_recovery_store(&store_path, dim)?;
+        let written = store
+            .reembed_all(provider.as_ref())
+            .with_whatever_context(|err| {
+                format!("failed to re-embed facts in {}: {err}", store_path.display())
+            })?;
+        println!("reembed: {} -> {} facts", store_path.display(), written);
+        total = total.saturating_add(written);
+    }
+
+    println!("Re-embedded {total} facts across {} store(s).", store_count);
+    Ok(())
+}
+
+#[cfg(feature = "recall")]
+fn run_gc(oikos: &taxis::oikos::Oikos, dim: usize) -> Result<()> {
+    let stores = recovery_store_paths(oikos)?;
+    if stores.is_empty() {
+        whatever!(
+            "no knowledge stores found under {}\n  \
+             Start the server or run a migration/import first.",
+            oikos.knowledge_db().display()
+        );
+    }
+
+    let mut total = 0usize;
+    for store_path in &stores {
+        let store = open_recovery_store(store_path, dim)?;
+        let removed = store
+            .remove_orphaned_entities()
+            .with_whatever_context(|err| {
+                format!(
+                    "failed to remove orphaned entities in {}: {err}",
+                    store_path.display()
+                )
+            })?;
+        println!(
+            "gc: {} -> {} orphaned entities removed",
+            store_path.display(),
+            removed
+        );
+        total = total.saturating_add(removed);
+    }
+
+    println!(
+        "Removed {total} orphaned entities across {} store(s).",
+        stores.len()
+    );
+    Ok(())
+}
+
 // --- check ---
 
 #[cfg(feature = "recall")]
@@ -659,20 +841,9 @@ fn count_relation(
 fn find_orphaned_entities(
     store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
 ) -> Result<Vec<String>> {
-    use std::collections::BTreeMap;
-    let script = r"
-        ?[id] :=
-            *entities{id},
-            not *relationships{src: id},
-            not *relationships{dst: id},
-            not *fact_entities{entity_id: id}
-    ";
-    let result = store
-        .run_query(script, BTreeMap::new())
-        .whatever_context("orphan query failed")?;
-    Ok((0..result.row_count())
-        .filter_map(|i| result.get_string(i, "id"))
-        .collect())
+    store
+        .orphaned_entity_ids()
+        .whatever_context("orphan query failed")
 }
 
 #[cfg(feature = "recall")]

--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -171,53 +171,14 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
             );
 
         match action {
-            Action::Check { json } => {
-                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
-                run_check(&store, json)
-            }
-            Action::Sample { count, nous_id } => {
-                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
-                run_sample(&store, count, nous_id.as_deref())
-            }
-            Action::Dedup { nous_id, dry_run } => {
-                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
-                run_dedup(&store, &nous_id, dry_run, &dedup_tuning)
-            }
-            Action::Patterns { nous_id, limit } => {
-                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
-                run_patterns(&store, nous_id.as_deref(), limit)
-            }
-            Action::ExportGraph {
-                format,
-                nous_id,
-                scope,
-                output_path,
-            } => {
-                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
-                run_export_graph(&store, format, nous_id.as_deref(), scope, &output_path)
-            }
-            Action::DedupPending { nous_id } => {
-                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
-                run_dedup_pending(&store, &nous_id)
-            }
-            Action::DedupApprove {
-                nous_id,
-                canonical_id,
-                merged_id,
-            } => {
-                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
-                run_dedup_approve(&store, &nous_id, &canonical_id, &merged_id)
-            }
-            Action::DedupReject {
-                nous_id,
-                entity_a,
-                entity_b,
-            } => {
-                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
-                run_dedup_reject(&store, &nous_id, &entity_a, &entity_b)
-            }
+            // WHY: reembed/gc iterate every cohort store themselves, so they
+            // must not pre-open the shared store like the other actions.
             Action::Reembed => run_reembed(&oikos, recovery_dim, loaded_config.as_ref()),
             Action::Gc => run_gc(&oikos, recovery_dim),
+            store_action => {
+                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
+                run_store_action(&store, store_action, &dedup_tuning)
+            }
         }
     }
 
@@ -237,7 +198,7 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
 /// `session_export.rs` (refs #4255 / #4259 / #4263 / #4265).
 fn validate_action(action: &Action) -> Result<()> {
     match action {
-        Action::Check { .. } => Ok(()),
+        Action::Check { .. } | Action::Reembed | Action::Gc => Ok(()),
         Action::Sample { count, nous_id } => {
             if *count == 0 {
                 whatever!("--count must be greater than 0");
@@ -274,7 +235,6 @@ fn validate_action(action: &Action) -> Result<()> {
             }
             Ok(())
         }
-        Action::Reembed | Action::Gc => Ok(()),
         Action::DedupApprove {
             nous_id,
             canonical_id,
@@ -562,6 +522,41 @@ async fn run_check_via_api(url: &str, json: bool) -> Result<()> {
 
 // --- recovery ---
 
+/// Dispatch the store-backed memory actions against an opened shared store.
+#[cfg(feature = "recall")]
+fn run_store_action(
+    store: &std::sync::Arc<mneme::knowledge_store::KnowledgeStore>,
+    action: Action,
+    dedup_tuning: &mneme::dedup::DedupTuning,
+) -> Result<()> {
+    match action {
+        Action::Check { json } => run_check(store, json),
+        Action::Sample { count, nous_id } => run_sample(store, count, nous_id.as_deref()),
+        Action::Dedup { nous_id, dry_run } => run_dedup(store, &nous_id, dry_run, dedup_tuning),
+        Action::Patterns { nous_id, limit } => run_patterns(store, nous_id.as_deref(), limit),
+        Action::ExportGraph {
+            format,
+            nous_id,
+            scope,
+            output_path,
+        } => run_export_graph(store, format, nous_id.as_deref(), scope, &output_path),
+        Action::DedupPending { nous_id } => run_dedup_pending(store, &nous_id),
+        Action::DedupApprove {
+            nous_id,
+            canonical_id,
+            merged_id,
+        } => run_dedup_approve(store, &nous_id, &canonical_id, &merged_id),
+        Action::DedupReject {
+            nous_id,
+            entity_a,
+            entity_b,
+        } => run_dedup_reject(store, &nous_id, &entity_a, &entity_b),
+        Action::Reembed | Action::Gc => {
+            whatever!("BUG: reembed/gc must dispatch before the shared store opens")
+        }
+    }
+}
+
 #[cfg(feature = "recall")]
 fn open_recovery_store(
     path: &Path,
@@ -571,26 +566,15 @@ fn open_recovery_store(
         dim,
         ..Default::default()
     };
+    // NOTE: lock contention surfaces from the typed
+    // `krites::storage::StorageError::Locked` with operator guidance baked
+    // into its display; no string inspection is needed here.
     mneme::knowledge_store::KnowledgeStore::open_fjall(path, config).map_err(|err| {
-        let message = err.to_string();
-        if is_store_lock_error(&message) {
-            crate::error::Error::msg(format!(
-                "knowledge store at {} is locked by another process. Stop the server first, then rerun this command.",
-                path.display()
-            ))
-        } else {
-            crate::error::Error::msg(format!(
-                "failed to open knowledge store at {}: {message}",
-                path.display()
-            ))
-        }
+        crate::error::Error::msg(format!(
+            "failed to open knowledge store at {}: {err}",
+            path.display()
+        ))
     })
-}
-
-#[cfg(feature = "recall")]
-fn is_store_lock_error(message: &str) -> bool {
-    let lower = message.to_ascii_lowercase();
-    lower.contains("lock") || lower.contains("busy") || lower.contains("in use")
 }
 
 #[cfg(feature = "recall")]
@@ -657,13 +641,16 @@ fn run_reembed(
         let written = store
             .reembed_all(provider.as_ref())
             .with_whatever_context(|err| {
-                format!("failed to re-embed facts in {}: {err}", store_path.display())
+                format!(
+                    "failed to re-embed facts in {}: {err}",
+                    store_path.display()
+                )
             })?;
         println!("reembed: {} -> {} facts", store_path.display(), written);
         total = total.saturating_add(written);
     }
 
-    println!("Re-embedded {total} facts across {} store(s).", store_count);
+    println!("Re-embedded {total} facts across {store_count} store(s).");
     Ok(())
 }
 

--- a/crates/episteme/src/knowledge_store/entity.rs
+++ b/crates/episteme/src/knowledge_store/entity.rs
@@ -36,6 +36,26 @@ impl KnowledgeStore {
         self.run_mut(&queries::upsert_relationship(), params)
     }
 
+    /// Remove entities that have neither relationships nor fact references.
+    ///
+    /// The orphan predicate matches the operator-facing validation check:
+    /// entities are safe to delete only when they have no incoming or
+    /// outgoing relationships and no `fact_entities` rows pointing at them.
+    #[instrument(skip(self))]
+    pub fn remove_orphaned_entities(&self) -> crate::error::Result<usize> {
+        let orphaned_ids = self.orphaned_entity_ids()?;
+        let mut removed = 0usize;
+
+        for orphan_id in orphaned_ids {
+            let entity_id =
+                crate::id::EntityId::new(&orphan_id).context(crate::error::InvalidIdSnafu)?;
+            self.delete_entity(&entity_id)?;
+            removed = removed.saturating_add(1);
+        }
+
+        Ok(removed)
+    }
+
     /// Query 2-hop entity neighborhood.
     ///
     /// Returns a [`QueryResult`] whose rows correspond to the Datalog output of
@@ -815,6 +835,29 @@ impl KnowledgeStore {
             });
         }
         Ok(entities)
+    }
+
+    /// Return the entity IDs that can be garbage-collected safely.
+    ///
+    /// This keeps the garbage-collection command aligned with the same orphan
+    /// predicate used by the validation report: no relationships in either
+    /// direction and no facts referencing the entity.
+    pub fn orphaned_entity_ids(&self) -> crate::error::Result<Vec<String>> {
+        use std::collections::BTreeMap;
+
+        let script = r"?[id] :=
+            *entities{id},
+            not *relationships{src: id},
+            not *relationships{dst: id},
+            not *fact_entities{entity_id: id}";
+        let rows = self.run_read(script, BTreeMap::new())?;
+        let mut ids = Vec::with_capacity(rows.rows.len());
+        for row in &rows.rows {
+            if let Some(id) = row.first().and_then(|v| v.get_str()) {
+                ids.push(id.to_owned());
+            }
+        }
+        Ok(ids)
     }
 
     /// Load a single entity by ID.

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -4,6 +4,27 @@ use super::marshal::{extract_str, fact_to_params, rows_to_facts};
 use super::{KnowledgeStore, queries};
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
+    /// Recompute and persist embeddings for every fact in the store.
+    ///
+    /// This is the recovery path for restored or migrated stores that still
+    /// have facts but lost their vector rows. The provider is expected to be
+    /// the active configured embedding backend; the helper reuses the same
+    /// batch/backoff logic as the import-time backfill path.
+    #[instrument(skip(self, provider))]
+    pub fn reembed_all(
+        &self,
+        provider: &dyn crate::embedding::EmbeddingProvider,
+    ) -> crate::error::Result<usize> {
+        let facts = self.list_all_facts(i64::MAX)?;
+        let written = self.backfill_fact_embeddings(&facts, provider);
+        usize::try_from(written).map_err(|_| {
+            crate::error::ConversionSnafu {
+                message: "reembedded fact count overflowed usize".to_owned(),
+            }
+            .build()
+        })
+    }
+
     /// Insert or update a fact.
     ///
     /// The fact is validated (non-empty content, length limit, confidence range)

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -17,9 +17,9 @@ impl KnowledgeStore {
     ) -> crate::error::Result<usize> {
         let facts = self.list_all_facts(i64::MAX)?;
         let written = self.backfill_fact_embeddings(&facts, provider);
-        usize::try_from(written).map_err(|_| {
+        usize::try_from(written).map_err(|err| {
             crate::error::ConversionSnafu {
-                message: "reembedded fact count overflowed usize".to_owned(),
+                message: format!("reembedded fact count overflowed usize: {err}"),
             }
             .build()
         })

--- a/crates/episteme/src/knowledge_store/tests/entities.rs
+++ b/crates/episteme/src/knowledge_store/tests/entities.rs
@@ -474,6 +474,74 @@ fn update_entity_name_embedding_clears_with_none() {
     );
 }
 
+/// Recovery path: recompute fact embeddings for a restored store that has
+/// facts but no rows in the embeddings relation yet.
+#[test]
+fn reembed_all_populates_fact_embeddings() {
+    let store = make_store();
+    let f1 = make_fact("fact-1", "agent-a", "Alice likes Rust");
+    let f2 = make_fact("fact-2", "agent-b", "Bob prefers Go");
+    store.insert_fact(&f1).expect("insert fact 1");
+    store.insert_fact(&f2).expect("insert fact 2");
+
+    let provider = crate::embedding::MockEmbeddingProvider::new(crate::test_fixtures::DIM);
+    let written = store.reembed_all(&provider).expect("reembed all facts");
+    assert_eq!(written, 2, "every fact should receive an embedding");
+
+    let rows = store
+        .run_query(
+            r"?[id, source_id] := *embeddings{id, source_id}",
+            std::collections::BTreeMap::new(),
+        )
+        .expect("query embeddings");
+    assert_eq!(rows.row_count(), 2, "two embedding rows should exist");
+
+    let mut source_ids = Vec::new();
+    for row in 0..rows.row_count() {
+        source_ids.push(rows.get_string(row, "source_id").expect("source_id"));
+    }
+    assert!(
+        source_ids.iter().any(|id| id == "fact-1"),
+        "fact-1 embedding should be present"
+    );
+    assert!(
+        source_ids.iter().any(|id| id == "fact-2"),
+        "fact-2 embedding should be present"
+    );
+}
+
+/// Garbage-collection path: delete only entities that have no relationships
+/// and no fact references, leaving linked entities intact.
+#[test]
+fn remove_orphaned_entities_deletes_only_unlinked_rows() {
+    let store = make_store();
+
+    let orphan = make_entity("ent-orphan", "Orphan", "concept");
+    let linked = make_entity("ent-linked", "Linked", "concept");
+    store.insert_entity(&orphan).expect("insert orphan");
+    store.insert_entity(&linked).expect("insert linked");
+
+    let fact = make_fact("fact-linked", "agent-a", "linked fact");
+    store.insert_fact(&fact).expect("insert fact");
+    store
+        .insert_fact_entity(&fact.id, &linked.id)
+        .expect("link fact to entity");
+
+    let removed = store
+        .remove_orphaned_entities()
+        .expect("remove orphaned entities");
+    assert_eq!(removed, 1, "only the orphan should be removed");
+
+    let surviving = store.list_entities().expect("list entities");
+    assert_eq!(surviving.len(), 1, "linked entity should remain");
+    assert_eq!(surviving[0].id, linked.id);
+
+    let removed_again = store
+        .remove_orphaned_entities()
+        .expect("second remove_orphaned_entities call");
+    assert_eq!(removed_again, 0, "garbage collection should be idempotent");
+}
+
 /// `approve_merge` is the operational half of #4165 Path A. Insert two
 /// entities that land in the review queue (score in `[0.70, 0.90)`),
 /// then approve the merge and assert that:

--- a/crates/krites/src/storage/error.rs
+++ b/crates/krites/src/storage/error.rs
@@ -15,6 +15,23 @@ pub enum StorageError {
         location: snafu::Location,
     },
 
+    /// The on-disk store is locked by another process.
+    ///
+    /// WHY: fjall takes an exclusive lock per keyspace; without a dedicated
+    /// variant the lock surfaces as an opaque "transaction failed: open"
+    /// message. Mirrors `koina::fjall::FjallOpenError::Locked` so every
+    /// store (session, auth, knowledge) reports lock contention the same
+    /// actionable way.
+    #[snafu(display(
+        "the store at {} is locked — a running aletheia server holds it. Stop the server, or use the HTTP API (e.g. `aletheia memory`, `aletheia maintenance`) which talks to the running server instead of opening the store directly.",
+        path.display()
+    ))]
+    Locked {
+        path: std::path::PathBuf,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// Attempted a write operation on a read-only transaction.
     #[snafu(display("write attempted on a read-only transaction"))]
     WriteInReadTransaction {

--- a/crates/krites/src/storage/fjall_backend.rs
+++ b/crates/krites/src/storage/fjall_backend.rs
@@ -40,6 +40,12 @@ pub fn new_krites_fjall(
     let db = fjall::SingleWriterTxDatabase::builder(path)
         .open()
         .map_err(|e| {
+            if matches!(e, fjall::Error::Locked) {
+                return crate::storage::error::LockedSnafu {
+                    path: path.to_path_buf(),
+                }
+                .build();
+            }
             TransactionFailedSnafu {
                 backend: "fjall",
                 message: format!("open: {e}"),


### PR DESCRIPTION
## Problem

Found live on a real migrated instance (v0.29 → v0.30): the knowledge store carried 92 facts with **zero vector embeddings** (semantic recall silently dead; only text recall worked) plus a stray orphaned entity — and no command could fix either. `memory check` detects both conditions; re-embed-on-import (#4399) only covers the import path; `dedup` only merges duplicates. Any restored or migrated instance hits this with no recovery path.

Separately, krites never mapped fjall's lock error: a locked knowledge store surfaced as `transaction failed (fjall): open: …` while the koina-backed session/auth stores already report actionable guidance (#4461/#4469) — the same issue class, half-fixed.

## Fix

- **`aletheia memory reembed`** — iterates every cohort store, recomputes embeddings for all facts via the configured embedding provider (reuses the #4399 backfill path: `KnowledgeStore::reembed_all`). Reports per-store + total counts.
- **`aletheia memory gc`** — removes orphaned entities (no relationships either direction, no fact references; same predicate as the validation report, now shared via `orphaned_entity_ids`). Idempotent.
- **`krites::storage::StorageError::Locked`** — typed variant mirroring koina's actionable display; `new_krites_fjall` maps `fjall::Error::Locked`. The memory CLI's compensating string-sniff is deleted; store-backed actions dispatch through a single open site.

## Verification

2064/2064 tests pass across krites + episteme + aletheia (`--features episteme/test-core`), including new unit tests: reembed populates embeddings on a store with un-embedded facts; gc removes only unlinked entities and is idempotent; both subcommands parse. Clippy `-D warnings` clean. Next step (post-merge): run both commands against the live migrated instance to restore semantic recall.

Co-authored-by: Cody Kickertz <cody.kickertz@pm.me>