### PR TITLE
fix(organon,koina): revalidate redirect targets against SSRF — manual bounded redirects, shared validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5180,6 +5180,7 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "regex",
+ "reqwest 0.13.2",
  "rustix 1.1.4",
  "serde",
  "serde_json",

--- a/_llm/L3-api-index/koina.md
+++ b/_llm/L3-api-index/koina.md
@@ -667,6 +667,11 @@ pub const API_V1: &str = "/api/v1";
 pub const API_HEALTH: &str = "/api/health";
 ```
 
+> Cloud-metadata and loopback hostnames rejected outright.
+```rust
+pub const BLOCKED_HOSTNAMES: &[&str] = &["localhost", "metadata.google.internal"];
+```
+
 > TLS-protected URL scheme, including the `://` separator.
 ```rust
 pub const HTTPS_SCHEME_PREFIX: &str = "https://";
@@ -678,6 +683,53 @@ pub fn has_http_or_https_scheme (url: &str) -> bool
 
 ```rust
 pub fn is_plaintext_loopback_url (url: &str) -> bool
+```
+
+> Future returned by [`HostResolver`] implementations.
+```rust
+pub type ResolveHostFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<SocketAddr>, String>> + Send + 'a>>;
+```
+
+> Resolver seam for SSRF guard tests.
+```rust
+pub trait HostResolver {
+    fn resolve_host <'a> (&'a self, host: &'a str, port: u16) -> ResolveHostFuture<'a>;
+}
+```
+
+```rust
+pub struct TokioHostResolver;
+```
+
+```rust
+pub fn is_private_ip (ip: &IpAddr) -> bool
+```
+
+> Resolve a URL host and verify none of its addresses are private/internal.
+> 
+> # Errors
+> 
+> Returns an error when the URL is invalid, has no host, uses a blocked
+> hostname, fails DNS resolution, resolves to no addresses, or resolves to
+> a private/internal address.
+```rust
+pub async fn validate_url_not_internal (url_str: &str) -> Result<(), String>
+```
+
+> Resolve a URL host with a supplied resolver and reject private/internal targets.
+> 
+> # Errors
+> 
+> Returns an error when the URL is invalid, has no host, uses a blocked
+> hostname, fails DNS resolution, resolves to no addresses, or resolves to
+> a private/internal address.
+```rust
+pub async fn validate_url_not_internal_with_resolver <R> (
+    url_str: &str,
+    resolver: &R,
+) -> Result<(), String> where
+    R: HostResolver + ?Sized,
 ```
 
 ## `src/id.rs`

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -122,8 +122,8 @@ l3_token_estimate = 11570
 [[crates]]
 name = "koina"
 path = "crates/koina"
-source_hash = "6a501263be79591481c1f9f8d54e5d2161291c7ab91541eb4827d8743fb329f9"
-l3_token_estimate = 7453
+source_hash = "d33f1c6f1b36a7a5a134ea71a30e82bc5d683a6b8e34822dbd6cede278781150"
+l3_token_estimate = 7804
 
 [[crates]]
 name = "krites"
@@ -158,7 +158,7 @@ l3_token_estimate = 12375
 [[crates]]
 name = "organon"
 path = "crates/organon"
-source_hash = "9b444115c265a131cf3bbc0bfb2e5aa6ffd821af0f14ffbb6f8e4266f1dd3291"
+source_hash = "3ef590e6ccfe8382fc5bc73e81347355ded332c1ef4e8b749759c906899a6672"
 l3_token_estimate = 11818
 
 [[crates]]

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -32,6 +32,7 @@ tracing-subscriber = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }
 prometheus-client = { workspace = true }
+reqwest = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }

--- a/crates/koina/src/http.rs
+++ b/crates/koina/src/http.rs
@@ -1,4 +1,8 @@
-//! Shared HTTP constants used across Aletheia crates.
+//! Shared HTTP constants and network-boundary guards used across Aletheia crates.
+
+use std::future::Future;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::pin::Pin;
 
 /// `application/json` content type.
 pub const CONTENT_TYPE_JSON: &str = "application/json";
@@ -14,6 +18,9 @@ pub const API_V1: &str = "/api/v1";
 
 /// Health check endpoint path.
 pub const API_HEALTH: &str = "/api/health";
+
+/// Cloud-metadata and loopback hostnames rejected outright.
+pub const BLOCKED_HOSTNAMES: &[&str] = &["localhost", "metadata.google.internal"];
 
 /// TLS-protected URL scheme, including the `://` separator.
 pub const HTTPS_SCHEME_PREFIX: &str = "https://";
@@ -69,8 +76,113 @@ pub fn is_plaintext_loopback_url(url: &str) -> bool {
     rest.starts_with("localhost") || rest.starts_with("127.0.0.1") || rest.starts_with("[::1]")
 }
 
