### PR TITLE
fix(episteme): enforce schema version integrity — per-step stamps, fail-closed verification

### DIFF
--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -86,7 +86,7 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "b1b835055e19efb3716e6a22d40569e757be29e0e31f116e4424a98a485bf7a0"
+source_hash = "761c56e0dadb3ea1a720ac2fa2d162939ffe108cf949fa99e263711e54b73b88"
 l3_token_estimate = 32852
 
 [[crates]]

--- a/crates/episteme/src/knowledge_store/migration.rs
+++ b/crates/episteme/src/knowledge_store/migration.rs
@@ -4,16 +4,68 @@
 )]
 use super::{KNOWLEDGE_DDL, KnowledgeStore, entities_ddl, fts_ddl};
 
+pub(super) struct MigrationStep {
+    pub(super) target_version: i64,
+    pub(super) run: fn(&KnowledgeStore) -> crate::error::Result<()>,
+}
+
+pub(super) const MIGRATIONS: &[MigrationStep] = &[
+    MigrationStep {
+        target_version: 2,
+        run: KnowledgeStore::migrate_v1_to_v2,
+    },
+    MigrationStep {
+        target_version: 3,
+        run: KnowledgeStore::migrate_v2_to_v3,
+    },
+    MigrationStep {
+        target_version: 4,
+        run: KnowledgeStore::migrate_v3_to_v4,
+    },
+    MigrationStep {
+        target_version: 5,
+        run: KnowledgeStore::migrate_v4_to_v5,
+    },
+    MigrationStep {
+        target_version: 6,
+        run: KnowledgeStore::migrate_v5_to_v6,
+    },
+    MigrationStep {
+        target_version: 7,
+        run: KnowledgeStore::migrate_v6_to_v7,
+    },
+    MigrationStep {
+        target_version: 8,
+        run: KnowledgeStore::migrate_v7_to_v8,
+    },
+    MigrationStep {
+        target_version: 9,
+        run: KnowledgeStore::migrate_v8_to_v9,
+    },
+    MigrationStep {
+        target_version: 10,
+        run: KnowledgeStore::migrate_v9_to_v10,
+    },
+    MigrationStep {
+        target_version: 11,
+        run: KnowledgeStore::migrate_v10_to_v11,
+    },
+    MigrationStep {
+        target_version: 12,
+        run: KnowledgeStore::migrate_v11_to_v12,
+    },
+    MigrationStep {
+        target_version: 13,
+        run: KnowledgeStore::migrate_v12_to_v13,
+    },
+];
+
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
-    #[expect(
-        clippy::too_many_lines,
-        reason = "migration is a single linear sequence"
-    )]
     pub(super) fn migrate_v1_to_v2(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v1 -> v2");
 
         let all_facts = self
@@ -109,21 +161,7 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v1->v2 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(2, "v1->v2")?;
 
         tracing::info!("knowledge schema migration v1 -> v2 complete");
         Ok(())
@@ -136,7 +174,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v2_to_v3(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v2 -> v3");
 
         let all_facts = self
@@ -241,21 +279,7 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v2->v3 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(3, "v2->v3")?;
 
         tracing::info!("knowledge schema migration v2 -> v3 complete");
         Ok(())
@@ -265,7 +289,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v3_to_v4(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v3 -> v4");
 
         // WHY: bounded range [3..6) to avoid creating relations from later migrations (causal_edges = index 6).
@@ -293,21 +317,7 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v3->v4 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(4, "v3->v4")?;
 
         tracing::info!("knowledge schema migration v3 -> v4 complete");
         Ok(())
@@ -316,7 +326,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v4_to_v5(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v4 -> v5");
 
         self.db
@@ -332,21 +342,7 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v4->v5 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(5, "v4->v5")?;
 
         tracing::info!("knowledge schema migration v4 -> v5 complete");
         Ok(())
@@ -356,7 +352,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v5_to_v6(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v5 -> v6");
 
         // KNOWLEDGE_DDL[6] is the causal_edges relation (index 6, zero-based).
@@ -369,21 +365,7 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v5->v6 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(6, "v5->v6")?;
 
         tracing::info!("knowledge schema migration v5 -> v6 complete");
         Ok(())
@@ -393,7 +375,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v6_to_v7(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v6 -> v7");
 
         let all_edges = self
@@ -459,21 +441,7 @@ impl KnowledgeStore {
                 })?;
         }
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v6->v7 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(7, "v6->v7")?;
 
         tracing::info!("knowledge schema migration v6 -> v7 complete");
         Ok(())
@@ -492,7 +460,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v8_to_v9(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v8 -> v9");
 
         self.db
@@ -508,21 +476,7 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v8->v9 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(9, "v8->v9")?;
 
         tracing::info!("knowledge schema migration v8 -> v9 complete");
         Ok(())
@@ -540,7 +494,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v7_to_v8(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v7 -> v8");
 
         // KNOWLEDGE_DDL[7] = type_hierarchy, [8] = derived_facts, [9] = defaults.
@@ -555,21 +509,7 @@ impl KnowledgeStore {
                 })?;
         }
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v7->v8 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(8, "v7->v8")?;
 
         tracing::info!("knowledge schema migration v7 -> v8 complete");
         Ok(())
@@ -582,7 +522,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v9_to_v10(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v9 -> v10");
 
         // KNOWLEDGE_DDL[10] = published_facts, [11] = provenance.
@@ -597,21 +537,7 @@ impl KnowledgeStore {
                 })?;
         }
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v9->v10 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(10, "v9->v10")?;
 
         tracing::info!("knowledge schema migration v9 -> v10 complete");
         Ok(())
@@ -630,7 +556,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v10_to_v11(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v10 -> v11");
 
         let all_facts = self
@@ -743,21 +669,7 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v10->v11 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(11, "v10->v11")?;
 
         tracing::info!("knowledge schema migration v10 -> v11 complete");
         Ok(())
@@ -775,7 +687,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v11_to_v12(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v11 -> v12");
 
         let all_facts = self
@@ -890,21 +802,7 @@ impl KnowledgeStore {
                 .build()
             })?;
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v11->v12 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(12, "v11->v12")?;
 
         tracing::info!("knowledge schema migration v11 -> v12 complete");
         Ok(())
@@ -928,7 +826,7 @@ impl KnowledgeStore {
     pub(super) fn migrate_v12_to_v13(&self) -> crate::error::Result<()> {
         use std::collections::BTreeMap;
 
-        use crate::engine::{DataValue, ScriptMutability};
+        use crate::engine::ScriptMutability;
         tracing::info!("migrating knowledge schema v12 -> v13");
 
         let all_entities = self
@@ -1002,21 +900,7 @@ impl KnowledgeStore {
                 })?;
         }
 
-        let mut params = BTreeMap::new();
-        params.insert("key".to_owned(), DataValue::Str("schema".into()));
-        params.insert("version".to_owned(), DataValue::from(Self::SCHEMA_VERSION));
-        self.db
-            .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
-                params,
-                ScriptMutability::Mutable,
-            )
-            .map_err(|e| {
-                crate::error::EngineQuerySnafu {
-                    message: format!("v12->v13 version write failed: {e}"),
-                }
-                .build()
-            })?;
+        self.stamp_schema_version(13, "v12->v13")?;
 
         tracing::info!("knowledge schema migration v12 -> v13 complete");
         Ok(())

--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -552,6 +552,7 @@ pub struct KnowledgeStore {
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
     const SCHEMA_VERSION: i64 = 13;
+    const MIN_SCHEMA_VERSION: i64 = 1;
 
     /// Open an in-memory knowledge store with default configuration.
     ///
@@ -745,54 +746,20 @@ impl KnowledgeStore {
         use std::collections::BTreeMap;
 
         use crate::engine::ScriptMutability;
-        let already_initialized = self
-            .db
-            .run(
-                "?[v] := *schema_version{version: v}",
-                BTreeMap::new(),
-                ScriptMutability::Immutable,
-            )
-            .is_ok();
-
-        if already_initialized {
-            let current_version = self.schema_version().unwrap_or(0);
-            if current_version < 2 {
-                self.migrate_v1_to_v2()?;
-            }
-            if current_version < 3 {
-                self.migrate_v2_to_v3()?;
-            }
-            if current_version < 4 {
-                self.migrate_v3_to_v4()?;
-            }
-            if current_version < 5 {
-                self.migrate_v4_to_v5()?;
-            }
-            if current_version < 6 {
-                self.migrate_v5_to_v6()?;
-            }
-            if current_version < 7 {
-                self.migrate_v6_to_v7()?;
-            }
-            if current_version < 8 {
-                self.migrate_v7_to_v8()?;
-            }
-            if current_version < 9 {
-                self.migrate_v8_to_v9()?;
-            }
-            if current_version < 10 {
-                self.migrate_v9_to_v10()?;
-            }
-            if current_version < 11 {
-                self.migrate_v10_to_v11()?;
-            }
-            if current_version < 12 {
-                self.migrate_v11_to_v12()?;
-            }
-            if current_version < 13 {
-                self.migrate_v12_to_v13()?;
-            }
+        if self.schema_version_relation_exists()? {
+            let current_version = self.schema_version_for_startup()?;
+            self.verify_schema_integrity(current_version)?;
+            self.apply_pending_migrations(current_version)?;
+            self.verify_schema_integrity(Self::SCHEMA_VERSION)?;
             return Ok(());
+        }
+
+        let relations = self.relation_names()?;
+        if !relations.is_empty() {
+            return Err(Self::schema_integrity_error(format!(
+                "schema version corruption: schema_version relation is missing but store has relations {}; repair by restoring from backup or re-stamping only after verifying the schema version",
+                relations.join(", ")
+            )));
         }
 
         // WHY: skip KNOWLEDGE_DDL[1] — the entities relation needs a
@@ -907,29 +874,208 @@ impl KnowledgeStore {
                 .build()
             })?;
 
+        self.stamp_fresh_schema_versions()?;
+
+        Ok(())
+    }
+
+    fn schema_version_relation_exists(&self) -> crate::error::Result<bool> {
+        self.relation_names()
+            .map(|names| names.iter().any(|name| name == "schema_version"))
+    }
+
+    fn relation_names(&self) -> crate::error::Result<Vec<String>> {
+        let rows = self.run_read("::relations", std::collections::BTreeMap::new())?;
+        rows.rows
+            .into_iter()
+            .map(|row| {
+                row.first()
+                    .and_then(crate::engine::DataValue::get_str)
+                    .map(str::to_owned)
+                    .ok_or_else(|| {
+                        crate::error::EngineQuerySnafu {
+                            message: "schema relation listing returned a non-string relation name"
+                                .to_owned(),
+                        }
+                        .build()
+                    })
+            })
+            .collect()
+    }
+
+    fn schema_version_for_startup(&self) -> crate::error::Result<i64> {
+        self.schema_version().map_err(|err| {
+            Self::schema_integrity_error(format!(
+                "schema version corruption: schema_version relation is present but row 'schema' is missing; repair by restoring from backup or re-stamping only after verifying the applied schema version: {err}"
+            ))
+        })
+    }
+
+    fn verify_schema_integrity(&self, current_version: i64) -> crate::error::Result<()> {
+        if current_version < Self::MIN_SCHEMA_VERSION {
+            return Err(Self::schema_integrity_error(format!(
+                "schema version corruption: stored version {current_version} is below minimum {}; repair by restoring from backup or re-stamping only after verifying the schema version",
+                Self::MIN_SCHEMA_VERSION
+            )));
+        }
+        if current_version > Self::SCHEMA_VERSION {
+            return Err(crate::error::SchemaVersionSnafu {
+                expected: Self::SCHEMA_VERSION,
+                found: current_version,
+            }
+            .build());
+        }
+
+        for step in migration::MIGRATIONS {
+            if step.target_version > current_version {
+                break;
+            }
+            let stamp = self.migration_stamp_version(step.target_version)?;
+            match stamp {
+                Some(version) if version == step.target_version => {}
+                Some(version) => {
+                    return Err(Self::schema_integrity_error(format!(
+                        "schema version integrity hole: migration stamp for version {} recorded version {version}; repair by restoring from backup or re-stamping only after verifying migration v{} to v{} was applied",
+                        step.target_version,
+                        step.target_version - 1,
+                        step.target_version
+                    )));
+                }
+                None => {
+                    return Err(Self::schema_integrity_error(format!(
+                        "schema version integrity hole: store version {current_version} is missing migration stamp for version {}; repair by restoring from backup or re-stamping only after verifying migration v{} to v{} was applied",
+                        step.target_version,
+                        step.target_version - 1,
+                        step.target_version
+                    )));
+                }
+            }
+        }
+
+        tracing::info!(
+            current_version,
+            expected_version = Self::SCHEMA_VERSION,
+            "knowledge schema version integrity verified"
+        );
+        Ok(())
+    }
+
+    fn apply_pending_migrations(&self, current_version: i64) -> crate::error::Result<()> {
+        for step in migration::MIGRATIONS {
+            if step.target_version <= current_version {
+                continue;
+            }
+            tracing::info!(
+                current_version,
+                target_version = step.target_version,
+                expected_version = Self::SCHEMA_VERSION,
+                "applying pending knowledge schema migration"
+            );
+            (step.run)(self)?;
+            let stamped_version = self.schema_version()?;
+            if stamped_version != step.target_version {
+                return Err(crate::error::SchemaVersionSnafu {
+                    expected: step.target_version,
+                    found: stamped_version,
+                }
+                .build());
+            }
+        }
+        Ok(())
+    }
+
+    fn migration_stamp_key(version: i64) -> String {
+        format!("migration:{version}")
+    }
+
+    fn migration_stamp_version(&self, version: i64) -> crate::error::Result<Option<i64>> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::DataValue;
         let mut params = BTreeMap::new();
         params.insert(
             "key".to_owned(),
-            crate::engine::DataValue::Str("schema".into()),
+            DataValue::Str(Self::migration_stamp_key(version).into()),
         );
+        let rows = self.run_read(r"?[version] := *schema_version{key: $key, version}", params)?;
+        let Some(row) = rows.rows.into_iter().next() else {
+            return Ok(None);
+        };
+        marshal::extract_int(row.first().ok_or_else(|| {
+            crate::error::EngineQuerySnafu {
+                message: format!("migration stamp for version {version} is empty"),
+            }
+            .build()
+        })?)
+        .map(Some)
+    }
+
+    fn stamp_schema_version(&self, version: i64, context: &str) -> crate::error::Result<()> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::{DataValue, ScriptMutability};
+        let mut params = BTreeMap::new();
+        params.insert("schema_key".to_owned(), DataValue::Str("schema".into()));
         params.insert(
-            "version".to_owned(),
-            crate::engine::DataValue::from(Self::SCHEMA_VERSION),
+            "stamp_key".to_owned(),
+            DataValue::Str(Self::migration_stamp_key(version).into()),
         );
+        params.insert("version".to_owned(), DataValue::from(version));
         self.db
             .run(
-                r"?[key, version] <- [[$key, $version]] :put schema_version { key => version }",
+                r"?[key, version] <- [[$schema_key, $version], [$stamp_key, $version]]
+                  :put schema_version { key => version }",
                 params,
                 ScriptMutability::Mutable,
             )
             .map_err(|e| {
                 crate::error::EngineQuerySnafu {
-                    message: e.to_string(),
+                    message: format!("{context} version write failed: {e}"),
                 }
                 .build()
             })?;
-
+        tracing::info!(
+            target_version = version,
+            "knowledge schema migration version stamped"
+        );
         Ok(())
+    }
+
+    fn stamp_fresh_schema_versions(&self) -> crate::error::Result<()> {
+        use crate::engine::ScriptMutability;
+
+        let mut rows = vec![format!(r#"["schema", {}]"#, Self::SCHEMA_VERSION)];
+        rows.extend(migration::MIGRATIONS.iter().map(|step| {
+            format!(
+                r#"["{}", {}]"#,
+                Self::migration_stamp_key(step.target_version),
+                step.target_version
+            )
+        }));
+        let script = format!(
+            "?[key, version] <- [{}] :put schema_version {{ key => version }}",
+            rows.join(", ")
+        );
+        self.db
+            .run(
+                &script,
+                std::collections::BTreeMap::new(),
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("fresh schema version stamp failed: {e}"),
+                }
+                .build()
+            })?;
+        Ok(())
+    }
+
+    fn schema_integrity_error(message: impl Into<String>) -> crate::error::Error {
+        crate::error::EngineQuerySnafu {
+            message: message.into(),
+        }
+        .build()
     }
 
     /// Query the stored schema version from the database.

--- a/crates/episteme/src/knowledge_store/tests/migration.rs
+++ b/crates/episteme/src/knowledge_store/tests/migration.rs
@@ -1,9 +1,12 @@
 #![expect(clippy::expect_used, reason = "test setup failures should panic")]
 
+#[cfg(feature = "storage-fjall")]
 use std::io::Write;
 
-use super::super::KnowledgeStore;
+use super::super::{KnowledgeConfig, KnowledgeStore, migration};
+use crate::test_fixtures::make_fact;
 
+#[cfg(feature = "storage-fjall")]
 #[test]
 fn open_fjall_copies_legacy_root_into_shared_cohort() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -23,4 +26,162 @@ fn open_fjall_copies_legacy_root_into_shared_cohort() {
             .len(),
         6
     );
+}
+
+#[test]
+fn migration_registry_is_sequential_and_current() {
+    for (offset, step) in migration::MIGRATIONS.iter().enumerate() {
+        let expected = i64::try_from(offset).expect("offset fits i64") + 2;
+        assert_eq!(
+            step.target_version, expected,
+            "migration registry must allocate versions sequentially"
+        );
+    }
+    assert_eq!(
+        migration::MIGRATIONS
+            .last()
+            .expect("migration registry is nonempty")
+            .target_version,
+        KnowledgeStore::SCHEMA_VERSION,
+        "latest migration target should match schema version"
+    );
+}
+
+#[test]
+fn missing_schema_version_row_fails_closed_without_remigrating() {
+    let store = make_store();
+    let fact = make_fact("f1", "alice", "schema integrity preserves facts");
+    store.insert_fact(&fact).expect("insert fact");
+
+    store
+        .run_mut_query(
+            r#"?[key] <- [["schema"]] :rm schema_version {key}"#,
+            std::collections::BTreeMap::new(),
+        )
+        .expect("remove schema row");
+
+    let err = store
+        .init_schema()
+        .expect_err("missing schema row should fail closed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("schema_version relation is present but row 'schema' is missing"),
+        "error should name missing schema row, got: {msg}"
+    );
+
+    let facts = store
+        .query_facts("alice", "2026-06-01", 10)
+        .expect("query facts after failed init");
+    assert_eq!(facts.len(), 1, "failed init must not drop facts");
+}
+
+#[test]
+fn downgrade_is_detected_before_migration() {
+    let store = make_store();
+    store
+        .stamp_schema_version(KnowledgeStore::SCHEMA_VERSION + 1, "test")
+        .expect("stamp future version");
+
+    let err = store
+        .init_schema()
+        .expect_err("newer store should fail closed");
+    assert!(
+        matches!(
+            err,
+            crate::error::Error::SchemaVersion {
+                expected: KnowledgeStore::SCHEMA_VERSION,
+                found,
+                ..
+            } if found == KnowledgeStore::SCHEMA_VERSION + 1
+        ),
+        "expected schema version mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn missing_intermediate_stamp_is_detected_as_hole() {
+    let store = make_store();
+    store
+        .run_mut_query(
+            r#"?[key] <- [["migration:12"]] :rm schema_version {key}"#,
+            std::collections::BTreeMap::new(),
+        )
+        .expect("remove migration stamp");
+
+    let err = store
+        .init_schema()
+        .expect_err("missing migration stamp should fail closed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("schema version integrity hole"),
+        "error should name integrity hole, got: {msg}"
+    );
+    assert!(
+        msg.contains("version 12"),
+        "error should name missing version, got: {msg}"
+    );
+}
+
+#[test]
+fn crash_mid_sequence_resume_applies_only_missing_tail() {
+    let store = make_store();
+    store
+        .run_mut_query(
+            r#"?[key] <- [["migration:13"]] :rm schema_version {key}"#,
+            std::collections::BTreeMap::new(),
+        )
+        .expect("remove v13 stamp");
+    store
+        .stamp_schema_version(12, "test")
+        .expect("stamp partial migration state");
+
+    store
+        .init_schema()
+        .expect("partial migration sequence should resume");
+
+    assert_eq!(
+        store.schema_version().expect("schema version"),
+        KnowledgeStore::SCHEMA_VERSION
+    );
+    assert_eq!(
+        store
+            .migration_stamp_version(13)
+            .expect("read v13 stamp")
+            .expect("v13 stamp present"),
+        13
+    );
+}
+
+#[test]
+fn rerun_current_schema_is_noop() {
+    let store = KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        ..Default::default()
+    })
+    .expect("open store");
+    let before = store.schema_version().expect("schema version before");
+
+    store.init_schema().expect("re-run init schema");
+
+    assert_eq!(
+        store.schema_version().expect("schema version after"),
+        before
+    );
+    for step in migration::MIGRATIONS {
+        assert_eq!(
+            store
+                .migration_stamp_version(step.target_version)
+                .expect("read migration stamp"),
+            Some(step.target_version),
+            "stamp should remain present"
+        );
+    }
+}
+
+fn make_store() -> std::sync::Arc<KnowledgeStore> {
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        ..Default::default()
+    })
+    .expect("open in-memory knowledge store")
 }

