### PR TITLE
docs: define the public app golden path — desktop-first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Cross-tool guide for AI coding agents (Claude Code, Cursor, Windsurf, Copilot, etc.).
 
+## Depth
+
+Read `docs/GOLDEN-PATH.md` first to understand the public desktop-first app workflow and the implemented versus planned app surfaces.
+
 ## Build / Test / Lint
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Repo-level conventions for AI coding agents working on Aletheia. Key crates: ale
 
 ## Depth
 
-See also [AGENTS.md](AGENTS.md) for a cross-tool quick-reference (build commands, crate selection flowchart, common mistakes).
+Read [docs/GOLDEN-PATH.md](docs/GOLDEN-PATH.md) first to understand the public desktop-first app workflow. See also [AGENTS.md](AGENTS.md) for a cross-tool quick-reference (build commands, crate selection flowchart, common mistakes).
 
 ## Standards
 
@@ -22,6 +22,7 @@ Shell: [standards/](standards/)
 
 ## Structure
 
+[docs/GOLDEN-PATH.md](docs/GOLDEN-PATH.md): first orientation read for the public app workflow and implemented/planned app surfaces.
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md): crate workspace, module map, dependency graph, trait boundaries.
 [docs/ARCHITECTURE-QUICK.md](docs/ARCHITECTURE-QUICK.md): one-page crate reference for cold-start.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Talk to an AI that remembers your previous conversations, learns your preference
 
 One binary. No containers. No external databases. Beyond your LLM provider, there are no cloud dependencies.
 
-[Quickstart](docs/QUICKSTART.md) · [Configuration](docs/CONFIGURATION.md) · [Deployment](docs/DEPLOYMENT.md) · [Architecture](docs/ARCHITECTURE.md)
+[Golden Path](docs/GOLDEN-PATH.md) · [Quickstart](docs/QUICKSTART.md) · [Configuration](docs/CONFIGURATION.md) · [Deployment](docs/DEPLOYMENT.md) · [Architecture](docs/ARCHITECTURE.md)
 
 ---
 

