### PR TITLE
fix(taxis,pylon): preserve secrets during config writes — stop persisting [REDACTED]

### DIFF
--- a/_llm/L3-api-index/taxis.md
+++ b/_llm/L3-api-index/taxis.md
@@ -2254,6 +2254,29 @@ pub fn check_preconditions (
 pub fn redact (config: &AletheiaConfig) -> Value
 ```
 
+> Restore redacted secret leaves from the current in-memory config.
+> 
+> Call this after serializing `AletheiaConfig` through serde for mutation,
+> before deserializing the value back into typed config.
+```rust
+pub fn preserve_secret_leaves (root: &mut Value, current: &AletheiaConfig)
+```
+
+> Return `staged` with any redacted secret leaves restored from `current`.
+> 
+> This is for config paths that must serialize through `serde_json::Value`
+> before producing a live `AletheiaConfig`.
+> 
+> # Errors
+> 
+> Returns an error if the restored JSON cannot deserialize into config.
+```rust
+pub fn preserve_config_secret_leaves (
+    staged: &AletheiaConfig,
+    current: &AletheiaConfig,
+) -> Result<AletheiaConfig, serde_json::Error>
+```
+
 ## `src/registry.rs`
 
 ```rust

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -122,7 +122,7 @@ l3_token_estimate = 11570
 [[crates]]
 name = "koina"
 path = "crates/koina"
-source_hash = "e6416dbe6ad7469b3458cf056c039eb544c2710c64ad89b71b9c0943527f6ee9"
+source_hash = "6a501263be79591481c1f9f8d54e5d2161291c7ab91541eb4827d8743fb329f9"
 l3_token_estimate = 7453
 
 [[crates]]
@@ -266,7 +266,7 @@ l3_token_estimate = 1354
 [[crates]]
 name = "pylon"
 path = "crates/pylon"
-source_hash = "25e98a2610dc4e86913cd240dcf165e62de4ff92ea80fe4c966ac9345bcaff0a"
+source_hash = "b1da2c8f3d7d846346eede85fb296b651c69816631aabaa16584fb46f5ae9a08"
 l3_token_estimate = 17603
 
 [[crates]]
@@ -284,8 +284,8 @@ l3_token_estimate = 6585
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "957669e85efccd49b622bba86bbe8f9f02c165b9917d63a42a68c37bc4f8fd52"
-l3_token_estimate = 23493
+source_hash = "c4278d863aca018a5d39904acff0e78137723d8bc8cb35323483226af0ccef52"
+l3_token_estimate = 23677
 
 [[crates]]
 name = "theatron"

--- a/crates/koina/src/secret.rs
+++ b/crates/koina/src/secret.rs
@@ -104,49 +104,6 @@ impl<'de> Deserialize<'de> for SecretString {
     }
 }
 
-#[expect(
-    dead_code,
-    reason = "serde helper for config fields with optional secrets"
-)]
-/// Deserialize an `Option<SecretString>` that treats empty strings as `None`.
-///
-/// Useful for config fields where an empty value means "not set."
-pub(crate) fn deserialize_option_secret_non_empty<'de, D>(
-    deserializer: D,
-) -> Result<Option<SecretString>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let opt: Option<String> = Option::deserialize(deserializer)?;
-    Ok(opt.filter(|s| !s.is_empty()).map(SecretString::from))
-}
-
-/// Serialize an `Option<SecretString>` that uses the default serde behavior
-/// (serialize the field as `[REDACTED]` if Some, skip if None when combined
-/// with `#[serde(skip_serializing_if = "Option::is_none")]`).
-///
-#[expect(
-    dead_code,
-    reason = "serde helper for config fields with optional secrets"
-)]
-#[expect(
-    clippy::ref_option,
-    reason = "serde serialize_with requires &Option<T> signature"
-)]
-/// This exists for symmetry with [`deserialize_option_secret_non_empty`].
-pub(crate) fn serialize_option_secret_redacted<S>(
-    value: &Option<SecretString>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    match value {
-        Some(_) => serializer.serialize_str(REDACTED),
-        None => serializer.serialize_none(),
-    }
-}
-
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {

--- a/crates/pylon/src/handlers/config.rs
+++ b/crates/pylon/src/handlers/config.rs
@@ -455,6 +455,7 @@ pub async fn update_section(
             .or_insert_with(|| Value::Object(serde_json::Map::default()));
         deep_merge(existing, body_value);
     }
+    taxis::redact::preserve_secret_leaves(&mut config_value, &config);
 
     // WHY: Deserialize back to verify structural validity.
     // Log serde details internally; the error message exposed to the client must not
@@ -472,11 +473,6 @@ pub async fn update_section(
             }
         })?;
 
