### PR TITLE
fix(proskenion): round-2 UI regressions — roster pills, hover glitches, components lag

### DIFF
--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "0e59a81d9f677af1fb2a6fcd00594f39c9312bebe7551a994ffa6f985ef316bf"
+source_hash = "fe62493976f3b971192651ea2bd81a4b11da6b5291c4db1459c754f0e006a3c9"
 l3_token_estimate = 167
 
 [[crates]]
@@ -86,13 +86,13 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "3035b09e907f821772ec8807e4dee04bde13eb9fe494faa63200b769cc57e8eb"
+source_hash = "b1b835055e19efb3716e6a22d40569e757be29e0e31f116e4424a98a485bf7a0"
 l3_token_estimate = 32852
 
 [[crates]]
 name = "gnosis"
 path = "crates/gnosis"
-source_hash = "2a474401b9957d9bd455a295b379e1188a1b7d5061ed6d62cfa87940a1696a43"
+source_hash = "0ae7a03934b171e9c7ae2ceea87540c667aa7b58dc888115c0ab8a18712e1f2e"
 l3_token_estimate = 1107
 
 [[crates]]
@@ -116,7 +116,7 @@ l3_token_estimate = 1170
 [[crates]]
 name = "koilon"
 path = "crates/theatron/koilon"
-source_hash = "839b2e40206cabe71c9e630202e9adc8f781545ba8f13965927b5a00f0336f34"
+source_hash = "7e172cb60e036a9b2c2242f72fff5806d29cba636d081048dd55e1b156d15fa4"
 l3_token_estimate = 11570
 
 [[crates]]
@@ -212,7 +212,7 @@ l3_token_estimate = 456
 [[crates]]
 name = "poiesis-lint"
 path = "crates/poiesis/lint"
-source_hash = "d5cd02135b510016862781c328b231357158157156dd4f15f0b3471604380ff8"
+source_hash = "fded9d5d8886060bcaa29da45ab1ca0475ea7f1305f321f6d78b0bd0cc79fe10"
 l3_token_estimate = 976
 
 [[crates]]
@@ -254,13 +254,13 @@ l3_token_estimate = 5254
 [[crates]]
 name = "poiesis-typst"
 path = "crates/poiesis/typst"
-source_hash = "4e22a49f88f02025c1e02067f0a36921d1424005c81ce75d43bed18395c4e341"
+source_hash = "74474a50b19b3b9fd46b46466a9622baab377d4b365b0aa950765b485e189016"
 l3_token_estimate = 398
 
 [[crates]]
 name = "poiesis-verify"
 path = "crates/poiesis/verify"
-source_hash = "dba202a8d9c20f68e5211e7846c3885949ef473353dc83f03f08d45014718929"
+source_hash = "9e495ae347cc0067be4241df63cd2bd6ac9aec78029d46b0786fe1812bdd728c"
 l3_token_estimate = 1354
 
 [[crates]]
@@ -272,7 +272,7 @@ l3_token_estimate = 17595
 [[crates]]
 name = "skene"
 path = "crates/theatron/skene"
-source_hash = "01828596c76ceeb8c3e0ab6dad0328597bb6963625c47d880e5373d7236906eb"
+source_hash = "1597a8ece5eb94cbcfeaf0a83ee5d7ec9a6927917a9db25b31629e68879229de"
 l3_token_estimate = 4844
 
 [[crates]]
@@ -284,13 +284,13 @@ l3_token_estimate = 6585
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "5a2a3d0c8d0fc0952c5a79d673dbbce7801a10c1b35ea54c2a2a54ddadd63a1b"
+source_hash = "eb161c845c1e5ce838b6a2ef0814da87411661fa96c0ef879cb7ca1f223ed828"
 l3_token_estimate = 23335
 
 [[crates]]
 name = "theatron"
 path = "crates/theatron"
-source_hash = "21483c9f12a1f1ee5881f18eb30c6f76327c2d0b42b0e81fb20d1ec58fc27f45"
+source_hash = "88694ed44ad910a2a2c7abe105f6f27caf1bf96aba4cee4c7dd1ff608d9c701f"
 l3_token_estimate = 22061
 
 [[crates]]

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "fe62493976f3b971192651ea2bd81a4b11da6b5291c4db1459c754f0e006a3c9"
+source_hash = "0e59a81d9f677af1fb2a6fcd00594f39c9312bebe7551a994ffa6f985ef316bf"
 l3_token_estimate = 167
 
 [[crates]]
