### PR TITLE
fix(organon,nous,taxis): fail-closed ToolGroupPolicy — empty tool_groups no longer means allow-all

### DIFF
--- a/_llm/L3-api-index/nous.md
+++ b/_llm/L3-api-index/nous.md
@@ -1047,13 +1047,12 @@ pub struct NousConfig {
     /// during ephemeral sub-agent spawning.
     #[serde(default)]
     pub tool_allowlist: Option<Vec<String>>,
-    /// Allowed tool groups for role-based gating.
+    /// Tool-group policy for role-based gating.
     ///
-    /// When non-empty, only tools whose `groups` intersect this list are
-    /// visible to the LLM and executable.  Empty means all tools (legacy
-    /// fallback).  Populated from `RoleContract.tool_groups`.
+    /// Only tools permitted by this policy are visible to the LLM and
+    /// executable. Absent or empty configuration resolves to deny-all.
     #[serde(default)]
-    pub tool_groups: Vec<organon::types::ToolGroupId>,
+    pub tool_groups: organon::types::ToolGroupPolicy,
     /// Turn-level hook configuration.
     #[serde(default)]
     pub hooks: HookConfig,
@@ -3042,9 +3041,9 @@ pub struct RoleContract {
     pub behaviors: Vec<String>,
     /// Constraints: what this role MUST NOT do.
     pub constraints: Vec<String>,
-    /// Allowed tool groups.  Empty means all tools (legacy fallback).
+    /// Tool-group policy. Missing or empty configuration denies all tools.
     #[serde(default)]
-    pub tool_groups: Vec<ToolGroupId>,
+    pub tool_groups: ToolGroupPolicy,
 }
 ```
 
@@ -3106,8 +3105,8 @@ pub struct RoleTemplate {
     pub system_prompt: &'static str,
     /// Tool access restrictions.
     pub tool_policy: ToolPolicy,
-    /// Allowed tool groups for role-based gating.
-    pub tool_groups: Vec<organon::types::ToolGroupId>,
+    /// Tool-group policy for role-based gating.
+    pub tool_groups: organon::types::ToolGroupPolicy,
     /// Preferred model identifier.
     pub model: &'static str,
 }

--- a/_llm/L3-api-index/organon.md
+++ b/_llm/L3-api-index/organon.md
@@ -658,21 +658,30 @@ impl ToolRegistry {
         input: &ToolInput,
         ctx: &ToolContext,
         role: &str,
-        allowed_groups: &[ToolGroupId],
+        policy: &ToolGroupPolicy,
     ) -> Result<ToolResult>;
     pub fn definitions (&self) -> Vec<&ToolDef>;
     pub fn definitions_for_category (&self, category: ToolCategory) -> Vec<&ToolDef>;
     pub fn definitions_for_tags (&self, tags: &[ToolTag]) -> Vec<&ToolDef>;
     pub fn definitions_for_groups (&self, allowed_groups: &[ToolGroupId]) -> Vec<&ToolDef>;
+    pub fn definitions_for_policy (&self, policy: &ToolGroupPolicy) -> Vec<&ToolDef>;
     pub fn to_hermeneus_tools (&self) -> Vec<hermeneus::types::ToolDefinition>;
     pub fn to_hermeneus_tools_for_groups (
         &self,
         allowed_groups: &[ToolGroupId],
     ) -> Vec<hermeneus::types::ToolDefinition>;
+    pub fn to_hermeneus_tools_for_policy (
+        &self,
+        policy: &ToolGroupPolicy,
+    ) -> Vec<hermeneus::types::ToolDefinition>;
     pub fn to_hermeneus_tools_summaries (&self) -> Vec<hermeneus::types::ToolDefinition>;
     pub fn to_hermeneus_tools_summaries_for_groups (
         &self,
         allowed_groups: &[ToolGroupId],
+    ) -> Vec<hermeneus::types::ToolDefinition>;
+    pub fn to_hermeneus_tools_summaries_for_policy (
+        &self,
+        policy: &ToolGroupPolicy,
     ) -> Vec<hermeneus::types::ToolDefinition>;
     pub fn to_hermeneus_tools_summaries_filtered (
         // kanon:ignore RUST/pub-visibility
@@ -684,6 +693,11 @@ impl ToolRegistry {
         active: &HashSet<ToolName>,
         allowed_groups: &[ToolGroupId],
     ) -> Vec<hermeneus::types::ToolDefinition>;
+    pub fn to_hermeneus_tools_summaries_filtered_for_policy (
+        &self,
+        active: &HashSet<ToolName>,
+        policy: &ToolGroupPolicy,
+    ) -> Vec<hermeneus::types::ToolDefinition>;
     pub fn schema_byte_sizes (&self) -> (usize, usize);
     pub fn to_hermeneus_tools_filtered (
         // kanon:ignore RUST/pub-visibility
@@ -694,6 +708,11 @@ impl ToolRegistry {
         &self,
         active: &HashSet<ToolName>,
         allowed_groups: &[ToolGroupId],
+    ) -> Vec<hermeneus::types::ToolDefinition>;
+    pub fn to_hermeneus_tools_filtered_for_policy (
+        &self,
+        active: &HashSet<ToolName>,
+        policy: &ToolGroupPolicy,
     ) -> Vec<hermeneus::types::ToolDefinition>;
     pub fn reversibility (&self, name: &ToolName) -> Option<Reversibility>;
     pub fn approval_requirement (&self, name: &ToolName) -> Option<ApprovalRequirement>;
@@ -1012,6 +1031,30 @@ pub enum ToolGroupId {
     Plan,
     /// Tests, lint, fmt, and verification tools (`lint_report`, `verify_report`, ...).
     Verify,
+}
+```
+
+```rust
+pub enum ToolGroupPolicy {
+    /// Every registered tool is permitted, including tools with no group metadata.
+    AllowAll {
+        /// Human-readable reason for granting every tool group.
+        reason: String,
+    },
+    /// Tools are permitted when their declared groups intersect this list.
+    Groups(Vec<ToolGroupId>),
+    /// No grouped tools are permitted.
+    #[default]
+    DenyAll,
+}
+```
+
+```rust
+impl ToolGroupPolicy {
+    pub fn groups (groups: Vec<ToolGroupId>) -> Self;
+    pub fn permits (&self, tool_groups: &[ToolGroupId]) -> bool;
+    pub fn allowed_groups (&self) -> &[ToolGroupId];
+    pub fn description (&self) -> String;
 }
 ```
 

--- a/_llm/L3-api-index/taxis.md
+++ b/_llm/L3-api-index/taxis.md
@@ -98,6 +98,18 @@ pub struct AgentsConfig {
 ```
 
 ```rust
+pub enum AgentToolGroupPolicy {
+    /// All tool groups are permitted.
+    AllowAll,
+    /// Only tools with one of these groups are permitted.
+    Groups(Vec<String>),
+    /// No tool groups are permitted.
+    #[default]
+    DenyAll,
+}
+```
+
+```rust
 pub struct RecallWeights {
     /// Temporal decay weight (0.0--1.0).
     pub decay: f64,
@@ -218,6 +230,8 @@ pub struct AgentDefaults {
     pub max_tool_iterations: u32,
     /// Filesystem paths the agent is permitted to access.
     pub allowed_roots: Vec<String>,
+    /// Default tool-group policy for agents. Missing or empty configuration denies all groups.
+    pub tool_groups: AgentToolGroupPolicy,
     /// Prompt caching configuration.
     pub caching: CachingConfig,
     /// Recall pipeline settings applied to all agents unless overridden.
@@ -291,6 +305,9 @@ pub struct NousDefinition {
     /// Tool allowlist override; when `None`, all tools are enabled.
     #[serde(default)]
     pub tool_allowlist: Option<Vec<String>>,
+    /// Tool-group policy override; when `None`, inherits from [`AgentDefaults::tool_groups`].
+    #[serde(default)]
+    pub tool_groups: Option<AgentToolGroupPolicy>,
     /// Named recall behavior profile; when `None`, resolves to [`RecallProfile::Default`].
     #[serde(default)]
     pub recall_profile: Option<RecallProfile>,
@@ -1922,6 +1939,8 @@ pub struct ResolvedNousConfig {
     pub episteme_cohort: Arc<str>,
     /// Merged set of permitted filesystem roots.
     pub allowed_roots: Vec<String>,
+    /// Resolved tool-group policy.
+    pub tool_groups: AgentToolGroupPolicy,
     /// Knowledge domains this agent covers.
     pub domains: Vec<String>,
     /// Resolved recall pipeline settings.

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-06-11T22:18:23Z"
+generated_at = "2026-06-08T17:46:24Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "0f1bba9523f31afa10d1f613c0d2af94c9d5d5c8e585494285be19e435d4bd86"
+source_hash = "08d0aa5f3ae74a920b6886f536995098b5c5fe008e8c71e82a3440376cf7b3f4"
 l3_token_estimate = 167
 
 [[crates]]
@@ -110,7 +110,7 @@ l3_token_estimate = 13698
 [[crates]]
 name = "integration-tests"
 path = "crates/integration-tests"
-source_hash = "e01bf3e044bd809ada8a6be7c0fa85386bd812682c580bf47d50dbd73dd2bac1"
+source_hash = "aac4c12699676af8fe21e93d34f89e949cb223964b97aad5e7db0e16b3231f2f"
 l3_token_estimate = 1170
 
 [[crates]]
@@ -146,8 +146,8 @@ l3_token_estimate = 51
 [[crates]]
 name = "nous"
 path = "crates/nous"
-source_hash = "7791c84dbebbab43c03c4f82f9d79992cca6866026367d9b3706f600e0bf263a"
-l3_token_estimate = 34323
+source_hash = "e44da68828b93c208d9a508423a5d1b748b5c3daa4a2b367ba33fa3e990db133"
+l3_token_estimate = 34306
 
 [[crates]]
 name = "oikonomos"
@@ -158,8 +158,8 @@ l3_token_estimate = 12375
 [[crates]]
 name = "organon"
 path = "crates/organon"
-source_hash = "3ef590e6ccfe8382fc5bc73e81347355ded332c1ef4e8b749759c906899a6672"
-l3_token_estimate = 11818
+source_hash = "7db6b08917d770bb288b424f2b46554aa292c0236e78e79e663ca260efce5300"
+l3_token_estimate = 12171
 
 [[crates]]
 name = "poiesis-charts"
@@ -266,7 +266,7 @@ l3_token_estimate = 1354
 [[crates]]
 name = "pylon"
 path = "crates/pylon"
-source_hash = "fcc13484f101d0ad0b1dfec9fa63671e3605aacfe0bde4c169b1eb1c8f34d8dc"
+source_hash = "6d5dbe440cc846a6ffe2f4a60639f700378f556c8df7576a61b4f30342d1de38"
 l3_token_estimate = 17977
 
 [[crates]]
@@ -284,8 +284,8 @@ l3_token_estimate = 6585
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "c4278d863aca018a5d39904acff0e78137723d8bc8cb35323483226af0ccef52"
-l3_token_estimate = 23677
+source_hash = "9167277e9e9ec11cd8cfc0861123c93ca47a1862ba87c2bb96b8654bca0bdd41"
+l3_token_estimate = 23836
 
 [[crates]]
 name = "theatron"

--- a/crates/aletheia/src/external_tools.rs
+++ b/crates/aletheia/src/external_tools.rs
@@ -1035,7 +1035,12 @@ done
             arguments: serde_json::json!({"message": "hello"}),
         };
         let err = registry
-            .execute_checked(&input, &test_ctx(), "reader", &[ToolGroupId::Read])
+            .execute_checked(
+                &input,
+                &test_ctx(),
+                "reader",
+                &organon::types::ToolGroupPolicy::groups(vec![ToolGroupId::Read]),
+            )
             .await
             .expect_err("mcp group denied");
         assert!(err.to_string().contains("tool group violation"));

--- a/crates/aletheia/src/init/scaffold.rs
+++ b/crates/aletheia/src/init/scaffold.rs
@@ -226,6 +226,7 @@ mode = "{auth_mode}"
 # --- Agents ---
 [agents.defaults]
 context_tokens = 200000  # auto-upgraded to 1M for Opus models
+toolGroups = ["read", "edit", "command", "mcp", "spawn_subtask", "plan", "verify"]
 max_output_tokens = 16384
 user_timezone = "{timezone}"
 timeout_seconds = 300

--- a/crates/aletheia/src/runtime/nous_config.rs
+++ b/crates/aletheia/src/runtime/nous_config.rs
@@ -5,7 +5,8 @@ use tracing::warn;
 
 use mneme::workspace::ProjectId;
 use nous::config::{NousConfig, PipelineConfig};
-use taxis::config::{AletheiaConfig, resolve_nous};
+use organon::types::{ToolGroupId, ToolGroupPolicy};
+use taxis::config::{AgentToolGroupPolicy, AletheiaConfig, resolve_nous};
 use taxis::oikos::Oikos;
 
 fn resolve_config_path(oikos: &Oikos, configured: &str) -> PathBuf {
@@ -48,6 +49,33 @@ fn detect_project_id(workspace: &Path) -> Option<ProjectId> {
 
     let remote = String::from_utf8(output.stdout).ok()?;
     ProjectId::from_git_remote(remote).ok()
+}
+
+fn resolve_tool_group_policy(agent_id: &str, policy: &AgentToolGroupPolicy) -> ToolGroupPolicy {
+    match policy {
+        AgentToolGroupPolicy::AllowAll => ToolGroupPolicy::AllowAll {
+            reason: "explicit agents toolGroups = \"all\"".to_owned(),
+        },
+        AgentToolGroupPolicy::DenyAll => ToolGroupPolicy::DenyAll,
+        AgentToolGroupPolicy::Groups(names) => {
+            let mut groups = Vec::with_capacity(names.len());
+            for name in names {
+                match name.parse::<ToolGroupId>() {
+                    Ok(group) => groups.push(group),
+                    Err(error) => {
+                        warn!(
+                            agent = %agent_id,
+                            group = %name,
+                            error = %error,
+                            "invalid tool group in agent config; denying all tool groups"
+                        );
+                        return ToolGroupPolicy::DenyAll;
+                    }
+                }
+            }
+            ToolGroupPolicy::groups(groups)
+        }
+    }
 }
 
 pub(super) fn build_nous_runtime_config(
@@ -132,7 +160,7 @@ pub(super) fn build_nous_runtime_config(
         recall: resolved.recall.into(),
         recall_profile: resolved.recall_profile.into(),
         tool_allowlist: None,
-        tool_groups: Vec::new(),
+        tool_groups: resolve_tool_group_policy(agent_id, &resolved.tool_groups),
         hooks: nous::config::HookConfig::default(),
         behavior: resolved.behavior,
     };

--- a/crates/integration-tests/src/harness.rs
+++ b/crates/integration-tests/src/harness.rs
@@ -21,6 +21,7 @@ use mneme::store::SessionStore;
 use nous::config::{NousConfig, PipelineConfig};
 use nous::manager::NousManager;
 use organon::registry::ToolRegistry;
+use organon::types::ToolGroupPolicy;
 use pylon::router::build_router;
 use pylon::state::AppState;
 use symbolon::auth::{AuthConfig, AuthFacade};
@@ -250,6 +251,9 @@ impl TestHarness {
             recall: nous::recall::RecallConfig {
                 min_score: 0.0,
                 ..nous::recall::RecallConfig::default()
+            },
+            tool_groups: ToolGroupPolicy::AllowAll {
+                reason: "integration test harness".to_owned(),
             },
             ..NousConfig::default()
         };

--- a/crates/integration-tests/tests/r722_substrate_canary.rs
+++ b/crates/integration-tests/tests/r722_substrate_canary.rs
@@ -843,7 +843,7 @@ async fn tool_group_gating_denies_calls_outside_allowed_groups() {
             model: "mock-model".to_owned(),
             ..Default::default()
         },
-        tool_groups: vec![ToolGroupId::Read],
+        tool_groups: organon::types::ToolGroupPolicy::groups(vec![ToolGroupId::Read]),
         limits: nous::config::NousLimits {
             max_tool_iterations: 1,
             ..Default::default()

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -277,13 +277,12 @@ pub struct NousConfig {
     /// during ephemeral sub-agent spawning.
     #[serde(default)]
     pub tool_allowlist: Option<Vec<String>>,
-    /// Allowed tool groups for role-based gating.
+    /// Tool-group policy for role-based gating.
     ///
-    /// When non-empty, only tools whose `groups` intersect this list are
-    /// visible to the LLM and executable.  Empty means all tools (legacy
-    /// fallback).  Populated from `RoleContract.tool_groups`.
+    /// Only tools permitted by this policy are visible to the LLM and
+    /// executable. Absent or empty configuration resolves to deny-all.
     #[serde(default)]
-    pub tool_groups: Vec<organon::types::ToolGroupId>,
+    pub tool_groups: organon::types::ToolGroupPolicy,
     /// Turn-level hook configuration.
     #[serde(default)]
     pub hooks: HookConfig,
@@ -397,7 +396,7 @@ impl Default for NousConfig {
             recall: RecallConfig::default(),
             recall_profile: RecallProfile::Default,
             tool_allowlist: None,
-            tool_groups: Vec::new(),
+            tool_groups: organon::types::ToolGroupPolicy::DenyAll,
             hooks: HookConfig::default(),
             behavior: AgentBehaviorDefaults::default(),
         }
@@ -662,7 +661,7 @@ mod tests {
             recall: RecallConfig::default(),
             recall_profile: RecallProfile::Default,
             tool_allowlist: None,
-            tool_groups: Vec::new(),
+            tool_groups: organon::types::ToolGroupPolicy::DenyAll,
             hooks: HookConfig::default(),
             behavior: AgentBehaviorDefaults::default(),
         };

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -76,7 +76,7 @@ pub async fn execute(
     // tier when tool_count crosses small integer breakpoints, so approximation
     // here doesn't bend routing off the correct tier.
     let tool_count = config.tool_allowlist.as_ref().map_or_else(
-        || tools.definitions_for_groups(&config.tool_groups).len(),
+        || tools.definitions_for_policy(&config.tool_groups).len(),
         Vec::len,
     );
     let turn_model = resolve_turn_model(ctx, config, providers, tool_count);
@@ -133,10 +133,10 @@ pub async fn execute(
         let (active, server_tools) = resolve_active_server_tools(tool_ctx, &config_server_tools);
         #[cfg(feature = "deferred-schemas")]
         let mut tool_defs =
-            tools.to_hermeneus_tools_summaries_filtered_for_groups(&active, &config.tool_groups);
+            tools.to_hermeneus_tools_summaries_filtered_for_policy(&active, &config.tool_groups);
         #[cfg(not(feature = "deferred-schemas"))]
         let mut tool_defs =
-            tools.to_hermeneus_tools_filtered_for_groups(&active, &config.tool_groups);
+            tools.to_hermeneus_tools_filtered_for_policy(&active, &config.tool_groups);
 
         if let Some(allowlist) = &config.tool_allowlist {
             tool_defs.retain(|td| allowlist.iter().any(|a| a == &td.name));
@@ -282,45 +282,29 @@ pub async fn execute(
             extracted.tool_uses
         };
 
-        // WHY: tool-group gating — reject calls whose tool groups do not intersect
-        // the role's allowed groups.  Empty allowed_groups is legacy fallback.
-        let effective_tool_uses: Vec<_> = if config.tool_groups.is_empty() {
-            effective_tool_uses
-        } else {
-            let (allowed, denied): (Vec<_>, Vec<_>) =
-                effective_tool_uses.into_iter().partition(|(_, name, _)| {
-                    ToolName::new(name)
-                        .ok()
-                        .and_then(|n| tools.get_def(&n))
-                        .is_none_or(|def| {
-                            def.groups.is_empty()
-                                || def.groups.iter().any(|g| config.tool_groups.contains(g))
-                        })
-                });
+        let (effective_tool_uses, denied): (Vec<_>, Vec<_>) =
+            effective_tool_uses.into_iter().partition(|(_, name, _)| {
+                ToolName::new(name)
+                    .ok()
+                    .and_then(|n| tools.get_def(&n))
+                    .is_none_or(|def| config.tool_groups.permits(&def.groups))
+            });
 
-            for (id, name, _) in &denied {
-                warn!(
-                    tool = %name,
-                    tool_use_id = %id,
-                    "tool call denied by group policy"
-                );
-                denied_blocks.push(ContentBlock::ToolResult {
-                    tool_use_id: id.clone(),
-                    content: ToolResultContent::Text(format!(
-                        "Tool '{name}' is not in your allowed tool groups. Allowed groups: {}",
-                        config
-                            .tool_groups
-                            .iter()
-                            .map(std::string::ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )),
-                    is_error: Some(true),
-                });
-            }
-
-            allowed
-        };
+        for (id, name, _) in &denied {
+            warn!(
+                tool = %name,
+                tool_use_id = %id,
+                "tool call denied by group policy"
+            );
+            denied_blocks.push(ContentBlock::ToolResult {
+                tool_use_id: id.clone(),
+                content: ToolResultContent::Text(format!(
+                    "Tool '{name}' is not in your allowed tool groups. Policy: {}",
+                    config.tool_groups.description()
+                )),
+                is_error: Some(true),
+            });
+        }
 
         // WHY: before_tool hooks run after allowlist filtering but before dispatch,
         // so hooks can deny individual tool calls based on budget/scope/policy.
@@ -483,7 +467,7 @@ pub async fn execute_streaming(
     // Must come before find_streaming_provider so the streaming provider is
     // looked up for the actual model the turn will use.
     let tool_count = config.tool_allowlist.as_ref().map_or_else(
-        || tools.definitions_for_groups(&config.tool_groups).len(),
+        || tools.definitions_for_policy(&config.tool_groups).len(),
         Vec::len,
     );
     let turn_model = resolve_turn_model(ctx, config, providers, tool_count);
@@ -519,7 +503,7 @@ pub async fn execute_streaming(
             budget_tokens: config.generation.thinking_budget,
         });
 
-    let mut tool_defs = tools.to_hermeneus_tools_for_groups(&config.tool_groups);
+    let mut tool_defs = tools.to_hermeneus_tools_for_policy(&config.tool_groups);
     if let Some(allowlist) = &config.tool_allowlist {
         tool_defs.retain(|td| allowlist.iter().any(|a| a == &td.name));
     }
@@ -660,45 +644,29 @@ pub async fn execute_streaming(
             extracted.tool_uses
         };
 
-        // WHY: tool-group gating — reject calls whose tool groups do not intersect
-        // the role's allowed groups.  Empty allowed_groups is legacy fallback.
-        let effective_tool_uses: Vec<_> = if config.tool_groups.is_empty() {
-            effective_tool_uses
-        } else {
-            let (allowed, denied): (Vec<_>, Vec<_>) =
-                effective_tool_uses.into_iter().partition(|(_, name, _)| {
-                    ToolName::new(name)
-                        .ok()
-                        .and_then(|n| tools.get_def(&n))
-                        .is_none_or(|def| {
-                            def.groups.is_empty()
-                                || def.groups.iter().any(|g| config.tool_groups.contains(g))
-                        })
-                });
+        let (effective_tool_uses, denied): (Vec<_>, Vec<_>) =
+            effective_tool_uses.into_iter().partition(|(_, name, _)| {
+                ToolName::new(name)
+                    .ok()
+                    .and_then(|n| tools.get_def(&n))
+                    .is_none_or(|def| config.tool_groups.permits(&def.groups))
+            });
 
-            for (id, name, _) in &denied {
-                warn!(
-                    tool = %name,
-                    tool_use_id = %id,
-                    "tool call denied by group policy"
-                );
-                denied_blocks.push(ContentBlock::ToolResult {
-                    tool_use_id: id.clone(),
-                    content: ToolResultContent::Text(format!(
-                        "Tool '{name}' is not in your allowed tool groups. Allowed groups: {}",
-                        config
-                            .tool_groups
-                            .iter()
-                            .map(std::string::ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )),
-                    is_error: Some(true),
-                });
-            }
-
-            allowed
-        };
+        for (id, name, _) in &denied {
+            warn!(
+                tool = %name,
+                tool_use_id = %id,
+                "tool call denied by group policy"
+            );
+            denied_blocks.push(ContentBlock::ToolResult {
+                tool_use_id: id.clone(),
+                content: ToolResultContent::Text(format!(
+                    "Tool '{name}' is not in your allowed tool groups. Policy: {}",
+                    config.tool_groups.description()
+                )),
+                is_error: Some(true),
+            });
+        }
 
         // WHY: before_tool hooks filter tool calls before streaming dispatch
         let effective_tool_uses = if let Some(hook_registry) = hooks {

--- a/crates/nous/src/execute/tests/core.rs
+++ b/crates/nous/src/execute/tests/core.rs
@@ -360,6 +360,80 @@ async fn single_tool_iteration() {
 }
 
 #[tokio::test]
+async fn deny_all_tool_policy_blocks_tool_dispatch() {
+    let mut providers = ProviderRegistry::new();
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            make_tool_response("exec", "toolu_1", serde_json::json!({"input": "test"})),
+            make_text_response("Done!"),
+        ])
+        .models(&["test-model"]),
+    ));
+
+    let tools = make_registry_with("exec", Box::new(EchoExecutor));
+    let mut config = test_config();
+    config.tool_groups = organon::types::ToolGroupPolicy::DenyAll;
+
+    let result = execute(
+        &test_pipeline_ctx(),
+        &test_session(),
+        &config,
+        &providers,
+        &tools,
+        &test_tool_ctx(),
+        None,
+    )
+    .await
+    .expect("execute");
+
+    assert_eq!(result.content, "Done!");
+    assert!(
+        result.tool_calls.is_empty(),
+        "deny-all policy should block dispatch before execution"
+    );
+}
+
+#[tokio::test]
+async fn empty_tool_def_groups_are_blocked_before_dispatch() {
+    let mut providers = ProviderRegistry::new();
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            make_tool_response("legacy", "toolu_1", serde_json::json!({})),
+            make_text_response("Done!"),
+        ])
+        .models(&["test-model"]),
+    ));
+
+    let mut def = make_tool_def("legacy");
+    def.groups = Vec::new();
+    let mut tools = ToolRegistry::new();
+    tools
+        .register(def, Box::new(EchoExecutor))
+        .expect("register");
+    let mut config = test_config();
+    config.tool_groups =
+        organon::types::ToolGroupPolicy::groups(vec![organon::types::ToolGroupId::Read]);
+
+    let result = execute(
+        &test_pipeline_ctx(),
+        &test_session(),
+        &config,
+        &providers,
+        &tools,
+        &test_tool_ctx(),
+        None,
+    )
+    .await
+    .expect("execute");
+
+    assert_eq!(result.content, "Done!");
+    assert!(
+        result.tool_calls.is_empty(),
+        "tools with empty group metadata should not dispatch under group policy"
+    );
+}
+
+#[tokio::test]
 async fn multi_tool_iteration() {
     let mut providers = ProviderRegistry::new();
     providers.register(Box::new(

--- a/crates/nous/src/execute/tests/mod.rs
+++ b/crates/nous/src/execute/tests/mod.rs
@@ -54,6 +54,9 @@ fn test_config() -> NousConfig {
             model: "test-model".to_owned(),
             ..crate::config::NousGenerationConfig::default()
         },
+        tool_groups: organon::types::ToolGroupPolicy::AllowAll {
+            reason: "execute test helper".to_owned(),
+        },
         ..NousConfig::default()
     }
 }

--- a/crates/nous/src/roles/contract.rs
+++ b/crates/nous/src/roles/contract.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
-use organon::types::ToolGroupId;
+use organon::types::{ToolGroupId, ToolGroupPolicy};
 
 use crate::error::{self, Result};
 use crate::roles::Role;
@@ -34,9 +34,9 @@ pub struct RoleContract {
     pub behaviors: Vec<String>,
     /// Constraints: what this role MUST NOT do.
     pub constraints: Vec<String>,
-    /// Allowed tool groups.  Empty means all tools (legacy fallback).
+    /// Tool-group policy. Missing or empty configuration denies all tools.
     #[serde(default)]
-    pub tool_groups: Vec<ToolGroupId>,
+    pub tool_groups: ToolGroupPolicy,
 }
 
 impl RoleContract {
@@ -60,12 +60,22 @@ impl RoleContract {
             out.push('\n');
         }
 
-        if !self.tool_groups.is_empty() {
-            out.push_str("### Allowed Tool Groups\n\n");
-            for group in &self.tool_groups {
-                out.push_str(&format!("- {group}\n"));
+        match &self.tool_groups {
+            ToolGroupPolicy::Groups(groups) => {
+                out.push_str("### Allowed Tool Groups\n\n");
+                for group in groups {
+                    out.push_str(&format!("- {group}\n"));
+                }
+                out.push('\n');
             }
-            out.push('\n');
+            ToolGroupPolicy::AllowAll { reason } => {
+                out.push_str("### Tool Group Policy\n\n");
+                out.push_str(&format!("- all ({reason})\n\n"));
+            }
+            ToolGroupPolicy::DenyAll => {
+                out.push_str("### Tool Group Policy\n\n");
+                out.push_str("- deny\n\n");
+            }
         }
 
         if !self.constraints.is_empty() {
@@ -106,7 +116,7 @@ struct RoleContractToml {
     #[serde(default)]
     constraints: Vec<String>,
     #[serde(default)]
-    tool_groups: Vec<ToolGroupId>,
+    tool_groups: ToolGroupPolicy,
 }
 
 /// Registry of role contracts, keyed by role name.
@@ -180,19 +190,12 @@ impl ContractRegistry {
                 constraints: toml_contract.constraints,
                 tool_groups: toml_contract.tool_groups,
             };
-            if contract.tool_groups.is_empty() {
-                warn!(
-                    role = %role_name,
-                    "role contract has no tool_groups; allowing all tools (legacy fallback). \
-                     File a follow-up issue to populate explicit tool_groups."
-                );
-            }
             info!(
                 role = %role_name,
                 version = contract.version,
                 behaviors = contract.behaviors.len(),
                 constraints = contract.constraints.len(),
-                tool_groups = contract.tool_groups.len(),
+                tool_group_policy = %contract.tool_groups.description(),
                 "loaded role contract from file"
             );
             registry.contracts.insert(role_name, contract);
@@ -263,12 +266,12 @@ fn coder_contract() -> RoleContract {
             "Ask clarifying questions instead of making conservative choices".to_owned(),
             "Leave the build broken".to_owned(),
         ],
-        tool_groups: vec![
+        tool_groups: ToolGroupPolicy::groups(vec![
             ToolGroupId::Read,
             ToolGroupId::Edit,
             ToolGroupId::Command,
             ToolGroupId::Verify,
-        ],
+        ]),
     }
 }
 
@@ -290,7 +293,11 @@ fn researcher_contract() -> RoleContract {
             "Omit source citations".to_owned(),
             "Modify files or execute commands".to_owned(),
         ],
-        tool_groups: vec![ToolGroupId::Read, ToolGroupId::Mcp, ToolGroupId::Plan],
+        tool_groups: ToolGroupPolicy::groups(vec![
+            ToolGroupId::Read,
+            ToolGroupId::Mcp,
+            ToolGroupId::Plan,
+        ]),
     }
 }
 
@@ -312,7 +319,11 @@ fn reviewer_contract() -> RoleContract {
             "Invent problems to appear thorough".to_owned(),
             "Provide vague feedback without specific locations".to_owned(),
         ],
-        tool_groups: vec![ToolGroupId::Read, ToolGroupId::Verify, ToolGroupId::Mcp],
+        tool_groups: ToolGroupPolicy::groups(vec![
+            ToolGroupId::Read,
+            ToolGroupId::Verify,
+            ToolGroupId::Mcp,
+        ]),
     }
 }
 
@@ -331,7 +342,7 @@ fn explorer_contract() -> RoleContract {
             "Dump entire file contents without summarizing".to_owned(),
             "Report findings without file paths".to_owned(),
         ],
-        tool_groups: vec![ToolGroupId::Read, ToolGroupId::Plan],
+        tool_groups: ToolGroupPolicy::groups(vec![ToolGroupId::Read, ToolGroupId::Plan]),
     }
 }
 
@@ -351,7 +362,11 @@ fn runner_contract() -> RoleContract {
             "Add extra commands not requested".to_owned(),
             "Retry commands unless instructed".to_owned(),
         ],
-        tool_groups: vec![ToolGroupId::Read, ToolGroupId::Command, ToolGroupId::Verify],
+        tool_groups: ToolGroupPolicy::groups(vec![
+            ToolGroupId::Read,
+            ToolGroupId::Command,
+            ToolGroupId::Verify,
+        ]),
     }
 }
 
@@ -363,6 +378,13 @@ fn runner_contract() -> RoleContract {
 )]
 mod tests {
     use super::*;
+
+    fn groups(policy: &ToolGroupPolicy) -> &[ToolGroupId] {
+        match policy {
+            ToolGroupPolicy::Groups(groups) => groups,
+            ToolGroupPolicy::AllowAll { .. } | ToolGroupPolicy::DenyAll => &[],
+        }
+    }
 
     #[test]
     fn default_registry_has_all_roles() {
@@ -457,6 +479,11 @@ constraints = ["Execute plans"]
         let planner = registry.get("planner").unwrap();
         assert_eq!(planner.role, "planner");
         assert_eq!(planner.version, 1);
+        assert_eq!(
+            planner.tool_groups,
+            ToolGroupPolicy::DenyAll,
+            "missing tool_groups should deny all tools"
+        );
 
         // Built-in defaults still present
         assert!(registry.get("coder").is_some());
@@ -475,7 +502,7 @@ constraints = ["Execute plans"]
             version: 2,
             behaviors: vec!["Write code".to_owned(), "Run tests".to_owned()],
             constraints: vec!["Break the build".to_owned()],
-            tool_groups: vec![ToolGroupId::Read, ToolGroupId::Edit],
+            tool_groups: ToolGroupPolicy::groups(vec![ToolGroupId::Read, ToolGroupId::Edit]),
         };
 
         let section = contract.to_prompt_section();
@@ -497,7 +524,7 @@ constraints = ["Execute plans"]
             version: 1,
             behaviors: Vec::new(),
             constraints: Vec::new(),
-            tool_groups: Vec::new(),
+            tool_groups: ToolGroupPolicy::DenyAll,
         };
         let section = contract.to_prompt_section();
         assert!(
@@ -536,6 +563,7 @@ constraints = ["Custom constraint"]
         let coder = registry.get("coder").unwrap();
         assert_eq!(coder.version, 3);
         assert_eq!(coder.behaviors, vec!["Custom behavior"]);
+        assert_eq!(coder.tool_groups, ToolGroupPolicy::DenyAll);
     }
 
     #[test]
@@ -545,7 +573,7 @@ constraints = ["Custom constraint"]
             version: 2,
             behaviors: vec!["Write code".to_owned()],
             constraints: vec!["Break things".to_owned()],
-            tool_groups: vec![ToolGroupId::Read, ToolGroupId::Edit],
+            tool_groups: ToolGroupPolicy::groups(vec![ToolGroupId::Read, ToolGroupId::Edit]),
         };
         let json = serde_json::to_string(&contract).unwrap();
         let back: RoleContract = serde_json::from_str(&json).unwrap();