-    taxis::loader::write_config(&state.oikos, &new_config).map_err(|e| ApiError::Internal {
-        message: format!("failed to write config: {e}"),
-        location: snafu::location!(),
-    })?;
-
     let diff = taxis::reload::diff_configs(&config, &new_config);
     let restart_required: Vec<String> = diff
         .cold_changes()
@@ -489,6 +485,18 @@ pub async fn update_section(
             message: format!("failed to preserve cold config values: {e}"),
             location: snafu::location!(),
         })?;
+    let live_config =
+        taxis::redact::preserve_config_secret_leaves(&live_config, &config).map_err(|e| {
+            ApiError::Internal {
+                message: format!("failed to preserve secret config values: {e}"),
+                location: snafu::location!(),
+            }
+        })?;
+
+    taxis::loader::write_config(&state.oikos, &new_config).map_err(|e| ApiError::Internal {
+        message: format!("failed to write config: {e}"),
+        location: snafu::location!(),
+    })?;
 
     *config = live_config.clone();
     let redacted = taxis::redact::redact(&config);

--- a/crates/pylon/tests/public_api_config_secret.rs
+++ b/crates/pylon/tests/public_api_config_secret.rs
@@ -1,0 +1,80 @@
+#![expect(clippy::expect_used, reason = "test assertions use expect")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use tower::ServiceExt;
+
+use koina::http::API_V1;
+use koina::secret::SecretString;
+use pylon::router::build_router;
+
+mod common;
+use common::{TestEnv, bearer, issue_test_token, permissive_security};
+
+#[tokio::test]
+async fn config_put_and_nous_toggle_preserve_signing_key_on_disk() {
+    let env = TestEnv::builder().with_actor(true).build().await;
+    let signing_key = "synthetic-signing-key-for-secret-write-preservation";
+
+    {
+        let mut config = env.state.config.write().await;
+        config.gateway.auth.signing_key = Some(SecretString::from(signing_key));
+        taxis::loader::write_config(&env.state.oikos, &config).expect("seed config");
+    }
+
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+    let token = issue_test_token(&env.state);
+
+    let put_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::PUT)
+                .uri(format!("{API_V1}/config/maintenance"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .expect("build config PUT request"),
+        )
+        .await
+        .expect("config PUT response");
+    assert_eq!(put_response.status(), StatusCode::OK);
+
+    let toggle_response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::PATCH)
+                .uri(format!("{API_V1}/nous/syn"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"enabled":false}"#))
+                .expect("build nous toggle request"),
+        )
+        .await
+        .expect("nous toggle response");
+    assert_eq!(toggle_response.status(), StatusCode::OK);
+
+    let config_path = env.state.oikos.config().join("aletheia.toml");
+    let persisted = std::fs::read_to_string(&config_path).expect("read persisted config");
+    assert!(
+        persisted.contains(signing_key),
+        "persisted config must contain the raw signing key"
+    );
+    assert!(
+        !persisted.contains("[REDACTED]"),
+        "persisted config must not contain SecretString redaction marker"
+    );
+
+    let reloaded = taxis::loader::load_config(&env.state.oikos).expect("reload config");
+    assert_eq!(
+        reloaded
+            .gateway
+            .auth
+            .signing_key
+            .as_ref()
+            .map(SecretString::expose_secret),
+        Some(signing_key)
+    );
+}

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -390,20 +390,28 @@ pub(crate) fn write_config_checked(
         }
     }
 