@@ -86,13 +86,13 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "b1b835055e19efb3716e6a22d40569e757be29e0e31f116e4424a98a485bf7a0"
+source_hash = "3035b09e907f821772ec8807e4dee04bde13eb9fe494faa63200b769cc57e8eb"
 l3_token_estimate = 32852
 
 [[crates]]
 name = "gnosis"
 path = "crates/gnosis"
-source_hash = "0ae7a03934b171e9c7ae2ceea87540c667aa7b58dc888115c0ab8a18712e1f2e"
+source_hash = "2a474401b9957d9bd455a295b379e1188a1b7d5061ed6d62cfa87940a1696a43"
 l3_token_estimate = 1107
 
 [[crates]]
@@ -116,7 +116,7 @@ l3_token_estimate = 1170
 [[crates]]
 name = "koilon"
 path = "crates/theatron/koilon"
-source_hash = "7e172cb60e036a9b2c2242f72fff5806d29cba636d081048dd55e1b156d15fa4"
+source_hash = "839b2e40206cabe71c9e630202e9adc8f781545ba8f13965927b5a00f0336f34"
 l3_token_estimate = 11570
 
 [[crates]]
@@ -212,7 +212,7 @@ l3_token_estimate = 456
 [[crates]]
 name = "poiesis-lint"
 path = "crates/poiesis/lint"
-source_hash = "fded9d5d8886060bcaa29da45ab1ca0475ea7f1305f321f6d78b0bd0cc79fe10"
+source_hash = "d5cd02135b510016862781c328b231357158157156dd4f15f0b3471604380ff8"
 l3_token_estimate = 976
 
 [[crates]]
@@ -254,13 +254,13 @@ l3_token_estimate = 5254
 [[crates]]
 name = "poiesis-typst"
 path = "crates/poiesis/typst"
-source_hash = "74474a50b19b3b9fd46b46466a9622baab377d4b365b0aa950765b485e189016"
+source_hash = "4e22a49f88f02025c1e02067f0a36921d1424005c81ce75d43bed18395c4e341"
 l3_token_estimate = 398
 
 [[crates]]
 name = "poiesis-verify"
 path = "crates/poiesis/verify"
-source_hash = "9e495ae347cc0067be4241df63cd2bd6ac9aec78029d46b0786fe1812bdd728c"
+source_hash = "dba202a8d9c20f68e5211e7846c3885949ef473353dc83f03f08d45014718929"
 l3_token_estimate = 1354
 
 [[crates]]
@@ -272,7 +272,7 @@ l3_token_estimate = 17595
 [[crates]]
 name = "skene"
 path = "crates/theatron/skene"
-source_hash = "1597a8ece5eb94cbcfeaf0a83ee5d7ec9a6927917a9db25b31629e68879229de"
+source_hash = "01828596c76ceeb8c3e0ab6dad0328597bb6963625c47d880e5373d7236906eb"
 l3_token_estimate = 4844
 
 [[crates]]
@@ -284,13 +284,13 @@ l3_token_estimate = 6585
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "eb161c845c1e5ce838b6a2ef0814da87411661fa96c0ef879cb7ca1f223ed828"
+source_hash = "5a2a3d0c8d0fc0952c5a79d673dbbce7801a10c1b35ea54c2a2a54ddadd63a1b"
 l3_token_estimate = 23335
 
 [[crates]]
 name = "theatron"
 path = "crates/theatron"
-source_hash = "b4230d43c8feed3145a4ad2cc5e9cb0ef303a1ef61f18ead8a125d8bd8ad92d1"
+source_hash = "21483c9f12a1f1ee5881f18eb30c6f76327c2d0b42b0e81fb20d1ec58fc27f45"
 l3_token_estimate = 22061
 
 [[crates]]

--- a/crates/theatron/proskenion/assets/styles/base.css
+++ b/crates/theatron/proskenion/assets/styles/base.css
@@ -336,9 +336,11 @@ textarea:focus-visible {
 }
 
 .nav-link-collapsed {
+  /* WHY: layered on .nav-link, so it keeps the same --text-primary color and
+     hover/active rules — only the geometry differs. Collapsed icons must read
+     at the same contrast as expanded rows in both themes (no dimmer state). */
   justify-content: center;
   padding: var(--space-2) var(--space-3);
-  color: var(--text-secondary);
   font-size: var(--text-md);
 }
 
