### PR TITLE
fix(krites): bound semi-naive evaluation epochs — config default, structured abort

### DIFF
--- a/_llm/L3-api-index/krites.md
+++ b/_llm/L3-api-index/krites.md
@@ -18,6 +18,7 @@ impl AsyncDb {
     pub async fn open_mem () -> crate::Result<Self>;
     pub async fn open_fjall (path: impl AsRef<Path> + Send + 'static) -> crate::Result<Self>;
     pub fn with_cache (self, capacity: NonZeroUsize) -> Self;
+    pub fn with_config (self, config: DbConfig) -> Self;
     pub async fn cache_stats (&self) -> Option<QueryCacheStats>;
     pub async fn run (
         &self,
@@ -448,6 +449,19 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Semi-naive query evaluation exceeded the configured epoch limit.
+    #[snafu(display(
+        "evaluation exceeded epoch limit: epoch_count={epoch_count}, max_epochs={max_epochs}, stratum={stratum}, rules={rule_context}"
+    ))]
+    EpochLimitExceeded {
+        epoch_count: u32,
+        max_epochs: u32,
+        stratum: usize,
+        rule_context: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// A parse error (query syntax).
     #[snafu(display("parse error: {source}"))]
     Parse {
@@ -724,6 +738,7 @@ impl Db {
     pub fn open_mem () -> crate::Result<Self>;
     pub fn open_fjall (path: impl AsRef<Path>) -> crate::Result<Self>;
     pub fn with_cache (mut self, capacity: NonZeroUsize) -> Self;
+    pub fn with_config (mut self, config: DbConfig) -> Self;
     pub fn with_rule_store (
         mut self,
         store: Arc<arc_swap::ArcSwap<crate::hot_reload::RuleSet>>,
@@ -1128,6 +1143,24 @@ pub struct CallbackDeclaration {
 
 ## `src/runtime/db.rs`
 
+> Default maximum semi-naive evaluation epochs for one stratum.
+```rust
+pub const DEFAULT_MAX_EVALUATION_EPOCHS: u32 = 10_000;
+```
+
+```rust
+pub struct DbConfig {
+    /// Maximum semi-naive evaluation epochs per stratum.
+    pub max_evaluation_epochs: u32,
+}
+```
+
+```rust
+impl DbConfig {
+    pub fn new (max_evaluation_epochs: u32) -> Self;
+}
+```
+
 ```rust
 pub enum ScriptMutability {
     /// The script is mutable.
@@ -1140,6 +1173,7 @@ pub enum ScriptMutability {
 ```rust
 pub struct Db<S> {
     pub(crate) db: S,
+    pub(crate) config: DbConfig,
     pub(crate) temp_db: TempStorage,
     pub(crate) relation_store_id: Arc<AtomicU64>,
     pub(crate) queries_count: Arc<AtomicU64>,

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -128,8 +128,8 @@ l3_token_estimate = 7453
 [[crates]]
 name = "krites"
 path = "crates/krites"
-source_hash = "ac7b7eb91438b96f844ae3582abf774ee6961f13ababdd84000ee5e9457c8d9c"
-l3_token_estimate = 10102
+source_hash = "da3f0705126016dbaede3ce7648934689e637ae88e3d82a4a00635b88f3101a1"
+l3_token_estimate = 10335
 
 [[crates]]
 name = "melete"

--- a/crates/krites/src/async_surface.rs
+++ b/crates/krites/src/async_surface.rs
@@ -29,7 +29,9 @@ use tracing::instrument;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::runtime::callback::CallbackOp;
-use crate::{DataValue, Db, FixedRule, NamedRows, QueryCache, QueryCacheStats, ScriptMutability};
+use crate::{
+    DataValue, Db, DbConfig, FixedRule, NamedRows, QueryCache, QueryCacheStats, ScriptMutability,
+};
 
 /// Tokio-native async wrapper over the blocking [`Db`] core.
 ///
@@ -87,6 +89,22 @@ impl AsyncDb {
             },
         };
         db.cache = Some(Arc::new(QueryCache::new(capacity)));
+        Self {
+            inner: Arc::new(db),
+        }
+    }
+
+    /// Replace runtime limits for this database.
+    #[must_use]
+    pub fn with_config(self, config: DbConfig) -> Self {
+        let db = match Arc::try_unwrap(self.inner) {
+            Ok(db) => db,
+            Err(arc) => Db {
+                inner: arc.clone_inner(),
+                cache: None,
+            },
+        }
+        .with_config(config);
         Self {
             inner: Arc::new(db),
         }

--- a/crates/krites/src/error.rs
+++ b/crates/krites/src/error.rs
@@ -33,6 +33,19 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Semi-naive query evaluation exceeded the configured epoch limit.
+    #[snafu(display(
+        "evaluation exceeded epoch limit: epoch_count={epoch_count}, max_epochs={max_epochs}, stratum={stratum}, rules={rule_context}"
+    ))]
+    EpochLimitExceeded {
+        epoch_count: u32,
+        max_epochs: u32,
+        stratum: usize,
+        rule_context: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// A parse error (query syntax).
     #[snafu(display("parse error: {source}"))]
     Parse {

--- a/crates/krites/src/lib.rs
+++ b/crates/krites/src/lib.rs
@@ -33,7 +33,9 @@ pub use async_surface::AsyncDb;
 pub use crate::data::value::{DataValue, ValidityTs, Vector};
 pub use crate::fixed_rule::{FixedRule, FixedRuleInputRelation, FixedRulePayload};
 pub use crate::runtime::callback::CallbackOp;
-pub use crate::runtime::db::{NamedRows, ScriptMutability, TransactionPayload};
+pub use crate::runtime::db::{
+    DEFAULT_MAX_EVALUATION_EPOCHS, DbConfig, NamedRows, ScriptMutability, TransactionPayload,
+};
 #[cfg(feature = "storage-fjall")]
 pub use crate::storage::fjall_backend::FjallStorage;
 pub use crate::storage::mem::MemStorage;
@@ -73,6 +75,22 @@ fn convert_internal(e: crate::error::InternalError) -> Error {
         InternalError::Runtime {
             source: crate::runtime::error::RuntimeError::QueryKilled { .. },
         } => error::QueryKilledSnafu.build(),
+        InternalError::Query {
+            source:
+                crate::query::error::QueryError::EpochLimitExceeded {
+                    epoch_count,
+                    max_epochs,
+                    stratum,
+                    rule_context,
+                    ..
+                },
+        } => error::EpochLimitExceededSnafu {
+            epoch_count,
+            max_epochs,
+            stratum,
+            rule_context,
+        }
+        .build(),
         InternalError::Parse { source } => error::ParseSnafu.into_error(source),
         InternalError::Storage { source } => error::StorageSnafu.into_error(source),
         other => error::EngineSnafu {
@@ -92,6 +110,14 @@ enum DbInner {
 }
 
 impl DbInner {
+    fn set_config(&mut self, config: DbConfig) {
+        match self {
+            DbInner::Mem(db) => db.config = config,
+            #[cfg(feature = "storage-fjall")]
+            DbInner::Fjall(db) => db.config = config,
+        }
+    }
+
     fn run_multi_transaction_inner(
         self,
         write: bool,
@@ -157,6 +183,13 @@ impl Db {
     #[must_use]
     pub fn with_cache(mut self, capacity: NonZeroUsize) -> Self {
         self.cache = Some(Arc::new(QueryCache::new(capacity)));
+        self
+    }
+
+    /// Replace runtime limits for this database.
+    #[must_use]
+    pub fn with_config(mut self, config: DbConfig) -> Self {
+        self.inner.set_config(config);
         self
     }
 

--- a/crates/krites/src/query/error.rs
+++ b/crates/krites/src/query/error.rs
@@ -58,6 +58,19 @@ pub(crate) enum QueryError {
         location: snafu::Location,
     },
 
+    /// Semi-naive evaluation exceeded the configured epoch limit before reaching a fixpoint.
+    #[snafu(display(
+        "evaluation exceeded epoch limit: epoch_count={epoch_count}, max_epochs={max_epochs}, stratum={stratum}, rules={rule_context}"
+    ))]
+    EpochLimitExceeded {
+        epoch_count: u32,
+        max_epochs: u32,
+        stratum: usize,
+        rule_context: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// Arity mismatch between rule/relation and its application.
     #[snafu(display("arity mismatch: {message}"))]
     ArityMismatch {

--- a/crates/krites/src/query/eval.rs
+++ b/crates/krites/src/query/eval.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use itertools::Itertools;
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 use crate::data::aggr::Aggregation;
 use crate::data::program::{MagicSymbol, NoEntryError};
@@ -85,6 +85,7 @@ impl<'a> SessionTx<'a> {
         store_lifetimes: BTreeMap<MagicSymbol, usize>,
         total_num_to_take: Option<usize>,
         num_to_skip: Option<usize>,
+        max_epochs: u32,
         poison: Poison,
     ) -> Result<(EpochStore, bool)> {
         let mut stores: BTreeMap<MagicSymbol, EpochStore> = BTreeMap::new();
@@ -118,6 +119,8 @@ impl<'a> SessionTx<'a> {
                 &mut stores,
                 total_num_to_take,
                 num_to_skip,
+                max_epochs,
+                stratum,
                 poison.clone(),
             )?;
         }
@@ -340,6 +343,8 @@ impl<'a> SessionTx<'a> {
         stores: &mut BTreeMap<MagicSymbol, EpochStore>,
         total_num_to_take: Option<usize>,
         num_to_skip: Option<usize>,
+        max_epochs: u32,
+        stratum: usize,
         poison: Poison,
     ) -> Result<bool> {
         let limiter = QueryLimiter {
@@ -349,7 +354,7 @@ impl<'a> SessionTx<'a> {
         };
         let used_limiter: AtomicBool = false.into();
 
-        for epoch in 0u32.. {
+        for epoch in 0..max_epochs {
             debug!("epoch {}", epoch);
             let borrowed_stores = stores as &BTreeMap<_, _>;
             let to_merge = if epoch == 0 {
@@ -386,10 +391,24 @@ impl<'a> SessionTx<'a> {
                 changed |= old_store.has_delta();
             }
             if !changed {
-                break;
+                return Ok(used_limiter.load(Ordering::Acquire));
             }
         }
-        Ok(used_limiter.load(Ordering::Acquire))
+        let rule_context = prog.keys().map(ToString::to_string).join(", ");
+        warn!(
+            epoch_count = max_epochs,
+            max_epochs,
+            stratum,
+            rule_context = %rule_context,
+            "semi-naive evaluation exceeded epoch limit"
+        );
+        EpochLimitExceededSnafu {
+            epoch_count: max_epochs,
+            max_epochs,
+            stratum,
+            rule_context,
+        }
+        .fail()?
     }
     /// Returns `true` if early return is activated.
     ///

--- a/crates/krites/src/runtime/db.rs
+++ b/crates/krites/src/runtime/db.rs
@@ -39,6 +39,35 @@ use crate::runtime::relation::RelationId;
 use crate::storage::Storage;
 use crate::storage::temp::TempStorage;
 
+/// Default maximum semi-naive evaluation epochs for one stratum.
+pub const DEFAULT_MAX_EVALUATION_EPOCHS: u32 = 10_000;
+
+/// Runtime limits for a database instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DbConfig {
+    /// Maximum semi-naive evaluation epochs per stratum.
+    pub max_evaluation_epochs: u32,
+}
+
+impl Default for DbConfig {
+    fn default() -> Self {
+        Self {
+            max_evaluation_epochs: DEFAULT_MAX_EVALUATION_EPOCHS,
+        }
+    }
+}
+
+impl DbConfig {
+    /// Create runtime limits with the given semi-naive epoch cap.
+    #[must_use]
+    pub fn new(max_evaluation_epochs: u32) -> Self {
+        Self {
+            max_evaluation_epochs,
+        }
+    }
+}
+
 pub(crate) struct RunningQueryHandle {
     pub(crate) started_at: f64,
     pub(crate) poison: Poison,
@@ -78,6 +107,7 @@ pub enum ScriptMutability {
 #[derive(Clone)]
 pub struct Db<S> {
     pub(crate) db: S,
+    pub(crate) config: DbConfig,
     pub(crate) temp_db: TempStorage,
     pub(crate) relation_store_id: Arc<AtomicU64>,
     pub(crate) queries_count: Arc<AtomicU64>,
@@ -311,6 +341,7 @@ impl<'s, S: Storage<'s>> Db<S> {
     pub fn new(storage: S) -> Result<Self> {
         let ret = Self {
             db: storage,
+            config: DbConfig::default(),
             temp_db: Default::default(),
             relation_store_id: Default::default(),
             queries_count: Default::default(),

--- a/crates/krites/src/runtime/exec.rs
+++ b/crates/krites/src/runtime/exec.rs
@@ -508,6 +508,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             store_lifetimes,
             total_num_to_take,
             num_to_skip,
+            self.config.max_evaluation_epochs,
             poison,
         )?;
 

--- a/crates/krites/tests/integration_queries.rs
+++ b/crates/krites/tests/integration_queries.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use krites::{DataValue, Db, ScriptMutability};
+use krites::{DataValue, Db, DbConfig, Error, ScriptMutability};
 
 // ── Database lifecycle ──────────────────────────────────────────────────────
 
@@ -42,6 +42,38 @@ fn db_multiple_independent_queries() {
             .expect("query should succeed");
         assert_eq!(result.rows[0][0], DataValue::from(i));
     }
+}
+
+#[test]
+fn non_converging_recursive_query_exceeds_epoch_limit() {
+    let db = Db::open_mem()
+        .expect("in-memory db creation should succeed")
+        .with_config(DbConfig::new(3));
+
+    let err = db
+        .run_read_only(
+            r"
+            looped[id] := id = rand_uuid_v4()
+            looped[id] := looped[prev], id = rand_uuid_v4(), prev != id
+            ?[id] := looped[id]
+            ",
+            BTreeMap::new(),
+        )
+        .expect_err("non-converging recursive query should hit the epoch limit");
+
+    assert!(
+        matches!(
+            err,
+            Error::EpochLimitExceeded {
+                epoch_count: 3,
+                max_epochs: 3,
+                stratum: 0,
+                ref rule_context,
+                ..
+            } if rule_context.contains("looped")
+        ),
+        "expected epoch limit error with looped rule context, got {err:?}"
+    );
 }
 
 // ── Relation create/insert/query pipeline ───────────────────────────────────


### PR DESCRIPTION
Closes #4499

Semi-naive Datalog evaluation could loop unbounded (`aletheia memory repl` runaway). This bounds it:

- `for epoch in 0..max_epochs` in `semi_naive_magic_evaluate`, threaded through `stratified_magic_evaluate`.
- `DbConfig { max_evaluation_epochs }` (default 10_000, `#[non_exhaustive]`) — Db-level config, not a literal at the loop site.
- Structured `EpochLimitExceeded` snafu (epoch_count / max_epochs / stratum / rule_context + implicit Location), shaped to fold into the #4511 budget model later.
- `warn!` tracing at the abort site with rule context.
- Non-converging-program regression test running under DEFAULT features so CI actually executes it.

Worker-gated CI-exact on verda (fmt, clippy `-D warnings`, full nextest `test-core`) before push.