-    let toml = toml::to_string(config).map_err(|e| {
+    let config_dir = oikos.config();
+    let target = config_dir.join("aletheia.toml");
+    let tmp = config_dir.join("aletheia.toml.tmp");
+
+    let mut toml_value = toml::Value::try_from(config).map_err(|e| {
+        SerializeTomlSnafu {
+            reason: e.to_string(),
+        }
+        .build()
+    })?;
+    crate::redact::expose_secret_leaves_for_toml(&mut toml_value, config);
+
+    let toml = toml::to_string(&toml_value).map_err(|e| {
         SerializeTomlSnafu {
             reason: e.to_string(),
         }
         .build()
     })?;
 
-    let config_dir = oikos.config();
     std::fs::create_dir_all(&config_dir).context(WriteConfigSnafu {
         path: config_dir.clone(),
     })?;
-
-    let target = config_dir.join("aletheia.toml");
-    let tmp = config_dir.join("aletheia.toml.tmp");
 
     // WHY: mode 0600 ensures config file (which may contain secrets) is
     // readable only by the owning user.
@@ -429,6 +437,7 @@ pub(crate) fn write_config_checked(
     reason = "test harness: seeding fixtures must panic loudly on setup failure"
 )]
 mod tests {
+    use koina::secret::SecretString;
     use koina::system::TestSystem;
 
     use super::*;
@@ -530,6 +539,42 @@ mod tests {
         assert_eq!(
             loaded.agents.defaults.model_defaults.context_tokens, 200_000,
             "default context tokens should survive roundtrip"
+        );
+    }
+
+    #[test]
+    fn write_config_persists_secret_string_values_unredacted() {
+        let jail = EnvJail::new();
+        std::fs::create_dir_all(jail.directory().join("config")).expect("create config dir");
+
+        let oikos = Oikos::from_root(jail.directory());
+        let mut config = AletheiaConfig::default();
+        let signing_key = "synthetic-signing-key-survives-write";
+        config.gateway.auth.signing_key = Some(SecretString::from(signing_key));
+
+        write_config(&oikos, &config).unwrap_or_else(|e| panic!("write: {e}"));
+
+        let persisted =
+            std::fs::read_to_string(oikos.config().join("aletheia.toml")).expect("read config");
+        assert!(
+            persisted.contains(signing_key),
+            "persisted config should contain the raw signing key"
+        );
+        assert!(
+            !persisted.contains("[REDACTED]"),
+            "persisted config should not contain the redaction marker"
+        );
+
+        let loaded = load_config(&oikos).unwrap_or_else(|e| panic!("load: {e}"));
+        assert_eq!(
+            loaded
+                .gateway
+                .auth
+                .signing_key
+                .as_ref()
+                .map(SecretString::expose_secret),
+            Some(signing_key),
+            "signing key should survive write/load roundtrip"
         );
     }
 

--- a/crates/taxis/src/redact.rs
+++ b/crates/taxis/src/redact.rs
@@ -3,16 +3,42 @@
 use serde_json::Value;
 use tracing::debug;
 
+use koina::secret::SecretString;
+
 use crate::config::AletheiaConfig;
 use crate::sensitive::key_is_sensitive;
 
 const REDACTED: &str = "***";
+const SECRET_REDACTED: &str = "[REDACTED]";
+
+type SecretAccessor = for<'a> fn(&'a AletheiaConfig) -> Option<&'a SecretString>;
+
+#[derive(Clone, Copy)]
+enum SensitiveLeafValue {
+    Secret(SecretAccessor),
+    RedactOnly,
+}
+
+#[derive(Clone, Copy)]
+struct SensitiveLeaf {
+    path: &'static [&'static str],
+    value: SensitiveLeafValue,
+}
 
 /// Paths whose leaf values are replaced with `"***"` in redacted output.
