### PR TITLE
fix(deps): pin fjall to explicit lz4 feature across the workspace — cross-build store compatibility

### DIFF
--- a/crates/aletheia-sessions-migrate/Cargo.toml
+++ b/crates/aletheia-sessions-migrate/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 graphe = { path = "../graphe" }
 eidos = { path = "../eidos" }
-fjall = { version = "3", default-features = false }
+fjall = { version = "3", default-features = false, features = ["lz4"] }
 koina = { path = "../koina", features = ["fjall"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 serde = { workspace = true }

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -60,7 +60,7 @@ energeia = { path = "../energeia", optional = true }
 oikonomos = { path = "../daemon" }
 koina = { path = "../koina", features = ["fjall"] }
 taxis = { path = "../taxis" }
-fjall = { version = "3", default-features = false }
+fjall = { version = "3", default-features = false, features = ["lz4"] }
 hermeneus = { path = "../hermeneus" }
 organon = { path = "../organon" }
 mneme = { path = "../mneme" }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -30,7 +30,7 @@ axum = { workspace = true }
 # the lock to the file descriptor, so the lock lives until the File is dropped.
 rustix = { version = "1", default-features = false, features = ["fs", "std"] }
 # WHY: fjall is the task-state backend -- pure Rust LSM-tree, zero C deps.
-fjall = { version = "3", default-features = false }
+fjall = { version = "3", default-features = false, features = ["lz4"] }
 flate2 = { workspace = true }
 jiff = { workspace = true, features = ["serde"] }
 # WHY: file watcher triggers (inotify on Linux)

--- a/crates/energeia/Cargo.toml
+++ b/crates/energeia/Cargo.toml
@@ -24,7 +24,7 @@ hermeneus = { path = "../hermeneus" }
 prometheus-client = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
-fjall = { version = "3", optional = true }
+fjall = { version = "3", default-features = false, features = ["lz4"], optional = true }
 jiff = { workspace = true, features = ["serde"] }
 jiff-cron = "0.3"
 parking_lot = { version = "0.12", default-features = false }

--- a/crates/gnosis/Cargo.toml
+++ b/crates/gnosis/Cargo.toml
@@ -17,7 +17,7 @@ cargo_metadata = "0.18"
 parking_lot = "0.12"
 proc-macro2 = { version = "1", features = ["span-locations"] }
 syn = { version = "2", features = ["full", "extra-traits", "visit"] }
-fjall = { version = "3", default-features = false }
+fjall = { version = "3", default-features = false, features = ["lz4"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/graphe/Cargo.toml
+++ b/crates/graphe/Cargo.toml
@@ -25,7 +25,7 @@ test-full = []
 [dependencies]
 eidos = { path = "../eidos" }
 koina = { path = "../koina", features = ["fjall"] }
-fjall = { version = "3", default-features = false }
+fjall = { version = "3", default-features = false, features = ["lz4"] }
 jiff = { workspace = true, features = ["serde"] }
 prometheus-client = { workspace = true }
 serde = { workspace = true }

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -18,7 +18,7 @@ test-full = []
 test-support = []
 
 [dependencies]
-fjall = { version = "3", default-features = false, optional = true }
+fjall = { version = "3", default-features = false, features = ["lz4"], optional = true }
 tempfile = { workspace = true, optional = true }
 jiff = { workspace = true }
 rustix = { workspace = true, features = ["fs"] }

--- a/crates/krites/Cargo.toml
+++ b/crates/krites/Cargo.toml
@@ -60,7 +60,7 @@ snafu = { workspace = true }
 tracing = { workspace = true }
 
 # Storage backends
-fjall = { version = "3", default-features = false, optional = true }
+fjall = { version = "3", default-features = false, features = ["lz4"], optional = true }
 
 # Hot-reload
 notify = { workspace = true, optional = true }

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -47,7 +47,7 @@ taxis = { path = "../taxis" }
 thesauros = { path = "../thesauros" }
 # WHY: nous owns two small fjall-backed trackers (competence, uncertainty)
 # that persist per-agent/domain scores and calibration points.
-fjall = { version = "3", default-features = false }
+fjall = { version = "3", default-features = false, features = ["lz4"] }
 jiff = { workspace = true }
 prometheus-client = { workspace = true }
 regex = { workspace = true }

--- a/crates/organon/Cargo.toml
+++ b/crates/organon/Cargo.toml
@@ -93,7 +93,7 @@ optional = true
 
 [dev-dependencies]
 energeia = { path = "../energeia", features = ["storage-fjall"] }
-fjall = { version = "3" }
+fjall = { version = "3", default-features = false, features = ["lz4"] }
 indexmap = { workspace = true }
 proptest = { workspace = true }
 rustls = { workspace = true }

--- a/crates/symbolon/Cargo.toml
+++ b/crates/symbolon/Cargo.toml
@@ -22,7 +22,7 @@ koina = { path = "../koina", features = ["fjall"] }
 keyring = { version = "3", optional = true }
 argon2 = { version = "0.5", features = ["std"] }
 blake3 = "1"
-fjall = { version = "3", default-features = false }
+fjall = { version = "3", default-features = false, features = ["lz4"] }
 jiff = { workspace = true, features = ["serde"] }
 prometheus-client = { workspace = true }
 rand = { workspace = true }


### PR DESCRIPTION
## Problem

fjall-3.1.4's default features include `lz4`. Most workspace crates declared `fjall = { version = "3", default-features = false }` (no compression), but organon declared bare `fjall = { version = "3" }` and energeia left defaults on behind `storage-fjall`. Cargo feature unification therefore enabled lz4 **only in builds whose graph includes those edges** (e.g. `--features energeia`) and not in default builds.

Hit live twice today on the metis test instance: a store written by a featured build (lz4 segments) is unreadable by a default build of the *same version* — `FjallError: Storage(InvalidTag(("CompressionType", 1)))` at open. Same code, different feature graph → bricked store reads.

## Fix

Every fjall dependency declaration in the workspace is now explicit and identical: `default-features = false, features = ["lz4"]` (11 crates: organon, energeia, koina, krites, daemon, nous, graphe, gnosis, symbolon, aletheia, aletheia-sessions-migrate). Every binary of every feature combination both reads and writes lz4 consistently; lz4 readers also read uncompressed segments, so existing stores stay readable.

## Verification

Gate-verified in the worktree (attestation trailer on the commit). Metadata-only change — no source edits.

Co-authored-by: Cody Kickertz <cody.kickertz@pm.me>