@@ -580,7 +608,7 @@ constraints = ["Custom constraint"]
         let registry = ContractRegistry::defaults();
         for (name, contract) in registry.all() {
             assert!(
-                !contract.tool_groups.is_empty(),
+                !groups(&contract.tool_groups).is_empty(),
                 "contract for {name} should have non-empty tool_groups"
             );
         }
@@ -590,20 +618,22 @@ constraints = ["Custom constraint"]
     fn coder_has_edit_and_command_groups() {
         let registry = ContractRegistry::defaults();
         let coder = registry.get("coder").unwrap();
-        assert!(coder.tool_groups.contains(&ToolGroupId::Read));
-        assert!(coder.tool_groups.contains(&ToolGroupId::Edit));
-        assert!(coder.tool_groups.contains(&ToolGroupId::Command));
-        assert!(coder.tool_groups.contains(&ToolGroupId::Verify));
+        let groups = groups(&coder.tool_groups);
+        assert!(groups.contains(&ToolGroupId::Read));
+        assert!(groups.contains(&ToolGroupId::Edit));
+        assert!(groups.contains(&ToolGroupId::Command));
+        assert!(groups.contains(&ToolGroupId::Verify));
     }
 
     #[test]
     fn explorer_is_read_only_plus_plan() {
         let registry = ContractRegistry::defaults();
         let explorer = registry.get("explorer").unwrap();
-        assert!(explorer.tool_groups.contains(&ToolGroupId::Read));
-        assert!(explorer.tool_groups.contains(&ToolGroupId::Plan));
-        assert!(!explorer.tool_groups.contains(&ToolGroupId::Edit));
-        assert!(!explorer.tool_groups.contains(&ToolGroupId::Command));
+        let groups = groups(&explorer.tool_groups);
+        assert!(groups.contains(&ToolGroupId::Read));
+        assert!(groups.contains(&ToolGroupId::Plan));
+        assert!(!groups.contains(&ToolGroupId::Edit));
+        assert!(!groups.contains(&ToolGroupId::Command));
     }
 
     #[test]
