### PR TITLE
ci: dedicated desktop (proskenion) job — path-filtered compile, clippy, tests

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,83 @@
+# WHY: proskenion is workspace-excluded; this job compiles, lints, and tests it when desktop paths change.
+name: Desktop
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/theatron/proskenion/**"
+      - "crates/theatron/skene/**"
+      - "scripts/*proskenion*"
+      - ".github/workflows/desktop.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/theatron/proskenion/**"
+      - "crates/theatron/skene/**"
+      - "scripts/*proskenion*"
+      - ".github/workflows/desktop.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  proskenion:
+    name: proskenion
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: "1.94.0"
+          components: rustfmt, clippy
+
+      - name: Install GTK/WebKit system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libxdo-dev librsvg2-dev
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: proskenion-${{ hashFiles('crates/theatron/proskenion/Cargo.toml') }}
+          workspaces: "crates/theatron/proskenion"
+
+      - name: Configure git credentials for private fleet deps
+        env:
+          FLEET_REPO_TOKEN: ${{ secrets.FLEET_REPO_TOKEN }}
+        run: |
+          if [ -z "${FLEET_REPO_TOKEN}" ]; then
+            echo "FLEET_REPO_TOKEN is not set; private fleet deps will fail to fetch." >&2
+            exit 1
+          fi
+          git config --global credential.helper store
+          printf 'https://forkwright:%s@github.com\n' "${FLEET_REPO_TOKEN}" > ~/.git-credentials
+          chmod 0600 ~/.git-credentials
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
+        with:
+          tool: nextest
+
+      - name: Check proskenion theatron pins
+        run: scripts/check-proskenion-pins.py
+
+      - name: cargo fmt --check
+        run: cargo fmt --manifest-path crates/theatron/proskenion/Cargo.toml --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --manifest-path crates/theatron/proskenion/Cargo.toml --all-targets -- -D warnings
+
+      - name: cargo nextest run
+        run: cargo nextest run --manifest-path crates/theatron/proskenion/Cargo.toml --no-tests=pass

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ members = [
     "crates/aletheia-sessions-migrate",
 ]
 # WHY: proskenion requires GTK3/webkit2gtk system libraries (via Dioxus
-# desktop/webview) which are not available in CI. Excluded from workspace to
-# avoid cargo-deny advisory failures on GTK deps and build failures on CI.
+# desktop/webview) and carries desktop-only GTK advisory noise. Keep it outside
+# root workspace gates; the dedicated desktop CI job compiles and lints it.
 # Build/install flow and system deps: docs/DESKTOP.md
 # Build standalone: `cargo build -p proskenion --manifest-path crates/theatron/proskenion/Cargo.toml`
 exclude = [

--- a/crates/theatron/proskenion/Cargo.toml
+++ b/crates/theatron/proskenion/Cargo.toml
@@ -40,7 +40,8 @@ features = ["logging"]
 [package]
 name = "proskenion"
 # WHY: explicit values instead of workspace inheritance because this crate
-# is excluded from the workspace (GTK/webkit2gtk deps break CI).
+# is excluded from the root workspace; dedicated desktop CI compiles and lints
+# it through this standalone manifest.
 version = "0.13.1"
 edition = "2024"
 license = "AGPL-3.0-or-later"
@@ -142,8 +143,9 @@ notify-rust = "4"
 [dev-dependencies]
 tempfile = "3"
 
-# WHY: proskenion is excluded from the workspace (GTK3/webkit2gtk
-# system library requirement). Inline lints replace workspace inheritance.
+# WHY: proskenion is excluded from the root workspace (GTK3/webkit2gtk system
+# library requirement). Inline lints replace workspace inheritance while
+# dedicated desktop CI compiles and lints this standalone manifest.
 [lints.rust]
 future_incompatible = { level = "warn", priority = -1 }
 nonstandard_style = { level = "warn", priority = -1 }

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -22,7 +22,7 @@ sudo dnf install gtk3-devel webkit2gtk4.1-devel libxdo-devel
 
 ## Build
 
-The desktop crate is excluded from the workspace because its GTK/webkit2gtk dependencies are not available in CI and would cause build failures and cargo-deny advisory noise.
+The desktop crate is excluded from the root workspace because its GTK/webkit2gtk dependency set needs dedicated system packages and carries desktop-only cargo-deny advisory noise. The path-filtered desktop CI job installs those packages and compiles, lints, and tests `proskenion` through its standalone manifest.
 
 For the standard local install flow, run:
 
@@ -69,7 +69,7 @@ The standard installer runs this check before building, and the release workflow
 
 ## Why excluded from workspace
 
-1. **CI compatibility.** GTK3 and webkit2gtk are not installed in the CI environment. Including the crate in the workspace would fail `cargo build --workspace` and `cargo clippy --workspace`.
+1. **Root workspace compatibility.** GTK3 and webkit2gtk are installed only by the dedicated desktop CI job. Keeping `proskenion` outside the root workspace avoids forcing every workspace gate to install desktop system packages, while the desktop job still runs compile, clippy, and tests through the standalone manifest.
 2. **Dependency advisories.** GTK bindings pull in crates with known advisories that are acceptable for a desktop app but would block cargo-deny checks for the rest of the workspace.
 3. **Independent versioning.** The desktop crate tracks its own version instead of inheriting from `[workspace.package]`, since it ships on a separate release cadence.
 


### PR DESCRIPTION
Closes #4509.

proskenion is workspace-excluded (GTK/webkit2gtk system deps), so no CI job compiled it — main shipped a non-compiling meta view undetected (the wave-d/wave-c batch each had to carry the fix). This adds `.github/workflows/desktop.yml`: path-filtered to `crates/theatron/proskenion/**`, `crates/theatron/skene/**`, `scripts/*proskenion*`; ubuntu-latest with the proven GTK/webkit apt set; rust-cache scoped to the standalone manifest; `check-proskenion-pins.py` + fmt + clippy `-D warnings` + nextest (`--no-tests=pass`); action SHAs pinned in the existing house style.

Also corrects the now-stale "not available in CI" rationale in the root and proskenion manifests and `docs/DESKTOP.md` — the truth is now: excluded from the root workspace, compiled+linted by the dedicated desktop job.

Workspace-inclusion question (#4509 discussion) deliberately left open — operator-escalated.