-const SENSITIVE_LEAVES: &[&[&str]] = &[
-    &["gateway", "auth", "signingKey"],
-    &["gateway", "tls", "keyPath"],
-    &["gateway", "tls", "certPath"],
+const SENSITIVE_LEAVES: &[SensitiveLeaf] = &[
+    SensitiveLeaf {
+        path: &["gateway", "auth", "signingKey"],
+        value: SensitiveLeafValue::Secret(gateway_auth_signing_key),
+    },
+    SensitiveLeaf {
+        path: &["gateway", "tls", "keyPath"],
+        value: SensitiveLeafValue::RedactOnly,
+    },
+    SensitiveLeaf {
+        path: &["gateway", "tls", "certPath"],
+        value: SensitiveLeafValue::RedactOnly,
+    },
 ];
 
 /// Serialize config to JSON, then redact sensitive fields.
@@ -28,14 +54,97 @@ pub fn redact(config: &AletheiaConfig) -> Value {
 }
 
 fn redact_sensitive_leaves(root: &mut Value) {
-    for path in SENSITIVE_LEAVES {
-        let json_pointer = format!("/{}", path.join("/"));
+    for leaf in SENSITIVE_LEAVES {
+        let json_pointer = format!("/{}", leaf.path.join("/"));
         if let Some(val) = root.pointer_mut(&json_pointer)
             && (val.is_string() || val.is_null())
         {
             *val = Value::String(REDACTED.to_owned());
         }
     }
+}
+
+/// Restore redacted secret leaves from the current in-memory config.
+///
+/// Call this after serializing `AletheiaConfig` through serde for mutation,
+/// before deserializing the value back into typed config.
+pub fn preserve_secret_leaves(root: &mut Value, current: &AletheiaConfig) {
+    for leaf in SENSITIVE_LEAVES {
+        let SensitiveLeafValue::Secret(accessor) = leaf.value else {
+            continue;
+        };
+        let Some(secret) = accessor(current) else {
+            continue;
+        };
+        let Some(slot) = json_path_mut(root, leaf.path) else {
+            continue;
+        };
+        if is_redaction_marker(slot) {
+            *slot = Value::String(secret.expose_secret().to_owned());
+        }
+    }
+}
+
+/// Return `staged` with any redacted secret leaves restored from `current`.
+///
+/// This is for config paths that must serialize through `serde_json::Value`
+/// before producing a live `AletheiaConfig`.
+///
+/// # Errors
+///
+/// Returns an error if the restored JSON cannot deserialize into config.
+pub fn preserve_config_secret_leaves(
+    staged: &AletheiaConfig,
+    current: &AletheiaConfig,
+) -> Result<AletheiaConfig, serde_json::Error> {
+    let mut value = serde_json::to_value(staged)?;
+    preserve_secret_leaves(&mut value, current);
+    serde_json::from_value(value)
+}
+
+pub(crate) fn expose_secret_leaves_for_toml(root: &mut toml::Value, current: &AletheiaConfig) {
+    for leaf in SENSITIVE_LEAVES {
+        let SensitiveLeafValue::Secret(accessor) = leaf.value else {
+            continue;
+        };
+        let Some(secret) = accessor(current) else {
+            continue;
+        };
+        let Some(slot) = toml_path_mut(root, leaf.path) else {
+            continue;
+        };
+        if slot.as_str().is_some_and(is_redaction_marker_str) {
+            *slot = toml::Value::String(secret.expose_secret().to_owned());
+        }
+    }
+}
+
+fn gateway_auth_signing_key(config: &AletheiaConfig) -> Option<&SecretString> {
+    config.gateway.auth.signing_key.as_ref()
+}
+
+fn is_redaction_marker(value: &Value) -> bool {
+    value.as_str().is_some_and(is_redaction_marker_str)
+}
+
+fn is_redaction_marker_str(value: &str) -> bool {
+    value == REDACTED || value == SECRET_REDACTED
+}
+
+fn json_path_mut<'a>(root: &'a mut Value, path: &[&str]) -> Option<&'a mut Value> {
+    let mut cursor = root;
+    for segment in path {
+        cursor = cursor.as_object_mut()?.get_mut(*segment)?;
+    }
+    Some(cursor)
+}
+
+fn toml_path_mut<'a>(root: &'a mut toml::Value, path: &[&str]) -> Option<&'a mut toml::Value> {
+    let mut cursor = root;
+    for segment in path {
+        cursor = cursor.as_table_mut()?.get_mut(*segment)?;
+    }
+    Some(cursor)
 }
 
 /// Test-only re-export of the recursive redaction pass so the cross-module


### PR DESCRIPTION
Closes #4478
Closes #4488

Config writes persisted `SecretString` leaves as the literal `"[REDACTED]"`: any desktop config PUT or nous toggle round-tripped the in-memory config through the redacting serializer and wrote that form to disk — destroying `gateway.auth.signing_key` on next reload (JWT-forgery class).

- **taxis `write_config`**: `expose_secret_leaves_for_toml` re-injects raw secret values into the serialized TOML before the atomic write — every caller (config PUT, nous toggle, future writers) is safe by construction. Leaf enumeration lives beside the existing redaction list in `redact.rs` (single source of truth).
- **pylon `update_section`**: `preserve_secret_leaves` re-attaches secrets after the serde_json round-trip so the in-memory config is never redacted either (#4488's diff+preserve-before-write ordering).
- **koina**: the two dead expose-on-write stubs deleted.
- **Regression tests**: unit test on `write_config` (secret persists unredacted) + end-to-end `config_put_and_nous_toggle_preserve_signing_key_on_disk` (set key → PUT unrelated section → toggle nous → assert raw key on disk → reload → assert equality).

Worker-gated CI-exact on verda (fmt, clippy `-D warnings`, full nextest `test-core`) before push.