### PR TITLE
docs(hermeneus,koina,eidos): comment cleanup pilot — delete restates, strip narrative, retag load-bearing freeform

### DIFF
--- a/_llm/L3-api-index/eidos.md
+++ b/_llm/L3-api-index/eidos.md
@@ -1356,7 +1356,6 @@ pub struct ArtefactMeta {
     /// Named row/item counts for the primary collections in this artefact.
     pub row_counts: BTreeMap<String, u64>,
 
-    // ── Mnemosyne-aligned optional fields ─────────────────────────────────────
     /// Unified actor identity. Maps to mnemosyne `Annotation::agent_id` and
     /// episteme `Fact::nous_id`. Use `"<crate>@<version>"` for automated
     /// producers; use the agent ID string for nous-authored artefacts.
@@ -1518,16 +1517,7 @@ pub struct TrainingConfig {
 
 > Current schema version for [`TrainingRecord`].
 > 
-> Bump this constant whenever fields are added, removed, or change
-> semantics so that records from different epochs can be distinguished
-> at read time.
-> 
-> # History
-> 
-> - v0: initial, no `schema_version` field persisted
-> - v1: added `schema_version` field
-> - v2: added episteme labels (`turn_type`, `is_correction`, `fact_types`, `quality_score`)
-> - v3: added `tool_outcomes`, `recall_signals`, `pii_redacted`
+> Bump this constant when the persisted record shape changes incompatibly.
 ```rust
 pub const TRAINING_RECORD_SCHEMA_VERSION: u32 = 3;
 ```
@@ -1602,7 +1592,7 @@ pub struct TrainingRecord {
     /// When the turn was captured.
     pub timestamp: Timestamp,
 
-    // ── Episteme labels (v2) ──────────────────────────────────────────
+    // NOTE: Episteme labels (v2) group the four fields below.
     /// Classification of the conversation turn (e.g. "discussion", "correction").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_type: Option<String>,
@@ -1616,7 +1606,7 @@ pub struct TrainingRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quality_score: Option<f32>,
 
-    // ── Behavioural signals (v3) ──────────────────────────────────────
+    // NOTE: Behavioural signals (v3) covers `tool_outcomes`.
     /// Outcomes of tool calls made during the turn, in invocation order.
     ///
     /// `None` when the turn had no tool calls. An empty vec is reserved

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -74,8 +74,8 @@ l3_token_estimate = 8198
 [[crates]]
 name = "eidos"
 path = "crates/eidos"
-source_hash = "1404454c2879c915436790243e3ee6c7e3214024ae3c8db84cc12ee62b2755b7"
-l3_token_estimate = 13450
+source_hash = "87c77416bf821e6107ed73a027c6092149b193d760ac3743c3443226c32ac225"
+l3_token_estimate = 13338
 
 [[crates]]
 name = "energeia"
@@ -104,7 +104,7 @@ l3_token_estimate = 5222
 [[crates]]
 name = "hermeneus"
 path = "crates/hermeneus"
-source_hash = "6438ff4c4173ef4fa0b9ee5bd431ea74874cba2c1da356d908a824e63e5e97a0"
+source_hash = "bdba659c1bdd132e71e64523aa37a0f67d94d8eea249dcd33751d8aa1ca36743"
 l3_token_estimate = 13698
 
 [[crates]]
@@ -122,7 +122,7 @@ l3_token_estimate = 11570
 [[crates]]
 name = "koina"
 path = "crates/koina"
-source_hash = "f2d971d8fb72f6ecbef58b8b250ab47f43c7f5f9da6d216f075ce4af8f1b6aef"
+source_hash = "e6416dbe6ad7469b3458cf056c039eb544c2710c64ad89b71b9c0943527f6ee9"
 l3_token_estimate = 7453
 
 [[crates]]

--- a/crates/eidos/src/knowledge/architecture_fact.rs
+++ b/crates/eidos/src/knowledge/architecture_fact.rs
@@ -36,8 +36,6 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
-// ── Error types ──────────────────────────────────────────────────────────────
-
 /// Errors from [`FactStore`] operations.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
@@ -81,8 +79,6 @@ pub enum FactError {
         source: serde_json::Error,
     },
 }
-
-// ── Core types ───────────────────────────────────────────────────────────────
 
 /// Architectural scope that a fact applies to.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -168,8 +164,6 @@ impl ArchitectureFact {
     }
 }
 
-// ── FactStore ────────────────────────────────────────────────────────────────
-
 /// Flat-JSON-file backed store for [`ArchitectureFact`]s.
 ///
 /// One file per fact: `<dir>/<safe_id>.json` where `<safe_id>` is the fact's
