### PR TITLE
fix(hermeneus): rotate retired dated default model + correct stale fallback pricing

### DIFF
--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -104,7 +104,7 @@ l3_token_estimate = 5222
 [[crates]]
 name = "hermeneus"
 path = "crates/hermeneus"
-source_hash = "bdba659c1bdd132e71e64523aa37a0f67d94d8eea249dcd33751d8aa1ca36743"
+source_hash = "af0cb56cb209b1bfb8cf2070862b43ef9022ea4281b6d6746368a68b7c89983a"
 l3_token_estimate = 13698
 
 [[crates]]

--- a/crates/hermeneus/src/anthropic/client_tests.rs
+++ b/crates/hermeneus/src/anthropic/client_tests.rs
@@ -490,14 +490,14 @@ fn estimate_cost_haiku_family_resolution() {
     pricing.insert(
         "claude-haiku-4-5".to_owned(),
         ModelPricing {
-            input_cost_per_mtok: 0.8,
-            output_cost_per_mtok: 4.0,
+            input_cost_per_mtok: 1.0,
+            output_cost_per_mtok: 5.0,
         },
     );
     let cost = estimate_cost(&pricing, "claude-haiku-4-5-20251001", 0, 1_000_000);
     assert!(
-        (cost - 4.0).abs() < 0.0001,
-        "expected ~$4.00 via family resolution, got {cost}"
+        (cost - 5.0).abs() < 0.0001,
+        "expected ~$5.00 via family resolution, got {cost}"
     );
 }
 
