### PR TITLE
feat(proskenion,taxis,pylon): desktop wave C — operator UI-test feedback

### DIFF
--- a/_llm/L3-api-index/pylon.md
+++ b/_llm/L3-api-index/pylon.md
@@ -2250,7 +2250,7 @@ impl AppState {
 ```
 
 ```rust
-pub fn resolve_workspace_root (oikos: &Oikos) -> PathBuf
+pub fn resolve_workspace_root (oikos: &Oikos, configured_root: Option<&Path>) -> PathBuf
 ```
 
 ```rust

--- a/_llm/L3-api-index/taxis.md
+++ b/_llm/L3-api-index/taxis.md
@@ -1579,11 +1579,28 @@ pub struct ObservabilitySettings {
 ```
 
 ```rust
+pub struct WorkspaceSettings {
+    /// Root directory served by the workspace file API.
+    ///
+    /// Relative paths resolve against the instance root. When unset, the
+    /// gateway serves the instance theke directory if present, then the
+    /// shared agent workspace, then the instance root.
+    pub root: Option<PathBuf>,
+}
+```
+
+```rust
 pub struct AletheiaConfig {
     /// Agent definitions and shared defaults.
     pub agents: AgentsConfig,
     /// HTTP gateway settings (port, bind address, auth, TLS, CORS).
     pub gateway: GatewayConfig,
+    /// Workspace file-API root override.
+    ///
+    /// WHY configurable: the desktop Theke view browses one directory tree;
+    /// deployments choose which tree the gateway exposes (theke vault, agent
+    /// workspace, ...) without code changes.
+    pub workspace: WorkspaceSettings,
     /// Messaging transport configuration (Signal, etc.).
     pub channels: ChannelsConfig,
     /// Routes mapping channel sources to nous agents.

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "fe62493976f3b971192651ea2bd81a4b11da6b5291c4db1459c754f0e006a3c9"
+source_hash = "0f1bba9523f31afa10d1f613c0d2af94c9d5d5c8e585494285be19e435d4bd86"
 l3_token_estimate = 167
 
 [[crates]]
@@ -110,7 +110,7 @@ l3_token_estimate = 13698
 [[crates]]
 name = "integration-tests"
 path = "crates/integration-tests"
-source_hash = "e5568141f1e193d8b499322e3de258c4cc774c16df45bcad7353c92d2e8b95dc"
+source_hash = "e01bf3e044bd809ada8a6be7c0fa85386bd812682c580bf47d50dbd73dd2bac1"
 l3_token_estimate = 1170
 
 [[crates]]
@@ -266,8 +266,8 @@ l3_token_estimate = 1354
 [[crates]]
 name = "pylon"
 path = "crates/pylon"
-source_hash = "7f828994b7468d5577ac08b82cb02be981874d4a78b843af54d03434c7ccda4c"
-l3_token_estimate = 17595
+source_hash = "25e98a2610dc4e86913cd240dcf165e62de4ff92ea80fe4c966ac9345bcaff0a"
+l3_token_estimate = 17603
 
 [[crates]]
 name = "skene"
@@ -284,13 +284,13 @@ l3_token_estimate = 6585
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "eb161c845c1e5ce838b6a2ef0814da87411661fa96c0ef879cb7ca1f223ed828"
-l3_token_estimate = 23335
+source_hash = "957669e85efccd49b622bba86bbe8f9f02c165b9917d63a42a68c37bc4f8fd52"
+l3_token_estimate = 23493
 
 [[crates]]
 name = "theatron"
 path = "crates/theatron"
-source_hash = "88694ed44ad910a2a2c7abe105f6f27caf1bf96aba4cee4c7dd1ff608d9c701f"
+source_hash = "917a8eaad3c168004a13b5305ed8ea4bfb6f777be0b85da277ea62a31080c38d"
 l3_token_estimate = 22061
 
 [[crates]]

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -788,7 +788,10 @@ impl RuntimeBuilder {
             }
             .instrument(tracing::info_span!("config_reload_actor_sync")),
         );
-        let workspace_root = pylon::state::resolve_workspace_root(&self.oikos);
+        let workspace_root = pylon::state::resolve_workspace_root(
+            &self.oikos,
+            self.config.workspace.root.as_deref(),
+        );
         let state = Arc::new(AppState {
             session_store,
             nous_manager: Arc::clone(&nous_manager),

--- a/crates/integration-tests/src/harness.rs
+++ b/crates/integration-tests/src/harness.rs
@@ -219,7 +219,7 @@ impl TestHarness {
             with_knowledge_store.then(|| -> Arc<dyn EmbeddingProvider> {
                 Arc::new(TestEmbeddingProvider::new(TEST_EMBEDDING_DIM))
             });
-        let workspace_root = pylon::state::resolve_workspace_root(&oikos);
+        let workspace_root = pylon::state::resolve_workspace_root(&oikos, None);
 
         #[cfg(feature = "knowledge-store")]
         let knowledge_stores = knowledge_store

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -148,7 +148,8 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
     let knowledge_store = nous_manager.knowledge_store().cloned();
 
     let (config_tx, _config_rx) = tokio::sync::watch::channel(aletheia_config.clone());
-    let workspace_root = crate::state::resolve_workspace_root(&oikos);
+    let workspace_root =
+        crate::state::resolve_workspace_root(&oikos, aletheia_config.workspace.root.as_deref());
 
     // WHY: pylon's standalone server only registers its own metric families.
     // The aletheia binary uses `register_all_metrics` to register every

--- a/crates/pylon/src/state.rs
+++ b/crates/pylon/src/state.rs
@@ -1,6 +1,6 @@
 //! Shared application state accessible in all Axum handlers.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -103,13 +103,43 @@ impl AppState {
 
 /// Resolve the workspace root used by the desktop file browser.
 ///
-/// WHY: the desktop app expects a stable workspace tree under `nous/workspace`.
-/// When that directory is present and canonicalizes inside the instance root,
-/// we use it directly. Otherwise we fall back to the instance root so the
-/// gateway still serves a usable file browser even when the shared workspace
-/// directory has not been created yet.
+/// Resolution order:
+/// 1. `[workspace] root` from config; relative paths resolve against the
+///    instance root.
+/// 2. The instance theke directory, when present.
+/// 3. The shared agent workspace (`nous/workspace`), when it canonicalizes
+///    inside the instance root.
+/// 4. The instance root.
+///
+/// WHY theke-first: the desktop Theke view is a direct file manager for the
+/// human + nous collaborative space; the agent workspace remains the fallback
+/// for instances without one. Every returned root is canonicalized so the
+/// handlers' path-traversal guard (`canonical.starts_with(root)`) holds even
+/// when the root itself is a symlink.
 #[must_use]
-pub fn resolve_workspace_root(oikos: &Oikos) -> PathBuf {
+pub fn resolve_workspace_root(oikos: &Oikos, configured_root: Option<&Path>) -> PathBuf {
+    if let Some(configured) = configured_root {
+        let absolute = if configured.is_absolute() {
+            configured.to_path_buf()
+        } else {
+            oikos.root().join(configured)
+        };
+        match std::fs::canonicalize(&absolute) {
+            Ok(canonical) => return canonical,
+            Err(e) => {
+                tracing::warn!(
+                    path = %absolute.display(),
+                    error = %e,
+                    "configured workspace root is unusable; falling back to instance defaults"
+                );
+            }
+        }
+    }
+
+    if let Ok(canonical_theke) = std::fs::canonicalize(oikos.theke()) {
+        return canonical_theke;
+    }
+
     let instance_root = std::fs::canonicalize(oikos.root()).unwrap_or_else(|_| oikos.root().into());
     let workspace_root = oikos.workspace_root();
 

--- a/crates/pylon/src/tests/helpers.rs
+++ b/crates/pylon/src/tests/helpers.rs
@@ -117,7 +117,7 @@ async fn test_state_with_provider_private_and_auth_mode(
         std::fs::create_dir_all(root.join("nous/hidden")).expect("mkdir nous/hidden");
     }
     std::fs::create_dir_all(root.join("shared")).expect("mkdir shared");
-    std::fs::create_dir_all(root.join("theke")).expect("mkdir theke");
+    std::fs::create_dir_all(root.join("theke/src")).expect("mkdir theke/src");
     std::fs::create_dir_all(root.join("data")).expect("mkdir data");
     std::fs::create_dir_all(root.join("config")).expect("mkdir config");
 
@@ -157,17 +157,14 @@ bind = "localhost"
         clippy::disallowed_methods,
         reason = "pylon test helpers write workspace fixtures to temp directories; synchronous I/O is required in test setup"
     )]
-    std::fs::write(
-        root.join("nous/workspace/README.md"),
-        "Workspace root fixture.\n",
-    )
-    .expect("write workspace README");
+    std::fs::write(root.join("theke/README.md"), "Workspace root fixture.\n")
+        .expect("write workspace README");
     #[expect(
         clippy::disallowed_methods,
         reason = "pylon test helpers write workspace fixtures to temp directories; synchronous I/O is required in test setup"
     )]
     std::fs::write(
-        root.join("nous/workspace/src/main.rs"),
+        root.join("theke/src/main.rs"),
         "fn main() {\n    println!(\"hello from workspace\");\n}\n",
     )
     .expect("write workspace source");
@@ -241,7 +238,7 @@ bind = "localhost"
 
     let jwt_manager = test_jwt_manager();
     let auth_facade = test_auth_facade();
-    let workspace_root = crate::state::resolve_workspace_root(&oikos);
+    let workspace_root = crate::state::resolve_workspace_root(&oikos, None);
 
     let mut default_config = taxis::config::AletheiaConfig::default();
     default_config.gateway.sse_heartbeat_interval_secs = 1;

--- a/crates/pylon/src/tests/signal.rs
+++ b/crates/pylon/src/tests/signal.rs
@@ -105,7 +105,7 @@ fn minimal_app_state() -> Arc<AppState> {
 
     let metrics_registry = koina::metrics::MetricsRegistry::new();
     crate::metrics::init(&metrics_registry);
-    let workspace_root = crate::state::resolve_workspace_root(&oikos);
+    let workspace_root = crate::state::resolve_workspace_root(&oikos, None);
 
     Arc::new(AppState {
         session_store,

--- a/crates/pylon/src/tests/workspace.rs
+++ b/crates/pylon/src/tests/workspace.rs
@@ -49,7 +49,7 @@ async fn workspace_path_traversal_is_rejected() {
     let (app, _dir) = app().await;
     let req = Request::builder()
         .method("GET")
-        .uri("/api/v1/workspace/files/content?path=../theke/USER.md")
+        .uri("/api/v1/workspace/files/content?path=../nous/syn/SOUL.md")
         .header("authorization", format!("Bearer {}", default_token()))
         .body(Body::empty())
         .expect("request");

--- a/crates/pylon/tests/common/mod.rs
+++ b/crates/pylon/tests/common/mod.rs
@@ -157,7 +157,7 @@ impl TestEnvBuilder {
         }
 
         let (jwt_manager, auth_facade) = test_auth_state(self.jwt_access_ttl);
-        let workspace_root = pylon::state::resolve_workspace_root(&oikos);
+        let workspace_root = pylon::state::resolve_workspace_root(&oikos, None);
 
         let default_config = AletheiaConfig::default();
         let (config_tx, _config_rx) = tokio::sync::watch::channel(default_config.clone());

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -57,6 +57,20 @@ impl Default for ObservabilitySettings {
     }
 }
 
+/// Gateway workspace file-API configuration.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceSettings {
+    /// Root directory served by the workspace file API.
+    ///
+    /// Relative paths resolve against the instance root. When unset, the
+    /// gateway serves the instance theke directory if present, then the
+    /// shared agent workspace, then the instance root.
+    pub root: Option<PathBuf>,
+}
+
 /// Root configuration for an Aletheia instance.
 // kanon:ignore RUST/no-debug-derive-on-public-types
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -69,6 +83,12 @@ pub struct AletheiaConfig {
     pub agents: AgentsConfig,
     /// HTTP gateway settings (port, bind address, auth, TLS, CORS).
     pub gateway: GatewayConfig,
+    /// Workspace file-API root override.
+    ///
+    /// WHY configurable: the desktop Theke view browses one directory tree;
+    /// deployments choose which tree the gateway exposes (theke vault, agent
+    /// workspace, ...) without code changes.
+    pub workspace: WorkspaceSettings,
     /// Messaging transport configuration (Signal, etc.).
     pub channels: ChannelsConfig,
     /// Routes mapping channel sources to nous agents.

--- a/crates/taxis/src/reload.rs
+++ b/crates/taxis/src/reload.rs
@@ -27,7 +27,8 @@ const RESTART_PREFIXES: &[&str] = &[
     "messaging.bufferCapacity",
     // WHY: idempotency capacity sets the LRU cache size at server startup.
     "apiLimits.idempotencyCapacity",
-    // WHY: model context limits are loaded into provider/model routing state.
+    // WHY: the workspace file-API root is resolved into AppState at startup.
+    "workspace.root",
 ];
 
 /// Returns true if changing the given dotted field path requires a restart.

--- a/crates/taxis/src/validate.rs
+++ b/crates/taxis/src/validate.rs
@@ -165,7 +165,7 @@ pub fn validate_section(section: &str, value: &Value) -> Result<(), ValidationEr
         "providers" => validate_providers(value, &mut errors),
         // NOTE: pass-through sections with no validation rules.
         "packs" | "pricing" | "sandbox" | "logging" | "observability" | "mcp" | "localProvider"
-        | "training" | "anthropic" | "promptAudit" | "dispatch" => {}
+        | "training" | "anthropic" | "promptAudit" | "dispatch" | "workspace" => {}
         _ => errors.push(format!("unknown config section: {section}")),
     }
 

--- a/crates/theatron/proskenion/assets/styles/themes.css
+++ b/crates/theatron/proskenion/assets/styles/themes.css
@@ -74,6 +74,9 @@
   --scrollbar-thumb: #2e2b27;
   --scrollbar-thumb-hover: #3d3832;
 
+  /* Progress veil — elapsed-region tint over status-colored blocks */
+  --progress-veil: rgb(255 255 255 / 0.06);
+
   /* Focus ring */
   --focus-ring: rgb(154 123 79 / 0.5);
 
@@ -138,7 +141,7 @@
 
   /* Status — same palette, lighter values */
   --status-success: #4A6A3A;
-  --status-warning: #9A7A2E;
+  --status-warning: #7A6020; /* WHY: darkened from #9A7A2E (3.46:1) for WCAG AA (≥4.5:1) on warning-bg/bg/surface */
   --status-error: #8A3030;
   --status-info: #4A6A7A;
 
@@ -175,6 +178,9 @@
   --scrollbar-thumb: #D4CFC7;
   --scrollbar-thumb-hover: #C0BAB0;
 
+  /* Progress veil — elapsed-region tint over status-colored blocks */
+  --progress-veil: rgb(44 36 24 / 0.08);
+
   /* Focus ring */
   --focus-ring: rgb(154 123 79 / 0.4);
 
@@ -201,4 +207,25 @@
 
   --natural: #8B5A2B;
   --natural-bg: #ECE0D0;
+}
+
+/* ===================================================================== */
+/* Root lift for light theme                                             */
+/* WHY: ThemeProvider sets [data-theme] on an inner display:contents     */
+/* div, so html/body sit outside it and keep dark :root tokens — any     */
+/* region not painted by an inner element (overscroll, transparent       */
+/* panels) rendered near-black on parchment. This rule lifts the tokens  */
+/* consumed at/above the provider div to the root when light is active.  */
+/* Kept as a separate rule so an engine without :has() degrades to the   */
+/* previous behavior instead of dropping the whole light block.          */
+/* ===================================================================== */
+
+:root:has([data-theme="light"]) {
+  --bg: #F7F3E8;
+  --text-primary: #2C2418;
+  --scrollbar-track: #EDE8E0;
+  --scrollbar-thumb: #D4CFC7;
+  --scrollbar-thumb-hover: #C0BAB0;
+  --selection-bg: rgb(154 123 79 / 0.25);
+  --selection-fg: #2C2418;
 }

--- a/crates/theatron/proskenion/src/api/sse.rs
+++ b/crates/theatron/proskenion/src/api/sse.rs
@@ -1,10 +1,11 @@
-//! Global SSE connection to `GET /api/v1/events/subscribe`.
+//! Global SSE connection to `GET /api/v1/events`.
 //!
-//! Provides cross-session awareness: turn completion and session lifecycle.
-//! The connection subscribes to pylon's domain-event topics (dot-separated,
-//! e.g. `turn.complete`) and maps each onto the UI-level [`SseEvent`]. It
-//! auto-reconnects with exponential backoff (1s to 30s) and treats 45s of
-//! byte silence as a stale connection.
+//! Provides cross-session awareness: agent status changes, session lifecycle,
+//! and memory distillation progress. The connection auto-reconnects with
+//! exponential backoff (1s to 30s) and treats 45s of *byte-level* silence as
+//! a stale connection (server keepalives are SSE comments the parser never
+//! surfaces as events). Losses are reported to the UI only once confirmed;
+//! clean reconnects are silent.
 //!
 //! # Dioxus integration
 //!
@@ -26,6 +27,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use futures_util::StreamExt;
 use reqwest::Client;
@@ -35,15 +37,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 use skene::api::types::SseEvent;
-use skene::id::{NousId, SessionId};
+use skene::id::{NousId, SessionId, TurnId};
 
-/// If no bytes arrive from the server within this window, the connection
-/// is treated as stale. The server emits a keepalive every 30s
-/// (`gateway.sse_heartbeat_interval_secs` default), so 45s gives 50% margin.
-///
-/// NOTE: keepalives are SSE comment lines, which the parser consumes
-/// without yielding an event — staleness is therefore measured on raw
-/// byte activity, not on parsed events.
+/// If no bytes arrive on the wire within this window, the connection is
+/// treated as stale. The server keepalive is an SSE *comment* line every
+/// 15s, which the parser swallows by design — liveness must therefore be
+/// judged at the byte level, never by parsed-event arrival.
 const HEARTBEAT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
 
 /// Initial backoff delay after a connection failure.
@@ -52,29 +51,13 @@ const INITIAL_BACKOFF: std::time::Duration = std::time::Duration::from_secs(1);
 /// Maximum backoff delay: caps exponential growth.
 const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Topics requested from `GET /api/v1/events/subscribe`.
-///
-/// NOTE: mirrors the server's topic registry (`GET /api/v1/events/discovery`).
-/// Only `turn.complete` and `fact.created` have live publish sites today;
-/// the session lifecycle topics are declared by the server and subscribed
-/// here so they light up without a client change.
-const SUBSCRIBE_TOPICS: &[&str] = &[
-    "turn.complete",
-    "fact.created",
-    "session.started",
-    "session.ended",
-];
+/// Consecutive failed connect attempts required before the loss is reported.
+const LOSS_CONFIRM_ATTEMPTS: u32 = 2;
 
-/// Build the topic-filtered subscribe URL for `base_url`.
-fn subscribe_url(base_url: &str) -> String {
-    format!(
-        "{}/api/v1/events/subscribe?topics={}",
-        base_url.trim_end_matches('/'),
-        SUBSCRIBE_TOPICS.join(",")
-    )
-}
+/// Minimum elapsed time since the stream dropped before the loss is reported.
+const LOSS_CONFIRM_WINDOW: std::time::Duration = std::time::Duration::from_secs(15);
 
-/// Manages the global SSE connection to `/api/v1/events/subscribe`.
+/// Manages the global SSE connection to `/api/v1/events`.
 ///
 /// Runs in a background tokio task. Parsed events flow through an mpsc
 /// channel. The connection automatically reconnects with exponential
@@ -97,7 +80,7 @@ impl SseConnection {
     #[tracing::instrument(skip_all)]
     pub(crate) fn connect(client: Client, base_url: &str, cancel: CancellationToken) -> Self {
         let (tx, rx) = mpsc::channel(256);
-        let url = subscribe_url(base_url);
+        let url = format!("{}/api/v1/events", base_url.trim_end_matches('/'));
         let child = cancel.child_token();
 
         let span = tracing::info_span!("sse_connection");
@@ -123,6 +106,12 @@ async fn run_sse_connection(
     tx: mpsc::Sender<SseEvent>,
 ) {
     let mut backoff = INITIAL_BACKOFF;
+    // WHY: a dropped stream is reconnected silently; `Disconnected` is only
+    // emitted once the loss is confirmed (LOSS_CONFIRM_ATTEMPTS failures
+    // spanning LOSS_CONFIRM_WINDOW), so a clean reconnect never flips UI
+    // state or fires lost/restored toast pairs.
+    let mut lost_at: Option<Instant> = None;
+    let mut failed_attempts: u32 = 0;
 
     loop {
         if child.is_cancelled() {
@@ -140,7 +129,11 @@ async fn run_sse_connection(
             Ok(resp) => resp,
             Err(e) => {
                 tracing::error!("SSE connection failed: {e}");
-                if tx.send(SseEvent::Disconnected).await.is_err() {
+                failed_attempts = failed_attempts.saturating_add(1);
+                lost_at.get_or_insert_with(Instant::now);
+                if loss_confirmed(failed_attempts, lost_at)
+                    && tx.send(SseEvent::Disconnected).await.is_err()
+                {
                     return;
                 }
                 tokio::select! {
@@ -165,7 +158,11 @@ async fn run_sse_connection(
             };
             let message = extract_error_message(&body, status.as_u16(), reason);
             tracing::warn!("SSE error: {message}");
-            if tx.send(SseEvent::Disconnected).await.is_err() {
+            failed_attempts = failed_attempts.saturating_add(1);
+            lost_at.get_or_insert_with(Instant::now);
+            if loss_confirmed(failed_attempts, lost_at)
+                && tx.send(SseEvent::Disconnected).await.is_err()
+            {
                 return;
             }
             backoff = advance_backoff(backoff);
@@ -182,16 +179,23 @@ async fn run_sse_connection(
         }
         tracing::info!("SSE connected");
         backoff = INITIAL_BACKOFF;
+        failed_attempts = 0;
 
-        // WHY: server keepalives are comment-only and the parser drops
-        // comments without yielding, so byte arrival is the only liveness
-        // signal on an idle stream. Track it on the raw byte stream.
-        let connected_at = std::time::Instant::now();
-        let last_rx_ms = Arc::new(AtomicU64::new(0));
-        let byte_activity = Arc::clone(&last_rx_ms);
-        let mut es = SseStream::new(resp.bytes_stream().inspect(move |_chunk| {
-            byte_activity.store(elapsed_ms(connected_at), Ordering::Relaxed);
-        }));
+        // WHY: the server keepalive (`: keepalive` comment every 15s) is
+        // swallowed by the SSE parser per spec, so `es.next()` can stay
+        // pending indefinitely on a perfectly healthy connection. Record raw
+        // byte arrival; only byte-level silence past HEARTBEAT_TIMEOUT is a
+        // dead link.
+        let connected_at = Instant::now();
+        let last_activity_ms = Arc::new(AtomicU64::new(0));
+        let activity = Arc::clone(&last_activity_ms);
+        let byte_stream = resp.bytes_stream().inspect(move |chunk| {
+            if chunk.is_ok() {
+                let elapsed = u64::try_from(connected_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+                activity.store(elapsed, Ordering::Relaxed);
+            }
+        });
+        let mut es = SseStream::new(byte_stream);
 
         loop {
             let maybe_event = tokio::select! {
@@ -204,16 +208,18 @@ async fn run_sse_connection(
                 Ok(Some(event)) => event,
                 Ok(None) => break,
                 Err(_elapsed) => {
-                    let idle_ms =
-                        elapsed_ms(connected_at).saturating_sub(last_rx_ms.load(Ordering::Relaxed));
-                    if std::time::Duration::from_millis(idle_ms) < HEARTBEAT_TIMEOUT {
-                        // NOTE: no parsed event, but bytes (keepalives)
-                        // arrived recently — the link is alive.
+                    let now_ms =
+                        u64::try_from(connected_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+                    let idle_ms = now_ms.saturating_sub(last_activity_ms.load(Ordering::Relaxed));
+                    if idle_ms < u64::try_from(HEARTBEAT_TIMEOUT.as_millis()).unwrap_or(u64::MAX) {
+                        // NOTE: keepalive comments are byte activity without
+                        // parsed events; the link is alive — keep waiting.
                         continue;
                     }
                     tracing::warn!(
                         timeout_secs = HEARTBEAT_TIMEOUT.as_secs(),
-                        "SSE heartbeat timeout — treating as disconnect"
+                        idle_ms,
+                        "SSE byte-level silence — treating as disconnect"
                     );
                     break;
                 }
@@ -227,10 +233,13 @@ async fn run_sse_connection(
             }
         }
 
-        if tx.send(SseEvent::Disconnected).await.is_err() {
-            return;
-        }
-        tracing::info!(backoff_secs = backoff.as_secs(), "SSE reconnecting");
+        // NOTE: stream ended — begin a silent reconnect; only a confirmed
+        // loss (see above) is reported to the UI.
+        lost_at = Some(Instant::now());
+        tracing::info!(
+            backoff_secs = backoff.as_secs(),
+            "SSE stream ended — reconnecting"
+        );
         tokio::select! {
             biased;
             _ = child.cancelled() => return,
@@ -240,15 +249,21 @@ async fn run_sse_connection(
     }
 }
 
+/// Whether a connection loss has persisted long enough to report.
+///
+/// Both gates must hold: at least [`LOSS_CONFIRM_ATTEMPTS`] consecutive
+/// failed attempts AND [`LOSS_CONFIRM_WINDOW`] elapsed since the loss began.
+/// Single blips and clean reconnects recover silently.
+#[must_use]
+fn loss_confirmed(failed_attempts: u32, lost_at: Option<Instant>) -> bool {
+    failed_attempts >= LOSS_CONFIRM_ATTEMPTS
+        && lost_at.is_some_and(|t| t.elapsed() >= LOSS_CONFIRM_WINDOW)
+}
+
 /// Advance exponential backoff: double the interval, capped at `MAX_BACKOFF`.
 #[must_use]
 fn advance_backoff(current: std::time::Duration) -> std::time::Duration {
     (current * 2).min(MAX_BACKOFF)
-}
-
-/// Milliseconds elapsed since `since`, saturating at `u64::MAX`.
-fn elapsed_ms(since: std::time::Instant) -> u64 {
-    u64::try_from(since.elapsed().as_millis()).unwrap_or(u64::MAX)
 }
 
 /// Extract a human-readable error message from an HTTP error response body.
@@ -271,13 +286,6 @@ fn str_field<'a>(json: &'a serde_json::Value, field: &str, event_type: &str) -> 
     })
 }
 
-/// Map a pylon domain event (`event: <topic>` + JSON payload) onto the
-/// UI-level [`SseEvent`].
-///
-/// Payload keys are snake_case (the event-bus convention). Topics without
-/// a UI mapping are dropped at debug level — the subscription is
-/// topic-filtered server-side, so anything unexpected here is contract
-/// drift, not an error.
 fn parse_sse_event(event_type: &str, data: &str) -> Option<SseEvent> {
     let json: serde_json::Value = match serde_json::from_str(data) {
         Ok(v) => v,
@@ -288,26 +296,61 @@ fn parse_sse_event(event_type: &str, data: &str) -> Option<SseEvent> {
     };
 
     match event_type {
-        // NOTE: the server publishes turn completion only; there is no
-        // turn-start topic, so `TurnBefore` is never produced here.
-        "turn.complete" => Some(SseEvent::TurnAfter {
-            nous_id: NousId::from(str_field(&json, "nous_id", event_type)?.to_string()),
-            session_id: SessionId::from(str_field(&json, "session_id", event_type)?.to_string()),
-        }),
-        "session.started" => Some(SseEvent::SessionCreated {
-            nous_id: NousId::from(str_field(&json, "nous_id", event_type)?.to_string()),
-            session_id: SessionId::from(str_field(&json, "session_id", event_type)?.to_string()),
-        }),
-        "session.ended" => Some(SseEvent::SessionArchived {
-            nous_id: NousId::from(str_field(&json, "nous_id", event_type)?.to_string()),
-            session_id: SessionId::from(str_field(&json, "session_id", event_type)?.to_string()),
-        }),
-        "fact.created" => {
-            // NOTE: no SseEvent variant models fact ingestion yet; the
-            // topic is subscribed for forward-compat and dropped here.
-            tracing::debug!(event_type, "no UI mapping for topic; dropping");
-            None
+        "init" => {
+            let active_turns = json
+                .get("activeTurns")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .or_else(|| {
+                    tracing::warn!("SSE init: missing or invalid activeTurns");
+                    None
+                })?;
+            Some(SseEvent::Init { active_turns })
         }
+        "turn:before" => Some(SseEvent::TurnBefore {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
+            turn_id: TurnId::from(str_field(&json, "turnId", event_type)?.to_string()),
+        }),
+        "turn:after" => Some(SseEvent::TurnAfter {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
+        }),
+        "tool:called" => Some(SseEvent::ToolCalled {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
+        }),
+        "tool:failed" => Some(SseEvent::ToolFailed {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            tool_name: str_field(&json, "toolName", event_type)?.to_string(),
+            error: json
+                .get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or("unknown")
+                .to_string(),
+        }),
+        "status:update" => Some(SseEvent::StatusUpdate {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            status: str_field(&json, "status", event_type)?.to_string(),
+        }),
+        "session:created" => Some(SseEvent::SessionCreated {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
+        }),
+        "session:archived" => Some(SseEvent::SessionArchived {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            session_id: SessionId::from(str_field(&json, "sessionId", event_type)?.to_string()),
+        }),
+        "distill:before" => Some(SseEvent::DistillBefore {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+        }),
+        "distill:stage" => Some(SseEvent::DistillStage {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+            stage: str_field(&json, "stage", event_type)?.to_string(),
+        }),
+        "distill:after" => Some(SseEvent::DistillAfter {
+            nous_id: NousId::from(str_field(&json, "nousId", event_type)?.to_string()),
+        }),
+        "ping" => Some(SseEvent::Ping),
         other => {
             tracing::debug!("unknown SSE event type: {other}");
             None
@@ -320,55 +363,107 @@ mod tests {
     use super::*;
 
     #[test]
-    fn subscribe_url_trims_trailing_slash() {
-        assert_eq!(
-            subscribe_url("http://192.168.1.100:18789/"),
-            "http://192.168.1.100:18789/api/v1/events/subscribe\
-             ?topics=turn.complete,fact.created,session.started,session.ended"
-        );
-    }
-
-    #[test]
-    fn subscribe_url_without_trailing_slash() {
-        let url = subscribe_url("http://192.168.1.100:18789");
-        assert!(url.starts_with("http://192.168.1.100:18789/api/v1/events/subscribe?topics="));
-    }
-
-    #[test]
-    fn parse_turn_complete_valid() {
-        // NOTE: mirrors the real publish payload (sessions/streaming.rs):
-        // extra token-count fields must be tolerated.
-        let data = r#"{"session_id":"sess-1","nous_id":"syn","turn_id":"turn-1","input_tokens":10,"output_tokens":20}"#;
-        let result = parse_sse_event("turn.complete", data);
-        if let Some(SseEvent::TurnAfter {
+    fn parse_turn_before_valid() {
+        let data = r#"{"nousId":"syn","sessionId":"sess-1","turnId":"turn-1"}"#;
+        let result = parse_sse_event("turn:before", data);
+        assert!(result.is_some());
+        if let Some(SseEvent::TurnBefore {
             nous_id,
             session_id,
+            turn_id,
         }) = result
         {
             assert_eq!(&*nous_id, "syn");
             assert_eq!(&*session_id, "sess-1");
+            assert_eq!(&*turn_id, "turn-1");
         } else {
-            panic!("expected TurnAfter");
+            panic!("expected TurnBefore");
         }
     }
 
     #[test]
     fn parse_invalid_json_returns_none() {
-        let result = parse_sse_event("turn.complete", "not json");
+        let result = parse_sse_event("turn:before", "not json");
         assert!(result.is_none());
     }
 
     #[test]
     fn parse_missing_field_returns_none() {
-        let data = r#"{"nous_id":"syn"}"#;
-        let result = parse_sse_event("turn.complete", data);
+        let data = r#"{"nousId":"syn"}"#;
+        let result = parse_sse_event("turn:before", data);
         assert!(result.is_none());
     }
 
     #[test]
-    fn parse_session_started() {
-        let data = r#"{"nous_id":"syn","session_id":"s-new"}"#;
-        let result = parse_sse_event("session.started", data);
+    fn parse_unknown_event_returns_none() {
+        let data = r#"{"foo":"bar"}"#;
+        let result = parse_sse_event("custom:unknown", data);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_init_with_active_turns() {
+        let data = r#"{"activeTurns":[{"nousId":"syn","sessionId":"s1","turnId":"t1"}]}"#;
+        let result = parse_sse_event("init", data);
+        assert!(result.is_some());
+        if let Some(SseEvent::Init { active_turns }) = result {
+            assert_eq!(active_turns.len(), 1);
+            assert_eq!(&*active_turns[0].nous_id, "syn");
+        } else {
+            panic!("expected Init");
+        }
+    }
+
+    #[test]
+    fn parse_ping() {
+        let data = r#"{}"#;
+        let result = parse_sse_event("ping", data);
+        assert!(matches!(result, Some(SseEvent::Ping)));
+    }
+
+    #[test]
+    fn parse_tool_called() {
+        let data = r#"{"nousId":"syn","toolName":"read_file"}"#;
+        let result = parse_sse_event("tool:called", data);
+        if let Some(SseEvent::ToolCalled { nous_id, tool_name }) = result {
+            assert_eq!(&*nous_id, "syn");
+            assert_eq!(tool_name, "read_file");
+        } else {
+            panic!("expected ToolCalled");
+        }
+    }
+
+    #[test]
+    fn parse_tool_failed_with_default_error() {
+        let data = r#"{"nousId":"syn","toolName":"exec"}"#;
+        let result = parse_sse_event("tool:failed", data);
+        if let Some(SseEvent::ToolFailed {
+            error, tool_name, ..
+        }) = result
+        {
+            assert_eq!(tool_name, "exec");
+            assert_eq!(error, "unknown");
+        } else {
+            panic!("expected ToolFailed");
+        }
+    }
+
+    #[test]
+    fn parse_distill_stage() {
+        let data = r#"{"nousId":"syn","stage":"extracting"}"#;
+        let result = parse_sse_event("distill:stage", data);
+        if let Some(SseEvent::DistillStage { nous_id, stage }) = result {
+            assert_eq!(&*nous_id, "syn");
+            assert_eq!(stage, "extracting");
+        } else {
+            panic!("expected DistillStage");
+        }
+    }
+
+    #[test]
+    fn parse_session_created() {
+        let data = r#"{"nousId":"syn","sessionId":"s-new"}"#;
+        let result = parse_sse_event("session:created", data);
         if let Some(SseEvent::SessionCreated {
             nous_id,
             session_id,
@@ -379,42 +474,6 @@ mod tests {
         } else {
             panic!("expected SessionCreated");
         }
-    }
-
-    #[test]
-    fn parse_session_ended() {
-        let data = r#"{"nous_id":"syn","session_id":"s-old"}"#;
-        let result = parse_sse_event("session.ended", data);
-        if let Some(SseEvent::SessionArchived {
-            nous_id,
-            session_id,
-        }) = result
-        {
-            assert_eq!(&*nous_id, "syn");
-            assert_eq!(&*session_id, "s-old");
-        } else {
-            panic!("expected SessionArchived");
-        }
-    }
-
-    #[test]
-    fn parse_fact_created_dropped_gracefully() {
-        let data = r#"{"fact_id":"f-1","nous_id":"syn","content_preview":"alice"}"#;
-        assert!(parse_sse_event("fact.created", data).is_none());
-    }
-
-    #[test]
-    fn parse_legacy_colon_name_returns_none() {
-        // NOTE: regression guard — pre-rewrite colon names are not topics.
-        let data = r#"{"nousId":"syn","sessionId":"s1","turnId":"t1"}"#;
-        assert!(parse_sse_event("turn:before", data).is_none());
-    }
-
-    #[test]
-    fn parse_unknown_event_returns_none() {
-        let data = r#"{"foo":"bar"}"#;
-        let result = parse_sse_event("custom.unknown", data);
-        assert!(result.is_none());
     }
 
     #[test]
@@ -450,5 +509,33 @@ mod tests {
     fn extract_error_message_error_field() {
         let body = r#"{"error":"forbidden"}"#;
         assert_eq!(extract_error_message(body, 403, "Forbidden"), "forbidden");
+    }
+
+    #[test]
+    fn loss_not_confirmed_without_loss_start() {
+        assert!(!loss_confirmed(5, None));
+    }
+
+    #[test]
+    fn loss_not_confirmed_below_attempt_threshold() {
+        let past = Instant::now()
+            .checked_sub(LOSS_CONFIRM_WINDOW)
+            .unwrap_or_else(Instant::now);
+        assert!(!loss_confirmed(1, Some(past)));
+    }
+
+    #[test]
+    fn loss_not_confirmed_within_window() {
+        assert!(!loss_confirmed(LOSS_CONFIRM_ATTEMPTS, Some(Instant::now())));
+    }
+
+    #[test]
+    fn loss_confirmed_past_both_gates() {
+        let past = Instant::now()
+            .checked_sub(LOSS_CONFIRM_WINDOW)
+            .unwrap_or_else(Instant::now);
+        if past.elapsed() >= LOSS_CONFIRM_WINDOW {
+            assert!(loss_confirmed(LOSS_CONFIRM_ATTEMPTS, Some(past)));
+        }
     }
 }

--- a/crates/theatron/proskenion/src/app.rs
+++ b/crates/theatron/proskenion/src/app.rs
@@ -171,9 +171,9 @@ fn ConnectedApp() -> Element {
     // and has access to the finalized connection config.
     crate::services::sse_coroutine::start_sse_coroutine(&config.read());
 
-    // WHY: Fetch agents immediately on connection so the topbar agent pills
-    // are populated. Without this, agents only appear when the Ops view is
-    // visited — the topbar would be empty on first launch.
+    // WHY: Fetch agents immediately on connection so the sidebar nous roster
+    // is populated. Without this, agents only appear when the Ops view is
+    // visited — the roster would be empty on first launch.
     {
         let cfg = config.read().clone();
         let mut agents: Signal<AgentStore> = use_context();

--- a/crates/theatron/proskenion/src/components/agent_sidebar.rs
+++ b/crates/theatron/proskenion/src/components/agent_sidebar.rs
@@ -39,10 +39,16 @@ pub(crate) fn AgentSidebarView(collapsed: bool) -> Element {
         let agent_count = store.read().all().len();
         return rsx! {
             div {
-                class: "agent-roster-rail",
-                span { class: "agent-roster-rail-label", "NOUS" }
+                style: "display: flex; flex-direction: column; align-items: center; padding: var(--space-2) 0;",
+                span {
+                    style: "font-size: var(--text-xs); color: var(--text-muted); writing-mode: vertical-rl; text-orientation: mixed;",
+                    "NOUS"
+                }
                 if agent_count > 0 {
-                    span { class: "agent-roster-rail-count", "● {agent_count}" }
+                    span {
+                        style: "font-size: var(--text-xs); color: var(--status-success); margin-top: var(--space-1);",
+                        "● {agent_count}"
+                    }
                 }
             }
         };

--- a/crates/theatron/proskenion/src/components/chart.rs
+++ b/crates/theatron/proskenion/src/components/chart.rs
@@ -398,15 +398,18 @@ pub(crate) fn GroupedBarChart(
 // ── Series colors ──
 
 /// Palette for multi-series charts (8 visually distinct hues).
+///
+/// WHY: Every entry resolves through `[data-theme]` so series hues stay
+/// legible and on-palette in both dark and light themes.
 pub(crate) const SERIES_COLORS: &[&str] = &[
-    "#5b6af0",
+    "var(--status-info)",
     "var(--status-success)",
     "var(--status-warning)",
     "var(--status-error)",
-    "#a855f7",
-    "#06b6d4",
-    "#f97316",
-    "#ec4899",
+    "var(--thanatochromia)",
+    "var(--aporia)",
+    "var(--natural)",
+    "var(--aima)",
 ];
 
 // ── Line chart types ──
@@ -554,7 +557,7 @@ pub(crate) fn PercentileBarChart(entries: Vec<PercentileEntry>) -> Element {
             div {
                 style: "display: flex; gap: var(--space-3); font-size: var(--text-xs); color: var(--text-muted);",
                 span { "min-p25" }
-                span { style: "color: #5b6af0;", "p25-p50" }
+                span { style: "color: var(--status-info);", "p25-p50" }
                 span { style: "color: var(--status-success);", "p50-p75" }
                 span { style: "color: var(--status-warning);", "p75-p95" }
                 span { style: "color: var(--status-error);", "p95-max" }
@@ -589,7 +592,7 @@ pub(crate) fn PercentileBarChart(entries: Vec<PercentileEntry>) -> Element {
                                 style: "flex: 1; height: 16px; display: flex; border-radius: var(--radius-sm); overflow: hidden;",
                                 title: "{tip}",
                                 div { style: "width: {w_min_p25}%; background: var(--input-border); min-width: 1px;" }
-                                div { style: "width: {w_p25_p50}%; background: #5b6af0; min-width: 1px;" }
+                                div { style: "width: {w_p25_p50}%; background: var(--status-info); min-width: 1px;" }
                                 div { style: "width: {w_p50_p75}%; background: var(--status-success); min-width: 1px;" }
                                 div { style: "width: {w_p75_p95}%; background: var(--status-warning); min-width: 1px;" }
                                 div { style: "width: {w_p95_max}%; background: var(--status-error); min-width: 1px;" }

--- a/crates/theatron/proskenion/src/components/chat/mod.rs
+++ b/crates/theatron/proskenion/src/components/chat/mod.rs
@@ -135,6 +135,18 @@ impl Default for ChatState {
 }
 
 impl ChatState {
+    /// Whether the most recent history entry is a user message with `text`.
+    ///
+    /// WHY: When a turn fails and the operator retries, the original user
+    /// bubble is still the last history entry. The retry path uses this to
+    /// re-send in place instead of appending a visual duplicate.
+    #[must_use]
+    pub(crate) fn last_is_user_message(&self, text: &str) -> bool {
+        self.messages
+            .last()
+            .is_some_and(|m| m.role == MessageRole::User && m.content == text)
+    }
+
     /// Project legacy messages into the render-ready `ChatMessage` model.
     ///
     /// WHY(#3323): Centralizes the legacy-to-render projection so it is

--- a/crates/theatron/proskenion/src/components/chat/tests.rs
+++ b/crates/theatron/proskenion/src/components/chat/tests.rs
@@ -408,6 +408,44 @@ fn chat_state_default() {
 }
 
 #[test]
+fn last_is_user_message_matches_failed_turn_tail() {
+    let mut state = make_state();
+    state.messages.push(ChatMessage {
+        role: MessageRole::User,
+        content: "send this".to_string(),
+        model: None,
+        tool_calls: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        thinking: None,
+        tool_call_details: Vec::new(),
+        plans: Vec::new(),
+    });
+
+    assert!(state.last_is_user_message("send this"));
+    assert!(!state.last_is_user_message("different text"));
+}
+
+#[test]
+fn last_is_user_message_false_for_empty_or_assistant_tail() {
+    let mut state = make_state();
+    assert!(!state.last_is_user_message("anything"));
+
+    state.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: "reply".to_string(),
+        model: None,
+        tool_calls: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        thinking: None,
+        tool_call_details: Vec::new(),
+        plans: Vec::new(),
+    });
+    assert!(!state.last_is_user_message("reply"));
+}
+
+#[test]
 fn full_turn_lifecycle() {
     let mut state = make_state();
     let mut mgr = make_manager();

--- a/crates/theatron/proskenion/src/components/checkpoint_card.rs
+++ b/crates/theatron/proskenion/src/components/checkpoint_card.rs
@@ -55,7 +55,7 @@ const SECTION_LABEL: &str = "\
 
 const CONTEXT_STYLE: &str = "\
     font-size: var(--text-sm); \
-    color: #c0c0e0; \
+    color: var(--text-primary); \
     background: var(--bg-surface-dim); \
     border: 1px solid var(--border); \
     border-radius: var(--radius-sm); \
@@ -137,7 +137,7 @@ const OVERRIDE_BTN: &str = "\
 
 const SUBMIT_BTN_ACTIVE: &str = "\
     background: var(--accent); \
-    color: white; \
+    color: var(--text-inverse); \
     border: none; \
     border-radius: var(--radius-md); \
     padding: var(--space-2) var(--space-4); \
@@ -323,7 +323,7 @@ pub(crate) fn CheckpointCard(
                             style: if req.met { "color: var(--status-success); width: 18px;" } else { "color: var(--status-error); width: 18px;" },
                             if req.met { "[v]" } else { "[x]" }
                         }
-                        span { style: "color: #c0c0e0;", "{req.title}" }
+                        span { style: "color: var(--text-primary);", "{req.title}" }
                     }
                 }
             }
@@ -335,7 +335,7 @@ pub(crate) fn CheckpointCard(
                         key: "{i}",
                         style: "{ARTIFACT_ROW}",
                         span { style: "color: var(--text-muted);", "{artifact.label}:" }
-                        span { style: "color: #c0c0e0; font-family: var(--font-mono);", "{artifact.value}" }
+                        span { style: "color: var(--text-primary); font-family: var(--font-mono);", "{artifact.value}" }
                     }
                 }
             }
@@ -423,19 +423,19 @@ pub(crate) fn CheckpointCard(
 fn card_container_style(status: CheckpointStatus) -> String {
     let (bg, border) = match status {
         CheckpointStatus::Pending => ("var(--bg-surface)", "var(--accent)"),
-        CheckpointStatus::Approved => ("#0f1f0f", "var(--status-success)"),
-        CheckpointStatus::Skipped => ("#1e1a10", "var(--status-warning)"),
-        CheckpointStatus::Overridden => ("#1e0f0f", "var(--status-error)"),
+        CheckpointStatus::Approved => ("var(--status-success-bg)", "var(--status-success)"),
+        CheckpointStatus::Skipped => ("var(--status-warning-bg)", "var(--status-warning)"),
+        CheckpointStatus::Overridden => ("var(--status-error-bg)", "var(--status-error)"),
     };
     format!("{CARD_BASE} background: {bg}; border-color: {border};")
 }
 
 fn status_badge_style(status: CheckpointStatus) -> String {
     let (bg, color) = match status {
-        CheckpointStatus::Pending => ("#1e1e5a", "#8080ff"),
-        CheckpointStatus::Approved => ("#0f2a0f", "var(--status-success)"),
-        CheckpointStatus::Skipped => ("#2a1f05", "var(--status-warning)"),
-        CheckpointStatus::Overridden => ("#2a0f0f", "var(--status-error)"),
+        CheckpointStatus::Pending => ("var(--status-info-bg)", "var(--status-info)"),
+        CheckpointStatus::Approved => ("var(--status-success-bg)", "var(--status-success)"),
+        CheckpointStatus::Skipped => ("var(--status-warning-bg)", "var(--status-warning)"),
+        CheckpointStatus::Overridden => ("var(--status-error-bg)", "var(--status-error)"),
     };
     format!("{BADGE_BASE} background: {bg}; color: {color};")
 }

--- a/crates/theatron/proskenion/src/components/help_overlay.rs
+++ b/crates/theatron/proskenion/src/components/help_overlay.rs
@@ -11,7 +11,7 @@ const OVERLAY_BACKDROP: &str = "\
     left: 0; \
     right: 0; \
     bottom: 0; \
-    background: rgba(0, 0, 0, 0.6); \
+    background: var(--bg-overlay); \
     display: flex; \
     align-items: center; \
     justify-content: center; \
@@ -58,7 +58,7 @@ const KEY_STYLE: &str = "\
     font-family: var(--font-mono, monospace); \
     font-size: var(--text-xs); \
     color: var(--text-secondary); \
-    background: var(--bg-hover, var(--bg)); \
+    background: var(--bg-surface-bright); \
     border: 1px solid var(--border); \
     border-radius: var(--radius-sm); \
     padding: var(--space-1) var(--space-2); \
@@ -75,7 +75,7 @@ const FOOTER_STYLE: &str = "\
     padding-top: var(--space-3); \
     border-top: 1px solid var(--border); \
     font-size: var(--text-xs); \
-    color: var(--text-muted, var(--text-secondary)); \
+    color: var(--text-muted); \
     text-align: center;\
 ";
 
@@ -92,7 +92,7 @@ const NAV_SHORTCUTS: &[ShortcutEntry] = &[
     },
     ShortcutEntry {
         keys: "Ctrl+2 / Ctrl+Shift+F",
-        description: "Files",
+        description: "Theke",
     },
     ShortcutEntry {
         keys: "Ctrl+3",

--- a/crates/theatron/proskenion/src/components/input_bar.rs
+++ b/crates/theatron/proskenion/src/components/input_bar.rs
@@ -66,10 +66,13 @@ const SEND_BTN_DISABLED: &str = "\
     color: var(--text-muted); \
     border: none; \
     border-radius: var(--radius-md); \
-    padding: var(--space-3) var(--space-5); \
-    font-size: var(--text-base); \
+    padding: var(--space-2) var(--space-4); \
+    font-size: var(--text-sm); \
+    font-weight: var(--weight-semibold); \
     cursor: not-allowed; \
-    white-space: nowrap;\
+    white-space: nowrap; \
+    flex-shrink: 0; \
+    min-width: 70px;\
 ";
 
 const ABORT_BTN_STYLE: &str = "\
@@ -102,8 +105,8 @@ pub(crate) struct InputBarProps {
 
 /// Rich chat input bar with multiline textarea and history navigation.
 ///
-/// - Submit: Ctrl+Enter (Linux)
-/// - Newline: Shift+Enter or Enter
+/// - Submit: Enter (Ctrl+Enter also works)
+/// - Newline: Shift+Enter
 /// - History: Up/Down arrows when cursor is at start/end
 /// - Disabled with "Streaming..." placeholder during active stream
 #[component]
@@ -130,7 +133,7 @@ pub(crate) fn InputBar(props: InputBarProps) -> Element {
             style: "{INPUT_BAR_STYLE}",
             textarea {
                 style: if is_streaming { "{TEXTAREA_DISABLED_STYLE}" } else { "{TEXTAREA_STYLE}" },
-                placeholder: if is_streaming { "Streaming..." } else { "Type a message... (Ctrl+Enter to send)" },
+                placeholder: if is_streaming { "Streaming..." } else { "Type a message... (Enter to send, Shift+Enter for newline)" },
                 disabled: is_streaming,
                 rows: "1",
                 value: "{input.read().text}",
@@ -141,22 +144,19 @@ pub(crate) fn InputBar(props: InputBarProps) -> Element {
                     let key = evt.key();
                     let modifiers = evt.modifiers();
 
-                    if key == Key::Enter && modifiers.contains(Modifiers::CONTROL) {
-                        evt.prevent_default();
-                        do_submit();
-                        return;
-                    }
-
                     // Shift+Enter: newline (default textarea behavior, no prevention)
                     if key == Key::Enter && modifiers.contains(Modifiers::SHIFT) {
                         return;
                     }
 
-                    // Plain Enter: also newline in a multiline textarea
+                    // Enter (plain or Ctrl): submit
                     if key == Key::Enter {
+                        evt.prevent_default();
+                        do_submit();
                         return;
                     }
 
+                    // Up arrow: navigate to previous history entry
                     if key == Key::ArrowUp && !is_streaming {
                         if input.write().history_prev() {
                             evt.prevent_default();
@@ -164,6 +164,7 @@ pub(crate) fn InputBar(props: InputBarProps) -> Element {
                         return;
                     }
 
+                    // Down arrow: navigate to next history entry
                     if key == Key::ArrowDown && !is_streaming && input.write().history_next() {
                         evt.prevent_default();
                     }

--- a/crates/theatron/proskenion/src/components/message.rs
+++ b/crates/theatron/proskenion/src/components/message.rs
@@ -55,7 +55,7 @@ pub(crate) fn MessageBubble(
             padding: var(--space-3) var(--space-4); \
             max-width: min(75%, 720px); \
             color: var(--text-primary); \
-            box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.04); \
+            box-shadow: var(--shadow-inner-highlight); \
             animation: message-in 0.2s cubic-bezier(0.16, 1, 0.3, 1); \
         "
     } else if is_system {
@@ -79,7 +79,7 @@ pub(crate) fn MessageBubble(
             padding: var(--space-3) var(--space-4); \
             max-width: min(85%, 720px); \
             color: var(--text-primary); \
-            box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.04); \
+            box-shadow: var(--shadow-inner-highlight); \
             animation: message-in 0.2s cubic-bezier(0.16, 1, 0.3, 1); \
         "
     };

--- a/crates/theatron/proskenion/src/components/mod.rs
+++ b/crates/theatron/proskenion/src/components/mod.rs
@@ -1,6 +1,6 @@
 //! Dioxus components for the streaming chat interface.
 
-/// Agent roster panel for the left sidebar (soft shaded box, distinct from nav).
+/// Agent presence roster for the sidebar (the sole agent home).
 pub(crate) mod agent_sidebar;
 /// SVG chart primitives: horizontal bars, stacked bars, line charts, percentile bars.
 pub(crate) mod chart;
@@ -35,6 +35,6 @@ pub(crate) mod toast_container;
 pub(crate) mod tool_approval;
 pub(crate) mod tool_panel;
 pub(crate) mod tool_status;
-/// Top bar with brand, agent status pills, and connection/theme controls.
+/// Top bar with brand, theme toggle, and connection indicator.
 pub(crate) mod topbar;
 pub(crate) mod wave_band;

--- a/crates/theatron/proskenion/src/components/option_card.rs
+++ b/crates/theatron/proskenion/src/components/option_card.rs
@@ -17,7 +17,7 @@ const CARD_STYLE: &str = "\
 
 const CARD_RECOMMENDED: &str = "\
     background: var(--bg-surface); \
-    border: 2px solid #4a9aff; \
+    border: 2px solid var(--status-info); \
     border-radius: var(--radius-md); \
     padding: var(--space-4) var(--space-4); \
     cursor: pointer; \
@@ -27,7 +27,7 @@ const CARD_RECOMMENDED: &str = "\
 ";
 
 const CARD_SELECTED: &str = "\
-    background: #1a2a3a; \
+    background: var(--status-success-bg); \
     border: 2px solid var(--status-success); \
     border-radius: var(--radius-md); \
     padding: var(--space-4) var(--space-4); \
@@ -56,8 +56,8 @@ const BADGE_RECOMMENDED: &str = "\
     font-weight: var(--weight-semibold); \
     padding: var(--space-1) var(--space-2); \
     border-radius: var(--radius-md); \
-    background: #1a2a4a; \
-    color: #4a9aff; \
+    background: var(--status-info-bg); \
+    color: var(--status-info); \
     text-transform: uppercase; \
     letter-spacing: 0.3px;\
 ";
@@ -68,7 +68,7 @@ const BADGE_SELECTED: &str = "\
     font-weight: var(--weight-semibold); \
     padding: var(--space-1) var(--space-2); \
     border-radius: var(--radius-md); \
-    background: #0f2a0f; \
+    background: var(--status-success-bg); \
     color: var(--status-success); \
     text-transform: uppercase; \
     letter-spacing: 0.3px;\

--- a/crates/theatron/proskenion/src/components/plan_card.rs
+++ b/crates/theatron/proskenion/src/components/plan_card.rs
@@ -56,12 +56,12 @@ const STEP_ICON_STYLE: &str = "\
     font-size: var(--text-xs);\
 ";
 
-const STEP_DESC: &str = "color: #c0c0e0;";
+const STEP_DESC: &str = "color: var(--text-primary);";
 
 const DETAIL_BOX: &str = "\
     margin-top: var(--space-1); \
     padding: var(--space-2) var(--space-2); \
-    background: #151525; \
+    background: var(--bg); \
     border: 1px solid var(--border); \
     border-radius: var(--radius-sm); \
     font-size: var(--text-xs);\
@@ -79,7 +79,7 @@ const TIME_ROW: &str = "\
 const EXPAND_BTN: &str = "\
     background: transparent; \
     border: none; \
-    color: #4a9aff; \
+    color: var(--accent); \
     font-size: var(--text-xs); \
     cursor: pointer; \
     padding: 0; \
@@ -205,7 +205,7 @@ pub(crate) fn step_icon(status: StepStatus) -> &'static str {
 pub(crate) fn step_color(status: StepStatus) -> &'static str {
     match status {
         StepStatus::Pending => "var(--text-muted)",
-        StepStatus::Running => "#4a9aff",
+        StepStatus::Running => "var(--status-info)",
         StepStatus::Complete => "var(--status-success)",
         StepStatus::Failed => "var(--status-error)",
         StepStatus::Skipped => "var(--text-secondary)",

--- a/crates/theatron/proskenion/src/components/planning_card.rs
+++ b/crates/theatron/proskenion/src/components/planning_card.rs
@@ -5,7 +5,7 @@ use dioxus::prelude::*;
 use crate::state::tools::{PlanCardState, PlanStatus, StepStatus};
 
 const CARD_STYLE: &str = "\
-    background: #1a1a30; \
+    background: var(--bg-surface); \
     border: 1px solid var(--border); \
     border-radius: var(--radius-md); \
     padding: var(--space-3); \
@@ -14,8 +14,8 @@ const CARD_STYLE: &str = "\
 ";
 
 const CARD_COMPLETE_STYLE: &str = "\
-    background: #1a2a1a; \
-    border: 1px solid #2a4a2a; \
+    background: var(--status-success-bg); \
+    border: 1px solid var(--status-success); \
     border-radius: var(--radius-md); \
     padding: var(--space-3); \
     margin-top: var(--space-1); \
@@ -24,7 +24,7 @@ const CARD_COMPLETE_STYLE: &str = "\
 
 const TITLE_STYLE: &str = "\
     font-weight: var(--weight-semibold); \
-    color: #c0c0e0; \
+    color: var(--text-primary); \
     font-size: var(--text-base); \
     margin-bottom: var(--space-2);\
 ";
@@ -161,11 +161,13 @@ fn render_step_icon(status: StepStatus) -> Element {
 fn step_label_style(status: StepStatus) -> String {
     match status {
         StepStatus::Pending => "color: var(--text-muted);".to_string(),
-        StepStatus::InProgress => "color: #c0c0e0; font-weight: var(--weight-medium);".to_string(),
+        StepStatus::InProgress => {
+            "color: var(--text-primary); font-weight: var(--weight-medium);".to_string()
+        }
         StepStatus::Complete => {
             "color: var(--text-secondary); text-decoration: line-through;".to_string()
         }
-        StepStatus::Failed => "color: #f87171;".to_string(),
+        StepStatus::Failed => "color: var(--status-error);".to_string(),
     }
 }
 

--- a/crates/theatron/proskenion/src/components/quick_input.rs
+++ b/crates/theatron/proskenion/src/components/quick_input.rs
@@ -16,7 +16,7 @@ const OVERLAY_BACKDROP: &str = "\
     left: 0; \
     right: 0; \
     bottom: 0; \
-    background: rgba(0, 0, 0, 0.5); \
+    background: var(--bg-overlay); \
     display: flex; \
     align-items: flex-start; \
     justify-content: center; \

--- a/crates/theatron/proskenion/src/components/timeline.rs
+++ b/crates/theatron/proskenion/src/components/timeline.rs
@@ -136,7 +136,7 @@ pub(crate) fn Timeline(
                                     onclick: move |_| on_block_click.call(idx),
 
                                     div {
-                                        style: "position: absolute; left: 0; top: 0; width: {progress_w}px; height: 100%; background: rgba(255,255,255,0.06); border-radius: var(--radius-md) 0 0 var(--radius-md);",
+                                        style: "position: absolute; left: 0; top: 0; width: {progress_w}px; height: 100%; background: var(--progress-veil); border-radius: var(--radius-md) 0 0 var(--radius-md);",
                                     }
 
                                     div {
@@ -199,18 +199,17 @@ fn render_dependency(
         end_y + 3.5,
     );
 
+    // NOTE: SVG presentation attributes do not resolve var(); theme tokens
+    // must go through the style attribute.
     rsx! {
         path {
             key: "line-{dep.from_idx}-{dep.to_idx}",
             d: "{curve}",
-            stroke: "#4a9aff",
-            stroke_width: "1.5",
-            fill: "none",
+            style: "stroke: var(--status-info); stroke-width: 1.5; fill: none;",
         }
         path {
             d: "{arrow}",
-            fill: "#4a9aff",
-            stroke: "none",
+            style: "fill: var(--status-info); stroke: none;",
         }
     }
 }

--- a/crates/theatron/proskenion/src/components/topbar.rs
+++ b/crates/theatron/proskenion/src/components/topbar.rs
@@ -1,13 +1,9 @@
-//! Top bar with brand, agent status pills, and connection/theme controls.
+//! Top bar with brand and connection/theme controls.
 //!
-//! Sits above the main content area, providing at-a-glance agent status
-//! and quick theme switching. Mirrors the Svelte webui's TopBar pattern.
+//! Sits above the main content area. The agent roster lives solely in the
+//! sidebar ([`crate::components::agent_sidebar`]); the top bar stays lean.
 
 use dioxus::prelude::*;
-use skene::id::NousId;
-
-use crate::state::agents::{AgentStatus, AgentStore};
-use crate::state::events::EventState;
 
 const TOPBAR_STYLE: &str = "\
     display: flex; \
@@ -29,150 +25,27 @@ const BRAND_STYLE: &str = "\
     letter-spacing: 0.02em;\
 ";
 
-const PILLS_CONTAINER_STYLE: &str = "\
-    display: flex; \
-    align-items: center; \
-    gap: var(--space-2); \
-    flex: 1; \
-    overflow-x: auto; \
-    scrollbar-width: none;\
-";
-
-const PILL_STYLE: &str = "\
-    display: inline-flex; \
-    align-items: center; \
-    gap: var(--space-1); \
-    padding: 6px var(--space-3); \
-    border-radius: var(--radius-full); \
-    border: 1px solid var(--border); \
-    background: var(--bg); \
-    color: var(--text-secondary); \
-    font-size: var(--text-sm); \
-    cursor: pointer; \
-    white-space: nowrap; \
-    transition: border-color var(--transition-quick), \
-                background-color var(--transition-quick);\
-";
-
-const PILL_ACTIVE_STYLE: &str = "\
-    display: inline-flex; \
-    align-items: center; \
-    gap: var(--space-1); \
-    padding: 6px var(--space-3); \
-    border-radius: var(--radius-full); \
-    border: 1px solid var(--accent); \
-    background: var(--bg-surface-bright); \
-    color: var(--text-primary); \
-    font-size: var(--text-sm); \
-    cursor: pointer; \
-    white-space: nowrap; \
-    transition: background-color var(--transition-quick), \
-                color var(--transition-quick), \
-                border-color var(--transition-quick); \
-    box-shadow: 0 0 0 3px rgb(154 123 79 / 0.2);\
-";
-
 const CONTROLS_STYLE: &str = "\
     display: flex; \
     align-items: center; \
     gap: var(--space-2); \
-    flex-shrink: 0;\
+    flex-shrink: 0; \
+    margin-left: auto;\
 ";
 
-/// Derive the display status for an agent from the current `EventState`.
-fn derive_status(nous_id: &NousId, event_state: &EventState) -> AgentStatus {
-    if event_state
-        .active_turns
-        .iter()
-        .any(|t| &t.nous_id == nous_id)
-    {
-        return AgentStatus::Active;
-    }
-    match event_state.agent_statuses.get(nous_id).map(String::as_str) {
-        Some("error") => AgentStatus::Error,
-        _ => AgentStatus::Idle,
-    }
-}
-
-/// Top bar with brand, agent pills, and controls.
+/// Top bar with brand and controls.
 #[component]
 pub(crate) fn TopBar() -> Element {
-    let mut store = use_context::<Signal<AgentStore>>();
-    let event_state = use_context::<Signal<EventState>>();
-
-    let agents: Vec<(NousId, String, String, AgentStatus, bool)> = {
-        let s = store.read();
-        let es = event_state.read();
-        s.all()
-            .iter()
-            .map(|rec| {
-                let status = derive_status(&rec.agent.id, &es);
-                let is_active = s.active_id.as_ref() == Some(&rec.agent.id);
-                (
-                    rec.agent.id.clone(),
-                    rec.display_name().to_string(),
-                    rec.agent.emoji.clone().unwrap_or_default(),
-                    status,
-                    is_active,
-                )
-            })
-            .collect()
-    };
-
     rsx! {
         div {
             style: "{TOPBAR_STYLE}",
             role: "banner",
             "aria-label": "Top bar",
 
+            // Brand
             span { style: "{BRAND_STYLE}", "Aletheia" }
 
-            div {
-                style: "{PILLS_CONTAINER_STYLE}",
-                "aria-label": "Agent status",
-                for (id , name , emoji , status , is_active) in agents {
-                    {
-                        let id_clone = id.clone();
-                        let color = status.dot_color();
-                        let pill_style = if is_active {
-                            PILL_ACTIVE_STYLE
-                        } else {
-                            PILL_STYLE
-                        };
-                        let status_label = status.label();
-                        let dot_style = if matches!(status, AgentStatus::Active) {
-                            format!("width: 10px; height: 10px; border-radius: 50%; background: {color}; flex-shrink: 0; animation: status-pulse 2s ease-in-out infinite;")
-                        } else {
-                            format!("width: 10px; height: 10px; border-radius: 50%; background: {color}; flex-shrink: 0;")
-                        };
-                        rsx! {
-                            button {
-                                key: "{id}",
-                                r#type: "button",
-                                style: "{pill_style}",
-                                title: "{name} — {status_label}",
-                                "aria-label": "Agent {name}, status {status_label}",
-                                onclick: move |_| {
-                                    store.write().set_active(&id_clone);
-                                },
-                                span {
-                                    style: "{dot_style}",
-                                    aria_hidden: "true",
-                                }
-                                if !emoji.is_empty() {
-                                    span { style: "font-size: var(--text-base);", "{emoji}" }
-                                }
-                                span { "{name} " }
-                                span {
-                                    style: "font-size: var(--text-xs); color: var(--text-muted);",
-                                    "{status_label}"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
+            // Controls
             div {
                 style: "{CONTROLS_STYLE}",
                 crate::components::theme_toggle::ThemeToggle {}

--- a/crates/theatron/proskenion/src/components/wave_band.rs
+++ b/crates/theatron/proskenion/src/components/wave_band.rs
@@ -102,15 +102,15 @@ pub(crate) fn WaveBand(wave: Wave, children: Element) -> Element {
 
 fn band_colors(status: WaveStatus) -> (&'static str, &'static str) {
     match status {
-        WaveStatus::Active => ("var(--bg-surface)", "#4a9aff"),
-        WaveStatus::Complete => ("#0f1a0f", "#2a4a2a"),
-        WaveStatus::Pending => ("#151520", "var(--border)"),
+        WaveStatus::Active => ("var(--bg-surface)", "var(--status-info)"),
+        WaveStatus::Complete => ("var(--status-success-bg)", "var(--status-success)"),
+        WaveStatus::Pending => ("var(--bg-surface-dim)", "var(--border)"),
     }
 }
 
 fn progress_color(status: WaveStatus) -> &'static str {
     match status {
-        WaveStatus::Active => "#4a9aff",
+        WaveStatus::Active => "var(--status-info)",
         WaveStatus::Complete => "var(--status-success)",
         WaveStatus::Pending => "var(--border)",
     }
@@ -119,8 +119,8 @@ fn progress_color(status: WaveStatus) -> &'static str {
 #[must_use]
 pub(crate) fn status_badge_style(status: WaveStatus) -> String {
     let (bg, color) = match status {
-        WaveStatus::Active => ("#1e1e5a", "#4a9aff"),
-        WaveStatus::Complete => ("#0f2a0f", "var(--status-success)"),
+        WaveStatus::Active => ("var(--status-info-bg)", "var(--status-info)"),
+        WaveStatus::Complete => ("var(--status-success-bg)", "var(--status-success)"),
         WaveStatus::Pending => ("var(--border)", "var(--text-muted)"),
     };
     format!("{BADGE_BASE} background: {bg}; color: {color};")

--- a/crates/theatron/proskenion/src/layout.rs
+++ b/crates/theatron/proskenion/src/layout.rs
@@ -3,30 +3,15 @@
 use dioxus::prelude::*;
 
 use crate::app::Route;
-use crate::components::agent_sidebar::AgentSidebarView;
 use crate::components::help_overlay::HelpOverlay;
 use crate::components::topbar::TopBar;
 use crate::state::navigation::NavAction;
 use crate::state::pipeline::RoutingState;
 use crate::state::view_preservation::ViewPreservationStore;
 
-const SIDEBAR_COLLAPSED_STYLE: &str = "\
-    width: 48px; \
-    background: var(--bg-surface); \
-    color: var(--text-primary); \
-    padding: var(--space-4) 0; \
-    display: flex; \
-    flex-direction: column; \
-    gap: var(--space-1); \
-    flex-shrink: 0; \
-    border-right: 1px solid var(--border-separator); \
-    overflow-y: auto; \
-    overflow-x: hidden; \
-    transition: width var(--duration-slow, 350ms) cubic-bezier(0.16, 1, 0.3, 1);\
-";
+use crate::components::agent_sidebar::AgentSidebarView;
 
-const SIDEBAR_EXPANDED_STYLE: &str = "\
-    width: 220px; \
+const SIDEBAR_BASE_STYLE: &str = "\
     background: var(--bg-surface); \
     color: var(--text-primary); \
     padding: var(--space-4) 0; \
@@ -37,7 +22,7 @@ const SIDEBAR_EXPANDED_STYLE: &str = "\
     border-right: 1px solid var(--border-separator); \
     overflow-y: auto; \
     overflow-x: hidden; \
-    transition: width var(--duration-slow, 350ms) cubic-bezier(0.16, 1, 0.3, 1);\
+    transition: width var(--duration-slow) var(--ease-out-expo);\
 ";
 
 const CONTENT_STYLE: &str = "\
@@ -90,22 +75,25 @@ pub(crate) fn Layout() -> Element {
         help_visible,
     );
 
-    let sidebar_style = if *sidebar_collapsed.read() {
-        SIDEBAR_COLLAPSED_STYLE
+    let sidebar_width = if *sidebar_collapsed.read() {
+        "var(--sidebar-width-collapsed)"
     } else {
-        SIDEBAR_EXPANDED_STYLE
+        "var(--sidebar-width)"
     };
 
     rsx! {
         div {
-            style: "display: flex; height: 100vh; font-family: var(--font-body, system-ui, -apple-system, sans-serif);",
+            // WHY: paint the shell root explicitly — body resolves dark-theme
+            // tokens (data-theme lives on an inner div), so any unpainted gap
+            // would render near-black on the light theme.
+            style: "display: flex; height: 100vh; background: var(--bg); color: var(--text-primary); font-family: var(--font-body, system-ui, -apple-system, sans-serif);",
             // NOTE: tabindex="-1" + onkeydown lets the root div capture keyboard events.
             tabindex: "-1",
             onkeydown: keyboard_handler,
             "aria-label": "Aletheia application",
 
             nav {
-                style: "{sidebar_style}",
+                style: "width: {sidebar_width}; {SIDEBAR_BASE_STYLE}",
                 role: "navigation",
                 "aria-label": "Main navigation",
                 if !*sidebar_collapsed.read() {
@@ -121,7 +109,7 @@ pub(crate) fn Layout() -> Element {
                     div { class: "sidebar-section-label", "Workspace" }
                 }
                 NavItem { to: Route::Chat {}, icon: "💬", label: "Chat", shortcut: "Ctrl+1", collapsed: *sidebar_collapsed.read() }
-                NavItem { to: Route::Files {}, icon: "📁", label: "Files", shortcut: "Ctrl+2", collapsed: *sidebar_collapsed.read() }
+                NavItem { to: Route::Files {}, icon: "📁", label: "Theke", shortcut: "Ctrl+2", collapsed: *sidebar_collapsed.read() }
                 NavItem { to: Route::Planning {}, icon: "📋", label: "Planning", shortcut: "Ctrl+3", collapsed: *sidebar_collapsed.read() }
 
                 // ── Knowledge section ──
@@ -152,6 +140,7 @@ pub(crate) fn Layout() -> Element {
                 // sits below nav so it reads as a distinct shaded panel.
                 AgentSidebarView { collapsed: *sidebar_collapsed.read() }
             }
+            // Content area: topbar + main
             div {
                 style: "flex: 1; display: flex; flex-direction: column; overflow: hidden;",
                 TopBar {}
@@ -163,6 +152,7 @@ pub(crate) fn Layout() -> Element {
                 }
             }
 
+            // Help overlay (F1)
             HelpOverlay { visible: help_visible }
         }
     }

--- a/crates/theatron/proskenion/src/services/connection.rs
+++ b/crates/theatron/proskenion/src/services/connection.rs
@@ -13,9 +13,11 @@
 //!                              │       │
 //!                              │   Connected ──► periodic health check (30s)
 //!                              │                        │
-//!                              │                   failure detected
+//!                              │              sustained loss confirmed
+//!                              │              (2+ failures spanning 15s;
+//!                              │               single blips stay silent)
 //!                              │                        │
-//!                              │                  Reconnecting(1)
+//!                              │                  Reconnecting(n)
 //!                              │                        │
 //!                              │                  backoff → retry
 //!                              │                        │
@@ -26,7 +28,7 @@
 //!
 //! This module includes a minimal HTTP client for server communication.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use snafu::{ResultExt, Snafu};
@@ -36,6 +38,12 @@ use tokio_util::sync::CancellationToken;
 use crate::state::connection::{
     ConnectionConfig, ConnectionState, HEALTH_CHECK_INTERVAL, backoff_duration,
 };
+
+/// Consecutive health-check failures required before the loss is reported.
+const LOSS_CONFIRM_FAILURES: u32 = 2;
+
+/// Minimum elapsed time since the first failure before the loss is reported.
+const LOSS_CONFIRM_WINDOW: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
@@ -289,9 +297,12 @@ impl ConnectionService {
 
     /// Periodically verify the connection is still alive.
     ///
-    /// On failure, attempts reconnection with exponential backoff.
+    /// On failure, attempts reconnection with exponential backoff. A loss is
+    /// reported to the UI only once confirmed ([`LOSS_CONFIRM_FAILURES`]
+    /// consecutive failures spanning [`LOSS_CONFIRM_WINDOW`]); single blips
+    /// recover silently without flipping connection state.
     async fn health_check_loop(&self, client: &PylonClient) {
-        let mut consecutive_failures: u32 = 0;
+        let mut loss = LossTracker::default();
 
         loop {
             tokio::select! {
@@ -303,19 +314,15 @@ impl ConnectionService {
 
             match client.health().await {
                 Ok(()) => {
-                    if consecutive_failures > 0 {
-                        tracing::info!(
-                            "connection restored after {} failures",
-                            consecutive_failures
-                        );
-                        self.emit(ConnectionState::Connected);
-                        consecutive_failures = 0;
+                    if loss.failures > 0 {
+                        tracing::info!("connection restored after {} failures", loss.failures);
+                        self.emit_recovery(&mut loss);
                     }
                 }
                 Err(e) => {
-                    consecutive_failures = consecutive_failures.saturating_add(1);
+                    loss.record_failure();
                     tracing::warn!(
-                        attempt = consecutive_failures,
+                        attempt = loss.failures,
                         error = %e,
                         "health check failed"
                     );
@@ -327,12 +334,10 @@ impl ConnectionService {
                         return;
                     }
 
-                    self.emit(ConnectionState::Reconnecting {
-                        attempt: consecutive_failures,
-                    });
+                    self.report_loss_if_confirmed(&mut loss);
 
                     // Attempt reconnection with backoff.
-                    if !self.try_reconnect(client, &mut consecutive_failures).await {
+                    if !self.try_reconnect(client, &mut loss).await {
                         return;
                     }
                 }
@@ -343,9 +348,9 @@ impl ConnectionService {
     /// Attempt reconnection with exponential backoff.
     ///
     /// Returns `true` if reconnected or should keep trying, `false` if cancelled.
-    async fn try_reconnect(&self, client: &PylonClient, consecutive_failures: &mut u32) -> bool {
+    async fn try_reconnect(&self, client: &PylonClient, loss: &mut LossTracker) -> bool {
         for _ in 0..5 {
-            let delay = backoff_duration(*consecutive_failures);
+            let delay = backoff_duration(loss.failures);
             tokio::select! {
                 biased;
                 _ = self.cancel.cancelled() => return false,
@@ -356,25 +361,74 @@ impl ConnectionService {
             match client.health().await {
                 Ok(()) => {
                     tracing::info!("reconnected to pylon");
-                    self.emit(ConnectionState::Connected);
-                    *consecutive_failures = 0;
+                    self.emit_recovery(loss);
                     return true;
                 }
                 Err(e) => {
-                    *consecutive_failures = consecutive_failures.saturating_add(1);
+                    loss.record_failure();
                     tracing::warn!(
-                        attempt = *consecutive_failures,
+                        attempt = loss.failures,
                         error = %e,
                         "reconnection attempt failed"
                     );
-                    self.emit(ConnectionState::Reconnecting {
-                        attempt: *consecutive_failures,
-                    });
+                    self.report_loss_if_confirmed(loss);
                 }
             }
         }
 
         true
+    }
+
+    /// Emit `Reconnecting` only once the loss is confirmed.
+    ///
+    /// WHY: `Reconnecting` unmounts the connected UI (`needs_connect_view`),
+    /// so a single health-check blip must never reach the signal — only a
+    /// sustained loss (consecutive failures spanning the confirm window).
+    fn report_loss_if_confirmed(&self, loss: &mut LossTracker) {
+        if loss.confirmed() {
+            loss.reported = true;
+            self.emit(ConnectionState::Reconnecting {
+                attempt: loss.failures,
+            });
+        }
+    }
+
+    /// Reset loss tracking; emit `Connected` only if a loss was reported.
+    ///
+    /// A silently-recovered blip leaves the signal untouched (still
+    /// `Connected`), so no state flip or notification fires.
+    fn emit_recovery(&self, loss: &mut LossTracker) {
+        if loss.reported {
+            self.emit(ConnectionState::Connected);
+        }
+        *loss = LossTracker::default();
+    }
+}
+
+/// Tracks an in-progress connection loss for confirm-before-report.
+#[derive(Default)]
+struct LossTracker {
+    /// Consecutive health-check failures (0 = healthy).
+    failures: u32,
+    /// When the first failure of the current run occurred.
+    first_failure_at: Option<Instant>,
+    /// Whether `Reconnecting` has been emitted for this run.
+    reported: bool,
+}
+
+impl LossTracker {
+    fn record_failure(&mut self) {
+        self.failures = self.failures.saturating_add(1);
+        self.first_failure_at.get_or_insert_with(Instant::now);
+    }
+
+    /// Both gates must hold: enough consecutive failures AND enough elapsed
+    /// time since the run began.
+    fn confirmed(&self) -> bool {
+        self.failures >= LOSS_CONFIRM_FAILURES
+            && self
+                .first_failure_at
+                .is_some_and(|t| t.elapsed() >= LOSS_CONFIRM_WINDOW)
     }
 }
 
@@ -594,6 +648,94 @@ mod tests {
         let _ = handle.await;
         assert!(saw_connecting, "must transition through Connecting");
         assert!(saw_connected, "must reach Connected against healthy server");
+    }
+
+    #[test]
+    fn loss_tracker_not_confirmed_on_single_failure() {
+        let mut loss = LossTracker::default();
+        loss.record_failure();
+        assert!(!loss.confirmed(), "one blip must not confirm a loss");
+    }
+
+    #[test]
+    fn loss_tracker_not_confirmed_within_window() {
+        let mut loss = LossTracker::default();
+        loss.record_failure();
+        loss.record_failure();
+        // Two failures, but the confirm window has not elapsed.
+        assert!(!loss.confirmed());
+    }
+
+    #[test]
+    fn loss_tracker_confirmed_past_both_gates() {
+        let mut loss = LossTracker::default();
+        loss.record_failure();
+        loss.record_failure();
+        loss.first_failure_at = Instant::now().checked_sub(LOSS_CONFIRM_WINDOW);
+        if loss.first_failure_at.is_some() {
+            assert!(loss.confirmed());
+        }
+    }
+
+    #[tokio::test]
+    async fn unconfirmed_loss_emits_nothing() {
+        install_crypto();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let svc = ConnectionService::new(ConnectionConfig::default(), CancellationToken::new(), tx);
+
+        let mut loss = LossTracker::default();
+        loss.record_failure();
+        svc.report_loss_if_confirmed(&mut loss);
+
+        assert!(!loss.reported);
+        assert!(
+            rx.try_recv().is_err(),
+            "no state must be emitted for a blip"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirmed_loss_emits_reconnecting_and_recovery_emits_connected() {
+        install_crypto();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let svc = ConnectionService::new(ConnectionConfig::default(), CancellationToken::new(), tx);
+
+        let mut loss = LossTracker::default();
+        loss.record_failure();
+        loss.record_failure();
+        loss.first_failure_at = Instant::now().checked_sub(LOSS_CONFIRM_WINDOW);
+        if loss.first_failure_at.is_none() {
+            return; // NOTE: process younger than the window; skip rather than flake.
+        }
+
+        svc.report_loss_if_confirmed(&mut loss);
+        assert!(loss.reported);
+        assert!(matches!(
+            rx.try_recv().unwrap(),
+            ConnectionState::Reconnecting { attempt: 2 }
+        ));
+
+        svc.emit_recovery(&mut loss);
+        assert!(matches!(rx.try_recv().unwrap(), ConnectionState::Connected));
+        assert_eq!(loss.failures, 0);
+        assert!(!loss.reported);
+    }
+
+    #[tokio::test]
+    async fn silent_recovery_emits_nothing() {
+        install_crypto();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let svc = ConnectionService::new(ConnectionConfig::default(), CancellationToken::new(), tx);
+
+        let mut loss = LossTracker::default();
+        loss.record_failure();
+        svc.emit_recovery(&mut loss);
+
+        assert!(
+            rx.try_recv().is_err(),
+            "recovery from an unreported blip must stay silent"
+        );
+        assert_eq!(loss.failures, 0);
     }
 
     #[tokio::test]

--- a/crates/theatron/proskenion/src/services/notification_dispatch.rs
+++ b/crates/theatron/proskenion/src/services/notification_dispatch.rs
@@ -138,6 +138,10 @@ impl NotificationDispatch {
                     self.disconnect_at = Some(Instant::now());
                 }
                 self.was_connected = false;
+                // WHY: While disconnected, no other event types arrive — the
+                // reconnect loop's repeated Disconnected events are the only
+                // chance for the delayed loss notification to fire.
+                self.check_connection_lost(prefs, dnd, window_focused, on_sent, toast_fallback);
             }
             _ => {
                 // NOTE: On other events, check if the delayed connection-loss

--- a/crates/theatron/proskenion/src/services/sse_coroutine.rs
+++ b/crates/theatron/proskenion/src/services/sse_coroutine.rs
@@ -25,9 +25,10 @@ use crate::state::toasts::{ToastSeverity, ToastStore};
 /// and `Signal<DndState>` to already be in context (provided by `ConnectedApp`).
 ///
 /// The coroutine automatically reconnects when the SSE stream drops
-/// (handled internally by `SseConnection`). Toast notifications are
-/// emitted on disconnect/reconnect transitions. Desktop notifications are
-/// dispatched via [`NotificationDispatch`].
+/// (handled internally by `SseConnection`, which reports only confirmed
+/// losses). Toast notifications fire only on sustained loss/recovery
+/// transitions — transient blips and clean reconnects stay silent.
+/// Desktop notifications are dispatched via [`NotificationDispatch`].
 pub(crate) fn start_sse_coroutine(config: &ConnectionConfig) {
     let mut event_state = use_context_provider(|| Signal::new(EventState::new()));
     let mut sse_connection_state =
@@ -49,6 +50,7 @@ pub(crate) fn start_sse_coroutine(config: &ConnectionConfig) {
         let mut sse = SseConnection::connect(client, &base_url, cancel);
         let mut router = SseEventRouter::new();
         let mut dispatch = NotificationDispatch::new();
+        let mut loss_announced = false;
 
         while let Some(event) = sse.next().await {
             let prev_connected = router.state().connection.is_connected();
@@ -63,10 +65,17 @@ pub(crate) fn start_sse_coroutine(config: &ConnectionConfig) {
                 // so the connection indicator can subscribe to just this.
                 sse_connection_state.set(new_state.connection.clone());
 
-                // WHY: Emit toasts on connection transitions so the user
-                // has visibility into SSE health without watching the indicator.
+                // WHY: Toast only on sustained transitions: the connection
+                // task already debounces losses, and `connection_toast`
+                // pairs them — one lost toast per episode, one restored
+                // toast after, nothing on startup or silent reconnects.
                 let now_connected = new_state.connection.is_connected();
-                emit_connection_toasts(prev_connected, now_connected);
+                let toast = connection_toast(prev_connected, now_connected, &mut loss_announced);
+                if let Some((severity, message)) = toast
+                    && let Some(mut store) = try_consume_context::<Signal<ToastStore>>()
+                {
+                    store.write().push(severity, message);
+                }
             }
 
             // NOTE: Window focus state defaults to false (always notify).
@@ -90,24 +99,65 @@ pub(crate) fn start_sse_coroutine(config: &ConnectionConfig) {
     });
 }
 
-/// Emit toast notifications on SSE connection state transitions.
-fn emit_connection_toasts(was_connected: bool, is_connected: bool) {
+/// Decide whether a connection transition warrants a toast.
+///
+/// `loss_announced` pairs the toasts across calls: a restored toast fires
+/// only after a lost toast, so the initial connect and silently-recovered
+/// blips never produce notifications.
+fn connection_toast(
+    was_connected: bool,
+    is_connected: bool,
+    loss_announced: &mut bool,
+) -> Option<(ToastSeverity, &'static str)> {
     match (was_connected, is_connected) {
         (true, false) => {
-            // NOTE: We need a mutable signal write, access via context.
-            if let Some(mut store) = try_consume_context::<Signal<ToastStore>>() {
-                store
-                    .write()
-                    .push(ToastSeverity::Warning, "Server connection lost");
-            }
+            *loss_announced = true;
+            Some((ToastSeverity::Warning, "Server connection lost"))
         }
-        (false, true) => {
-            if let Some(mut store) = try_consume_context::<Signal<ToastStore>>() {
-                store
-                    .write()
-                    .push(ToastSeverity::Success, "Server connection restored");
-            }
+        (false, true) if *loss_announced => {
+            *loss_announced = false;
+            Some((ToastSeverity::Success, "Server connection restored"))
         }
-        _ => {} // NOTE: other SSE event types require no UI-level handling
+        _ => None, // NOTE: steady states and the initial connect stay quiet
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_connect_is_silent() {
+        let mut announced = false;
+        assert!(connection_toast(false, true, &mut announced).is_none());
+        assert!(!announced);
+    }
+
+    #[test]
+    fn sustained_loss_then_recovery_toasts_once_each() {
+        let mut announced = false;
+
+        let lost = connection_toast(true, false, &mut announced);
+        assert_eq!(
+            lost,
+            Some((ToastSeverity::Warning, "Server connection lost"))
+        );
+        assert!(announced);
+
+        // Repeated reconnect attempts while down: no further toasts.
+        assert!(connection_toast(false, false, &mut announced).is_none());
+
+        let restored = connection_toast(false, true, &mut announced);
+        assert_eq!(
+            restored,
+            Some((ToastSeverity::Success, "Server connection restored"))
+        );
+        assert!(!announced);
+    }
+
+    #[test]
+    fn steady_connected_is_silent() {
+        let mut announced = false;
+        assert!(connection_toast(true, true, &mut announced).is_none());
     }
 }

--- a/crates/theatron/proskenion/src/state/agents.rs
+++ b/crates/theatron/proskenion/src/state/agents.rs
@@ -19,16 +19,6 @@ pub enum AgentStatus {
 }
 
 impl AgentStatus {
-    /// CSS color for the status indicator dot, using design tokens.
-    #[must_use]
-    pub(crate) fn dot_color(&self) -> &'static str {
-        match self {
-            Self::Active => "var(--status-success)",
-            Self::Idle => "var(--text-muted)",
-            Self::Error => "var(--status-error)",
-        }
-    }
-
     /// Human-readable status label.
     #[must_use]
     pub(crate) fn label(&self) -> &'static str {

--- a/crates/theatron/proskenion/src/state/commands.rs
+++ b/crates/theatron/proskenion/src/state/commands.rs
@@ -115,7 +115,7 @@ fn client_commands() -> Vec<Command> {
         },
         Command {
             name: "files".to_string(),
-            description: "Switch to Files view".to_string(),
+            description: "Switch to Theke view".to_string(),
             usage: "/files".to_string(),
             source: CommandSource::Client,
             agent_specific: false,

--- a/crates/theatron/proskenion/src/state/meta/mod.rs
+++ b/crates/theatron/proskenion/src/state/meta/mod.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-// ── Shared types ──
+// -- Shared types -------------------------------------------------------------
 
 /// A single data point in a time series.
 #[derive(Debug, Clone, PartialEq)]
@@ -41,7 +41,7 @@ impl TrendDirection {
     }
 }
 
-// ── Agent performance ──
+// -- Agent performance --------------------------------------------------------
 
 /// Performance scorecard for a single agent.
 #[derive(Debug, Clone, PartialEq)]
@@ -196,7 +196,7 @@ impl AgentPerformanceStore {
     }
 }
 
-// ── Conversation quality ──
+// -- Conversation quality -----------------------------------------------------
 
 /// Conversation quality time series data.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -303,7 +303,7 @@ pub(crate) fn compute_ratio(numerator: u64, denominator: u64) -> f64 {
     }
 }
 
-// ── Knowledge growth ──
+// -- Knowledge growth ---------------------------------------------------------
 
 /// Knowledge graph growth metrics over time.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -359,13 +359,7 @@ pub(crate) fn compute_acceleration(values: &[f64]) -> TrendDirection {
     }
 }
 
-/// Palette for entity type stacked area charts.
-pub(crate) const ENTITY_TYPE_COLORS: &[&str] = &[
-    "#4a9aff", "#22c55e", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899", "#06b6d4", "#84cc16",
-    "#f97316", "#6366f1",
-];
-
-// ── Memory health ──
+// -- Memory health ------------------------------------------------------------
 
 /// Composite memory health data.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -463,7 +457,7 @@ pub(crate) fn generate_recommendations(
     recs
 }
 
-// ── System reflection ──
+// -- System reflection --------------------------------------------------------
 
 /// System overview statistics.
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/crates/theatron/proskenion/src/state/metrics.rs
+++ b/crates/theatron/proskenion/src/state/metrics.rs
@@ -1,7 +1,7 @@
 // kanon:ignore RUST/file-too-long -- metrics state split is tracked under #3988
 //! Metrics state: token usage, cost tracking, and budget management.
 
-// ── Enums ──
+// -- Enums --------------------------------------------------------------------
 
 /// Time granularity for metric series.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -114,7 +114,7 @@ pub(crate) enum AgentCostSort {
     CostPer1k,
 }
 
-// ── API response types ──
+// -- API response types -------------------------------------------------------
 
 /// A single data point in a token usage time series.
 #[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
@@ -358,7 +358,7 @@ pub(crate) struct CostMetricsResponse {
     pub prev_month_cost: f64,
 }
 
-// ── Budget config (local-only) ──
+// -- Budget config (local-only) -----------------------------------------------
 
 /// Monthly spend budget configured locally.
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -367,7 +367,7 @@ pub(crate) struct BudgetConfig {
     pub monthly_limit_usd: f64,
 }
 
-// ── Computed display types ──
+// -- Computed display types ---------------------------------------------------
 
 /// Summary card data: current value with delta vs previous period.
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -377,7 +377,7 @@ pub(crate) struct SummaryDelta {
     pub is_up: bool,
 }
 
-// ── Helper functions ──
+// -- Helper functions ---------------------------------------------------------
 
 /// Compute a summary delta from current and previous u64 values.
 #[expect(
@@ -434,7 +434,7 @@ pub(crate) fn project_month_end(current_spend: f64, day_of_month: u32, days_in_m
     daily_rate * f64::from(days_in_month)
 }
 
-// ── Display formatters ──
+// -- Display formatters -------------------------------------------------------
 
 /// Format a token count with K/M suffix.
 #[expect(
@@ -462,7 +462,7 @@ pub(crate) fn format_cost(value: f64) -> String {
     format!("${value:.2}")
 }
 
-// ── Date helpers ──
+// -- Date helpers -------------------------------------------------------------
 
 /// Today's date as an ISO-8601 string (YYYY-MM-DD).
 pub(crate) fn today_date_str() -> String {
@@ -539,33 +539,7 @@ fn days_in_month(year: u32, month: u32) -> u32 {
     }
 }
 
-// ── Pricing table (client-side fallback) ──
-
-/// Cost per 1K output tokens for a model (USD).
-///
-/// NOTE: Pricing as of 2026-03. Used only when the API does not return costs.
-pub(crate) fn cost_per_1k_output(model: &str) -> f64 {
-    if model.contains("opus-4") {
-        0.075
-    } else if model.contains("sonnet-4") {
-        0.015
-    } else if model.contains("haiku-4") {
-        0.00125
-    } else if model.contains("opus-3") {
-        0.060
-    } else if model.contains("sonnet-3-5")
-        || model.contains("sonnet-3.5")
-        || model.contains("sonnet-3")
-    {
-        0.015
-    } else if model.contains("haiku-3") {
-        0.00125
-    } else {
-        0.015
-    }
-}
-
-// ── Color helpers ──
+// -- Color helpers ------------------------------------------------------------
 
 /// Consistent accent color for an agent by list position.
 pub(crate) fn agent_color(index: usize) -> &'static str {
@@ -588,7 +562,7 @@ pub(crate) fn model_color(model: &str) -> &'static str {
     }
 }
 
-// ── Sort helpers ──
+// -- Sort helpers -------------------------------------------------------------
 
 /// Sort agent token rows in-place.
 pub(crate) fn sort_agent_token_rows(
@@ -647,7 +621,7 @@ pub(crate) fn sort_agent_cost_rows(rows: &mut [AgentCostRow], col: AgentCostSort
     });
 }
 
-// ── Tests ──
+// -- Tests --------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -950,20 +924,6 @@ mod tests {
     fn today_date_str_format() {
         let s = today_date_str();
         assert_eq!(s.len(), 10);
-    }
-
-    #[test]
-    fn cost_per_1k_output_pricing_table() {
-        assert!((cost_per_1k_output("claude-opus-4") - 0.075).abs() < 0.0001);
-        assert!((cost_per_1k_output("claude-sonnet-4") - 0.015).abs() < 0.0001);
-        assert!((cost_per_1k_output("claude-haiku-4") - 0.00125).abs() < 0.00001);
-        assert!((cost_per_1k_output("claude-opus-3") - 0.060).abs() < 0.0001);
-        assert!((cost_per_1k_output("claude-sonnet-3-5") - 0.015).abs() < 0.0001);
-        assert!((cost_per_1k_output("claude-sonnet-3.5") - 0.015).abs() < 0.0001);
-        assert!((cost_per_1k_output("claude-sonnet-3") - 0.015).abs() < 0.0001);
-        assert!((cost_per_1k_output("claude-haiku-3") - 0.00125).abs() < 0.00001);
-        // Unknown model defaults to sonnet pricing.
-        assert!((cost_per_1k_output("unknown-model-9000") - 0.015).abs() < 0.0001);
     }
 
     #[test]

--- a/crates/theatron/proskenion/src/state/settings.rs
+++ b/crates/theatron/proskenion/src/state/settings.rs
@@ -416,7 +416,7 @@ pub(crate) fn default_actions() -> Vec<KeyAction> {
         },
         KeyAction {
             id: "nav_files",
-            label: "Go to Files",
+            label: "Go to Theke",
             category: KeyCategory::Navigation,
             default: KeyCombo {
                 ctrl: true,

--- a/crates/theatron/proskenion/src/views/chat.rs
+++ b/crates/theatron/proskenion/src/views/chat.rs
@@ -167,7 +167,7 @@ pub(crate) fn Chat() -> Element {
         })
         .collect();
 
-    let mut on_submit = move |text: String| {
+    let mut send_message = move |text: String, is_retry: bool| {
         if text.is_empty() || is_streaming {
             return;
         }
@@ -177,7 +177,7 @@ pub(crate) fn Chat() -> Element {
             if let Some(mut toast_store) = try_consume_context::<Signal<ToastStore>>() {
                 toast_store.write().push(
                     ToastSeverity::Warning,
-                    "Select an agent first \u{2014} click a pill in the top bar",
+                    "Select an agent first \u{2014} pick one in the sidebar",
                 );
             }
             return;
@@ -212,17 +212,23 @@ pub(crate) fn Chat() -> Element {
         stream_start_time.set(Some(Instant::now()));
         elapsed_tick.set(0);
 
-        legacy_state.write().messages.push(LegacyChatMessage {
-            role: MessageRole::User,
-            content: text.clone(),
-            model: None,
-            tool_calls: 0,
-            input_tokens: 0,
-            output_tokens: 0,
-            thinking: None,
-            tool_call_details: Vec::new(),
-            plans: Vec::new(),
-        });
+        // WHY: A retry re-sends the failed turn in place. The original user
+        // bubble is already the last history entry, so appending again would
+        // render the same message twice (or more on repeated retries).
+        let already_last = is_retry && legacy_state.read().last_is_user_message(&text);
+        if !already_last {
+            legacy_state.write().messages.push(LegacyChatMessage {
+                role: MessageRole::User,
+                content: text.clone(),
+                model: None,
+                tool_calls: 0,
+                input_tokens: 0,
+                output_tokens: 0,
+                thinking: None,
+                tool_call_details: Vec::new(),
+                plans: Vec::new(),
+            });
+        }
 
         if let Some(ref agent_id) = agent_store.read().active_id {
             let bar = tab_bar.read();
@@ -384,18 +390,21 @@ pub(crate) fn Chat() -> Element {
         });
     };
 
+    let on_submit = move |text: String| send_message(text, false);
+
     let on_abort = move |()| {
         cancel_token.read().cancel();
     };
 
-    // WHY: Retry re-sends the last user message after clearing the error.
-    // This is a separate closure so it can be used in the error banner
-    // without interfering with the InputBar's on_submit prop.
+    // WHY: Retry re-sends the last user message in place after clearing the
+    // error -- `is_retry` suppresses the duplicate user bubble. This is a
+    // separate closure so it can be used in the error banner without
+    // interfering with the InputBar's on_submit prop.
     let on_retry = move |_| {
         let msg = last_user_message.read().clone();
         if !msg.is_empty() {
             legacy_state.write().streaming.error = None;
-            on_submit(msg);
+            send_message(msg, true);
         }
     };
 
@@ -568,12 +577,30 @@ pub(crate) fn Chat() -> Element {
                                                 // re-renders, then compute actual elapsed
                                                 // from the Instant for accuracy.
                                                 std::hint::black_box(elapsed_tick());
+                                                // WHY: Surface the live pipeline phase instead
+                                                // of a bare "thinking" so the operator can see
+                                                // what the turn is actually doing.
+                                                let phase = match routing_signal.read().as_ref().map(|r| r.stage.clone()) {
+                                                    Some(PipelineStage::Bootstrap) => "assembling context\u{2026}".to_string(),
+                                                    Some(PipelineStage::Recalling) => "recalling memories\u{2026}".to_string(),
+                                                    Some(PipelineStage::Executing { tool_name }) => {
+                                                        format!("using {tool_name}\u{2026}")
+                                                    }
+                                                    Some(PipelineStage::Thinking) => {
+                                                        if legacy_state.read().streaming.thinking.is_empty() {
+                                                            "writing\u{2026}".to_string()
+                                                        } else {
+                                                            "thinking\u{2026}".to_string()
+                                                        }
+                                                    }
+                                                    _ => "thinking\u{2026}".to_string(),
+                                                };
                                                 match stream_start_time.read().as_ref() {
                                                     Some(start) => {
                                                         let secs = start.elapsed().as_secs();
-                                                        format!("Thinking... ({secs}s)")
+                                                        format!("{phase} ({secs}s)")
                                                     }
-                                                    None => "Thinking...".to_string(),
+                                                    None => phase,
                                                 }
                                             }
                                         }

--- a/crates/theatron/proskenion/src/views/files/mod.rs
+++ b/crates/theatron/proskenion/src/views/files/mod.rs
@@ -1,4 +1,4 @@
-//! Two-panel workspace file browser: tree explorer (left) + viewer (right).
+//! Two-panel theke file browser: tree explorer (left) + viewer (right).
 
 pub(crate) mod diff;
 mod search;
@@ -145,7 +145,7 @@ pub(crate) fn Files() -> Element {
                         style: "{HEADER_STYLE}",
                         h2 {
                             style: "font-size: var(--text-lg); margin: 0; color: var(--text-primary, var(--text-primary));",
-                            "Files"
+                            "Theke"
                         }
                         button {
                             style: "{COLLAPSE_BTN_STYLE}",

--- a/crates/theatron/proskenion/src/views/memory/actions.rs
+++ b/crates/theatron/proskenion/src/views/memory/actions.rs
@@ -9,7 +9,7 @@ use crate::state::memory::{EntityListStore, FlagSeverity};
 const OVERLAY_STYLE: &str = "\
     position: fixed; \
     top: 0; left: 0; right: 0; bottom: 0; \
-    background: rgba(0, 0, 0, 0.6); \
+    background: var(--bg-overlay); \
     display: flex; \
     align-items: center; \
     justify-content: center; \
@@ -141,8 +141,8 @@ const MERGE_NAME_STYLE: &str = "\
 ";
 
 const WARNING_STYLE: &str = "\
-    background: #4a2a1a; \
-    border: 1px solid var(--status-warning)44; \
+    background: var(--status-warning-bg); \
+    border: 1px solid color-mix(in srgb, var(--status-warning) 35%, transparent); \
     border-radius: var(--radius-md); \
     padding: var(--space-3); \
     color: var(--status-warning); \
@@ -151,8 +151,8 @@ const WARNING_STYLE: &str = "\
 ";
 
 const IMPACT_STYLE: &str = "\
-    background: #4a1a1a; \
-    border: 1px solid var(--status-error)44; \
+    background: var(--status-error-bg); \
+    border: 1px solid color-mix(in srgb, var(--status-error) 35%, transparent); \
     border-radius: var(--radius-md); \
     padding: var(--space-3); \
     color: var(--status-error); \

--- a/crates/theatron/proskenion/src/views/memory/detail.rs
+++ b/crates/theatron/proskenion/src/views/memory/detail.rs
@@ -101,7 +101,7 @@ const REL_TYPE_STYLE: &str = "\
 ";
 
 const REL_ENTITY_STYLE: &str = "\
-    color: #7a7aff; \
+    color: var(--accent); \
     font-weight: var(--weight-medium); \
     flex: 1;\
 ";
@@ -131,7 +131,7 @@ const MEMORY_META_STYLE: &str = "\
 ";
 
 const EXPAND_BTN_STYLE: &str = "\
-    color: #7a7aff; \
+    color: var(--accent); \
     font-size: var(--text-xs); \
     cursor: pointer; \
     background: none; \
@@ -175,9 +175,9 @@ const ACTION_BTN_STYLE: &str = "\
 ";
 
 const ACTION_BTN_DANGER_STYLE: &str = "\
-    background: #4a1a1a; \
+    background: var(--status-error-bg); \
     color: var(--status-error); \
-    border: 1px solid var(--status-error)44; \
+    border: 1px solid color-mix(in srgb, var(--status-error) 35%, transparent); \
     border-radius: var(--radius-md); \
     padding: var(--space-1) var(--space-3); \
     font-size: var(--text-xs); \
@@ -262,7 +262,7 @@ pub(crate) fn EntityDetail(
                             }
                         }
                         span {
-                            style: "{TYPE_BADGE_STYLE} background: {type_color}22; color: {type_color};",
+                            style: "{TYPE_BADGE_STYLE} background: color-mix(in srgb, {type_color} 14%, transparent); color: {type_color};",
                             "{type_label}"
                         }
                         div {

--- a/crates/theatron/proskenion/src/views/memory/facts.rs
+++ b/crates/theatron/proskenion/src/views/memory/facts.rs
@@ -1,0 +1,189 @@
+//! Facts list: flat fact browser shown while the knowledge graph has no entities.
+
+use dioxus::prelude::*;
+
+use crate::state::memory::format_confidence;
+use crate::state::sessions::format_relative_time;
+
+/// Maximum facts fetched for the fallback list.
+pub(crate) const FACTS_FETCH_LIMIT: usize = 200;
+
+/// Parsed `/api/v1/knowledge/facts` response plus a load marker.
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize)]
+pub(crate) struct FactsSnapshot {
+    #[serde(default)]
+    pub facts: Vec<FactRow>,
+    #[serde(default)]
+    pub total: usize,
+    /// True once a fetch has completed; gates the empty-state copy.
+    #[serde(skip)]
+    pub loaded: bool,
+}
+
+/// One fact from the knowledge API (temporal/provenance fields arrive flattened).
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub(crate) struct FactRow {
+    // kanon:ignore RUST/primitive-for-domain-id — mirrors server-side string IDs from the knowledge API
+    pub id: String,
+    #[serde(default)]
+    pub nous_id: String,
+    #[serde(default)]
+    pub fact_type: String,
+    #[serde(default)]
+    pub content: String,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub recorded_at: Option<String>,
+    #[serde(default)]
+    pub confidence: f64,
+    #[serde(default)]
+    pub tier: Option<String>,
+}
+
+const PANEL_STYLE: &str = "\
+    display: flex; \
+    flex-direction: column; \
+    flex: 1; \
+    min-height: 0; \
+    overflow-y: auto;\
+";
+
+const BANNER_STYLE: &str = "\
+    padding: var(--space-3) var(--space-4); \
+    background: var(--bg-surface); \
+    border: 1px solid var(--border); \
+    border-radius: var(--radius-md); \
+    color: var(--text-secondary); \
+    font-size: var(--text-sm); \
+    margin-bottom: var(--space-3);\
+";
+
+const FACT_CARD_STYLE: &str = "\
+    background: var(--bg-surface); \
+    border: 1px solid var(--border); \
+    border-radius: var(--radius-md); \
+    padding: var(--space-3); \
+    margin-bottom: var(--space-2);\
+";
+
+const FACT_CONTENT_STYLE: &str = "\
+    color: var(--text-primary); \
+    font-size: var(--text-sm); \
+    line-height: var(--leading-normal); \
+    white-space: pre-wrap; \
+    overflow-wrap: anywhere;\
+";
+
+const FACT_META_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: var(--space-3); \
+    flex-wrap: wrap; \
+    font-size: var(--text-xs); \
+    color: var(--text-muted); \
+    margin-top: var(--space-2);\
+";
+
+const NOUS_TAG_STYLE: &str = "\
+    background: color-mix(in srgb, var(--accent) 14%, transparent); \
+    color: var(--accent); \
+    border-radius: var(--radius-full); \
+    padding: 1px var(--space-2); \
+    font-weight: var(--weight-medium);\
+";
+
+const FOOTER_STYLE: &str = "\
+    padding: var(--space-2) 0; \
+    font-size: var(--text-xs); \
+    color: var(--text-muted); \
+    text-align: center;\
+";
+
+const LOADING_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: center; \
+    flex: 1; \
+    color: var(--text-muted); \
+    font-size: var(--text-base);\
+";
+
+/// Facts fallback panel: empty-state banner plus a recency-ordered fact list.
+#[component]
+pub(crate) fn FactsPanel(snapshot: FactsSnapshot, scope_label: Option<String>) -> Element {
+    if !snapshot.loaded {
+        return rsx! {
+            div { style: "{LOADING_STYLE}", "Loading memory…" }
+        };
+    }
+
+    let total = snapshot.total;
+    let shown = snapshot.facts.len();
+    let noun = if total == 1 { "fact" } else { "facts" };
+    let banner = match (&scope_label, total) {
+        (Some(name), 0) => format!("No entities for {name} yet — no facts recorded."),
+        (Some(name), n) => format!(
+            "No entities for {name} yet — {n} {noun} recorded; \
+             entities appear as the knowledge graph links them."
+        ),
+        (None, 0) => {
+            "No entities yet — no facts recorded. Facts appear as agents learn.".to_string()
+        }
+        (None, n) => format!(
+            "No entities yet — {n} {noun} recorded; \
+             entities appear as the knowledge graph links them."
+        ),
+    };
+
+    rsx! {
+        div {
+            style: "{PANEL_STYLE}",
+            div { style: "{BANNER_STYLE}", "{banner}" }
+            for fact in snapshot.facts.iter() {
+                {
+                    let fact_id = fact.id.clone();
+                    let content = fact.content.clone();
+                    let nous = fact.nous_id.clone();
+                    let fact_type = fact.fact_type.clone();
+                    let scope = fact.scope.clone();
+                    let tier = fact.tier.clone();
+                    let confidence = fact.confidence;
+                    let recorded_at = fact.recorded_at.clone();
+
+                    rsx! {
+                        div {
+                            key: "{fact_id}",
+                            style: "{FACT_CARD_STYLE}",
+                            div { style: "{FACT_CONTENT_STYLE}", "{content}" }
+                            div {
+                                style: "{FACT_META_STYLE}",
+                                if !nous.is_empty() {
+                                    span { style: "{NOUS_TAG_STYLE}", "{nous}" }
+                                }
+                                if !fact_type.is_empty() {
+                                    span { "{fact_type}" }
+                                }
+                                if let Some(ref s) = scope {
+                                    span { "scope: {s}" }
+                                }
+                                if let Some(ref t) = tier {
+                                    span { "{t}" }
+                                }
+                                if confidence > 0.0 {
+                                    span { "{format_confidence(confidence)}" }
+                                }
+                                if let Some(ref ts) = recorded_at {
+                                    span { title: "{ts}", "recorded {format_relative_time(ts)}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if total > 0 {
+                div { style: "{FOOTER_STYLE}", "{shown} of {total} {noun}" }
+            }
+        }
+    }
+}

--- a/crates/theatron/proskenion/src/views/memory/list.rs
+++ b/crates/theatron/proskenion/src/views/memory/list.rs
@@ -98,7 +98,7 @@ const FLAG_ICON_STYLE: &str = "\
 const LOAD_MORE_STYLE: &str = "\
     padding: var(--space-3); \
     text-align: center; \
-    color: #7a7aff; \
+    color: var(--accent); \
     cursor: pointer; \
     font-size: var(--text-sm); \
     transition: background-color var(--transition-quick), \
@@ -213,7 +213,7 @@ pub(crate) fn EntityList(
                                             }
                                         }
                                         span {
-                                            style: "{TYPE_BADGE_STYLE} background: {type_color}22; color: {type_color};",
+                                            style: "{TYPE_BADGE_STYLE} background: color-mix(in srgb, {type_color} 14%, transparent); color: {type_color};",
                                             "{type_label}"
                                         }
                                     }

--- a/crates/theatron/proskenion/src/views/memory/mod.rs
+++ b/crates/theatron/proskenion/src/views/memory/mod.rs
@@ -2,20 +2,23 @@
 
 pub(crate) mod actions;
 pub(crate) mod detail;
+pub(crate) mod facts;
 pub(crate) mod list;
 pub(crate) mod search;
 
 use dioxus::prelude::*;
 
 use crate::api::client::authenticated_client;
+use crate::state::agents::AgentStore;
 use crate::state::connection::ConnectionConfig;
 use crate::state::fetch::FetchState;
 use crate::state::memory::{
-    Entity, EntityDetailStore, EntityListStore, EntityMemory, EntityNavigationHistory, EntitySort,
-    Relationship,
+    Entity, EntityDetailStore, EntityListStore, EntityMemory, EntityNavigationHistory,
+    EntityProperty, EntitySort, EntityType, Relationship,
 };
 use crate::state::view_preservation::{PreservedViewState, ViewKey, ViewPreservationStore};
 use crate::views::memory::detail::EntityDetail;
+use crate::views::memory::facts::{FACTS_FETCH_LIMIT, FactsPanel, FactsSnapshot};
 use crate::views::memory::list::EntityList;
 use crate::views::memory::search::EntitySearchBar;
 
@@ -123,6 +126,46 @@ const EMPTY_DETAIL_STYLE: &str = "\
     font-size: var(--text-base);\
 ";
 
+const NOUS_PILL_ROW_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: var(--space-2); \
+    flex-wrap: wrap; \
+    padding-bottom: var(--space-2);\
+";
+
+const NOUS_PILL_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: var(--space-2); \
+    padding: var(--space-1) var(--space-3); \
+    border-radius: var(--radius-full); \
+    border: 1px solid var(--border); \
+    background: var(--bg-surface); \
+    color: var(--text-secondary); \
+    font-size: var(--text-sm); \
+    cursor: pointer; \
+    transition: background-color var(--transition-quick), \
+                color var(--transition-quick), \
+                border-color var(--transition-quick);\
+";
+
+const NOUS_PILL_ACTIVE_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: var(--space-2); \
+    padding: var(--space-1) var(--space-3); \
+    border-radius: var(--radius-full); \
+    border: 1px solid var(--border-selected); \
+    background: var(--border); \
+    color: var(--text-primary); \
+    font-size: var(--text-sm); \
+    cursor: pointer; \
+    transition: background-color var(--transition-quick), \
+                color var(--transition-quick), \
+                border-color var(--transition-quick);\
+";
+
 const DEFAULT_LIST_WIDTH: f64 = 480.0;
 const MIN_LIST_WIDTH: f64 = 280.0;
 const MAX_LIST_WIDTH: f64 = 800.0;
@@ -131,12 +174,15 @@ const MAX_LIST_WIDTH: f64 = 800.0;
 #[component]
 pub(crate) fn Memory() -> Element {
     let config: Signal<ConnectionConfig> = use_context();
+    let agent_store = use_context::<Signal<AgentStore>>();
 
     let mut list_store = use_signal(EntityListStore::new);
     let mut detail_state =
         use_signal(|| FetchState::<EntityDetailStore>::Loaded(EntityDetailStore::default()));
     let mut nav_history = use_signal(EntityNavigationHistory::new);
     let mut selected_entity_id: Signal<Option<String>> = use_signal(|| None);
+    let mut facts_state = use_signal(FactsSnapshot::default);
+    let mut nous_scope: Signal<Option<String>> = use_signal(|| None);
 
     let mut list_width = use_signal(|| DEFAULT_LIST_WIDTH);
     let mut is_resizing = use_signal(|| false);
@@ -147,14 +193,14 @@ pub(crate) fn Memory() -> Element {
     let mut preservation = use_context::<Signal<ViewPreservationStore>>();
     use_hook(|| {
         if let Some(saved) = preservation.write().restore(&ViewKey::Memory) {
-            // NOTE: an empty preserved input means no search was active; leave
-            // the store's default query untouched.
+            // Restore search query from the preserved input text.
             if !saved.input_text.is_empty() {
                 list_store.write().search_query = saved.input_text;
             }
         }
     });
 
+    // Save state on unmount.
     use_drop(move || {
         preservation.write().save(
             ViewKey::Memory,
@@ -169,7 +215,10 @@ pub(crate) fn Memory() -> Element {
     let fetch_entities = {
         move || {
             let cfg = config.read().clone();
-            let store = list_store.read();
+            let scope = nous_scope.read().clone();
+            // WHY: peek, not read — the fetch writes list_store on completion,
+            // and a tracked read here would re-trigger the mount effect forever.
+            let store = list_store.peek();
             let search = store.search_query.clone();
             let sort = store.sort;
             let type_filter = store.type_filter.clone();
@@ -228,6 +277,12 @@ pub(crate) fn Memory() -> Element {
                     url.push_str(&format!("&agent={encoded}"));
                 }
 
+                if let Some(ref nous) = scope {
+                    let encoded: String =
+                        form_urlencoded::byte_serialize(nous.as_bytes()).collect();
+                    url.push_str(&format!("&agent={encoded}"));
+                }
+
                 match client.get(&url).send().await {
                     Ok(resp) if resp.status().is_success() => {
                         let text = match resp.text().await {
@@ -238,17 +293,21 @@ pub(crate) fn Memory() -> Element {
                             }
                         };
 
-                        let entities: Vec<Entity> = if let Ok(list) =
-                            serde_json::from_str::<Vec<Entity>>(&text)
-                        {
-                            list
-                        } else if let Ok(wrapper) = serde_json::from_str::<EntitiesResponse>(&text)
+                        // WHY: deserialize through EntityWire — the server sends
+                        // entity_type as a free-form string ("person"), which the
+                        // EntityType enum's derived Deserialize rejects, killing
+                        // the whole response parse and blanking the explorer.
+                        let wires: Vec<EntityWire> = if let Ok(wrapper) =
+                            serde_json::from_str::<EntitiesResponse>(&text)
                         {
                             wrapper.entities
+                        } else if let Ok(list) = serde_json::from_str::<Vec<EntityWire>>(&text) {
+                            list
                         } else {
                             tracing::warn!("failed to parse entities response");
                             return;
                         };
+                        let entities: Vec<Entity> = wires.into_iter().map(Entity::from).collect();
 
                         let has_more = entities.len() >= EntityListStore::PAGE_SIZE;
 
@@ -271,8 +330,48 @@ pub(crate) fn Memory() -> Element {
         }
     };
 
+    let fetch_facts = {
+        move || {
+            let cfg = config.read().clone();
+            let scope = nous_scope.read().clone();
+
+            spawn(async move {
+                let client = authenticated_client(&cfg);
+                let base = cfg.server_url.trim_end_matches('/');
+
+                let mut url = format!(
+                    "{base}/api/v1/knowledge/facts?limit={FACTS_FETCH_LIMIT}&sort=recency&order=desc"
+                );
+                if let Some(ref nous) = scope {
+                    let encoded: String =
+                        form_urlencoded::byte_serialize(nous.as_bytes()).collect();
+                    url.push_str(&format!("&nous_id={encoded}"));
+                }
+
+                match client.get(&url).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        match resp.json::<FactsSnapshot>().await {
+                            Ok(mut snapshot) => {
+                                snapshot.loaded = true;
+                                facts_state.set(snapshot);
+                            }
+                            Err(e) => tracing::warn!("failed to parse facts response: {e}"),
+                        }
+                    }
+                    Ok(resp) => {
+                        tracing::warn!(status = %resp.status(), "facts request failed");
+                    }
+                    Err(e) => {
+                        tracing::warn!("facts connection error: {e}");
+                    }
+                }
+            });
+        }
+    };
+
     use_effect(move || {
         fetch_entities();
+        fetch_facts();
     });
 
     let fetch_detail = {
@@ -286,6 +385,7 @@ pub(crate) fn Memory() -> Element {
                 let base = cfg.server_url.trim_end_matches('/');
                 let encoded: String = form_urlencoded::byte_serialize(id.as_bytes()).collect();
 
+                // Fetch entity detail, relationships, and memories in parallel.
                 let entity_url = format!("{base}/api/v1/knowledge/entities/{encoded}");
                 let rels_url = format!("{base}/api/v1/knowledge/entities/{encoded}/relationships");
                 let mems_url = format!("{base}/api/v1/knowledge/entities/{encoded}/memories");
@@ -296,32 +396,40 @@ pub(crate) fn Memory() -> Element {
 
                 let (entity_res, rels_res, mems_res) = tokio::join!(entity_fut, rels_fut, mems_fut);
 
-                let entity: Option<Entity> = match entity_res {
-                    Ok(resp) if resp.status().is_success() => resp.json::<Entity>().await.ok(),
+                // WHY: response bodies stream in after send() resolves; they
+                // must be awaited fully — a single poll yields no data.
+                let mut entity: Option<Entity> = match entity_res {
+                    Ok(r) if r.status().is_success() => {
+                        r.json::<EntityWire>().await.ok().map(Entity::from)
+                    }
                     _ => None,
                 };
-
-                // WHY: If the entity fetch failed, still try to show what we can.
+                if entity.is_none() {
+                    // WHY: detail endpoint may be unavailable (knowledge store
+                    // disabled); fall back to the already-fetched list row.
+                    entity = list_store
+                        .peek()
+                        .entities
+                        .iter()
+                        .find(|e| e.id == id)
+                        .cloned();
+                }
 
                 let relationships: Vec<Relationship> = match rels_res {
-                    Ok(resp) if resp.status().is_success() => match resp.text().await {
-                        Ok(text) => parse_relationships_response(&text),
-                        Err(e) => {
-                            tracing::warn!("failed to read relationships response: {e}");
-                            Vec::new()
-                        }
+                    Ok(r) if r.status().is_success() => match r.text().await {
+                        Ok(text) => serde_json::from_str::<RelationshipsResponse>(&text)
+                            .map(|w| w.relationships)
+                            .or_else(|_| serde_json::from_str::<Vec<Relationship>>(&text))
+                            .unwrap_or_default(),
+                        Err(_) => Vec::new(),
                     },
                     _ => Vec::new(),
                 };
 
                 let memories: Vec<EntityMemory> = match mems_res {
-                    Ok(resp) if resp.status().is_success() => match resp.text().await {
-                        Ok(text) => parse_entity_memories_response(&text),
-                        Err(e) => {
-                            tracing::warn!("failed to read entity memories response: {e}");
-                            Vec::new()
-                        }
-                    },
+                    Ok(r) if r.status().is_success() => {
+                        r.json::<Vec<EntityMemory>>().await.unwrap_or_default()
+                    }
                     _ => Vec::new(),
                 };
 
@@ -350,9 +458,39 @@ pub(crate) fn Memory() -> Element {
     let can_forward = nav_history.read().can_go_forward();
     let breadcrumbs: Vec<String> = nav_history.read().breadcrumbs().to_vec();
 
+    // Nous scope pills: (id, label) per known agent, mirroring the sidebar roster.
+    let nous_pills: Vec<(String, String)> = agent_store
+        .read()
+        .all()
+        .iter()
+        .map(|rec| {
+            let emoji = rec.agent.emoji.clone().unwrap_or_default();
+            let label = if emoji.is_empty() {
+                rec.display_name().to_string()
+            } else {
+                format!("{emoji} {}", rec.display_name())
+            };
+            (rec.agent.id.to_string(), label)
+        })
+        .collect();
+    let active_scope = nous_scope.read().clone();
+    let scope_label: Option<String> = active_scope.as_deref().and_then(|scope_id| {
+        nous_pills
+            .iter()
+            .find(|(id, _)| id == scope_id)
+            .map(|(_, label)| label.clone())
+    });
+
+    // WHY: an entity-empty store with no filters is the correct-empty case
+    // (facts exist but the graph has not linked them yet) — show facts, not
+    // a blank pane. Filtered-empty keeps the normal list's "No entities found".
+    let show_facts_fallback =
+        list_store.read().entities.is_empty() && !list_store.read().has_active_filters();
+
     rsx! {
         div {
             style: "{MEMORY_LAYOUT_STYLE}",
+            // Header
             div {
                 style: "{HEADER_STYLE}",
                 h2 {
@@ -361,6 +499,7 @@ pub(crate) fn Memory() -> Element {
                 }
                 div {
                     style: "display: flex; gap: var(--space-2); align-items: center;",
+                    // Back/forward navigation
                     button {
                         style: if can_back { "{NAV_BTN_STYLE}" } else { "{NAV_BTN_DISABLED_STYLE}" },
                         disabled: !can_back,
@@ -396,12 +535,53 @@ pub(crate) fn Memory() -> Element {
                         onclick: move |_| {
                             list_store.write().page = 0;
                             fetch_entities();
+                            fetch_facts();
                         },
                         "Refresh"
                     }
                 }
             }
 
+            // Nous scope pills
+            if !nous_pills.is_empty() {
+                div {
+                    style: "{NOUS_PILL_ROW_STYLE}",
+                    button {
+                        style: if active_scope.is_none() { "{NOUS_PILL_ACTIVE_STYLE}" } else { "{NOUS_PILL_STYLE}" },
+                        onclick: move |_| {
+                            if nous_scope.peek().is_some() {
+                                list_store.write().page = 0;
+                                nous_scope.set(None);
+                            }
+                        },
+                        "All"
+                    }
+                    for (id , label) in nous_pills.iter() {
+                        {
+                            let is_active = active_scope.as_deref() == Some(id.as_str());
+                            let id_for_click = id.clone();
+                            rsx! {
+                                button {
+                                    key: "nous-{id}",
+                                    style: if is_active { "{NOUS_PILL_ACTIVE_STYLE}" } else { "{NOUS_PILL_STYLE}" },
+                                    onclick: move |_| {
+                                        let next = if nous_scope.peek().as_deref() == Some(id_for_click.as_str()) {
+                                            None
+                                        } else {
+                                            Some(id_for_click.clone())
+                                        };
+                                        list_store.write().page = 0;
+                                        nous_scope.set(next);
+                                    },
+                                    "{label}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Breadcrumbs
             if breadcrumbs.len() > 1 {
                 div {
                     style: "{BREADCRUMB_STYLE}",
@@ -432,6 +612,7 @@ pub(crate) fn Memory() -> Element {
                 }
             }
 
+            // Search bar
             EntitySearchBar {
                 list_store,
                 on_search_change: move |_query: String| {
@@ -448,71 +629,83 @@ pub(crate) fn Memory() -> Element {
                 },
             }
 
-            div {
-                style: "{PANELS_STYLE}",
-                onmousemove: move |evt: Event<MouseData>| {
-                    if *is_resizing.read() {
-                        let delta = evt.client_coordinates().x - *resize_start_x.read();
-                        let new_width = (*resize_start_width.read() + delta)
-                            .clamp(MIN_LIST_WIDTH, MAX_LIST_WIDTH);
-                        list_width.set(new_width);
-                    }
-                },
-                onmouseup: move |_| {
-                    is_resizing.set(false);
-                },
-                div {
-                    style: "{LIST_PANEL_STYLE} width: {width}px;",
-                    EntityList {
-                        list_store,
-                        selected_id: selected_entity_id.read().clone(),
-                        on_select_entity: {
-                            let mut navigate = navigate_to_entity;
-                            move |id: String| {
-                                navigate(id);
-                            }
-                        },
-                        on_sort_change: move |sort: EntitySort| {
-                            let mut store = list_store.write();
-                            store.sort = sort;
-                            store.sort_entities();
-                        },
-                        on_load_more: move |_| {
-                            list_store.write().page += 1;
-                            fetch_entities();
-                        },
-                    }
+            // Facts fallback (correct-empty graph) or the two-panel explorer
+            if show_facts_fallback {
+                FactsPanel {
+                    snapshot: facts_state.read().clone(),
+                    scope_label,
                 }
+            } else {
                 div {
-                    style: "{RESIZE_HANDLE_STYLE}",
-                    onmousedown: move |evt: Event<MouseData>| {
-                        is_resizing.set(true);
-                        resize_start_x.set(evt.client_coordinates().x);
-                        resize_start_width.set(*list_width.read());
+                    style: "{PANELS_STYLE}",
+                    onmousemove: move |evt: Event<MouseData>| {
+                        if *is_resizing.read() {
+                            let delta = evt.client_coordinates().x - *resize_start_x.read();
+                            let new_width = (*resize_start_width.read() + delta)
+                                .clamp(MIN_LIST_WIDTH, MAX_LIST_WIDTH);
+                            list_width.set(new_width);
+                        }
                     },
-                }
-                div {
-                    style: "{DETAIL_PANEL_STYLE}",
-                    if selected_entity_id.read().is_some() {
-                        EntityDetail {
-                            detail_state,
+                    onmouseup: move |_| {
+                        is_resizing.set(false);
+                    },
+                    // List panel
+                    div {
+                        style: "{LIST_PANEL_STYLE} width: {width}px;",
+                        EntityList {
                             list_store,
-                            on_navigate_entity: {
+                            selected_id: selected_entity_id.read().clone(),
+                            on_select_entity: {
                                 let mut navigate = navigate_to_entity;
                                 move |id: String| {
                                     navigate(id);
                                 }
                             },
-                            on_entity_changed: move |_| {
-                                // WHY: Refresh list after merge/delete/flag to reflect changes.
-                                list_store.write().page = 0;
+                            on_sort_change: move |sort: EntitySort| {
+                                let mut store = list_store.write();
+                                store.sort = sort;
+                                store.sort_entities();
+                            },
+                            on_load_more: move |_| {
+                                list_store.write().page += 1;
                                 fetch_entities();
                             },
                         }
-                    } else {
-                        div {
-                            style: "{EMPTY_DETAIL_STYLE}",
-                            "Select an entity to view details"
+                    }
+                    // Resize handle
+                    div {
+                        style: "{RESIZE_HANDLE_STYLE}",
+                        onmousedown: move |evt: Event<MouseData>| {
+                            is_resizing.set(true);
+                            resize_start_x.set(evt.client_coordinates().x);
+                            resize_start_width.set(*list_width.read());
+                        },
+                    }
+                    // Detail panel
+                    div {
+                        style: "{DETAIL_PANEL_STYLE}",
+                        if selected_entity_id.read().is_some() {
+                            EntityDetail {
+                                detail_state,
+                                list_store,
+                                on_navigate_entity: {
+                                    let mut navigate = navigate_to_entity;
+                                    move |id: String| {
+                                        navigate(id);
+                                    }
+                                },
+                                on_entity_changed: move |_| {
+                                    // WHY: Refresh list after merge/delete/flag to reflect changes.
+                                    list_store.write().page = 0;
+                                    fetch_entities();
+                                    fetch_facts();
+                                },
+                            }
+                        } else {
+                            div {
+                                style: "{EMPTY_DETAIL_STYLE}",
+                                "Select an entity to view details"
+                            }
                         }
                     }
                 }
@@ -521,58 +714,73 @@ pub(crate) fn Memory() -> Element {
     }
 }
 
-/// Response wrapper for entity list endpoint.
+/// Response wrapper for the entity list endpoint.
 #[derive(Debug, serde::Deserialize)]
 struct EntitiesResponse {
-    entities: Vec<Entity>,
+    entities: Vec<EntityWire>,
 }
 
 /// Response wrapper for the entity relationships endpoint.
 #[derive(Debug, serde::Deserialize)]
 struct RelationshipsResponse {
-    #[serde(default)]
     relationships: Vec<Relationship>,
 }
 
-/// Response wrapper for the entity memories endpoint.
+/// Wire shape for one entity row; `entity_type` arrives as a free-form string.
 #[derive(Debug, serde::Deserialize)]
-struct EntityMemoriesResponse {
+struct EntityWire {
+    // kanon:ignore RUST/primitive-for-domain-id — mirrors server-side string IDs from the knowledge API
+    id: String,
+    name: String,
     #[serde(default)]
-    memories: Vec<EntityMemory>,
+    entity_type: String,
+    #[serde(default)]
+    confidence: f64,
+    #[serde(default)]
+    page_rank: f64,
+    #[serde(default)]
+    memory_count: u32,
+    #[serde(default)]
+    relationship_count: u32,
+    #[serde(default)]
+    properties: Vec<EntityProperty>,
+    #[serde(default)]
+    updated_at: Option<String>,
+    #[serde(default)]
+    created_by: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    flagged: bool,
 }
 
-/// Parse the `{relationships: [...]}` envelope, falling back to a bare array.
-fn parse_relationships_response(text: &str) -> Vec<Relationship> {
-    match serde_json::from_str::<RelationshipsResponse>(text) {
-        Ok(wrapper) => wrapper.relationships,
-        Err(wrapped_err) => match serde_json::from_str::<Vec<Relationship>>(text) {
-            Ok(list) => list,
-            Err(array_err) => {
-                tracing::warn!(
-                    wrapped_error = %wrapped_err,
-                    array_error = %array_err,
-                    "failed to parse relationships response"
-                );
-                Vec::new()
-            }
-        },
+impl From<EntityWire> for Entity {
+    fn from(wire: EntityWire) -> Self {
+        Self {
+            id: wire.id,
+            name: wire.name,
+            entity_type: parse_entity_type(&wire.entity_type),
+            confidence: wire.confidence,
+            page_rank: wire.page_rank,
+            memory_count: wire.memory_count,
+            relationship_count: wire.relationship_count,
+            properties: wire.properties,
+            updated_at: wire.updated_at,
+            created_by: wire.created_by,
+            created_at: wire.created_at,
+            flagged: wire.flagged,
+        }
     }
 }
 
-/// Parse the `{memories: [...]}` envelope, falling back to a bare array.
-fn parse_entity_memories_response(text: &str) -> Vec<EntityMemory> {
-    match serde_json::from_str::<EntityMemoriesResponse>(text) {
-        Ok(wrapper) => wrapper.memories,
-        Err(wrapped_err) => match serde_json::from_str::<Vec<EntityMemory>>(text) {
-            Ok(list) => list,
-            Err(array_err) => {
-                tracing::warn!(
-                    wrapped_error = %wrapped_err,
-                    array_error = %array_err,
-                    "failed to parse entity memories response"
-                );
-                Vec::new()
-            }
-        },
+/// Map a server entity-type string onto the fixed display set, case-insensitively.
+fn parse_entity_type(raw: &str) -> EntityType {
+    if raw.is_empty() {
+        return EntityType::Other("Unknown".to_string());
     }
+    EntityType::FIXED
+        .iter()
+        .find(|et| et.label().eq_ignore_ascii_case(raw))
+        .cloned()
+        .unwrap_or_else(|| EntityType::Other(raw.to_string()))
 }

--- a/crates/theatron/proskenion/src/views/memory/search.rs
+++ b/crates/theatron/proskenion/src/views/memory/search.rs
@@ -51,11 +51,12 @@ const CHIPS_ROW_STYLE: &str = "\
 const CHIP_STYLE: &str = "\
     display: flex; \
     align-items: center; \
-    gap: var(--space-1); \
-    background: var(--border); \
+    gap: var(--space-2); \
+    background: var(--bg-surface); \
     color: var(--text-primary); \
-    border-radius: var(--radius-lg); \
-    padding: var(--space-1) 10px; \
+    border: 1px solid var(--border); \
+    border-radius: var(--radius-full); \
+    padding: var(--space-1) var(--space-3); \
     font-size: var(--text-xs);\
 ";
 
@@ -70,7 +71,7 @@ const CHIP_DISMISS_STYLE: &str = "\
 ";
 
 const CLEAR_ALL_STYLE: &str = "\
-    color: #7a7aff; \
+    color: var(--accent); \
     font-size: var(--text-xs); \
     cursor: pointer; \
     background: none; \
@@ -191,7 +192,7 @@ pub(crate) fn EntitySearchBar(
                             rsx! {
                                 div {
                                     key: "type-{label}",
-                                    style: "{CHIP_STYLE} border: 1px solid {color}44;",
+                                    style: "{CHIP_STYLE} border-color: color-mix(in srgb, {color} 35%, transparent);",
                                     span { style: "color: {color};", "{label}" }
                                     span {
                                         style: "{CHIP_DISMISS_STYLE}",

--- a/crates/theatron/proskenion/src/views/meta/assembly.rs
+++ b/crates/theatron/proskenion/src/views/meta/assembly.rs
@@ -5,8 +5,9 @@ use std::collections::HashMap;
 use super::{
     AgentEntry, AgentPerformanceApiResponse, AgentPerformanceStore, CostMetricsApiResponse,
     EntityEntry, FactEntry, HealthApiResponse, JournalEventEntry, KnowledgeGrowthStore,
-    MemoryHealthStore, MetaData, QualityMetricsApiResponse, QualityStore, SessionEntry,
-    SystemReflectionStore, TimeSeriesPointEntry, TimelineEntry, TokenMetricsApiResponse,
+    META_SERIES_COLORS, MemoryHealthStore, MetaData, QualityMetricsApiResponse, QualityStore,
+    SessionEntry, SystemReflectionStore, TimeSeriesPointEntry, TimelineEntry,
+    TokenMetricsApiResponse,
 };
 
 /// Assemble all fetched data into the composite `MetaData` structure.
@@ -27,7 +28,7 @@ pub(super) fn assemble_meta_data(
     quality: QualityMetricsApiResponse,
     journal: Vec<JournalEventEntry>,
 ) -> MetaData {
-    // ── Performance ──
+    // -- Performance --
     let mut scorecards = Vec::new();
     let mut anomalies = Vec::new();
     let mut tokens_per_response_series: HashMap<String, Vec<crate::state::meta::DataPoint>> =
@@ -114,7 +115,7 @@ pub(super) fn assemble_meta_data(
         endpoint_available: true,
     };
 
-    // ── Quality ──
+    // -- Quality --
     let mut depth = crate::state::meta::DepthDistribution::default();
     for s in &sessions {
         match crate::state::meta::DepthDistribution::classify(s.message_count) {
@@ -139,7 +140,7 @@ pub(super) fn assemble_meta_data(
         charts_endpoint_available: true,
     };
 
-    // ── Knowledge growth ──
+    // -- Knowledge growth --
     let total_entity_count = usize_to_u64(entities.len());
     let total_relationship_count: u32 = entities.iter().map(|e| e.relationship_count).sum();
 
@@ -182,8 +183,7 @@ pub(super) fn assemble_meta_data(
             |(i, (t, count)): (usize, (&str, u32))| crate::state::meta::EntityTypeSlice {
                 entity_type: t.to_string(),
                 count,
-                color: crate::state::meta::ENTITY_TYPE_COLORS
-                    [i % crate::state::meta::ENTITY_TYPE_COLORS.len()],
+                color: META_SERIES_COLORS[i % META_SERIES_COLORS.len()],
             },
         )
         .collect();
@@ -212,7 +212,7 @@ pub(super) fn assemble_meta_data(
         acceleration,
     };
 
-    // ── Memory health ──
+    // -- Memory health --
     let avg_confidence = if facts.is_empty() {
         0.0
     } else {

--- a/crates/theatron/proskenion/src/views/meta/charts.rs
+++ b/crates/theatron/proskenion/src/views/meta/charts.rs
@@ -4,6 +4,15 @@ use dioxus::prelude::*;
 
 use super::MUTED_TEXT;
 
+const PAD: f64 = 30.0;
+/// Left padding leaves room for right-anchored y-axis value ticks.
+const PAD_LEFT: f64 = 44.0;
+
+/// WHY: SVGs declare intrinsic width/height for aspect ratio but render at
+/// 100% of the containing card, so charts fill the pane in both themes and
+/// scale with the window.
+const RESPONSIVE_SVG_STYLE: &str = "display: block; width: 100%; height: auto;";
+
 /// Render a simple SVG line chart.
 #[component]
 pub(crate) fn LineChart(
@@ -25,9 +34,8 @@ pub(crate) fn LineChart(
         .fold(f64::NEG_INFINITY, f64::max)
         .max(1.0);
 
-    let padding = 30.0;
-    let chart_w = width - padding * 2.0;
-    let chart_h = height - padding * 2.0;
+    let chart_w = width - PAD_LEFT - PAD;
+    let chart_h = height - PAD * 2.0;
 
     let points: Vec<(f64, f64)> = data
         .iter()
@@ -39,13 +47,13 @@ pub(crate) fn LineChart(
                         clippy::as_conversions,
                         reason = "point index to f64 for SVG coordinate"
                     )]
-                    let x = padding + (i as f64 / (data.len() - 1) as f64) * chart_w;
+                    let x = PAD_LEFT + (i as f64 / (data.len() - 1) as f64) * chart_w;
                     x
                 }
             } else {
-                padding + chart_w / 2.0
+                PAD_LEFT + chart_w / 2.0
             };
-            let y = padding + chart_h - (p.value / max_val) * chart_h;
+            let y = PAD + chart_h - (p.value / max_val) * chart_h;
             (x, y)
         })
         .collect();
@@ -70,24 +78,9 @@ pub(crate) fn LineChart(
             width: "{width}",
             height: "{height}",
             view_box: "{viewbox}",
-            style: "display: block;",
+            style: "{RESPONSIVE_SVG_STYLE}",
 
-            // NOTE: Grid lines.
-            for i in 0..5u32 {
-                {
-                    let y = padding + (f64::from(i) / 4.0) * chart_h;
-                    rsx! {
-                        line {
-                            x1: "{padding}",
-                            y1: "{y:.1}",
-                            x2: "{padding + chart_w:.1}",
-                            y2: "{y:.1}",
-                            stroke: "var(--border)",
-                            stroke_width: "1",
-                        }
-                    }
-                }
-            }
+            {grid_elements(max_val, chart_w, chart_h)}
 
             path {
                 d: "{path}",
@@ -144,7 +137,7 @@ fn label_elements(
                 x: "{x:.1}",
                 y: "{y_pos}",
                 fill: "var(--text-muted)",
-                font_size: "10",
+                font_size: "11",
                 text_anchor: "start",
                 "{label}"
             }
@@ -154,11 +147,57 @@ fn label_elements(
                 x: "{x:.1}",
                 y: "{y_pos}",
                 fill: "var(--text-muted)",
-                font_size: "10",
+                font_size: "11",
                 text_anchor: "end",
                 "{label}"
             }
         }
+    }
+}
+
+/// Build horizontal gridlines with right-anchored y-axis value ticks.
+///
+/// WHY: Extracted for the same rsx-parser reason as `label_elements`; shared
+/// by the line and bar charts so both carry readable value axes.
+fn grid_elements(max_val: f64, chart_w: f64, chart_h: f64) -> Element {
+    rsx! {
+        for i in 0..5u32 {
+            {
+                let y = PAD + (f64::from(i) / 4.0) * chart_h;
+                let tick = format_axis_value(max_val * (1.0 - f64::from(i) / 4.0));
+                rsx! {
+                    line {
+                        x1: "{PAD_LEFT:.1}",
+                        y1: "{y:.1}",
+                        x2: "{PAD_LEFT + chart_w:.1}",
+                        y2: "{y:.1}",
+                        stroke: "var(--border)",
+                        stroke_width: "1",
+                    }
+                    text {
+                        x: "{PAD_LEFT - 6.0:.1}",
+                        y: "{y + 3.0:.1}",
+                        fill: "var(--text-muted)",
+                        font_size: "10",
+                        text_anchor: "end",
+                        "{tick}"
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Compact axis tick formatting (K/M suffix, short decimals).
+fn format_axis_value(v: f64) -> String {
+    if v >= 1_000_000.0 {
+        format!("{:.1}M", v / 1_000_000.0)
+    } else if v >= 1_000.0 {
+        format!("{:.1}K", v / 1_000.0)
+    } else if v >= 10.0 || v == 0.0 {
+        format!("{v:.0}")
+    } else {
+        format!("{v:.1}")
     }
 }
 
@@ -182,9 +221,8 @@ pub(crate) fn BarChart(
         .fold(f64::NEG_INFINITY, f64::max)
         .max(1.0);
 
-    let padding = 30.0;
-    let chart_w = width - padding * 2.0;
-    let chart_h = height - padding * 2.0;
+    let chart_w = width - PAD_LEFT - PAD;
+    let chart_h = height - PAD * 2.0;
     #[expect(clippy::as_conversions, reason = "data count to f64 for SVG bar width")]
     let bar_width = (chart_w / data.len() as f64) * 0.7;
     #[expect(clippy::as_conversions, reason = "data count to f64 for SVG gap")]
@@ -192,19 +230,33 @@ pub(crate) fn BarChart(
 
     let viewbox = format!("0 0 {width} {height}");
 
+    // WHY: Label only every Nth bar so x-axis labels never overlap on dense
+    // series; ~70 viewBox units per label keeps date strings legible.
+    #[expect(clippy::as_conversions, reason = "bounded label stride for display")]
+    let label_step = ((data.len() as f64) * 70.0 / chart_w).ceil().max(1.0) as usize;
+
     rsx! {
         svg {
             width: "{width}",
             height: "{height}",
             view_box: "{viewbox}",
-            style: "display: block;",
+            style: "{RESPONSIVE_SVG_STYLE}",
+
+            {grid_elements(max_val, chart_w, chart_h)}
 
             for (i , point) in data.iter().enumerate() {
                 {
                     let bar_h = (point.value / max_val) * chart_h;
                     #[expect(clippy::as_conversions, reason = "bar index to f64 for SVG position")]
-                    let x = padding + (i as f64 * (bar_width + gap)) + gap / 2.0;
-                    let y = padding + chart_h - bar_h;
+                    let x = PAD_LEFT + (i as f64 * (bar_width + gap)) + gap / 2.0;
+                    let y = PAD + chart_h - bar_h;
+                    // NOTE: Empty label skips rendering without an rsx `if`
+                    // around a `text` node (parser limitation, see above).
+                    let label = if i % label_step == 0 {
+                        point.label.as_str()
+                    } else {
+                        ""
+                    };
                     rsx! {
                         rect {
                             x: "{x:.1}",
@@ -218,9 +270,9 @@ pub(crate) fn BarChart(
                             x: "{x + bar_width / 2.0:.1}",
                             y: "{height - 4.0:.1}",
                             fill: "var(--text-muted)",
-                            font_size: "9",
+                            font_size: "10",
                             text_anchor: "middle",
-                            "{point.label}"
+                            "{label}"
                         }
                     }
                 }

--- a/crates/theatron/proskenion/src/views/meta/drilldown.rs
+++ b/crates/theatron/proskenion/src/views/meta/drilldown.rs
@@ -1,0 +1,163 @@
+//! Chart drill-down: clickable chart cards that expand into a modal overlay.
+
+use dioxus::prelude::*;
+
+use crate::state::meta::DataPoint;
+
+use super::{BarChart, CARD_LABEL, CARD_STYLE, LineChart};
+
+/// Which renderer an expandable chart card uses.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum ChartKind {
+    Line,
+    Bar,
+}
+
+/// Chart currently selected for the enlarged drill-down overlay.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ExpandedChart {
+    pub title: &'static str,
+    pub kind: ChartKind,
+    pub data: Vec<DataPoint>,
+    pub color: &'static str,
+}
+
+const BACKDROP_STYLE: &str = "\
+    position: fixed; \
+    top: 0; \
+    left: 0; \
+    right: 0; \
+    bottom: 0; \
+    background: var(--bg-overlay); \
+    display: flex; \
+    align-items: center; \
+    justify-content: center; \
+    z-index: var(--z-modal);\
+";
+
+const DIALOG_STYLE: &str = "\
+    background: var(--bg-surface); \
+    border: 1px solid var(--border); \
+    border-radius: var(--radius-lg); \
+    box-shadow: var(--shadow-modal); \
+    padding: var(--space-6); \
+    width: min(90vw, 1000px); \
+    max-height: 85vh; \
+    overflow-y: auto;\
+";
+
+const DIALOG_HEADER_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    justify-content: space-between; \
+    margin-bottom: var(--space-4);\
+";
+
+const CLOSE_BTN_STYLE: &str = "\
+    background: var(--bg-surface); \
+    color: var(--text-secondary); \
+    border: 1px solid var(--input-border); \
+    border-radius: var(--radius-md); \
+    padding: var(--space-1) var(--space-3); \
+    font-size: var(--text-xs); \
+    cursor: pointer; \
+    transition: background-color var(--transition-quick), \
+                color var(--transition-quick), \
+                border-color var(--transition-quick);\
+";
+
+/// Card wrapping a chart; clicking anywhere on it opens the drill-down overlay.
+#[component]
+pub(crate) fn ChartCard(
+    title: &'static str,
+    kind: ChartKind,
+    data: Vec<DataPoint>,
+    color: &'static str,
+    width: f64,
+    height: f64,
+    card_style: &'static str,
+) -> Element {
+    let mut expanded: Signal<Option<ExpandedChart>> = use_context();
+    let modal_data = data.clone();
+
+    rsx! {
+        div {
+            style: "{CARD_STYLE} cursor: zoom-in; {card_style}",
+            title: "Click to enlarge",
+            onclick: move |_| {
+                expanded.set(Some(ExpandedChart {
+                    title,
+                    kind,
+                    data: modal_data.clone(),
+                    color,
+                }));
+            },
+            div {
+                style: "display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--space-2);",
+                div { style: "{CARD_LABEL} margin-top: 0;", "{title}" }
+                span { style: "color: var(--text-muted); font-size: var(--text-xs);", "\u{2922}" }
+            }
+            ChartByKind { kind, data, color, width, height }
+        }
+    }
+}
+
+/// Dispatch to the line or bar renderer.
+#[component]
+fn ChartByKind(
+    kind: ChartKind,
+    data: Vec<DataPoint>,
+    color: &'static str,
+    width: f64,
+    height: f64,
+) -> Element {
+    match kind {
+        ChartKind::Line => rsx! {
+            LineChart { data, width, height, color, show_labels: true }
+        },
+        ChartKind::Bar => rsx! {
+            BarChart { data, width, height, color }
+        },
+    }
+}
+
+/// Modal overlay rendering the selected chart at full pane width.
+///
+/// Closes on backdrop click or the explicit close button.
+#[component]
+pub(super) fn ChartDrilldown() -> Element {
+    let mut expanded: Signal<Option<ExpandedChart>> = use_context();
+    let current = expanded.read().clone();
+
+    rsx! {
+        if let Some(chart) = current {
+            div {
+                style: "{BACKDROP_STYLE}",
+                onclick: move |_| expanded.set(None),
+                div {
+                    style: "{DIALOG_STYLE}",
+                    onclick: move |e| e.stop_propagation(),
+                    div {
+                        style: "{DIALOG_HEADER_STYLE}",
+                        h3 {
+                            style: "font-size: var(--text-lg); color: var(--text-primary); margin: 0;",
+                            "{chart.title}"
+                        }
+                        button {
+                            style: "{CLOSE_BTN_STYLE}",
+                            onclick: move |_| expanded.set(None),
+                            "Close"
+                        }
+                    }
+                    ChartByKind {
+                        kind: chart.kind,
+                        data: chart.data.clone(),
+                        color: chart.color,
+                        width: 940.0,
+                        height: 420.0,
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/theatron/proskenion/src/views/meta/health.rs
+++ b/crates/theatron/proskenion/src/views/meta/health.rs
@@ -4,7 +4,7 @@ use dioxus::prelude::*;
 
 use crate::state::meta::{MemoryHealthStore, health_score_color};
 use crate::views::meta::{
-    CARD_LABEL, CARD_STYLE, CARD_SUB, CARD_VALUE, GRID_STYLE, LineChart, MUTED_TEXT,
+    CARD_LABEL, CARD_STYLE, CARD_SUB, CARD_VALUE, ChartCard, ChartKind, GRID_STYLE, MUTED_TEXT,
 };
 
 const TABLE_HEADER_STYLE: &str = "\
@@ -85,19 +85,14 @@ pub(super) fn MemoryHealthSection(store: MemoryHealthStore) -> Element {
 
         // NOTE: Health trend over time.
         if !store.health_over_time.is_empty() {
-            h3 {
-                style: "font-size: var(--text-base); color: var(--text-secondary); margin: var(--space-4) 0 var(--space-3) 0;",
-                "Health Trend"
-            }
-            div {
-                style: "{CARD_STYLE}",
-                LineChart {
-                    data: store.health_over_time.clone(),
-                    width: 600.0,
-                    height: 150.0,
-                    color: "var(--status-success)",
-                    show_labels: true,
-                }
+            ChartCard {
+                title: "Health Trend",
+                kind: ChartKind::Line,
+                data: store.health_over_time.clone(),
+                color: "var(--status-success)",
+                width: 960.0,
+                height: 220.0,
+                card_style: "margin-top: var(--space-3);",
             }
         }
 
@@ -214,7 +209,7 @@ fn confidence_bucket_color(range_label: &str) -> &'static str {
     // WHY: Higher confidence = greener, lower = redder.
     match range_label {
         s if s.starts_with("0.8") || s.starts_with("0.9") => "var(--status-success)",
-        s if s.starts_with("0.6") || s.starts_with("0.7") => "#4a9aff",
+        s if s.starts_with("0.6") || s.starts_with("0.7") => "var(--status-info)",
         s if s.starts_with("0.4") || s.starts_with("0.5") => "var(--status-warning)",
         _ => "var(--status-error)",
     }

--- a/crates/theatron/proskenion/src/views/meta/knowledge.rs
+++ b/crates/theatron/proskenion/src/views/meta/knowledge.rs
@@ -4,8 +4,10 @@ use dioxus::prelude::*;
 
 use crate::state::meta::KnowledgeGrowthStore;
 use crate::views::meta::{
-    BarChart, CARD_LABEL, CARD_STYLE, CARD_SUB, CARD_VALUE, GRID_STYLE, LineChart,
+    CARD_LABEL, CARD_STYLE, CARD_SUB, CARD_VALUE, ChartCard, ChartKind, GRID_STYLE,
 };
+
+const STACKED_CARD_STYLE: &str = "margin-top: var(--space-3);";
 
 #[component]
 pub(super) fn KnowledgeGrowthSection(store: KnowledgeGrowthStore) -> Element {
@@ -45,51 +47,37 @@ pub(super) fn KnowledgeGrowthSection(store: KnowledgeGrowthStore) -> Element {
         }
 
         // NOTE: Cumulative entity growth.
-        h3 {
-            style: "font-size: var(--text-base); color: var(--text-secondary); margin: var(--space-4) 0 var(--space-3) 0;",
-            "Total Entities Over Time"
-        }
-        div {
-            style: "{CARD_STYLE}",
-            LineChart {
-                data: store.total_entities.clone(),
-                width: 600.0,
-                height: 200.0,
-                color: "#4a9aff",
-                show_labels: true,
-            }
+        ChartCard {
+            title: "Total Entities Over Time",
+            kind: ChartKind::Line,
+            data: store.total_entities.clone(),
+            color: "var(--natural)",
+            width: 960.0,
+            height: 280.0,
+            card_style: STACKED_CARD_STYLE,
         }
 
         // NOTE: New entities per period.
-        h3 {
-            style: "font-size: var(--text-base); color: var(--text-secondary); margin: var(--space-4) 0 var(--space-3) 0;",
-            "New Entities Per Period"
-        }
-        div {
-            style: "{CARD_STYLE}",
-            BarChart {
-                data: store.new_entities_per_period.clone(),
-                width: 600.0,
-                height: 180.0,
-                color: "var(--status-success)",
-            }
+        ChartCard {
+            title: "New Entities Per Period",
+            kind: ChartKind::Bar,
+            data: store.new_entities_per_period.clone(),
+            color: "var(--status-success)",
+            width: 960.0,
+            height: 260.0,
+            card_style: STACKED_CARD_STYLE,
         }
 
         // NOTE: Knowledge density.
         if !store.density_over_time.is_empty() {
-            h3 {
-                style: "font-size: var(--text-base); color: var(--text-secondary); margin: var(--space-4) 0 var(--space-3) 0;",
-                "Knowledge Density (Relationships / Entity)"
-            }
-            div {
-                style: "{CARD_STYLE}",
-                LineChart {
-                    data: store.density_over_time.clone(),
-                    width: 600.0,
-                    height: 150.0,
-                    color: "var(--status-warning)",
-                    show_labels: true,
-                }
+            ChartCard {
+                title: "Knowledge Density (Relationships / Entity)",
+                kind: ChartKind::Line,
+                data: store.density_over_time.clone(),
+                color: "var(--status-warning)",
+                width: 960.0,
+                height: 220.0,
+                card_style: STACKED_CARD_STYLE,
             }
         }
 

--- a/crates/theatron/proskenion/src/views/meta/mod.rs
+++ b/crates/theatron/proskenion/src/views/meta/mod.rs
@@ -2,6 +2,7 @@
 
 mod assembly;
 mod charts;
+mod drilldown;
 mod health;
 mod knowledge;
 mod performance;
@@ -20,8 +21,10 @@ use crate::state::meta::{
 };
 
 pub(crate) use charts::{BarChart, LineChart};
+pub(crate) use drilldown::{ChartCard, ChartKind};
 
 use assembly::assemble_meta_data;
+use drilldown::{ChartDrilldown, ExpandedChart};
 use health::MemoryHealthSection;
 use knowledge::KnowledgeGrowthSection;
 use performance::AgentPerformanceSection;
@@ -305,14 +308,14 @@ const HEADER_STYLE: &str = "\
     padding: 0 0 var(--space-3) 0; \
     position: sticky; \
     top: 0; \
-    background: var(--bg-surface-dim); \
+    background: var(--bg); \
     z-index: 10;\
 ";
 
 const REFRESH_BTN: &str = "\
-    background: var(--border); \
+    background: var(--bg-surface); \
     color: var(--text-primary); \
-    border: 1px solid var(--border); \
+    border: 1px solid var(--input-border); \
     border-radius: var(--radius-md); \
     padding: var(--space-1) var(--space-3); \
     font-size: var(--text-xs); \
@@ -355,10 +358,10 @@ pub(crate) const SECTION_TITLE_STYLE: &str = "\
 
 pub(crate) const SECTION_BODY_STYLE: &str = "\
     padding: var(--space-4); \
-    background: #12121e; \
+    background: var(--bg-surface-dim); \
     border: 1px solid var(--border); \
     border-top: none; \
-    border-radius: 0 0 var(--radius-lg) var(--radius-lg); \
+    border-radius: 0 0 var(--radius-md) var(--radius-md); \
     margin-bottom: var(--space-3);\
 ";
 
@@ -397,6 +400,21 @@ pub(crate) const CARD_SUB: &str = "\
 
 pub(crate) const MUTED_TEXT: &str = "font-size: var(--text-xs); color: var(--text-muted);";
 
+/// Theme-token palette for multi-series meta charts.
+///
+/// WHY: Every entry resolves through `[data-theme]` so series hues stay
+/// legible and on-palette in both dark and light themes.
+pub(crate) const META_SERIES_COLORS: &[&str] = &[
+    "var(--natural)",
+    "var(--aporia)",
+    "var(--status-info)",
+    "var(--aima)",
+    "var(--thanatochromia)",
+    "var(--status-warning)",
+    "var(--status-success)",
+    "var(--accent)",
+];
+
 const AUTO_REFRESH_INTERVAL_MS: u64 = 300_000;
 
 // ── Component ──
@@ -406,6 +424,7 @@ pub(crate) fn Meta() -> Element {
     let config: Signal<ConnectionConfig> = use_context();
     let mut fetch_state = use_signal(|| FetchState::<MetaData>::Loading);
     let mut expanded = use_signal(|| [true, true, true, true, true]);
+    use_context_provider(|| Signal::new(Option::<ExpandedChart>::None));
 
     let mut do_refresh = move || {
         let cfg = config.read().clone();
@@ -500,6 +519,8 @@ pub(crate) fn Meta() -> Element {
                     }
                 },
             }
+
+            ChartDrilldown {}
         }
     }
 }

--- a/crates/theatron/proskenion/src/views/meta/performance.rs
+++ b/crates/theatron/proskenion/src/views/meta/performance.rs
@@ -3,11 +3,11 @@
 use dioxus::prelude::*;
 
 use crate::state::meta::{AgentPerformanceStore, AgentScorecard, Anomaly};
-use crate::views::meta::{GRID_STYLE, MUTED_TEXT};
+use crate::views::meta::{GRID_STYLE, META_SERIES_COLORS, MUTED_TEXT};
 
-const RADAR_SIZE: f64 = 250.0;
+const RADAR_SIZE: f64 = 300.0;
 const RADAR_CENTER: f64 = RADAR_SIZE / 2.0;
-const RADAR_RADIUS: f64 = 90.0;
+const RADAR_RADIUS: f64 = 110.0;
 
 const RADAR_AXIS_LABELS: [&str; 5] = [
     "Quality",
@@ -15,14 +15,6 @@ const RADAR_AXIS_LABELS: [&str; 5] = [
     "Context",
     "Productivity",
     "Reliability",
-];
-
-const RADAR_COLORS: &[&str] = &[
-    "#4a9aff",
-    "var(--status-success)",
-    "var(--status-warning)",
-    "var(--status-error)",
-    "#8b5cf6",
 ];
 
 const SCORECARD_STYLE: &str = "\
@@ -35,12 +27,12 @@ const SCORECARD_STYLE: &str = "\
 ";
 
 const ALERT_STYLE: &str = "\
-    background: #2a1a1a; \
-    border: 1px solid #4a2a2a; \
+    background: var(--status-error-bg); \
+    border: 1px solid var(--status-error); \
     border-radius: var(--radius-md); \
     padding: var(--space-3) var(--space-4); \
     font-size: var(--text-sm); \
-    color: #f87171;\
+    color: var(--status-error);\
 ";
 
 #[component]
@@ -256,7 +248,7 @@ fn RadarChart(scorecards: Vec<AgentScorecard>) -> Element {
                                 x: "{x:.1}",
                                 y: "{y:.1}",
                                 fill: "var(--text-secondary)",
-                                font_size: "10",
+                                font_size: "11",
                                 text_anchor: "middle",
                                 dominant_baseline: "middle",
                                 "{label}"
@@ -280,7 +272,7 @@ fn RadarChart(scorecards: Vec<AgentScorecard>) -> Element {
                             })
                             .collect::<Vec<_>>()
                             .join(" ");
-                        let color = RADAR_COLORS[idx % RADAR_COLORS.len()];
+                        let color = META_SERIES_COLORS[idx % META_SERIES_COLORS.len()];
                         rsx! {
                             polygon {
                                 points: "{points}",
@@ -299,7 +291,7 @@ fn RadarChart(scorecards: Vec<AgentScorecard>) -> Element {
                 style: "display: flex; flex-direction: column; gap: var(--space-2);",
                 for (idx , card) in scorecards.iter().enumerate() {
                     {
-                        let color = RADAR_COLORS[idx % RADAR_COLORS.len()];
+                        let color = META_SERIES_COLORS[idx % META_SERIES_COLORS.len()];
                         rsx! {
                             div {
                                 style: "display: flex; align-items: center; gap: var(--space-2);",

--- a/crates/theatron/proskenion/src/views/meta/quality.rs
+++ b/crates/theatron/proskenion/src/views/meta/quality.rs
@@ -3,7 +3,9 @@
 use dioxus::prelude::*;
 
 use crate::state::meta::QualityStore;
-use crate::views::meta::{CARD_LABEL, CARD_STYLE, GRID_STYLE, LineChart, MUTED_TEXT};
+use crate::views::meta::{CARD_STYLE, ChartCard, ChartKind, GRID_STYLE, MUTED_TEXT};
+
+const GRID_CARD_STYLE: &str = "flex: 1; min-width: 280px;";
 
 const HISTOGRAM_BAR_STYLE: &str = "\
     display: flex; \
@@ -41,52 +43,44 @@ pub(super) fn ConversationQualitySection(store: QualityStore) -> Element {
         if store.charts_endpoint_available {
             div {
                 style: "{GRID_STYLE}",
-                div {
-                    style: "{CARD_STYLE} flex: 1; min-width: 280px;",
-                    div { style: "{CARD_LABEL} margin-bottom: var(--space-2);", "Avg Turn Length" }
-                    LineChart {
-                        data: store.avg_turn_length.clone(),
-                        width: 300.0,
-                        height: 150.0,
-                        color: "#4a9aff",
-                        show_labels: true,
-                    }
+                ChartCard {
+                    title: "Avg Turn Length",
+                    kind: ChartKind::Line,
+                    data: store.avg_turn_length.clone(),
+                    color: "var(--status-info)",
+                    width: 460.0,
+                    height: 220.0,
+                    card_style: GRID_CARD_STYLE,
                 }
-                div {
-                    style: "{CARD_STYLE} flex: 1; min-width: 280px;",
-                    div { style: "{CARD_LABEL} margin-bottom: var(--space-2);", "Response-to-Question Ratio" }
-                    LineChart {
-                        data: store.response_to_question_ratio.clone(),
-                        width: 300.0,
-                        height: 150.0,
-                        color: "var(--status-success)",
-                        show_labels: true,
-                    }
+                ChartCard {
+                    title: "Response-to-Question Ratio",
+                    kind: ChartKind::Line,
+                    data: store.response_to_question_ratio.clone(),
+                    color: "var(--status-success)",
+                    width: 460.0,
+                    height: 220.0,
+                    card_style: GRID_CARD_STYLE,
                 }
             }
             div {
                 style: "{GRID_STYLE} margin-top: var(--space-3);",
-                div {
-                    style: "{CARD_STYLE} flex: 1; min-width: 280px;",
-                    div { style: "{CARD_LABEL} margin-bottom: var(--space-2);", "Tool Call Density" }
-                    LineChart {
-                        data: store.tool_call_density.clone(),
-                        width: 300.0,
-                        height: 150.0,
-                        color: "var(--status-warning)",
-                        show_labels: true,
-                    }
+                ChartCard {
+                    title: "Tool Call Density",
+                    kind: ChartKind::Line,
+                    data: store.tool_call_density.clone(),
+                    color: "var(--status-warning)",
+                    width: 460.0,
+                    height: 220.0,
+                    card_style: GRID_CARD_STYLE,
                 }
-                div {
-                    style: "{CARD_STYLE} flex: 1; min-width: 280px;",
-                    div { style: "{CARD_LABEL} margin-bottom: var(--space-2);", "Thinking Time Ratio" }
-                    LineChart {
-                        data: store.thinking_time_ratio.clone(),
-                        width: 300.0,
-                        height: 150.0,
-                        color: "#8b5cf6",
-                        show_labels: true,
-                    }
+                ChartCard {
+                    title: "Thinking Time Ratio",
+                    kind: ChartKind::Line,
+                    data: store.thinking_time_ratio.clone(),
+                    color: "var(--thanatochromia)",
+                    width: 460.0,
+                    height: 220.0,
+                    card_style: GRID_CARD_STYLE,
                 }
             }
         } else {
@@ -133,7 +127,7 @@ fn DepthHistogram(short: u32, medium: u32, long: u32) -> Element {
     let max_val = short.max(medium).max(long).max(1);
 
     let buckets: Vec<(&str, u32, &str)> = vec![
-        ("Short (<10)", short, "#4a9aff"),
+        ("Short (<10)", short, "var(--status-info)"),
         ("Medium (10-50)", medium, "var(--status-success)"),
         ("Long (50+)", long, "var(--status-warning)"),
     ];

--- a/crates/theatron/proskenion/src/views/meta/reflection.rs
+++ b/crates/theatron/proskenion/src/views/meta/reflection.rs
@@ -7,8 +7,25 @@ use crate::views::meta::{CARD_LABEL, CARD_STYLE, CARD_SUB, CARD_VALUE, GRID_STYL
 
 const DAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-const CELL_SIZE: f64 = 18.0;
+const CELL_SIZE: f64 = 20.0;
 const CELL_GAP: f64 = 2.0;
+
+/// Legend swatches mirroring the `heatmap_color` intensity scale, low to high.
+const HEATMAP_LEGEND_COLORS: [&str; 5] = [
+    "var(--bg-surface-dim)",
+    "var(--bg-surface)",
+    "var(--accent-muted)",
+    "var(--status-info)",
+    "var(--status-success)",
+];
+
+const JOURNAL_FILTERS: [(&str, Option<JournalEventType>); 5] = [
+    ("All", None),
+    ("Errors", Some(JournalEventType::Error)),
+    ("Distillation", Some(JournalEventType::Distillation)),
+    ("Config", Some(JournalEventType::ConfigChange)),
+    ("Memory", Some(JournalEventType::MemoryMerge)),
+];
 
 const JOURNAL_ROW_STYLE: &str = "\
     display: flex; \
@@ -27,9 +44,9 @@ const BADGE_STYLE: &str = "\
 ";
 
 const FILTER_BTN_STYLE: &str = "\
-    background: var(--border); \
+    background: var(--bg-surface); \
     color: var(--text-secondary); \
-    border: 1px solid var(--border); \
+    border: 1px solid var(--input-border); \
     border-radius: var(--radius-sm); \
     padding: var(--space-1) var(--space-2); \
     font-size: var(--text-xs); \
@@ -37,6 +54,12 @@ const FILTER_BTN_STYLE: &str = "\
     transition: background-color var(--transition-quick), \
                 color var(--transition-quick), \
                 border-color var(--transition-quick);\
+";
+
+const FILTER_BTN_ACTIVE: &str = " \
+    background: var(--accent-muted); \
+    color: var(--text-primary); \
+    border-color: var(--accent);\
 ";
 
 #[component]
@@ -114,7 +137,7 @@ fn OverviewCard(value: String, label: &'static str) -> Element {
     }
 }
 
-// ── Activity heatmap ──
+// -- Activity heatmap ---------------------------------------------------------
 
 #[component]
 fn ActivityHeatmap(cells: Vec<crate::state::meta::HeatmapCell>) -> Element {
@@ -200,9 +223,10 @@ fn ActivityHeatmap(cells: Vec<crate::state::meta::HeatmapCell>) -> Element {
                 style: "display: flex; align-items: center; gap: var(--space-1); margin-top: var(--space-2); \
                         font-size: var(--text-xs); color: var(--text-muted);",
                 span { "Less" }
-                for color in &["var(--bg-surface)", "#1a2a3e", "#2a4a6a", "#4a9aff", "var(--status-success)"] {
+                for color in HEATMAP_LEGEND_COLORS {
                     div {
                         style: "width: 12px; height: 12px; background: {color}; \
+                                border: 1px solid var(--border); \
                                 border-radius: var(--radius-sm);",
                     }
                 }
@@ -212,7 +236,7 @@ fn ActivityHeatmap(cells: Vec<crate::state::meta::HeatmapCell>) -> Element {
     }
 }
 
-// ── Efficiency panel ──
+// -- Efficiency panel ---------------------------------------------------------
 
 #[component]
 fn EfficiencyPanel(
@@ -255,7 +279,7 @@ fn EfficiencyPanel(
     }
 }
 
-// ── System journal ──
+// -- System journal -----------------------------------------------------------
 
 #[component]
 fn SystemJournal(events: Vec<JournalEvent>) -> Element {
@@ -271,30 +295,21 @@ fn SystemJournal(events: Vec<JournalEvent>) -> Element {
             style: "{CARD_STYLE}",
             div {
                 style: "display: flex; gap: var(--space-2); margin-bottom: var(--space-3);",
-                button {
-                    style: "{FILTER_BTN_STYLE}",
-                    onclick: move |_| filter.set(None),
-                    "All"
-                }
-                button {
-                    style: "{FILTER_BTN_STYLE}",
-                    onclick: move |_| filter.set(Some(JournalEventType::Error)),
-                    "Errors"
-                }
-                button {
-                    style: "{FILTER_BTN_STYLE}",
-                    onclick: move |_| filter.set(Some(JournalEventType::Distillation)),
-                    "Distillation"
-                }
-                button {
-                    style: "{FILTER_BTN_STYLE}",
-                    onclick: move |_| filter.set(Some(JournalEventType::ConfigChange)),
-                    "Config"
-                }
-                button {
-                    style: "{FILTER_BTN_STYLE}",
-                    onclick: move |_| filter.set(Some(JournalEventType::MemoryMerge)),
-                    "Memory"
+                for (label , value) in JOURNAL_FILTERS {
+                    {
+                        let active_style = if *filter.read() == value {
+                            FILTER_BTN_ACTIVE
+                        } else {
+                            ""
+                        };
+                        rsx! {
+                            button {
+                                style: "{FILTER_BTN_STYLE}{active_style}",
+                                onclick: move |_| filter.set(value),
+                                "{label}"
+                            }
+                        }
+                    }
                 }
             }
 
@@ -308,7 +323,8 @@ fn SystemJournal(events: Vec<JournalEvent>) -> Element {
                     style: "max-height: 300px; overflow-y: auto;",
                     for event in &filtered {
                         {
-                            let badge_bg = event.event_type.color();
+                            let badge_fg = event.event_type.color();
+                            let badge_bg = journal_badge_bg(event.event_type);
                             let label = event.event_type.label();
                             rsx! {
                                 div {
@@ -318,7 +334,7 @@ fn SystemJournal(events: Vec<JournalEvent>) -> Element {
                                         "{event.timestamp}"
                                     }
                                     span {
-                                        style: "{BADGE_STYLE} background: {badge_bg}20; color: {badge_bg};",
+                                        style: "{BADGE_STYLE} background: {badge_bg}; color: {badge_fg};",
                                         "{label}"
                                     }
                                     span {
@@ -335,7 +351,20 @@ fn SystemJournal(events: Vec<JournalEvent>) -> Element {
     }
 }
 
-// ── Formatters ──
+/// Background token paired with `JournalEventType::color()` foregrounds.
+///
+/// WHY: The theme's `--status-*-bg` tokens are tuned per theme; deriving a
+/// translucent bg by suffixing alpha onto a `var()` string is invalid CSS.
+fn journal_badge_bg(event_type: JournalEventType) -> &'static str {
+    match event_type {
+        JournalEventType::Error => "var(--status-error-bg)",
+        JournalEventType::Distillation => "var(--status-info-bg)",
+        JournalEventType::ConfigChange => "var(--status-warning-bg)",
+        JournalEventType::MemoryMerge => "var(--status-success-bg)",
+    }
+}
+
+// -- Formatters ---------------------------------------------------------------
 
 fn format_uptime(seconds: u64) -> String {
     let days = seconds / 86400;

--- a/crates/theatron/proskenion/src/views/metrics/agent_costs.rs
+++ b/crates/theatron/proskenion/src/views/metrics/agent_costs.rs
@@ -144,19 +144,13 @@ fn cost_th(
     }
 }
 
-/// Muted variant of an accent color for previous-period bars.
+/// Muted variant of an agent's accent color for previous-period bars.
 ///
-/// WHY: previous-period bars use 40% opacity to visually recede behind current-period bars.
+/// WHY: previous-period bars recede to 40% strength behind current-period
+/// bars; deriving from agent_color keeps the two palettes in lockstep.
 fn muted_color(index: usize) -> String {
-    const PALETTE: &[&str] = &[
-        "rgba(91,106,240,0.4)",
-        "rgba(16,185,129,0.4)",
-        "rgba(245,158,11,0.4)",
-        "rgba(244,63,94,0.4)",
-        "rgba(14,165,233,0.4)",
-        "rgba(139,92,246,0.4)",
-        "rgba(236,72,153,0.4)",
-        "rgba(20,184,166,0.4)",
-    ];
-    PALETTE[index % PALETTE.len()].to_string()
+    format!(
+        "color-mix(in srgb, {} 40%, transparent)",
+        agent_color(index)
+    )
 }

--- a/crates/theatron/proskenion/src/views/metrics/costs.rs
+++ b/crates/theatron/proskenion/src/views/metrics/costs.rs
@@ -188,10 +188,15 @@ pub(crate) fn Costs() -> Element {
 }
 
 fn loaded_costs_view(
-    data: CostMetricsResponse,
+    mut data: CostMetricsResponse,
     mut budget: Signal<BudgetConfig>,
     mut budget_input: Signal<String>,
 ) -> Element {
+    // WHY: the comparison must reflect only agents that actually spent in
+    // the current or previous period — zero rows are noise, not data.
+    data.agents
+        .retain(|a| a.total_cost > 0.0 || a.prev_period_cost > 0.0);
+
     let today_d = compute_delta_f64(data.today_cost, data.prev_today_cost);
     let week_d = compute_delta_f64(data.week_cost, data.prev_week_cost);
     let month_d = compute_delta_f64(data.month_cost, data.prev_month_cost);

--- a/crates/theatron/proskenion/src/views/metrics/mod.rs
+++ b/crates/theatron/proskenion/src/views/metrics/mod.rs
@@ -18,7 +18,7 @@ use crate::state::metrics::MetricsTab;
 const TAB_BAR_STYLE: &str = "\
     display: flex; \
     gap: var(--space-1); \
-    border-bottom: 1px solid #2a2724; \
+    border-bottom: 1px solid var(--border); \
     padding: 0 var(--space-4); \
     margin-bottom: var(--space-4);\
 ";
@@ -26,10 +26,10 @@ const TAB_BAR_STYLE: &str = "\
 const TAB_ACTIVE_STYLE: &str = "\
     padding: var(--space-2) var(--space-4); \
     font-size: var(--text-sm); \
-    color: #e8e6e3; \
+    color: var(--text-primary); \
     background: transparent; \
     border: none; \
-    border-bottom: 2px solid #5b6af0; \
+    border-bottom: 2px solid var(--accent); \
     cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick); \
     font-family: var(--font-mono);\
 ";
@@ -37,7 +37,7 @@ const TAB_ACTIVE_STYLE: &str = "\
 const TAB_INACTIVE_STYLE: &str = "\
     padding: var(--space-2) var(--space-4); \
     font-size: var(--text-sm); \
-    color: #706c66; \
+    color: var(--text-muted); \
     background: transparent; \
     border: none; \
     border-bottom: 2px solid transparent; \

--- a/crates/theatron/proskenion/src/views/metrics/model_breakdown.rs
+++ b/crates/theatron/proskenion/src/views/metrics/model_breakdown.rs
@@ -3,7 +3,7 @@
 use dioxus::prelude::*;
 
 use crate::components::chart::{ChartEntry, DonutChart};
-use crate::state::metrics::{ModelTokenRow, cost_per_1k_output, format_tokens, model_color};
+use crate::state::metrics::{ModelTokenRow, format_tokens, model_color};
 
 /// Per-model token breakdown with donut chart.
 ///
@@ -57,14 +57,12 @@ pub(crate) fn ModelBreakdown(models: Vec<ModelTokenRow>, grand_total: u64) -> El
                             th { style: "padding: var(--space-2) var(--space-2); text-align: right; color: var(--text-muted);", "Output" }
                             th { style: "padding: var(--space-2) var(--space-2); text-align: right; color: var(--text-muted);", "Total" }
                             th { style: "padding: var(--space-2) var(--space-2); text-align: right; color: var(--text-muted);", "%" }
-                            th { style: "padding: var(--space-2) var(--space-2); text-align: right; color: var(--text-muted);", "$/1K out" }
                         }
                     }
                     tbody {
                         for model in &models {
                             {
                                 let pct = model.pct_of_total(grand_total);
-                                let price = cost_per_1k_output(&model.model);
                                 let color = model_color(&model.model);
                                 let short = short_model_name(&model.model);
                                 rsx! {
@@ -80,7 +78,6 @@ pub(crate) fn ModelBreakdown(models: Vec<ModelTokenRow>, grand_total: u64) -> El
                                         td { style: "padding: var(--space-2) var(--space-2); color: var(--text-secondary); text-align: right;", "{format_tokens(model.output_tokens)}" }
                                         td { style: "padding: var(--space-2) var(--space-2); color: var(--text-primary); text-align: right; font-weight: var(--weight-semibold);", "{format_tokens(model.total())}" }
                                         td { style: "padding: var(--space-2) var(--space-2); color: var(--text-muted); text-align: right;", "{pct:.1}%" }
-                                        td { style: "padding: var(--space-2) var(--space-2); color: var(--text-muted); text-align: right;", "${price:.4}" }
                                     }
                                 }
                             }

--- a/crates/theatron/proskenion/src/views/metrics/tokens.rs
+++ b/crates/theatron/proskenion/src/views/metrics/tokens.rs
@@ -233,9 +233,14 @@ pub(crate) fn Tokens() -> Element {
 }
 
 fn loaded_tokens_view(
-    data: TokenMetricsResponse,
+    mut data: TokenMetricsResponse,
     mut agent_filter: Signal<Option<String>>,
 ) -> Element {
+    // WHY: breakdowns must reflect only what the period actually used —
+    // zero-usage agents and models are noise, not data.
+    data.agents.retain(|a| a.total() > 0);
+    data.models.retain(|m| m.total() > 0);
+
     let today_d = compute_delta_u64(data.today_total(), data.prev_today_total());
     let week_d = compute_delta_u64(data.week_total(), data.prev_week_total());
     let month_d = compute_delta_u64(data.month_total(), data.prev_month_total());
@@ -262,8 +267,8 @@ fn loaded_tokens_view(
                 reason = "u64 token counts to f64 for chart series"
             )]
             secondary: pt.output_tokens as f64,
-            primary_color: "#5b6af0".to_string(),
-            secondary_color: "#10b981".to_string(),
+            primary_color: "var(--accent)".to_string(),
+            secondary_color: "var(--status-success)".to_string(),
         })
         .collect();
 

--- a/crates/theatron/proskenion/src/views/metrics/tool_detail.rs
+++ b/crates/theatron/proskenion/src/views/metrics/tool_detail.rs
@@ -43,7 +43,7 @@ const TH_STYLE: &str = "\
 
 const TD_STYLE: &str = "\
     padding: var(--space-1) var(--space-2); \
-    border-bottom: 1px solid #1e1e38; \
+    border-bottom: 1px solid var(--border-separator); \
     color: var(--text-primary);\
 ";
 
@@ -85,8 +85,8 @@ const PAGE_BTN: &str = "\
 
 const PAGE_BTN_DISABLED: &str = "\
     background: var(--bg-surface); \
-    color: var(--border); \
-    border: 1px solid #2a2a2a; \
+    color: var(--text-muted); \
+    border: 1px solid var(--border-separator); \
     border-radius: var(--radius-sm); \
     padding: var(--space-1) var(--space-2); \
     font-size: var(--text-xs); \

--- a/crates/theatron/proskenion/src/views/ops/credentials.rs
+++ b/crates/theatron/proskenion/src/views/ops/credentials.rs
@@ -648,9 +648,9 @@ fn CredentialCard(
     let show_remove = *confirm_remove.read();
 
     let role_bg = if entry.role == CredentialRole::Primary {
-        "background: #1a2a4a; color: #4a9aff;"
+        "background: var(--status-info-bg); color: var(--status-info);"
     } else {
-        "background: #2a2a2a; color: var(--text-secondary);"
+        "background: var(--bg-surface-bright); color: var(--text-secondary);"
     };
 
     rsx! {

--- a/crates/theatron/proskenion/src/views/ops/health.rs
+++ b/crates/theatron/proskenion/src/views/ops/health.rs
@@ -35,7 +35,7 @@ const ROW_STYLE: &str = "\
     align-items: center; \
     gap: var(--space-2); \
     padding: var(--space-1) 0; \
-    border-bottom: 1px solid #222; \
+    border-bottom: 1px solid var(--border-separator); \
     font-size: var(--text-xs);\
 ";
 

--- a/crates/theatron/proskenion/src/views/ops/mod.rs
+++ b/crates/theatron/proskenion/src/views/ops/mod.rs
@@ -246,7 +246,7 @@ const ENTRY_STYLE: &str = "\
     align-items: center; \
     gap: var(--space-2); \
     padding: var(--space-2) 0; \
-    border-bottom: 1px solid #222; \
+    border-bottom: 1px solid var(--border-separator); \
     font-size: var(--text-sm);\
 ";
 

--- a/crates/theatron/proskenion/src/views/ops/toggles.rs
+++ b/crates/theatron/proskenion/src/views/ops/toggles.rs
@@ -37,7 +37,7 @@ const ROW_STYLE: &str = "\
     align-items: center; \
     justify-content: space-between; \
     padding: var(--space-2) 0; \
-    border-bottom: 1px solid #222;\
+    border-bottom: 1px solid var(--border-separator);\
 ";
 
 const TOGGLE_LABEL: &str = "\
@@ -82,7 +82,7 @@ const EMPTY_STATE: &str = "\
 const CONFIRM_OVERLAY: &str = "\
     position: fixed; \
     top: 0; left: 0; right: 0; bottom: 0; \
-    background: rgba(0, 0, 0, 0.5); \
+    background: var(--bg-overlay); \
     display: flex; \
     align-items: center; \
     justify-content: center; \
@@ -376,7 +376,7 @@ fn ConfirmDisableDialog(
                 }
                 div {
                     button {
-                        style: "{CONFIRM_BTN} background: #3a1a1a; color: var(--status-error);",
+                        style: "{CONFIRM_BTN} background: var(--status-error-bg); color: var(--status-error);",
                         onclick: {
                             let id = agent_id.clone();
                             move |_| {

--- a/crates/theatron/proskenion/src/views/planning/category_proposal.rs
+++ b/crates/theatron/proskenion/src/views/planning/category_proposal.rs
@@ -7,7 +7,7 @@ use crate::state::connection::ConnectionConfig;
 use crate::state::planning::{CategoryProposal, ProposalAction, ProposalActionRequest};
 
 const CARD_STYLE: &str = "\
-    background: #1e1e3a; \
+    background: var(--bg-surface); \
     border: 1px solid var(--accent); \
     border-radius: var(--radius-md); \
     padding: var(--space-3) var(--space-4); \
@@ -30,7 +30,7 @@ const BADGE: &str = "\
 ";
 
 const ACCEPT_BTN: &str = "\
-    background: #1a3a1a; \
+    background: var(--status-success-bg); \
     color: var(--status-success); \
     border: 1px solid var(--status-success); \
     border-radius: var(--radius-md); \
@@ -43,7 +43,7 @@ const ACCEPT_BTN: &str = "\
 ";
 
 const REJECT_BTN: &str = "\
-    background: #3a1a1a; \
+    background: var(--status-error-bg); \
     color: var(--status-error); \
     border: 1px solid var(--status-error); \
     border-radius: var(--radius-md); \

--- a/crates/theatron/proskenion/src/views/planning/discussion.rs
+++ b/crates/theatron/proskenion/src/views/planning/discussion.rs
@@ -139,8 +139,8 @@ const ANSWER_SUMMARY: &str = "\
     font-size: var(--text-sm); \
     color: var(--status-success); \
     padding: var(--space-2) var(--space-3); \
-    background: #0f1a0f; \
-    border: 1px solid #1a3a1a; \
+    background: var(--status-success-bg); \
+    border: 1px solid var(--status-success); \
     border-radius: var(--radius-sm); \
     margin-top: var(--space-2);\
 ";
@@ -479,11 +479,11 @@ fn discussion_card_colors(
     status: DiscussionStatus,
 ) -> (&'static str, &'static str) {
     if status == DiscussionStatus::Answered {
-        return ("#0f1a0f", "#2a4a2a");
+        return ("var(--status-success-bg)", "var(--status-success)");
     }
     match priority {
-        DiscussionPriority::Blocking => ("#1e0f0f", "var(--status-error)"),
-        DiscussionPriority::Important => ("#1e1a10", "var(--status-warning)"),
+        DiscussionPriority::Blocking => ("var(--status-error-bg)", "var(--status-error)"),
+        DiscussionPriority::Important => ("var(--status-warning-bg)", "var(--status-warning)"),
         DiscussionPriority::NiceToHave => ("var(--bg-surface)", "var(--border)"),
     }
 }
@@ -507,8 +507,8 @@ fn status_label(status: DiscussionStatus) -> &'static str {
 
 fn priority_badge_style(priority: DiscussionPriority) -> String {
     let (bg, color) = match priority {
-        DiscussionPriority::Blocking => ("#3a0f0f", "var(--status-error)"),
-        DiscussionPriority::Important => ("#2a1f05", "var(--status-warning)"),
+        DiscussionPriority::Blocking => ("var(--status-error-bg)", "var(--status-error)"),
+        DiscussionPriority::Important => ("var(--status-warning-bg)", "var(--status-warning)"),
         DiscussionPriority::NiceToHave => ("var(--border)", "var(--text-secondary)"),
     };
     format!("{BADGE_BASE} background: {bg}; color: {color};")
@@ -541,7 +541,7 @@ mod tests {
         let (_, border) =
             discussion_card_colors(DiscussionPriority::Blocking, DiscussionStatus::Answered);
         assert_eq!(
-            border, "#2a4a2a",
+            border, "var(--status-success)",
             "answered status should override blocking priority color"
         );
     }

--- a/crates/theatron/proskenion/src/views/planning/discussion_detail.rs
+++ b/crates/theatron/proskenion/src/views/planning/discussion_detail.rs
@@ -85,7 +85,7 @@ pub(crate) fn DiscussionDetailView(
                             style: "font-size: var(--text-xs); font-weight: var(--weight-semibold); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; margin: var(--space-3) 0 var(--space-2);",
                             "Current Answer"
                         }
-                        div { style: "font-size: var(--text-base); color: var(--status-success); padding: var(--space-2) var(--space-3); background: #0f1a0f; border: 1px solid #1a3a1a; border-radius: var(--radius-md);", "{summary}" }
+                        div { style: "font-size: var(--text-base); color: var(--status-success); padding: var(--space-2) var(--space-3); background: var(--status-success-bg); border: 1px solid var(--status-success); border-radius: var(--radius-md);", "{summary}" }
                     }
                 }
 
@@ -111,7 +111,7 @@ pub(crate) fn DiscussionDetailView(
                             key: "{i}",
                             style: "display: flex; align-items: flex-start; gap: var(--space-2); padding: var(--space-2) var(--space-3); border-left: 2px solid var(--border); margin-bottom: var(--space-1);",
                             div {
-                                span { style: "font-size: var(--text-xs); font-weight: var(--weight-semibold); color: #c0c0e0;", "{entry.action}" }
+                                span { style: "font-size: var(--text-xs); font-weight: var(--weight-semibold); color: var(--text-primary);", "{entry.action}" }
                                 span { style: "font-size: var(--text-xs); color: var(--text-muted);", " by {entry.actor} at {entry.timestamp}" }
                                 if !entry.detail.is_empty() {
                                     div { style: "font-size: var(--text-xs); color: var(--text-secondary); font-style: italic;", "\"{entry.detail}\"" }

--- a/crates/theatron/proskenion/src/views/planning/gap_analysis.rs
+++ b/crates/theatron/proskenion/src/views/planning/gap_analysis.rs
@@ -195,8 +195,12 @@ pub(crate) fn GapAnalysisPanel(requirements: Vec<RequirementVerification>) -> El
 
 fn priority_badge_style(priority: RequirementPriority) -> &'static str {
     match priority {
-        RequirementPriority::P0 => "background: #3a0f0f; color: var(--status-error);",
-        RequirementPriority::P1 => "background: #2a1f05; color: var(--status-warning);",
+        RequirementPriority::P0 => {
+            "background: var(--status-error-bg); color: var(--status-error);"
+        }
+        RequirementPriority::P1 => {
+            "background: var(--status-warning-bg); color: var(--status-warning);"
+        }
         RequirementPriority::P2 => "background: var(--bg-surface-dim); color: var(--accent);",
         RequirementPriority::P3 => "background: var(--bg-surface); color: var(--text-muted);",
     }

--- a/crates/theatron/proskenion/src/views/planning/requirements.rs
+++ b/crates/theatron/proskenion/src/views/planning/requirements.rs
@@ -117,7 +117,7 @@ const TH_STYLE: &str = "\
 
 const TD_STYLE: &str = "\
     padding: var(--space-2) 10px; \
-    border-bottom: 1px solid #1a1a2a; \
+    border-bottom: 1px solid var(--border-separator); \
     vertical-align: top;\
 ";
 

--- a/crates/theatron/proskenion/src/views/planning/verification.rs
+++ b/crates/theatron/proskenion/src/views/planning/verification.rs
@@ -67,7 +67,7 @@ const TH_STYLE: &str = "\
 
 const TD_STYLE: &str = "\
     padding: var(--space-2) 10px; \
-    border-bottom: 1px solid #1a1a2a; \
+    border-bottom: 1px solid var(--border-separator); \
     vertical-align: top;\
 ";
 
@@ -93,7 +93,7 @@ const REFRESH_BTN: &str = "\
 ";
 
 const VERIFY_BTN: &str = "\
-    background: #1a2a4a; \
+    background: var(--bg-surface); \
     color: var(--accent); \
     border: 1px solid var(--accent); \
     border-radius: var(--radius-md); \

--- a/crates/theatron/proskenion/src/views/sessions/actions.rs
+++ b/crates/theatron/proskenion/src/views/sessions/actions.rs
@@ -50,17 +50,18 @@ const DIALOG_OVERLAY_STYLE: &str = "\
     left: 0; \
     right: 0; \
     bottom: 0; \
-    background: rgba(0, 0, 0, 0.6); \
+    background: var(--bg-overlay); \
     display: flex; \
     align-items: center; \
     justify-content: center; \
-    z-index: 100;\
+    z-index: var(--z-modal);\
 ";
 
 const DIALOG_STYLE: &str = "\
     background: var(--bg-surface); \
     border: 1px solid var(--border); \
     border-radius: var(--radius-lg); \
+    box-shadow: var(--shadow-modal); \
     padding: var(--space-6); \
     max-width: 400px; \
     width: 100%;\
@@ -101,7 +102,7 @@ const DIALOG_CANCEL_BTN: &str = "\
 
 const DIALOG_CONFIRM_BTN: &str = "\
     background: var(--accent); \
-    color: white; \
+    color: var(--text-inverse); \
     border: none; \
     border-radius: var(--radius-md); \
     padding: var(--space-2) var(--space-4); \

--- a/crates/theatron/proskenion/src/views/sessions/detail.rs
+++ b/crates/theatron/proskenion/src/views/sessions/detail.rs
@@ -4,9 +4,7 @@ use dioxus::prelude::*;
 use skene::id::SessionId;
 
 use crate::state::fetch::FetchState;
-use crate::state::sessions::{
-    SessionDetailStore, format_relative_time, session_display_status, status_color,
-};
+use crate::state::sessions::{SessionDetailStore, format_relative_time, session_display_status};
 
 const DETAIL_CONTAINER_STYLE: &str = "\
     display: flex; \
@@ -42,8 +40,8 @@ const AGENT_BADGE_STYLE: &str = "\
     padding: var(--space-1) var(--space-2); \
     border-radius: var(--radius-sm); \
     font-size: var(--text-xs); \
-    background: var(--border); \
-    color: #7a7aff;\
+    background: var(--natural-bg); \
+    color: var(--natural);\
 ";
 
 const STATS_GRID_STYLE: &str = "\
@@ -80,7 +78,7 @@ const STAT_SUB_STYLE: &str = "\
 const TOKEN_BAR_BG_STYLE: &str = "\
     width: 100%; \
     height: 6px; \
-    background: #222; \
+    background: var(--bg-surface-dim); \
     border-radius: var(--radius-sm); \
     margin-top: var(--space-2); \
     overflow: hidden;\
@@ -117,7 +115,7 @@ const MSG_PREVIEW_STYLE: &str = "\
     display: flex; \
     gap: var(--space-2); \
     padding: var(--space-2) 0; \
-    border-bottom: 1px solid var(--bg-surface); \
+    border-bottom: 1px solid var(--border-separator); \
     font-size: var(--text-sm);\
 ";
 
@@ -125,7 +123,7 @@ const ROLE_BADGE_USER: &str = "\
     flex-shrink: 0; \
     width: 60px; \
     font-size: var(--text-xs); \
-    color: #4a9aff; \
+    color: var(--role-user); \
     font-weight: var(--weight-bold);\
 ";
 
@@ -133,13 +131,13 @@ const ROLE_BADGE_ASSISTANT: &str = "\
     flex-shrink: 0; \
     width: 60px; \
     font-size: var(--text-xs); \
-    color: var(--status-success); \
+    color: var(--role-assistant); \
     font-weight: var(--weight-bold);\
 ";
 
 const OPEN_CHAT_BTN: &str = "\
     background: var(--accent); \
-    color: white; \
+    color: var(--text-inverse); \
     border: none; \
     border-radius: var(--radius-md); \
     padding: var(--space-2) var(--space-4); \
@@ -216,12 +214,12 @@ pub(crate) fn SessionDetail(
                     Some(session) => {
                         let session_id = session.id.clone();
                         let status = session_display_status(session);
-                        let status_bg = match status {
-                            "active" => "background: #1a3a1a;",
-                            "archived" => "background: var(--border);",
-                            _ => "background: #2a2a1a;",
+                        // NOTE: archived pairs with the thanatochromia dye token (archived semantics).
+                        let (status_bg, status_fg) = match status {
+                            "active" => ("var(--status-success-bg)", "var(--status-success)"),
+                            "archived" => ("var(--thanatochromia-bg)", "var(--thanatochromia)"),
+                            _ => ("var(--status-warning-bg)", "var(--status-warning)"),
                         };
-                        let s_color = status_color(status);
                         let is_archived = session.is_archived();
 
                         let id_for_chat = session_id.clone();
@@ -238,7 +236,7 @@ pub(crate) fn SessionDetail(
                                             style: "display: flex; gap: var(--space-2); align-items: center; margin-top: var(--space-1);",
                                             span { style: "{AGENT_BADGE_STYLE}", "{session.nous_id}" }
                                             span {
-                                                style: "{STATUS_BADGE_STYLE} {status_bg} color: {s_color};",
+                                                style: "{STATUS_BADGE_STYLE} background: {status_bg}; color: {status_fg};",
                                                 "{status}"
                                             }
                                             if let Some(ref updated) = session.updated_at {
@@ -302,7 +300,7 @@ pub(crate) fn SessionDetail(
                                             div {
                                                 style: "{TOKEN_BAR_BG_STYLE}",
                                                 div {
-                                                    style: "height: 100%; background: #4a9aff; border-radius: var(--radius-sm); width: {token_input_pct(detail)}%;",
+                                                    style: "height: 100%; background: var(--accent); border-radius: var(--radius-sm); width: {token_input_pct(detail)}%;",
                                                 }
                                             }
                                         }

--- a/crates/theatron/proskenion/src/views/sessions/list.rs
+++ b/crates/theatron/proskenion/src/views/sessions/list.rs
@@ -1,6 +1,9 @@
-//! Session list component: paginated rows with sort options.
+//! Session list component: nous-grouped rows with sort options and a system-session filter.
+
+use std::collections::HashSet;
 
 use dioxus::prelude::*;
+use skene::api::types::Session;
 use skene::id::SessionId;
 
 use crate::state::sessions::{
@@ -19,16 +22,6 @@ const TITLE_STYLE: &str = "\
     color: var(--text-primary); \
     overflow: hidden; \
     text-overflow: ellipsis; \
-    white-space: nowrap;\
-";
-
-const AGENT_BADGE_STYLE: &str = "\
-    display: inline-block; \
-    padding: var(--space-1) var(--space-2); \
-    border-radius: var(--radius-sm); \
-    font-size: var(--text-xs); \
-    background: var(--border); \
-    color: #7a7aff; \
     white-space: nowrap;\
 ";
 
@@ -69,12 +62,13 @@ const SORT_BTN_STYLE: &str = "\
 ";
 
 const SORT_BTN_ACTIVE_STYLE: &str = "\
-    background: var(--border); \
-    border: 1px solid var(--accent); \
+    background: var(--bg-surface); \
+    border: 1px solid var(--border-selected); \
     border-radius: var(--radius-sm); \
     padding: var(--space-1) var(--space-2); \
     font-size: var(--text-xs); \
-    color: #7a7aff; \
+    font-weight: var(--weight-semibold); \
+    color: var(--text-primary); \
     cursor: pointer; \
     transition: background-color var(--transition-quick), \
                 color var(--transition-quick), \
@@ -111,7 +105,7 @@ const LOAD_MORE_STYLE: &str = "\
     display: flex; \
     justify-content: center; \
     padding: var(--space-3); \
-    border-top: 1px solid #222;\
+    border-top: 1px solid var(--border-separator);\
 ";
 
 const LOAD_MORE_BTN: &str = "\
@@ -127,13 +121,107 @@ const LOAD_MORE_BTN: &str = "\
                 border-color var(--transition-quick);\
 ";
 
-/// Sort bar above the session list.
+const SELECT_ALL_BAR_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: var(--space-2); \
+    padding: var(--space-1) var(--space-3); \
+    border-bottom: 1px solid var(--border-separator); \
+    font-size: var(--text-xs); \
+    color: var(--text-secondary);\
+";
+
+const GROUP_HEADER_STYLE: &str = "\
+    display: flex; \
+    align-items: center; \
+    gap: var(--space-2); \
+    padding: var(--space-2) var(--space-3); \
+    background: var(--bg-surface); \
+    border-bottom: 1px solid var(--border-separator); \
+    cursor: pointer; \
+    user-select: none; \
+    position: sticky; \
+    top: 0; \
+    z-index: 1; \
+    transition: background-color var(--transition-quick), \
+                color var(--transition-quick), \
+                border-color var(--transition-quick);\
+";
+
+const GROUP_CARET_STYLE: &str = "\
+    font-size: var(--text-xs); \
+    color: var(--text-muted); \
+    flex-shrink: 0;\
+";
+
+const GROUP_NAME_STYLE: &str = "\
+    font-size: var(--text-sm); \
+    font-weight: var(--weight-semibold); \
+    color: var(--text-primary); \
+    overflow: hidden; \
+    text-overflow: ellipsis; \
+    white-space: nowrap;\
+";
+
+const GROUP_COUNT_STYLE: &str = "\
+    font-size: var(--text-xs); \
+    color: var(--text-muted);\
+";
+
+const SYSTEM_TOGGLE_STYLE: &str = "\
+    display: inline-flex; \
+    align-items: center; \
+    gap: var(--space-1); \
+    margin-left: auto; \
+    color: var(--text-secondary); \
+    cursor: pointer; \
+    white-space: nowrap;\
+";
+
+/// Session-key prefixes that mark background/system bookkeeping rather than conversation.
+const SYSTEM_KEY_PREFIXES: &[&str] = &[
+    "daemon:",
+    "cron:",
+    "eval-",
+    "web:",
+    "test",
+    "diagnostic",
+    "cross:",
+];
+
+/// Whether a session is a system/background session (hidden by default).
+fn is_system_session(session: &Session) -> bool {
+    session.session_type.as_deref() == Some("background")
+        || SYSTEM_KEY_PREFIXES
+            .iter()
+            .any(|prefix| session.key.starts_with(prefix))
+}
+
+/// Group sessions by owning nous, preserving the store's sort order within
+/// groups and ordering groups by first appearance (top item of current sort).
+fn group_by_nous(sessions: Vec<Session>) -> Vec<(String, Vec<Session>)> {
+    let mut groups: Vec<(String, Vec<Session>)> = Vec::new();
+    for session in sessions {
+        let nous = session.nous_id.to_string();
+        if let Some((_, rows)) = groups.iter_mut().find(|(id, _)| *id == nous) {
+            rows.push(session);
+        } else {
+            groups.push((nous, vec![session]));
+        }
+    }
+    groups
+}
+
+/// Sort bar above the session list, with the system-session visibility toggle.
 #[component]
 pub(crate) fn SessionSortBar(
     list_store: Signal<SessionListStore>,
     on_sort_change: EventHandler<SessionSort>,
+    mut show_system: Signal<bool>,
+    system_count: usize,
 ) -> Element {
     let current_sort = list_store.read().sort;
+    let system_shown = *show_system.read();
 
     rsx! {
         div {
@@ -149,6 +237,23 @@ pub(crate) fn SessionSortBar(
                     "{sort.label()}"
                 }
             }
+            label {
+                style: "{SYSTEM_TOGGLE_STYLE}",
+                title: "Show system sessions (daemon, cron, eval, web, test, diagnostic, cross, background)",
+                input {
+                    r#type: "checkbox",
+                    style: "{CHECKBOX_STYLE}",
+                    checked: system_shown,
+                    onchange: move |_| {
+                        let shown = *show_system.read();
+                        show_system.set(!shown);
+                    },
+                }
+                span { "System" }
+                if system_count > 0 {
+                    span { style: "{GROUP_COUNT_STYLE}", "({system_count})" }
+                }
+            }
         }
     }
 }
@@ -158,7 +263,6 @@ pub(crate) fn SessionSortBar(
 pub(crate) fn SessionRow(
     session_id: SessionId,
     title: String,
-    agent_name: String,
     message_count: u32,
     updated_at: String,
     status: String,
@@ -179,6 +283,7 @@ pub(crate) fn SessionRow(
                 let id = id_for_click;
                 move |_| on_click.call(id.clone())
             },
+            // Checkbox
             input {
                 r#type: "checkbox",
                 style: "{CHECKBOX_STYLE}",
@@ -191,21 +296,24 @@ pub(crate) fn SessionRow(
                     move |_| on_toggle_select.call(id.clone())
                 },
             }
+            // Status dot
             div {
                 style: "{STATUS_DOT_STYLE} background: {status_dot_color};",
             }
+            // Title
             div {
                 style: "{TITLE_STYLE}",
                 "{title}"
             }
-            span { style: "{AGENT_BADGE_STYLE}", "{agent_name}" }
+            // Message count
             span { style: "{META_STYLE}", "{message_count} msgs" }
+            // Last activity
             span { style: "{META_STYLE}", "{relative_time}" }
         }
     }
 }
 
-/// The main session list component.
+/// The main session list component: sessions grouped under collapsible nous sections.
 #[component]
 pub(crate) fn SessionList(
     list_store: Signal<SessionListStore>,
@@ -214,44 +322,89 @@ pub(crate) fn SessionList(
     on_sort_change: EventHandler<SessionSort>,
     on_load_more: EventHandler<()>,
 ) -> Element {
+    let show_system = use_signal(|| false);
+    let collapsed = use_signal(HashSet::<String>::new);
+
     let store = list_store.read();
-    let sessions = &store.sessions;
+    let system_shown = *show_system.read();
+    let system_count = store
+        .sessions
+        .iter()
+        .filter(|s| is_system_session(s))
+        .count();
+    let visible: Vec<Session> = store
+        .sessions
+        .iter()
+        .filter(|s| system_shown || !is_system_session(s))
+        .cloned()
+        .collect();
+    let visible_count = visible.len();
+    let hidden_count = if system_shown { 0 } else { system_count };
     let has_more = store.has_more;
+    let total_count = store.total_count;
+    let has_filters = store.has_active_filters();
+    drop(store);
+
+    let collapsed_set = collapsed.read().clone();
+    let groups: Vec<(String, bool, Vec<Session>)> = group_by_nous(visible)
+        .into_iter()
+        .map(|(nous, rows)| {
+            let is_collapsed = collapsed_set.contains(&nous);
+            (nous, is_collapsed, rows)
+        })
+        .collect();
 
     rsx! {
         div {
             style: "display: flex; flex-direction: column; height: 100%;",
+            // Sort bar + system toggle
             SessionSortBar {
                 list_store,
                 on_sort_change,
+                show_system,
+                system_count,
             }
-            if !sessions.is_empty() {
+            // Select all bar
+            if visible_count > 0 {
                 div {
-                    style: "display: flex; align-items: center; gap: var(--space-2); padding: var(--space-1) var(--space-3); border-bottom: 1px solid var(--bg-surface); font-size: var(--text-xs); color: var(--text-secondary);",
+                    style: "{SELECT_ALL_BAR_STYLE}",
                     input {
                         r#type: "checkbox",
                         style: "{CHECKBOX_STYLE}",
                         checked: selection_store.read().select_all,
                         onchange: move |_| {
-                            let all_ids: Vec<SessionId> = list_store.read().sessions
+                            let shown = *show_system.read();
+                            let visible_ids: Vec<SessionId> = list_store.read().sessions
                                 .iter()
+                                .filter(|s| shown || !is_system_session(s))
                                 .map(|s| s.id.clone())
                                 .collect();
-                            selection_store.write().toggle_all(&all_ids);
+                            selection_store.write().toggle_all(&visible_ids);
                         },
                     }
-                    span { "{sessions.len()} sessions" }
-                    if let Some(total) = store.total_count {
+                    span { "{visible_count} sessions" }
+                    if let Some(total) = total_count {
                         span { " of {total}" }
+                    }
+                    if hidden_count > 0 {
+                        span {
+                            style: "color: var(--text-muted);",
+                            "({hidden_count} system hidden)"
+                        }
                     }
                 }
             }
-            if sessions.is_empty() {
+            // Grouped session rows
+            if visible_count == 0 {
                 div {
                     style: "{EMPTY_STYLE}",
                     div { style: "font-size: var(--text-3xl);", "[S]" }
                     div { style: "font-size: var(--text-md);", "No sessions found" }
-                    if list_store.read().has_active_filters() {
+                    if hidden_count > 0 {
+                        div { style: "font-size: var(--text-sm);",
+                            "{hidden_count} system sessions hidden — toggle System to show them."
+                        }
+                    } else if has_filters {
                         div { style: "font-size: var(--text-sm);",
                             "Try adjusting your filters or search query."
                         }
@@ -260,22 +413,51 @@ pub(crate) fn SessionList(
             } else {
                 div {
                     style: "{LIST_CONTAINER_STYLE}",
-                    for session in sessions.iter() {
-                        SessionRow {
-                            key: "{session.id}",
-                            session_id: session.id.clone(),
-                            title: session.label().to_string(),
-                            agent_name: session.nous_id.to_string(),
-                            message_count: session.message_count,
-                            updated_at: session.updated_at.clone().unwrap_or_default(),
-                            status: session_display_status(session).to_string(),
-                            is_selected: selection_store.read().is_selected(&session.id),
-                            on_click: move |id: SessionId| on_select_session.call(id),
-                            on_toggle_select: move |id: SessionId| {
-                                selection_store.write().toggle(&id);
-                            },
+                    for (nous , is_collapsed , rows) in groups {
+                        div {
+                            key: "{nous}",
+                            // Nous section header
+                            div {
+                                style: "{GROUP_HEADER_STYLE}",
+                                role: "button",
+                                "aria-expanded": if is_collapsed { "false" } else { "true" },
+                                onclick: {
+                                    let nous_id = nous.clone();
+                                    let mut collapsed = collapsed;
+                                    move |_| {
+                                        let mut set = collapsed.write();
+                                        if !set.remove(&nous_id) {
+                                            set.insert(nous_id.clone());
+                                        }
+                                    }
+                                },
+                                span {
+                                    style: "{GROUP_CARET_STYLE}",
+                                    if is_collapsed { "\u{25B8}" } else { "\u{25BE}" }
+                                }
+                                span { style: "{GROUP_NAME_STYLE}", "{nous}" }
+                                span { style: "{GROUP_COUNT_STYLE}", "{rows.len()}" }
+                            }
+                            if !is_collapsed {
+                                for session in rows {
+                                    SessionRow {
+                                        key: "{session.id}",
+                                        session_id: session.id.clone(),
+                                        title: session.label().to_string(),
+                                        message_count: session.message_count,
+                                        updated_at: session.updated_at.clone().unwrap_or_default(),
+                                        status: session_display_status(&session).to_string(),
+                                        is_selected: selection_store.read().is_selected(&session.id),
+                                        on_click: move |id: SessionId| on_select_session.call(id),
+                                        on_toggle_select: move |id: SessionId| {
+                                            selection_store.write().toggle(&id);
+                                        },
+                                    }
+                                }
+                            }
                         }
                     }
+                    // Load more
                     if has_more {
                         div {
                             style: "{LOAD_MORE_STYLE}",
@@ -289,5 +471,72 @@ pub(crate) fn SessionList(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(nous: &str, key: &str) -> Session {
+        Session {
+            id: SessionId::from(key),
+            nous_id: skene::id::NousId::from(nous),
+            key: key.to_string(),
+            status: Some("active".to_string()),
+            message_count: 1,
+            session_type: None,
+            updated_at: None,
+            display_name: None,
+        }
+    }
+
+    #[test]
+    fn system_key_prefixes_classify_as_system() {
+        for key in [
+            "daemon:tick",
+            "cron:nightly",
+            "eval-suite",
+            "web:fetch",
+            "test-run",
+            "diagnostic-probe",
+            "cross:sync",
+        ] {
+            assert!(
+                is_system_session(&session("syn", key)),
+                "{key} should classify as system"
+            );
+        }
+    }
+
+    #[test]
+    fn background_session_type_classifies_as_system() {
+        let mut s = session("syn", "incident-review");
+        s.session_type = Some("background".to_string());
+        assert!(is_system_session(&s));
+    }
+
+    #[test]
+    fn conversational_keys_are_not_system() {
+        for key in ["incident-review", "chat", "attest", "daily-notes"] {
+            assert!(
+                !is_system_session(&session("syn", key)),
+                "{key} should not classify as system"
+            );
+        }
+    }
+
+    #[test]
+    fn group_by_nous_preserves_order_and_membership() {
+        let groups = group_by_nous(vec![
+            session("syn", "a"),
+            session("ker", "b"),
+            session("syn", "c"),
+        ]);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].0, "syn");
+        assert_eq!(groups[0].1.len(), 2);
+        assert_eq!(groups[1].0, "ker");
+        assert_eq!(groups[1].1.len(), 1);
     }
 }

--- a/crates/theatron/proskenion/src/views/sessions/mod.rs
+++ b/crates/theatron/proskenion/src/views/sessions/mod.rs
@@ -400,7 +400,7 @@ pub(crate) fn Sessions() -> Element {
             div {
                 style: "{HEADER_STYLE}",
                 h2 {
-                    style: "font-size: var(--text-lg); margin: 0; color: var(--text-primary, var(--text-primary));",
+                    style: "font-size: var(--text-lg); margin: 0; color: var(--text-primary);",
                     "Sessions"
                 }
                 button {

--- a/crates/theatron/proskenion/src/views/sessions/search.rs
+++ b/crates/theatron/proskenion/src/views/sessions/search.rs
@@ -46,18 +46,18 @@ const CHIP_STYLE: &str = "\
     display: inline-flex; \
     align-items: center; \
     gap: var(--space-1); \
-    background: var(--border); \
-    border: 1px solid var(--accent); \
+    background: var(--bg-surface); \
+    border: 1px solid var(--border-selected); \
     border-radius: var(--radius-xl); \
     padding: var(--space-1) var(--space-3); \
     font-size: var(--text-xs); \
-    color: #7a7aff;\
+    color: var(--text-primary);\
 ";
 
 const CHIP_CLOSE_STYLE: &str = "\
     background: none; \
     border: none; \
-    color: #7a7aff; \
+    color: var(--text-secondary); \
     cursor: pointer; \
     font-size: var(--text-base); \
     padding: 0; \

--- a/crates/theatron/proskenion/src/views/settings/appearance.rs
+++ b/crates/theatron/proskenion/src/views/settings/appearance.rs
@@ -107,9 +107,43 @@ pub(crate) fn AppearancePanel() -> Element {
                         style: "font-size: var(--text-xs); color: var(--text-muted); width: 22px;",
                         "20"
                     }
+                    input {
+                        r#type: "number",
+                        min: "12",
+                        max: "20",
+                        step: "1",
+                        value: "{current.font_size}",
+                        style: "width: 52px; background: var(--input-bg); border: 1px solid var(--input-border); \
+                                border-radius: var(--radius-sm); padding: var(--space-1) var(--space-2); \
+                                color: var(--text-primary); font-size: var(--text-sm); \
+                                font-family: var(--font-mono); text-align: center;",
+                        // WHY: oninput applies only in-range values so partial typing
+                        // ("1" en route to "16") does not snap to the clamp floor.
+                        oninput: move |e| {
+                            if let Ok(v) = e.value().parse::<u8>() {
+                                if (12..=20).contains(&v) {
+                                    appearance.write().set_font_size(v);
+                                    let store = server_store.read();
+                                    let app = appearance.read();
+                                    let keys = keybindings.read();
+                                    settings_config::save_state(&store, &app, &keys);
+                                }
+                            }
+                        },
+                        // WHY: onchange (blur/Enter) clamps out-of-range final values to [12, 20].
+                        onchange: move |e| {
+                            if let Ok(v) = e.value().parse::<u8>() {
+                                appearance.write().set_font_size(v);
+                                let store = server_store.read();
+                                let app = appearance.read();
+                                let keys = keybindings.read();
+                                settings_config::save_state(&store, &app, &keys);
+                            }
+                        },
+                    }
                     span {
-                        style: "font-size: var(--text-sm); color: var(--text-primary); width: 36px; text-align: right;",
-                        "{current.font_size}px"
+                        style: "font-size: var(--text-xs); color: var(--text-muted);",
+                        "px"
                     }
                 }
             }

--- a/crates/theatron/proskenion/src/views/settings/keybindings.rs
+++ b/crates/theatron/proskenion/src/views/settings/keybindings.rs
@@ -44,7 +44,7 @@ pub(crate) fn KeybindingsPanel() -> Element {
 
             if recording_id.read().is_some() {
                 div {
-                    style: "position: fixed; inset: 0; background: rgba(0,0,0,0.6); \
+                    style: "position: fixed; inset: 0; background: var(--bg-overlay); \
                             display: flex; align-items: center; justify-content: center; z-index: 100;",
                     tabindex: "0",
                     autofocus: true,
@@ -82,8 +82,8 @@ pub(crate) fn KeybindingsPanel() -> Element {
                         }
                     },
                     div {
-                        style: "background: var(--bg-surface); border: 1px solid #5b6af0; border-radius: var(--radius-lg); \
-                                padding: var(--space-8) 48px; text-align: center; color: var(--text-primary);",
+                        style: "background: var(--bg-surface); border: 1px solid var(--accent); border-radius: var(--radius-lg); \
+                                padding: var(--space-8) var(--space-12); text-align: center; color: var(--text-primary);",
                         div {
                             style: "font-size: var(--text-md); margin-bottom: var(--space-2);",
                             "Press a key combination"
@@ -110,7 +110,7 @@ pub(crate) fn KeybindingsPanel() -> Element {
 
                     rsx! {
                         div {
-                            style: "position: fixed; inset: 0; background: rgba(0,0,0,0.6); \
+                            style: "position: fixed; inset: 0; background: var(--bg-overlay); \
                                     display: flex; align-items: center; justify-content: center; z-index: 110;",
                             div {
                                 style: "background: var(--bg-surface); border: 1px solid var(--status-warning); border-radius: var(--radius-lg); \
@@ -133,7 +133,7 @@ pub(crate) fn KeybindingsPanel() -> Element {
                                     }
                                     button {
                                         style: "padding: var(--space-2) var(--space-4); background: var(--status-warning); border: none; \
-                                                border-radius: var(--radius-sm); color: #000; font-size: var(--text-xs); cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick);",
+                                                border-radius: var(--radius-sm); color: var(--text-inverse); font-size: var(--text-xs); cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick);",
                                         onclick: move |_| {
                                             keybindings.write().reset(&conflict_clone);
                                             keybindings.write().set(&target_clone, combo_clone.clone());
@@ -168,7 +168,7 @@ pub(crate) fn KeybindingsPanel() -> Element {
 
                             div {
                                 style: "display: flex; justify-content: space-between; align-items: center; \
-                                        padding: var(--space-3) var(--space-4); background: #161626; border-bottom: 1px solid var(--border);",
+                                        padding: var(--space-3) var(--space-4); background: var(--bg-surface-dim); border-bottom: 1px solid var(--border);",
                                 span {
                                     style: "font-size: var(--text-xs); font-weight: var(--weight-bold); color: var(--text-muted); \
                                             text-transform: uppercase; letter-spacing: 0.6px;",
@@ -194,12 +194,12 @@ pub(crate) fn KeybindingsPanel() -> Element {
                                     let action_id = action.id;
                                     let combo_str = keybindings.read().effective(action).display();
                                     let is_recording = recording_id.read().as_deref() == Some(action_id);
-                                    let row_bg = if is_recording { "#1e1e3a" } else { "transparent" };
+                                    let row_bg = if is_recording { "var(--selection-bg)" } else { "transparent" };
                                     let combo_style = if is_recording {
-                                        "padding: var(--space-1) var(--space-3); background: #5b6af0; border: none; \
-                                         border-radius: var(--radius-sm); color: var(--text-primary); font-size: var(--text-xs); cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick); min-width: 90px;"
+                                        "padding: var(--space-1) var(--space-3); background: var(--accent); border: none; \
+                                         border-radius: var(--radius-sm); color: var(--text-inverse); font-size: var(--text-xs); cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick); min-width: 90px;"
                                     } else {
-                                        "padding: var(--space-1) var(--space-3); background: #0d0d1a; border: 1px solid var(--border); \
+                                        "padding: var(--space-1) var(--space-3); background: var(--bg-surface-dim); border: 1px solid var(--border); \
                                          border-radius: var(--radius-sm); color: var(--text-primary); font-size: var(--text-xs); cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick); min-width: 90px; \
                                          font-family: var(--font-mono);"
                                     };
@@ -209,7 +209,7 @@ pub(crate) fn KeybindingsPanel() -> Element {
                                         div {
                                             key: "{action_id}",
                                             style: "display: flex; justify-content: space-between; align-items: center; \
-                                                    padding: var(--space-2) var(--space-4); background: {row_bg}; border-bottom: 1px solid #222;",
+                                                    padding: var(--space-2) var(--space-4); background: {row_bg}; border-bottom: 1px solid var(--border-separator);",
                                             span {
                                                 style: "font-size: var(--text-sm); color: var(--text-primary);",
                                                 "{action.label}"

--- a/crates/theatron/proskenion/src/views/settings/mod.rs
+++ b/crates/theatron/proskenion/src/views/settings/mod.rs
@@ -40,25 +40,13 @@ pub(crate) fn Settings() -> Element {
             style: "display: flex; flex-direction: column; height: 100%; overflow: hidden;",
 
             div {
-                style: "display: flex; gap: 0; padding: 0 var(--space-5); border-bottom: 1px solid var(--border); background: var(--bg-surface);",
+                style: "display: flex; gap: var(--space-2); padding: 0 var(--space-5); border-bottom: 1px solid var(--border); background: var(--bg-surface);",
                 for tab in [SettingsTab::Servers, SettingsTab::Appearance, SettingsTab::Keybindings, SettingsTab::Notifications] {
-                    {
-                        let is_active = active_tab() == tab;
-                        let border = if is_active { "2px solid var(--accent)" } else { "2px solid transparent" };
-                        let color = if is_active { "var(--text-primary)" } else { "var(--text-secondary)" };
-                        let style = format!(
-                            "padding: var(--space-3) 18px; background: none; border: none; border-bottom: {border}; \
-                             color: {color}; font-size: var(--text-sm); cursor: pointer; \
-                             transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick);"
-                        );
-                        rsx! {
-                            button {
-                                key: "{tab:?}",
-                                style: "{style}",
-                                onclick: move |_| active_tab.set(tab),
-                                "{tab.label()}"
-                            }
-                        }
+                    SettingsTabButton {
+                        key: "{tab:?}",
+                        label: tab.label(),
+                        is_active: active_tab() == tab,
+                        on_select: move |_| active_tab.set(tab),
                     }
                 }
             }
@@ -72,6 +60,46 @@ pub(crate) fn Settings() -> Element {
                     SettingsTab::Notifications => rsx! { NotificationSettings {} },
                 } }
             }
+        }
+    }
+}
+
+/// Single settings tab: mono-uppercase label with active underline and hover state.
+#[component]
+fn SettingsTabButton(label: &'static str, is_active: bool, on_select: EventHandler<()>) -> Element {
+    let mut hovered = use_signal(|| false);
+
+    let underline = if is_active {
+        "var(--accent)"
+    } else {
+        "transparent"
+    };
+    let color = if is_active || hovered() {
+        "var(--text-primary)"
+    } else {
+        "var(--text-secondary)"
+    };
+    let bg = if hovered() && !is_active {
+        "var(--bg-surface-bright)"
+    } else {
+        "transparent"
+    };
+    let style = format!(
+        "padding: var(--space-3) var(--space-4); background: {bg}; border: none; \
+         border-bottom: 2px solid {underline}; border-radius: var(--radius-sm) var(--radius-sm) 0 0; \
+         color: {color}; font-family: var(--font-mono); font-size: var(--text-xs); \
+         font-weight: var(--weight-medium); text-transform: uppercase; letter-spacing: var(--tracking-wide); \
+         cursor: pointer; transition: background-color var(--transition-quick), \
+         color var(--transition-quick), border-color var(--transition-quick);"
+    );
+
+    rsx! {
+        button {
+            style: "{style}",
+            onmouseenter: move |_| hovered.set(true),
+            onmouseleave: move |_| hovered.set(false),
+            onclick: move |_| on_select.call(()),
+            "{label}"
         }
     }
 }

--- a/crates/theatron/proskenion/src/views/settings/notifications.rs
+++ b/crates/theatron/proskenion/src/views/settings/notifications.rs
@@ -30,7 +30,7 @@ const ROW_STYLE: &str = "\
     justify-content: space-between; \
     align-items: center; \
     padding: var(--space-2) 0; \
-    border-bottom: 1px solid #222;\
+    border-bottom: 1px solid var(--border-separator);\
 ";
 
 const LABEL_STYLE: &str = "\
@@ -39,9 +39,9 @@ const LABEL_STYLE: &str = "\
 ";
 
 const TOGGLE_ON: &str = "\
-    background: #4f46e5; \
-    color: var(--text-primary); \
-    border: 1px solid #6366f1; \
+    background: var(--accent); \
+    color: var(--text-inverse); \
+    border: 1px solid var(--accent); \
     border-radius: var(--radius-md); \
     padding: var(--space-2) var(--space-4); \
     font-size: var(--text-sm); \
@@ -138,7 +138,7 @@ pub(crate) fn NotificationSettings() -> Element {
             }
 
             div {
-                style: if !tool_approval { ROW_STYLE } else { ROW_STYLE },
+                style: "{ROW_STYLE}",
                 span {
                     style: "{LABEL_STYLE}",
                     "Tool approval requests"
@@ -224,7 +224,7 @@ pub(crate) fn NotificationSettings() -> Element {
                     style: "{LABEL_STYLE}",
                     "Do Not Disturb"
                     if dnd_active {
-                        div { style: "color: #4f46e5; font-size: var(--text-xs); margin-top: var(--space-1);", "Active" }
+                        div { style: "color: var(--accent-hover); font-size: var(--text-xs); margin-top: var(--space-1);", "Active" }
                     }
                 }
                 div {

--- a/crates/theatron/proskenion/src/views/settings/servers.rs
+++ b/crates/theatron/proskenion/src/views/settings/servers.rs
@@ -1,7 +1,9 @@
 //! Server connections management panel.
 //!
 //! Displays saved server entries with health indicators. Supports add, edit,
-//! remove, test-connection, and switch-to-server actions.
+//! remove, test-connection, and switch-to-server actions. When the live
+//! connection URL drifts from the active entry's saved URL, the entry offers
+//! a one-click "Update to current".
 
 use std::collections::{HashMap, HashSet};
 
@@ -51,7 +53,9 @@ pub(crate) fn ServersPanel() -> Element {
     let appearance = use_context::<Signal<crate::state::settings::AppearanceSettings>>();
     let keybindings = use_context::<Signal<crate::state::settings::KeybindingStore>>();
 
-    let mut health_map: Signal<HashMap<String, ServerHealth>> = use_signal(HashMap::new);
+    // WHY: Health results carry the URL they probed so a stale result is
+    // attributable ("Unreachable — <url>") instead of an anonymous failure.
+    let mut health_map: Signal<HashMap<String, (ServerHealth, String)>> = use_signal(HashMap::new);
     let mut testing_ids: Signal<HashSet<String>> = use_signal(HashSet::new);
     let mut show_add = use_signal(|| false);
 
@@ -69,6 +73,15 @@ pub(crate) fn ServersPanel() -> Element {
                 is_active: store.active_id.as_deref() == Some(e.id.as_str()),
             })
             .collect()
+    };
+
+    // Live connection URL, present only while actually connected. Drives the
+    // "Update to current" offer when the active entry's saved URL has drifted.
+    let connected_url: Option<String> = if matches!(connection_state(), ConnectionState::Connected)
+    {
+        Some(connection_config.read().server_url.clone())
+    } else {
+        None
     };
 
     rsx! {
@@ -107,10 +120,24 @@ pub(crate) fn ServersPanel() -> Element {
                     let sid_test = sid.clone();
                     let sid_switch = sid.clone();
                     let sid_remove = sid.clone();
+                    let sid_update = sid.clone();
+                    let sid_saved = sid.clone();
                     let surl = snap.url.clone();
                     let stoken = snap.auth_token.clone();
-                    let health = *health_map.read().get(&snap.id).unwrap_or(&ServerHealth::Unchecked);
+                    let (health, tested_url) = health_map
+                        .read()
+                        .get(&snap.id)
+                        .map(|(h, u)| (*h, Some(u.clone())))
+                        .unwrap_or((ServerHealth::Unchecked, None));
                     let is_testing = testing_ids.read().contains(&snap.id);
+                    // Offer the live URL only on the active entry; other saved
+                    // entries are intentionally different servers.
+                    let update_url = connected_url
+                        .clone()
+                        .filter(|u| snap.is_active && *u != snap.url);
+                    let update_url_apply = update_url.clone();
+                    let name_update = snap.name.clone();
+                    let token_update = snap.auth_token.clone();
 
                     rsx! {
                         ServerCard {
@@ -121,6 +148,8 @@ pub(crate) fn ServersPanel() -> Element {
                             auth_token: stoken.clone(),
                             is_active: snap.is_active,
                             health,
+                            tested_url,
+                            update_url,
                             is_testing,
                             on_test: move |_| {
                                 let url = surl.clone();
@@ -131,8 +160,28 @@ pub(crate) fn ServersPanel() -> Element {
                                 spawn(async move {
                                     let result = probe_health(&url, token.as_deref()).await;
                                     testing_ids.write().remove(&id);
-                                    health_map.write().insert(id, result);
+                                    health_map.write().insert(id, (result, url));
                                 });
+                            },
+                            on_update_url: move |_| {
+                                if let Some(u) = update_url_apply.clone() {
+                                    server_store.write().update(
+                                        &sid_update,
+                                        name_update.clone(),
+                                        u,
+                                        token_update.clone(),
+                                    );
+                                    health_map.write().remove(&sid_update);
+                                    let store = server_store.read();
+                                    let app = appearance.read();
+                                    let keys = keybindings.read();
+                                    settings_config::save_state(&store, &app, &keys);
+                                }
+                            },
+                            on_saved: move |_| {
+                                // WHY: A health result probed against the pre-edit URL
+                                // must not linger next to the new one.
+                                health_map.write().remove(&sid_saved);
                             },
                             on_switch: move |_| {
                                 {
@@ -177,8 +226,12 @@ fn ServerCard(
     auth_token: Option<String>,
     is_active: bool,
     health: ServerHealth,
+    tested_url: Option<String>,
+    update_url: Option<String>,
     is_testing: bool,
     on_test: EventHandler<()>,
+    on_update_url: EventHandler<()>,
+    on_saved: EventHandler<()>,
     on_switch: EventHandler<()>,
     on_remove: EventHandler<()>,
 ) -> Element {
@@ -192,7 +245,18 @@ fn ServerCard(
     let keybindings = use_context::<Signal<crate::state::settings::KeybindingStore>>();
 
     let health_color = health.color();
-    let health_label = health.label();
+    let status_text = if is_testing {
+        "Testing…".to_string()
+    } else if health == ServerHealth::Unreachable {
+        // WHY: Name the URL the probe actually hit so a stale saved URL is
+        // self-diagnosing instead of an anonymous "Unreachable".
+        match tested_url.as_deref() {
+            Some(tried) => format!("Unreachable — {tried}"),
+            None => health.label().to_string(),
+        }
+    } else {
+        health.label().to_string()
+    };
     let card_border = if is_active {
         "1px solid var(--accent)"
     } else {
@@ -249,7 +313,7 @@ fn ServerCard(
                         }
                         button {
                             style: "padding: var(--space-2) var(--space-4); background: var(--accent); border: none; \
-                                    border-radius: var(--radius-sm); color: var(--text-primary); font-size: var(--text-xs); cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick);",
+                                    border-radius: var(--radius-sm); color: var(--text-inverse); font-size: var(--text-xs); cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick);",
                             onclick: move |_| {
                                 let new_name = edit_name();
                                 let new_url = edit_url();
@@ -263,6 +327,7 @@ fn ServerCard(
                                     settings_config::save_state(&store, &app, &keys);
                                 }
                                 editing.set(false);
+                                on_saved.call(());
                             },
                             "Save"
                         }
@@ -298,8 +363,24 @@ fn ServerCard(
                                 style: "width: 7px; height: 7px; border-radius: 50%; background: {health_color};",
                             }
                             span {
-                                style: "font-size: var(--text-xs); color: {health_color};",
-                                if is_testing { "Testing…" } else { "{health_label}" }
+                                style: "font-size: var(--text-xs); color: {health_color}; word-break: break-all;",
+                                "{status_text}"
+                            }
+                        }
+                        if let Some(live_url) = update_url.clone() {
+                            div {
+                                style: "display: flex; align-items: center; gap: var(--space-2); margin-top: var(--space-1); flex-wrap: wrap;",
+                                span {
+                                    style: "font-size: var(--text-xs); color: var(--status-warning); word-break: break-all;",
+                                    "Connected to {live_url}"
+                                }
+                                button {
+                                    style: "padding: var(--space-1) var(--space-3); background: var(--border); border: 1px solid var(--accent); \
+                                            border-radius: var(--radius-sm); color: var(--accent-hover); font-size: var(--text-xs); cursor: pointer; \
+                                            transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick);",
+                                    onclick: move |_| on_update_url.call(()),
+                                    "Update to current"
+                                }
                             }
                         }
                     }
@@ -397,7 +478,7 @@ fn AddServerForm(server_store: Signal<ServerConfigStore>, on_saved: EventHandler
                     style: "display: flex; justify-content: flex-end;",
                     button {
                         style: "padding: var(--space-2) var(--space-4); background: var(--accent); border: none; \
-                                border-radius: var(--radius-md); color: var(--text-primary); font-size: var(--text-sm); cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick);",
+                                border-radius: var(--radius-md); color: var(--text-inverse); font-size: var(--text-sm); cursor: pointer; transition: background-color var(--transition-quick), color var(--transition-quick), border-color var(--transition-quick);",
                         onclick: move |_| {
                             let n = name();
                             let u = url();


### PR DESCRIPTION
Third desktop wave, implementing the operator's live round-1 UI-test feedback. 8 parallel disjoint-file agents + build-verified (pylon 521/521, skene clean, proskenion builds release).

## By feedback item
- **Light theme broke (sidebar dark/unreadable)** → app-wide `[data-theme]` token correctness; semantic tokens added where roles were missing; status pills + dividers verified in both themes.
- **Nous pills still in topbar** → topbar pill row removed; the sidebar roster is the sole agent home.
- **Enter behavior** → Enter sends, Shift+Enter newline; send/abort button heights matched.
- **"thinking" too vague + no streaming** → live pipeline-phase status (assembling context / recalling memories / using ⟨tool⟩ / writing); confirmed text deltas render progressively.
- **Retry stacked duplicate bubbles** → retry re-sends in place.
- **Sessions tab** → grouped under collapsible per-nous sections; system/background sessions (daemon/cron/eval/web/test) hidden behind an off-by-default toggle. (Continuous-conversation/compaction-chain model sketched for a follow-up — it needs backend support.)
- **Memory explorer rendered nothing** → facts view when entities are empty (the store is fact-heavy, entity-sparse), with a clear empty state; nous selector themed.
- **Metrics determinism** → zero-usage models filtered from period summaries; totals derive from API data.
- **Insights out-of-theme blue + small charts** → token-themed backgrounds, larger charts, drill-down.
- **Settings tabs cramped / font-size typeable / stale server entry** → tab-bar spacing, numeric font input, self-healing "update to current" on the connected entry.
- **Connect/disconnect toast spam** → indicator + toasts only flip on sustained loss, not transient SSE reconnects.
- **Files → Theke** → renamed; backed by a config-driven `[workspace] root` (defaults to the instance theke).

## Verification
pylon 521/521 + taxis/pylon check clean; skene clean; proskenion `check --all-targets` zero warnings + release build. No hardcoded colors introduced (tokens only). `_llm` regenerated.

Co-authored-by: Cody Kickertz <cody.kickertz@pm.me>