@@ -203,7 +197,6 @@ impl FactStore {
 
     /// Translate a fact `id` to a safe filename (no path separators).
     fn id_to_filename(id: &str) -> String {
-        // Replace chars that are unsafe in filenames.
         let mut name: String = id
             .chars()
             .map(|c| match c {
@@ -331,8 +324,6 @@ impl FactStore {
     }
 }
 
-// ── Seed facts helper (used by tests and initial population) ─────────────────
-
 /// Build the five seed facts that describe aletheia's own architecture.
 ///
 /// These are written by `PR-3789` and provide the initial populated state
@@ -409,14 +400,10 @@ pub fn seed_facts() -> Vec<ArchitectureFact> {
     ]
 }
 
-// ── Tests ────────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
-
-    // ── ArchitectureFact serde round-trip ────────────────────────────────
 
     #[test]
     fn serde_round_trip() {
@@ -478,8 +465,6 @@ mod tests {
         );
     }
 
-    // ── FactScope parsing ────────────────────────────────────────────────
-
     #[test]
     fn fact_scope_serde_all_variants() {
         for (scope, expected) in [
@@ -502,8 +487,6 @@ mod tests {
         assert_eq!(FactScope::Concept.to_string(), "concept");
         assert_eq!(FactScope::Boundary.to_string(), "boundary");
     }
-
-    // ── FactStore get/put/list/search ────────────────────────────────────
 
     #[tokio::test]
     async fn put_then_get_returns_fact() {

--- a/crates/eidos/src/knowledge/knowledge_tests/path_validation.rs
+++ b/crates/eidos/src/knowledge/knowledge_tests/path_validation.rs
@@ -1,14 +1,6 @@
-//! (See parent module for full rationale.)
-
 use std::path::{Path, PathBuf};
 
 use super::super::*;
-
-// Split: PathValidationLayer / PathValidationError / ValidatedPath tests.
-
-// ---------------------------------------------------------------------------
-// PathValidationLayer tests
-// ---------------------------------------------------------------------------
 
 #[test]
 fn path_validation_layer_serde_roundtrip() {
@@ -148,10 +140,6 @@ fn symlink_hop_limit_matches_linux_eloop() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// PathValidationError tests
-// ---------------------------------------------------------------------------
-
 #[test]
 fn path_validation_error_layer_mapping() {
     // WHY: Every error variant must map back to the correct layer for logging.
@@ -256,10 +244,6 @@ fn path_validation_error_is_std_error() {
     let _: &dyn std::error::Error = &err;
 }
 
-// ---------------------------------------------------------------------------
-// ValidatedPath tests
-// ---------------------------------------------------------------------------
-
 #[test]
 fn validated_path_accessors() {
     // WHY: ValidatedPath's public API must expose path and scope without
@@ -322,10 +306,6 @@ fn validated_path_display() {
         "Display should render the path"
     );
 }
-
-// ---------------------------------------------------------------------------
-// validate_memory_path() — positive tests per scope
-// ---------------------------------------------------------------------------
 
 #[test]
 fn valid_user_scope_path() {
@@ -414,5 +394,3 @@ fn valid_path_with_dots_in_filename() {
         "dots in filename (not traversal) should validate"
     );
 }
-
-// ---------------------------------------------------------------------------

--- a/crates/eidos/src/knowledge/path.rs
+++ b/crates/eidos/src/knowledge/path.rs
@@ -51,7 +51,7 @@ pub const PATH_VALIDATION_FS_LAYERS: usize = 7;
 pub const SYMLINK_HOP_LIMIT: usize = 40;
 
 impl PathValidationLayer {
-    /// All layer variants in application order.
+    /// All layer variants in enum order.
     pub const ALL: [Self; 8] = [
         Self::NullByte,
         Self::Canonicalization,
@@ -109,8 +109,6 @@ impl std::str::FromStr for PathValidationLayer {
         }
     }
 }
-
-// ── Path validation error ────────────────────────────────────────────────
 
 /// Error from defense-in-depth path validation.
 ///
@@ -228,8 +226,6 @@ impl std::fmt::Display for PathValidationError {
 
 impl std::error::Error for PathValidationError {}
 
-// ── Validated path newtype ───────────────────────────────────────────────
-
 /// A filesystem path that has passed all defense-in-depth validation layers.
 ///
 /// This newtype can only be constructed through [`validate_memory_path()`],
@@ -300,8 +296,6 @@ impl std::fmt::Display for ValidatedPath {
     }
 }
 
-// ── Path validation function ─────────────────────────────────────────────
-
 /// Validate a memory path against all defense-in-depth security layers.
 ///
 /// Applies each [`PathValidationLayer`] in order. The path must pass all
@@ -331,14 +325,14 @@ pub fn validate_memory_path(
 ) -> std::result::Result<ValidatedPath, PathValidationError> {
     let path_str = path.to_string_lossy();
 
-    // SAFETY: Layer 1 — reject null bytes that truncate C-level syscalls.
+    // INVARIANT: Layer 1 rejects null bytes before any filesystem access.
     if path_str.contains('\0') {
         return Err(PathValidationError::NullByte {
             path: path_str.into_owned(),
         });
     }
 
-    // SAFETY: Layer 2 — reject `..` components and backslashes.
+    // INVARIANT: Layer 2 rejects `..` components and backslashes before normalization.
     for component in path.components() {
         if matches!(component, Component::ParentDir) {
             return Err(PathValidationError::Canonicalization {
@@ -354,7 +348,7 @@ pub fn validate_memory_path(
         });
     }
 
-    // SAFETY: Layer 3 — detect percent-encoded traversal separators.
+    // INVARIANT: Layer 3 rejects percent-encoded traversal separators.
     let lower = path_str.to_ascii_lowercase();
     for pattern in &["%2e", "%2f", "%5c"] {
         if lower.contains(pattern) {
@@ -365,9 +359,7 @@ pub fn validate_memory_path(
         }
     }
 
-    // SAFETY: Layer 4 — detect fullwidth characters that
-    // normalize to ASCII separators under NFKC (U+FF0E → '.', U+FF0F → '/',
-    // U+FF3C → '\').
+    // INVARIANT: Layer 4 rejects fullwidth separators that normalize to ASCII.
     for ch in path_str.chars() {
         if matches!(ch, '\u{FF0E}' | '\u{FF0F}' | '\u{FF3C}') {
             return Err(PathValidationError::UnicodeNormalization {
@@ -385,7 +377,7 @@ pub fn validate_memory_path(
     };
     let normalized = normalize_path_components(&full_path);
 
-    // SAFETY: Layer 5 — resolved path must stay within scope_dir.
+    // INVARIANT: Layer 5 keeps the normalized path within `scope_dir`.
     if !normalized.starts_with(&scope_dir) {
         return Err(PathValidationError::ScopeContainment {
             path: normalized,
@@ -394,10 +386,8 @@ pub fn validate_memory_path(
         });
     }
 
-    // SAFETY: Layers 6–7 — symlink resolution, dangling symlink, loop detection.
-    // WHY: Only checked when the path exists on the filesystem. Pure string
-    // layers above have already validated the path structure for paths that
-    // don't yet exist.
+    // WHY: Layers 6-7 only run when the path exists; pure string layers above
+    // already validated the shape for non-existent paths.
     validate_symlinks(&normalized, root, &scope_dir, scope)?;
 
     Ok(ValidatedPath {
@@ -414,8 +404,7 @@ fn normalize_path_components(path: &Path) -> PathBuf {
     let mut parts: Vec<Component<'_>> = Vec::new();
     for c in path.components() {
         match c {
-            // WHY: ParentDir should already be rejected by Layer 2, but
-            // defense-in-depth means we handle it here too.
+            // WHY: ParentDir should already be rejected by Layer 2, but defense in depth keeps this helper defensive.
             Component::ParentDir => {
                 parts.pop();
             }
@@ -437,8 +426,7 @@ fn validate_symlinks(
     scope_dir: &Path,
     scope: MemoryScope,
 ) -> std::result::Result<(), PathValidationError> {
-    // WHY: symlink_metadata returns info about the link itself (not its target),
-    // so is_symlink() is accurate even for dangling links.
+    // WHY: `symlink_metadata` reports the link itself, so `is_symlink()` stays accurate even when dangling.
     let Ok(meta) = std::fs::symlink_metadata(path) else {
         return Ok(()); // Path doesn't exist yet; pure layers sufficient.
     };
@@ -447,10 +435,9 @@ fn validate_symlinks(
         return Ok(()); // Not a symlink; no further checks needed.
     }
 
-    // Resolve symlinks with hop counting for loop detection.
+    // WHY: resolve symlinks with hop counting so loops are bounded.
     let canonical = resolve_with_hop_limit(path)?;
 
-    // Layer 6: Symlink resolution — canonical path must stay within root.
     if !canonical.starts_with(root) {
         return Err(PathValidationError::SymlinkResolution {
             path: path.to_path_buf(),
@@ -458,7 +445,6 @@ fn validate_symlinks(
         });
     }
 
-    // Re-check scope containment on the canonical path.
     if !canonical.starts_with(scope_dir) {
         return Err(PathValidationError::ScopeContainment {
             path: canonical,

--- a/crates/eidos/src/meta.rs
+++ b/crates/eidos/src/meta.rs
@@ -45,8 +45,6 @@ use crate::knowledge::{
     finding::Finding, format_timestamp,
 };
 
-// ── Stamped trait ─────────────────────────────────────────────────────────────
-
 /// Every persistable artefact carries provenance metadata.
 ///
 /// Implement this trait on your artefact struct and call `.stamp()` in the
@@ -56,8 +54,6 @@ pub trait Stamped {
     /// Returns the artefact's stamp at the moment of persistence.
     fn stamp(&self) -> ArtefactMeta;
 }
-
-// ── Provenance ────────────────────────────────────────────────────────────────
 
 /// Canonical provenance projection for eidos public knowledge shapes.
 ///
@@ -158,16 +154,12 @@ impl Provenance {
     }
 }
 
-// ── ArtefactMeta ──────────────────────────────────────────────────────────────
-
 /// Uniform provenance envelope attached to every persistable fleet artefact.
 ///
 /// # Stability
 ///
-/// `#[non_exhaustive]` ensures downstream `match` on field subsets or struct
-/// literals do not break when new fields are appended. Per kanon #108 lesson:
-/// a simple field addition to a widely-used struct broke 90 sites without this
-/// guard.
+/// WHY(#108): `#[non_exhaustive]` keeps downstream matches and struct literals
+/// from breaking when new fields are appended.
 ///
 /// # Field conventions
 ///
@@ -201,7 +193,6 @@ pub struct ArtefactMeta {
     /// Named row/item counts for the primary collections in this artefact.
     pub row_counts: BTreeMap<String, u64>,
 
-    // ── Mnemosyne-aligned optional fields ─────────────────────────────────────
     /// Unified actor identity. Maps to mnemosyne `Annotation::agent_id` and
     /// episteme `Fact::nous_id`. Use `"<crate>@<version>"` for automated
     /// producers; use the agent ID string for nous-authored artefacts.
@@ -475,14 +466,10 @@ where
     }
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
-
-    // ── Helper ───────────────────────────────────────────────────────────────
 
     /// Assert two `ArtefactMeta` values are equal field-by-field. We do not
     /// derive `Eq` because `f32` doesn't implement `Eq`; we use approximate
@@ -502,8 +489,6 @@ mod tests {
         // f32 comparison: must be identical bit-for-bit after serde round-trip.
         assert_eq!(a.confidence, b.confidence, "confidence");
     }
-
-    // ── Existing tests (backward-compat) ─────────────────────────────────────
 
     #[test]
     fn artefact_meta_new_round_trip_serde() {
@@ -569,8 +554,6 @@ mod tests {
         assert!(back.row_counts.is_empty(), "row_counts should be empty");
     }
 
-    // ── Backward-compat: old JSON with no optional fields deserializes ─────────
-
     #[test]
     fn artefact_meta_legacy_json_deserializes_cleanly() {
         // Simulates JSON produced before the mnemosyne-aligned fields were added.
@@ -601,8 +584,6 @@ mod tests {
             "evidence_refs defaults to empty"
         );
     }
-
-    // ── New builder tests ─────────────────────────────────────────────────────
 
     #[test]
     fn artefact_meta_with_actor_sets_fields() {
@@ -648,8 +629,6 @@ mod tests {
         );
     }
 
-    // ── Optional fields round-trip ─────────────────────────────────────────────
-
     #[test]
     fn artefact_meta_full_optional_fields_round_trip_serde() {
         let meta = ArtefactMeta::new("mneme@0.21.1", 1, "2026-04-22T00:00:00Z")
@@ -662,8 +641,6 @@ mod tests {
         let back: ArtefactMeta = serde_json::from_str(&json).expect("deserialize");
         assert_meta_eq(&meta, &back);
     }
-
-    // ── Optional-none fields are absent in JSON (skip_serializing_if) ─────────
 
     #[test]
     fn artefact_meta_minimal_serializes_without_optional_keys() {

--- a/crates/eidos/src/training.rs
+++ b/crates/eidos/src/training.rs
@@ -1,7 +1,5 @@
 //! Training data capture types.
 //!
-//! Configuration and record types for training data capture.
-
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -84,16 +82,7 @@ impl Default for TrainingConfig {
 
 /// Current schema version for [`TrainingRecord`].
 ///
-/// Bump this constant whenever fields are added, removed, or change
-/// semantics so that records from different epochs can be distinguished
-/// at read time.
-///
-/// # History
-///
-/// - v0: initial, no `schema_version` field persisted
-/// - v1: added `schema_version` field
-/// - v2: added episteme labels (`turn_type`, `is_correction`, `fact_types`, `quality_score`)
-/// - v3: added `tool_outcomes`, `recall_signals`, `pii_redacted`
+/// Bump this constant when the persisted record shape changes incompatibly.
 pub const TRAINING_RECORD_SCHEMA_VERSION: u32 = 3;
 
 /// Outcome of a single tool invocation during a turn.
@@ -186,7 +175,7 @@ pub struct TrainingRecord {
     /// When the turn was captured.
     pub timestamp: Timestamp,
 
-    // ── Episteme labels (v2) ──────────────────────────────────────────
+    // NOTE: Episteme labels (v2) group the four fields below.
     /// Classification of the conversation turn (e.g. "discussion", "correction").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_type: Option<String>,
@@ -200,7 +189,7 @@ pub struct TrainingRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quality_score: Option<f32>,
 
-    // ── Behavioural signals (v3) ──────────────────────────────────────
+    // NOTE: Behavioural signals (v3) covers `tool_outcomes`.
     /// Outcomes of tool calls made during the turn, in invocation order.
     ///
     /// `None` when the turn had no tool calls. An empty vec is reserved

--- a/crates/eidos/tests/public_api.rs
+++ b/crates/eidos/tests/public_api.rs
@@ -14,8 +14,6 @@
 
 #![expect(clippy::expect_used, reason = "test assertions")]
 
-// --- ID newtypes ---
-
 mod ids {
     use eidos::id::{CausalEdgeId, EmbeddingId, EntityId, FactId, IdValidationError};
 
@@ -142,8 +140,6 @@ mod ids {
     }
 }
 
-// --- EpistemicTier ---
-
 mod epistemic_tier {
     use eidos::knowledge::EpistemicTier;
 
@@ -206,8 +202,6 @@ mod epistemic_tier {
         assert_eq!(back, tier);
     }
 }
-
-// --- KnowledgeStage ---
 
 mod knowledge_stage {
     use std::str::FromStr;
@@ -293,8 +287,6 @@ mod knowledge_stage {
     }
 }
 
-// --- FactType ---
-
 mod fact_type {
     use eidos::knowledge::FactType;
 
@@ -350,7 +342,6 @@ mod fact_type {
         // must always yield a classification, not panic.
         assert_eq!(
             FactType::classify("The sky was grey today morning"),
-            // "today" matches event
             FactType::Event
         );
         assert_eq!(
@@ -370,8 +361,6 @@ mod fact_type {
         assert_eq!(FactType::from_str_lossy("preference"), FactType::Preference);
     }
 }
-
-// --- MemoryScope and ScopeAccessPolicy ---
 
 mod memory_scope {
     use std::str::FromStr;
@@ -437,7 +426,6 @@ mod memory_scope {
             let s = scope.as_str();
             let parsed = MemoryScope::from_str(s).expect("round trip");
             assert_eq!(parsed, scope);
-            // from_str_opt is the infallible sibling used at API boundaries
             assert_eq!(MemoryScope::from_str_opt(s), Some(scope));
         }
     }
@@ -448,8 +436,6 @@ mod memory_scope {
         assert_eq!(MemoryScope::from_str_opt("global"), None);
     }
 }
-
-// --- CausalRelationType, TemporalOrdering ---
 
 mod causal {
     use std::str::FromStr;
@@ -489,8 +475,6 @@ mod causal {
         }
     }
 }
-
-// --- ForgetReason, VerificationSource, VerificationStatus ---
 
 mod audit_classifiers {
     use std::str::FromStr;
@@ -553,8 +537,6 @@ mod audit_classifiers {
     }
 }
 
-// --- Path validation layers and error mapping ---
-
 mod path_validation {
     use std::path::PathBuf;
 
@@ -566,11 +548,9 @@ mod path_validation {
     #[test]
     fn all_layers_contains_every_variant() {
         // WHY: PATH_VALIDATION_FS_LAYERS counts I/O-requiring layers; ALL
-        // contains every layer in application order. Dropping one would
-        // silently disable a class of defense.
+        // contains every layer in enum order.
         assert_eq!(PathValidationLayer::ALL.len(), 8);
         assert_eq!(PATH_VALIDATION_FS_LAYERS, 7);
-        // Four non-I/O layers + scope containment + the three I/O layers = 8
         let io_count = PathValidationLayer::ALL
             .iter()
             .filter(|l| l.requires_io())
@@ -669,8 +649,6 @@ mod path_validation {
     }
 }
 
-// --- validate_memory_path end-to-end ---
-
 mod validate_memory_path {
     use std::path::PathBuf;
 
@@ -720,8 +698,6 @@ mod validate_memory_path {
         assert_eq!(validated.scope(), MemoryScope::Project);
     }
 }
-
-// --- TrainingConfig ---
 
 mod training_config {
     use eidos::training::TrainingConfig;
@@ -773,8 +749,6 @@ mod training_config {
         assert!((back.author_classifier_threshold - cfg.author_classifier_threshold).abs() < 1e-6);
     }
 }
-
-// --- Provenance ---
 
 mod provenance {
     use eidos::id::{CausalEdgeId, FactId};

--- a/crates/hermeneus/src/cc/parse.rs
+++ b/crates/hermeneus/src/cc/parse.rs
@@ -21,12 +21,9 @@ pub(crate) enum CcEvent {
 
     /// Final result event with usage and cost.
     ///
-    /// WHY(#3717): `result` is only present on success-shaped events
-    /// (`subtype = "success"`). When CC hits `error_max_turns` or another
-    /// error subtype, it omits `result` entirely and populates `errors`
-    /// (array of messages) + `terminal_reason` instead. Making `result`
-    /// optional + surfacing `errors`/`terminal_reason` keeps the parser
-    /// from dropping the whole event on error-subtype terminations.
+    /// WHY(#3717): success-shaped result events carry `result`; error subtypes
+    /// carry `errors` and `terminal_reason` instead, so the parser must accept
+    /// both shapes.
     #[serde(rename = "result")]
     Result {
         #[cfg_attr(
@@ -84,22 +81,10 @@ pub(crate) enum CcEvent {
 
 /// Assistant message body.
 ///
-/// Two on-wire shapes coexist depending on `claude` CLI version:
-///
-/// 1. **Legacy** (CC ≤ 1.x): the message envelope itself carries `text`:
-///    `{"type":"assistant","message":{"type":"text","text":"…"}}`
-///
-/// 2. **Current** (CC 2.x, `2.1.119` confirmed): the envelope wraps an
-///    Anthropic-API-shaped message whose `content` is an array of blocks,
-///    of which a `text`-typed block carries the actual text:
-///    `{"type":"assistant","message":{"type":"message","role":"assistant",
-///      "content":[{"type":"text","text":"…"}], …}}`
-///
-/// `Self::deserialize` accepts both. The flattened text is exposed on
-/// `Self::text` regardless of which shape arrived. Without this, CC 2.x's
-/// nested `content[0].text` lands as an empty string, the `on_delta`
-/// guard at `process.rs:531` skips emitting `TextDelta`, and TUIs that
-/// render incrementally see nothing until the final `result` event.
+/// `Self::deserialize` accepts both the legacy CC ≤ 1.x envelope with
+/// top-level `text` and the CC 2.x Anthropic-shaped envelope with a text
+/// block. The flattened text is exposed on `Self::text` so the streaming
+/// path in `read_stream_with_callback` still emits `TextDelta`s incrementally.
 #[derive(Debug)]
 pub(crate) struct AssistantMessage {
     /// Message type kept for forward compat / debugging.
@@ -151,11 +136,7 @@ impl<'de> Deserialize<'de> for AssistantMessage {
                 message_type,
                 content,
             } => {
-                // Concatenate every text-typed block's text. A normal
-                // assistant turn has exactly one `text` block; tool-use
-                // turns have a `text` block plus `tool_use` blocks
-                // whose text we ignore here (they go through the
-                // tool-stream channel, not the text-delta channel).
+                // Concatenate text blocks; tool-use blocks are handled on the tool stream.
                 let text = content
                     .into_iter()
                     .filter(|b| b.block_type == "text")
@@ -294,11 +275,9 @@ mod tests {
         }
     }
 
-    // WHY(#3717): regression — when CC hits `error_max_turns` the `result`
-    // field is absent and the event instead carries `errors` + `terminal_reason`.
-    // Before this fix, `result: String` made the whole event fail to parse
-    // with "missing field `result`", dropping it and producing a
-    // pipeline_error upstream.
+    // WHY(#3717): error-subtype result events omit `result` and carry
+    // `errors` + `terminal_reason` instead; accept that shape instead of
+    // dropping the event.
     #[test]
     fn parse_result_event_error_subtype_omits_result_field() {
         let line = r#"{"type":"result","subtype":"error_max_turns","duration_ms":4065,"duration_api_ms":5062,"is_error":true,"num_turns":2,"stop_reason":"tool_use","session_id":"sess_456","total_cost_usd":0.125,"usage":{"input_tokens":1,"output_tokens":2},"permission_denials":[],"terminal_reason":"max_turns","fast_mode_state":"off","uuid":"u-1","errors":["Reached maximum number of turns (1)"]}"#;
@@ -327,11 +306,8 @@ mod tests {
         }
     }
 
-    // WHY(#3717): regression — CC's stream-json emits a top-level
-    // `{"type":"user"}` envelope for tool_result messages. The parser must
-    // accept this variant and route it to the ignored `User` arm (the
-    // tool-result content is handled via the Assistant turn that preceded
-    // it; this echo is informational).
+    // WHY(#3717): CC emits `{"type":"user"}` echo envelopes for tool_result
+    // messages; accept and ignore them so the stream keeps advancing.
     #[test]
     fn parse_user_event_with_tool_result_message() {
         let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"File does not exist.","is_error":true,"tool_use_id":"toolu_abc"}]},"parent_tool_use_id":null,"session_id":"s-1","uuid":"u-2","timestamp":"2026-04-19T13:41:32.010Z","tool_use_result":"Error: File does not exist"}"#;

--- a/crates/hermeneus/src/cc/process_tests.rs
+++ b/crates/hermeneus/src/cc/process_tests.rs
@@ -9,26 +9,8 @@ use super::*;
 /// has an open writable descriptor anywhere in the kernel.
 const ETXTBSY: i32 = 26;
 
-/// Write a shell script to a unique temp path, make it executable, and
-/// verify the path is safe to exec before returning.
-///
-/// Returns the final script path. The caller is responsible for cleanup
-/// (or letting the OS reclaim the temp dir on process exit).
-///
-/// Defeats the Linux ETXTBSY (errno 26, "Text file busy") race described
-/// in forkwright/aletheia#3723 with two layers of defense:
-///
-/// 1. Stage the script at a `.tmp` sibling and rename into place. The
-///    writer's file descriptor is tied to the tmp dentry and fully
-///    released before rename exposes the final inode, so the common
-///    case sees the final path land with a zero writer-count.
-/// 2. Probe the final path by sacrificially spawning it and killing the
-///    child immediately. An exec syscall is the only observer that
-///    fires when the inode still has an open writer, so a successful
-///    spawn is the definitive signal that the caller's real spawn
-///    cannot race. Transient ETXTBSY is swallowed and retried on a
-///    short sleep; the loop caps so a genuinely busy file surfaces an
-///    error rather than hanging.
+/// WHY: stage the script at a temp sibling, rename into place, and probe
+/// the final path so a real spawn cannot race ETXTBSY.
 fn write_script(name: &str, body: &str) -> PathBuf {
     use std::sync::atomic::{AtomicU64, Ordering};
     static NONCE: AtomicU64 = AtomicU64::new(0);
@@ -107,8 +89,7 @@ async fn read_stream_assistant_then_result() {
 
 #[tokio::test]
 async fn read_stream_result_only() {
-    // WHY: CC can emit a result event with no preceding assistant deltas
-    // (e.g. when the response is short and CC batches it into the result).
+    // WHY: CC can emit a result event with no preceding assistant deltas.
     let buf =
         stream_buf(&[r#"{"type":"result","subtype":"success","result":"ok","is_error":false}"#]);
     let output = read_stream(buf.as_slice()).await.unwrap();
@@ -118,8 +99,7 @@ async fn read_stream_result_only() {
 
 #[tokio::test]
 async fn read_stream_no_result_synthesizes_from_deltas() {
-    // WHY: If CC exits without emitting a result event we fall back to
-    // joining the collected text deltas. This guards graceful degradation.
+    // WHY: If CC exits without a result event, join collected text deltas.
     let buf = stream_buf(&[
         r#"{"type":"assistant","message":{"type":"text","text":"part1 "}}"#,
         r#"{"type":"assistant","message":{"type":"text","text":"part2"}}"#,
@@ -131,8 +111,7 @@ async fn read_stream_no_result_synthesizes_from_deltas() {
 
 #[tokio::test]
 async fn read_stream_empty_input_errors() {
-    // WHY: No result event AND no deltas is unrecoverable — caller needs to
-    // know the subprocess produced nothing usable.
+    // WHY: no result event and no deltas is unrecoverable.
     let buf: Vec<u8> = Vec::new();
     let err = read_stream(buf.as_slice()).await.unwrap_err();
     assert!(
@@ -143,8 +122,7 @@ async fn read_stream_empty_input_errors() {
 
 #[tokio::test]
 async fn read_stream_blank_lines_skipped() {
-    // WHY: parse_event treats blank lines as None — read_stream must not
-    // crash on them and must not synthesize empty deltas.
+    // WHY: blank lines parse as `None`, so read_stream must skip them.
     let buf = b"\n\n   \n{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"ok\",\"is_error\":false}\n";
     let output = read_stream(buf.as_slice()).await.unwrap();
     assert_eq!(output.result_text, "ok");
@@ -152,8 +130,7 @@ async fn read_stream_blank_lines_skipped() {
 
 #[tokio::test]
 async fn read_stream_invalid_json_skipped() {
-    // WHY: parse_event returns None on invalid JSON (logged as warning) —
-    // read_stream should continue past it to subsequent valid events.
+    // WHY: invalid JSON yields `None`, so read_stream should continue past it.
     let buf = stream_buf(&[
         "not json at all",
         r#"{"type":"result","subtype":"success","result":"recovered","is_error":false}"#,
@@ -184,8 +161,7 @@ async fn read_stream_with_callback_invokes_for_each_delta() {
 
 #[tokio::test]
 async fn read_stream_with_callback_skips_empty_text() {
-    // WHY: An assistant event with empty text should not invoke the
-    // callback (matches read_stream behavior to avoid empty UI updates).
+    // WHY: empty assistant text should not invoke the callback.
     let buf = stream_buf(&[
         r#"{"type":"assistant","message":{"type":"text","text":""}}"#,
         r#"{"type":"assistant","message":{"type":"text","text":"real"}}"#,
@@ -204,8 +180,7 @@ async fn read_stream_with_callback_skips_empty_text() {
 
 #[tokio::test]
 async fn read_stream_propagates_is_error_flag() {
-    // WHY: A `result` event with is_error=true is preserved on the output
-    // so the provider layer can map it to a hermeneus::Error variant.
+    // WHY: preserve `is_error=true` so the provider layer can map the error.
     let buf = stream_buf(&[
         r#"{"type":"result","subtype":"error","result":"rate limit","is_error":true}"#,
     ]);
@@ -214,13 +189,8 @@ async fn read_stream_propagates_is_error_flag() {
     assert_eq!(output.result_text, "rate limit");
 }
 
-// WHY(#3717): regression — when CC terminates with `subtype = "error_max_turns"`
-// (or any error subtype) it omits the `result` field entirely, populating
-// `errors` + `terminal_reason` instead. Before the fix, the event failed
-// deserialization ("missing field `result`") and the whole turn was
-// dropped as pipeline_error. Now we parse it, propagate is_error=true,
-// and synthesize a human-readable result_text from terminal_reason +
-// errors for downstream error mapping.
+// WHY(#3717): error subtypes omit `result`; parse `errors` and `terminal_reason`
+// instead, then synthesize `result_text` for downstream error mapping.
 #[tokio::test]
 async fn read_stream_error_subtype_without_result_field() {
     let buf = stream_buf(&[
@@ -243,11 +213,8 @@ async fn read_stream_error_subtype_without_result_field() {
     assert_eq!(output.session_id.as_deref(), Some("sess_err"));
 }
 
-// WHY(#3717): regression — CC also emits `{"type":"user"}` echo events
-// carrying `tool_result` content blocks. These must parse without
-// emitting the `unknown variant \`user\`` warning and must not end the
-// read_stream loop. Verify by feeding a user event followed by a normal
-// result event and checking the result survives.
+// WHY(#3717): CC emits `{"type":"user"}` echo events for `tool_result` blocks;
+// accept them so the stream keeps flowing.
 #[tokio::test]
 async fn read_stream_ignores_user_tool_result_event() {
     let buf = stream_buf(&[
@@ -259,16 +226,11 @@ async fn read_stream_ignores_user_tool_result_event() {
     assert_eq!(output.result_text, "recovered");
 }
 
-// ── parse_oauth_token_from_json ───────────────────────────────────────────
-// WHY: Tests target the JSON-parsing helper rather than read_oauth_token
-// directly. read_oauth_token wraps parse_oauth_token_from_json with I/O
-// and HOME resolution. Testing the parser in isolation avoids env var
-// manipulation (unsafe in Rust 2024) while covering all key branches.
+// WHY: tests target the JSON parser directly so they avoid I/O and env mutation.
 
 #[test]
 fn parse_oauth_token_succeeds_with_valid_credentials() {
-    // WHY: Happy path — valid JSON with the expected key hierarchy returns
-    // the access token string without error.
+    // WHY: valid JSON with the expected key hierarchy returns the access token.
     let json = r#"{"claudeAiOauth":{"accessToken":"test-token-abc123"}}"#;
     let token = parse_oauth_token_from_json(json).unwrap();
     assert_eq!(token, "test-token-abc123");
@@ -276,9 +238,7 @@ fn parse_oauth_token_succeeds_with_valid_credentials() {
 
 #[test]
 fn parse_oauth_token_fails_when_access_token_key_absent() {
-    // WHY: JSON exists but lacks the `accessToken` key — must return an
-    // error rather than silently returning empty, so callers don't inject
-    // a blank token into the subprocess environment.
+    // WHY: missing `accessToken` must return an error, not an empty token.
     let json = r#"{"claudeAiOauth":{"someOtherKey":"value"}}"#;
     let err = parse_oauth_token_from_json(json).unwrap_err();
     assert!(
@@ -289,8 +249,7 @@ fn parse_oauth_token_fails_when_access_token_key_absent() {
 
 #[test]
 fn parse_oauth_token_fails_when_top_level_key_absent() {
-    // WHY: JSON without the `claudeAiOauth` wrapper must fail cleanly —
-    // this covers flat credential formats that don't contain CC OAuth data.
+    // WHY: missing `claudeAiOauth` must fail cleanly.
     let json = r#"{"someOtherProvider":{"accessToken":"irrelevant"}}"#;
     let err = parse_oauth_token_from_json(json).unwrap_err();
     assert!(
@@ -301,8 +260,7 @@ fn parse_oauth_token_fails_when_top_level_key_absent() {
 
 #[test]
 fn parse_oauth_token_fails_on_malformed_json() {
-    // WHY: Malformed credentials (e.g. truncated write) must return an
-    // error, not panic. The caller silently skips OAuth injection on error.
+    // WHY: malformed credentials must return an error, not panic.
     let err = parse_oauth_token_from_json("not-json{{{").unwrap_err();
     assert!(
         !err.to_string().is_empty(),
@@ -347,12 +305,9 @@ fn scrub_cc_auth_env_marks_token_env_for_removal() {
     );
 }
 
-// ── run_completion ────────────────────────────────────────────────────────
-
 #[tokio::test]
 async fn run_completion_spawn_failure_reports_binary_path() {
-    // WHY: A missing or non-executable binary must produce a ProviderInit
-    // error that names the bad path so the operator can diagnose it.
+    // WHY: a missing or non-executable binary must name the bad path.
     let binary = PathBuf::from("/nonexistent/path/to/claude-binary");
     let err = run_completion(
         &binary,
@@ -378,10 +333,8 @@ async fn run_completion_spawn_failure_reports_binary_path() {
 
 #[tokio::test]
 async fn run_completion_tolerates_nonzero_max_tokens() {
-    // WHY: The claude CLI exposes no max-output-token flag, so a non-zero
-    // max_tokens is unenforceable and must be ignored (with a one-time warning),
-    // not rejected. Previously this hard-errored, breaking every turn on the
-    // default zero-config CC provider. See #4158.
+    // WHY(#4158): `claude` has no max-output-token flag, so non-zero `max_tokens`
+    // must be ignored rather than rejected.
     let script = write_script(
         "completion_max_tokens_ok",
         r#"cat > /dev/null
@@ -407,9 +360,7 @@ printf '{"type":"result","subtype":"success","result":"ok","is_error":false}\n'"
 
 #[tokio::test]
 async fn run_completion_success_collects_output() {
-    // WHY: End-to-end subprocess path with a real script. Verifies that
-    // run_completion feeds stdin, reads stdout stream-json, and returns
-    // a populated CcOutput with the result text and delta list intact.
+    // WHY: end-to-end subprocess path verifies stdin, stdout, and delta capture.
     let script = write_script(
         "completion_ok",
         // Discard all args and stdin; emit a two-event stream.
@@ -528,8 +479,6 @@ exit 1"#,
     );
     let _ = fs::remove_file(&script);
 }
-
-// ── run_streaming ─────────────────────────────────────────────────────────
 
 #[tokio::test]
 async fn run_streaming_spawn_failure_reports_binary_path() {
@@ -659,8 +608,6 @@ async fn run_streaming_timeout_returns_error() {
     );
     let _ = fs::remove_file(&script);
 }
-
-// ── output size limits (#3324) ───────────────────────────────────────────
 
 #[tokio::test]
 async fn read_stream_rejects_oversized_output_by_bytes() {

--- a/crates/hermeneus/src/codex/provider.rs
+++ b/crates/hermeneus/src/codex/provider.rs
@@ -403,9 +403,8 @@ mod tests {
         assert!(prompt.contains("User: And 3+3?"));
     }
 
-    // WHY(#3980): regression — ToolUse blocks were silently dropped by the
-    // wildcard arm of extract_text_content, causing entire assistant turns to
-    // vanish from the Codex prompt when a conversation included tool calls.
+    // WHY(#3980): ToolUse blocks must be rendered so assistant turns with tool
+    // calls do not disappear from the Codex prompt.
     #[test]
     fn extract_text_content_renders_tool_use_blocks() {
         let content = Content::Blocks(vec![
@@ -434,11 +433,8 @@ mod tests {
         );
     }
 
-    // WHY(#3980): a conversation with a tool-use assistant turn followed by a
-    // tool-result user turn must round-trip through format_prompt without
-    // losing the tool-call context. Before the fix, the assistant turn was
-    // entirely skipped (extract_text_content returned ""), so Codex received
-    // a tool result with no corresponding call visible in context.
+    // WHY(#3980): tool-use assistant turns must round-trip through format_prompt
+    // so a later tool-result still has matching call context.
     #[test]
     fn format_prompt_preserves_tool_use_turns() {
         let request = CompletionRequest {

--- a/crates/hermeneus/src/complexity/mod.rs
+++ b/crates/hermeneus/src/complexity/mod.rs
@@ -27,8 +27,6 @@ const DEFAULT_HIGH_THRESHOLD: u32 = 70;
 /// Default threshold below which queries are eligible for a no-LLM fast path.
 const DEFAULT_NO_LLM_THRESHOLD: u32 = 5;
 
-// --- Regex patterns (compiled once) ---
-
 #[expect(
     clippy::expect_used,
     reason = "compile-time-constant regex literals cannot fail"

--- a/crates/hermeneus/src/complexity/tier1.rs
+++ b/crates/hermeneus/src/complexity/tier1.rs
@@ -22,10 +22,6 @@ use std::borrow::Cow;
 use regex::Regex;
 use tracing::debug;
 
-// ---------------------------------------------------------------------------
-// Tier1Handler trait
-// ---------------------------------------------------------------------------
-
 /// A deterministic handler for `NoLlm`-tier prompts.
 ///
 /// Implementors inspect the user's message and either return a direct
@@ -39,10 +35,6 @@ pub trait Tier1Handler: Send + Sync {
     /// to pass to the next handler.
     fn try_handle(&self, prompt: &str) -> Option<String>;
 }
-
-// ---------------------------------------------------------------------------
-// Tier1Registry
-// ---------------------------------------------------------------------------
 
 /// Registry of [`Tier1Handler`]s tried in registration order.
 ///
@@ -115,10 +107,6 @@ impl Tier1Registry {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RegexReplaceHandler
-// ---------------------------------------------------------------------------
-
 /// Handler that matches a prompt against a regex and returns a template
 /// response with named captures substituted.
 ///
@@ -180,10 +168,6 @@ impl Tier1Handler for RegexReplaceHandler {
     }
 }
 
-// ---------------------------------------------------------------------------
-// ExactMatchHandler
-// ---------------------------------------------------------------------------
-
 /// Handler that matches a prompt via case-insensitive exact match and returns
 /// a fixed response.
 ///
@@ -231,10 +215,6 @@ impl Tier1Handler for ExactMatchHandler {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Built-in registry builder
-// ---------------------------------------------------------------------------
 
 /// Build a `Tier1Registry` pre-populated with the default built-in handlers.
 ///

--- a/crates/hermeneus/src/concurrency.rs
+++ b/crates/hermeneus/src/concurrency.rs
@@ -25,11 +25,9 @@ use parking_lot::Mutex;
 use tokio::sync::Notify;
 use tower::{Layer, Service};
 
-/// Stored in `ConcurrencyPermit.outcome` as a `u8` without any `as` cast.
+// Encoded request outcomes stored in `ConcurrencyPermit::outcome` as `u8`.
 const OUTCOME_NEUTRAL: u8 = 0;
-/// Stored in `ConcurrencyPermit.outcome` as a `u8` without any `as` cast.
 const OUTCOME_SUCCESS: u8 = 1;
-/// Stored in `ConcurrencyPermit.outcome` as a `u8` without any `as` cast.
 const OUTCOME_OVERLOAD: u8 = 2;
 
 /// Default EWMA smoothing factor (higher = more weight on history).
@@ -190,8 +188,8 @@ impl AdaptiveConcurrencyLimiter {
     #[tracing::instrument(skip_all)]
     pub async fn acquire(self: &Arc<Self>) -> ConcurrencyPermit {
         loop {
-            // Create the notified future *before* inspecting state to avoid
-            // missing a notification between the check and the await.
+            // WHY: create the notified future before the limit check so a wakeup
+            // cannot land between the check and the await.
             let notified = self.notify.notified();
 
             {
@@ -231,8 +229,7 @@ impl AdaptiveConcurrencyLimiter {
                 });
             }
 
-            // WHY: If EWMA latency exceeds threshold, treat success as overload
-            // to trigger back-off.
+            // WHY: treat high EWMA latency as overload so successes back off.
             let effective_outcome = match outcome {
                 RequestOutcome::Success => {
                     if let Some(ewma) = inner.latency_ewma {
@@ -254,8 +251,8 @@ impl AdaptiveConcurrencyLimiter {
                         (inner.limit + self.config.increase_step).min(self.config.max_limit);
                 }
                 RequestOutcome::Overload => {
-                    // SAFETY: f64::from(u32) is lossless; all u32 values fit in
-                    // f64 mantissa.
+                    // INVARIANT: f64::from(u32) is lossless; all u32 values fit in
+                    // the f64 mantissa.
                     let limit_f64 = f64::from(inner.limit);
                     let decreased_f64 = (limit_f64 * self.config.decrease_factor).floor();
                     #[expect(
@@ -348,10 +345,6 @@ impl Drop for ConcurrencyPermit {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tower Layer / Service
-// ---------------------------------------------------------------------------
 
 /// Tower `Layer` that wraps an inner service with adaptive concurrency limiting.
 ///
@@ -590,10 +583,6 @@ mod tests {
         assert_send_sync::<ConcurrencyPermit>();
     }
 
-    // -----------------------------------------------------------------------
-    // Latency EWMA tests
-    // -----------------------------------------------------------------------
-
     #[tokio::test]
     async fn latency_ewma_initialized_on_first_sample() {
         let l = limiter_with_threshold(10, 5.0);
@@ -673,10 +662,6 @@ mod tests {
         assert_eq!(l.limit(), 5, "explicit overload must decrease limit");
     }
 
-    // -----------------------------------------------------------------------
-    // Tower Layer / Service tests
-    // -----------------------------------------------------------------------
-
     /// Minimal tower service for testing.
     #[derive(Clone)]
     struct EchoService;
@@ -753,10 +738,6 @@ mod tests {
         fn assert_clone_send<T: Clone + Send>() {}
         assert_clone_send::<ConcurrencyLayer>();
     }
-
-    // -----------------------------------------------------------------------
-    // Mutex-poisoning resilience
-    // -----------------------------------------------------------------------
 
     #[test]
     fn limiter_survives_panic_during_unwind() {

--- a/crates/hermeneus/src/metrics.rs
+++ b/crates/hermeneus/src/metrics.rs
@@ -15,10 +15,6 @@ use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::metrics::histogram::Histogram;
 use prometheus_client::registry::Registry;
 
-// ---------------------------------------------------------------------------
-// Label sets
-// ---------------------------------------------------------------------------
-
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct ProviderDirectionLabels {
     provider: String,
@@ -48,10 +44,6 @@ struct CircuitTransitionLabels {
     from: String,
     to: String,
 }
-
-// ---------------------------------------------------------------------------
-// Metric families
-// ---------------------------------------------------------------------------
 
 static LLM_TOKENS_TOTAL: LazyLock<Family<ProviderDirectionLabels, Counter>> =
     LazyLock::new(Family::default);
@@ -92,10 +84,6 @@ static LLM_CONCURRENCY_LATENCY_EWMA: LazyLock<Family<ProviderLabels, Gauge<f64, 
 
 static LLM_CONCURRENCY_IN_FLIGHT: LazyLock<Family<ProviderLabels, Gauge>> =
     LazyLock::new(Family::default);
-
-// ---------------------------------------------------------------------------
-// Registration
-// ---------------------------------------------------------------------------
 
 /// Register this crate's metrics with the shared registry.
 ///
@@ -154,10 +142,6 @@ pub fn register(registry: &mut Registry) {
         LLM_CONCURRENCY_IN_FLIGHT.clone(),
     );
 }
-
-// ---------------------------------------------------------------------------
-// Recording
-// ---------------------------------------------------------------------------
 
 /// Record a completed LLM API call.
 pub fn record_completion(

--- a/crates/hermeneus/src/openai/client.rs
+++ b/crates/hermeneus/src/openai/client.rs
@@ -142,10 +142,8 @@ impl Default for OpenAiProviderConfig {
             request_timeout: Duration::from_mins(2),
             max_retries: 3,
             api_family: OpenAiApiFamily::ChatCompletions,
-            // WHY (#3736): the trait default is Cloud and we must mirror it
-            // here so `..Default::default()` in call sites (e.g. the
-            // declarative registration path in aletheia's setup.rs) does
-            // not silently downgrade a caller-specified target.
+            // WHY(#3736): mirror the trait default so `..Default::default()`
+            // does not silently downgrade a caller-specified target.
             deployment_target: DeploymentTarget::Cloud,
         }
     }
@@ -153,9 +151,8 @@ impl Default for OpenAiProviderConfig {
 
 /// Returns true when the URL is safe to use without TLS.
 ///
-/// WHY: delegates to `koina::http::is_plaintext_loopback_url` so the
-/// plaintext HTTP scheme literal lives in exactly one audited place
-/// (see `SECURITY/insecure-transport`).
+/// WHY: delegate to `koina::http::is_plaintext_loopback_url` so the plaintext
+/// HTTP scheme literal lives in exactly one audited place.
 fn is_loopback_url(url: &str) -> bool {
     koina::http::is_plaintext_loopback_url(url)
 }
@@ -633,12 +630,8 @@ impl LlmProvider for OpenAiProvider {
         &self.config.name
     }
 
-    /// WHY (#3736): the trait default is Cloud, but OpenAI-compatible
-    /// providers also cover loopback llama.cpp / logismos / ollama
-    /// deployments that should receive `Internal` or `Confidential` facts.
-    /// Returning the configured value propagates the TOML-level
-    /// `deployment_target` all the way to the recall sovereignty filter in
-    /// `nous::recall::filter_by_sensitivity`.
+    /// WHY(#3736): OpenAI-compatible providers can still be loopback/self-hosted,
+    /// so they must propagate the configured deployment target to recall filtering.
     fn deployment_target(&self) -> DeploymentTarget {
         self.config.deployment_target
     }
@@ -699,16 +692,8 @@ mod tests {
 
     #[test]
     fn deployment_target_propagates_from_config() {
-        // WHY (#3736): regression for the sovereignty bug where
-        // OpenAiProviderConfig.deployment_target was accepted in TOML,
-        // logged at startup, then silently discarded. The recall
-        // pipeline's sensitivity filter reads this value off the
-        // provider trait, so if it never propagates, every
-        // OpenAI-compat provider — including loopback llama.cpp /
-        // logismos — gets treated as Cloud and has Internal /
-        // Confidential facts stripped.
-
-        // LocalHosted propagates.
+        // WHY(#3736): regression — deployment_target was accepted in TOML but
+        // dropped before recall filtering, treating non-cloud providers as Cloud.
         let local_hosted = OpenAiProvider::new(OpenAiProviderConfig {
             name: "local-hosted".to_owned(),
             base_url: "http://127.0.0.1:8088/v1".to_owned(),
@@ -723,7 +708,6 @@ mod tests {
             "LocalHosted config must propagate through OpenAiProvider::deployment_target()"
         );
 
-        // Embedded propagates.
         let embedded = OpenAiProvider::new(OpenAiProviderConfig {
             name: "embedded".to_owned(),
             base_url: "http://127.0.0.1:8089/v1".to_owned(),
@@ -738,7 +722,6 @@ mod tests {
             "Embedded config must propagate through OpenAiProvider::deployment_target()"
         );
 
-        // Default (no field set) stays Cloud — the safe trait default.
         let default_cloud = OpenAiProvider::new(OpenAiProviderConfig {
             name: "cloud".to_owned(),
             base_url: "https://api.openai.com/v1".to_owned(),
@@ -755,12 +738,8 @@ mod tests {
 
     #[test]
     fn deployment_target_ordering_is_sovereignty_safe() {
-        // WHY (#3736): the recall admission rule is `sensitivity <=
-        // target` under the ordering `Cloud < LocalHosted < Embedded`.
-        // If a refactor ever reorders the variants, the filter would
-        // admit Internal/Confidential facts to Cloud providers. Guard
-        // the ordering here so any reorder blows up this test loudly
-        // instead of silently leaking data.
+        // WHY(#3736): the recall rule is `sensitivity <= target`; reordering
+        // the enum would let Cloud providers admit `Internal`/`Confidential` facts.
         assert!(DeploymentTarget::Cloud < DeploymentTarget::LocalHosted);
         assert!(DeploymentTarget::LocalHosted < DeploymentTarget::Embedded);
     }

--- a/crates/hermeneus/src/openai/mod.rs
+++ b/crates/hermeneus/src/openai/mod.rs
@@ -1,8 +1,5 @@
-// WHY: the `OpenAI` brand name and related proper nouns (llama.cpp,
-// ollama, vllm) pervade the docs of this module. clippy::doc_markdown
-// flags bare CamelCase as missing backticks. Backticks would visually
-// muddle the rustdoc-rendered prose and are not appropriate for a
-// brand, so the lint is opted out at the module root only.
+// WHY: `clippy::doc_markdown` would flag brand names in the rustdoc prose;
+// the module-level allow keeps the docs readable without noisy backticks.
 #![allow(clippy::doc_markdown)]
 
 //! OpenAI LLM provider.

--- a/crates/hermeneus/src/openai/wire/request.rs
+++ b/crates/hermeneus/src/openai/wire/request.rs
@@ -181,9 +181,8 @@ impl<'a> ChatCompletionRequest<'a> {
             .build());
         }
 
-        // Thinking: the OpenAI Chat Completions wire format has no equivalent
-        // concept. The model is never given a separate thinking budget, so the
-        // request is sent verbatim and the operator's budget_tokens is dropped.
+        // WHY: Chat Completions has no separate thinking budget, so we drop it
+        // and warn instead of inventing wire-format fields.
         if let Some(thinking) = &req.thinking
             && thinking.enabled
         {
@@ -220,8 +219,7 @@ impl<'a> ChatCompletionRequest<'a> {
 
         let mut messages: Vec<ChatMessage> = Vec::with_capacity(req.messages.len() + 1);
 
-        // Prepend system message. Anthropic carries `system` at the top level;
-        // OpenAI expects it as the first message with role="system".
+        // WHY: OpenAI expects `system` as the first message rather than a top-level field.
         if let Some(system) = req.system.as_deref()
             && !system.is_empty()
         {
@@ -377,8 +375,6 @@ impl<'a> ResponsesRequest<'a> {
 fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
     match msg.role {
         Role::System => {
-            // System messages inside the messages vec (rather than at top
-            // level) get merged as plain system prefaces.
             out.push(ChatMessage {
                 role: "system",
                 content: Some(msg.content.text()),
@@ -386,55 +382,48 @@ fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
                 tool_call_id: None,
             });
         }
-        Role::User => {
-            // User messages with tool_result blocks split into one
-            // `role: "tool"` per result, plus one message for remaining
-            // user text.
-            match &msg.content {
-                Content::Text(text) => {
+        Role::User => match &msg.content {
+            Content::Text(text) => {
+                out.push(ChatMessage {
+                    role: "user",
+                    content: Some(text.clone()),
+                    tool_calls: Vec::new(),
+                    tool_call_id: None,
+                });
+            }
+            Content::Blocks(blocks) => {
+                let mut text_parts: Vec<String> = Vec::new();
+                for block in blocks {
+                    match block {
+                        ContentBlock::Text { text, .. } if !text.is_empty() => {
+                            text_parts.push(text.clone());
+                        }
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                            ..
+                        } => {
+                            out.push(ChatMessage {
+                                role: "tool",
+                                content: Some(tool_result_to_string(content)),
+                                tool_calls: Vec::new(),
+                                tool_call_id: Some(tool_use_id.clone()),
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                if !text_parts.is_empty() {
                     out.push(ChatMessage {
                         role: "user",
-                        content: Some(text.clone()),
+                        content: Some(text_parts.join("\n")),
                         tool_calls: Vec::new(),
                         tool_call_id: None,
                     });
                 }
-                Content::Blocks(blocks) => {
-                    let mut text_parts: Vec<String> = Vec::new();
-                    for block in blocks {
-                        match block {
-                            ContentBlock::Text { text, .. } if !text.is_empty() => {
-                                text_parts.push(text.clone());
-                            }
-                            ContentBlock::ToolResult {
-                                tool_use_id,
-                                content,
-                                ..
-                            } => {
-                                out.push(ChatMessage {
-                                    role: "tool",
-                                    content: Some(tool_result_to_string(content)),
-                                    tool_calls: Vec::new(),
-                                    tool_call_id: Some(tool_use_id.clone()),
-                                });
-                            }
-                            _ => {} // Thinking/server-side blocks have no user-side equivalent.
-                        }
-                    }
-                    if !text_parts.is_empty() {
-                        out.push(ChatMessage {
-                            role: "user",
-                            content: Some(text_parts.join("\n")),
-                            tool_calls: Vec::new(),
-                            tool_call_id: None,
-                        });
-                    }
-                }
             }
-        }
+        },
         Role::Assistant => {
-            // Assistant messages coalesce text + tool_use into a single
-            // message with `content` and `tool_calls`.
             let mut text_parts: Vec<String> = Vec::new();
             let mut tool_calls: Vec<ChatToolCall> = Vec::new();
             match &msg.content {
@@ -462,7 +451,7 @@ fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
                                     },
                                 });
                             }
-                            _ => {} // Thinking/server-side blocks have no OpenAI equivalent (thinking warned at request build; server_tools rejected).
+                            _ => {}
                         }
                     }
                 }
@@ -472,9 +461,9 @@ fn translate_message(msg: &Message, out: &mut Vec<ChatMessage>) {
             } else {
                 Some(text_parts.join("\n"))
             };
-            // OpenAI rejects assistant messages where both `content` and
-            // `tool_calls` are empty. Synthesize a single space to keep
-            // the payload valid — matches openai-python behavior.
+            // WHY: OpenAI rejects assistant messages where both `content` and
+            // `tool_calls` are empty, so synthesize an empty string to keep the
+            // payload valid.
             let content = if content.is_none() && tool_calls.is_empty() {
                 Some(String::new())
             } else {
@@ -494,8 +483,7 @@ fn tool_result_to_string(content: &ToolResultContent) -> String {
     match content {
         ToolResultContent::Text(s) => s.clone(),
         ToolResultContent::Blocks(_) => {
-            // OpenAI tool role accepts only text content; collapse via the
-            // existing summary helper (images / documents become tags).
+            // WHY: OpenAI tool-role content must be text; summarize non-text blocks.
             content.text_summary()
         }
     }
@@ -543,7 +531,7 @@ fn translate_responses_user_message(msg: &Message, out: &mut Vec<ResponsesInputI
                         output: tool_result_to_string(content),
                     }),
                     _ => {
-                        // Images/documents have no Responses input mapping yet.
+                        // NOTE: Images/documents have no Responses input mapping yet.
                     }
                 }
             }
@@ -578,7 +566,7 @@ fn translate_responses_assistant_message(msg: &Message, out: &mut Vec<ResponsesI
                         });
                     }
                     _ => {
-                        // Tool results and non-text media are not assistant output items.
+                        // NOTE: Tool results and non-text media are not assistant output items.
                     }
                 }
             }
@@ -612,7 +600,7 @@ fn translate_output_format(format: &OutputFormat) -> WireResponseFormat {
 fn translate_tool_choice(choice: &ToolChoice) -> serde_json::Value {
     match choice {
         ToolChoice::Auto => serde_json::Value::String("auto".to_owned()),
-        // OpenAI uses "required" to force any tool; Anthropic calls this "any".
+        // NOTE: OpenAI uses "required" to force any tool; Anthropic calls this "any".
         ToolChoice::Any => serde_json::Value::String("required".to_owned()),
         ToolChoice::Tool { name } => serde_json::json!({
             "type": "function",

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -274,9 +274,8 @@ impl std::fmt::Debug for ProviderConfig {
 
 impl Default for ProviderConfig {
     fn default() -> Self {
-        // NOTE: Built-in pricing for all first-party Anthropic models (USD per million tokens).
-        // Operator configs are merged on top, so these act as sensible fallbacks.
-        // Prices last verified against https://www.anthropic.com/pricing (2025-10-01).
+        // NOTE: Built-in pricing for first-party Anthropic models (USD per million tokens);
+        // operator configs merge on top, so these act as fallbacks.
         let pricing = HashMap::from([
             (
                 "claude-opus-4-6".to_owned(),
@@ -330,11 +329,8 @@ impl Default for ProviderConfig {
             pricing,
             cc_mimicry: None,
             prompt_cache_mode: PromptCacheMode::Disabled,
-            // WHY (#3404, #3413): Anthropic is a cloud provider — only
-            // `Public`-classified facts may be sent. Operators running a
-            // self-hosted proxy or embedded model MUST override this in
-            // `aletheia.toml` so the recall filter lets `Internal` /
-            // `Confidential` facts through to the non-cloud boundary.
+            // WHY(#3404, #3413): Anthropic is cloud-only here, so only `Public`
+            // facts may be sent unless the operator overrides the boundary.
             deployment_target: DeploymentTarget::Cloud,
             name: None,
             models: Vec::new(),
@@ -408,18 +404,9 @@ impl ProviderRegistry {
     ///
     /// # Selection contract
     ///
-    /// WHY: a first-match linear scan over registration order is
-    /// non-deterministic when multiple providers claim overlapping model IDs
-    /// (e.g. `CcProvider` accepts all `claude-*` via a broad family pattern,
-    /// while `AnthropicProvider` lists exact model IDs). Registration order is
-    /// an incidental artifact of startup sequencing, not an intentful
-    /// contract. Specificity-based selection makes routing deterministic and
-    /// intent-driven: a provider that names the model explicitly
-    /// (`MatchKind::Exact`) always wins over one that matches by a broad
-    /// family pattern (`MatchKind::CatchAll`), regardless of which was
-    /// registered first. When multiple providers share the same specificity
-    /// level the tie is broken by registration order (first registered wins),
-    /// which is a stable, auditable contract.
+    /// WHY: specificity beats registration order so overlapping providers route
+    /// deterministically; exact matches win over broad family matches, and ties
+    /// fall back to first-registered wins.
     ///
     /// # Complexity
     ///
@@ -572,7 +559,7 @@ mod tests {
 
     #[test]
     fn provider_config_deployment_target_defaults_to_cloud() {
-        // WHY (#3404, #3413): the safe default — any unconfigured provider
+        // WHY(#3404, #3413): the safe default — any unconfigured provider
         // is treated as a cloud target so the sovereignty filter only
         // admits `Public` facts until the operator explicitly opts in to a
         // lower-trust boundary.
@@ -722,8 +709,6 @@ mod tests {
             "unknown provider must remain absent from health lookup"
         );
     }
-
-    // --- Specificity-based routing tests ---
 
     #[test]
     fn match_kind_ordering() {

--- a/crates/koina/src/base64.rs
+++ b/crates/koina/src/base64.rs
@@ -160,7 +160,7 @@ fn decode_inner(
 ) -> Result<Vec<u8>, DecodeError> {
     let bytes = input.as_bytes();
 
-    // Locate the end of actual data (before any trailing '=').
+    // WHY: split data from trailing '=' padding before decoding.
     let data_end = bytes.iter().rposition(|&b| b != b'=').map_or(0, |i| i + 1);
     let padding_len = bytes.len().saturating_sub(data_end);
 
@@ -175,7 +175,7 @@ fn decode_inner(
             return InvalidPaddingSnafu.fail();
         }
     } else if data_end % 4 == 1 {
-        // No-pad mode: 1 mod 4 can never represent a valid number of bytes.
+        // WHY: a no-pad input with length ≡ 1 (mod 4) cannot be valid base64.
         return InvalidLengthSnafu { length: data_end }.fail();
     }
 
@@ -199,7 +199,7 @@ fn decode_inner(
         }
     }
 
-    // Validate that any leftover bits in the final sextet are zero.
+    // INVARIANT: leftover bits in the final sextet must be zero.
     if bits > 0 {
         let mask = (1u32 << bits) - 1;
         if (buf & mask) != 0 {
@@ -228,8 +228,6 @@ fn char_to_sextet(b: u8, allow_url_safe: bool) -> Option<u8> {
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
     use super::*;
-
-    // ── RFC 4648 test vectors (section 10) ─────────────────────────────
 
     #[test]
     fn rfc4648_empty() {
@@ -272,8 +270,6 @@ mod tests {
         assert_eq!(encode(b"foobar"), "Zm9vYmFy");
         assert_eq!(decode("Zm9vYmFy").unwrap(), b"foobar");
     }
-
-    // ── URL-safe no-pad vectors ───────────────────────────────────────
 
     #[test]
     fn url_safe_empty() {
@@ -349,8 +345,6 @@ mod tests {
         assert_eq!(decoded, br#"{"alg":"HS256","typ":"JWT"}"#);
     }
 
-    // ── Error cases ───────────────────────────────────────────────────
-
     #[test]
     fn decode_invalid_char() {
         // Valid length (8), invalid character in the middle.
@@ -411,8 +405,6 @@ mod tests {
             Err(DecodeError::InvalidPadding { .. })
         ));
     }
-
-    // ── Roundtrip property test (proptest) ────────────────────────────
 
     #[test]
     fn roundtrip_standard() {

--- a/crates/koina/src/fs.rs
+++ b/crates/koina/src/fs.rs
@@ -18,8 +18,7 @@ use std::path::{Path, PathBuf};
 /// - The canonicalized path does not start with the canonicalized root.
 /// - Canonicalization itself fails (e.g. root directory does not exist).
 pub fn validate_within_root(path: &Path, root: &Path) -> std::io::Result<PathBuf> {
-    // Pre-canonicalization: reject `..` components to catch obvious traversal
-    // attempts before touching the filesystem.
+    // WHY: reject `..` before filesystem access to catch traversal early.
     for component in path.components() {
         if let std::path::Component::ParentDir = component {
             return Err(std::io::Error::new(
@@ -44,7 +43,7 @@ pub fn validate_within_root(path: &Path, root: &Path) -> std::io::Result<PathBuf
         }
     };
 
-    // Post-canonicalization containment check (catches symlink escapes).
+    // WHY: re-check containment after canonicalization to catch symlink escapes.
     if !canonical_path.starts_with(&canonical_root) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
@@ -169,7 +168,6 @@ mod tests {
         let outside_file = outside.path().join("secret.txt");
         std::fs::write(&outside_file, b"secret").unwrap();
 
-        // Create a symlink inside root that points outside
         let link = root.path().join("escape-link");
         std::os::unix::fs::symlink(&outside_file, &link).unwrap();
 

--- a/crates/koina/src/system.rs
+++ b/crates/koina/src/system.rs
@@ -47,8 +47,6 @@ use std::sync::{Arc, Mutex};
 
 use jiff::{SignedDuration, Timestamp};
 
-// ── FileSystem ────────────────────────────────────────────────────────────────
-
 /// Abstraction over filesystem read, write, and query operations.
 ///
 /// Implement this trait to substitute an in-memory store in tests instead of
@@ -118,8 +116,6 @@ pub trait FileSystem: Send + Sync {
     fn rename(&self, from: &Path, to: &Path) -> io::Result<()>;
 }
 
-// ── Clock ─────────────────────────────────────────────────────────────────────
-
 /// Abstraction over the system clock.
 ///
 /// Use [`RealSystem`] in production and a frozen [`TestSystem`] in tests to
@@ -136,8 +132,6 @@ pub trait Clock: Send + Sync {
     #[must_use]
     fn elapsed(&self, since: Timestamp) -> SignedDuration;
 }
-
-// ── Environment ───────────────────────────────────────────────────────────────
 
 /// Abstraction over the process environment.
 ///
@@ -189,16 +183,12 @@ pub trait Environment: Send + Sync {
     fn args(&self) -> Vec<String>;
 }
 
-// ── RealSystem ────────────────────────────────────────────────────────────────
-
 /// Production system implementation backed by the operating system.
 ///
 /// Delegates every operation to the standard library or OS syscalls.
 /// Construct once and pass by reference wherever a trait bound is required.
 #[derive(Debug, Clone, Default)]
 pub struct RealSystem;
-
-// ── TestSystem ────────────────────────────────────────────────────────────────
 
 /// In-memory system implementation for deterministic testing.
 ///
@@ -364,8 +354,6 @@ impl Default for TestSystem {
 // Trait implementations are in a separate module to avoid trait-impl colocation.
 mod system_impl;
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 mod tests {
@@ -374,8 +362,6 @@ mod tests {
     use jiff::Timestamp;
 
     use super::*;
-
-    // ── FileSystem ────────────────────────────────────────────────────────
 
     #[test]
     fn read_missing_file_returns_not_found() {
@@ -517,8 +503,6 @@ mod tests {
         assert!(sys.get_file(Path::new("/absent")).is_none());
     }
 
-    // ── Clock ─────────────────────────────────────────────────────────────
-
     #[test]
     fn frozen_clock_returns_configured_time() {
         let ts: Timestamp = "2025-06-15T12:00:00Z".parse().unwrap();
@@ -540,8 +524,6 @@ mod tests {
         let sys = TestSystem::new();
         assert_eq!(sys.now(), Timestamp::UNIX_EPOCH);
     }
-
-    // ── Environment ───────────────────────────────────────────────────────
 
     #[test]
     fn var_returns_configured_value() {
@@ -581,8 +563,6 @@ mod tests {
         sys.add_env("LATE", "value");
         assert_eq!(sys.var("LATE").as_deref(), Some("value"));
     }
-
-    // ── Trait-object compatibility ─────────────────────────────────────────
 
     #[test]
     fn filesystem_trait_object_compiles() {

--- a/crates/koina/src/uuid.rs
+++ b/crates/koina/src/uuid.rs
@@ -1,15 +1,7 @@
 //! Clean-room UUID implementation covering v4 generation and v1 construction.
 //!
-//! WHY: The `uuid` crate is 8,574 LOC (~50-100KB) we don't need. UUID v4 is
-//! just 16 random bytes with 6 bits fixed for version/variant. UUID v1 is a
-//! timestamp + clock-seq + node packed per RFC 4122 §4.1. We use `rand` which
-//! we already depend on for other purposes.
-//!
-//! This module now covers all UUID operations required by krites (formerly
-//! delegated to the `uuid` crate): v4 generation, v1 construction, field
-//! decomposition (`as_fields`/`from_fields`), byte-array access, nil check,
-//! and v1 timestamp extraction. The `uuid` crate has been removed from the
-//! workspace.
+//! WHY: keep UUID handling local instead of depending on the external `uuid`
+//! crate; this module covers the v4/v1 operations krites actually needs.
 
 use std::fmt;
 
@@ -17,11 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// A UUID (128-bit identifier), supporting v4 and v1 variants.
 ///
-/// WHY: Internal implementation eliminates the `uuid` crate dependency.
-/// Supports all operations needed by the Datalog engine in krites:
-/// v4 generation, v1 construction, RFC 4122 field decomposition, binary
-/// serialization, and v1 timestamp extraction.
-///
+/// WHY: this internal type covers the v4/v1 operations krites needs.
 /// The underlying storage is always big-endian byte order per RFC 4122 §4.1.2.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -57,7 +45,6 @@ impl Uuid {
     /// # Errors
     /// Returns an error if the string is not a valid UUID format.
     pub fn parse_str(s: &str) -> Result<Self, UuidParseError> {
-        // Expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36 chars)
         if s.len() != 36 {
             return Err(UuidParseError);
         }


### PR DESCRIPTION
## What

Calibration batch (B01 of 11) of the fleet-wide comment cleanup, from the 10-agent comment audit (56K comment lines, 6,626 violations, ~5K LOC removable with zero knowledge loss). This pilot covers hermeneus + koina + eidos: **-497/+142 across 23 files** (net −355 comment lines).

Per-class treatment, mechanical rules from the audit plan:
- **RESTATE** deleted (step narration, banners naming the next call, one-word labels).
- **NARRATIVE** stripped to the live constraint (change-history, `# History` version logs, "Before the fix…" tails on regression headers — git log owns history).
- **Untagged load-bearing freeform retagged** (WHY/INVARIANT/NOTE), never deleted — base64 bit-math, fs traversal guards, OpenAI wire-mapping rationale all preserved in tag form.
- **SAFETY misuse** on non-unsafe code → INVARIANT/WHY (eidos path.rs "Layer N" ×7).
- **DRIFT** fixed per audit-verified rewrites (stale fn locations, false enum-order claim, line-ref → function-name anchor).
- Keep-guards held: zero deletions of kanon:ignore waivers, pii-allow trailers, SAFETY-on-unsafe, cancel-safety docs, or pub rustdoc.

T0 reviewed the diff (keep-guard grep + hunk spot-checks) before opening. Remaining 10 batches (~4.7K LOC) proceed after this lands, applying any calibration learnings.

## Verification

Comment-only diff; gate-verified in the worktree (fmt, clippy `-D warnings`, nextest for all three crates; attestation trailer). `_llm` regenerated.

Co-authored-by: Cody Kickertz <cody.kickertz@pm.me>