### PR TITLE
fix(poiesis): render hardening — failure honesty, timeouts, sandbox opt-in, schema truth

### DIFF
--- a/_llm/L3-api-index/poiesis-doc.md
+++ b/_llm/L3-api-index/poiesis-doc.md
@@ -48,7 +48,7 @@ pub enum Error {
     #[snafu(display("pdf LaTeX engine unavailable: {source}"))]
     PdfLatexEngineUnavailable {
         /// Detailed probing error from the Pandoc `LaTeX` route.
-        source: crate::pandoc::PandocError,
+        source: Box<crate::pandoc::PandocError>,
     },
 
     /// ODT rendering via the clean-room backend failed.
@@ -59,12 +59,19 @@ pub enum Error {
     },
 
     /// A Pandoc-backed format could not be rendered.
-    #[snafu(display(
-        "{format} output requires Pandoc; install pandoc >= 3.0 or use pdf/xlsx for now"
-    ))]
+    #[snafu(display("{format} output requires Pandoc; install pandoc >= 3.0"))]
     PandocRequired {
         /// The requested format name (e.g. "docx").
         format: String,
+    },
+
+    /// A Pandoc-backed format failed after Pandoc was found.
+    #[snafu(display("{format} output failed: {source}"))]
+    PandocFailed {
+        /// The requested format name (e.g. "docx").
+        format: String,
+        /// Detailed Pandoc subprocess error.
+        source: Box<crate::pandoc::PandocError>,
     },
 }
 ```
@@ -87,6 +94,13 @@ pub enum LatexProbe {
         /// Candidate paths that were searched.
         searched: Vec<PathBuf>,
     },
+    /// A candidate engine exceeded its probe deadline.
+    TimedOut {
+        /// Candidate path that timed out.
+        path: PathBuf,
+        /// Timeout in seconds.
+        timeout_secs: u64,
+    },
 }
 ```
 
@@ -107,6 +121,18 @@ pub enum LatexProbeError {
     NotInstalled {
         /// Candidate paths that were searched.
         searched: Vec<PathBuf>,
+    },
+
+    /// A candidate `LaTeX` engine probe timed out.
+    #[snafu(display(
+        "latex engine at {} timed out after {timeout_secs}s while probing --version",
+        path.display()
+    ))]
+    Timeout {
+        /// Candidate path that timed out.
+        path: PathBuf,
+        /// Timeout in seconds.
+        timeout_secs: u64,
     },
 }
 ```
@@ -244,6 +270,28 @@ pub enum PandocError {
     /// Pandoc process could not be spawned (I/O error).
     #[snafu(display("failed to spawn pandoc: {source}"))]
     Spawn {
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// Pandoc subprocess exceeded its deadline.
+    #[snafu(display("pandoc {operation} timed out after {timeout_secs}s"))]
+    Timeout {
+        /// Operation being performed.
+        operation: String,
+        /// Timeout in seconds.
+        timeout_secs: u64,
+        /// Child-process kill error, when cleanup failed.
+        kill_error: Option<String>,
+        /// Child-process wait error, when cleanup failed.
+        wait_error: Option<String>,
+    },
+
+    /// Pandoc subprocess I/O failed after spawning.
+    #[snafu(display("pandoc {operation} I/O failed: {source}"))]
+    SubprocessIo {
+        /// Operation being performed.
+        operation: String,
         /// Underlying I/O error.
         source: std::io::Error,
     },
@@ -426,6 +474,13 @@ pub enum PandocProbe {
         /// Minimum version required by the crate.
         required: PandocVersion,
     },
+    /// `pandoc --version` exceeded its probe deadline.
+    TimedOut {
+        /// Absolute path to the binary that timed out.
+        path: PathBuf,
+        /// Timeout in seconds.
+        timeout_secs: u64,
+    },
 }
 ```
 
@@ -466,6 +521,18 @@ pub enum PandocProbeError {
         found: PandocVersion,
         /// Minimum version required.
         required: PandocVersion,
+    },
+
+    /// The `pandoc --version` probe timed out.
+    #[snafu(display(
+        "pandoc at {} timed out after {timeout_secs}s while probing --version",
+        path.display()
+    ))]
+    Timeout {
+        /// Path to the binary that timed out.
+        path: PathBuf,
+        /// Timeout in seconds.
+        timeout_secs: u64,
     },
 }
 ```

--- a/_llm/L3-api-index/poiesis-printer-chromium.md
+++ b/_llm/L3-api-index/poiesis-printer-chromium.md
@@ -26,10 +26,25 @@ pub enum PrinterError {
         #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+    #[snafu(display("{operation} timed out after {timeout_secs}s"))]
+    Timeout {
+        operation: &'static str,
+        timeout_secs: u64,
+    },
+    #[snafu(display("Browser cleanup failed: {source}"))]
+    Cleanup {
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 ```
 
 ## `src/lib.rs`
+
+> Default deadline for an HTML-to-PDF print operation.
+```rust
+pub const DEFAULT_PRINT_TIMEOUT: Duration = Duration::from_secs(60);
+```
 
 ```rust
 pub struct PrintOptions {
@@ -47,6 +62,10 @@ pub struct PrintOptions {
     pub margin_right_mm: f64,
     /// Page scale factor (1.0 = 100%).
     pub scale: f64,
+    /// Overall deadline for browser launch, page setup, and PDF generation.
+    pub timeout: Duration,
+    /// Explicitly disable the Chromium sandbox.
+    pub disable_sandbox: bool,
 }
 ```
 

--- a/_llm/L3-api-index/poiesis-typst.md
+++ b/_llm/L3-api-index/poiesis-typst.md
@@ -55,3 +55,25 @@ pub fn render_typst (source: &str, data: &serde_json::Value) -> Result<Vec<u8>>
 ```rust
 pub fn render_template (slug: &str, data: &serde_json::Value) -> Result<Vec<u8>>
 ```
+
+## `src/templates.rs`
+
+> Slug for the default one-page report template.
+```rust
+pub const DEFAULT: &str = "default";
+```
+
+> Slug for the eval-report template.
+```rust
+pub const EVAL_REPORT: &str = "eval-report";
+```
+
+> Slug for the graph-audit template.
+```rust
+pub const GRAPH_AUDIT: &str = "graph-audit";
+```
+
+> List of all known template slugs.
+```rust
+pub const SLUGS: &[&str] = &[DEFAULT, EVAL_REPORT, GRAPH_AUDIT];
+```

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -158,7 +158,7 @@ l3_token_estimate = 12375
 [[crates]]
 name = "organon"
 path = "crates/organon"
-source_hash = "9fd052cef6e161204ff8952d7c8c44215e451a8ba7d2da4889d584f4bbdac3bf"
+source_hash = "3f676cdc0432fce914ab41bcf439f7776c5f53c838cdb4e1129b27679e8bf4e7"
 l3_token_estimate = 11818
 
 [[crates]]
@@ -194,8 +194,8 @@ l3_token_estimate = 446
 [[crates]]
 name = "poiesis-doc"
 path = "crates/poiesis/doc"
-source_hash = "a99e3abbf3dd1fde68be970f2ce28b1ac3d5428fe76c3a22518cbcb0fca1c37c"
-l3_token_estimate = 3417
+source_hash = "677b25fb18c2026b939f8f2b2a99e25189aeca481293c9691301912fd4311a05"
+l3_token_estimate = 3945
 
 [[crates]]
 name = "poiesis-inspect"
@@ -218,8 +218,8 @@ l3_token_estimate = 976
 [[crates]]
 name = "poiesis-printer-chromium"
 path = "crates/poiesis/printer-chromium"
-source_hash = "a88d3d6903f18a19f2f4ae0763014527cf13bfdf863191011bcc9def99c573d9"
-l3_token_estimate = 459
+source_hash = "fa06aa3e9d9cfef4b45af7e4626aaa86484fc54e5522c71eff7fac74f98709f6"
+l3_token_estimate = 631
 
 [[crates]]
 name = "poiesis-scaffold"