@@ -613,7 +643,7 @@ constraints = ["Custom constraint"]
             version: 1,
             behaviors: vec!["Write code".to_owned()],
             constraints: vec!["Break things".to_owned()],
-            tool_groups: vec![ToolGroupId::Read, ToolGroupId::Edit],
+            tool_groups: ToolGroupPolicy::groups(vec![ToolGroupId::Read, ToolGroupId::Edit]),
         };
         let section = contract.to_prompt_section();
         assert!(
@@ -631,18 +661,22 @@ constraints = ["Custom constraint"]
     }
 
     #[test]
-    fn to_prompt_section_omits_tool_groups_when_empty() {
+    fn to_prompt_section_marks_deny_all() {
         let contract = RoleContract {
             role: "empty".to_owned(),
             version: 1,
             behaviors: vec!["Behave".to_owned()],
             constraints: vec!["Misbehave".to_owned()],
-            tool_groups: Vec::new(),
+            tool_groups: ToolGroupPolicy::DenyAll,
         };
         let section = contract.to_prompt_section();
         assert!(
-            !section.contains("Allowed Tool Groups"),
-            "prompt section should omit tool groups when empty"
+            section.contains("Tool Group Policy"),
+            "prompt section should state deny-all policy"
+        );
+        assert!(
+            section.contains("- deny"),
+            "prompt section should state deny-all policy"
         );
     }
 
@@ -657,8 +691,37 @@ tool_groups = ["read", "edit"]
 "#;
         let registry = ContractRegistry::from_toml(toml).unwrap();
         let coder = registry.get("coder").unwrap();
-        assert_eq!(coder.tool_groups.len(), 2);
-        assert!(coder.tool_groups.contains(&ToolGroupId::Read));
-        assert!(coder.tool_groups.contains(&ToolGroupId::Edit));
+        let groups = groups(&coder.tool_groups);
+        assert_eq!(groups.len(), 2);
+        assert!(groups.contains(&ToolGroupId::Read));
+        assert!(groups.contains(&ToolGroupId::Edit));
+    }
+
+    #[test]
+    fn from_toml_parses_allow_all_policy() {
+        let toml = r#"
+[admin]
+version = 1
+tool_groups = "all"
+"#;
+        let registry = ContractRegistry::from_toml(toml).unwrap();
+        assert!(matches!(
+            registry.get("admin").unwrap().tool_groups,
+            ToolGroupPolicy::AllowAll { .. }
+        ));
+    }
+
+    #[test]
+    fn from_toml_empty_groups_denies_all() {
+        let toml = r"
+[empty]
+version = 1
+tool_groups = []
+";
+        let registry = ContractRegistry::from_toml(toml).unwrap();
+        assert_eq!(
+            registry.get("empty").unwrap().tool_groups,
+            ToolGroupPolicy::DenyAll
+        );
     }
 }

