### PR TITLE
ci: give gate-attestation disk headroom — reclaim runner bloat, line-tables debuginfo

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -22,6 +22,12 @@ jobs:
     name: gate-attestation
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      # WHY: full debuginfo is the bulk of the dev-profile target dir; with a
+      # cold cargo cache the workspace test build exceeded the hosted runner's
+      # free disk (ENOSPC killed the gate mid-nextest, 2026-06-11). Line tables
+      # keep usable backtraces for test failures at a fraction of the size.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       # WHY: bypass keys off the PR author login, not github.actor. The actor
       # changes to a maintainer login whenever someone re-runs the workflow
@@ -40,6 +46,18 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      # WHY: hosted runners ship ~25 GB of toolchains this job never uses
+      # (dotnet, Android, GHC, CodeQL bundles). The workspace test build needs
+      # that headroom when the cargo cache is cold — ENOSPC killed the gate
+      # mid-nextest on 2026-06-11. Plain rm keeps this dependency-free.
+      - name: Reclaim runner disk
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'release-please[bot]' }}
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/share/swift
+          echo "free disk after reclaim:"
+          df -h / | tail -1
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'release-please[bot]' }}


### PR DESCRIPTION
The full-workspace test build exceeds the hosted runner's ~14 GB free disk when the cargo cache is cold: gate-attestation died on ENOSPC mid-nextest on #4525 (run 27374268387 — runner diag literally `No space left on device`). Warm-cache runs survived, which is why this was latent until today's cache churn.

Two-part fix, both in the gate job only:
1. **Reclaim runner disk** step (dependency-free `rm -rf` of dotnet/Android/GHC/CodeQL/swift bundles, ~25 GB) right after checkout.
2. **`CARGO_PROFILE_DEV_DEBUG: line-tables-only`** at job level — debuginfo is the bulk of the dev target dir; line tables keep usable test backtraces.

Self-validating: this PR's own gate-attestation run executes the fixed workflow from the merge ref. After it lands, the queued/failed gates on #4525/#4671/#4696/#4697 get re-run against the fixed workflow.