### PR TITLE
ci+docs: feature-check truth sweep — matrix legs, passthrough features, sandbox-default docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,25 @@ jobs:
           - crate: aletheia
             feature: cc-provider
           - crate: aletheia
+            feature: codex-provider
+          - crate: aletheia
+            feature: kimi-provider
+          - crate: aletheia
             feature: energeia
           # organon features
-          - crate: aletheia-organon
+          - crate: organon
             feature: computer-use
+          - crate: organon
+            feature: bookkeeper
+          - crate: organon
+            feature: energeia
+          - crate: organon
+            feature: z3
           # hermeneus features
-          - crate: aletheia-hermeneus
-            feature: local-llm
+          - crate: hermeneus
+            feature: codex-provider
+          - crate: hermeneus
+            feature: kimi-provider
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -80,6 +92,54 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: feature-${{ matrix.feature }}
+      - name: Validate feature references
+        env:
+          CRATE: ${{ matrix.crate }}
+          FEATURE: ${{ matrix.feature }}
+        run: |
+          cargo metadata --format-version 1 --no-deps > metadata.json
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          crate = os.environ["CRATE"]
+          feature = os.environ["FEATURE"]
+          import pathlib
+          import re
+
+          packages = json.load(open("metadata.json", encoding="utf-8"))["packages"]
+          feature_map = {pkg["name"]: set(pkg["features"]) for pkg in packages}
+          package = next((pkg for pkg in packages if pkg["name"] == crate), None)
+          if package is None:
+              sys.exit(f"unknown package in release feature matrix: {crate}")
+          if feature not in package["features"]:
+              sys.exit(f"unknown feature in release feature matrix: {crate}/{feature}")
+
+          docs = [pathlib.Path("README.md"), *pathlib.Path("docs").rglob("*.md")]
+          feature_docs = [
+              pathlib.Path("README.md"),
+              pathlib.Path("docs/FEATURE-FLAGS.md"),
+              pathlib.Path("docs/test-tiers.md"),
+          ]
+          feature_ref = re.compile(r"`([a-z0-9_-]+)/([a-z0-9_.-]+)`")
+          removed_feature = "local" + "-llm"
+          for path in docs:
+              text = path.read_text(encoding="utf-8")
+              if removed_feature in text:
+                  sys.exit(
+                      f"removed feature reference found in {path}: "
+                      f"{removed_feature}"
+                  )
+          for path in feature_docs:
+              text = path.read_text(encoding="utf-8")
+              for doc_crate, doc_feature in feature_ref.findall(text):
+                  if doc_crate in feature_map and doc_feature not in feature_map[doc_crate]:
+                      sys.exit(
+                          f"unknown documented feature in {path}: "
+                          f"{doc_crate}/{doc_feature}"
+                      )
+          PY
       - name: Check feature ${{ matrix.feature }}
         env:
           CRATE: ${{ matrix.crate }}
@@ -87,7 +147,7 @@ jobs:
         run: cargo check -p "$CRATE" --features "$FEATURE"
 
   build:
-    needs: [test]
+    needs: [test, feature-check]
     permissions:
       contents: write
       attestations: write
@@ -273,7 +333,7 @@ jobs:
             --clobber
 
   sbom:
-    needs: [test]
+    needs: [test, feature-check]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The tarball contains `instance.example/` with the reference config layout. See [
 - **Persistent memory.** Conversations carry forward. The agent builds a knowledge graph of facts, entities, and relationships that persists across sessions and grows over time.
 - **Working-memory continuity.** Each turn can inject agent-curated `<key_info>` from the prior working checkpoint before recall and history are assembled.
 - **Multiple agents.** Each agent has its own character (SOUL.md), goals, memory, and workspace. They can coordinate, delegate, and specialize.
-- **Tools.** 67 built-in tools (default build): file I/O, shell execution, web search, memory search, planning, agent coordination, plus external MCP tools bridged through the organon tool plane. Feature-gated additions bring the total to 76 (energeia) or 80 (all features: energeia + bookkeeper + computer-use + z3).
+- **Tools.** 67 built-in tools (default build): file I/O, shell execution, web search, memory search, planning, agent coordination, plus external MCP tools bridged through the organon tool plane. Feature-gated additions bring the total to 76 with `aletheia/energeia`, or 80 with `cargo build -p aletheia --all-features` (`energeia` + `bookkeeper` + `computer-use` + `z3`).
 - **Runtime guardrails.** Tool calls carry HMAC-SHA256 receipts, loop detection combines ping-pong, no-progress, and doom-loop signals, and per-stage timeouts bound long-running turns.
 - **Terminal dashboard.** Rich TUI with markdown rendering, session management, and real-time streaming.
 - **Signal messaging.** Talk to your agents over Signal. Messages arrive as plain conversational turns routed to the configured agent.

--- a/crates/aletheia/Cargo.toml
+++ b/crates/aletheia/Cargo.toml
@@ -47,6 +47,12 @@ kimi-provider = ["hermeneus/kimi-provider"]
 # Dispatch orchestration and agent-facing Energeia capability tools. Default off for
 # incremental development.
 energeia = ["dep:energeia", "energeia/storage-fjall", "organon/energeia"]
+# Bookkeeper tool passthrough. Default off; enables operator maintenance tools.
+bookkeeper = ["organon/bookkeeper"]
+# Computer-use tool passthrough. Default off; requires Linux sandbox support.
+computer-use = ["organon/computer-use"]
+# Z3 SMT solver passthrough. Default off to avoid pulling bundled libz3.
+z3 = ["organon/z3"]
 # Test tiers (see docs/test-tiers.md)
 test-core = ["mneme/test-core", "nous/test-core", "pylon/test-core"]
 test-full = ["test-core", "mneme/test-full", "online-tests"]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -152,6 +152,7 @@ HTTP gateway serving the API.
 | `port` | u16 | `18789` | Listen port |
 | `bind` | string | `"localhost"` | Bind mode: `"localhost"` (loopback only), `"lan"` (all interfaces), or a custom address |
 | `auth.mode` | string | `"token"` | Auth mode: `"token"` (bearer) or `"none"` |
+| `auth.none_role` | string | `"admin"` | Role assigned to anonymous requests when `auth.mode = "none"`; valid values are `"readonly"`, `"agent"`, `"operator"`, and `"admin"` |
 
 ### gateway.tls
 
@@ -602,18 +603,28 @@ Filesystem sandbox applied to tool execution. When enabled, tools are restricted
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | bool | `true` | Whether sandbox restrictions are applied |
-| `enforcement` | string | `"enforcing"` | `"enforcing"` blocks violations; `"permissive"` logs them without blocking |
+| `enforcement` | string | `"permissive"` | `"enforcing"` blocks violations; `"permissive"` logs them without blocking |
 | `extra_read_paths` | string[] | `[]` | Additional filesystem paths granted read access to all tools |
 | `extra_write_paths` | string[] | `[]` | Additional filesystem paths granted read+write access to all tools |
 | `extra_exec_paths` | string[] | `[]` | Additional filesystem paths granted execute access. Values may begin with `~`, which expands to `$HOME` at policy-build time. |
+| `egress` | string | `"allow"` | Child-process network policy: `"allow"` permits outbound network, `"deny"` blocks it, and `"allowlist"` permits only listed destinations |
+| `egress_allowlist` | string[] | `[]` | Addresses or CIDR ranges permitted when `egress = "allowlist"`; loopback entries are enforceable without root privileges |
+| `nproc_limit` | u32 | `256` | Maximum process count (`RLIMIT_NPROC`) applied to exec child processes |
+
+Defaults are defined in `crates/taxis/src/config/maintenance.rs` and mirrored by the execution policy in `crates/organon/src/sandbox/config.rs`; `gateway.auth.none_role` is defined in `crates/taxis/src/config/gateway.rs`.
+
+Combined default posture: a fresh config binds the gateway to localhost and uses bearer-token auth, but rate limiting is disabled, sandbox violations are logged rather than blocked, exec child processes keep outbound network egress, and switching `gateway.auth.mode` to `"none"` without changing `gateway.auth.none_role` grants anonymous callers the `admin` role. For production-like deployments, set the restrictive values explicitly.
 
 ```toml
 [sandbox]
 enabled = true
-enforcement = "enforcing"
+enforcement = "permissive"
 extra_read_paths = ["/usr/share/doc"]
 extra_write_paths = []
 extra_exec_paths = ["~/.cargo/bin"]
+egress = "allow"
+egress_allowlist = []
+nproc_limit = 256
 ```
 
 ---

--- a/docs/FEATURE-FLAGS.md
+++ b/docs/FEATURE-FLAGS.md
@@ -18,7 +18,12 @@ Every feature flag defined in the workspace, how flags interact across crates, a
 | **aletheia** | `keyring` | no | Keyring integration | `symbolon/keyring` |
 | **aletheia** | `tui` | no | `dep:koilon` | - |
 | **aletheia** | `cc-provider` | no | Claude Code subprocess provider | `hermeneus/cc-provider` |
+| **aletheia** | `codex-provider` | no | Codex subprocess provider | `hermeneus/codex-provider` |
+| **aletheia** | `kimi-provider` | no | Kimi subprocess provider | `hermeneus/kimi-provider` |
 | **aletheia** | `energeia` | no | Dispatch orchestration plus service-backed Energeia agent tools in the runtime registry | `dep:energeia`, `energeia/storage-fjall`, `organon/energeia` |
+| **aletheia** | `bookkeeper` | no | Bookkeeper maintenance tools | `organon/bookkeeper` |
+| **aletheia** | `computer-use` | no | Computer-use tools | `organon/computer-use` |
+| **aletheia** | `z3` | no | Z3 SMT solver tool | `organon/z3` |
 | **aletheia** | `test-core` | no | - | `mneme/test-core`, `nous/test-core`, `pylon/test-core` |
 | **aletheia** | `test-full` | no | - | `test-core`, `mneme/test-full` |
 | **daemon** (oikonomos) | `default` | **yes** | *(empty)* | - |
@@ -52,6 +57,8 @@ Every feature flag defined in the workspace, how flags interact across crates, a
 | **graphe** | `test-core` | no | - | - |
 | **graphe** | `test-full` | no | - | - |
 | **hermeneus** | `cc-provider` | no | Claude Code subprocess provider | - |
+| **hermeneus** | `codex-provider` | no | Codex subprocess provider | - |
+| **hermeneus** | `kimi-provider` | no | Kimi subprocess provider | - |
 | **hermeneus** | `test-utils` | no | Legacy mock LLM provider alias | - |
 | **hermeneus** | `test-support` | no | Mock LLM provider for tests | `test-utils` |
 | **hermeneus** | `test-core` | no | - | - |
@@ -88,6 +95,8 @@ Every feature flag defined in the workspace, how flags interact across crates, a
 | **nous** | `test-full` | no | - | `test-core` |
 | **organon** | `computer-use` | no | Screen capture, Landlock sandbox (Linux 5.13+) | - |
 | **organon** | `energeia` | no | Energeia capability tools | `dep:energeia` (pre-enabled with `storage-fjall`) |
+| **organon** | `bookkeeper` | no | Bookkeeper maintenance tools | - |
+| **organon** | `z3` | no | Z3 SMT solver tool | `dep:z3` |
 | **organon** | `test-support` | no | `MockToolExecutor`, `ToolExecutorSpec`, etc. | `hermeneus/test-support`, `dep:rustls` |
 | **organon** | `test-core` | no | - | - |
 | **organon** | `test-full` | no | - | - |
@@ -165,12 +174,19 @@ aletheia/embed-candle
 | `aletheia/keyring` | `symbolon/keyring` (`dep:keyring`) |
 | `aletheia/tui` | `dep:koilon` |
 | `aletheia/cc-provider` | `hermeneus/cc-provider` |
+| `aletheia/codex-provider` | `hermeneus/codex-provider` |
+| `aletheia/kimi-provider` | `hermeneus/kimi-provider` |
 | `aletheia/energeia` | `dep:energeia`, `energeia/storage-fjall`, `organon/energeia` |
+| `aletheia/bookkeeper` | `organon/bookkeeper` |
+| `aletheia/computer-use` | `organon/computer-use` |
+| `aletheia/z3` | `organon/z3` |
 | `organon/energeia` | `dep:energeia` (with `storage-fjall` pre-enabled) |
 | `daemon/knowledge-store` | `episteme/mneme-engine` |
 | `diaporeia/knowledge-store` | `nous/knowledge-store` |
 
 ## Test feature tiers
+
+Feature scope matters. `cargo test --workspace --all-features` activates every feature on every workspace member. `cargo test -p aletheia --all-features` activates only the `aletheia` package features, plus dependency features reached through its passthroughs. Use dependency features such as `organon/computer-use` directly only when building or testing that dependency crate.
 
 Every workspace crate declares `test-core` and `test-full`. Most crates leave them empty; crates with storage- or ML-dependent tests wire them to the relevant engine features.
 
@@ -179,7 +195,7 @@ Every workspace crate declares `test-core` and `test-full`. Most crates leave th
 | **default** | *(none)* | ~5,400 | Pure-logic unit tests, config validation, type invariants |
 | **test-core** | `--features test-core` | ~5,435 | Storage engine tests (Datalog, HNSW, fjall, knowledge store CRUD) |
 | **test-full** | `--features test-full` | ~5,435 | ML embedding tests (candle model loading, vector generation) |
-| **all** | `--all-features` | ~5,475 | + local-llm, computer-use, other optional features |
+| **all** | `--all-features` | ~5,475 | provider subprocess adapters, computer-use, bookkeeper, z3, other optional features |
 
 ### Notable tier wiring
 

--- a/docs/test-tiers.md
+++ b/docs/test-tiers.md
@@ -10,10 +10,15 @@ coverage against build time and resource requirements.
 | **default** | *(none)* | Pure-logic unit tests, config validation, type invariants | ~5,400 |
 | **test-core** | `--features test-core` | Storage engine tests (Datalog, HNSW, fjall, knowledge store CRUD) | ~5,435 |
 | **test-full** | `--features test-full` | ML embedding tests (candle model loading, vector generation) - includes `online-tests` | ~5,435 |
-| **all** | `--all-features` | + local-llm, computer-use, other optional features | ~5,475 |
+| **all** | `--all-features` | Provider subprocess adapters, computer-use, bookkeeper, z3, other optional features | ~5,475 |
 
 Each tier is a strict superset of the previous: `test-full` implies `test-core`,
 which adds to the default set.
+
+Feature scope matters. `cargo test --workspace --all-features` enables every
+workspace member's feature set. `cargo test -p aletheia --all-features` enables
+only the `aletheia` package features, plus dependency features wired through
+its passthroughs.
 
 ### Online-only tests
 


### PR DESCRIPTION
Closes #4487
Closes #4492
Closes #4493

(#4493 lands per the 2026-06-11 operator decision: defaults stay permissive; this is the docs-objective half — no code defaults changed.)

- **#4487** — release.yml feature-check: corrected package names, replaced the dead `local-llm` matrix leg with legs that exist, and wired `feature-check` into the `build`/`sbom` `needs:` so a red matrix blocks release artifacts.
- **#4492** — purged stale `local-llm` references from docs (CHANGELOG retained — history); added `bookkeeper`, `computer-use`, `z3` passthrough features (all default-off; z3 deliberately so to avoid bundled libz3) making the README tool-count claim mechanically true.
- **#4493** — CONFIGURATION.md: sandbox default corrected to `permissive` (verified in source), documented `egress`, `egress_allowlist`, `none_role`, `nproc_limit`, added the combined default-posture paragraph.