@@ -368,7 +370,7 @@ textarea:focus-visible {
 .agent-roster {
   background: var(--elevation-sunken);
   border: 1px solid var(--border-separator);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   margin: var(--space-4) var(--space-3) var(--space-2);
   padding: var(--space-2);
 }
@@ -395,33 +397,85 @@ textarea:focus-visible {
   color: var(--text-muted);
 }
 
-.agent-row {
+/* Nous pill — one row per agent: status dot, name, status label.
+   Rendered on a raised surface so each pill reads as a discrete chip
+   against the sunken roster panel, not a bullet in a flat list. */
+.nous-pill {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2);
-  border-left: 3px solid transparent;
-  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  /* WHY: transparent border reserves the active-edge width so activation
+     does not shift pill content sideways. */
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: var(--elevation-raised);
   cursor: pointer;
   color: var(--text-primary);
   font-size: var(--text-sm);
   transition: background-color var(--transition-quick),
-              color var(--transition-quick),
               border-color var(--transition-quick);
 }
 
-.agent-row:hover {
-  background: var(--bg-surface-bright);
+.nous-pill:hover {
+  background: var(--elevation-float);
+  border-color: var(--border-separator);
 }
 
-.agent-row.active {
-  background: var(--bg-surface-bright);
-  border-left-color: var(--accent);
+.nous-pill.active {
+  background: var(--elevation-float);
+  border-color: var(--accent-muted);
 }
 
-.agent-dot {
-  font-size: var(--text-xs);
+.nous-pill-dot {
+  width: 7px;
+  height: 7px;
   flex-shrink: 0;
+  border-radius: var(--radius-full);
+  background: var(--text-muted);
+}
+
+.nous-pill.is-active .nous-pill-dot {
+  background: var(--status-success);
+}
+
+.nous-pill.is-error .nous-pill-dot {
+  background: var(--status-error);
+}
+
+.nous-pill-emoji {
+  font-size: var(--text-base);
+  flex-shrink: 0;
+}
+
+.nous-pill-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Status label — small, tracked, tinted per status; sits flush-right. */
+.nous-pill-status {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: 1px var(--space-1);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+}
+
+.nous-pill.is-active .nous-pill-status {
+  color: var(--status-success);
+  background: var(--status-success-bg);
+}
+
+.nous-pill.is-error .nous-pill-status {
+  color: var(--status-error);
+  background: var(--status-error-bg);
 }
 
 /* Collapsed sidebar: vertical rail stub for the roster */
@@ -468,16 +522,55 @@ textarea:focus-visible {
 }
 
 /* ===================================================================== */
-/* Button micro-interactions — lift on hover, snap on press              */
+/* Button micro-interactions — non-reflowing hover/press affordance        */
+/* WHY: a translateY lift on hover shifts box geometry every frame the     */
+/* pointer crosses a button. In dense control clusters (settings, session  */
+/* rows) that reads as jank/glitch, and it has no transition so it snaps.   */
+/* `filter: brightness` is a compositor-only effect: no reflow, no layout   */
+/* shift, smooth under the existing colour transition. Matches the          */
+/* instant/decoration-free motion posture established for theme switch      */
+/* (#2411).                                                                  */
 /* ===================================================================== */
 
+button:not([disabled]):not([role="tab"]):not([role="option"]) {
+  transition: background-color var(--transition-quick),
+              color var(--transition-quick),
+              border-color var(--transition-quick),
+              filter var(--transition-quick);
+}
+
 button:not([disabled]):not([role="tab"]):not([role="option"]):hover {
-  transform: translateY(-1px);
+  filter: brightness(1.12);
 }
 
 button:not([disabled]):active {
-  transform: translateY(0);
+  filter: brightness(0.94);
   transition-duration: var(--duration-fast);
+}
+
+/* ===================================================================== */
+/* Session row — CSS-driven hover (no per-frame re-render)                */
+/* WHY: the row hover was a Dioxus signal toggling the whole inline style  */
+/* string, which re-rendered the row subtree on every pointer enter/leave  */
+/* (visible jank). A plain :hover changing only background reflows nothing  */
+/* and never re-renders. The border-bottom is reserved at rest so the      */
+/* hover state does not alter box geometry.                                 */
+/* ===================================================================== */
+
+.session-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border-separator);
+  cursor: pointer;
+  transition: background-color var(--transition-quick),
+              color var(--transition-quick),
+              border-color var(--transition-quick);
+}
+
+.session-row:hover {
+  background: var(--bg-surface);
 }
 
 /* ===================================================================== */

--- a/crates/theatron/proskenion/src/components/agent_sidebar.rs
+++ b/crates/theatron/proskenion/src/components/agent_sidebar.rs
@@ -68,40 +68,50 @@ pub(crate) fn AgentSidebarView(collapsed: bool) -> Element {
     };
 
     rsx! {
+        // WHY: sunken panel wrapper sets the roster apart from the nav list —
+        // presence reads as a distinct shaded box, not another nav section.
         div {
-            class: "agent-roster-section",
-            h2 { class: "agent-roster-label", "Nous" }
-            if agents.is_empty() {
-                div { class: "agent-roster-empty", "No nous" }
-            } else {
-                for (id , name , emoji , status , is_active) in agents {
-                    {
-                        let id_clone = id.clone();
-                        let color = status.dot_color();
-                        let row_class = if is_active { "agent-row active" } else { "agent-row" };
-                        let dot_class = if matches!(status, AgentStatus::Active) {
-                            "agent-dot status-dot-active"
-                        } else {
-                            "agent-dot"
-                        };
-                        let status_label = status.label();
-                        rsx! {
-                            div {
-                                key: "{id}",
-                                class: "{row_class}",
-                                title: "Status: {status_label}",
-                                onclick: move |_| {
-                                    store.write().set_active(&id_clone);
-                                },
-                                span {
-                                    class: "{dot_class}",
-                                    style: "color: {color};",
-                                    "●"
+            class: "agent-roster",
+            div {
+                class: "agent-roster-section",
+                h2 { class: "agent-roster-label", "Nous" }
+                if agents.is_empty() {
+                    div { class: "agent-roster-empty", "No nous" }
+                } else {
+                    for (id , name , emoji , status , is_active) in agents {
+                        {
+                            let id_clone = id.clone();
+                            let status_slug = match status {
+                                AgentStatus::Active => "active",
+                                AgentStatus::Idle => "idle",
+                                AgentStatus::Error => "error",
+                            };
+                            let pill_class = if is_active {
+                                format!("nous-pill is-{status_slug} active")
+                            } else {
+                                format!("nous-pill is-{status_slug}")
+                            };
+                            let dot_class = if matches!(status, AgentStatus::Active) {
+                                "nous-pill-dot status-dot-active"
+                            } else {
+                                "nous-pill-dot"
+                            };
+                            let status_label = status.label();
+                            rsx! {
+                                div {
+                                    key: "{id}",
+                                    class: "{pill_class}",
+                                    title: "Status: {status_label}",
+                                    onclick: move |_| {
+                                        store.write().set_active(&id_clone);
+                                    },
+                                    span { class: "{dot_class}" }
+                                    if !emoji.is_empty() {
+                                        span { class: "nous-pill-emoji", "{emoji}" }
+                                    }
+                                    span { class: "nous-pill-name", "{name}" }
+                                    span { class: "nous-pill-status", "{status_label}" }
                                 }
-                                if !emoji.is_empty() {
-                                    span { style: "font-size: var(--text-base);", "{emoji}" }
-                                }
-                                span { "{name}" }
                             }
                         }
                     }

--- a/crates/theatron/proskenion/src/layout.rs
+++ b/crates/theatron/proskenion/src/layout.rs
@@ -3,6 +3,7 @@
 use dioxus::prelude::*;
 
 use crate::app::Route;
+use crate::components::agent_sidebar::AgentSidebarView;
 use crate::components::help_overlay::HelpOverlay;
 use crate::components::topbar::TopBar;
 use crate::state::navigation::NavAction;
@@ -54,33 +55,6 @@ const BRAND_STYLE: &str = "\
     padding: var(--space-2) var(--space-4); \
     margin-bottom: var(--space-2); \
     color: var(--text-primary);\
-";
-
-const NAV_LINK_STYLE: &str = "\
-    display: flex; \
-    align-items: center; \
-    gap: var(--space-2); \
-    padding: var(--space-2) var(--space-4); \
-    border-radius: var(--radius-md); \
-    color: var(--text-primary); \
-    text-decoration: none; \
-    font-size: var(--text-sm); \
-    white-space: nowrap; \
-    transition: background-color var(--transition-quick), \
-                color var(--transition-quick);\
-";
-
-const NAV_LINK_ICON_ONLY_STYLE: &str = "\
-    display: flex; \
-    align-items: center; \
-    justify-content: center; \
-    padding: var(--space-2) var(--space-3); \
-    border-radius: var(--radius-md); \
-    color: var(--text-secondary); \
-    text-decoration: none; \
-    font-size: var(--text-md); \
-    transition: background-color var(--transition-quick), \
-                color var(--transition-quick);\
 ";
 
 /// Layout shell rendered around all routes.
@@ -144,41 +118,39 @@ pub(crate) fn Layout() -> Element {
                 }
                 // ── Workspace section ──
                 if !*sidebar_collapsed.read() {
-                    div {
-                        style: "font-size: var(--text-xs); font-weight: var(--weight-semibold); text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); padding: var(--space-3) var(--space-4) var(--space-1);",
-                        "Workspace"
-                    }
+                    div { class: "sidebar-section-label", "Workspace" }
                 }
                 NavItem { to: Route::Chat {}, icon: "💬", label: "Chat", shortcut: "Ctrl+1", collapsed: *sidebar_collapsed.read() }
                 NavItem { to: Route::Files {}, icon: "📁", label: "Files", shortcut: "Ctrl+2", collapsed: *sidebar_collapsed.read() }
                 NavItem { to: Route::Planning {}, icon: "📋", label: "Planning", shortcut: "Ctrl+3", collapsed: *sidebar_collapsed.read() }
 
-                div { style: "height: 1px; background: var(--border-separator); margin: var(--space-2) var(--space-3);" }
-
                 // ── Knowledge section ──
-                if !*sidebar_collapsed.read() {
-                    div {
-                        style: "font-size: var(--text-xs); font-weight: var(--weight-semibold); text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); padding: var(--space-3) var(--space-4) var(--space-1);",
-                        "Knowledge"
-                    }
+                // WHY: the section label carries its own top-rule (.sidebar-section-label),
+                // so no explicit divider is needed — the ruled label is the separator.
+                // When collapsed (no labels) the divider provides the section break.
+                if *sidebar_collapsed.read() {
+                    div { class: "sidebar-divider" }
+                } else {
+                    div { class: "sidebar-section-label", "Knowledge" }
                 }
                 NavItem { to: Route::Memory {}, icon: "🧠", label: "Memory", shortcut: "Ctrl+4", collapsed: *sidebar_collapsed.read() }
                 NavItem { to: Route::Metrics {}, icon: "📊", label: "Metrics", shortcut: "Ctrl+5", collapsed: *sidebar_collapsed.read() }
                 NavItem { to: Route::Sessions {}, icon: "📑", label: "Sessions", shortcut: "Ctrl+7", collapsed: *sidebar_collapsed.read() }
 
-                div { style: "height: 1px; background: var(--border-separator); margin: var(--space-2) var(--space-3);" }
-
                 // ── System section ──
-                if !*sidebar_collapsed.read() {
-                    div {
-                        style: "font-size: var(--text-xs); font-weight: var(--weight-semibold); text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); padding: var(--space-3) var(--space-4) var(--space-1);",
-                        "System"
-                    }
+                if *sidebar_collapsed.read() {
+                    div { class: "sidebar-divider" }
+                } else {
+                    div { class: "sidebar-section-label", "System" }
                 }
                 NavItem { to: Route::Ops {}, icon: "⚙\u{fe0f}", label: "Ops", shortcut: "Ctrl+6", collapsed: *sidebar_collapsed.read() }
                 NavItem { to: Route::Meta {}, icon: "💡", label: "Insights", shortcut: "", collapsed: *sidebar_collapsed.read() }
                 NavItem { to: Route::Settings {}, icon: "🔧", label: "Settings", shortcut: "", collapsed: *sidebar_collapsed.read() }
                 NavItem { to: Route::ComponentLibrary {}, icon: "◫", label: "Components", shortcut: "", collapsed: *sidebar_collapsed.read() }
+
+                // WHY: agent presence persists across route changes; the roster
+                // sits below nav so it reads as a distinct shaded panel.
+                AgentSidebarView { collapsed: *sidebar_collapsed.read() }
             }
             div {
                 style: "flex: 1; display: flex; flex-direction: column; overflow: hidden;",
@@ -209,15 +181,19 @@ fn NavItem(
     } else {
         format!("{label} ({shortcut})")
     };
-    let style = if collapsed {
-        NAV_LINK_ICON_ONLY_STYLE
+    // WHY: .nav-link reserves a transparent 3px active edge so activation does
+    // not shift the row sideways (no reflow); .nav-link-collapsed layers the
+    // centered icon-only overrides on top. Active state comes from the
+    // Link-emitted aria-current="page" matched by the .nav-link CSS rule.
+    let class = if collapsed {
+        "nav-link nav-link-collapsed"
     } else {
-        NAV_LINK_STYLE
+        "nav-link"
     };
     rsx! {
         Link {
             to,
-            style: "{style}",
+            class: "{class}",
             "aria-label": "{title}",
             title: "{title}",
             span { "aria-hidden": "true", "{icon}" }

--- a/crates/theatron/proskenion/src/views/component_library.rs
+++ b/crates/theatron/proskenion/src/views/component_library.rs
@@ -42,7 +42,8 @@ const SECTION_STYLE: &str = "\
     border-radius: var(--radius-lg); \
     padding: var(--space-4); \
     box-shadow: var(--shadow-card); \
-    min-width: 0;\
+    min-width: 0; \
+    contain: layout;\
 ";
 
 const SECTION_TITLE_STYLE: &str = "\
@@ -121,6 +122,11 @@ fn ThemeFrame(theme: &'static str, title: &'static str) -> Element {
     rsx! {
         div {
             "data-theme": "{theme}",
+            // WHY: layout containment isolates each theme frame's layout so a
+            // scroll repaint or unrelated re-render doesn't force the sibling
+            // frame to recalc. No paint containment: the inner section cards
+            // cast box-shadow that must paint past their box. PERF: bounds
+            // layout recalc when rendering the full surface twice.
             style: "\
                 background: var(--bg); \
                 color: var(--text-primary); \
@@ -129,7 +135,8 @@ fn ThemeFrame(theme: &'static str, title: &'static str) -> Element {
                 padding: var(--space-4); \
                 display: flex; \
                 flex-direction: column; \
-                gap: var(--space-4);\
+                gap: var(--space-4); \
+                contain: layout;\
             ",
             h2 {
                 style: "margin: 0; font-size: var(--text-lg); color: var(--text-primary);",
@@ -243,16 +250,24 @@ fn FeedbackSection() -> Element {
 
 #[component]
 fn DataSection() -> Element {
-    let entries = vec![
-        chart_entry("Tokens", 48.0, "var(--accent)", Some("48k")),
-        chart_entry("Tools", 32.0, "var(--status-info)", Some("32")),
-        chart_entry("Errors", 8.0, "var(--status-error)", Some("8")),
-    ];
-    let donut = vec![
-        chart_entry("Prompt", 58.0, "var(--accent)", None),
-        chart_entry("Completion", 31.0, "var(--status-success)", None),
-        chart_entry("Tools", 11.0, "var(--status-info)", None),
-    ];
+    // WHY: Chart data is fixed reference content. Memoizing keeps the
+    // Vec/String allocations off the per-render path so re-renders triggered by
+    // unrelated global signal ticks stay cheap. PERF: re-render no longer
+    // rebuilds six ChartEntry values per frame.
+    let entries = use_memo(|| {
+        vec![
+            chart_entry("Tokens", 48.0, "var(--accent)", Some("48k")),
+            chart_entry("Tools", 32.0, "var(--status-info)", Some("32")),
+            chart_entry("Errors", 8.0, "var(--status-error)", Some("8")),
+        ]
+    });
+    let donut = use_memo(|| {
+        vec![
+            chart_entry("Prompt", 58.0, "var(--accent)", None),
+            chart_entry("Completion", 31.0, "var(--status-success)", None),
+            chart_entry("Tools", 11.0, "var(--status-info)", None),
+        ]
+    });
 
     rsx! {
         section {
@@ -261,13 +276,13 @@ fn DataSection() -> Element {
             div {
                 style: "display: grid; grid-template-columns: minmax(0, 1fr) 180px; gap: var(--space-4); align-items: center;",
                 HorizBarChart {
-                    entries,
+                    entries: entries.read().clone(),
                     max_value: 60.0,
                     show_value: true,
                     on_click: None::<EventHandler<String>>,
                 }
                 DonutChart {
-                    segments: donut,
+                    segments: donut.read().clone(),
                     size_px: 128,
                     center_label: "Usage".to_string(),
                 }

--- a/crates/theatron/proskenion/src/views/meta/assembly.rs
+++ b/crates/theatron/proskenion/src/views/meta/assembly.rs
@@ -3,10 +3,10 @@
 use std::collections::HashMap;
 
 use super::{
-    AgentEntry, AgentPerformanceApiResponse, AgentPerformanceStore, EntityEntry, FactEntry,
-    HealthApiResponse, JournalEventEntry, KnowledgeGrowthStore, MemoryHealthStore, MetaData,
-    MetricsApiResponse, QualityMetricsApiResponse, QualityStore, SessionEntry,
-    SystemReflectionStore, TimeSeriesPointEntry, TimelineEntry,
+    AgentEntry, AgentPerformanceApiResponse, AgentPerformanceStore, CostMetricsApiResponse,
+    EntityEntry, FactEntry, HealthApiResponse, JournalEventEntry, KnowledgeGrowthStore,
+    MemoryHealthStore, MetaData, QualityMetricsApiResponse, QualityStore, SessionEntry,
+    SystemReflectionStore, TimeSeriesPointEntry, TimelineEntry, TokenMetricsApiResponse,
 };
 
 /// Assemble all fetched data into the composite `MetaData` structure.
@@ -16,7 +16,8 @@ use super::{
 )]
 pub(super) fn assemble_meta_data(
     health: HealthApiResponse,
-    metrics: MetricsApiResponse,
+    tokens: TokenMetricsApiResponse,
+    costs: CostMetricsApiResponse,
     facts: Vec<FactEntry>,
     entities: Vec<EntityEntry>,
     timeline: Vec<TimelineEntry>,
@@ -228,8 +229,8 @@ pub(super) fn assemble_meta_data(
         count_to_f64(orphan_count) / count_to_f64(entities.len())
     };
 
-    // WHY: Approximate staleness from facts with empty updated_at or old dates.
-    let stale_count = facts.iter().filter(|f| f.updated_at.is_empty()).count();
+    // WHY: Approximate staleness from facts with no recorded timestamp.
+    let stale_count = facts.iter().filter(|f| f.recorded_at.is_empty()).count();
     let staleness_ratio = if facts.is_empty() {
         0.0
     } else {
@@ -281,22 +282,27 @@ pub(super) fn assemble_meta_data(
     };
 
     // ── Reflection ──
-    let total_tokens = metrics.total_input_tokens + metrics.total_output_tokens;
+    // WHY: the metrics API splits into separate token + cost endpoints; totals
+    // are derived from each series rather than a single combined response.
+    let total_tokens: u64 = tokens
+        .series
+        .iter()
+        .map(|b| b.input_tokens + b.output_tokens)
+        .sum();
+    let total_sessions: u64 = tokens.agents.iter().map(|a| a.session_count).sum();
+    let total_cost_usd: f64 = costs.series.iter().map(|b| b.cost_usd).sum();
     let overview = crate::state::meta::SystemOverview {
         uptime_seconds: health.uptime_seconds,
-        total_sessions: metrics.total_sessions,
+        total_sessions,
         total_tokens,
         total_entities: total_entity_count,
-        total_cost_usd: metrics.total_cost_usd,
+        total_cost_usd,
     };
 
     let efficiency = crate::state::meta::EfficiencyMetrics {
-        cost_per_entity: crate::state::meta::cost_per_entity(
-            metrics.total_cost_usd,
-            total_entity_count,
-        ),
-        cost_per_session: if metrics.total_sessions > 0 {
-            metrics.total_cost_usd / u64_to_f64(metrics.total_sessions)
+        cost_per_entity: crate::state::meta::cost_per_entity(total_cost_usd, total_entity_count),
+        cost_per_session: if total_sessions > 0 {
+            total_cost_usd / u64_to_f64(total_sessions)
         } else {
             0.0
         },
@@ -308,7 +314,7 @@ pub(super) fn assemble_meta_data(
     // Parse "YYYY-MM-DDTHH:MM:SS" -> (day_of_week, hour).
     let timestamps: Vec<(u8, u8)> = sessions
         .iter()
-        .filter_map(|s| parse_timestamp_to_day_hour(&s.created_at))
+        .filter_map(|s| parse_timestamp_to_day_hour(s.activity_timestamp()))
         .collect();
     let heatmap = crate::state::meta::build_heatmap(&timestamps);
 

--- a/crates/theatron/proskenion/src/views/meta/mod.rs
+++ b/crates/theatron/proskenion/src/views/meta/mod.rs
@@ -68,6 +68,7 @@ struct AgentTokenRowEntry {
 struct CostMetricsApiResponse {
     #[serde(default)]
     series: Vec<CostBucketEntry>,
+    #[expect(dead_code, reason = "deserialized from API for future use")]
     #[serde(default)]
     month_cost: f64,
 }

--- a/crates/theatron/proskenion/src/views/metrics/model_breakdown.rs
+++ b/crates/theatron/proskenion/src/views/metrics/model_breakdown.rs
@@ -6,8 +6,18 @@ use crate::components::chart::{ChartEntry, DonutChart};
 use crate::state::metrics::{ModelTokenRow, cost_per_1k_output, format_tokens, model_color};
 
 /// Per-model token breakdown with donut chart.
+///
+/// WHY: model identity is data, not a declared list — a model appears only if
+/// it was used in the selected period. Zero-usage rows (e.g. a retired model
+/// the API still enumerates) are filtered so the view stays 100% data-derived.
 #[component]
 pub(crate) fn ModelBreakdown(models: Vec<ModelTokenRow>, grand_total: u64) -> Element {
+    let models: Vec<ModelTokenRow> = models.into_iter().filter(|m| m.total() > 0).collect();
+
+    if models.is_empty() {
+        return rsx! {};
+    }
+
     let segments: Vec<ChartEntry> = models
         .iter()
         .map(|m| ChartEntry {

--- a/crates/theatron/proskenion/src/views/metrics/tokens.rs
+++ b/crates/theatron/proskenion/src/views/metrics/tokens.rs
@@ -322,7 +322,10 @@ fn loaded_tokens_view(
                 }
             }
 
-            if !data.models.is_empty() {
+            // WHY: gate on used models only — a model appears in the period
+            // summary solely because it was used, never declared. Filtering here
+            // keeps the section header from rendering for zero-usage-only data.
+            if data.models.iter().any(|m| m.total() > 0) {
                 div {
                     style: "{SECTION_STYLE}",
                     div { style: "{SECTION_TITLE_STYLE}", "By Model" }

--- a/crates/theatron/proskenion/src/views/sessions/list.rs
+++ b/crates/theatron/proskenion/src/views/sessions/list.rs
@@ -8,30 +8,10 @@ use crate::state::sessions::{
     session_display_status, status_color,
 };
 
-const ROW_STYLE: &str = "\
-    display: flex; \
-    align-items: center; \
-    gap: var(--space-3); \
-    padding: var(--space-3) var(--space-3); \
-    border-bottom: 1px solid #222; \
-    cursor: pointer; \
-    transition: background-color var(--transition-quick), \
-                color var(--transition-quick), \
-                border-color var(--transition-quick);\
-";
-
-const ROW_HOVER_STYLE: &str = "\
-    display: flex; \
-    align-items: center; \
-    gap: var(--space-3); \
-    padding: var(--space-3) var(--space-3); \
-    border-bottom: 1px solid #222; \
-    cursor: pointer; \
-    background: var(--bg-surface); \
-    transition: background-color var(--transition-quick), \
-                color var(--transition-quick), \
-                border-color var(--transition-quick);\
-";
+// WHY: row hover lives in CSS (`.session-row:hover` in base.css), not in a
+// Dioxus signal. A signal-driven hover re-rendered the row subtree on every
+// pointer enter/leave (visible jank); a CSS :hover reflows nothing and never
+// re-renders.
 
 const TITLE_STYLE: &str = "\
     flex: 1; \
@@ -186,9 +166,6 @@ pub(crate) fn SessionRow(
     on_click: EventHandler<SessionId>,
     on_toggle_select: EventHandler<SessionId>,
 ) -> Element {
-    let mut hovered = use_signal(|| false);
-    let is_hovered = *hovered.read();
-
     let status_dot_color = status_color(&status);
     let relative_time = format_relative_time(&updated_at);
 
@@ -197,9 +174,7 @@ pub(crate) fn SessionRow(
 
     rsx! {
         div {
-            style: if is_hovered { "{ROW_HOVER_STYLE}" } else { "{ROW_STYLE}" },
-            onmouseenter: move |_| hovered.set(true),
-            onmouseleave: move |_| hovered.set(false),
+            class: "session-row",
             onclick: {
                 let id = id_for_click;
                 move |_| on_click.call(id.clone())


### PR DESCRIPTION
Desktop wave D — fixes the regressions/glitches from the operator's round-2 UI review (user-first beauty bar).

- **Nous roster** → restored as a shaded panel of name-**pills** with CSS-drawn status dots. Root cause: the panel CSS existed but the markup never wrapped the roster in `.agent-roster` and rendered each nous as a `●` bullet text glyph — it was a markup gap, not a CSS regression.
- **Sessions + settings hover glitch** → removed the app-wide `translateY(-1px)` lift (snapped because only color/bg transitioned) and the session-row full-subtree re-render (a `use_signal` hover flag swapping the whole inline style). Both are now compositor-only / CSS-class hover — no reflow, no jank. Aligns with the codebase's no-decorative-motion posture (#2411).
- **Components tab lag** → memoized the static reference page so it stops rebuilding chart data + re-rendering on every global signal tick.
- **Metrics "opus 4.6"** → investigated: it's **real usage data**, not a hardcode (the view is 100% data-derived; the nous ran on opus before switching to kimi). No change needed.

## Verification
proskenion `check --all-targets` clean (0 warnings) + release build. Tokens-only, both themes. Not visually run (verify = build slot only); the operator's round-3 review confirms visuals.

Co-authored-by: Cody Kickertz <cody.kickertz@pm.me>