--- a/crates/episteme/src/knowledge_store/tests/mod.rs
+++ b/crates/episteme/src/knowledge_store/tests/mod.rs
@@ -21,7 +21,7 @@ mod entities;
 mod facts;
 #[cfg(feature = "mneme-engine")]
 mod lesson_e2e;
-#[cfg(all(feature = "mneme-engine", feature = "storage-fjall"))]
+#[cfg(feature = "mneme-engine")]
 mod migration;
 #[cfg(feature = "mneme-engine")]
 mod proptests;


### PR DESCRIPTION
Closes #4494
Closes #4495

Schema migrations lacked per-step version stamping and open-time integrity verification — a crash mid-sequence or a re-run could destructively re-migrate applied steps (the class behind the operator store's v11→v13 risk).

- `MigrationStep` registry asserted sequential + current at registration; each step stamps its applied version atomically WITH its data changes (`stamp_schema_version` with context), so a crash mid-sequence resumes at the missing tail instead of re-running applied steps.
- `verify_schema_integrity` on open fails closed with structured errors naming the versions: downgrade detected (store newer than binary), missing intermediate stamps detected as holes, missing version row refuses to re-migrate.
- Migration-number allocation is now collision-proof for the B4/B10 follow-ups (sequential, asserted unique).
- Regression tests: crash-mid-sequence-resume, rerun-is-noop, downgrade-detected, hole-detected, fail-closed-without-remigrating — all under CI-run features.

Worker-gated CI-exact on verda before push.