+/// Future returned by [`HostResolver`] implementations.
+pub type ResolveHostFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<SocketAddr>, String>> + Send + 'a>>;
+
+/// Resolver seam for SSRF guard tests.
+pub trait HostResolver {
+    /// Resolve `host:port` to socket addresses.
+    fn resolve_host<'a>(&'a self, host: &'a str, port: u16) -> ResolveHostFuture<'a>;
+}
+
+/// Host resolver backed by Tokio DNS.
+#[derive(Debug, Default)]
+pub struct TokioHostResolver;
+
+impl HostResolver for TokioHostResolver {
+    fn resolve_host<'a>(&'a self, host: &'a str, port: u16) -> ResolveHostFuture<'a> {
+        Box::pin(async move {
+            tokio::net::lookup_host((host, port))
+                .await
+                .map_err(|e| format!("DNS resolution failed for {host}: {e}"))
+                .map(Iterator::collect)
+        })
+    }
+}
+
+/// Check whether an IP address belongs to a private, loopback, or link-local range.
+#[must_use]
+pub fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.octets().first() == Some(&0)
+                || *v4 == Ipv4Addr::new(169, 254, 169, 254)
+                || *v4 == Ipv4Addr::new(169, 254, 169, 123)
+        }
+        IpAddr::V6(v6) => {
+            *v6 == Ipv6Addr::LOCALHOST
+                || (v6.segments().first().unwrap_or(&0) & 0xfe00) == 0xfc00
+                || (v6.segments().first().unwrap_or(&0) & 0xffc0) == 0xfe80
+                || v6.to_ipv4_mapped().is_some_and(|v4| {
+                    v4.is_loopback()
+                        || v4.is_private()
+                        || v4.is_link_local()
+                        || v4.octets().first() == Some(&0)
+                })
+        }
+    }
+}
+
+/// Resolve a URL host and verify none of its addresses are private/internal.
+///
+/// # Errors
+///
+/// Returns an error when the URL is invalid, has no host, uses a blocked
+/// hostname, fails DNS resolution, resolves to no addresses, or resolves to
+/// a private/internal address.
+pub async fn validate_url_not_internal(url_str: &str) -> Result<(), String> {
+    validate_url_not_internal_with_resolver(url_str, &TokioHostResolver).await
+}
+
+/// Resolve a URL host with a supplied resolver and reject private/internal targets.
+///
+/// # Errors
+///
+/// Returns an error when the URL is invalid, has no host, uses a blocked
+/// hostname, fails DNS resolution, resolves to no addresses, or resolves to
+/// a private/internal address.
+pub async fn validate_url_not_internal_with_resolver<R>(
+    url_str: &str,
+    resolver: &R,
+) -> Result<(), String>
+where
+    R: HostResolver + ?Sized,
+{
+    let parsed: reqwest::Url = url_str.parse().map_err(|e| format!("invalid URL: {e}"))?;
+    let host = parsed.host_str().ok_or("URL has no host")?;
+
+    let host_lower = host.to_lowercase();
+    for blocked in BLOCKED_HOSTNAMES {
+        if host_lower == *blocked {
+            return Err(format!("blocked hostname: {host}"));
+        }
+    }
+
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let addrs = resolver.resolve_host(host, port).await?;
+
+    if addrs.is_empty() {
+        return Err(format!("DNS resolution returned no addresses for {host}"));
+    }
+
+    for addr in &addrs {
+        if is_private_ip(&addr.ip()) {
+            return Err("URL resolves to a private/internal IP address".to_owned());
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
 
     #[test]
@@ -101,5 +213,53 @@ mod tests {
     fn non_loopback_is_not_plaintext_loopback() {
         assert!(!is_plaintext_loopback_url("http://example.com"));
         assert!(!is_plaintext_loopback_url("https://localhost:8080"));
+    }
+
+    #[test]
+    fn is_private_ip_flags_loopback_v4() {
+        assert!(is_private_ip(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn is_private_ip_flags_aws_metadata() {
+        assert!(is_private_ip(&IpAddr::V4(Ipv4Addr::new(
+            169, 254, 169, 254
+        ))));
+    }
+
+    #[test]
+    fn is_private_ip_allows_public_v4() {
+        assert!(!is_private_ip(&IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+    }
+
+    #[derive(Default)]
+    struct MockResolver {
+        addrs_by_host: HashMap<String, Vec<SocketAddr>>,
+    }
+
+    impl HostResolver for MockResolver {
+        fn resolve_host<'a>(&'a self, host: &'a str, _port: u16) -> ResolveHostFuture<'a> {
+            Box::pin(async move {
+                self.addrs_by_host
+                    .get(host)
+                    .cloned()
+                    .ok_or_else(|| format!("missing mock host: {host}"))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_url_blocks_hostname_that_resolves_private() {
+        let mut resolver = MockResolver::default();
+        resolver.addrs_by_host.insert(
+            "rebind.example".to_owned(),
+            vec![SocketAddr::from(([10, 0, 0, 1], 443))],
+        );
+
+        let err = validate_url_not_internal_with_resolver("https://rebind.example/", &resolver)
+            .await
+            .expect_err("private DNS target must be rejected");
+
+        assert!(err.contains("private/internal"), "unexpected error: {err}");
     }
 }

--- a/crates/organon/src/builtins/http_client.rs
+++ b/crates/organon/src/builtins/http_client.rs
@@ -8,12 +8,15 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::future::Future;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::pin::Pin;
 
 use indexmap::IndexMap;
-use reqwest::{Method, redirect};
+use reqwest::{Method, StatusCode, redirect};
 
+use koina::http::{
+    HostResolver, TokioHostResolver, validate_url_not_internal,
+    validate_url_not_internal_with_resolver,
+};
 use koina::id::ToolName;
 
 use crate::error::Result;
@@ -25,13 +28,6 @@ use crate::types::{
 
 use super::workspace::{extract_opt_str, extract_opt_u64, extract_str};
 
-/// Cloud-metadata / loopback hostnames rejected outright.
-///
-/// WHY: duplicated with `research.rs` rather than shared, because each tool's
-/// allowlist is an independent security boundary; a future widening of one
-/// should not silently widen the other. Kept in sync by convention.
-const BLOCKED_HOSTNAMES: &[&str] = &["localhost", "metadata.google.internal"];
-
 /// Headers that must never be forwarded from LLM input.
 ///
 /// WHY: Host/Content-Length are computed by reqwest; the LLM setting them
@@ -42,59 +38,7 @@ const FORBIDDEN_REQUEST_HEADERS: &[&str] = &["host", "content-length"];
 /// Upper bound on response body size forwarded to the LLM.
 const MAX_RESPONSE_BYTES: usize = 1_000_000;
 
-fn is_private_ip(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.octets().first() == Some(&0)
-                || *v4 == Ipv4Addr::new(169, 254, 169, 254)
-                || *v4 == Ipv4Addr::new(169, 254, 169, 123)
-        }
-        IpAddr::V6(v6) => {
-            *v6 == Ipv6Addr::LOCALHOST
-                || (v6.segments().first().unwrap_or(&0) & 0xfe00) == 0xfc00
-                || (v6.segments().first().unwrap_or(&0) & 0xffc0) == 0xfe80
-                || v6.to_ipv4_mapped().is_some_and(|v4| {
-                    v4.is_loopback()
-                        || v4.is_private()
-                        || v4.is_link_local()
-                        || v4.octets().first() == Some(&0)
-                })
-        }
-    }
-}
-
-async fn validate_url_not_internal(url_str: &str) -> std::result::Result<(), String> {
-    let parsed: reqwest::Url = url_str.parse().map_err(|e| format!("invalid URL: {e}"))?;
-
-    let host = parsed.host_str().ok_or("URL has no host")?;
-    let host_lower = host.to_lowercase();
-    for blocked in BLOCKED_HOSTNAMES {
-        if host_lower == *blocked {
-            return Err(format!("blocked hostname: {host}"));
-        }
-    }
-
-    let port = parsed.port_or_known_default().unwrap_or(80);
-    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host(format!("{host}:{port}"))
-        .await
-        .map_err(|e| format!("DNS resolution failed for {host}: {e}"))?
-        .collect();
-
-    if addrs.is_empty() {
-        return Err(format!("DNS resolution returned no addresses for {host}"));
-    }
-
-    for addr in &addrs {
-        if is_private_ip(&addr.ip()) {
-            return Err("URL resolves to a private/internal IP address".to_owned());
-        }
-    }
-
-    Ok(())
-}
+const MAX_REDIRECTS: usize = 5;
 
 fn parse_method(raw: &str) -> std::result::Result<Method, String> {
     match raw.to_ascii_uppercase().as_str() {
@@ -131,21 +75,116 @@ fn extract_headers(
     Ok(out)
 }
 
+async fn validated_redirect_target<R>(
+    current_url: &reqwest::Url,
+    location: &str,
+    redirects_followed: usize,
+    resolver: &R,
+) -> std::result::Result<reqwest::Url, String>
+where
+    R: HostResolver + ?Sized,
+{
+    if redirects_followed >= MAX_REDIRECTS {
+        return Err(format!("redirect limit exceeded: max {MAX_REDIRECTS}"));
+    }
+
+    let next_url = current_url
+        .join(location)
+        .map_err(|e| format!("invalid redirect Location: {e}"))?;
+
+    // WARNING: DNS may change after validation and before reqwest connects.
+    // The guard revalidates every URL before following it, but it cannot pin
+    // the resolved address for the subsequent connection.
+    validate_url_not_internal_with_resolver(next_url.as_str(), resolver).await?;
+
+    Ok(next_url)
+}
+
+fn redirect_method(method: &Method, status: StatusCode) -> Method {
+    if status == StatusCode::SEE_OTHER
+        || ((status == StatusCode::MOVED_PERMANENTLY || status == StatusCode::FOUND)
+            && *method != Method::GET
+            && *method != Method::HEAD)
+    {
+        Method::GET
+    } else {
+        method.clone()
+    }
+}
+
+async fn send_with_safe_redirects<R>(
+    client: &reqwest::Client,
+    method: Method,
+    url: &str,
+    headers: &HashMap<String, String>,
+    body: Option<&str>,
+    resolver: &R,
+) -> std::result::Result<reqwest::Response, String>
+where
+    R: HostResolver + ?Sized,
+{
+    let mut current_url: reqwest::Url = url.parse().map_err(|e| format!("invalid URL: {e}"))?;
+    let mut current_method = method;
+    let mut include_body = body.is_some();
+    let mut redirects_followed = 0;
+
+    loop {
+        let mut req = client
+            .request(current_method.clone(), current_url.clone())
+            .header(
+                "User-Agent",
+                concat!(
+                    "aletheia/",
+                    env!("CARGO_PKG_VERSION"),
+                    " (organon http_request)"
+                ),
+            );
+        for (k, v) in headers {
+            req = req.header(k, v);
+        }
+        if include_body && let Some(b) = body {
+            req = req.body(b.to_owned());
+        }
+
+        let response = req
+            .send()
+            .await
+            .map_err(|e| format!("request failed: {e}"))?;
+
+        if !response.status().is_redirection() {
+            return Ok(response);
+        }
+
+        let status = response.status();
+        let Some(location) = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+        else {
+            return Ok(response);
+        };
+
+        current_url =
+            validated_redirect_target(&current_url, location, redirects_followed, resolver).await?;
+        let next_method = redirect_method(&current_method, status);
+        include_body = include_body
+            && next_method == current_method
+            && (status == StatusCode::TEMPORARY_REDIRECT
+                || status == StatusCode::PERMANENT_REDIRECT);
+        current_method = next_method;
+        redirects_followed += 1;
+    }
+}
+
 struct HttpRequestExecutor;
 
 impl ToolExecutor for HttpRequestExecutor {
-    #[expect(
-        clippy::too_many_lines,
-        reason = "single HTTP lifecycle — validate URL, build client, send, render response; splitting would fragment one cohesive I/O operation"
-    )]
     fn execute<'a>(
         &'a self,
         input: &'a ToolInput,
-        ctx: &'a ToolContext,
+        _ctx: &'a ToolContext,
     ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
         Box::pin(async {
-            let _ = ctx; // unused: no service dependencies
-
             let url = extract_str(&input.arguments, "url", &input.name)?;
             let method_str = extract_opt_str(&input.arguments, "method").unwrap_or("GET");
             let body = extract_opt_str(&input.arguments, "body");
@@ -173,27 +212,7 @@ impl ToolExecutor for HttpRequestExecutor {
             }
 
             let client = match reqwest::Client::builder()
-                .redirect(redirect::Policy::custom(|attempt| {
-                    let url = attempt.url();
-                    let host = match url.host_str() {
-                        Some(h) => h.to_lowercase(),
-                        None => return attempt.stop(),
-                    };
-                    for blocked in BLOCKED_HOSTNAMES {
-                        if host == *blocked {
-                            return attempt.stop();
-                        }
-                    }
-                    if let Some(addr) = url.host_str().and_then(|h| h.parse::<IpAddr>().ok())
-                        && is_private_ip(&addr)
-                    {
-                        return attempt.stop();
-                    }
-                    if attempt.previous().len() >= 5 {
-                        return attempt.stop();
-                    }
-                    attempt.follow()
-                }))
+                .redirect(redirect::Policy::none())
                 .timeout(std::time::Duration::from_secs(timeout_secs))
                 .build()
             {
@@ -201,24 +220,18 @@ impl ToolExecutor for HttpRequestExecutor {
                 Err(e) => return Ok(ToolResult::error(format!("client build failed: {e}"))),
             };
 
-            let mut req = client.request(method.clone(), url).header(
-                "User-Agent",
-                concat!(
-                    "aletheia/",
-                    env!("CARGO_PKG_VERSION"),
-                    " (organon http_request)"
-                ),
-            );
-            for (k, v) in &headers {
-                req = req.header(k, v);
-            }
-            if let Some(b) = body {
-                req = req.body(b.to_owned());
-            }
-
-            let response = match req.send().await {
+            let response = match send_with_safe_redirects(
+                &client,
+                method.clone(),
+                url,
+                &headers,
+                body,
+                &TokioHostResolver,
+            )
+            .await
+            {
                 Ok(r) => r,
-                Err(e) => return Ok(ToolResult::error(format!("request failed: {e}"))),
+                Err(e) => return Ok(ToolResult::error(e)),
             };
 
             let status = response.status();
@@ -361,7 +374,34 @@ fn http_request_def() -> ToolDef {
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+
+    use koina::http::ResolveHostFuture;
+
     use super::*;
+
+    #[derive(Default)]
+    struct MockResolver {
+        addrs_by_host: HashMap<String, Vec<SocketAddr>>,
+    }
+
+    impl HostResolver for MockResolver {
+        fn resolve_host<'a>(&'a self, host: &'a str, _port: u16) -> ResolveHostFuture<'a> {
+            Box::pin(async move {
+                self.addrs_by_host
+                    .get(host)
+                    .cloned()
+                    .ok_or_else(|| format!("missing mock host: {host}"))
+            })
+        }
+    }
+
+    fn public_base_url() -> reqwest::Url {
+        "https://public.example/start"
+            .parse()
+            .expect("test URL should parse")
+    }
 
     #[test]
     fn parse_method_accepts_standard_methods() {
@@ -402,26 +442,77 @@ mod tests {
     }
 
     #[test]
-    fn is_private_ip_flags_loopback_v4() {
-        assert!(is_private_ip(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
-    }
-
-    #[test]
-    fn is_private_ip_flags_aws_metadata() {
-        assert!(is_private_ip(&IpAddr::V4(Ipv4Addr::new(
-            169, 254, 169, 254
-        ))));
-    }
-
-    #[test]
-    fn is_private_ip_allows_public_v4() {
-        assert!(!is_private_ip(&IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
-    }
-
-    #[test]
     fn http_request_def_is_lazy() {
         let def = http_request_def();
         assert!(!def.auto_activate);
         assert_eq!(def.category, ToolCategory::Research);
+    }
+
+    #[tokio::test]
+    async fn redirect_to_private_ip_literal_is_blocked() {
+        let mut resolver = MockResolver::default();
+        resolver.addrs_by_host.insert(
+            "169.254.169.254".to_owned(),
+            vec![SocketAddr::from(([169, 254, 169, 254], 443))],
+        );
+
+        let err = validated_redirect_target(
+            &public_base_url(),
+            "https://169.254.169.254/latest",
+            0,
+            &resolver,
+        )
+        .await
+        .expect_err("private redirect target must be rejected");
+
+        assert!(err.contains("private/internal"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn redirect_to_blocked_hostname_is_blocked() {
+        let err = validated_redirect_target(
+            &public_base_url(),
+            "https://localhost/admin",
+            0,
+            &MockResolver::default(),
+        )
+        .await
+        .expect_err("blocked hostname must be rejected");
+
+        assert!(err.contains("blocked hostname"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn redirect_to_hostname_resolving_private_is_blocked() {
+        let mut resolver = MockResolver::default();
+        resolver.addrs_by_host.insert(
+            "rebind.example".to_owned(),
+            vec![SocketAddr::from(([10, 0, 0, 7], 443))],
+        );
+
+        let err = validated_redirect_target(
+            &public_base_url(),
+            "https://rebind.example/metadata",
+            0,
+            &resolver,
+        )
+        .await
+        .expect_err("private DNS redirect target must be rejected");
+
+        assert!(err.contains("private/internal"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn sixth_redirect_is_refused() {
+        let err = validated_redirect_target(
+            &public_base_url(),
+            "https://public.example/six",
+            5,
+            &MockResolver::default(),
+        )
+        .await
+        .expect_err("sixth redirect must be rejected");
+
+        assert!(err.contains("redirect limit"), "unexpected error: {err}");
     }
 }

--- a/crates/organon/src/builtins/research.rs
+++ b/crates/organon/src/builtins/research.rs
@@ -5,12 +5,15 @@
 //! `web_fetch` for direct URL retrieval.
 
 use std::future::Future;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::pin::Pin;
 
 use indexmap::IndexMap;
 use reqwest::redirect;
 
+use koina::http::{
+    HostResolver, TokioHostResolver, validate_url_not_internal,
+    validate_url_not_internal_with_resolver,
+};
 use koina::id::ToolName;
 
 use crate::error::Result;
@@ -34,69 +37,75 @@ fn require_services(
         .ok_or_else(|| ToolResult::error("tool services not configured"))
 }
 
-/// Blocked cloud metadata hostnames.
-const BLOCKED_HOSTNAMES: &[&str] = &["localhost", "metadata.google.internal"];
+const MAX_REDIRECTS: usize = 5;
 
-/// Check whether an IP address belongs to a private, loopback, or link-local range.
-///
-/// WHY: Blocks SSRF to internal infrastructure including IPv6 loopback, ULA ranges,
-/// IPv4-mapped loopback (`::ffff:127.x.x.x`), and cloud metadata endpoints.
-fn is_private_ip(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()                                          // 127.0.0.0/8
-                || v4.is_private()                                    // 10/8, 172.16/12, 192.168/16
-                || v4.is_link_local()                                 // 169.254.0.0/16
-                || v4.octets().first() == Some(&0)                     // 0.0.0.0/8
-                || *v4 == Ipv4Addr::new(169, 254, 169, 254)          // AWS metadata
-                || *v4 == Ipv4Addr::new(169, 254, 169, 123) // AWS NTP
-        }
-        IpAddr::V6(v6) => {
-            *v6 == Ipv6Addr::LOCALHOST                                // ::1
-                || (v6.segments().first().unwrap_or(&0) & 0xfe00) == 0xfc00  // fc00::/7 (ULA)
-                || (v6.segments().first().unwrap_or(&0) & 0xffc0) == 0xfe80  // fe80::/10 (link-local)
-                // WHY: IPv4-mapped addresses (::ffff:127.x.x.x) are loopback when
-                // the embedded IPv4 address is private. Unmap and re-check.
-                || v6.to_ipv4_mapped().is_some_and(|v4| {
-                    v4.is_loopback()
-                        || v4.is_private()
-                        || v4.is_link_local()
-                        || v4.octets().first() == Some(&0)
-                })
-        }
+async fn validated_redirect_target<R>(
+    current_url: &reqwest::Url,
+    location: &str,
+    redirects_followed: usize,
+    resolver: &R,
+) -> std::result::Result<reqwest::Url, String>
+where
+    R: HostResolver + ?Sized,
+{
+    if redirects_followed >= MAX_REDIRECTS {
+        return Err(format!("redirect limit exceeded: max {MAX_REDIRECTS}"));
     }
+
+    let next_url = current_url
+        .join(location)
+        .map_err(|e| format!("invalid redirect Location: {e}"))?;
+
+    // WARNING: DNS may change after validation and before reqwest connects.
+    // The guard revalidates every URL before following it, but it cannot pin
+    // the resolved address for the subsequent connection.
+    validate_url_not_internal_with_resolver(next_url.as_str(), resolver).await?;
+
+    Ok(next_url)
 }
 
-/// Resolve hostname and verify none of the addresses are private/internal.
-async fn validate_url_not_internal(url_str: &str) -> std::result::Result<(), String> {
-    let parsed: reqwest::Url = url_str.parse().map_err(|e| format!("invalid URL: {e}"))?;
+async fn get_with_safe_redirects<R>(
+    client: &reqwest::Client,
+    url: &str,
+    resolver: &R,
+) -> std::result::Result<reqwest::Response, String>
+where
+    R: HostResolver + ?Sized,
+{
+    let mut current_url: reqwest::Url = url.parse().map_err(|e| format!("invalid URL: {e}"))?;
+    let mut redirects_followed = 0;
 
-    let host = parsed.host_str().ok_or("URL has no host")?;
+    loop {
+        let response = client
+            .get(current_url.clone())
+            .header(
+                "User-Agent",
+                concat!(
+                    "aletheia/",
+                    env!("CARGO_PKG_VERSION"),
+                    " (github.com/forkwright/aletheia)"
+                ),
+            )
+            .send()
+            .await
+            .map_err(|e| format!("fetch failed: {e}"))?;
 
-    let host_lower = host.to_lowercase();
-    for blocked in BLOCKED_HOSTNAMES {
-        if host_lower == *blocked {
-            return Err(format!("blocked hostname: {host}"));
+        if !response.status().is_redirection() {
+            return Ok(response);
         }
+
+        let Some(location) = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+        else {
+            return Ok(response);
+        };
+
+        current_url =
+            validated_redirect_target(&current_url, location, redirects_followed, resolver).await?;
+        redirects_followed += 1;
     }
-
-    let port = parsed.port_or_known_default().unwrap_or(80);
-    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host(format!("{host}:{port}"))
-        .await
-        .map_err(|e| format!("DNS resolution failed for {host}: {e}"))?
-        .collect();
-
-    if addrs.is_empty() {
-        return Err(format!("DNS resolution returned no addresses for {host}"));
-    }
-
-    for addr in &addrs {
-        if is_private_ip(&addr.ip()) {
-            return Err("URL resolves to a private/internal IP address".to_owned());
-        }
-    }
-
-    Ok(())
 }
 
 struct WebFetchExecutor;
@@ -110,7 +119,7 @@ impl ToolExecutor for WebFetchExecutor {
         ctx: &'a ToolContext,
     ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
         Box::pin(async {
-            let services = match require_services(ctx) {
+            let _services = match require_services(ctx) {
                 Ok(s) => s,
                 Err(r) => return Ok(r),
             };
@@ -129,53 +138,20 @@ impl ToolExecutor for WebFetchExecutor {
                 return Ok(ToolResult::error(msg));
             }
 
-            let ssrf_safe_client = reqwest::Client::builder()
-                .redirect(redirect::Policy::custom(|attempt| {
-                    let url = attempt.url();
-                    let host = match url.host_str() {
-                        Some(h) => h.to_lowercase(),
-                        None => return attempt.stop(),
-                    };
-                    for blocked in BLOCKED_HOSTNAMES {
-                        if host == *blocked {
-                            return attempt.stop();
-                        }
-                    }
-                    // WHY: For redirects we can only check parsed IPs directly;
-                    // full async DNS isn't available in the sync callback.
-                    // Reject if the redirect target is an IP literal in a private range.
-                    if let Some(addr) = url.host_str().and_then(|h| h.parse::<IpAddr>().ok())
-                        && is_private_ip(&addr)
-                    {
-                        return attempt.stop();
-                    }
-                    // WHY: Limit redirect chain to prevent redirect loops.
-                    if attempt.previous().len() >= 5 {
-                        return attempt.stop();
-                    }
-                    attempt.follow()
-                }))
+            let ssrf_safe_client = match reqwest::Client::builder()
+                .redirect(redirect::Policy::none())
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
-                .unwrap_or_else(|_| services.http_client.clone());
-
-            let response = ssrf_safe_client
-                .get(url)
-                .header(
-                    "User-Agent",
-                    concat!(
-                        "aletheia/",
-                        env!("CARGO_PKG_VERSION"),
-                        " (github.com/forkwright/aletheia)"
-                    ),
-                )
-                .send()
-                .await;
-
-            let response = match response {
-                Ok(r) => r,
-                Err(e) => return Ok(ToolResult::error(format!("fetch failed: {e}"))),
+            {
+                Ok(c) => c,
+                Err(e) => return Ok(ToolResult::error(format!("client build failed: {e}"))),
             };
+
+            let response =
+                match get_with_safe_redirects(&ssrf_safe_client, url, &TokioHostResolver).await {
+                    Ok(r) => r,
+                    Err(e) => return Ok(ToolResult::error(e)),
+                };
 
             if !response.status().is_success() {
                 return Ok(ToolResult::error(format!("HTTP {}", response.status())));
@@ -378,15 +354,40 @@ pub(crate) fn register(registry: &mut ToolRegistry) -> Result<()> {
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
+    use std::collections::HashMap;
     use std::collections::HashSet;
+    use std::net::SocketAddr;
     use std::sync::{Arc, RwLock};
 
+    use koina::http::ResolveHostFuture;
     use koina::id::{NousId, SessionId, ToolName};
 
     use crate::testing::install_crypto_provider;
     use crate::types::{ServerToolConfig, ToolContext, ToolInput, ToolServices};
 
     use super::*;
+
+    #[derive(Default)]
+    struct MockResolver {
+        addrs_by_host: HashMap<String, Vec<SocketAddr>>,
+    }
+
+    impl HostResolver for MockResolver {
+        fn resolve_host<'a>(&'a self, host: &'a str, _port: u16) -> ResolveHostFuture<'a> {
+            Box::pin(async move {
+                self.addrs_by_host
+                    .get(host)
+                    .cloned()
+                    .ok_or_else(|| format!("missing mock host: {host}"))
+            })
+        }
+    }
+
+    fn public_base_url() -> reqwest::Url {
+        "https://public.example/start"
+            .parse()
+            .expect("test URL should parse")
+    }
 
     fn mock_ctx() -> ToolContext {
         install_crypto_provider();
@@ -482,5 +483,73 @@ mod tests {
             result.content.text_summary().contains("http"),
             "expected result.content.text_summary().contains(\"http\") to be true"
         );
+    }
+
+    #[tokio::test]
+    async fn redirect_to_private_ip_literal_is_blocked() {
+        let mut resolver = MockResolver::default();
+        resolver.addrs_by_host.insert(
+            "169.254.169.254".to_owned(),
+            vec![SocketAddr::from(([169, 254, 169, 254], 443))],
+        );
+
+        let err = validated_redirect_target(
+            &public_base_url(),
+            "https://169.254.169.254/latest",
+            0,
+            &resolver,
+        )
+        .await
+        .expect_err("private redirect target must be rejected");
+
+        assert!(err.contains("private/internal"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn redirect_to_blocked_hostname_is_blocked() {
+        let err = validated_redirect_target(
+            &public_base_url(),
+            "https://localhost/admin",
+            0,
+            &MockResolver::default(),
+        )
+        .await
+        .expect_err("blocked hostname must be rejected");
+
+        assert!(err.contains("blocked hostname"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn redirect_to_hostname_resolving_private_is_blocked() {
+        let mut resolver = MockResolver::default();
+        resolver.addrs_by_host.insert(
+            "rebind.example".to_owned(),
+            vec![SocketAddr::from(([10, 0, 0, 7], 443))],
+        );
+
+        let err = validated_redirect_target(
+            &public_base_url(),
+            "https://rebind.example/metadata",
+            0,
+            &resolver,
+        )
+        .await
+        .expect_err("private DNS redirect target must be rejected");
+
+        assert!(err.contains("private/internal"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn sixth_redirect_is_refused() {
+        let err = validated_redirect_target(
+            &public_base_url(),
+            "https://public.example/six",
+            5,
+            &MockResolver::default(),
+        )
+        .await
+        .expect_err("sixth redirect must be rejected");
+
+        assert!(err.contains("redirect limit"), "unexpected error: {err}");
     }
 }

--- a/docs/NETWORK.md
+++ b/docs/NETWORK.md
@@ -20,7 +20,7 @@ Sorted by criticality (highest sovereignty impact first).
 | Configurable OAuth provider (PKCE / device code) | HTTPS | Outbound | Authorization codes, device codes, access tokens | `aletheia credential login` (PKCE) or `aletheia credential device-code` | `crates/symbolon/src/credential/pkce.rs:361` (authorization URL build); `crates/symbolon/src/credential/pkce.rs:612` (code→token exchange); `crates/symbolon/src/credential/device_code.rs:220` (device authorization POST); `crates/symbolon/src/credential/device_code.rs:285` (token polling POST) |
 | HuggingFace Hub (`hf-hub` internal endpoint) | HTTPS (via `ureq`) | Outbound | Model files: `config.json`, `tokenizer.json`, `model.safetensors` | First initialization of the `candle` embedding provider | `crates/episteme/src/embedding.rs:165` (hub API init); `crates/episteme/src/embedding.rs:173` (`config.json` download); `crates/episteme/src/embedding.rs:179` (`tokenizer.json` download); `crates/episteme/src/embedding.rs:185` (`model.safetensors` download) |
 | `api.github.com` | HTTPS | Outbound | Public issue metadata (title, state, labels, milestone) | Agent uses `issue_scan` or `issue_triage` built-in tool | `crates/organon/src/builtins/triage/mod.rs:359` (URL template); `crates/organon/src/builtins/triage/mod.rs:369` (HTTP GET) |
-| Arbitrary URLs (`web_fetch` tool) | HTTPS/HTTP | Outbound | Arbitrary web page body (HTML, markdown, etc.) | Agent uses `web_fetch` built-in tool | `crates/organon/src/builtins/research.rs:118` (protocol guard); `crates/organon/src/builtins/research.rs:156` (HTTP GET execution) |
+| Arbitrary URLs (`web_fetch` tool) | HTTPS/HTTP | Outbound | Arbitrary web page body (HTML, markdown, etc.) | Agent uses `web_fetch` built-in tool | `crates/organon/src/builtins/research.rs:130` (protocol guard); `crates/organon/src/builtins/research.rs:77` (HTTP GET execution); `crates/organon/src/builtins/research.rs:141` (automatic redirects disabled) |
 | Operator-configured external tool endpoints | HTTPS/HTTP (config-driven) | Outbound | JSON tool body (`tool`, `kind`, `arguments`) | Agent invokes an external tool registered in `aletheia.toml` | `crates/aletheia/src/external_tools.rs:30` (config types); `crates/aletheia/src/external_tools.rs:330` (HTTP POST executor) |
 | Qdrant (migration only) | HTTPS/gRPC (configurable, default `localhost:6333`) | Outbound | Vector memory records (scroll points, payloads) | One-time `aletheia agent-io migrate-memory` CLI command | `crates/aletheia/src/migrate_memory.rs:68` (client build); `crates/aletheia/src/commands/agent_io.rs:106` (CLI `--qdrant-url` arg) |
 | signal-cli daemon (`localhost:8080` by default) | HTTP (JSON-RPC) | Outbound | Signal message text, recipient IDs, JSON-RPC envelopes | Sending or receiving Signal messages when Signal channel is enabled | `crates/taxis/src/config/mod.rs:268` (default host); `crates/agora/src/semeion/client.rs:88` (URL construction); `crates/agora/src/semeion/client.rs:144` (`send` RPC); `crates/agora/src/semeion/mod.rs:170` (receive poll loop) |
@@ -57,13 +57,21 @@ Sorted by criticality (highest sovereignty impact first).
 | Configurable OAuth PKCE / device code | Partial (URLs are configurable per provider) | Do not run login commands; use static API key |
 | HuggingFace Hub | Partial (model repo is configurable) | Use a pre-cached model directory (`HF_HOME`), or air-gap the host |
 | `api.github.com` | No (host is hard-coded) | Do not enable or invoke `issue_scan` / `issue_triage` |
-| Arbitrary URLs (`web_fetch`) | No (arbitrary by design) | Do not invoke `web_fetch`; SSRF guards block internal ranges |
+| Arbitrary URLs (`web_fetch`) | No (arbitrary by design) | Do not invoke `web_fetch`; SSRF guards reject blocked hostnames and URLs that resolve to internal ranges |
 | External tool endpoints | Yes (operator must explicitly declare them in `aletheia.toml`) | Remove the tool from config |
 | Qdrant | Yes (`--qdrant-url` or `QDRANT_URL` env) | Do not run `migrate-memory`; feature is off by default |
 | signal-cli daemon | Yes (`channels.signal.accounts.*.http_host`, `http_port`) | Disable Signal channel or set `enabled = false` |
 | Tailscale local status query | No | Do not install `tailscale` binary; discovery gracefully degrades to `localhost` |
 
 ---
+
+## Arbitrary URL SSRF guard
+
+`web_fetch` and `http_request` validate the initial URL before sending a request. They reject blocked hostnames such as `localhost` and `metadata.google.internal`, and they reject hosts whose DNS resolution returns private, loopback, link-local, or cloud metadata addresses.
+
+Both tools disable reqwest automatic redirects. They follow redirects manually, revalidate every `Location` target with the same hostname and DNS policy before the next request, and refuse the sixth redirect in a chain. Relative redirect targets are resolved against the current URL before validation.
+
+Known limitation: DNS can change after validation and before the subsequent TCP connection. The guard reduces SSRF exposure by validating each URL the process chooses to request, but it does not pin the validated address through connect time.
 
 ## Inbound connections
 


### PR DESCRIPTION
Closes #4517

reqwest auto-redirects bypassed the URL guard entirely: a public URL 302ing to `169.254.169.254`/`10.x`/a-hostname-resolving-private sailed through (SSRF redirect + DNS-rebind gap), and NETWORK.md over-claimed the guard held.

- `redirect::Policy::none()` in both `research.rs` and `http_client.rs`; redirects followed by a manual loop (`send_with_safe_redirects`, cap 5) that revalidates EVERY `Location` target — including method semantics on 303 (`redirect_method`).
- `validate_url_not_internal` + `is_private_ip` + `BLOCKED_HOSTNAMES` extracted to `koina::http` (beside `has_http_or_https_scheme`); both byte-identical duplicates deleted.
- The web_fetch shared-client fallback no longer silently restores auto-redirects on client-build failure — build failure is now explicit.
- Tests: redirect-to-private-IP-literal, redirect-to-blocked-hostname, redirect-to-hostname-that-DNS-resolves-private (resolver seam, no real DNS), sixth-redirect-refused.
- NETWORK.md states the actual guarantee (every target revalidated, cap 5) + the residual TOCTOU/rebind window as a documented limitation.

Worker-gated CI-exact on verda before push.