### PR TITLE
docs: disambiguate the three MCP planes — operator-side, runtime-bridged, server-exposed

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,8 +30,12 @@ Key substrate properties as of the 2026-05-08 refresh:
 - **Tool receipt integrity:** `organon` emits HMAC-SHA256 receipts and an
   in-memory receipt ledger so the pipeline can detect hallucinated tool
   results.
-- **External tool plane:** `diaporeia` can bridge external MCP servers into the
-  `organon` registry while preserving RBAC claims and shared-state boundaries.
+- **Runtime-bridged MCP tools:** `crates/aletheia/src/external_tools.rs` can
+  bridge configured external MCP servers into `organon::registry::ToolRegistry`
+  when the binary is built with MCP support.
+- **DiaporeiaServer-exposed MCP tools:** `diaporeia` exposes Aletheia's own MCP
+  server surface over stdio or `/mcp` using an `rmcp` tool router; those tools
+  are intentionally separate from the in-process `organon::registry::ToolRegistry`.
 - **Auth facade:** `symbolon::AuthFacade` is the admin-token verification and
   revocation boundary shared by `pylon` and `diaporeia`.
 - **Bounded stages:** `nous` carries per-stage timeout configuration for LLM
@@ -59,7 +63,7 @@ aletheia
 ├── nous           -  agent pipeline, bootstrap, recall, finalize, actor model
 ├── dianoia        -  planning / project orchestration
 ├── pylon          -  Axum HTTP gateway, SSE streaming, auth enforcement
-├── diaporeia      -  MCP server interface and external tool-plane bridge
+├── diaporeia      -  MCP server interface exposed over stdio and streamable HTTP
 ├── symbolon       -  JWT auth, admin facade, sessions, RBAC
 ├── agora          -  channel registry + ChannelProvider trait
 │   └── semeion    -  Signal (signal-cli subprocess)

--- a/docs/GROUNDS.md
+++ b/docs/GROUNDS.md
@@ -83,8 +83,8 @@ An abstraction with only one creation path is a mesh with a single root. If that
 2. **Thesauros domain packs** - `crates/aletheia/src/runtime/mod.rs:358`
    `thesauros::tools::register_pack_tools` validates pack manifest tool definitions and registers them into the same `ToolRegistry`.
 
-3. **External tools config** - `crates/aletheia/src/runtime/mod.rs:366`
-   `external_tools::register_external_tools` reads `config/tools/*.toml` and registers HTTP-proxy tools into the same `ToolRegistry`.
+3. **External tools config** - `crates/aletheia/src/runtime/mod.rs:312`
+   `external_tools::register_external_tools` reads the `[tools]` section from `aletheia.toml` and registers configured HTTP tools, plus MCP tools when the binary is built with MCP support, into the same `ToolRegistry`.
 
 ### Non-equivalent ground
 
