### PR TITLE
fix(episteme,pylon): persist fact sensitivity through storage — v14 migration, hydrated reads

### DIFF
--- a/_llm/L3-api-index/episteme.md
+++ b/_llm/L3-api-index/episteme.md
@@ -2359,7 +2359,8 @@ pub const KNOWLEDGE_DDL: &[&str] = &[
         forget_reason: String?,
         scope: String?,
         project_id: String?,
-        visibility: String default 'private'
+        visibility: String default 'private',
+        sensitivity: String default 'public'
     }",
     // WHY: index 1 is a sentinel — `init_schema` skips this entry and runs
     // the dim-parameterized `entities_ddl(self.dim)` instead so the relation
@@ -2921,6 +2922,7 @@ pub enum FactsField {
     Scope,
     ProjectId,
     Visibility,
+    Sensitivity,
 }
 ```
 

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -86,8 +86,8 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "761c56e0dadb3ea1a720ac2fa2d162939ffe108cf949fa99e263711e54b73b88"
-l3_token_estimate = 32852
+source_hash = "73cf258de9eb529d9a50ceba2681ef891bf7b4e4417c4cff179337940c148a88"
+l3_token_estimate = 32868
 
 [[crates]]
 name = "gnosis"
@@ -110,7 +110,7 @@ l3_token_estimate = 13698
 [[crates]]
 name = "integration-tests"
 path = "crates/integration-tests"
-source_hash = "aac4c12699676af8fe21e93d34f89e949cb223964b97aad5e7db0e16b3231f2f"
+source_hash = "83f34cf41a2b7b27d6980b6e59a4286ba91274b9d3dbf5b26fa09735b8f77d68"
 l3_token_estimate = 1170
 
 [[crates]]
@@ -266,7 +266,7 @@ l3_token_estimate = 1354
 [[crates]]
 name = "pylon"
 path = "crates/pylon"
-source_hash = "6d5dbe440cc846a6ffe2f4a60639f700378f556c8df7576a61b4f30342d1de38"
+source_hash = "7daca293eb5f57e6ec3d1a908d8e7dc14081a494f61b65b1b45d365c8eecd22b"
 l3_token_estimate = 17977
 
 [[crates]]

--- a/crates/episteme/src/consolidation/engine.rs
+++ b/crates/episteme/src/consolidation/engine.rs
@@ -509,11 +509,11 @@ impl KnowledgeStore {
 ?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by,
    source_session_id, recorded_at, access_count, last_accessed_at,
    stability_hours, fact_type, is_forgotten, forgotten_at, forget_reason,
-   scope, project_id, visibility] :=
+   scope, project_id, visibility, sensitivity] :=
     *facts{id, valid_from, content, nous_id, confidence, tier,
            source_session_id, recorded_at, access_count, last_accessed_at,
            stability_hours, fact_type, is_forgotten, forgotten_at, forget_reason,
-           scope, project_id, visibility},
+           scope, project_id, visibility, sensitivity},
     id = $id,
     valid_to = $now,
     superseded_by = $superseding_id
@@ -521,7 +521,7 @@ impl KnowledgeStore {
 :put facts {id, valid_from => content, nous_id, confidence, tier, valid_to,
             superseded_by, source_session_id, recorded_at, access_count,
             last_accessed_at, stability_hours, fact_type, is_forgotten,
-            forgotten_at, forget_reason, scope, project_id, visibility}
+            forgotten_at, forget_reason, scope, project_id, visibility, sensitivity}
 ";
         let mut params = BTreeMap::new();
         params.insert("id".to_owned(), DataValue::Str(fact_id.as_str().into()));

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -265,6 +265,28 @@ impl KnowledgeStore {
         );
         params.insert(String::from("old_forgotten_at"), DataValue::Null);
         params.insert(String::from("old_forget_reason"), DataValue::Null);
+        params.insert(
+            String::from("old_scope"),
+            old_fact
+                .scope
+                .as_ref()
+                .map_or(DataValue::Null, |s| DataValue::Str(s.as_str().into())),
+        );
+        params.insert(
+            String::from("old_project_id"),
+            old_fact
+                .project_id
+                .as_ref()
+                .map_or(DataValue::Null, |id| DataValue::Str(id.as_str().into())),
+        );
+        params.insert(
+            String::from("old_visibility"),
+            DataValue::Str(old_fact.visibility.as_str().into()),
+        );
+        params.insert(
+            String::from("old_sensitivity"),
+            DataValue::Str(old_fact.sensitivity.as_str().into()),
+        );
 
         params.insert(
             String::from("new_content"),
@@ -296,6 +318,28 @@ impl KnowledgeStore {
         params.insert(
             String::from("fact_type"),
             DataValue::Str(new_fact.fact_type.as_str().into()),
+        );
+        params.insert(
+            String::from("scope"),
+            new_fact
+                .scope
+                .as_ref()
+                .map_or(DataValue::Null, |s| DataValue::Str(s.as_str().into())),
+        );
+        params.insert(
+            String::from("project_id"),
+            new_fact
+                .project_id
+                .as_ref()
+                .map_or(DataValue::Null, |id| DataValue::Str(id.as_str().into())),
+        );
+        params.insert(
+            String::from("visibility"),
+            DataValue::Str(new_fact.visibility.as_str().into()),
+        );
+        params.insert(
+            String::from("sensitivity"),
+            DataValue::Str(new_fact.sensitivity.as_str().into()),
         );
 
         self.run_mut(&queries::supersede_fact(), params)
@@ -413,11 +457,12 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       scope, project_id, visibility},
+                       scope, project_id, visibility, sensitivity},
                 id = $id,
                 is_forgotten = true,
                 forgotten_at = $now,
@@ -425,7 +470,8 @@ impl KnowledgeStore {
             :put facts {id, valid_from => content, nous_id, confidence, tier,
                         valid_to, superseded_by, source_session_id, recorded_at,
                         access_count, last_accessed_at, stability_hours, fact_type,
-                        is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
+                        is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                        visibility, sensitivity}
         ";
         let mut params = std::collections::BTreeMap::new();
         params.insert(
@@ -471,11 +517,12 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       scope, project_id, visibility},
+                       scope, project_id, visibility, sensitivity},
                 id = $id,
                 is_forgotten = false,
                 forgotten_at = null,
@@ -483,7 +530,8 @@ impl KnowledgeStore {
             :put facts {id, valid_from => content, nous_id, confidence, tier,
                         valid_to, superseded_by, source_session_id, recorded_at,
                         access_count, last_accessed_at, stability_hours, fact_type,
-                        is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
+                        is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                        visibility, sensitivity}
         ";
         let mut params = std::collections::BTreeMap::new();
         params.insert(
@@ -727,11 +775,13 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                       visibility, sensitivity}
             :order -recorded_at
             :limit $limit
         ";
@@ -878,18 +928,6 @@ impl KnowledgeStore {
     ///
     /// Returns the updated fact. Errors if no fact with the given ID exists.
     ///
-    /// # Note on persistence
-    ///
-    /// The current `facts` Datalog schema does not carry a sensitivity
-    /// column; this method round-trips the Rust-side [`Fact`] struct, so
-    /// the sensitivity survives for the in-memory flow through
-    /// [`read_facts_by_id`] → mutate → [`insert_fact`] but is not yet
-    /// persisted across restarts. A follow-up schema migration will lift
-    /// it to the store (tracked in #3413).
-    ///
-    /// [`Fact`]: crate::knowledge::Fact
-    /// [`read_facts_by_id`]: Self::read_facts_by_id
-    /// [`insert_fact`]: Self::insert_fact
     #[instrument(skip(self))]
     pub(crate) fn update_sensitivity(
         &self,
@@ -969,11 +1007,13 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                       visibility, sensitivity},
                 nous_id == $nous_id,
                 fact_type == $fact_type,
                 is_forgotten == false

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -112,6 +112,10 @@ pub(super) fn fact_to_params(
         "visibility".to_owned(),
         DataValue::Str(fact.visibility.as_str().into()),
     );
+    p.insert(
+        "sensitivity".to_owned(),
+        DataValue::Str(fact.sensitivity.as_str().into()),
+    );
     p
 }
 
@@ -392,6 +396,7 @@ pub(super) fn rows_to_facts(
             .unwrap_or_default()
             .parse::<crate::knowledge::Visibility>()
             .unwrap_or_default();
+        let sensitivity = parse_fact_sensitivity(row.get(20));
 
         let fact_id = crate::id::FactId::new(id).context(crate::error::InvalidIdSnafu)?;
         let superseded_by_id = superseded_by
@@ -434,7 +439,7 @@ pub(super) fn rows_to_facts(
                 access_count,
                 last_accessed_at: crate::knowledge::parse_timestamp(&last_accessed_at),
             },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity,
         });
     }
     Ok(out)
@@ -555,6 +560,7 @@ pub(super) fn rows_to_raw_facts(
             .unwrap_or_default()
             .parse::<crate::knowledge::Visibility>()
             .unwrap_or_default();
+        let sensitivity = parse_fact_sensitivity(row.get(20));
         let fact_id = crate::id::FactId::new(id).context(crate::error::InvalidIdSnafu)?;
         let superseded_by_id = superseded_by
             .map(crate::id::FactId::new)
@@ -592,7 +598,7 @@ pub(super) fn rows_to_raw_facts(
                 access_count,
                 last_accessed_at: crate::knowledge::parse_timestamp(&last_accessed_at),
             },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity,
         });
     }
     Ok(out)
@@ -630,6 +636,7 @@ pub(super) fn rows_to_facts_partial(
             .build()
         })?)?;
         let tier = parse_epistemic_tier(&tier_str);
+        let sensitivity = parse_fact_sensitivity(row.get(4));
 
         let fact_id = crate::id::FactId::new(id).context(crate::error::InvalidIdSnafu)?;
         out.push(Fact {
@@ -661,7 +668,7 @@ pub(super) fn rows_to_facts_partial(
                 access_count: 0,
                 last_accessed_at: None,
             },
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity,
         });
     }
     Ok(out)
@@ -725,16 +732,14 @@ pub(super) fn rows_to_recall_results(
             .get(8)
             .and_then(|v| extract_str(v).ok())
             .unwrap_or_default();
+        let sensitivity = parse_fact_sensitivity(row.get(9));
         out.push(RecallResult {
             content,
             distance,
             source_type,
             source_id,
             nous_id,
-            // WHY (#3404, #3413): embeddings relation does not carry
-            // sensitivity; `search_vectors` hydrates it from the facts
-            // table before results reach the recall scorer.
-            sensitivity: crate::knowledge::FactSensitivity::Public,
+            sensitivity,
             graph_importance: 0.0,
             scope,
             project_id,
@@ -944,6 +949,16 @@ pub(super) fn extract_bool(val: &crate::engine::DataValue) -> crate::error::Resu
         }
         .build()),
     }
+}
+
+#[cfg(feature = "mneme-engine")]
+fn parse_fact_sensitivity(
+    val: Option<&crate::engine::DataValue>,
+) -> crate::knowledge::FactSensitivity {
+    val.and_then(|v| extract_str(v).ok())
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<crate::knowledge::FactSensitivity>().ok())
+        .unwrap_or_default()
 }
 
 #[cfg(feature = "mneme-engine")]

--- a/crates/episteme/src/knowledge_store/migration.rs
+++ b/crates/episteme/src/knowledge_store/migration.rs
@@ -58,6 +58,10 @@ pub(super) const MIGRATIONS: &[MigrationStep] = &[
         target_version: 13,
         run: KnowledgeStore::migrate_v12_to_v13,
     },
+    MigrationStep {
+        target_version: 14,
+        run: KnowledgeStore::migrate_v13_to_v14,
+    },
 ];
 
 #[cfg(feature = "mneme-engine")]
@@ -903,6 +907,142 @@ impl KnowledgeStore {
         self.stamp_schema_version(13, "v12->v13")?;
 
         tracing::info!("knowledge schema migration v12 -> v13 complete");
+        Ok(())
+    }
+
+    /// Migrate v13 → v14: add `sensitivity` to `facts`.
+    ///
+    /// Existing rows predate durable sensitivity storage, so the migration
+    /// backfills the documented default (`public`) explicitly. Runtime
+    /// sensitivity edits and recall filtering then hydrate from the facts
+    /// relation instead of reconstructing protected facts as public after a
+    /// restart.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "migration is a single linear sequence"
+    )]
+    pub(super) fn migrate_v13_to_v14(&self) -> crate::error::Result<()> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::ScriptMutability;
+        tracing::info!("migrating knowledge schema v13 -> v14");
+
+        let all_facts = self
+            .db
+            .run(
+                r"?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+                    superseded_by, source_session_id, recorded_at,
+                    access_count, last_accessed_at, stability_hours, fact_type,
+                    is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+                    *facts{id, valid_from, content, nous_id, confidence, tier,
+                           valid_to, superseded_by, source_session_id, recorded_at,
+                           access_count, last_accessed_at, stability_hours, fact_type,
+                           is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}",
+                BTreeMap::new(),
+                ScriptMutability::Immutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v13->v14 read facts: {e}"),
+                }
+                .build()
+            })?;
+
+        let _ = self.db.run(
+            "::fts drop facts:content_fts",
+            BTreeMap::new(),
+            ScriptMutability::Mutable,
+        );
+
+        self.db
+            .run("::remove facts", BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v13->v14 remove facts: {e}"),
+                }
+                .build()
+            })?;
+
+        self.db
+            .run(KNOWLEDGE_DDL[0], BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v13->v14 recreate facts: {e}"),
+                }
+                .build()
+            })?;
+
+        for row in &all_facts.rows {
+            let script = r"
+                ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+                  superseded_by, source_session_id, recorded_at,
+                  access_count, last_accessed_at, stability_hours, fact_type,
+                  is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                  visibility, sensitivity] <- [[
+                    $id, $valid_from, $content, $nous_id, $confidence, $tier, $valid_to,
+                    $superseded_by, $source_session_id, $recorded_at,
+                    $access_count, $last_accessed_at, $stability_hours, $fact_type,
+                    $is_forgotten, $forgotten_at, $forget_reason, $scope, $project_id,
+                    $visibility, 'public'
+                ]]
+                :put facts {id, valid_from => content, nous_id, confidence, tier,
+                            valid_to, superseded_by, source_session_id, recorded_at,
+                            access_count, last_accessed_at, stability_hours, fact_type,
+                            is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                            visibility, sensitivity}
+            ";
+            let mut params = BTreeMap::new();
+            for (i, name) in [
+                "id",
+                "valid_from",
+                "content",
+                "nous_id",
+                "confidence",
+                "tier",
+                "valid_to",
+                "superseded_by",
+                "source_session_id",
+                "recorded_at",
+                "access_count",
+                "last_accessed_at",
+                "stability_hours",
+                "fact_type",
+                "is_forgotten",
+                "forgotten_at",
+                "forget_reason",
+                "scope",
+                "project_id",
+                "visibility",
+            ]
+            .iter()
+            .enumerate()
+            {
+                if let Some(val) = row.get(i) {
+                    params.insert((*name).to_owned(), val.clone());
+                }
+            }
+            self.db
+                .run(script, params, ScriptMutability::Mutable)
+                .map_err(|e| {
+                    crate::error::EngineQuerySnafu {
+                        message: format!("v13->v14 reinsert fact: {e}"),
+                    }
+                    .build()
+                })?;
+        }
+
+        self.db
+            .run(fts_ddl(), BTreeMap::new(), ScriptMutability::Mutable)
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("v13->v14 recreate FTS: {e}"),
+                }
+                .build()
+            })?;
+
+        self.stamp_schema_version(14, "v13->v14")?;
+
+        tracing::info!("knowledge schema migration v13 -> v14 complete");
         Ok(())
     }
 }

--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -16,7 +16,7 @@
 //!         access_count: Int, last_accessed_at: String, stability_hours: Float,
 //!         fact_type: String, is_forgotten: Bool, forgotten_at: String?,
 //!         forget_reason: String?, scope: String?, project_id: String?,
-//!         visibility: String }
+//!         visibility: String, sensitivity: String }
 //!
 //! entities { id: String => name: String, entity_type: String, aliases: String,
 //!            created_at: String, updated_at: String,
@@ -92,7 +92,8 @@ pub const KNOWLEDGE_DDL: &[&str] = &[
         forget_reason: String?,
         scope: String?,
         project_id: String?,
-        visibility: String default 'private'
+        visibility: String default 'private',
+        sensitivity: String default 'public'
     }",
     // WHY: index 1 is a sentinel — `init_schema` skips this entry and runs
     // the dim-parameterized `entities_ddl(self.dim)` instead so the relation
@@ -551,7 +552,7 @@ pub struct KnowledgeStore {
 
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
-    const SCHEMA_VERSION: i64 = 13;
+    pub(crate) const SCHEMA_VERSION: i64 = 14;
     const MIN_SCHEMA_VERSION: i64 = 1;
 
     /// Open an in-memory knowledge store with default configuration.
@@ -1293,11 +1294,13 @@ impl KnowledgeStore {
             ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
               superseded_by, source_session_id, recorded_at,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
                 *facts{id, valid_from, content, nous_id, confidence, tier,
                        valid_to, superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                       visibility, sensitivity},
                 id = $id
         ";
         let mut params = BTreeMap::new();

--- a/crates/episteme/src/knowledge_store/search.rs
+++ b/crates/episteme/src/knowledge_store/search.rs
@@ -71,9 +71,9 @@ impl KnowledgeStore {
         let mut results = rows_to_recall_results(rows)?;
 
         // WHY: Semantic search returns from the embeddings relation, which does
-        // not carry scope or visibility. Hydrate these fields from the facts
-        // table for fact-type results so downstream quota and visibility
-        // filters see accurate values.
+        // not carry scope, visibility, or sensitivity. Hydrate these fields from
+        // the facts table for fact-type results so downstream filters see
+        // accurate values.
         self.hydrate_recall_scope_visibility(&mut results);
 
         // WHY: Filter out forgotten facts; the HNSW index does not carry is_forgotten.
@@ -235,7 +235,7 @@ impl KnowledgeStore {
         }
     }
 
-    /// Hydrate recall results with `scope`, `project_id`, and `visibility` from the `facts` relation.
+    /// Hydrate recall results with `scope`, `project_id`, `visibility`, and `sensitivity`.
     ///
     /// Semantic search returns from the `embeddings` relation, which does not
     /// carry these fields. This enrichment looks them up from `facts` for
@@ -244,8 +244,8 @@ impl KnowledgeStore {
     fn hydrate_recall_scope_visibility(&self, results: &mut [crate::knowledge::RecallResult]) {
         for result in results.iter_mut().filter(|r| r.source_type == "fact") {
             let script = r"
-                ?[scope, project_id, visibility] :=
-                    *facts{id: $fid, scope, project_id, visibility}
+                ?[scope, project_id, visibility, sensitivity] :=
+                    *facts{id: $fid, scope, project_id, visibility, sensitivity}
             ";
             let mut params = std::collections::BTreeMap::new();
             params.insert(
@@ -286,6 +286,13 @@ impl KnowledgeStore {
                         .parse::<crate::knowledge::Visibility>()
                         .unwrap_or_default();
                 }
+                if let Some(sensitivity_str) = row.get(3).and_then(|v| v.get_str())
+                    && !sensitivity_str.is_empty()
+                {
+                    result.sensitivity = sensitivity_str
+                        .parse::<crate::knowledge::FactSensitivity>()
+                        .unwrap_or_default();
+                }
             }
         }
     }
@@ -296,6 +303,10 @@ impl KnowledgeStore {
     /// additional active facts linked to entities in those clusters. Adds
     /// new results with a neutral distance of 1.0, deduplicating by `source_id`.
     /// Limits expansion to at most `k` additional results.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "cluster expansion keeps query, hydration, and append logic together"
+    )]
     fn expand_recall_by_cluster(
         &self,
         results: &mut Vec<crate::knowledge::RecallResult>,
@@ -348,10 +359,11 @@ impl KnowledgeStore {
 
         for cluster_id in context_clusters {
             let script = r"
-                ?[fact_id, content, nous_id] :=
+                ?[fact_id, content, nous_id, sensitivity, scope, project_id, visibility] :=
                     *graph_scores{entity_id, score_type: 'cluster', cluster_id: $cid},
                     *fact_entities{fact_id: fid, entity_id},
-                    *facts{id: fid, content, nous_id, is_forgotten, superseded_by},
+                    *facts{id: fid, content, nous_id, is_forgotten, superseded_by,
+                           sensitivity, scope, project_id, visibility},
                     is_forgotten == false,
                     is_null(superseded_by),
                     fact_id = fid
@@ -383,17 +395,36 @@ impl KnowledgeStore {
                     .and_then(|v| v.get_str())
                     .unwrap_or("")
                     .to_owned();
+                let sensitivity = row
+                    .get(3)
+                    .and_then(|v| v.get_str())
+                    .and_then(|s| s.parse::<crate::knowledge::FactSensitivity>().ok())
+                    .unwrap_or_default();
+                let scope = row
+                    .get(4)
+                    .and_then(|v| v.get_str())
+                    .filter(|s| !s.is_empty())
+                    .and_then(|s| s.parse::<crate::knowledge::MemoryScope>().ok());
+                let project_id = row
+                    .get(5)
+                    .and_then(|v| v.get_str())
+                    .and_then(|s| eidos::workspace::ProjectId::from_sha256_hex(s).ok());
+                let visibility = row
+                    .get(6)
+                    .and_then(|v| v.get_str())
+                    .and_then(|s| s.parse::<crate::knowledge::Visibility>().ok())
+                    .unwrap_or_default();
                 results.push(crate::knowledge::RecallResult {
                     content,
                     distance: 1.0,
                     source_type: "fact".to_owned(),
                     source_id: fact_id.to_owned(),
                     nous_id,
-                    sensitivity: crate::knowledge::FactSensitivity::Public,
+                    sensitivity,
                     graph_importance: 0.0,
-                    scope: None,
-                    project_id: None,
-                    visibility: crate::knowledge::Visibility::Private,
+                    scope,
+                    project_id,
+                    visibility,
                     source_count: 0,
                 });
                 added += 1;

--- a/crates/episteme/src/knowledge_store/skills.rs
+++ b/crates/episteme/src/knowledge_store/skills.rs
@@ -60,11 +60,13 @@ impl KnowledgeStore {
         let script = r"?[id, content, confidence, tier, recorded_at, nous_id,
               valid_from, valid_to, superseded_by, source_session_id,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
             *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                    superseded_by, source_session_id, recorded_at,
                    access_count, last_accessed_at, stability_hours, fact_type,
-                   is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+                   is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                   visibility, sensitivity},
             nous_id = $nous_id,
             fact_type = 'skill',
             is_null(superseded_by),
@@ -113,12 +115,14 @@ impl KnowledgeStore {
             ?[id, content, confidence, tier, recorded_at, nous_id,
               valid_from, valid_to, superseded_by, source_session_id,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
                 candidates[id, _score],
                 *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                        superseded_by, source_session_id, recorded_at,
                        access_count, last_accessed_at, stability_hours, fact_type,
-                       is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                       visibility, sensitivity},
                 nous_id = $nous_id,
                 fact_type = 'skill',
                 is_null(superseded_by),
@@ -167,11 +171,13 @@ impl KnowledgeStore {
         let script = r"?[id, content, confidence, tier, recorded_at, nous_id,
               valid_from, valid_to, superseded_by, source_session_id,
               access_count, last_accessed_at, stability_hours, fact_type,
-              is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
             *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                    superseded_by, source_session_id, recorded_at,
                    access_count, last_accessed_at, stability_hours, fact_type,
-                   is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+                   is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                   visibility, sensitivity},
             nous_id = $nous_id,
             fact_type = 'skill_pending',
             is_null(superseded_by),

--- a/crates/episteme/src/knowledge_store/tests/ddl.rs
+++ b/crates/episteme/src/knowledge_store/tests/ddl.rs
@@ -22,6 +22,10 @@ fn ddl_templates_are_valid_strings() {
     let fts = fts_ddl();
     assert!(fts.contains("content_fts"));
     assert!(fts.contains("bm25") || fts.contains("Simple"));
+    assert!(
+        KNOWLEDGE_DDL[0].contains("sensitivity: String default 'public'"),
+        "facts DDL should persist sensitivity with documented default"
+    );
 }
 
 #[cfg(feature = "mneme-engine")]

--- a/crates/episteme/src/knowledge_store/tests/facts/crud.rs
+++ b/crates/episteme/src/knowledge_store/tests/facts/crud.rs
@@ -122,6 +122,88 @@ fn insert_fact_with_scope_and_visibility_roundtrips() {
 }
 
 #[test]
+fn insert_fact_with_each_sensitivity_roundtrips() {
+    let store = make_store();
+    for sensitivity in [
+        crate::knowledge::FactSensitivity::Public,
+        crate::knowledge::FactSensitivity::Internal,
+        crate::knowledge::FactSensitivity::Confidential,
+    ] {
+        let mut fact = make_fact(
+            &format!("f-{}", sensitivity.as_str()),
+            "agent-a",
+            &format!("{} sensitivity fact", sensitivity.as_str()),
+        );
+        fact.sensitivity = sensitivity;
+        store.insert_fact(&fact).expect("insert fact");
+
+        let results = store
+            .read_facts_by_id(fact.id.as_str())
+            .expect("read fact by id");
+        assert_eq!(results.len(), 1, "should retrieve inserted fact");
+        assert_eq!(
+            results[0].sensitivity, sensitivity,
+            "sensitivity should roundtrip through storage"
+        );
+    }
+}
+
+#[cfg(feature = "storage-fjall")]
+#[test]
+fn sensitivity_survives_fjall_reopen_for_each_level() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("knowledge.fjall").join("shared");
+
+    {
+        let store = KnowledgeStore::open_fjall(
+            &path,
+            KnowledgeConfig {
+                dim: crate::test_fixtures::DIM,
+                ..Default::default()
+            },
+        )
+        .expect("open fjall store");
+        for sensitivity in [
+            crate::knowledge::FactSensitivity::Public,
+            crate::knowledge::FactSensitivity::Internal,
+            crate::knowledge::FactSensitivity::Confidential,
+        ] {
+            let mut fact = make_fact(
+                &format!("f-reload-{}", sensitivity.as_str()),
+                "agent-a",
+                &format!("{} reload fact", sensitivity.as_str()),
+            );
+            fact.sensitivity = sensitivity;
+            store.insert_fact(&fact).expect("insert fact");
+        }
+    }
+
+    let reopened = KnowledgeStore::open_fjall(
+        &path,
+        KnowledgeConfig {
+            dim: crate::test_fixtures::DIM,
+            ..Default::default()
+        },
+    )
+    .expect("reopen fjall store");
+
+    for sensitivity in [
+        crate::knowledge::FactSensitivity::Public,
+        crate::knowledge::FactSensitivity::Internal,
+        crate::knowledge::FactSensitivity::Confidential,
+    ] {
+        let facts = reopened
+            .read_facts_by_id(&format!("f-reload-{}", sensitivity.as_str()))
+            .expect("read fact after reopen");
+        assert_eq!(facts.len(), 1, "reopened store should return fact");
+        assert_eq!(
+            facts[0].sensitivity, sensitivity,
+            "sensitivity should survive store reopen"
+        );
+    }
+}
+
+#[test]
 fn insert_multiple_facts_and_retrieve() {
     let store = make_store();
     for i in 0..5 {

--- a/crates/episteme/src/knowledge_store/tests/migration.rs
+++ b/crates/episteme/src/knowledge_store/tests/migration.rs
@@ -132,6 +132,12 @@ fn crash_mid_sequence_resume_applies_only_missing_tail() {
         )
         .expect("remove v13 stamp");
     store
+        .run_mut_query(
+            r#"?[key] <- [["migration:14"]] :rm schema_version {key}"#,
+            std::collections::BTreeMap::new(),
+        )
+        .expect("remove v14 stamp");
+    store
         .stamp_schema_version(12, "test")
         .expect("stamp partial migration state");
 
@@ -149,6 +155,13 @@ fn crash_mid_sequence_resume_applies_only_missing_tail() {
             .expect("read v13 stamp")
             .expect("v13 stamp present"),
         13
+    );
+    assert_eq!(
+        store
+            .migration_stamp_version(14)
+            .expect("read v14 stamp")
+            .expect("v14 stamp present"),
+        14
     );
 }
 
@@ -185,3 +198,78 @@ fn make_store() -> std::sync::Arc<KnowledgeStore> {
     })
     .expect("open in-memory knowledge store")
 }
+
+#[test]
+fn v14_migration_backfills_existing_fact_sensitivity_to_public() {
+    let store = make_store();
+    store
+        .run_mut_query(
+            "::fts drop facts:content_fts",
+            std::collections::BTreeMap::new(),
+        )
+        .expect("drop facts FTS index");
+    store
+        .run_mut_query("::remove facts", std::collections::BTreeMap::new())
+        .expect("remove current facts relation");
+    store
+        .run_mut_query(V13_FACTS_DDL, std::collections::BTreeMap::new())
+        .expect("create v13 facts relation");
+    store
+        .run_mut_query(INSERT_V13_FACT, std::collections::BTreeMap::new())
+        .expect("insert v13 fact");
+    store
+        .stamp_schema_version(13, "test")
+        .expect("stamp v13 schema");
+
+    store.init_schema().expect("apply v14 migration");
+
+    let facts = store.read_facts_by_id("f-v13").expect("read migrated fact");
+    assert_eq!(facts.len(), 1, "migration should preserve the fact row");
+    let fact = facts.first().expect("migrated fact present");
+    assert_eq!(
+        fact.sensitivity,
+        crate::knowledge::FactSensitivity::Public,
+        "v14 migration must explicitly backfill the documented default"
+    );
+    assert_eq!(
+        store.schema_version().expect("schema version"),
+        KnowledgeStore::SCHEMA_VERSION
+    );
+}
+
+const V13_FACTS_DDL: &str = r":create facts {
+    id: String, valid_from: String =>
+    content: String,
+    nous_id: String,
+    confidence: Float,
+    tier: String,
+    valid_to: String,
+    superseded_by: String?,
+    source_session_id: String?,
+    recorded_at: String,
+    access_count: Int,
+    last_accessed_at: String,
+    stability_hours: Float,
+    fact_type: String,
+    is_forgotten: Bool default false,
+    forgotten_at: String?,
+    forget_reason: String?,
+    scope: String?,
+    project_id: String?,
+    visibility: String default 'private'
+}";
+
+const INSERT_V13_FACT: &str = r#"
+?[id, valid_from, content, nous_id, confidence, tier, valid_to, superseded_by,
+  source_session_id, recorded_at, access_count, last_accessed_at,
+  stability_hours, fact_type, is_forgotten, forgotten_at, forget_reason,
+  scope, project_id, visibility] <- [[
+    "f-v13", "2026-01-01T00:00:00Z", "legacy fact", "alice", 0.8,
+    "inferred", "9999-12-31", null, null, "2026-01-01T00:00:00Z",
+    0, "", 720.0, "knowledge", false, null, null, null, null, "private"
+]]
+:put facts {id, valid_from => content, nous_id, confidence, tier, valid_to,
+            superseded_by, source_session_id, recorded_at, access_count,
+            last_accessed_at, stability_hours, fact_type, is_forgotten,
+            forgotten_at, forget_reason, scope, project_id, visibility}
+"#;

--- a/crates/episteme/src/query/queries.rs
+++ b/crates/episteme/src/query/queries.rs
@@ -38,6 +38,7 @@ pub(crate) fn upsert_fact() -> String {
             Scope,
             ProjectId,
             Visibility,
+            Sensitivity,
         ])
         .done()
         .build_script()
@@ -74,6 +75,7 @@ pub(crate) fn current_facts() -> String {
         .bind(Scope)
         .bind(ProjectId)
         .bind(Visibility)
+        .bind(Sensitivity)
         .filter("nous_id = $nous_id")
         .filter("valid_from <= $now")
         .filter("valid_to > $now")
@@ -113,6 +115,7 @@ pub(crate) fn full_current_facts() -> String {
             Scope,
             ProjectId,
             Visibility,
+            Sensitivity,
         ])
         .bind(Id)
         .bind(ValidFrom)
@@ -134,6 +137,7 @@ pub(crate) fn full_current_facts() -> String {
         .bind(Scope)
         .bind(ProjectId)
         .bind(Visibility)
+        .bind(Sensitivity)
         .filter("nous_id = $nous_id")
         .filter("valid_from <= $now")
         .filter("valid_to > $now")
@@ -151,13 +155,14 @@ pub(crate) fn facts_at_time() -> String {
     use FactsField::*;
     QueryBuilder::new()
         .scan(Relation::Facts)
-        .select(&[Id, Content, Confidence, Tier])
+        .select(&[Id, Content, Confidence, Tier, Sensitivity])
         .bind(Id)
         .bind(ValidFrom)
         .bind(Content)
         .bind(Confidence)
         .bind(Tier)
         .bind(ValidTo)
+        .bind(Sensitivity)
         .bind(IsForgotten)
         .bind(Scope)
         .bind(ProjectId)
@@ -199,6 +204,7 @@ pub(crate) fn supersede_fact() -> String {
             Scope,
             ProjectId,
             Visibility,
+            Sensitivity,
         ])
         .row(&[
             "$old_id",
@@ -221,6 +227,7 @@ pub(crate) fn supersede_fact() -> String {
             "$old_scope",
             "$old_project_id",
             "$old_visibility",
+            "$old_sensitivity",
         ])
         .row(&[
             "$new_id",
@@ -243,6 +250,7 @@ pub(crate) fn supersede_fact() -> String {
             "$scope",
             "$project_id",
             "$visibility",
+            "$sensitivity",
         ])
         .done()
         .build_script()
@@ -315,14 +323,14 @@ pub(crate) const ENTITY_NEIGHBORHOOD: &str = r"
 
 /// BM25 full-text recall (no vector embeddings required).
 /// Returns rows: id, content, `source_type`, `source_id`, dist, scope, `project_id`,
-/// visibility, `nous_id`.
+/// visibility, `nous_id`, sensitivity.
 /// Params: `$query_text`, `$k`.
 pub(crate) const BM25_RECALL: &str = r"
     bm25[id, score] := ~facts:content_fts{id | query: $query_text, k: $k, score_kind: 'bm25', bind_score: score}
 
-    ?[id, content, source_type, source_id, dist, scope, project_id, visibility, nous_id] :=
+    ?[id, content, source_type, source_id, dist, scope, project_id, visibility, nous_id, sensitivity] :=
         bm25[id, bm25_score],
-        *facts{id, content, is_forgotten, superseded_by, scope, project_id, visibility, nous_id},
+        *facts{id, content, is_forgotten, superseded_by, scope, project_id, visibility, nous_id, sensitivity},
         is_forgotten == false,
         is_null(superseded_by),
         source_type = 'fact',
@@ -334,16 +342,17 @@ pub(crate) const BM25_RECALL: &str = r"
 
 /// KNN vector search. Params: `$query_vec`, `$k`, `$ef`.
 /// Returns rows: id, content, `source_type`, `source_id`, dist, scope(null), `project_id`(null),
-/// visibility(empty), `nous_id`. The `scope`, `project_id`, and `visibility` columns are null
-/// here and hydrated by `search_vectors` from the facts table; `nous_id` comes directly from
-/// the embeddings relation.
+/// visibility(empty), `nous_id`, sensitivity(empty). The `scope`, `project_id`, `visibility`,
+/// and `sensitivity` columns are placeholders hydrated by `search_vectors` from the facts table;
+/// `nous_id` comes directly from the embeddings relation.
 pub(crate) const SEMANTIC_SEARCH: &str = r"
-    ?[id, content, source_type, source_id, dist, scope, project_id, visibility, nous_id] :=
+    ?[id, content, source_type, source_id, dist, scope, project_id, visibility, nous_id, sensitivity] :=
         ~embeddings:semantic_idx {id, content, source_type, source_id, nous_id |
             query: $query_vec, k: $k, ef: $ef, bind_distance: dist},
         scope = null,
         project_id = null,
-        visibility = ''
+        visibility = '',
+        sensitivity = ''
 ";
 
 #[expect(
@@ -408,7 +417,9 @@ pub(crate) fn temporal_facts() -> String {
             ForgottenAt,
             ForgetReason,
             Scope,
+            ProjectId,
             Visibility,
+            Sensitivity,
         ])
         .bind(Id)
         .bind(ValidFrom)
@@ -428,7 +439,9 @@ pub(crate) fn temporal_facts() -> String {
         .bind(ForgottenAt)
         .bind(ForgetReason)
         .bind(Scope)
+        .bind(ProjectId)
         .bind(Visibility)
+        .bind(Sensitivity)
         .filter("nous_id = $nous_id")
         .filter("is_forgotten == false")
         .filter("valid_from <= $at_time")
@@ -444,11 +457,11 @@ pub(crate) const TEMPORAL_FACTS_FILTERED: &str = r"
     ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
       superseded_by, source_session_id,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity] :=
         *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                superseded_by, source_session_id, recorded_at,
                access_count, last_accessed_at, stability_hours, fact_type,
-               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity},
         nous_id = $nous_id,
         is_forgotten == false,
         valid_from <= $at_time,
@@ -465,11 +478,11 @@ pub(crate) const TEMPORAL_DIFF_ADDED: &str = r"
     ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
       superseded_by, source_session_id,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity] :=
         *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                superseded_by, source_session_id, recorded_at,
                access_count, last_accessed_at, stability_hours, fact_type,
-               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity},
         nous_id = $nous_id,
         is_forgotten == false,
         valid_from > $from_time,
@@ -482,11 +495,11 @@ pub(crate) const TEMPORAL_DIFF_REMOVED: &str = r"
     ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to,
       superseded_by, source_session_id,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity] :=
         *facts{id, valid_from, content, nous_id, confidence, tier, valid_to,
                superseded_by, source_session_id, recorded_at,
                access_count, last_accessed_at, stability_hours, fact_type,
-               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity},
         nous_id = $nous_id,
         is_forgotten == false,
         valid_to > $from_time,
@@ -519,7 +532,9 @@ pub(crate) fn forgotten_facts() -> String {
             ForgottenAt,
             ForgetReason,
             Scope,
+            ProjectId,
             Visibility,
+            Sensitivity,
         ])
         .bind(Id)
         .bind(ValidFrom)
@@ -539,7 +554,9 @@ pub(crate) fn forgotten_facts() -> String {
         .bind(ForgottenAt)
         .bind(ForgetReason)
         .bind(Scope)
+        .bind(ProjectId)
         .bind(Visibility)
+        .bind(Sensitivity)
         .filter("nous_id = $nous_id")
         .filter("is_forgotten == true")
         .order("-forgotten_at")
@@ -574,7 +591,9 @@ pub(crate) fn audit_all_facts() -> String {
             ForgottenAt,
             ForgetReason,
             Scope,
+            ProjectId,
             Visibility,
+            Sensitivity,
         ])
         .bind(Id)
         .bind(ValidFrom)
@@ -594,7 +613,9 @@ pub(crate) fn audit_all_facts() -> String {
         .bind(ForgottenAt)
         .bind(ForgetReason)
         .bind(Scope)
+        .bind(ProjectId)
         .bind(Visibility)
+        .bind(Sensitivity)
         .filter("nous_id = $nous_id")
         .order("-recorded_at")
         .limit("$limit")

--- a/crates/episteme/src/query/schema.rs
+++ b/crates/episteme/src/query/schema.rs
@@ -71,6 +71,7 @@ pub enum FactsField {
     Scope,
     ProjectId,
     Visibility,
+    Sensitivity,
 }
 
 /// Fields in the `entities` relation.

--- a/crates/episteme/src/query/schema/field_impl.rs
+++ b/crates/episteme/src/query/schema/field_impl.rs
@@ -28,6 +28,7 @@ impl Field for FactsField {
             Self::Scope => "scope",
             Self::ProjectId => "project_id",
             Self::Visibility => "visibility",
+            Self::Sensitivity => "sensitivity",
         }
     }
 }

--- a/crates/episteme/src/query/tests/builders.rs
+++ b/crates/episteme/src/query/tests/builders.rs
@@ -24,15 +24,15 @@ fn test_builder_matches_upsert_fact() {
     ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
       superseded_by, source_session_id, recorded_at,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] <- [[$id, $valid_from,
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity] <- [[$id, $valid_from,
       $content, $nous_id, $confidence, $tier, $valid_to, $superseded_by,
       $source_session_id, $recorded_at,
       $access_count, $last_accessed_at, $stability_hours, $fact_type,
-      $is_forgotten, $forgotten_at, $forget_reason, $scope, $project_id, $visibility]]
+      $is_forgotten, $forgotten_at, $forget_reason, $scope, $project_id, $visibility, $sensitivity]]
     :put facts {id, valid_from => content, nous_id, confidence, tier,
                 valid_to, superseded_by, source_session_id, recorded_at,
                 access_count, last_accessed_at, stability_hours, fact_type,
-                is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
+                is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity}
 ";
     let built = queries::upsert_fact();
     assert_eq!(
@@ -49,7 +49,7 @@ fn test_builder_matches_current_facts() {
         *facts{id, valid_from, content, nous_id, confidence, tier,
                valid_to, superseded_by, recorded_at,
                access_count, last_accessed_at, stability_hours, fact_type,
-               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+               is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity},
         nous_id = $nous_id,
         valid_from <= $now,
         valid_to > $now,
@@ -69,8 +69,8 @@ fn test_builder_matches_current_facts() {
 #[test]
 fn test_builder_matches_facts_at_time() {
     let original = r"
-    ?[id, content, confidence, tier] :=
-        *facts{id, valid_from, content, confidence, tier, valid_to, is_forgotten, scope, project_id, visibility},
+    ?[id, content, confidence, tier, sensitivity] :=
+        *facts{id, valid_from, content, confidence, tier, valid_to, sensitivity, is_forgotten, scope, project_id, visibility},
         valid_from <= $time,
         valid_to > $time,
         is_forgotten == false
@@ -89,20 +89,20 @@ fn test_builder_matches_supersede_fact() {
     ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
       superseded_by, source_session_id, recorded_at,
       access_count, last_accessed_at, stability_hours, fact_type,
-      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] <- [
+      is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity] <- [
         [$old_id, $old_valid_from, $old_content, $nous_id, $old_confidence,
          $old_tier, $now, $new_id, $old_source, $old_recorded,
          $old_access_count, $old_last_accessed_at, $old_stability_hours, $old_fact_type,
-         $old_is_forgotten, $old_forgotten_at, $old_forget_reason, $old_scope, $old_project_id, $old_visibility],
+         $old_is_forgotten, $old_forgotten_at, $old_forget_reason, $old_scope, $old_project_id, $old_visibility, $old_sensitivity],
         [$new_id, $now, $new_content, $nous_id, $new_confidence,
          $new_tier, "9999-12-31", null, $source_session_id, $now,
          0, "", $stability_hours, $fact_type,
-         false, null, null, $scope, $project_id, $visibility]
+         false, null, null, $scope, $project_id, $visibility, $sensitivity]
     ]
     :put facts {id, valid_from => content, nous_id, confidence, tier,
                 valid_to, superseded_by, source_session_id, recorded_at,
                 access_count, last_accessed_at, stability_hours, fact_type,
-                is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility}
+                is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity}
 "#;
     let built = queries::supersede_fact();
     assert_eq!(
@@ -167,11 +167,11 @@ fn test_builder_matches_full_current_facts() {
     let original = r"
 ?[id, content, confidence, tier, recorded_at, nous_id, valid_from, valid_to, superseded_by, source_session_id,
   access_count, last_accessed_at, stability_hours, fact_type,
-  is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility] :=
+  is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity] :=
     *facts{id, valid_from, content, nous_id, confidence, tier,
            valid_to, superseded_by, source_session_id, recorded_at,
            access_count, last_accessed_at, stability_hours, fact_type,
-           is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility},
+           is_forgotten, forgotten_at, forget_reason, scope, project_id, visibility, sensitivity},
     nous_id = $nous_id,
     valid_from <= $now,
     valid_to > $now,

--- a/crates/episteme/src/query/tests/datalog.rs
+++ b/crates/episteme/src/query/tests/datalog.rs
@@ -166,6 +166,10 @@ fn test_field_names_match_schema() {
         "is_forgotten",
         "forgotten_at",
         "forget_reason",
+        "scope",
+        "project_id",
+        "visibility",
+        "sensitivity",
     ];
     let facts_enum_fields: Vec<&str> = [
         FactsField::Id,
@@ -185,6 +189,10 @@ fn test_field_names_match_schema() {
         FactsField::IsForgotten,
         FactsField::ForgottenAt,
         FactsField::ForgetReason,
+        FactsField::Scope,
+        FactsField::ProjectId,
+        FactsField::Visibility,
+        FactsField::Sensitivity,
     ]
     .iter()
     .map(|f| f.name())

--- a/crates/episteme/src/verification/tests.rs
+++ b/crates/episteme/src/verification/tests.rs
@@ -209,10 +209,9 @@ fn fresh_store_migrates_to_current_schema() {
 
     let store = KnowledgeStore::open_mem().expect("open_mem should succeed");
     let v = store.schema_version().expect("read schema version");
-    // #4165 Path A bumped to v13 to add the nullable `name_embedding`
-    // column on the entities relation.
     assert_eq!(
-        v, 13,
+        v,
+        KnowledgeStore::SCHEMA_VERSION,
         "fresh store should initialize at the current schema version"
     );
 

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -207,7 +207,7 @@ fn schema_version_queryable() {
     .expect("open_mem");
     let version = store.schema_version().expect("version");
     // NOTE: pins `KnowledgeStore::SCHEMA_VERSION`; bump when a migration lands.
-    assert_eq!(version, 13);
+    assert_eq!(version, 14);
 }
 
 // Verify ordering of multiple facts by confidence (descending).

--- a/crates/pylon/src/handlers/knowledge/knowledge_tests.rs
+++ b/crates/pylon/src/handlers/knowledge/knowledge_tests.rs
@@ -357,6 +357,78 @@ async fn get_entity_missing_returns_404() {
     }
 }
 
+#[cfg(feature = "knowledge-store")]
+#[tokio::test]
+async fn update_sensitivity_handler_persists_to_fact_list_path() {
+    use std::sync::Arc;
+
+    use axum::Json;
+    use axum::extract::{Path, State};
+    use symbolon::types::Role;
+
+    use crate::extract::Claims;
+    use crate::state::KnowledgeState;
+
+    let store = mneme::knowledge_store::KnowledgeStore::open_mem().unwrap();
+    let fact = make_fact("fact-sensitive", "Alice handles payroll", 0.95);
+    store.insert_fact(&fact).unwrap();
+
+    let config = taxis::config::AletheiaConfig::default();
+    let state = KnowledgeState {
+        knowledge_store: Some(Arc::clone(&store)),
+        config: Arc::new(tokio::sync::RwLock::new(config)),
+        event_bus: Arc::new(crate::event_bus::EventBus::new(16)),
+    };
+    let claims = Claims {
+        sub: "alice".to_owned(),
+        role: Role::Operator,
+        nous_id: None,
+    };
+
+    let response = match update_sensitivity(
+        State(state.clone()),
+        claims,
+        Path("fact-sensitive".to_owned()),
+        Json(UpdateSensitivityRequest {
+            sensitivity: "confidential".to_owned(),
+        }),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => panic!("update sensitivity: {error:?}"),
+    };
+
+    assert_eq!(response.0["status"], "updated");
+    assert_eq!(response.0["sensitivity"], "confidential");
+
+    let listed = match list_facts(
+        State(state),
+        Query(FactsQuery {
+            nous_id: Some("test-nous".to_owned()),
+            sort: "confidence".to_owned(),
+            order: "desc".to_owned(),
+            filter: None,
+            fact_type: None,
+            tier: None,
+            limit: 10,
+            offset: 0,
+            include_forgotten: false,
+        }),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => panic!("list facts: {error:?}"),
+    };
+
+    assert_eq!(listed.0.facts.len(), 1);
+    assert_eq!(
+        listed.0.facts[0].sensitivity,
+        mneme::knowledge::FactSensitivity::Confidential
+    );
+}
+
 #[test]
 fn default_limit_is_capped_at_max() {
     let config = taxis::config::ApiLimitsConfig::default();


### PR DESCRIPTION
Closes #4480

FactSensitivity was not persisted through the storage layer — sensitivity set at write time or via the desktop's curation actions (wave E) was lost on reload, silently downgrading protected facts to default visibility. Given the psyche local-only boundary, that's a security bug.

- Sensitivity persists through the full write path (extraction, curation updates, consolidation) and hydrates on every read path (fact queries, recall, export).
- **v13→v14 migration** registered through the new sequential `MigrationStep` registry (#4705): backfills existing rows to the documented default (`public`) explicitly, with the WHY in the migration doc comment.
- Desktop curation round-trip covered: the pylon update-sensitivity handler persists to the fact-list path (API-level test).
- Tests: per-level insert round-trip, sensitivity-survives-fjall-reopen per level, migration backfill correctness, handler persistence.

Worker-gated CI-exact on verda before push.