--- a/crates/nous/src/roles/mod.rs
+++ b/crates/nous/src/roles/mod.rs
@@ -128,8 +128,8 @@ pub struct RoleTemplate {
     pub system_prompt: &'static str,
     /// Tool access restrictions.
     pub tool_policy: ToolPolicy,
-    /// Allowed tool groups for role-based gating.
-    pub tool_groups: Vec<organon::types::ToolGroupId>,
+    /// Tool-group policy for role-based gating.
+    pub tool_groups: organon::types::ToolGroupPolicy,
     /// Preferred model identifier.
     pub model: &'static str,
 }
@@ -154,12 +154,12 @@ fn coder_template() -> RoleTemplate {
             "memory_search".into(),
             "note".into(),
         ]),
-        tool_groups: vec![
+        tool_groups: organon::types::ToolGroupPolicy::groups(vec![
             organon::types::ToolGroupId::Read,
             organon::types::ToolGroupId::Edit,
             organon::types::ToolGroupId::Command,
             organon::types::ToolGroupId::Verify,
-        ],
+        ]),
         model: SONNET_MODEL,
     }
 }
@@ -178,11 +178,11 @@ fn researcher_template() -> RoleTemplate {
             "memory_search".into(),
             "note".into(),
         ]),
-        tool_groups: vec![
+        tool_groups: organon::types::ToolGroupPolicy::groups(vec![
             organon::types::ToolGroupId::Read,
             organon::types::ToolGroupId::Mcp,
             organon::types::ToolGroupId::Plan,
-        ],
+        ]),
         model: SONNET_MODEL,
     }
 }