--- a/docs/GOLDEN-PATH.md
+++ b/docs/GOLDEN-PATH.md
@@ -1,0 +1,199 @@
+# Golden Path
+
+Aletheia's v1.0 app path is desktop-first. The desktop app (`proskenion`) is
+the canonical user surface for configuring a client connection, starting work,
+watching an agent act, inspecting memory, reviewing failures, and exporting the
+useful result. The terminal dashboard (`koilon`, launched with `aletheia tui`)
+is the headless and SSH fallback.
+
+The desktop app connects to a running Aletheia server over HTTP. It uses the
+same API and SSE stream as the TUI, but the desktop navigation is the public
+workflow described here.
+
+Status labels in this document mean:
+
+- **Implemented:** present in the current source and wired into a desktop view.
+- **Experimental:** present in source, but the backing server endpoint or app
+  integration is incomplete or documented as pending.
+- **Planned:** not present as a complete app surface yet.
+
+## 1. Configure Providers
+
+**Implemented:** Configure model providers and tool policy in the server config,
+then connect the desktop app to that server.
+
+The server reads `instance/config/aletheia.toml` through the taxis config
+cascade: compiled defaults, then TOML, then `ALETHEIA_` environment overrides.
+The agent model path starts under `agents.defaults.model` and can be overridden
+per `agents.list[]` entry. Provider backends live in `[[providers]]` tables.
+Each provider declares `name`, `providerType`, optional `baseUrl`, optional
+`apiKeyEnv`, `deploymentTarget`, and the `models` it can serve.
+
+Credential discovery is configured by `[credential]`. The documented strategies
+are `auto`, `api-key`, and `claude-code`; the Anthropic provider also reads
+`ANTHROPIC_API_KEY` outside the config cascade.
+
+Tool access is fail-closed. The `toolGroups` field accepts `"all"`, `"deny"`,
+or a list of group names. Missing `toolGroups`, `"deny"`, and `[]` all deny
+grouped tools. Normal agents should use an explicit list such as:
+
+```toml
+[agents.defaults]
+toolGroups = ["read", "edit", "command", "mcp", "spawn_subtask", "plan", "verify"]
+```
+
+The recognized group names are `read`, `edit`, `command`, `mcp`,
+`spawn_subtask`, `plan`, and `verify`.
+
+In the desktop app, the first-run wizard, Connect view, and Settings -> Servers
+manage the client connection: server URL, optional bearer token, saved servers,
+active server switching, and connection probes. They do not replace the server
+provider config.
+
+**Experimental:** Ops -> Credentials renders a credential-management panel for
+listing, validating, rotating, adding, and removing credentials. The source
+marks its API types as local until the server exposes `/api/system/credentials`,
+so treat this as an in-progress surface rather than the primary provider setup
+path.
+
+## 2. Start or Resume a Session
+
+**Implemented:** Use Chat for new work and Sessions for existing work.
+
+Open Chat, select an agent from the sidebar, type a message, and send it. The
+chat view creates a tab for the active agent when needed and streams the turn
+against the selected agent and session key. Session tabs keep active work
+visible while you move through the app.
+
+To resume existing work, open Sessions. The Sessions view lists sessions with
+search, status filters, agent filters, sort controls, and optional visibility
+for system sessions. Selecting a session opens its detail panel with message
+counts, token summary when available, model, duration, message previews, and an
+Open in Chat action. Archive and Restore actions close or re-open a session in
+the working list without deleting its history.
+
+**Fallback:** On a headless host or over SSH, use `aletheia tui`. The TUI accepts
+`--url`, `--token`, `--agent`, and `--session` flags and provides chat,
+planning, memory, metrics, and ops views in a terminal.
+
+## 3. Observe Tool Calls and Approvals
+
+**Implemented:** Watch the current turn in Chat and the broader tool stream in
+Ops.
+
+During a streamed turn, Chat shows the routing stage as the pipeline moves
+through bootstrap, recall, thinking, tool execution, completion, abort, or
+error states. Assistant messages include tool counts. Tool calls render as
+expandable panels with status, input JSON, output, error text, and duration.
+
+When the server emits a tool approval request, Chat renders an inline approval
+card with the tool name, risk level, reason, input preview, and Approve/Deny
+buttons. The desktop sends those decisions back to the server through the tool
+approval API.
+
+Ops -> Tools shows active tools, total calls, succeeded calls, failed calls, and
+tool history. Ops -> Dashboard shows agent cards, active turn counts, service
+health, daemon and cron status, and toggle state fetched from the server.
+
+## 4. Inspect Memory and Context
+
+**Implemented:** Use Memory for facts first, then the graph lens when needed.
+
+Memory opens on the Facts tab. Facts are readable memory rows with search,
+type and tier filters, sort controls, confidence display, sensitivity badges,
+and curation actions. Stated or verified facts are visually stronger than
+inferred facts. Forget, Restore, confidence adjustment, and sensitivity changes
+are available from the fact list.
+
+The Graph tab is an opt-in entity view. It lists entities with search and
+filters; selecting an entity shows properties, relationships, memories,
+confidence, PageRank, metadata, and entity actions such as merge, flag, and
+delete.
+
+Theke, the desktop file workspace, complements Memory. It provides a file tree,
+search, viewer, markdown preview/edit mode, save handling, conflict warnings,
+and a diff view opened from file-change notifications.
+
+Meta -> Insights provides aggregate memory and context signals: memory health,
+confidence distribution, stale entities, knowledge growth, agent performance,
+conversation quality, and system reflection. Use it to understand trends rather
+than to edit facts.
+
+## 5. Review Traces and Failure Causes
+
+**Implemented:** Review live failures in Chat, Ops, Sessions, Metrics, and
+connection surfaces.
+
+Chat preserves partial output on aborts, shows stream errors, and exposes Retry
+for the last failed user turn. Tool panels show per-call errors and durations.
+The input bar shows Abort while a stream is active.
+
+Ops -> Tools shows failed tool counts and per-tool history rows. Ops ->
+Dashboard shows service-health failures, daemon task status, cron job results,
+and agent connection health. Metrics shows token and cost trends, including
+daily, weekly, and monthly cost ranges and per-agent cost breakdowns. Sessions
+shows session-level message counts, token usage when present, model, duration,
+and distillation history.
+
+The Connect view and Settings -> Servers show connection failures, unreachable
+servers, retry state, and the URL that a health probe actually tested.
+
+**Planned:** A single desktop trace browser that opens a turn, shows every
+pipeline stage, links directly to logs, and explains root failure causes is not
+yet a complete primary surface. Today the evidence is split across Chat, Ops,
+Metrics, Sessions, server logs, and retained trace files.
+
+## 6. Continue, Retry, or Close Out Work
+
+**Implemented:** Continue in Chat, retry failed turns, or close sessions through
+Sessions.
+
+Continue work by sending another Chat message in the active session. If a turn
+is still streaming, Abort cancels it. If a stream fails after a user message,
+Retry re-sends that last message without duplicating the user bubble.
+
+Open Sessions to archive completed work, restore archived work, or bulk archive
+and restore selected sessions. Open in Chat returns a selected session to the
+working chat surface.
+
+**Experimental:** Planning is reachable from the desktop navigation and
+renders project dashboards, requirements, roadmap, checkpoints, execution,
+verification, gap analysis, discussion, and project detail views — but parts
+of the backing planning API are still incomplete, so some views do not load
+live data yet. Treat Planning as an in-progress surface; ordinary
+conversational work starts in Chat.
+
+## 7. Export or Persist the Result
+
+**Implemented:** Sessions and memory persist on the server. Desktop export
+copies the current conversation as Markdown.
+
+The server persists sessions, messages, knowledge facts, entity memories, and
+workspace files in its configured instance data. Desktop settings persist
+server entries, appearance, keybindings, notification preferences, and window
+state under the user's desktop config directory.
+
+In Chat, run `/export` from the command palette to copy the current
+conversation to the clipboard as Markdown. The export contains user, assistant,
+and system messages separated by Markdown dividers. If you invoke it outside
+Chat or before any messages exist, the desktop shows a warning instead of
+producing an empty export.
+
+The Theke file view persists edited workspace files through the server API and
+surfaces save conflicts, size-limit failures, and connection errors.
+
+**Implemented outside the desktop:** The CLI includes session and agent export
+commands for portable artifacts. Use those when you need a file on disk rather
+than clipboard Markdown.
+
+**Planned:** The desktop does not yet provide a full export dialog for choosing
+Markdown versus JSON, selecting a destination file, or packaging a session with
+its trace and memory evidence.
+
+## Headless Fallback
+
+Use the TUI when the desktop cannot run, such as SSH-only work or Wayland
+remote-launch limitations. The TUI is a ratatui client over the same server API
+and SSE events. It supports chat, planning, memory, metrics, ops, session focus,
+agent focus, and setup wizard flows, but it is the fallback path for v1.0. The
+desktop remains the canonical public app surface.


### PR DESCRIPTION
Closes #4534

Authors `docs/GOLDEN-PATH.md` per the operator decision (2026-06-12): **the desktop app is the canonical v1.0 surface**; the TUI is the documented headless/SSH fallback.

Covers the issue's seven steps desktop-first — configure providers (including the new fail-closed `toolGroups` contract from #4516), start/resume sessions, observe tool calls + approval cards, inspect memory (facts-first + Theke + insights), review traces/failures, continue/retry/close, export/persist. Every claim source-verified against post-wave-E main; implemented vs experimental vs planned explicitly labeled (credentials panel and Planning marked experimental per #4483/#4482; trace browser and export dialog marked planned). README header and agent-orientation docs point to it as the first orientation read. No private infrastructure or maintainer-local state referenced.