@@ -254,8 +254,8 @@ l3_token_estimate = 5254
 [[crates]]
 name = "poiesis-typst"
 path = "crates/poiesis/typst"
-source_hash = "74474a50b19b3b9fd46b46466a9622baab377d4b365b0aa950765b485e189016"
-l3_token_estimate = 398
+source_hash = "bf03aef22aab8f45a90e221ebb5725eb76f370881c99bd92ce87edc19fe1b211"
+l3_token_estimate = 505
 
 [[crates]]
 name = "poiesis-verify"

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -158,7 +158,7 @@ l3_token_estimate = 12375
 [[crates]]
 name = "organon"
 path = "crates/organon"
-source_hash = "3f676cdc0432fce914ab41bcf439f7776c5f53c838cdb4e1129b27679e8bf4e7"
+source_hash = "9b444115c265a131cf3bbc0bfb2e5aa6ffd821af0f14ffbb6f8e4266f1dd3291"
 l3_token_estimate = 11818
 
 [[crates]]

--- a/crates/organon/src/builtins/poiesis.rs
+++ b/crates/organon/src/builtins/poiesis.rs
@@ -63,6 +63,22 @@ const TYPST_CHART_APPENDIX: &str = r#"
 ]
 "#;
 
+pub(crate) fn json_data_property(description: &str) -> PropertyDef {
+    PropertyDef {
+        property_type: PropertyType::Object,
+        description: format!("{description} Also accepts a JSON string for legacy callers."),
+        enum_values: None,
+        default: None,
+    }
+}
+
+fn typst_template_enum_values() -> Vec<String> {
+    poiesis_typst::templates::SLUGS
+        .iter()
+        .map(|slug| (*slug).to_owned())
+        .collect()
+}
+
 fn render_chart_svg(data: &serde_json::Value) -> std::result::Result<Option<String>, String> {
     let Some(chart_value) = data.get("chart") else {
         return Ok(None);
@@ -749,20 +765,13 @@ fn render_typst_report_def() -> ToolDef {
                     PropertyDef {
                         property_type: PropertyType::String,
                         description: "Built-in template slug (e.g. `default`).".to_owned(),
-                        enum_values: Some(vec!["default".to_owned()]),
+                        enum_values: Some(typst_template_enum_values()),
                         default: None,
                     },
                 ),
                 (
                     "data".to_owned(),
-                    PropertyDef {
-                        property_type: PropertyType::String,
-                        description:
-                            "Inline JSON data blob exposed to the template as `data.json`."
-                                .to_owned(),
-                        enum_values: None,
-                        default: None,
-                    },
+                    json_data_property("JSON object exposed to the template as `data.json`."),
                 ),
                 (
                     "out_path".to_owned(),

--- a/crates/organon/src/builtins/poiesis.rs
+++ b/crates/organon/src/builtins/poiesis.rs
@@ -209,60 +209,36 @@ impl ToolExecutor for GenerateDocumentExecutor {
             };
 
             let format = format.to_lowercase();
-            let bytes = match format.as_str() {
-                "xlsx" => {
-                    let renderer = poiesis_sheet::XlsxRenderer::new();
-                    match renderer.render(&doc) {
-                        Ok(b) => b,
-                        Err(e) => {
-                            return Ok(ToolResult::error(format!("XLSX render failed: {e}")));
-                        }
-                    }
-                }
-                "pdf" => match poiesis_doc::render_pdf_from_doc(&doc) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        return Ok(ToolResult::error(format!("PDF render failed: {e}")));
-                    }
-                },
-                "odt" => match poiesis_doc::render_odt_from_doc(&doc) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        return Ok(ToolResult::error(format!("ODT render failed: {e}")));
-                    }
-                },
-                "docx" => match poiesis_doc::render_docx_from_doc(&doc) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        return Ok(ToolResult::error(format!("DOCX render failed: {e}")));
-                    }
-                },
-                "html" => match poiesis_doc::render_html_from_doc(&doc) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        return Ok(ToolResult::error(format!("HTML render failed: {e}")));
-                    }
-                },
-                "md" => match poiesis_doc::render_md_from_doc(&doc) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        return Ok(ToolResult::error(format!("MD render failed: {e}")));
-                    }
-                },
-                "latex" => match poiesis_doc::render_latex_from_doc(&doc) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        return Ok(ToolResult::error(format!("LATEX render failed: {e}")));
-                    }
-                },
-                "epub" => match poiesis_doc::render_epub_from_doc(&doc) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        return Ok(ToolResult::error(format!("EPUB render failed: {e}")));
-                    }
-                },
-                other => {
-                    return Ok(ToolResult::error(format!("unsupported format: {other}")));
+            // WHY: every renderer below blocks (pandoc/typst subprocesses,
+            // file IO); run on the blocking pool so a slow render occupies a
+            // blocking thread instead of pinning a tokio runtime worker.
+            let render_format = format.clone();
+            let render_result = tokio::task::spawn_blocking(move || match render_format.as_str() {
+                "xlsx" => poiesis_sheet::XlsxRenderer::new()
+                    .render(&doc)
+                    .map_err(|e| format!("XLSX render failed: {e}")),
+                "pdf" => poiesis_doc::render_pdf_from_doc(&doc)
+                    .map_err(|e| format!("PDF render failed: {e}")),
+                "odt" => poiesis_doc::render_odt_from_doc(&doc)
+                    .map_err(|e| format!("ODT render failed: {e}")),
+                "docx" => poiesis_doc::render_docx_from_doc(&doc)
+                    .map_err(|e| format!("DOCX render failed: {e}")),
+                "html" => poiesis_doc::render_html_from_doc(&doc)
+                    .map_err(|e| format!("HTML render failed: {e}")),
+                "md" => poiesis_doc::render_md_from_doc(&doc)
+                    .map_err(|e| format!("MD render failed: {e}")),
+                "latex" => poiesis_doc::render_latex_from_doc(&doc)
+                    .map_err(|e| format!("LATEX render failed: {e}")),
+                "epub" => poiesis_doc::render_epub_from_doc(&doc)
+                    .map_err(|e| format!("EPUB render failed: {e}")),
+                other => Err(format!("unsupported format: {other}")),
+            })
+            .await;
+            let bytes = match render_result {
+                Ok(Ok(b)) => b,
+                Ok(Err(msg)) => return Ok(ToolResult::error(msg)),
+                Err(e) => {
+                    return Ok(ToolResult::error(format!("render task failed: {e}")));
                 }
             };
 

--- a/crates/organon/src/builtins/poiesis_tests.rs
+++ b/crates/organon/src/builtins/poiesis_tests.rs
@@ -137,6 +137,31 @@ async fn render_typst_report_inline_source_returns_document_block() {
     }
 }
 