@@ -146,6 +146,6 @@ The following abstractions are worth extending because they have exactly one *wo
 1. **Sessions** - add a programmatic creation helper for tests and a `aletheia session-create` CLI subcommand.
 2. **Plans** - wire plan generation into the research output pipeline and add a `Plan::from_template` constructor for iterative planning.
 3. **Agents** - re-implement the fjall-backed agent import/export pipeline (#3446) and add a `POST /api/v1/nous` endpoint.
-4. **Tools (diaporeia)** - decide whether diaporeia MCP tools should be bridged into `organon::ToolRegistry` or documented as an intentionally separate tool plane.
+4. **Tools (diaporeia)** - Diaporeia MCP tools are an intentionally separate tool plane. This preserves the psyche boundary: psyche content remains local-only and does not transit the MCP tool plane.
 
 Follow-up issues have been filed for the three highest-priority single-grounded abstractions.

--- a/docs/MCP-SERVERS.md
+++ b/docs/MCP-SERVERS.md
@@ -2,7 +2,17 @@
 
 Operator-side MCP servers that extend an agent's capabilities without modifying the aletheia binary. Aletheia is a 48-crate Rust workspace plus the excluded desktop shell. Coding agents (Claude Code, Cursor, etc.) that only have grep and file reads burn tokens re-discovering structure that a Language Server could answer in one request. The servers below close that gap.
 
-These servers run as **operator-side tooling**, not as part of the aletheia binary. They are registered in the agent's client config (e.g. `~/.claude.json`, `.mcp.json`, or Cursor's `mcp.json`). No aletheia crate depends on them, and they are not wired into the `diaporeia` tool bus. See [Why external, not vendored](#why-external-not-vendored) below.
+These servers run as **operator-side tooling**, not as part of the aletheia binary. They are registered in the agent's client config (e.g. `~/.claude.json`, `.mcp.json`, or Cursor's `mcp.json`). No aletheia crate depends on them, and they are not registered into `organon::registry::ToolRegistry` or served by `DiaporeiaServer`. See [Why external, not vendored](#why-external-not-vendored) below.
+
+## MCP tool planes
+
+| Plane | Who configures it | Hosting process | Owning crate/module |
+|-------|-------------------|-----------------|---------------------|
+| Operator-side MCP servers | The operator configures the agent client (Claude Code, Cursor, Windsurf, etc.) to load servers such as Serena or kanon. | The operator's agent CLI and the external MCP server process; outside the aletheia runtime. | None in aletheia. These tools are not registered into `organon::registry::ToolRegistry` and are not hosted by `DiaporeiaServer`. |
+| Runtime-bridged MCP tools | The deployment configures `[tools]` entries in `aletheia.toml`; MCP entries require the `mcp` feature. | The aletheia runtime connects as an MCP client to configured external MCP servers, discovers `tools/list`, registers discovered tools into `organon::registry::ToolRegistry`, and calls back through MCP `tools/call`. | `crates/aletheia/src/external_tools.rs` owns the bridge; `crates/diaporeia/src/client` provides the MCP client types; `organon` owns in-process dispatch through `ToolRegistry`. |
+| DiaporeiaServer-exposed MCP tools | The deployment configures Aletheia's MCP/gateway settings and external clients connect to Aletheia. | The aletheia process hosts `DiaporeiaServer` over stdio (`aletheia mcp`) or streamable HTTP at `/mcp`. | `crates/diaporeia` owns the exposed server surface through `DiaporeiaServer` and its `rmcp::ToolRouter<Self>`; these tools are intentionally separate from `organon::registry::ToolRegistry`. |
+
+Any new MCP integration must state which plane it lives on before claiming tool availability in the `nous` loop, the Diaporeia server surface, or operator-local agent tooling.
 
 ## Index
 
@@ -111,7 +121,7 @@ An earlier draft of the integrating issue (#3355) proposed wiring Serena into th
 
 - **Lower blast radius.** Zero aletheia crate changes, zero new dependencies in `Cargo.toml`. The server lives outside the Rust workspace.
 - **Upstream stays upstream.** Serena releases often; vendoring would mean tracking their schema and prompts in-tree. Operators get upstream changes via `uv tool upgrade serena-agent` with no aletheia release required.
-- **Agents already have an MCP client.** Claude Code, Cursor, and Windsurf all speak MCP natively. Aletheia's internal `diaporeia` bus is for tools inside the aletheia process (e.g. things the `nous` pipeline calls), not for operator-side coding helpers.
+- **Agents already have an MCP client.** Claude Code, Cursor, and Windsurf all speak MCP natively. Aletheia's internal tool loop uses `organon::registry::ToolRegistry` for tools the `nous` pipeline calls, not for operator-side coding helpers.
 - **Sovereignty path preserved.** If the upstream trajectory diverges from our needs, a Rust-native MCP server wrapping `rust-analyzer` directly can be added under `crates/` later. This is tracked as a follow-up (see PR body for #3355).
 
 ## See also


### PR DESCRIPTION
Closes #4512.

The docs conflated three distinct MCP planes. This adds a disambiguation table to MCP-SERVERS.md (per plane: who configures it, which process hosts it, owning crate/module — all verified against source), reattributes ARCHITECTURE.md lines ~33-34 precisely (the `external_tools.rs` runtime bridge into `organon::registry::ToolRegistry` vs the `DiaporeiaServer` rmcp surface), replaces stale "diaporeia tool bus" phrasing, fixes a stale GROUNDS.md line-number reference, and records GROUNDS' separation from the MCP plane as intentional (psyche boundary).