@@ -510,8 +510,8 @@ fn estimate_cost_default_pricing_resolves_haiku() {
 
     let cost = estimate_cost(&pricing, "claude-haiku-4-5-20251001", 1_000_000, 1_000_000);
     assert!(
-        (cost - 4.8).abs() < 0.0001,
-        "expected ~$4.80 for haiku from default pricing, got {cost}"
+        (cost - 6.0).abs() < 0.0001,
+        "expected ~$6.00 for haiku from default pricing, got {cost}"
     );
 
     for model in SUPPORTED_MODELS {
@@ -591,12 +591,12 @@ fn merge_pricing_fills_defaults_for_unconfigured_models() {
         .get("claude-haiku-4-5-20251001")
         .expect("haiku pricing must be present from defaults");
     assert!(
-        (haiku.input_cost_per_mtok - 0.8).abs() < f64::EPSILON,
-        "haiku input price should be $0.80/MTok"
+        (haiku.input_cost_per_mtok - 1.0).abs() < f64::EPSILON,
+        "haiku input price should be $1.00/MTok"
     );
     assert!(
-        (haiku.output_cost_per_mtok - 4.0).abs() < f64::EPSILON,
-        "haiku output price should be $4.00/MTok"
+        (haiku.output_cost_per_mtok - 5.0).abs() < f64::EPSILON,
+        "haiku output price should be $5.00/MTok"
     );
 }
 

--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -54,7 +54,7 @@ impl Default for CcProviderConfig {
     fn default() -> Self {
         Self {
             cc_binary: None,
-            default_model: "claude-opus-4-6".to_owned(),
+            default_model: crate::models::names::OPUS.to_owned(),
             timeout: Duration::from_mins(5),
         }
     }
@@ -463,7 +463,7 @@ mod tests {
     fn cc_provider_reports_cloud_deployment_target() {
         let provider = CcProvider {
             cc_binary: PathBuf::from("claude"),
-            default_model: "claude-opus-4-6".to_owned(),
+            default_model: crate::models::names::OPUS.to_owned(),
             timeout: Duration::from_secs(1),
         };
         assert_eq!(provider.deployment_target(), DeploymentTarget::Cloud);
@@ -473,7 +473,7 @@ mod tests {
     fn seat_bridged_fields() {
         let provider = CcProvider {
             cc_binary: PathBuf::from("/usr/local/bin/claude"),
-            default_model: "claude-opus-4-6".to_owned(),
+            default_model: crate::models::names::OPUS.to_owned(),
             timeout: Duration::from_mins(5),
         };
         assert_eq!(

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -274,21 +274,22 @@ impl std::fmt::Debug for ProviderConfig {
 
 impl Default for ProviderConfig {
     fn default() -> Self {
-        // NOTE: Built-in pricing for first-party Anthropic models (USD per million tokens);
-        // operator configs merge on top, so these act as fallbacks.
+        // NOTE: Built-in pricing for all first-party Anthropic models (USD per million tokens).
+        // Operator configs are merged on top, so these act as sensible fallbacks.
+        // Prices last verified against https://www.anthropic.com/pricing (2026-06-11).
         let pricing = HashMap::from([
             (
                 "claude-opus-4-6".to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 15.0,
-                    output_cost_per_mtok: 75.0,
+                    input_cost_per_mtok: 5.0,
+                    output_cost_per_mtok: 25.0,
                 },
             ),
             (
                 "claude-opus-4-20250514".to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 15.0,
-                    output_cost_per_mtok: 75.0,
+                    input_cost_per_mtok: 5.0,
+                    output_cost_per_mtok: 25.0,
                 },
             ),
             (
@@ -308,15 +309,15 @@ impl Default for ProviderConfig {
             (
                 "claude-haiku-4-5".to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 0.8,
-                    output_cost_per_mtok: 4.0,
+                    input_cost_per_mtok: 1.0,
+                    output_cost_per_mtok: 5.0,
                 },
             ),
             (
                 "claude-haiku-4-5-20251001".to_owned(),
                 ModelPricing {
-                    input_cost_per_mtok: 0.8,
-                    output_cost_per_mtok: 4.0,
+                    input_cost_per_mtok: 1.0,
+                    output_cost_per_mtok: 5.0,
                 },
             ),
         ]);
@@ -324,13 +325,16 @@ impl Default for ProviderConfig {
             provider_type: "anthropic".to_owned(),
             api_key: None,
             base_url: None,
-            default_model: Some("claude-opus-4-20250514".to_owned()),
+            default_model: Some(crate::models::names::OPUS.to_owned()),
             max_retries: Some(3),
             pricing,
             cc_mimicry: None,
             prompt_cache_mode: PromptCacheMode::Disabled,
-            // WHY(#3404, #3413): Anthropic is cloud-only here, so only `Public`
-            // facts may be sent unless the operator overrides the boundary.
+            // WHY (#3404, #3413): Anthropic is a cloud provider — only
+            // `Public`-classified facts may be sent. Operators running a
+            // self-hosted proxy or embedded model MUST override this in
+            // `aletheia.toml` so the recall filter lets `Internal` /
+            // `Confidential` facts through to the non-cloud boundary.
             deployment_target: DeploymentTarget::Cloud,
             name: None,
             models: Vec::new(),
@@ -404,9 +408,18 @@ impl ProviderRegistry {
     ///
     /// # Selection contract
     ///
-    /// WHY: specificity beats registration order so overlapping providers route
-    /// deterministically; exact matches win over broad family matches, and ties
-    /// fall back to first-registered wins.
+    /// WHY: a first-match linear scan over registration order is
+    /// non-deterministic when multiple providers claim overlapping model IDs
+    /// (e.g. `CcProvider` accepts all `claude-*` via a broad family pattern,
+    /// while `AnthropicProvider` lists exact model IDs). Registration order is
+    /// an incidental artifact of startup sequencing, not an intentful
+    /// contract. Specificity-based selection makes routing deterministic and
+    /// intent-driven: a provider that names the model explicitly
+    /// (`MatchKind::Exact`) always wins over one that matches by a broad
+    /// family pattern (`MatchKind::CatchAll`), regardless of which was
+    /// registered first. When multiple providers share the same specificity
+    /// level the tie is broken by registration order (first registered wins),
+    /// which is a stable, auditable contract.
     ///
     /// # Complexity
     ///
@@ -559,7 +572,7 @@ mod tests {
 
     #[test]
     fn provider_config_deployment_target_defaults_to_cloud() {
-        // WHY(#3404, #3413): the safe default — any unconfigured provider
+        // WHY (#3404, #3413): the safe default — any unconfigured provider
         // is treated as a cloud target so the sovereignty filter only
         // admits `Public` facts until the operator explicitly opts in to a
         // lower-trust boundary.
@@ -589,7 +602,7 @@ mod tests {
         assert_eq!(config.provider_type, "anthropic");
         assert_eq!(
             config.default_model.as_deref(),
-            Some("claude-opus-4-20250514")
+            Some(crate::models::names::OPUS)
         );
         // WHY: Default pricing must cover the models used by background tasks.
         assert!(
@@ -602,11 +615,11 @@ mod tests {
         );
         let haiku = &config.pricing["claude-haiku-4-5-20251001"];
         assert!(
-            (haiku.input_cost_per_mtok - 0.8).abs() < f64::EPSILON,
+            (haiku.input_cost_per_mtok - 1.0).abs() < f64::EPSILON,
             "unexpected haiku input price"
         );
         assert!(
-            (haiku.output_cost_per_mtok - 4.0).abs() < f64::EPSILON,
+            (haiku.output_cost_per_mtok - 5.0).abs() < f64::EPSILON,
             "unexpected haiku output price"
         );
     }
@@ -709,6 +722,8 @@ mod tests {
             "unknown provider must remain absent from health lookup"
         );
     }
+
+    // --- Specificity-based routing tests ---
 
     #[test]
     fn match_kind_ordering() {


### PR DESCRIPTION
## Problem (urgent — retirement 2026-06-15)

From the model-identity audit (107 hardcoded model-ID sites; operator directive: model identity is data, not code):

1. `ProviderConfig::default().default_model` was the dated snapshot `claude-opus-4-20250514`, which is deprecated upstream with retirement **2026-06-15** — after that date every defaults-path call 404s.
2. The compiled fallback pricing table was stale-wrong: Opus priced at $15/$75 per MTok (previous-generation pricing — actual Opus 4.6 is **$5/$25**, a 3× overstatement in every cost metric computed from defaults) and Haiku at $0.8/$4.0 (actual $1/$5).
3. The CC provider carried its own independent default-opus literal — two compiled answers to "what is opus" that already disagreed.

## Fix (Step 1 of the model-identity migration — minimal, surgical)

- `default_model` derives from `models::names::OPUS` (the alias constant), not a dated literal.
- Pricing table corrected to current rates (opus 5/25, sonnet 3/15, haiku 1/5) with the verified-as-of note updated.
- `CcProviderConfig::default()` references the same `names::OPUS` constant — the two defaults can no longer disagree.

The full single-source-of-truth design (koina seed file, `/v1/models` runtime discovery, family-prefix routing, catalog API) is steps 2–8, landing separately: `metis-ops/projects/_recovery/model-identity-design.md`.

## Verification

Gate-verified in the worktree (attestation trailer): fmt, clippy `-D warnings`, nextest for hermeneus + koina (lockstep consistency pins updated — that is their job on rotation).

Co-authored-by: Cody Kickertz <cody.kickertz@pm.me>