+#[test]
+fn render_typst_report_schema_matches_executor_inputs() {
+    let def = render_typst_report_def();
+    let schema = def.input_schema.to_json_schema();
+
+    assert_eq!(schema["properties"]["data"]["type"], "object");
+    assert!(
+        schema["properties"]["data"]["description"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("JSON string"),
+        "data schema must document stringified JSON leniency"
+    );
+
+    let enum_values = schema["properties"]["template"]["enum"]
+        .as_array()
+        .expect("template enum values");
+    for slug in poiesis_typst::templates::SLUGS {
+        assert!(
+            enum_values.iter().any(|value| value.as_str() == Some(slug)),
+            "template schema must include {slug}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn render_typst_report_default_template_with_data() {
     let dir = tempfile::tempdir().expect("tmpdir");

--- a/crates/organon/src/builtins/render_docx_report.rs
+++ b/crates/organon/src/builtins/render_docx_report.rs
@@ -7,7 +7,7 @@ use hermeneus::types::{DocumentSource, ToolResultBlock};
 use indexmap::IndexMap;
 use poiesis_theme::{sinks::emit_reference_docx, summus};
 
-use crate::builtins::poiesis::{extract_zip_entry, rewrite_zip};
+use crate::builtins::poiesis::{extract_zip_entry, json_data_property, rewrite_zip};
 use crate::builtins::workspace::validate_path;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
@@ -132,14 +132,9 @@ fn render_docx_report_def() -> ToolDef {
             properties: IndexMap::from([
                 (
                     "data".to_owned(),
-                    PropertyDef {
-                        property_type: PropertyType::String,
-                        description:
-                            "Inline JSON data blob describing the document (title + paragraphs)."
-                                .to_owned(),
-                        enum_values: None,
-                        default: None,
-                    },
+                    json_data_property(
+                        "JSON data object describing the document (title + paragraphs).",
+                    ),
                 ),
                 (
                     "out_path".to_owned(),
@@ -168,4 +163,24 @@ fn render_docx_report_def() -> ToolDef {
 pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(render_docx_report_def(), Box::new(RenderDocxReportExecutor))?;
     Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::indexing_slicing, reason = "test schema assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_declares_data_object_with_string_leniency() {
+        let schema = render_docx_report_def().input_schema.to_json_schema();
+
+        assert_eq!(schema["properties"]["data"]["type"], "object");
+        assert!(
+            schema["properties"]["data"]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("JSON string"),
+            "data schema must document stringified JSON leniency"
+        );
+    }
 }

--- a/crates/organon/src/builtins/render_eval_report.rs
+++ b/crates/organon/src/builtins/render_eval_report.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use hermeneus::types::{DocumentSource, ToolResultBlock};
 use indexmap::IndexMap;
 
+use crate::builtins::poiesis::json_data_property;
 use crate::builtins::workspace::validate_path;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
@@ -106,13 +107,9 @@ fn render_eval_report_def() -> ToolDef {
             properties: IndexMap::from([
                 (
                     "data".to_owned(),
-                    PropertyDef {
-                        property_type: PropertyType::String,
-                        description: "JSON evaluation report data (summary + benchmarks array)."
-                            .to_owned(),
-                        enum_values: None,
-                        default: None,
-                    },
+                    json_data_property(
+                        "JSON evaluation report data object (summary + benchmarks array).",
+                    ),
                 ),
                 (
                     "out_path".to_owned(),
@@ -145,6 +142,7 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
 
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(clippy::indexing_slicing, reason = "test schema assertions")]
 mod tests {
     use std::collections::HashSet;
     use std::sync::{Arc, RwLock};
@@ -175,6 +173,20 @@ mod tests {
                 "out_path": out_path,
             }),
         }
+    }
+
+    #[test]
+    fn schema_declares_data_object_with_string_leniency() {
+        let schema = render_eval_report_def().input_schema.to_json_schema();
+
+        assert_eq!(schema["properties"]["data"]["type"], "object");
+        assert!(
+            schema["properties"]["data"]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("JSON string"),
+            "data schema must document stringified JSON leniency"
+        );
     }
 
     #[tokio::test]

--- a/crates/organon/src/builtins/render_graph_audit.rs
+++ b/crates/organon/src/builtins/render_graph_audit.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use hermeneus::types::{DocumentSource, ToolResultBlock};
 use indexmap::IndexMap;
 
+use crate::builtins::poiesis::json_data_property;
 use crate::builtins::workspace::validate_path;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
@@ -165,19 +166,15 @@ fn render_graph_audit_def() -> ToolDef {
             properties: IndexMap::from([
                 (
                     "data".to_owned(),
-                    PropertyDef {
-                        property_type: PropertyType::String,
-                        description: "JSON architecture fact audit data (summary + facts array). \
-                             Mutually exclusive with auto_load=true."
-                            .to_owned(),
-                        enum_values: None,
-                        default: None,
-                    },
+                    json_data_property(
+                        "JSON architecture fact audit data object (summary + facts array). \
+                         Mutually exclusive with auto_load=true.",
+                    ),
                 ),
                 (
                     "auto_load".to_owned(),
                     PropertyDef {
-                        property_type: PropertyType::String,
+                        property_type: PropertyType::Boolean,
                         description:
                             "If true, automatically load facts from the default fact store path. \
                              Mutually exclusive with providing data."
@@ -217,6 +214,7 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
 
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(clippy::indexing_slicing, reason = "test schema assertions")]
 mod tests {
     use std::collections::HashSet;
     use std::sync::{Arc, RwLock};
@@ -247,6 +245,21 @@ mod tests {
                 "out_path": out_path,
             }),
         }
+    }
+
+    #[test]
+    fn schema_matches_executor_input_types() {
+        let schema = render_graph_audit_def().input_schema.to_json_schema();
+
+        assert_eq!(schema["properties"]["data"]["type"], "object");
+        assert_eq!(schema["properties"]["auto_load"]["type"], "boolean");
+        assert!(
+            schema["properties"]["data"]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("JSON string"),
+            "data schema must document stringified JSON leniency"
+        );
     }
 
     #[tokio::test]

--- a/crates/organon/src/builtins/render_pptx_report.rs
+++ b/crates/organon/src/builtins/render_pptx_report.rs
@@ -10,7 +10,7 @@ use hermeneus::types::{DocumentSource, ToolResultBlock};
 use indexmap::IndexMap;
 use poiesis_theme::{sinks::emit_base_pptx, summus};
 
-use crate::builtins::poiesis::{extract_zip_entry, rewrite_zip};
+use crate::builtins::poiesis::{extract_zip_entry, json_data_property, rewrite_zip};
 use crate::builtins::workspace::validate_path;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
@@ -126,12 +126,9 @@ fn render_pptx_report_def() -> ToolDef {
             properties: IndexMap::from([
                 (
                     "data".to_owned(),
-                    PropertyDef {
-                        property_type: PropertyType::String,
-                        description: "Inline JSON slide descriptor (slides array with title and content).".to_owned(),
-                        enum_values: None,
-                        default: None,
-                    },
+                    json_data_property(
+                        "JSON slide descriptor object (slides array with title and content).",
+                    ),
                 ),
                 (
                     "out_path".to_owned(),
@@ -156,4 +153,24 @@ fn render_pptx_report_def() -> ToolDef {
 /// Register the `render_pptx_report` tool.
 pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(render_pptx_report_def(), Box::new(RenderPptxReportExecutor))
+}
+
+#[cfg(test)]
+#[expect(clippy::indexing_slicing, reason = "test schema assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_declares_data_object_with_string_leniency() {
+        let schema = render_pptx_report_def().input_schema.to_json_schema();
+
+        assert_eq!(schema["properties"]["data"]["type"], "object");
+        assert!(
+            schema["properties"]["data"]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("JSON string"),
+            "data schema must document stringified JSON leniency"
+        );
+    }
 }

--- a/crates/organon/src/builtins/render_xlsx_report.rs
+++ b/crates/organon/src/builtins/render_xlsx_report.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use hermeneus::types::{DocumentSource, ToolResultBlock};
 use indexmap::IndexMap;
 
+use crate::builtins::poiesis::json_data_property;
 use crate::builtins::workspace::validate_path;
 use crate::error::Result;
 use crate::registry::{ToolExecutor, ToolRegistry};
@@ -114,12 +115,7 @@ fn render_xlsx_report_def() -> ToolDef {
             properties: IndexMap::from([
                 (
                     "data".to_owned(),
-                    PropertyDef {
-                        property_type: PropertyType::String,
-                        description: "Inline JSON workbook descriptor.".to_owned(),
-                        enum_values: None,
-                        default: None,
-                    },
+                    json_data_property("JSON workbook descriptor object."),
                 ),
                 (
                     "out_path".to_owned(),
@@ -148,4 +144,24 @@ fn render_xlsx_report_def() -> ToolDef {
 pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
     registry.register(render_xlsx_report_def(), Box::new(RenderXlsxReportExecutor))?;
     Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::indexing_slicing, reason = "test schema assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_declares_data_object_with_string_leniency() {
+        let schema = render_xlsx_report_def().input_schema.to_json_schema();
+
+        assert_eq!(schema["properties"]["data"]["type"], "object");
+        assert!(
+            schema["properties"]["data"]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("JSON string"),
+            "data schema must document stringified JSON leniency"
+        );
+    }
 }

--- a/crates/poiesis/doc/src/error.rs
+++ b/crates/poiesis/doc/src/error.rs
@@ -46,7 +46,7 @@ pub enum Error {
     #[snafu(display("pdf LaTeX engine unavailable: {source}"))]
     PdfLatexEngineUnavailable {
         /// Detailed probing error from the Pandoc `LaTeX` route.
-        source: crate::pandoc::PandocError,
+        source: Box<crate::pandoc::PandocError>,
     },
 
     /// ODT rendering via the clean-room backend failed.
@@ -57,11 +57,18 @@ pub enum Error {
     },
 
     /// A Pandoc-backed format could not be rendered.
-    #[snafu(display(
-        "{format} output requires Pandoc; install pandoc >= 3.0 or use pdf/xlsx for now"
-    ))]
+    #[snafu(display("{format} output requires Pandoc; install pandoc >= 3.0"))]
     PandocRequired {
         /// The requested format name (e.g. "docx").
         format: String,
+    },
+
+    /// A Pandoc-backed format failed after Pandoc was found.
+    #[snafu(display("{format} output failed: {source}"))]
+    PandocFailed {
+        /// The requested format name (e.g. "docx").
+        format: String,
+        /// Detailed Pandoc subprocess error.
+        source: Box<crate::pandoc::PandocError>,
     },
 }

--- a/crates/poiesis/doc/src/latex_probe.rs
+++ b/crates/poiesis/doc/src/latex_probe.rs
@@ -6,9 +6,13 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use crate::pandoc::PdfEngine;
+use crate::process::{CommandOutputError, output_with_timeout};
 use snafu::Snafu;
+
+const LATEX_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Probe result for a system `LaTeX` engine.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,6 +31,13 @@ pub enum LatexProbe {
         /// Candidate paths that were searched.
         searched: Vec<PathBuf>,
     },
+    /// A candidate engine exceeded its probe deadline.
+    TimedOut {
+        /// Candidate path that timed out.
+        path: PathBuf,
+        /// Timeout in seconds.
+        timeout_secs: u64,
+    },
 }
 
 impl LatexProbe {
@@ -44,6 +55,9 @@ impl LatexProbe {
         match self {
             Self::Present { engine, .. } => Ok(engine),
             Self::Missing { searched } => Err(LatexProbeError::NotInstalled { searched }),
+            Self::TimedOut { path, timeout_secs } => {
+                Err(LatexProbeError::Timeout { path, timeout_secs })
+            }
         }
     }
 
@@ -56,15 +70,19 @@ impl LatexProbe {
     pub(crate) fn check_with<Search, Version>(search: Search, version_source: Version) -> Self
     where
         Search: FnOnce() -> Vec<(PdfEngine, PathBuf)>,
-        Version: Fn(&Path) -> Result<String, String>,
+        Version: Fn(&Path) -> Result<String, ProbeCommandError>,
     {
         let mut searched = Vec::new();
 
         for (engine, path) in search() {
             searched.push(path.clone());
 
-            let Ok(output) = version_source(&path) else {
-                continue;
+            let output = match version_source(&path) {
+                Ok(output) => output,
+                Err(ProbeCommandError::Failed(_detail)) => continue,
+                Err(ProbeCommandError::TimedOut { timeout_secs }) => {
+                    return Self::TimedOut { path, timeout_secs };
+                }
             };
 
             let version = output.lines().next().unwrap_or_default().trim().to_owned();
@@ -96,6 +114,24 @@ pub enum LatexProbeError {
         /// Candidate paths that were searched.
         searched: Vec<PathBuf>,
     },
+
+    /// A candidate `LaTeX` engine probe timed out.
+    #[snafu(display(
+        "latex engine at {} timed out after {timeout_secs}s while probing --version",
+        path.display()
+    ))]
+    Timeout {
+        /// Candidate path that timed out.
+        path: PathBuf,
+        /// Timeout in seconds.
+        timeout_secs: u64,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) enum ProbeCommandError {
+    Failed(String),
+    TimedOut { timeout_secs: u64 },
 }
 
 fn search_latex_candidates() -> Vec<(PdfEngine, PathBuf)> {
@@ -120,14 +156,23 @@ fn search_latex_candidates() -> Vec<(PdfEngine, PathBuf)> {
     candidates
 }
 
-fn real_version_source(path: &Path) -> Result<String, String> {
-    let output = Command::new(path)
-        .arg("--version")
-        .output()
-        .map_err(|e| e.to_string())?;
+fn real_version_source(path: &Path) -> Result<String, ProbeCommandError> {
+    let mut cmd = Command::new(path);
+    cmd.arg("--version");
+    let output = output_with_timeout(&mut cmd, LATEX_PROBE_TIMEOUT).map_err(|err| match err {
+        CommandOutputError::Timeout { timeout, .. } => ProbeCommandError::TimedOut {
+            timeout_secs: timeout.as_secs(),
+        },
+        CommandOutputError::Spawn { source }
+        | CommandOutputError::TempFile { source }
+        | CommandOutputError::Wait { source } => ProbeCommandError::Failed(source.to_string()),
+    })?;
 
     if !output.status.success() {
-        return Err(format!("exit status {}", output.status));
+        return Err(ProbeCommandError::Failed(format!(
+            "exit status {}",
+            output.status
+        )));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
@@ -180,7 +225,7 @@ mod tests {
             },
             |path| {
                 if path == Path::new("/tmp/xelatex") {
-                    Err("broken xelatex".to_owned())
+                    Err(ProbeCommandError::Failed("broken xelatex".to_owned()))
                 } else {
                     Ok("LuaHBTeX, Version 1.18.0 (TeX Live 2023)\n".to_owned())
                 }
@@ -193,6 +238,22 @@ mod tests {
                 engine: PdfEngine::LuaLaTeX,
                 path: PathBuf::from("/tmp/lualatex"),
                 version: "LuaHBTeX, Version 1.18.0 (TeX Live 2023)".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn check_with_returns_timeout_for_hung_version_source() {
+        let probe = LatexProbe::check_with(
+            || vec![(PdfEngine::XeLaTeX, PathBuf::from("/tmp/xelatex"))],
+            |_| Err(ProbeCommandError::TimedOut { timeout_secs: 5 }),
+        );
+
+        assert_eq!(
+            probe,
+            LatexProbe::TimedOut {
+                path: PathBuf::from("/tmp/xelatex"),
+                timeout_secs: 5,
             }
         );
     }

--- a/crates/poiesis/doc/src/lib.rs
+++ b/crates/poiesis/doc/src/lib.rs
@@ -38,6 +38,7 @@
 mod error;
 mod latex_probe;
 mod pandoc_probe;
+mod process;
 mod raster;
 
 /// Pandoc subprocess wrapper, AST serialization, and format dispatch (B-012).
@@ -216,7 +217,7 @@ pub fn render_pdf_from_doc(doc: &poiesis_core::Document) -> Result<Vec<u8>> {
         Ok(bytes) => Ok(bytes),
         Err(pandoc::PandocError::LatexEngineNotInstalled { searched }) => {
             Err(Error::PdfLatexEngineUnavailable {
-                source: pandoc::PandocError::LatexEngineNotInstalled { searched },
+                source: Box::new(pandoc::PandocError::LatexEngineNotInstalled { searched }),
             })
         }
         Err(e) => Err(Error::PdfRenderFailed {
@@ -276,8 +277,16 @@ fn render_pandoc_from_doc(
     format: &str,
     opts: &pandoc::DocOpts,
 ) -> Result<Vec<u8>> {
-    pandoc::render_doc(doc, opts).map_err(|_e| Error::PandocRequired {
-        format: format.to_owned(),
+    pandoc::render_doc(doc, opts).map_err(|e| match e {
+        pandoc::PandocError::NotInstalled { .. } | pandoc::PandocError::VersionTooOld { .. } => {
+            Error::PandocRequired {
+                format: format.to_owned(),
+            }
+        }
+        source => Error::PandocFailed {
+            format: format.to_owned(),
+            source: Box::new(source),
+        },
     })
 }
 

--- a/crates/poiesis/doc/src/pandoc/error.rs
+++ b/crates/poiesis/doc/src/pandoc/error.rs
@@ -64,6 +64,28 @@ pub enum PandocError {
         source: std::io::Error,
     },
 
+    /// Pandoc subprocess exceeded its deadline.
+    #[snafu(display("pandoc {operation} timed out after {timeout_secs}s"))]
+    Timeout {
+        /// Operation being performed.
+        operation: String,
+        /// Timeout in seconds.
+        timeout_secs: u64,
+        /// Child-process kill error, when cleanup failed.
+        kill_error: Option<String>,
+        /// Child-process wait error, when cleanup failed.
+        wait_error: Option<String>,
+    },
+
+    /// Pandoc subprocess I/O failed after spawning.
+    #[snafu(display("pandoc {operation} I/O failed: {source}"))]
+    SubprocessIo {
+        /// Operation being performed.
+        operation: String,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
     /// Failed to write the AST temp file.
     #[snafu(display("failed to write pandoc AST temp file: {source}"))]
     TempFile {
@@ -96,6 +118,12 @@ impl From<crate::latex_probe::LatexProbeError> for PandocError {
             crate::latex_probe::LatexProbeError::NotInstalled { searched } => {
                 Self::LatexEngineNotInstalled { searched }
             }
+            crate::latex_probe::LatexProbeError::Timeout { path, timeout_secs } => Self::Timeout {
+                operation: format!("latex probe {}", path.display()),
+                timeout_secs,
+                kill_error: None,
+                wait_error: None,
+            },
         }
     }
 }

--- a/crates/poiesis/doc/src/pandoc/mod.rs
+++ b/crates/poiesis/doc/src/pandoc/mod.rs
@@ -21,12 +21,20 @@ pub(crate) mod figure;
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
+use crate::process::{CommandOutputError, output_with_timeout};
 use crate::raster;
 use poiesis_core::Document;
 use tracing::instrument;
 
 pub use error::PandocError;
+
+const PANDOC_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+const PANDOC_RENDER_TIMEOUT: Duration = Duration::from_secs(120);
+const APX_CITE_LUA: &str = include_str!("../../../filters/apx-cite.lua");
+const APX_THEME_LUA: &str = include_str!("../../../filters/apx-theme.lua");
+const APX_FIGURE_LUA: &str = include_str!("../../../filters/apx-figure.lua");
 
 /// Supported export output formats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -201,24 +209,30 @@ impl PandocRunner {
             if !candidate.exists() {
                 continue;
             }
-            if let Ok(output) = Command::new(candidate).arg("--version").output()
-                && output.status.success()
-            {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                if let Some(ver) = parse_pandoc_version(&stdout) {
-                    if ver.0 >= 3 {
-                        return Ok(PandocRunner {
-                            bin: candidate.clone(),
-                            version: ver,
+            let mut cmd = Command::new(candidate);
+            cmd.arg("--version");
+            match output_with_timeout(&mut cmd, PANDOC_PROBE_TIMEOUT) {
+                Ok(output) if output.status.success() => {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    if let Some(ver) = parse_pandoc_version(&stdout) {
+                        if ver.0 >= 3 {
+                            return Ok(PandocRunner {
+                                bin: candidate.clone(),
+                                version: ver,
+                            });
+                        }
+                        return Err(PandocError::VersionTooOld {
+                            path: candidate.clone(),
+                            found_major: ver.0,
+                            found_minor: ver.1,
+                            found_patch: ver.2,
                         });
                     }
-                    return Err(PandocError::VersionTooOld {
-                        path: candidate.clone(),
-                        found_major: ver.0,
-                        found_minor: ver.1,
-                        found_patch: ver.2,
-                    });
                 }
+                Err(error @ CommandOutputError::Timeout { .. }) => {
+                    return Err(pandoc_process_error(error, "probe"));
+                }
+                Ok(_) | Err(_) => {}
             }
         }
 
@@ -292,7 +306,8 @@ impl PandocRunner {
 
         cmd.arg(tmp_path);
 
-        let output = cmd.output().map_err(|e| PandocError::Spawn { source: e })?;
+        let output = output_with_timeout(&mut cmd, PANDOC_RENDER_TIMEOUT)
+            .map_err(|e| pandoc_process_error(e, "render"))?;
 
         if output.status.success() {
             Ok(output.stdout)
@@ -345,7 +360,10 @@ pub fn render_doc(doc: &Document, opts: &DocOpts) -> Result<Vec<u8>, PandocError
     if let Some(engine) = pdf_engine {
         render_opts.pdf_engine = Some(engine);
     }
-    render_opts.lua_filters.extend(default_lua_filters());
+    let render_tmp = tempfile::tempdir().map_err(|source| PandocError::TempFile { source })?;
+    render_opts
+        .lua_filters
+        .extend(materialize_default_lua_filters(render_tmp.path())?);
     let facts_sidecar = write_apx_facts_sidecar(doc)?;
     let figures_sidecar = write_apx_figures_sidecar(doc)?;
     let extra_env = vec![
@@ -356,6 +374,10 @@ pub fn render_doc(doc: &Document, opts: &DocOpts) -> Result<Vec<u8>, PandocError
         (
             "APX_FIGURES".to_owned(),
             figures_sidecar.sidecar.path().display().to_string(),
+        ),
+        (
+            "APX_TMPDIR".to_owned(),
+            render_tmp.path().display().to_string(),
         ),
     ];
     runner.render(&ast_json, &render_opts, &extra_env)
@@ -397,13 +419,43 @@ struct ApxFactSidecarEntry {
     source_footnote: Option<String>,
 }
 
-fn default_lua_filters() -> Vec<PathBuf> {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../filters");
-    vec![
-        root.join("apx-cite.lua"),
-        root.join("apx-theme.lua"),
-        root.join("apx-figure.lua"),
-    ]
+fn pandoc_process_error(error: CommandOutputError, operation: &str) -> PandocError {
+    match error {
+        CommandOutputError::Spawn { source } => PandocError::Spawn { source },
+        CommandOutputError::TempFile { source } | CommandOutputError::Wait { source } => {
+            PandocError::SubprocessIo {
+                operation: operation.to_owned(),
+                source,
+            }
+        }
+        CommandOutputError::Timeout {
+            timeout,
+            kill_error,
+            wait_error,
+        } => PandocError::Timeout {
+            operation: operation.to_owned(),
+            timeout_secs: timeout.as_secs(),
+            kill_error,
+            wait_error,
+        },
+    }
+}
+
+fn materialize_default_lua_filters(dir: &Path) -> Result<Vec<PathBuf>, PandocError> {
+    let filters = [
+        ("apx-cite.lua", APX_CITE_LUA),
+        ("apx-theme.lua", APX_THEME_LUA),
+        ("apx-figure.lua", APX_FIGURE_LUA),
+    ];
+
+    let mut paths = Vec::with_capacity(filters.len());
+    for (name, source) in filters {
+        let path = dir.join(name);
+        std::fs::write(&path, source).map_err(|source| PandocError::TempFile { source })?;
+        paths.push(path);
+    }
+
+    Ok(paths)
 }
 
 struct FigureSidecarArtifacts {
@@ -743,6 +795,18 @@ mod tests {
         which::which("pandoc").is_ok()
     }
 
+    #[cfg(unix)]
+    fn write_executable_script(dir: &tempfile::TempDir, name: &str, script: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let path = dir.path().join(name);
+        std::fs::write(&path, script).expect("write script");
+        let mut perms = std::fs::metadata(&path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod script");
+        path
+    }
+
     #[test]
     fn default_pdf_routes_to_typst() {
         let doc = simple_doc();
@@ -775,6 +839,59 @@ mod tests {
         assert_eq!(OutputFormat::Latex.pandoc_flag(), "latex");
         assert_eq!(OutputFormat::Html.pandoc_flag(), "html5");
         assert_eq!(OutputFormat::Epub.pandoc_flag(), "epub3");
+    }
+
+    #[test]
+    fn embedded_lua_filters_materialize_for_each_render() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let filters = materialize_default_lua_filters(dir.path()).expect("filters");
+
+        assert_eq!(filters.len(), 3);
+        for filter in &filters {
+            assert!(
+                filter.exists(),
+                "materialized filter must exist: {}",
+                filter.display()
+            );
+            assert_eq!(
+                filter.parent(),
+                Some(dir.path()),
+                "filter must live under the render tempdir"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn writer_failure_preserves_stderr() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let fake_pandoc = write_executable_script(
+            &dir,
+            "pandoc",
+            r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "pandoc 3.1.1"
+  exit 0
+fi
+echo "writer exploded" >&2
+exit 23
+"#,
+        );
+
+        let runner = PandocRunner::probe(Some(&fake_pandoc)).expect("probe");
+        let err = runner
+            .render(b"{}", &DocOpts::markdown(), &[])
+            .expect_err("render must fail");
+
+        match err {
+            PandocError::WriterFailed { stderr, .. } => {
+                assert!(
+                    stderr.contains("writer exploded"),
+                    "stderr must be preserved: {stderr}"
+                );
+            }
+            other => panic!("expected WriterFailed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/poiesis/doc/src/pandoc_probe.rs
+++ b/crates/poiesis/doc/src/pandoc_probe.rs
@@ -6,11 +6,14 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
+use crate::process::{CommandOutputError, output_with_timeout};
 use snafu::Snafu;
 
 /// Minimum Pandoc version required by `poiesis-doc`.
 pub const REQUIRED_PANDOC_VERSION: PandocVersion = (3, 0, 0);
+const PANDOC_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Semantic version triple used by the probe.
 pub type PandocVersion = (u32, u32, u32);
@@ -39,6 +42,13 @@ pub enum PandocProbe {
         /// Minimum version required by the crate.
         required: PandocVersion,
     },
+    /// `pandoc --version` exceeded its probe deadline.
+    TimedOut {
+        /// Absolute path to the binary that timed out.
+        path: PathBuf,
+        /// Timeout in seconds.
+        timeout_secs: u64,
+    },
 }
 
 impl PandocProbe {
@@ -66,6 +76,9 @@ impl PandocProbe {
                 found,
                 required,
             }),
+            Self::TimedOut { path, timeout_secs } => {
+                Err(PandocProbeError::Timeout { path, timeout_secs })
+            }
         }
     }
 
@@ -78,7 +91,7 @@ impl PandocProbe {
     pub(crate) fn check_with<Search, Version>(search: Search, version_source: Version) -> Self
     where
         Search: FnOnce() -> Result<PathBuf, Vec<PathBuf>>,
-        Version: Fn(&Path) -> Result<String, String>,
+        Version: Fn(&Path) -> Result<String, ProbeCommandError>,
     {
         let path = match search() {
             Ok(path) => path,
@@ -87,10 +100,13 @@ impl PandocProbe {
 
         let output = match version_source(&path) {
             Ok(output) => output,
-            Err(_detail) => {
+            Err(ProbeCommandError::Failed(_detail)) => {
                 return Self::Missing {
                     searched: vec![path],
                 };
+            }
+            Err(ProbeCommandError::TimedOut { timeout_secs }) => {
+                return Self::TimedOut { path, timeout_secs };
             }
         };
 
@@ -148,6 +164,24 @@ pub enum PandocProbeError {
         /// Minimum version required.
         required: PandocVersion,
     },
+
+    /// The `pandoc --version` probe timed out.
+    #[snafu(display(
+        "pandoc at {} timed out after {timeout_secs}s while probing --version",
+        path.display()
+    ))]
+    Timeout {
+        /// Path to the binary that timed out.
+        path: PathBuf,
+        /// Timeout in seconds.
+        timeout_secs: u64,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) enum ProbeCommandError {
+    Failed(String),
+    TimedOut { timeout_secs: u64 },
 }
 
 fn find_pandoc_binary() -> Result<PathBuf, Vec<PathBuf>> {
@@ -169,14 +203,23 @@ fn searched_pandoc_candidates() -> Vec<PathBuf> {
         .collect()
 }
 
-fn real_version_source(path: &Path) -> Result<String, String> {
-    let output = Command::new(path)
-        .arg("--version")
-        .output()
-        .map_err(|e| e.to_string())?;
+fn real_version_source(path: &Path) -> Result<String, ProbeCommandError> {
+    let mut cmd = Command::new(path);
+    cmd.arg("--version");
+    let output = output_with_timeout(&mut cmd, PANDOC_PROBE_TIMEOUT).map_err(|err| match err {
+        CommandOutputError::Timeout { timeout, .. } => ProbeCommandError::TimedOut {
+            timeout_secs: timeout.as_secs(),
+        },
+        CommandOutputError::Spawn { source }
+        | CommandOutputError::TempFile { source }
+        | CommandOutputError::Wait { source } => ProbeCommandError::Failed(source.to_string()),
+    })?;
 
     if !output.status.success() {
-        return Err(format!("exit status {}", output.status));
+        return Err(ProbeCommandError::Failed(format!(
+            "exit status {}",
+            output.status
+        )));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
@@ -247,6 +290,22 @@ mod tests {
                 path: PathBuf::from("/tmp/fake-pandoc"),
                 found: (2, 19, 2),
                 required: REQUIRED_PANDOC_VERSION,
+            }
+        );
+    }
+
+    #[test]
+    fn probe_check_returns_timeout_for_hung_version_source() {
+        let probe = PandocProbe::check_with(
+            || Ok(PathBuf::from("/tmp/fake-pandoc")),
+            |_| Err(ProbeCommandError::TimedOut { timeout_secs: 5 }),
+        );
+
+        assert_eq!(
+            probe,
+            PandocProbe::TimedOut {
+                path: PathBuf::from("/tmp/fake-pandoc"),
+                timeout_secs: 5,
             }
         );
     }

--- a/crates/poiesis/doc/src/process.rs
+++ b/crates/poiesis/doc/src/process.rs
@@ -1,0 +1,107 @@
+//! Bounded subprocess helpers for render and probe commands.
+
+use std::io::{Read as _, Seek as _, SeekFrom};
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Debug)]
+pub(crate) enum CommandOutputError {
+    Spawn {
+        source: std::io::Error,
+    },
+    TempFile {
+        source: std::io::Error,
+    },
+    Wait {
+        source: std::io::Error,
+    },
+    Timeout {
+        timeout: Duration,
+        kill_error: Option<String>,
+        wait_error: Option<String>,
+    },
+}
+
+pub(crate) fn output_with_timeout(
+    cmd: &mut Command,
+    timeout: Duration,
+) -> Result<Output, CommandOutputError> {
+    let mut stdout =
+        tempfile::tempfile().map_err(|source| CommandOutputError::TempFile { source })?;
+    let mut stderr =
+        tempfile::tempfile().map_err(|source| CommandOutputError::TempFile { source })?;
+
+    cmd.stdout(Stdio::from(
+        stdout
+            .try_clone()
+            .map_err(|source| CommandOutputError::TempFile { source })?,
+    ))
+    .stderr(Stdio::from(
+        stderr
+            .try_clone()
+            .map_err(|source| CommandOutputError::TempFile { source })?,
+    ));
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|source| CommandOutputError::Spawn { source })?;
+    let started = Instant::now();
+
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|source| CommandOutputError::Wait { source })?
+        {
+            let stdout = read_temp_output(&mut stdout)?;
+            let stderr = read_temp_output(&mut stderr)?;
+            return Ok(Output {
+                status,
+                stdout,
+                stderr,
+            });
+        }
+
+        if started.elapsed() >= timeout {
+            let kill_error = child.kill().err().map(|err| err.to_string());
+            let wait_error = child.wait().err().map(|err| err.to_string());
+            return Err(CommandOutputError::Timeout {
+                timeout,
+                kill_error,
+                wait_error,
+            });
+        }
+
+        std::thread::sleep(PROCESS_POLL_INTERVAL);
+    }
+}
+
+fn read_temp_output(file: &mut std::fs::File) -> Result<Vec<u8>, CommandOutputError> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|source| CommandOutputError::TempFile { source })?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|source| CommandOutputError::TempFile { source })?;
+    Ok(bytes)
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_with_timeout_kills_slow_process() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("sleep 5");
+
+        let err = output_with_timeout(&mut cmd, Duration::from_millis(20))
+            .expect_err("sleep must time out");
+
+        assert!(
+            matches!(err, CommandOutputError::Timeout { .. }),
+            "expected timeout, got {err:?}"
+        );
+    }
+}

--- a/crates/poiesis/filters/apx-figure.lua
+++ b/crates/poiesis/filters/apx-figure.lua
@@ -1,6 +1,7 @@
 -- NOTE: apx-figure.lua swaps chart figures to SVG or PNG assets per writer.
 
 local figures_cache = nil
+local svg_counter = 0
 
 local function load_figures()
   if figures_cache ~= nil then
@@ -47,7 +48,10 @@ local function figure_id(img)
 end
 
 local function ensure_svg_file(figure_id_value, svg)
-  local path = os.tmpname() .. "-" .. figure_id_value .. ".svg"
+  svg_counter = svg_counter + 1
+  local tmpdir = os.getenv("APX_TMPDIR") or os.getenv("TMPDIR") or "."
+  local sep = package.config:sub(1, 1)
+  local path = tmpdir .. sep .. figure_id_value .. "-" .. tostring(svg_counter) .. ".svg"
   local handle = assert(io.open(path, "w"))
   handle:write(svg)
   handle:close()

--- a/crates/poiesis/printer-chromium/src/chromium_impl.rs
+++ b/crates/poiesis/printer-chromium/src/chromium_impl.rs
@@ -1,8 +1,10 @@
+use std::future::Future;
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use chromiumoxide::{Browser, BrowserConfig};
 use futures::StreamExt as _;
-use tracing::debug;
+use tracing::{debug, error, warn};
 
 use crate::{PrintOptions, PrinterError};
 
@@ -13,37 +15,77 @@ pub(crate) async fn print_to_pdf_inner(
     let exe = find_chromium().ok_or(PrinterError::ChromiumNotFound)?;
     debug!(path = %exe.display(), "launching Chromium");
 
-    let config = BrowserConfig::builder()
+    let mut config = BrowserConfig::builder()
         .chrome_executable(exe)
-        .arg("--no-sandbox")
         .arg("--disable-gpu")
-        .arg("--disable-dev-shm-usage")
-        .build()
-        .map_err(|e| PrinterError::BrowserLaunch {
-            source: Box::from(e),
-        })?;
+        .arg("--disable-dev-shm-usage");
 
-    let (mut browser, mut handler) =
-        Browser::launch(config)
-            .await
-            .map_err(|e| PrinterError::BrowserLaunch {
-                source: Box::from(e),
-            })?;
+    if opts.disable_sandbox || disable_sandbox_from_env() {
+        // WHY: Some locked-down containers lack user namespaces; sandbox disablement is explicit because it weakens Chromium's process isolation.
+        warn!("launching Chromium with sandbox disabled");
+        config = config.arg("--no-sandbox");
+    }
 
-    let _handle = tokio::spawn(async move { while let Some(_ev) = handler.next().await {} });
+    let config = config.build().map_err(|e| PrinterError::BrowserLaunch {
+        source: Box::from(e),
+    })?;
 
-    let page = browser
-        .new_page("about:blank")
-        .await
-        .map_err(|e| PrinterError::PageError {
-            source: Box::from(e),
-        })?;
+    let started = Instant::now();
+    let (mut browser, mut handler) = with_remaining_timeout(
+        started,
+        opts.timeout,
+        "browser launch",
+        Browser::launch(config),
+    )
+    .await?
+    .map_err(|e| PrinterError::BrowserLaunch {
+        source: Box::from(e),
+    })?;
 
-    page.set_content(html)
-        .await
-        .map_err(|e| PrinterError::PageError {
-            source: Box::from(e),
-        })?;
+    let handler_task = tokio::spawn(async move { while let Some(_ev) = handler.next().await {} });
+
+    let render_result = render_with_browser(&mut browser, html, opts, started).await;
+    let cleanup_result = cleanup_browser(&mut browser, Duration::from_secs(5)).await;
+    handler_task.abort();
+
+    match (render_result, cleanup_result) {
+        (Ok(pdf_bytes), Ok(())) => Ok(pdf_bytes),
+        (Ok(_pdf_bytes), Err(cleanup_error)) => Err(cleanup_error),
+        (Err(render_error), Ok(())) => Err(render_error),
+        (Err(render_error), Err(cleanup_error)) => {
+            error!(error = %cleanup_error, "Chromium cleanup failed after render error");
+            Err(render_error)
+        }
+    }
+}
+
+async fn render_with_browser(
+    browser: &mut Browser,
+    html: &str,
+    opts: &PrintOptions,
+    started: Instant,
+) -> Result<Vec<u8>, PrinterError> {
+    let page = with_remaining_timeout(
+        started,
+        opts.timeout,
+        "page creation",
+        browser.new_page("about:blank"),
+    )
+    .await?
+    .map_err(|e| PrinterError::PageError {
+        source: Box::from(e),
+    })?;
+
+    with_remaining_timeout(
+        started,
+        opts.timeout,
+        "page content",
+        page.set_content(html),
+    )
+    .await?
+    .map_err(|e| PrinterError::PageError {
+        source: Box::from(e),
+    })?;
 
     // WHY: CDP PrintToPdf takes inches; layout options are mm (1 in = 25.4 mm).
     let mm_to_in = |mm: f64| mm / 25.4;
@@ -59,16 +101,95 @@ pub(crate) async fn print_to_pdf_inner(
         .print_background(true)
         .build();
 
-    let pdf_bytes = page
-        .pdf(pdf_params)
-        .await
-        .map_err(|e| PrinterError::PdfError {
-            source: Box::from(e),
-        })?;
-
-    browser.close().await.ok();
+    let pdf_bytes = with_remaining_timeout(
+        started,
+        opts.timeout,
+        "pdf generation",
+        page.pdf(pdf_params),
+    )
+    .await?
+    .map_err(|e| PrinterError::PdfError {
+        source: Box::from(e),
+    })?;
 
     Ok(pdf_bytes)
+}
+
+async fn with_remaining_timeout<T, F>(
+    started: Instant,
+    timeout: Duration,
+    operation: &'static str,
+    future: F,
+) -> Result<T, PrinterError>
+where
+    F: Future<Output = T>,
+{
+    let remaining = timeout
+        .checked_sub(started.elapsed())
+        .ok_or(PrinterError::Timeout {
+            operation,
+            timeout_secs: timeout.as_secs().max(1),
+        })?;
+
+    tokio::time::timeout(remaining, future)
+        .await
+        .map_err(|_elapsed| PrinterError::Timeout {
+            operation,
+            timeout_secs: timeout.as_secs().max(1),
+        })
+}
+
+async fn cleanup_browser(browser: &mut Browser, timeout: Duration) -> Result<(), PrinterError> {
+    match tokio::time::timeout(timeout, browser.close()).await {
+        Ok(Ok(_closed)) => {}
+        Ok(Err(err)) => {
+            error!(error = %err, "Chromium close failed");
+            kill_browser(browser).await;
+            return Err(PrinterError::Cleanup {
+                source: Box::from(err),
+            });
+        }
+        Err(_elapsed) => {
+            warn!("Chromium close timed out; killing browser process");
+            kill_browser(browser).await;
+            return Err(PrinterError::Timeout {
+                operation: "browser close",
+                timeout_secs: timeout.as_secs().max(1),
+            });
+        }
+    }
+
+    match tokio::time::timeout(timeout, browser.wait()).await {
+        Ok(Ok(_status)) => Ok(()),
+        Ok(Err(err)) => {
+            error!(error = %err, "Chromium wait after close failed");
+            kill_browser(browser).await;
+            Err(PrinterError::Cleanup {
+                source: Box::from(err),
+            })
+        }
+        Err(_elapsed) => {
+            warn!("Chromium wait after close timed out; killing browser process");
+            kill_browser(browser).await;
+            Err(PrinterError::Timeout {
+                operation: "browser wait",
+                timeout_secs: timeout.as_secs().max(1),
+            })
+        }
+    }
+}
+
+async fn kill_browser(browser: &mut Browser) {
+    if let Some(Err(err)) = browser.kill().await {
+        error!(error = %err, "Chromium kill failed");
+    }
+}
+
+fn disable_sandbox_from_env() -> bool {
+    matches!(
+        std::env::var("POIESIS_CHROMIUM_DISABLE_SANDBOX").as_deref(),
+        Ok("1" | "true" | "TRUE" | "yes" | "YES")
+    )
 }
 
 fn find_chromium() -> Option<PathBuf> {

--- a/crates/poiesis/printer-chromium/src/error.rs
+++ b/crates/poiesis/printer-chromium/src/error.rs
@@ -20,4 +20,14 @@ pub enum PrinterError {
         #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+    #[snafu(display("{operation} timed out after {timeout_secs}s"))]
+    Timeout {
+        operation: &'static str,
+        timeout_secs: u64,
+    },
+    #[snafu(display("Browser cleanup failed: {source}"))]
+    Cleanup {
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, |e| e)))]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }

--- a/crates/poiesis/printer-chromium/src/lib.rs
+++ b/crates/poiesis/printer-chromium/src/lib.rs
@@ -10,8 +10,13 @@
 //!
 //! **Override binary path:** set the `CHROMIUM_PATH` environment variable.
 
+use std::time::Duration;
+
 pub mod error;
 pub use error::PrinterError;
+
+/// Default deadline for an HTML-to-PDF print operation.
+pub const DEFAULT_PRINT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// PDF print options controlling paper size and margins.
 #[derive(Debug, Clone)]
@@ -30,6 +35,10 @@ pub struct PrintOptions {
     pub margin_right_mm: f64,
     /// Page scale factor (1.0 = 100%).
     pub scale: f64,
+    /// Overall deadline for browser launch, page setup, and PDF generation.
+    pub timeout: Duration,
+    /// Explicitly disable the Chromium sandbox.
+    pub disable_sandbox: bool,
 }
 
 impl Default for PrintOptions {
@@ -50,6 +59,8 @@ impl PrintOptions {
             margin_left_mm: 0.0,
             margin_right_mm: 0.0,
             scale: 1.0,
+            timeout: DEFAULT_PRINT_TIMEOUT,
+            disable_sandbox: false,
         }
     }
 
@@ -64,6 +75,8 @@ impl PrintOptions {
             margin_left_mm: 0.0,
             margin_right_mm: 0.0,
             scale: 1.0,
+            timeout: DEFAULT_PRINT_TIMEOUT,
+            disable_sandbox: false,
         }
     }
 
@@ -92,4 +105,17 @@ mod chromium_impl;
 #[cfg(feature = "chromium")]
 pub async fn print_to_pdf(html: &str, opts: &PrintOptions) -> Result<Vec<u8>, PrinterError> {
     chromium_impl::print_to_pdf_inner(html, opts).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn print_options_default_keeps_sandbox_enabled() {
+        let opts = PrintOptions::default();
+
+        assert!(!opts.disable_sandbox);
+        assert_eq!(opts.timeout, DEFAULT_PRINT_TIMEOUT);
+    }
 }

--- a/crates/poiesis/typst/src/templates.rs
+++ b/crates/poiesis/typst/src/templates.rs
@@ -6,7 +6,7 @@
 //! (which [`crate::render_typst`] populates automatically).
 
 /// Slug for the default one-page report template.
-pub(crate) const DEFAULT: &str = "default";
+pub const DEFAULT: &str = "default";
 
 /// Source for the [`DEFAULT`] template.
 ///
@@ -14,7 +14,7 @@ pub(crate) const DEFAULT: &str = "default";
 pub(crate) const DEFAULT_SOURCE: &str = include_str!("../templates/default.typ");
 
 /// Slug for the eval-report template.
-pub(crate) const EVAL_REPORT: &str = "eval-report";
+pub const EVAL_REPORT: &str = "eval-report";
 
 /// Source for the [`EVAL_REPORT`] template.
 ///
@@ -22,7 +22,7 @@ pub(crate) const EVAL_REPORT: &str = "eval-report";
 pub(crate) const EVAL_REPORT_SOURCE: &str = include_str!("../templates/eval-report.typ");
 
 /// Slug for the graph-audit template.
-pub(crate) const GRAPH_AUDIT: &str = "graph-audit";
+pub const GRAPH_AUDIT: &str = "graph-audit";
 
 /// Source for the [`GRAPH_AUDIT`] template.
 ///
@@ -30,7 +30,7 @@ pub(crate) const GRAPH_AUDIT: &str = "graph-audit";
 pub(crate) const GRAPH_AUDIT_SOURCE: &str = include_str!("../templates/graph-audit.typ");
 
 /// List of all known template slugs.
-pub(crate) const SLUGS: &[&str] = &[DEFAULT, EVAL_REPORT, GRAPH_AUDIT];
+pub const SLUGS: &[&str] = &[DEFAULT, EVAL_REPORT, GRAPH_AUDIT];
 
 /// Resolve a slug to its Typst source, or `None` if unknown.
 #[must_use]


### PR DESCRIPTION
Closes #4500
Closes #4502
Closes #4501

- **#4500** — `PandocFailed` variant preserving stderr (no more "install pandoc" misreports); `output_with_timeout` bounded subprocess runner with kill-on-timeout (+ test); lua filters `include_str!`-embedded and materialized to a per-render TempDir (kills the `CARGO_MANIFEST_DIR` bake that broke deployed binaries); `APX_TMPDIR` for apx-figure.lua SVG litter; renders moved to the blocking pool via `spawn_blocking` in organon `generate_document` (bounded pin became no runtime-worker pin at all).
- **#4502** — schema honesty in the organon builtins: `auto_load` → Boolean (asserted in test), `data` typed properly, `template` enum derived from `poiesis_typst::templates::SLUGS` (now `pub`).
- **#4501** — hardcoded `--no-sandbox` removed; sandbox disablement is explicit opt-in (option/env) with a WHY comment and `warn!` at launch; overall print timeout with remaining-budget propagation across browser/page/pdf phases + `Timeout` variant; close-then-kill teardown.

Worker-gated CI-exact on verda; the organon `spawn_blocking` completion re-verified with `clippy -p organon -D warnings` + 29/29 poiesis tests.