@@ -199,11 +199,11 @@ fn reviewer_template() -> RoleTemplate {
             "view_file".into(),
             "memory_search".into(),
         ]),
-        tool_groups: vec![
+        tool_groups: organon::types::ToolGroupPolicy::groups(vec![
             organon::types::ToolGroupId::Read,
             organon::types::ToolGroupId::Verify,
             organon::types::ToolGroupId::Mcp,
-        ],
+        ]),
         model: OPUS_MODEL,
     }
 }
@@ -219,10 +219,10 @@ fn explorer_template() -> RoleTemplate {
             "ls".into(),
             "view_file".into(),
         ]),
-        tool_groups: vec![
+        tool_groups: organon::types::ToolGroupPolicy::groups(vec![
             organon::types::ToolGroupId::Read,
             organon::types::ToolGroupId::Plan,
-        ],
+        ]),
         model: HAIKU_MODEL,
     }
 }
@@ -239,11 +239,11 @@ fn runner_template() -> RoleTemplate {
             "ls".into(),
             "view_file".into(),
         ]),
-        tool_groups: vec![
+        tool_groups: organon::types::ToolGroupPolicy::groups(vec![
             organon::types::ToolGroupId::Read,
             organon::types::ToolGroupId::Command,
             organon::types::ToolGroupId::Verify,
-        ],
+        ]),
         model: HAIKU_MODEL,
     }
 }

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -165,7 +165,9 @@ impl SpawnService for SpawnServiceImpl {
 
         let tool_groups = template
             .as_ref()
-            .map_or_else(Vec::new, |t| t.tool_groups.clone());
+            .map_or_else(organon::types::ToolGroupPolicy::default, |t| {
+                t.tool_groups.clone()
+            });
 
         let timeout = Duration::from_secs(request.timeout_secs);
         let task = request.task.clone();

--- a/crates/organon/src/registry/mod.rs
+++ b/crates/organon/src/registry/mod.rs
@@ -14,7 +14,7 @@ use koina::id::ToolName;
 use crate::error::{self, Result};
 use crate::types::{
     ApprovalRequirement, Reversibility, ToolCallMetadata, ToolCategory, ToolContext, ToolDef,
-    ToolGroupId, ToolInput, ToolOutcome, ToolResult, ToolTag,
+    ToolGroupId, ToolGroupPolicy, ToolInput, ToolOutcome, ToolResult, ToolTag,
 };
 
 /// The trait tool implementations must satisfy.
@@ -116,6 +116,33 @@ impl ToolRegistry {
         Ok(())
     }
 
+    fn tools_for_policy<'s, 'p>(
+        &'s self,
+        policy: &'p ToolGroupPolicy,
+    ) -> impl Iterator<Item = &'s RegisteredTool> + 'p
+    where
+        's: 'p,
+    {
+        self.tools
+            .values()
+            .filter(move |tool| policy.permits(&tool.def.groups))
+    }
+
+    fn active_tools_for_policy<'s, 'p>(
+        &'s self,
+        active: &'p HashSet<ToolName>,
+        policy: &'p ToolGroupPolicy,
+    ) -> impl Iterator<Item = &'s RegisteredTool> + 'p
+    where
+        's: 'p,
+    {
+        self.tools_for_policy(policy).filter(move |tool| {
+            tool.def.auto_activate
+                || active.contains(&tool.def.name)
+                || tool.def.name.as_str() == "enable_tool"
+        })
+    }
+
     /// Look up a tool definition by name.
     #[must_use]
     pub fn get_def(&self, name: &ToolName) -> Option<&ToolDef> {
@@ -189,19 +216,19 @@ impl ToolRegistry {
         result
     }
 
-    /// Execute a tool by name, checking that the tool's groups intersect the
-    /// allowed groups for the calling role.
+    /// Execute a tool by name, checking that the tool's groups satisfy the
+    /// policy for the calling role.
     ///
     /// # Errors
     ///
     /// Returns [`Error::ToolGroupViolation`] if the tool's groups do not
-    /// intersect the allowed groups.
+    /// satisfy the policy.
     pub async fn execute_checked(
         &self,
         input: &ToolInput,
         ctx: &ToolContext,
         role: &str,
-        allowed_groups: &[ToolGroupId],
+        policy: &ToolGroupPolicy,
     ) -> Result<ToolResult> {
         let tool = self.tools.get(&input.name).ok_or_else(|| {
             error::ToolNotFoundSnafu {
@@ -210,17 +237,14 @@ impl ToolRegistry {
             .build()
         })?;
 
-        if !allowed_groups.is_empty() && !tool.def.groups.is_empty() {
-            let intersects = tool.def.groups.iter().any(|g| allowed_groups.contains(g));
-            if !intersects {
-                return Err(error::ToolGroupViolationSnafu {
-                    role: role.to_owned(),
-                    tool: input.name.as_str().to_owned(),
-                    allowed: allowed_groups.to_vec(),
-                    tool_groups: tool.def.groups.clone(),
-                }
-                .build());
+        if !policy.permits(&tool.def.groups) {
+            return Err(error::ToolGroupViolationSnafu {
+                role: role.to_owned(),
+                tool: input.name.as_str().to_owned(),
+                allowed: policy.allowed_groups().to_vec(),
+                tool_groups: tool.def.groups.clone(),
             }
+            .build());
         }
 
         self.execute(input, ctx).await
@@ -276,8 +300,7 @@ impl ToolRegistry {
 
     /// Tool definitions filtered by allowed tool groups.
     ///
-    /// Returns only tools whose `groups` intersect the provided `allowed_groups`.
-    /// When `allowed_groups` is empty, returns all tools (legacy fallback).
+    /// Returns only tools whose groups satisfy the provided policy.
     ///
     /// # Complexity
     ///
@@ -285,15 +308,19 @@ impl ToolRegistry {
     #[must_use]
     pub fn definitions_for_groups(&self, allowed_groups: &[ToolGroupId]) -> Vec<&ToolDef> {
         // kanon:ignore RUST/pub-visibility
-        if allowed_groups.is_empty() {
-            return self.definitions();
-        }
-        self.tools
-            .values()
-            .filter(|t| {
-                t.def.groups.is_empty() || t.def.groups.iter().any(|g| allowed_groups.contains(g))
-            })
-            .map(|t| &t.def)
+        self.definitions_for_policy(&ToolGroupPolicy::groups(allowed_groups.to_vec()))
+    }
+
+    /// Tool definitions filtered by explicit tool-group policy.
+    ///
+    /// # Complexity
+    ///
+    /// O(n) where n is the number of registered tools.
+    #[must_use]
+    pub fn definitions_for_policy(&self, policy: &ToolGroupPolicy) -> Vec<&ToolDef> {
+        // kanon:ignore RUST/pub-visibility
+        self.tools_for_policy(policy)
+            .map(|tool| &tool.def)
             .collect()
     }
 
@@ -320,7 +347,7 @@ impl ToolRegistry {
 
     /// Convert registered tools to the LLM wire format, filtered by allowed groups.
     ///
-    /// When `allowed_groups` is empty, returns all tools (legacy fallback).
+    /// An empty group list denies all tools.
     ///
     /// # Complexity
     ///
@@ -331,14 +358,21 @@ impl ToolRegistry {
         allowed_groups: &[ToolGroupId],
     ) -> Vec<hermeneus::types::ToolDefinition> {
         // kanon:ignore RUST/pub-visibility
-        if allowed_groups.is_empty() {
-            return self.to_hermeneus_tools();
-        }
-        self.tools
-            .values()
-            .filter(|t| {
-                t.def.groups.is_empty() || t.def.groups.iter().any(|g| allowed_groups.contains(g))
-            })
+        self.to_hermeneus_tools_for_policy(&ToolGroupPolicy::groups(allowed_groups.to_vec()))
+    }
+
+    /// Convert registered tools to the LLM wire format, filtered by policy.
+    ///
+    /// # Complexity
+    ///
+    /// O(n) where n is the number of registered tools.
+    #[must_use]
+    pub fn to_hermeneus_tools_for_policy(
+        &self,
+        policy: &ToolGroupPolicy,
+    ) -> Vec<hermeneus::types::ToolDefinition> {
+        // kanon:ignore RUST/pub-visibility
+        self.tools_for_policy(policy)
             .map(|t| hermeneus::types::ToolDefinition {
                 name: t.def.name.as_str().to_owned(),
                 description: t.def.description.clone(),
@@ -376,7 +410,7 @@ impl ToolRegistry {
     /// Convert tools to LLM wire format with **name + description only**, filtered by
     /// allowed groups.
     ///
-    /// When `allowed_groups` is empty, returns all tools (legacy fallback).
+    /// An empty group list denies all tools.
     #[cfg(feature = "deferred-schemas")]
     #[must_use]
     pub fn to_hermeneus_tools_summaries_for_groups(
@@ -384,15 +418,21 @@ impl ToolRegistry {
         allowed_groups: &[ToolGroupId],
     ) -> Vec<hermeneus::types::ToolDefinition> {
         // kanon:ignore RUST/pub-visibility
-        if allowed_groups.is_empty() {
-            return self.to_hermeneus_tools_summaries();
-        }
-        self.tools
-            .values()
-            .filter(|t| {
-                t.def.groups.is_empty()
-                    || t.def.groups.iter().any(|g| allowed_groups.contains(g))
-            })
+        self.to_hermeneus_tools_summaries_for_policy(&ToolGroupPolicy::groups(
+            allowed_groups.to_vec(),
+        ))
+    }
+
+    /// Convert tools to LLM wire format with **name + description only**, filtered by
+    /// policy.
+    #[cfg(feature = "deferred-schemas")]
+    #[must_use]
+    pub fn to_hermeneus_tools_summaries_for_policy(
+        &self,
+        policy: &ToolGroupPolicy,
+    ) -> Vec<hermeneus::types::ToolDefinition> {
+        // kanon:ignore RUST/pub-visibility
+        self.tools_for_policy(policy)
             .map(|t| hermeneus::types::ToolDefinition {
                 name: t.def.name.as_str().to_owned(),
                 description: t.def.description.clone(),
@@ -437,7 +477,7 @@ impl ToolRegistry {
     /// Convert tools to LLM wire format with **name + description only**, filtered by
     /// activation state and allowed groups.
     ///
-    /// When `allowed_groups` is empty, returns all activation-filtered tools (legacy fallback).
+    /// An empty group list denies all activation-filtered tools.
     #[cfg(feature = "deferred-schemas")]
     #[must_use]
     pub fn to_hermeneus_tools_summaries_filtered_for_groups(
@@ -446,19 +486,23 @@ impl ToolRegistry {
         allowed_groups: &[ToolGroupId],
     ) -> Vec<hermeneus::types::ToolDefinition> {
         // kanon:ignore RUST/pub-visibility
-        if allowed_groups.is_empty() {
-            return self.to_hermeneus_tools_summaries_filtered(active);
-        }
-        self.tools
-            .values()
-            .filter(|t| {
-                let active_ok = t.def.auto_activate
-                    || active.contains(&t.def.name)
-                    || t.def.name.as_str() == "enable_tool";
-                let group_ok = t.def.groups.is_empty()
-                    || t.def.groups.iter().any(|g| allowed_groups.contains(g));
-                active_ok && group_ok
-            })
+        self.to_hermeneus_tools_summaries_filtered_for_policy(
+            active,
+            &ToolGroupPolicy::groups(allowed_groups.to_vec()),
+        )
+    }
+
+    /// Convert tools to LLM wire format with **name + description only**, filtered by
+    /// activation state and policy.
+    #[cfg(feature = "deferred-schemas")]
+    #[must_use]
+    pub fn to_hermeneus_tools_summaries_filtered_for_policy(
+        &self,
+        active: &HashSet<ToolName>,
+        policy: &ToolGroupPolicy,
+    ) -> Vec<hermeneus::types::ToolDefinition> {
+        // kanon:ignore RUST/pub-visibility
+        self.active_tools_for_policy(active, policy)
             .map(|t| hermeneus::types::ToolDefinition {
                 name: t.def.name.as_str().to_owned(),
                 description: t.def.description.clone(),
@@ -557,7 +601,7 @@ impl ToolRegistry {
 
     /// Convert tools to LLM wire format, filtered by activation state and allowed groups.
     ///
-    /// When `allowed_groups` is empty, returns all activation-filtered tools (legacy fallback).
+    /// An empty group list denies all activation-filtered tools.
     #[must_use]
     pub fn to_hermeneus_tools_filtered_for_groups(
         &self,
@@ -565,19 +609,21 @@ impl ToolRegistry {
         allowed_groups: &[ToolGroupId],
     ) -> Vec<hermeneus::types::ToolDefinition> {
         // kanon:ignore RUST/pub-visibility
-        if allowed_groups.is_empty() {
-            return self.to_hermeneus_tools_filtered(active);
-        }
-        self.tools
-            .values()
-            .filter(|t| {
-                let active_ok = t.def.auto_activate
-                    || active.contains(&t.def.name)
-                    || t.def.name.as_str() == "enable_tool";
-                let group_ok = t.def.groups.is_empty()
-                    || t.def.groups.iter().any(|g| allowed_groups.contains(g));
-                active_ok && group_ok
-            })
+        self.to_hermeneus_tools_filtered_for_policy(
+            active,
+            &ToolGroupPolicy::groups(allowed_groups.to_vec()),
+        )
+    }
+
+    /// Convert tools to LLM wire format, filtered by activation state and policy.
+    #[must_use]
+    pub fn to_hermeneus_tools_filtered_for_policy(
+        &self,
+        active: &HashSet<ToolName>,
+        policy: &ToolGroupPolicy,
+    ) -> Vec<hermeneus::types::ToolDefinition> {
+        // kanon:ignore RUST/pub-visibility
+        self.active_tools_for_policy(active, policy)
             .map(|t| hermeneus::types::ToolDefinition {
                 name: t.def.name.as_str().to_owned(),
                 description: t.def.description.clone(),

--- a/crates/organon/src/registry/registry_tests.rs
+++ b/crates/organon/src/registry/registry_tests.rs
@@ -655,7 +655,7 @@ fn definitions_for_groups_filters_by_intersection() {
     multi_def.groups = vec![ToolGroupId::Read, ToolGroupId::Command];
     reg.register(multi_def, e3).expect("register");
 
-    let read_only = reg.definitions_for_groups(&[ToolGroupId::Read]);
+    let read_only = reg.definitions_for_policy(&ToolGroupPolicy::groups(vec![ToolGroupId::Read]));
     let names: Vec<&str> = read_only.iter().map(|d| d.name.as_str()).collect();
     assert!(names.contains(&"read"), "read should be in read-only set");
     assert!(
@@ -667,7 +667,10 @@ fn definitions_for_groups_filters_by_intersection() {
         "exec should be in read-only set (has Read)"
     );
 
-    let edit_cmd = reg.definitions_for_groups(&[ToolGroupId::Edit, ToolGroupId::Command]);
+    let edit_cmd = reg.definitions_for_policy(&ToolGroupPolicy::groups(vec![
+        ToolGroupId::Edit,
+        ToolGroupId::Command,
+    ]));
     let names: Vec<&str> = edit_cmd.iter().map(|d| d.name.as_str()).collect();
     assert!(
         !names.contains(&"read"),
@@ -684,7 +687,7 @@ fn definitions_for_groups_filters_by_intersection() {
 }
 
 #[test]
-fn definitions_for_groups_empty_fallback() {
+fn definitions_for_groups_empty_list_denies_all() {
     let mut reg = ToolRegistry::new();
     let (e1, _) = mock_executor("ok");
     let mut def = make_def("read", ToolCategory::Workspace);
@@ -692,22 +695,22 @@ fn definitions_for_groups_empty_fallback() {
     reg.register(def, e1).expect("register");
 
     let all = reg.definitions_for_groups(&[]);
-    assert_eq!(all.len(), 1, "empty allowed groups should return all tools");
+    assert!(all.is_empty(), "empty allowed groups should deny all tools");
 }
 
 #[test]
-fn definitions_for_groups_ignores_tools_with_empty_groups() {
+fn definitions_for_groups_denies_tools_with_empty_groups() {
     let mut reg = ToolRegistry::new();
     let (e1, _) = mock_executor("ok");
     let mut def = make_def("legacy", ToolCategory::Workspace);
     def.groups = vec![];
     reg.register(def, e1).expect("register");
 
-    let filtered = reg.definitions_for_groups(&[ToolGroupId::Read]);
+    let filtered = reg.definitions_for_policy(&ToolGroupPolicy::groups(vec![ToolGroupId::Read]));
     assert_eq!(
         filtered.len(),
-        1,
-        "tools with empty groups should always be included"
+        0,
+        "tools with empty groups should be denied under group policies"
     );
 }
 
@@ -725,7 +728,12 @@ async fn execute_checked_allows_tool_in_group() {
         arguments: serde_json::json!({}),
     };
     let result = reg
-        .execute_checked(&input, &mock_ctx(), "coder", &[ToolGroupId::Read])
+        .execute_checked(
+            &input,
+            &mock_ctx(),
+            "coder",
+            &ToolGroupPolicy::groups(vec![ToolGroupId::Read]),
+        )
         .await
         .expect("execute_checked should succeed");
     assert_eq!(result.content.text_summary(), "hello");
@@ -748,7 +756,12 @@ async fn execute_checked_denies_tool_outside_group() {
         arguments: serde_json::json!({}),
     };
     let err = reg
-        .execute_checked(&input, &mock_ctx(), "explorer", &[ToolGroupId::Read])
+        .execute_checked(
+            &input,
+            &mock_ctx(),
+            "explorer",
+            &ToolGroupPolicy::groups(vec![ToolGroupId::Read]),
+        )
         .await
         .expect_err("execute_checked should fail for out-of-group tool");
     assert!(
@@ -758,7 +771,7 @@ async fn execute_checked_denies_tool_outside_group() {
 }
 
 #[tokio::test]
-async fn execute_checked_legacy_empty_groups_allows_all() {
+async fn execute_checked_empty_groups_denies_all() {
     let mut reg = ToolRegistry::new();
     let (exec, _) = mock_executor("hello");
     let mut def = make_def("write", ToolCategory::Workspace);
@@ -770,10 +783,75 @@ async fn execute_checked_legacy_empty_groups_allows_all() {
         tool_use_id: "toolu_1".to_owned(),
         arguments: serde_json::json!({}),
     };
-    // Empty allowed_groups is legacy fallback — should allow the tool
-    let result = reg
-        .execute_checked(&input, &mock_ctx(), "legacy", &[])
+    let err = reg
+        .execute_checked(&input, &mock_ctx(), "legacy", &ToolGroupPolicy::DenyAll)
         .await
-        .expect("execute_checked should succeed with empty allowed groups");
+        .expect_err("execute_checked should fail with deny-all policy");
+    assert!(
+        err.to_string().contains("tool group violation"),
+        "error should mention tool group violation: {err}"
+    );
+}
+
+#[tokio::test]
+async fn execute_checked_allow_all_grants_tool() {
+    let mut reg = ToolRegistry::new();
+    let (exec, _) = mock_executor("hello");
+    let mut def = make_def("write", ToolCategory::Workspace);
+    def.groups = vec![ToolGroupId::Edit];
+    reg.register(def, exec).expect("register");
+
+    let input = ToolInput {
+        name: ToolName::from_static("write"),
+        tool_use_id: "toolu_1".to_owned(),
+        arguments: serde_json::json!({}),
+    };
+    let result = reg
+        .execute_checked(
+            &input,
+            &mock_ctx(),
+            "admin",
+            &ToolGroupPolicy::AllowAll {
+                reason: "test admin".to_owned(),
+            },
+        )
+        .await
+        .expect("execute_checked should succeed with allow-all policy");
     assert_eq!(result.content.text_summary(), "hello");
+}
+
+#[test]
+fn presentation_matches_execution_policy() {
+    let mut reg = ToolRegistry::new();
+    let (read_exec, _) = mock_executor("read");
+    let (edit_exec, _) = mock_executor("edit");
+    let (empty_exec, _) = mock_executor("empty");
+
+    let mut read_def = make_def("read", ToolCategory::Workspace);
+    read_def.groups = vec![ToolGroupId::Read];
+    reg.register(read_def, read_exec).expect("register read");
+
+    let mut edit_def = make_def("edit", ToolCategory::Workspace);
+    edit_def.groups = vec![ToolGroupId::Edit];
+    reg.register(edit_def, edit_exec).expect("register edit");
+
+    let mut empty_def = make_def("empty", ToolCategory::Workspace);
+    empty_def.groups = vec![];
+    reg.register(empty_def, empty_exec).expect("register empty");
+
+    let policy = ToolGroupPolicy::groups(vec![ToolGroupId::Read]);
+    let presented: Vec<_> = reg
+        .to_hermeneus_tools_for_policy(&policy)
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect();
+    let executable: Vec<_> = reg
+        .definitions()
+        .into_iter()
+        .filter(|def| policy.permits(&def.groups))
+        .map(|def| def.name.as_str().to_owned())
+        .collect();
+
+    assert_eq!(presented, executable);
+    assert_eq!(presented, vec!["read"]);
 }

--- a/crates/organon/src/types/mod.rs
+++ b/crates/organon/src/types/mod.rs
@@ -12,6 +12,8 @@ pub use services::{
 };
 
 use indexmap::IndexMap;
+use serde::de::{self, Deserializer, SeqAccess, Visitor};
+use serde::ser::{SerializeSeq as _, Serializer};
 use serde::{Deserialize, Serialize};
 
 pub use hermeneus::types::{DocumentSource, ImageSource, ToolResultBlock, ToolResultContent};
@@ -42,6 +44,23 @@ pub enum ToolGroupId {
     Verify,
 }
 
+impl std::str::FromStr for ToolGroupId {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value {
+            "read" => Ok(Self::Read),
+            "edit" => Ok(Self::Edit),
+            "command" => Ok(Self::Command),
+            "mcp" => Ok(Self::Mcp),
+            "spawn_subtask" => Ok(Self::SpawnSubtask),
+            "plan" => Ok(Self::Plan),
+            "verify" => Ok(Self::Verify),
+            other => Err(format!("unknown tool group: {other}")),
+        }
+    }
+}
+
 impl std::fmt::Display for ToolGroupId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -53,6 +72,132 @@ impl std::fmt::Display for ToolGroupId {
             Self::Plan => f.write_str("plan"),
             Self::Verify => f.write_str("verify"),
         }
+    }
+}
+
+/// Explicit role policy for tool-group gating.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ToolGroupPolicy {
+    /// Every registered tool is permitted, including tools with no group metadata.
+    AllowAll {
+        /// Human-readable reason for granting every tool group.
+        reason: String,
+    },
+    /// Tools are permitted when their declared groups intersect this list.
+    Groups(Vec<ToolGroupId>),
+    /// No grouped tools are permitted.
+    #[default]
+    DenyAll,
+}
+
+impl ToolGroupPolicy {
+    /// Build an explicit group policy, treating an empty list as deny-all.
+    #[must_use]
+    pub fn groups(groups: Vec<ToolGroupId>) -> Self {
+        if groups.is_empty() {
+            Self::DenyAll
+        } else {
+            Self::Groups(groups)
+        }
+    }
+
+    /// Returns true when the policy permits a tool with the given groups.
+    #[must_use]
+    pub fn permits(&self, tool_groups: &[ToolGroupId]) -> bool {
+        match self {
+            Self::AllowAll { .. } => true,
+            Self::Groups(allowed) => {
+                !tool_groups.is_empty() && tool_groups.iter().any(|group| allowed.contains(group))
+            }
+            Self::DenyAll => false,
+        }
+    }
+
+    /// The concrete allowed groups, if this is a group policy.
+    #[must_use]
+    pub fn allowed_groups(&self) -> &[ToolGroupId] {
+        match self {
+            Self::Groups(groups) => groups,
+            Self::AllowAll { .. } | Self::DenyAll => &[],
+        }
+    }
+
+    /// Human-readable policy text for denial messages and prompts.
+    #[must_use]
+    pub fn description(&self) -> String {
+        match self {
+            Self::AllowAll { reason } => format!("all ({reason})"),
+            Self::Groups(groups) => groups
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", "),
+            Self::DenyAll => "deny".to_owned(),
+        }
+    }
+}
+
+impl Serialize for ToolGroupPolicy {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::AllowAll { .. } => serializer.serialize_str("all"),
+            Self::DenyAll => serializer.serialize_str("deny"),
+            Self::Groups(groups) => {
+                let mut seq = serializer.serialize_seq(Some(groups.len()))?;
+                for group in groups {
+                    seq.serialize_element(group)?;
+                }
+                seq.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ToolGroupPolicy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PolicyVisitor;
+
+        impl<'de> Visitor<'de> for PolicyVisitor {
+            type Value = ToolGroupPolicy;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(r#""all", "deny", or a list of tool group names"#)
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                match value {
+                    "all" => Ok(ToolGroupPolicy::AllowAll {
+                        reason: "explicit tool_groups = \"all\"".to_owned(),
+                    }),
+                    "deny" => Ok(ToolGroupPolicy::DenyAll),
+                    other => Err(E::custom(format!(
+                        "unknown tool group policy {other:?}; expected \"all\", \"deny\", or a list"
+                    ))),
+                }
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut groups = Vec::new();
+                while let Some(group) = seq.next_element()? {
+                    groups.push(group);
+                }
+                Ok(ToolGroupPolicy::groups(groups))
+            }
+        }
+
+        deserializer.deserialize_any(PolicyVisitor)
     }
 }
 

--- a/crates/pylon/src/handlers/nous.rs
+++ b/crates/pylon/src/handlers/nous.rs
@@ -55,6 +55,7 @@ fn ensure_agent_definition<'a>(
         episteme_cohort: None,
         recall: None,
         tool_allowlist: None,
+        tool_groups: None,
         recall_profile: None,
         behavior: None,
     });

--- a/crates/taxis/src/config/agents.rs
+++ b/crates/taxis/src/config/agents.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 
 use eidos::id::FactId;
 use eidos::knowledge::MemoryScope;
+use serde::de::{self, Deserializer, SeqAccess, Visitor};
+use serde::ser::{SerializeSeq as _, Serializer};
 use serde::{Deserialize, Serialize};
 
 use super::{AgencyLevel, BookkeepingProviderKind, CompactionStrategyKind};
@@ -18,6 +20,84 @@ pub struct AgentsConfig {
     pub defaults: AgentDefaults,
     /// Individual agent definitions; merged with `defaults` at resolution time.
     pub list: Vec<NousDefinition>,
+}
+
+/// Tool-group policy configured for a nous agent.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum AgentToolGroupPolicy {
+    /// All tool groups are permitted.
+    AllowAll,
+    /// Only tools with one of these groups are permitted.
+    Groups(Vec<String>),
+    /// No tool groups are permitted.
+    #[default]
+    DenyAll,
+}
+
+impl Serialize for AgentToolGroupPolicy {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::AllowAll => serializer.serialize_str("all"),
+            Self::DenyAll => serializer.serialize_str("deny"),
+            Self::Groups(groups) => {
+                let mut seq = serializer.serialize_seq(Some(groups.len()))?;
+                for group in groups {
+                    seq.serialize_element(group)?;
+                }
+                seq.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentToolGroupPolicy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PolicyVisitor;
+
+        impl<'de> Visitor<'de> for PolicyVisitor {
+            type Value = AgentToolGroupPolicy;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(r#""all", "deny", or a list of tool group names"#)
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                match value {
+                    "all" => Ok(AgentToolGroupPolicy::AllowAll),
+                    "deny" => Ok(AgentToolGroupPolicy::DenyAll),
+                    other => Err(E::custom(format!(
+                        "unknown tool group policy {other:?}; expected \"all\", \"deny\", or a list"
+                    ))),
+                }
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut groups = Vec::new();
+                while let Some(group) = seq.next_element()? {
+                    groups.push(group);
+                }
+                if groups.is_empty() {
+                    Ok(AgentToolGroupPolicy::DenyAll)
+                } else {
+                    Ok(AgentToolGroupPolicy::Groups(groups))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(PolicyVisitor)
+    }
 }
 
 /// Per-factor scoring weights for the recall pipeline.
@@ -213,6 +293,8 @@ pub struct AgentDefaults {
     pub max_tool_iterations: u32,
     /// Filesystem paths the agent is permitted to access.
     pub allowed_roots: Vec<String>,
+    /// Default tool-group policy for agents. Missing or empty configuration denies all groups.
+    pub tool_groups: AgentToolGroupPolicy,
     /// Prompt caching configuration.
     pub caching: CachingConfig,
     /// Recall pipeline settings applied to all agents unless overridden.
@@ -231,6 +313,7 @@ impl Default for AgentDefaults {
             agency: AgencyLevel::Standard,
             max_tool_iterations: d::MAX_TOOL_ITERATIONS,
             allowed_roots: Vec::new(),
+            tool_groups: AgentToolGroupPolicy::DenyAll,
             caching: CachingConfig::default(),
             recall: RecallSettings::default(),
             history_budget_ratio: d::HISTORY_BUDGET_RATIO,
@@ -327,6 +410,9 @@ pub struct NousDefinition {
     /// Tool allowlist override; when `None`, all tools are enabled.
     #[serde(default)]
     pub tool_allowlist: Option<Vec<String>>,
+    /// Tool-group policy override; when `None`, inherits from [`AgentDefaults::tool_groups`].
+    #[serde(default)]
+    pub tool_groups: Option<AgentToolGroupPolicy>,
     /// Named recall behavior profile; when `None`, resolves to [`RecallProfile::Default`].
     #[serde(default)]
     pub recall_profile: Option<RecallProfile>,
@@ -352,6 +438,7 @@ impl Default for NousDefinition {
             episteme_cohort: None,
             recall: None,
             tool_allowlist: None,
+            tool_groups: None,
             recall_profile: None,
             behavior: None,
         }

--- a/crates/taxis/src/config/config_tests/basics.rs
+++ b/crates/taxis/src/config/config_tests/basics.rs
@@ -282,6 +282,55 @@ fn resolve_uses_defaults_for_unknown_agent() {
         resolved.domains.is_empty(),
         "unknown agent should have no domains"
     );
+    assert_eq!(
+        resolved.tool_groups,
+        AgentToolGroupPolicy::DenyAll,
+        "unknown agent should default to deny-all tool policy"
+    );
+}
+
+#[test]
+fn tool_groups_accepts_explicit_policies() {
+    let toml = r#"
+[agents.defaults]
+toolGroups = "all"
+
+[[agents.list]]
+id = "restricted"
+workspace = "/tmp/restricted"
+toolGroups = ["read", "verify"]
+"#;
+    let config: AletheiaConfig = toml::from_str(toml).expect("parse config");
+    assert_eq!(
+        config.agents.defaults.tool_groups,
+        AgentToolGroupPolicy::AllowAll
+    );
+    assert_eq!(
+        config.agents.list[0].tool_groups,
+        Some(AgentToolGroupPolicy::Groups(vec![
+            "read".to_owned(),
+            "verify".to_owned()
+        ]))
+    );
+
+    let resolved = resolve_nous(&config, "restricted");
+    assert_eq!(
+        resolved.tool_groups,
+        AgentToolGroupPolicy::Groups(vec!["read".to_owned(), "verify".to_owned()])
+    );
+}
+
+#[test]
+fn empty_tool_groups_deserializes_to_deny_all() {
+    let toml = r"
+[agents.defaults]
+toolGroups = []
+";
+    let config: AletheiaConfig = toml::from_str(toml).expect("parse config");
+    assert_eq!(
+        config.agents.defaults.tool_groups,
+        AgentToolGroupPolicy::DenyAll
+    );
 }
 
 #[test]

--- a/crates/taxis/src/config/mod.rs
+++ b/crates/taxis/src/config/mod.rs
@@ -8,8 +8,8 @@ mod maintenance;
 mod resolved;
 
 pub use agents::{
-    AgentBehaviorDefaults, AgentDefaults, AgentModelDefaults, AgentsConfig, CachingConfig,
-    ModelSpec, NousDefinition, RecallProfile, RecallSettings, RecallWeights,
+    AgentBehaviorDefaults, AgentDefaults, AgentModelDefaults, AgentToolGroupPolicy, AgentsConfig,
+    CachingConfig, ModelSpec, NousDefinition, RecallProfile, RecallSettings, RecallWeights,
 };
 pub use behavior::{
     AdmissionPolicyKind, AnthropicConfig, ApiLimitsConfig, BookkeepingProviderKind, CapacityConfig,

--- a/crates/taxis/src/config/resolved.rs
+++ b/crates/taxis/src/config/resolved.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use super::{
-    AgencyLevel, AgentBehaviorDefaults, AletheiaConfig, ExtractionConfig, RecallProfile,
-    RecallSettings,
+    AgencyLevel, AgentBehaviorDefaults, AgentToolGroupPolicy, AletheiaConfig, ExtractionConfig,
+    RecallProfile, RecallSettings,
 };
 
 /// Resolved model selection for an agent.
@@ -75,6 +75,8 @@ pub struct ResolvedNousConfig {
     pub episteme_cohort: Arc<str>,
     /// Merged set of permitted filesystem roots.
     pub allowed_roots: Vec<String>,
+    /// Resolved tool-group policy.
+    pub tool_groups: AgentToolGroupPolicy,
     /// Knowledge domains this agent covers.
     pub domains: Vec<String>,
     /// Resolved recall pipeline settings.
@@ -152,6 +154,9 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
     }
 
     let domains = agent.map_or_else(Vec::new, |agent| agent.domains.clone());
+    let tool_groups = agent
+        .and_then(|agent| agent.tool_groups.clone())
+        .unwrap_or_else(|| defaults.tool_groups.clone());
     let name = agent.and_then(|a| a.name.clone());
     let private = agent.is_some_and(|a| a.private);
     let episteme_cohort = agent
@@ -214,6 +219,7 @@ pub fn resolve_nous(config: &AletheiaConfig, nous_id: &str) -> ResolvedNousConfi
         private,
         episteme_cohort: Arc::from(episteme_cohort),
         allowed_roots,
+        tool_groups,
         domains,
         recall,
         extraction: config.knowledge.extraction.clone(),

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -71,6 +71,7 @@ Contains `defaults` (inherited by all agents) and `list` (per-agent definitions)
 | `thinking_budget` | u32 | `10000` | Max tokens for extended thinking |
 | `max_tool_iterations` | u32 | `200` | Safety limit on consecutive tool use per turn |
 | `allowed_roots` | string[] | `[]` | Filesystem paths the agent may access |
+| `toolGroups` | `"all"`, `"deny"`, or string[] | `"deny"` | Tool-group policy. Missing or empty values deny all groups. |
 | `tool_timeouts` | object | see `agents.defaults.tool_timeouts` section | Per-tool execution timeout overrides |
 | `working_state_ttl_secs` | u64 | `604800` | Working-state expiry window (7 days) |
 | `working_state_max_task_stack` | usize | `10` | Maximum working-state task stack depth before oldest entries are evicted |
@@ -112,6 +113,7 @@ primary = "claude-sonnet-4-6"
 [agents.defaults]
 context_tokens = 200000
 thinking_enabled = false
+toolGroups = ["read", "edit", "command", "mcp", "spawn_subtask", "plan", "verify"]
 
 [agents.defaults.tool_timeouts]
 default_ms = 120000
@@ -135,6 +137,10 @@ domains = ["research", "analysis"]
 primary = "claude-opus-4-6"
 fallbacks = ["claude-sonnet-4-6"]
 ```
+
+`toolGroups` is fail-closed. If the field is absent, set to `"deny"`, or set
+to `[]`, the agent receives no grouped tools. Use `"all"` only for an explicit
+admin/full-access policy; use an array for normal role-limited access.
 
 `nous::PipelineConfig` also carries per-stage turn budgets (`context`,
 `recall`, `history`, `guard`, `execute`, `finalize`, `reflection`, and

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -533,6 +533,12 @@ Every nous agent runs under a role that determines which tools it can call and w
 
 Enforcement happens twice: the tool list sent to the LLM is filtered to the allowlist, and any tool call in the response outside the allowlist is blocked before execution.
 
+Tool-group policy is explicit and fail-closed. In agent config, `toolGroups`
+accepts `"all"`, `"deny"`, or a list such as `["read", "verify"]`; absent or
+empty values deny all grouped tools. In `roles.toml`, `tool_groups` uses the
+same values. Use `"all"` only for admin/full-access roles with a documented
+reason in the change record.
+
 ### Roles in logs
 
 Span fields are set at spawn time. To find role-related activity:

--- a/instance.example/config/aletheia.toml
+++ b/instance.example/config/aletheia.toml
@@ -55,6 +55,7 @@ primary = "claude-sonnet-4-6"
 # retriesBeforeFallback = 2           # retry primary N times before fallback
 
 contextTokens = 200000  # auto-upgraded to 1M for Opus models
+toolGroups = ["read", "edit", "command", "mcp", "spawn_subtask", "plan", "verify"]
 # thinkingEnabled = false
 # thinkingBudget = 10000
 # maxToolIterations = 50

--- a/instance.example/shared/roles.toml
+++ b/instance.example/shared/roles.toml
@@ -16,6 +16,7 @@
 
 [coder]
 version = 1
+tool_groups = ["read", "edit", "command", "verify"]
 behaviors = [
     "Read relevant files before making changes",
     "Make the specified changes precisely",
@@ -34,6 +35,7 @@ constraints = [
 
 [researcher]
 version = 1
+tool_groups = ["read", "mcp", "plan"]
 behaviors = [
     "Cite sources for every claim",
     "Distinguish fact from inference",
@@ -51,6 +53,7 @@ constraints = [
 
 [reviewer]
 version = 1
+tool_groups = ["read", "verify", "mcp"]
 behaviors = [
     "Provide specific findings with file paths and line numbers",
     "Categorize issues by severity (error, warning, info)",
@@ -67,6 +70,7 @@ constraints = [
 
 [explorer]
 version = 1
+tool_groups = ["read", "plan"]
 behaviors = [
     "Use grep/find before reading whole files",
     "Include file paths and line numbers for every finding",
@@ -81,6 +85,7 @@ constraints = [
 
 [runner]
 version = 1
+tool_groups = ["read", "command", "verify"]
 behaviors = [
     "Run exactly the commands requested",
     "Capture exit codes, stdout, and stderr",

--- a/instance.example/versions/v0.19.0.toml
+++ b/instance.example/versions/v0.19.0.toml
@@ -17,6 +17,7 @@ maxToolResultBytes = 32768
 agency = "standard"
 maxToolIterations = 200
 allowedRoots = []
+toolGroups = ["read", "edit", "command", "mcp", "spawn_subtask", "plan", "verify"]
 historyBudgetRatio = 0.6
 
 [agents.defaults.model]


### PR DESCRIPTION
Closes #4516

A role contract with no `tool_groups` silently received the full tool surface, and tools with empty `def.groups` slipped every gate — presentation and execution each reimplemented the predicate (5 registry fns + 2 dispatch gates), so they could disagree.

- `ToolGroupPolicy` enum (`AllowAll { reason }` / `Groups(...)` / `DenyAll`, **default `DenyAll`**) in organon types; carried on `AgentConfig` and `RoleContract`. The legacy empty-list-allows-all fallback is deleted.
- ONE predicate — `policy.permits(&tool_def.groups)` — now backs all presentation fns and both dispatch gates: presentation == execution by construction. Tools with empty `def.groups` are denied under any non-AllowAll policy.
- Shipped role-contract TOMLs + `instance.example` set explicit policy; TOML shape: `tool_groups = "all"` | `["group", ...]` | absent ⇒ deny.
- Tests: empty-role-denies, empty-tool-def-denies, AllowAll-grants, deny-all-blocks-dispatch, TOML parse forms, legacy tests re-asserted to default-deny.

**Breaking (intended, fail-closed):** operator configs with agents lacking explicit `tool_groups` deny all tools after upgrade. Existing deployments must set `tool_groups = "all"` (or explicit groups) per agent — documented in CONFIGURATION.md + RUNBOOK.md. The metis live-instance deploy will set explicit groups as part of round-3.

Worker-gated CI-exact on verda before push.