### PR TITLE
fix(episteme,nous): enforce scoped cross-nous recall — visibility in the query, not after it

### DIFF
--- a/_llm/L3-api-index/episteme.md
+++ b/_llm/L3-api-index/episteme.md
@@ -2166,9 +2166,22 @@ impl KnowledgeStore {
         rel: &crate::knowledge::Relationship,
     ) -> crate::error::Result<()>;
     pub fn remove_orphaned_entities (&self) -> crate::error::Result<usize>;
+    pub fn insert_fact_entity (
+        &self,
+        fact_id: &crate::id::FactId,
+        entity_id: &crate::id::EntityId,
+    ) -> crate::error::Result<()>;
     pub fn list_entities (&self) -> crate::error::Result<Vec<crate::knowledge::Entity>>;
+    pub fn list_entities_for_facts (
+        &self,
+        fact_ids: &[crate::id::FactId],
+    ) -> crate::error::Result<Vec<crate::knowledge::Entity>>;
     pub fn list_all_relationships (
         &self,
+    ) -> crate::error::Result<Vec<crate::knowledge::Relationship>>;
+    pub fn list_relationships_between_entities (
+        &self,
+        entity_ids: &std::collections::HashSet<String>,
     ) -> crate::error::Result<Vec<crate::knowledge::Relationship>>;
     pub fn find_duplicate_entities (
         &self,
@@ -2250,6 +2263,12 @@ impl KnowledgeStore {
         now: &str,
         limit: i64,
     ) -> crate::error::Result<Vec<crate::knowledge::Fact>>;
+    pub fn query_visible_facts (
+        &self,
+        requester_nous_id: &str,
+        now: &str,
+        limit: i64,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>>;
     pub async fn increment_access_async (
         self: &std::sync::Arc<Self>,
         fact_ids: Vec<crate::id::FactId>,
@@ -2263,6 +2282,11 @@ impl KnowledgeStore {
         self: &std::sync::Arc<Self>,
         nous_id: String,
         limit: i64,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>>;
+    pub fn read_visible_facts_by_id (
+        &self,
+        fact_id: &str,
+        requester_nous_id: &str,
     ) -> crate::error::Result<Vec<crate::knowledge::Fact>>;
     pub async fn query_facts_temporal_async (
         self: &std::sync::Arc<Self>,
@@ -2329,6 +2353,12 @@ impl KnowledgeStore {
     pub async fn query_facts_async (
         self: &std::sync::Arc<Self>,
         nous_id: String,
+        now: String,
+        limit: i64,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>>;
+    pub async fn query_visible_facts_async (
+        self: &std::sync::Arc<Self>,
+        requester_nous_id: String,
         now: String,
         limit: i64,
     ) -> crate::error::Result<Vec<crate::knowledge::Fact>>;
@@ -2633,25 +2663,61 @@ impl KnowledgeStore {
         k: i64,
         ef: i64,
     ) -> crate::error::Result<Vec<crate::knowledge::RecallResult>>;
+    pub fn search_vectors_scoped (
+        &self,
+        query_vec: Vec<f32>,
+        k: i64,
+        ef: i64,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<Vec<crate::knowledge::RecallResult>>;
     pub async fn search_vectors_async (
         self: &std::sync::Arc<Self>,
         query_vec: Vec<f32>,
         k: i64,
         ef: i64,
     ) -> crate::error::Result<Vec<crate::knowledge::RecallResult>>;
+    pub async fn search_vectors_scoped_async (
+        self: &std::sync::Arc<Self>,
+        query_vec: Vec<f32>,
+        k: i64,
+        ef: i64,
+        requester_nous_id: String,
+    ) -> crate::error::Result<Vec<crate::knowledge::RecallResult>>;
     pub fn search_text_for_recall (
         &self,
         query_text: &str,
         k: i64,
     ) -> crate::error::Result<Vec<crate::knowledge::RecallResult>>;
+    pub fn search_text_for_recall_scoped (
+        &self,
+        query_text: &str,
+        k: i64,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<Vec<crate::knowledge::RecallResult>>;
+    pub fn search_hybrid_scoped (
+        &self,
+        q: &HybridQuery,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<Vec<HybridResult>>;
     pub async fn search_hybrid_async (
         self: &std::sync::Arc<Self>,
         q: HybridQuery,
+    ) -> crate::error::Result<Vec<HybridResult>>;
+    pub async fn search_hybrid_scoped_async (
+        self: &std::sync::Arc<Self>,
+        q: HybridQuery,
+        requester_nous_id: String,
     ) -> crate::error::Result<Vec<HybridResult>>;
     pub fn search_enhanced (
         &self,
         base_query: &HybridQuery,
         query_variants: &[String],
+    ) -> crate::error::Result<Vec<HybridResult>>;
+    pub fn search_enhanced_scoped (
+        &self,
+        base_query: &HybridQuery,
+        query_variants: &[String],
+        requester_nous_id: &str,
     ) -> crate::error::Result<Vec<HybridResult>>;
     pub fn search_tiered (
         &self,
@@ -2661,6 +2727,15 @@ impl KnowledgeStore {
         context: Option<&str>,
         config: &crate::query_rewrite::TieredSearchConfig,
     ) -> crate::error::Result<crate::query_rewrite::TieredSearchResult<HybridResult>>;
+    pub fn search_tiered_scoped (
+        &self,
+        base_query: &HybridQuery,
+        rewriter: &crate::query_rewrite::QueryRewriter,
+        provider: &dyn crate::query_rewrite::RewriteProvider,
+        context: Option<&str>,
+        config: &crate::query_rewrite::TieredSearchConfig,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<crate::query_rewrite::TieredSearchResult<HybridResult>>;
     pub fn search_tiered_for_recall (
         &self,
         base_query: &HybridQuery,
@@ -2668,6 +2743,17 @@ impl KnowledgeStore {
         provider: &dyn crate::query_rewrite::RewriteProvider,
         context: Option<&str>,
         config: &crate::query_rewrite::TieredSearchConfig,
+    ) -> crate::error::Result<
+        crate::query_rewrite::TieredSearchResult<crate::knowledge::RecallResult>,
+    >;
+    pub fn search_tiered_for_recall_scoped (
+        &self,
+        base_query: &HybridQuery,
+        rewriter: &crate::query_rewrite::QueryRewriter,
+        provider: &dyn crate::query_rewrite::RewriteProvider,
+        context: Option<&str>,
+        config: &crate::query_rewrite::TieredSearchConfig,
+        requester_nous_id: &str,
     ) -> crate::error::Result<
         crate::query_rewrite::TieredSearchResult<crate::knowledge::RecallResult>,
     >;

--- a/_llm/L3-api-index/nous.md
+++ b/_llm/L3-api-index/nous.md
@@ -2888,6 +2888,7 @@ pub trait VectorSearch : Send + Sync {
         query_vec: Vec<f32>,
         k: usize,
         ef: usize,
+        requester_nous_id: &str,
     ) -> error::Result<Vec<KnowledgeRecallResult>>;
     fn search_tiered (
         &self,
@@ -2895,6 +2896,7 @@ pub trait VectorSearch : Send + Sync {
         _query_vec: Vec<f32>,
         _k: usize,
         _ef: usize,
+        _requester_nous_id: &str,
         _rewrite_provider: &dyn mneme::query_rewrite::RewriteProvider,
     ) -> Option<error::Result<Vec<KnowledgeRecallResult>>>; // default impl
 }

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "08d0aa5f3ae74a920b6886f536995098b5c5fe008e8c71e82a3440376cf7b3f4"
+source_hash = "2617902368ad1c040fb60a4fbf550e8658e3743615b73dcad20da29ea9e6f9d7"
 l3_token_estimate = 167
 
 [[crates]]
@@ -86,8 +86,8 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "73cf258de9eb529d9a50ceba2681ef891bf7b4e4417c4cff179337940c148a88"
-l3_token_estimate = 32868
+source_hash = "4913f6e978dc610c7ab85759d35a3db392f8eb56f2f75cda216400ca707b86a4"
+l3_token_estimate = 33655
 
 [[crates]]
 name = "gnosis"
@@ -146,8 +146,8 @@ l3_token_estimate = 51
 [[crates]]
 name = "nous"
 path = "crates/nous"
-source_hash = "e44da68828b93c208d9a508423a5d1b748b5c3daa4a2b367ba33fa3e990db133"
-l3_token_estimate = 34306
+source_hash = "3983621821c6008c9f3f50d9e426c08a212782849797dcd2fcf3b106cb9db1dc"
+l3_token_estimate = 34322
 
 [[crates]]
 name = "oikonomos"

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -294,14 +294,16 @@ fn export_knowledge(
         .filter(|f| f.nous_id == nous_id)
         .collect();
 
-    // Entities and relationships are workspace-global today (no nous_id
-    // column). We round-trip the full set so a faithful restore reproduces
-    // the source's graph view.
+    let fact_ids: Vec<mneme::id::FactId> = facts.iter().map(|fact| fact.id.clone()).collect();
     let entities = store
-        .list_entities()
+        .list_entities_for_facts(&fact_ids)
         .with_whatever_context(|_| format!("failed to list entities for '{nous_id}'"))?;
+    let entity_ids: std::collections::HashSet<String> = entities
+        .iter()
+        .map(|entity| entity.id.as_str().to_owned())
+        .collect();
     let relationships = store
-        .list_all_relationships()
+        .list_relationships_between_entities(&entity_ids)
         .with_whatever_context(|_| format!("failed to list relationships for '{nous_id}'"))?;
 
     if facts.is_empty() && entities.is_empty() && relationships.is_empty() {
@@ -397,6 +399,15 @@ fn import_knowledge(
         store
             .insert_relationship(rel)
             .with_whatever_context(|_| format!("import rel {:?} -> {:?}", rel.src, rel.dst))?;
+    }
+    for fact in &knowledge.facts {
+        for entity in &knowledge.entities {
+            store
+                .insert_fact_entity(&fact.id, &entity.id)
+                .with_whatever_context(|_| {
+                    format!("import fact/entity link {:?} -> {:?}", fact.id, entity.id)
+                })?;
+        }
     }
 
     if let Some(provider) = embedding_provider.as_ref() {
@@ -1491,6 +1502,7 @@ pub(crate) async fn guard_knowledge_lock(url: &str) -> Result<()> {
     clippy::indexing_slicing,
     reason = "test: vec indices valid after len assertions"
 )]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use std::collections::HashMap;
     use std::fmt::Write as _;
@@ -2454,6 +2466,86 @@ workspace = "nous/{agent_id}"
     }
 
     #[cfg(feature = "recall")]
+    fn sample_fact(id: &str, nous_id: &str, content: &str) -> mneme::knowledge::Fact {
+        use mneme::knowledge::{
+            EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactSensitivity,
+            FactTemporal, Visibility, far_future, parse_timestamp,
+        };
+
+        Fact {
+            id: mneme::id::FactId::new(id).unwrap(),
+            nous_id: nous_id.to_owned(),
+            content: content.to_owned(),
+            fact_type: "test".to_owned(),
+            scope: None,
+            project_id: None,
+            sensitivity: FactSensitivity::Public,
+            visibility: Visibility::Private,
+            temporal: FactTemporal {
+                valid_from: parse_timestamp("2026-01-01T00:00:00Z").unwrap(),
+                valid_to: far_future(),
+                recorded_at: parse_timestamp("2026-03-01T00:00:00Z").unwrap(),
+            },
+            provenance: FactProvenance {
+                confidence: 0.95,
+                tier: EpistemicTier::Verified,
+                source_session_id: None,
+                stability_hours: 720.0,
+            },
+            lifecycle: FactLifecycle {
+                superseded_by: None,
+                is_forgotten: false,
+                forgotten_at: None,
+                forget_reason: None,
+            },
+            access: FactAccess {
+                access_count: 0,
+                last_accessed_at: None,
+            },
+        }
+    }
+
+    #[cfg(feature = "recall")]
+    fn sample_entity(id: &str, name: &str) -> mneme::knowledge::Entity {
+        mneme::knowledge::Entity {
+            id: mneme::id::EntityId::new(id).unwrap(),
+            name: name.to_owned(),
+            entity_type: "topic".to_owned(),
+            aliases: vec![],
+            created_at: mneme::knowledge::parse_timestamp("2026-03-01T00:00:00Z").unwrap(),
+            updated_at: mneme::knowledge::parse_timestamp("2026-03-01T00:00:00Z").unwrap(),
+        }
+    }
+
+    #[cfg(feature = "recall")]
+    fn link_fact_entity(
+        store: &mneme::knowledge_store::KnowledgeStore,
+        fact_id: &str,
+        entity_id: &str,
+    ) {
+        let script = r"
+            ?[fact_id, entity_id, created_at] <- [[$fact_id, $entity_id, $created_at]]
+            :put fact_entities {fact_id, entity_id => created_at}
+        ";
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(
+            "fact_id".to_owned(),
+            mneme::engine::DataValue::Str(fact_id.into()),
+        );
+        params.insert(
+            "entity_id".to_owned(),
+            mneme::engine::DataValue::Str(entity_id.into()),
+        );
+        params.insert(
+            "created_at".to_owned(),
+            mneme::engine::DataValue::Str("2026-03-01T00:00:00Z".into()),
+        );
+        store
+            .run_mut_query(script, params)
+            .expect("link fact to entity");
+    }
+
+    #[cfg(feature = "recall")]
     fn seed_typed_knowledge(oikos: &Oikos, nous_id: &str) {
         use mneme::id::{EntityId, FactId};
         use mneme::knowledge::{
@@ -2530,6 +2622,8 @@ workspace = "nous/{agent_id}"
         store.insert_entity(&entity1).unwrap();
         store.insert_entity(&entity2).unwrap();
         store.insert_relationship(&relationship).unwrap();
+        link_fact_entity(&store, fact.id.as_str(), entity1.id.as_str());
+        link_fact_entity(&store, fact.id.as_str(), entity2.id.as_str());
     }
 
     /// WHY(#4163): typed knowledge (Fact, Entity, Relationship) round-trips
@@ -2621,6 +2715,89 @@ workspace = "nous/{agent_id}"
         assert!((dest_rel.weight - 1.0).abs() < f64::EPSILON);
 
         // NOTE: HNSW vectors are covered by the #4399 regression below.
+    }
+
+    #[cfg(feature = "recall")]
+    #[test]
+    fn export_agent_scopes_knowledge_graph_to_exported_facts() {
+        let source = tempfile::tempdir().unwrap();
+        let source_oikos = Oikos::from_root(source.path());
+        write_agent_config(source.path(), "alice", "Alice");
+        std::fs::write(source_oikos.nous_dir("alice").join("SOUL.md"), "# Alice\n").unwrap();
+
+        let knowledge_path = knowledge_path_for_nous(&source_oikos, "alice");
+        let parent = knowledge_path.parent().unwrap();
+        std::fs::create_dir_all(parent).unwrap();
+        let store = mneme::knowledge_store::KnowledgeStore::open_fjall(
+            &knowledge_path,
+            mneme::knowledge_store::KnowledgeConfig::default(),
+        )
+        .unwrap();
+
+        let alice_fact = {
+            let mut fact = sample_fact("agent-export-alice-fact", "alice", "alice fact");
+            fact.visibility = mneme::knowledge::Visibility::Private;
+            fact
+        };
+        let bob_fact = {
+            let mut fact = sample_fact("agent-export-bob-fact", "bob", "bob fact");
+            fact.visibility = mneme::knowledge::Visibility::Private;
+            fact
+        };
+        let alice_entity = sample_entity("agent-export-alice-entity", "Alice Entity");
+        let bob_entity = sample_entity("agent-export-bob-entity", "Bob Entity");
+
+        store.insert_fact(&alice_fact).unwrap();
+        store.insert_fact(&bob_fact).unwrap();
+        store.insert_entity(&alice_entity).unwrap();
+        store.insert_entity(&bob_entity).unwrap();
+        link_fact_entity(&store, alice_fact.id.as_str(), alice_entity.id.as_str());
+        link_fact_entity(&store, bob_fact.id.as_str(), bob_entity.id.as_str());
+        store
+            .insert_relationship(&mneme::knowledge::Relationship {
+                src: alice_entity.id.clone(),
+                dst: bob_entity.id.clone(),
+                relation: "crosses".to_owned(),
+                weight: 0.9,
+                created_at: mneme::knowledge::parse_timestamp("2026-03-01T00:00:00Z").unwrap(),
+            })
+            .unwrap();
+        drop(store);
+
+        let export_path = source.path().join("alice-scoped.agent.json");
+        export_agent(
+            Some(&source.path().to_path_buf()),
+            &ExportArgs {
+                nous_id: "alice".to_owned(),
+                output: Some(export_path.clone()),
+                archived: false,
+                max_messages: 0,
+                compact: true,
+                force: false,
+            },
+        )
+        .unwrap();
+
+        let exported: AgentFile =
+            serde_json::from_str(&std::fs::read_to_string(export_path).unwrap()).unwrap();
+        let knowledge = exported.knowledge.expect("knowledge export present");
+        let entity_ids: Vec<&str> = knowledge
+            .entities
+            .iter()
+            .map(|entity| entity.id.as_str())
+            .collect();
+
+        assert_eq!(knowledge.facts.len(), 1);
+        assert_eq!(knowledge.facts[0].id.as_str(), "agent-export-alice-fact");
+        assert!(entity_ids.contains(&"agent-export-alice-entity"));
+        assert!(
+            !entity_ids.contains(&"agent-export-bob-entity"),
+            "foreign entity must not be exported"
+        );
+        assert!(
+            knowledge.relationships.is_empty(),
+            "relationship touching a foreign entity must not be exported"
+        );
     }
 
     /// #4399 / ADR-006 v2 — import must rebuild the HNSW index from restored facts.

--- a/crates/aletheia/src/knowledge_adapter.rs
+++ b/crates/aletheia/src/knowledge_adapter.rs
@@ -70,7 +70,7 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
 
             let results = self
                 .store
-                .search_hybrid_async(hybrid_query)
+                .search_hybrid_scoped_async(hybrid_query, nous_id.clone())
                 .await
                 .map_err(|e| {
                     SearchSnafu {
@@ -84,7 +84,7 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
                 .to_string();
             let facts = self
                 .store
-                .query_facts_async(nous_id, now, i64::try_from(limit).unwrap_or(i64::MAX))
+                .query_visible_facts_async(nous_id, now, i64::try_from(limit).unwrap_or(i64::MAX))
                 .await
                 .unwrap_or_else(|e| {
                     tracing::warn!(error = %e, "fact query failed, returning empty results");
@@ -95,16 +95,14 @@ impl KnowledgeSearchService for KnowledgeSearchAdapter {
 
             let mut out = Vec::with_capacity(results.len());
             for r in results {
-                let content = match fact_map.get(r.id.as_str()) {
-                    Some(f) => f.content.clone(),
-                    None => format!("[fact {}]", r.id),
-                };
-                out.push(MemoryResult {
-                    id: r.id.to_string(),
-                    content,
-                    score: r.rrf_score,
-                    source_type: "fact".to_owned(),
-                });
+                if let Some(f) = fact_map.get(r.id.as_str()) {
+                    out.push(MemoryResult {
+                        id: r.id.to_string(),
+                        content: f.content.clone(),
+                        score: r.rrf_score,
+                        source_type: "fact".to_owned(),
+                    });
+                }
             }
 
             // WHY: External recall sources (issue #2338) are queried in

--- a/crates/episteme/src/knowledge_portability.rs
+++ b/crates/episteme/src/knowledge_portability.rs
@@ -1,8 +1,6 @@
 //! Knowledge graph export/import for agent portability.
 
 #[cfg(feature = "mneme-engine")]
-use snafu::ResultExt;
-#[cfg(feature = "mneme-engine")]
 use tracing::{info, instrument, warn};
 
 #[cfg(feature = "mneme-engine")]
@@ -10,26 +8,39 @@ use crate::error::Result;
 
 /// Build a `KnowledgeExport` from the knowledge store.
 ///
-/// Queries all facts, entities, and relationships for the given nous.
+/// Queries scoped facts plus only graph data reachable from those facts.
 /// Returns `None` if the store is empty or the query fails.
 #[cfg(feature = "mneme-engine")]
 #[instrument(skip(store))]
-#[expect(dead_code, reason = "knowledge export for agent portability")]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "knowledge export for agent portability")
+)]
 pub(crate) fn export_knowledge(
     nous_id: &str,
     store: &crate::knowledge_store::KnowledgeStore,
 ) -> Option<graphe::portability::KnowledgeExport> {
     // kanon:ignore RUST/no-result-unwrap-or-default — best-effort portability snapshot: missing data on any leg yields an empty list (then the caller short-circuits to None below) rather than blocking the export.
+    let now = crate::knowledge::format_timestamp(&jiff::Timestamp::now());
     let facts = store
-        .query_facts(nous_id, "9999-01-01T00:00:00Z", 100_000)
+        .query_facts(nous_id, &now, 100_000)
         .ok()
         .unwrap_or_default();
 
-    // kanon:ignore RUST/no-result-unwrap-or-default — best-effort portability snapshot; see WHY above.
-    let entities = query_all_entities(store).unwrap_or_default();
+    let fact_ids: Vec<crate::id::FactId> = facts.iter().map(|fact| fact.id.clone()).collect();
 
     // kanon:ignore RUST/no-result-unwrap-or-default — best-effort portability snapshot; see WHY above.
-    let relationships = query_all_relationships(store).unwrap_or_default();
+    let entities = store.list_entities_for_facts(&fact_ids).unwrap_or_default();
+
+    let entity_ids: std::collections::HashSet<String> = entities
+        .iter()
+        .map(|entity| entity.id.as_str().to_owned())
+        .collect();
+
+    // kanon:ignore RUST/no-result-unwrap-or-default — best-effort portability snapshot; see WHY above.
+    let relationships = store
+        .list_relationships_between_entities(&entity_ids)
+        .unwrap_or_default();
 
     if facts.is_empty() && entities.is_empty() && relationships.is_empty() {
         return None;
@@ -48,92 +59,6 @@ pub(crate) fn export_knowledge(
         entities,
         relationships,
     })
-}
-
-#[cfg(feature = "mneme-engine")]
-fn query_all_entities(
-    store: &crate::knowledge_store::KnowledgeStore,
-) -> Result<Vec<crate::knowledge::Entity>> {
-    use std::collections::BTreeMap;
-
-    let script = r"?[id, name, entity_type, aliases, created_at, updated_at] := *entities{id, name, entity_type, aliases, created_at, updated_at}";
-    let rows = store.run_query(script, BTreeMap::new())?;
-
-    let mut entities = Vec::new();
-    for i in 0..rows.row_count() {
-        let Some(id_str) = rows.get_string(i, "id") else {
-            continue;
-        };
-        let id = crate::id::EntityId::new(&id_str).context(crate::error::InvalidIdSnafu)?;
-        let name = rows.get_string(i, "name").unwrap_or_default();
-        let entity_type = rows.get_string(i, "entity_type").unwrap_or_default();
-        let aliases_str = rows.get_string(i, "aliases").unwrap_or_default();
-        let aliases = if aliases_str.is_empty() {
-            vec![]
-        } else {
-            aliases_str
-                .split(',')
-                .map(|s: &str| s.trim().to_owned())
-                .collect()
-        };
-        let created_at = crate::knowledge::parse_timestamp(
-            &rows.get_string(i, "created_at").unwrap_or_default(),
-        )
-        .unwrap_or_else(jiff::Timestamp::now);
-        let updated_at = crate::knowledge::parse_timestamp(
-            &rows.get_string(i, "updated_at").unwrap_or_default(),
-        )
-        .unwrap_or_else(jiff::Timestamp::now);
-
-        entities.push(crate::knowledge::Entity {
-            id,
-            name,
-            entity_type,
-            aliases,
-            created_at,
-            updated_at,
-        });
-    }
-
-    Ok(entities)
-}
-
-#[cfg(feature = "mneme-engine")]
-fn query_all_relationships(
-    store: &crate::knowledge_store::KnowledgeStore,
-) -> Result<Vec<crate::knowledge::Relationship>> {
-    use std::collections::BTreeMap;
-
-    let script = r"?[src, dst, relation, weight, created_at] := *relationships{src, dst, relation, weight, created_at}";
-    let rows = store.run_query(script, BTreeMap::new())?;
-
-    let mut relationships = Vec::new();
-    for i in 0..rows.row_count() {
-        let Some(src_str) = rows.get_string(i, "src") else {
-            continue;
-        };
-        let src = crate::id::EntityId::new(&src_str).context(crate::error::InvalidIdSnafu)?;
-        let Some(dst_str) = rows.get_string(i, "dst") else {
-            continue;
-        };
-        let dst = crate::id::EntityId::new(&dst_str).context(crate::error::InvalidIdSnafu)?;
-        let relation = rows.get_string(i, "relation").unwrap_or_default();
-        let weight = rows.get_f64(i, "weight").unwrap_or(0.0);
-        let created_at = crate::knowledge::parse_timestamp(
-            &rows.get_string(i, "created_at").unwrap_or_default(),
-        )
-        .unwrap_or_else(jiff::Timestamp::now);
-
-        relationships.push(crate::knowledge::Relationship {
-            src,
-            dst,
-            relation,
-            weight,
-            created_at,
-        });
-    }
-
-    Ok(relationships)
 }
 
 /// Import knowledge graph data from a `KnowledgeExport` into a knowledge store.
@@ -173,6 +98,18 @@ pub(crate) fn import_knowledge(
         }
         result.facts_imported += 1;
     }
+    for fact in &knowledge.facts {
+        for entity in &knowledge.entities {
+            if let Err(e) = store.insert_fact_entity(&fact.id, &entity.id) {
+                warn!(
+                    fact_id = %fact.id,
+                    entity_id = %entity.id,
+                    error = %e,
+                    "failed to import fact/entity link"
+                );
+            }
+        }
+    }
 
     info!(
         facts = result.facts_imported,
@@ -198,7 +135,14 @@ pub struct KnowledgeImportResult {
 
 #[cfg(all(test, feature = "mneme-engine"))]
 mod tests {
+    #![expect(
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        reason = "test assertions"
+    )]
+
     use super::*;
+    use crate::test_fixtures::{make_entity, make_fact, make_relationship, make_store};
 
     #[test]
     fn knowledge_import_result_default_starts_at_zero() {
@@ -229,6 +173,55 @@ mod tests {
         assert_eq!(
             result.relationships_imported, 2,
             "relationships_imported should preserve 2"
+        );
+    }
+
+    #[test]
+    fn export_knowledge_includes_only_entities_reachable_from_exported_facts() {
+        let store = make_store();
+        let alice_fact = make_fact("export-alice-fact", "alice", "alice scoped fact");
+        let bob_fact = make_fact("export-bob-fact", "bob", "bob scoped fact");
+        let alice_entity = make_entity("export-alice-entity", "Alice Entity", "topic");
+        let bob_entity = make_entity("export-bob-entity", "Bob Entity", "topic");
+
+        store.insert_fact(&alice_fact).expect("insert alice fact");
+        store.insert_fact(&bob_fact).expect("insert bob fact");
+        store
+            .insert_entity(&alice_entity)
+            .expect("insert alice entity");
+        store.insert_entity(&bob_entity).expect("insert bob entity");
+        store
+            .insert_fact_entity(&alice_fact.id, &alice_entity.id)
+            .expect("link alice entity");
+        store
+            .insert_fact_entity(&bob_fact.id, &bob_entity.id)
+            .expect("link bob entity");
+        store
+            .insert_relationship(&make_relationship(
+                "export-alice-entity",
+                "export-bob-entity",
+                "knows",
+                0.8,
+            ))
+            .expect("insert cross-nous relationship");
+
+        let exported = export_knowledge("alice", &store).expect("knowledge export");
+        let entity_ids: Vec<&str> = exported
+            .entities
+            .iter()
+            .map(|entity| entity.id.as_str())
+            .collect();
+
+        assert_eq!(exported.facts.len(), 1);
+        assert_eq!(exported.facts[0].id.as_str(), "export-alice-fact");
+        assert!(entity_ids.contains(&"export-alice-entity"));
+        assert!(
+            !entity_ids.contains(&"export-bob-entity"),
+            "foreign entity must not appear in scoped export"
+        );
+        assert!(
+            exported.relationships.is_empty(),
+            "relationship to a foreign entity must not appear in scoped export"
         );
     }
 }

--- a/crates/episteme/src/knowledge_store/entity.rs
+++ b/crates/episteme/src/knowledge_store/entity.rs
@@ -79,11 +79,7 @@ impl KnowledgeStore {
 
     /// Insert a fact-entity mapping.
     #[instrument(skip(self))]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "entity operations for knowledge store")
-    )]
-    pub(crate) fn insert_fact_entity(
+    pub fn insert_fact_entity(
         &self,
         fact_id: &crate::id::FactId,
         entity_id: &crate::id::EntityId,
@@ -148,6 +144,32 @@ impl KnowledgeStore {
         Ok(entities)
     }
 
+    /// List entities reachable from the supplied fact IDs.
+    ///
+    /// Used by portability/export paths so a scoped fact export cannot carry
+    /// graph nodes that belong only to other nouses in the same cohort store.
+    pub fn list_entities_for_facts(
+        &self,
+        fact_ids: &[crate::id::FactId],
+    ) -> crate::error::Result<Vec<crate::knowledge::Entity>> {
+        use std::collections::BTreeMap;
+
+        if fact_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let fact_id_list = quoted_id_list(fact_ids.iter().map(crate::id::FactId::as_str));
+        let script = format!(
+            r"?[id, name, entity_type, aliases, created_at, updated_at] :=
+                *fact_entities{{fact_id, entity_id: id}},
+                fact_id in [{fact_id_list}],
+                *entities{{id, name, entity_type, aliases, created_at, updated_at}}
+            :order name"
+        );
+        let rows = self.run_read(&script, BTreeMap::new())?;
+        parse_entities(&rows)
+    }
+
     /// List all relationships in the knowledge graph.
     ///
     /// Used by agent portability export (issue #4163) to round-trip the full
@@ -186,6 +208,29 @@ impl KnowledgeStore {
             });
         }
         Ok(relationships)
+    }
+
+    /// List relationships whose endpoints are both in `entity_ids`.
+    pub fn list_relationships_between_entities(
+        &self,
+        entity_ids: &std::collections::HashSet<String>,
+    ) -> crate::error::Result<Vec<crate::knowledge::Relationship>> {
+        use std::collections::BTreeMap;
+
+        if entity_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let entity_id_list = quoted_id_list(entity_ids.iter().map(String::as_str));
+        let script = format!(
+            r"?[src, dst, relation, weight, created_at] :=
+                *relationships{{src, dst, relation, weight, created_at}},
+                src in [{entity_id_list}],
+                dst in [{entity_id_list}]
+            :order src"
+        );
+        let rows = self.run_read(&script, BTreeMap::new())?;
+        parse_relationships(&rows)
     }
 
     /// Build a serendipity-ready graph snapshot from the current store.
@@ -1204,4 +1249,76 @@ impl KnowledgeStore {
         params.insert("created_at".to_owned(), DataValue::Str(now.into()));
         self.run_mut(&queries::put_pending_merge(), params)
     }
+}
+
+#[cfg(feature = "mneme-engine")]
+fn quoted_id_list<'a>(ids: impl Iterator<Item = &'a str>) -> String {
+    ids.map(|id| format!("'{}'", id.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(feature = "mneme-engine")]
+fn parse_entities(
+    rows: &crate::engine::NamedRows,
+) -> crate::error::Result<Vec<crate::knowledge::Entity>> {
+    let mut entities = Vec::new();
+    for row in &rows.rows {
+        if row.len() < 6 {
+            continue;
+        }
+        let aliases_str = extract_str(&row[3])?;
+        let aliases: Vec<String> = if aliases_str.is_empty() {
+            Vec::new()
+        } else {
+            aliases_str
+                .split(',')
+                .map(|s| s.trim().to_owned())
+                .collect()
+        };
+        let created_at = crate::knowledge::parse_timestamp(&extract_str(&row[4])?)
+            .unwrap_or_else(jiff::Timestamp::now);
+        let updated_at = crate::knowledge::parse_timestamp(&extract_str(&row[5])?)
+            .unwrap_or_else(jiff::Timestamp::now);
+
+        let id = crate::id::EntityId::new(extract_str(&row[0])?)
+            .context(crate::error::InvalidIdSnafu)?;
+        entities.push(crate::knowledge::Entity {
+            id,
+            name: extract_str(&row[1])?,
+            entity_type: extract_str(&row[2])?,
+            aliases,
+            created_at,
+            updated_at,
+        });
+    }
+    Ok(entities)
+}
+
+#[cfg(feature = "mneme-engine")]
+fn parse_relationships(
+    rows: &crate::engine::NamedRows,
+) -> crate::error::Result<Vec<crate::knowledge::Relationship>> {
+    let mut relationships = Vec::new();
+    for row in &rows.rows {
+        if row.len() < 5 {
+            continue;
+        }
+        let src = crate::id::EntityId::new(extract_str(&row[0])?)
+            .context(crate::error::InvalidIdSnafu)?;
+        let dst = crate::id::EntityId::new(extract_str(&row[1])?)
+            .context(crate::error::InvalidIdSnafu)?;
+        let relation = extract_str(&row[2])?;
+        let weight = extract_float(&row[3])?;
+        let created_at = crate::knowledge::parse_timestamp(&extract_str(&row[4])?)
+            .unwrap_or_else(jiff::Timestamp::now);
+        relationships.push(crate::knowledge::Relationship {
+            src,
+            dst,
+            relation,
+            weight,
+            created_at,
+        });
+    }
+    Ok(relationships)
 }

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -1,6 +1,6 @@
 use tracing::instrument;
 
-use super::marshal::{extract_str, fact_to_params, rows_to_facts};
+use super::marshal::{extract_str, fact_to_params, rows_to_facts, scoped_visibility_rules};
 use super::{KnowledgeStore, queries};
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
@@ -365,6 +365,55 @@ impl KnowledgeStore {
         rows_to_facts(rows, nous_id)
     }
 
+    /// Query current facts visible to a requesting nous at a given time.
+    ///
+    /// The requester can read its own facts plus `Shared` and `Published`
+    /// facts from the same store. Foreign `Private`, `Restricted`, and future
+    /// unknown visibility values remain hidden.
+    #[instrument(skip(self))]
+    pub fn query_visible_facts(
+        &self,
+        requester_nous_id: &str,
+        now: &str,
+        limit: i64,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::DataValue;
+        let script = format!(
+            r"
+            {visible}
+            ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+              superseded_by, source_session_id, recorded_at,
+              access_count, last_accessed_at, stability_hours, fact_type,
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
+                visible_fact[id],
+                *facts{{id, valid_from, content, nous_id, confidence, tier,
+                       valid_to, superseded_by, source_session_id, recorded_at,
+                       access_count, last_accessed_at, stability_hours, fact_type,
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                       visibility, sensitivity}},
+                valid_from <= $now,
+                valid_to > $now,
+                is_null(superseded_by),
+                is_forgotten == false
+            :order -recorded_at
+            :limit $limit
+            ",
+            visible = scoped_visibility_rules()
+        );
+        let mut params = BTreeMap::new();
+        params.insert(
+            String::from("requester_nous_id"),
+            DataValue::Str(requester_nous_id.into()),
+        );
+        params.insert(String::from("now"), DataValue::Str(now.into()));
+        params.insert(String::from("limit"), DataValue::from(limit));
+        let rows = self.run_read(&script, params)?;
+        super::marshal::rows_to_raw_facts(rows)
+    }
+
     /// Point-in-time fact query.
     #[instrument(skip(self))]
     #[cfg_attr(
@@ -645,6 +694,77 @@ impl KnowledgeStore {
     ) -> crate::error::Result<std::collections::HashSet<String>> {
         let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
         self.query_forgotten_ids(&ids)
+    }
+
+    /// Read a fact by ID only when visible to the requester.
+    pub fn read_visible_facts_by_id(
+        &self,
+        fact_id: &str,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::DataValue;
+        let script = format!(
+            r"
+            {visible}
+            ?[id, valid_from, content, nous_id, confidence, tier, valid_to,
+              superseded_by, source_session_id, recorded_at,
+              access_count, last_accessed_at, stability_hours, fact_type,
+              is_forgotten, forgotten_at, forget_reason, scope, project_id,
+              visibility, sensitivity] :=
+                visible_fact[id],
+                id == $fact_id,
+                *facts{{id, valid_from, content, nous_id, confidence, tier,
+                       valid_to, superseded_by, source_session_id, recorded_at,
+                       access_count, last_accessed_at, stability_hours, fact_type,
+                       is_forgotten, forgotten_at, forget_reason, scope, project_id,
+                       visibility, sensitivity}}
+            ",
+            visible = scoped_visibility_rules()
+        );
+        let mut params = BTreeMap::new();
+        params.insert(String::from("fact_id"), DataValue::Str(fact_id.into()));
+        params.insert(
+            String::from("requester_nous_id"),
+            DataValue::Str(requester_nous_id.into()),
+        );
+        let rows = self.run_read(&script, params)?;
+        super::marshal::rows_to_raw_facts(rows)
+    }
+
+    pub(super) fn visible_fact_ids_for_entity(
+        &self,
+        entity_id: &str,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<Vec<String>> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::DataValue;
+        let script = format!(
+            r"
+            {visible}
+            ?[fact_id] :=
+                *fact_entities{{fact_id, entity_id: $entity_id}},
+                visible_fact[fact_id],
+                *facts{{id: fact_id, is_forgotten, superseded_by}},
+                is_forgotten == false,
+                is_null(superseded_by)
+            ",
+            visible = scoped_visibility_rules()
+        );
+        let mut params = BTreeMap::new();
+        params.insert(String::from("entity_id"), DataValue::Str(entity_id.into()));
+        params.insert(
+            String::from("requester_nous_id"),
+            DataValue::Str(requester_nous_id.into()),
+        );
+        let rows = self.run_read(&script, params)?;
+        Ok(rows
+            .rows
+            .iter()
+            .filter_map(|row| row.first().and_then(|v| v.get_str()).map(str::to_owned))
+            .collect())
     }
 
     /// Query facts valid at a specific point in time.
@@ -1052,6 +1172,23 @@ impl KnowledgeStore {
         tokio::task::spawn_blocking(move || this.query_facts(&nous_id, &now, limit))
             .await
             .context(crate::error::JoinSnafu)?
+    }
+
+    /// Async `query_visible_facts`: wraps sync call in `spawn_blocking`.
+    #[instrument(skip(self))]
+    pub async fn query_visible_facts_async(
+        self: &std::sync::Arc<Self>,
+        requester_nous_id: String,
+        now: String,
+        limit: i64,
+    ) -> crate::error::Result<Vec<crate::knowledge::Fact>> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || {
+            this.query_visible_facts(&requester_nous_id, &now, limit)
+        })
+        .await
+        .context(crate::error::JoinSnafu)?
     }
 }
 

--- a/crates/episteme/src/knowledge_store/marshal.rs
+++ b/crates/episteme/src/knowledge_store/marshal.rs
@@ -772,7 +772,26 @@ pub(super) fn sanitize_fts_query(raw: &str) -> String {
 }
 
 #[cfg(feature = "mneme-engine")]
+pub(super) fn scoped_visibility_rules() -> &'static str {
+    r"
+    visible_fact[id] := *facts{id, nous_id: $requester_nous_id}
+    visible_fact[id] := *facts{id, visibility: 'shared'}
+    visible_fact[id] := *facts{id, visibility: 'published'}
+"
+}
+
+#[cfg(feature = "mneme-engine")]
 pub(super) fn build_hybrid_query(q: &super::HybridQuery) -> String {
+    build_hybrid_query_inner(q, false)
+}
+
+#[cfg(feature = "mneme-engine")]
+pub(super) fn build_scoped_hybrid_query(q: &super::HybridQuery) -> String {
+    build_hybrid_query_inner(q, true)
+}
+
+#[cfg(feature = "mneme-engine")]
+fn build_hybrid_query_inner(q: &super::HybridQuery, scoped: bool) -> String {
     use super::queries;
 
     // WHY: When the message has no full-text terms (e.g. an emoji- or
@@ -782,6 +801,8 @@ pub(super) fn build_hybrid_query(q: &super::HybridQuery) -> String {
     // `$query_text` param is then left unbound by the caller.
     let bm25_rule = if sanitize_fts_query(&q.text).is_empty() {
         "bm25[id, score] <- []".to_owned()
+    } else if scoped {
+        "bm25_raw[id, score] := ~facts:content_fts{id | query: $query_text, k: $k, score_kind: 'bm25', bind_score: score}\n    bm25[id, score] := bm25_raw[id, score], visible_fact[id]".to_owned()
     } else {
         "bm25[id, score] := ~facts:content_fts{id | query: $query_text, k: $k, score_kind: 'bm25', bind_score: score}".to_owned()
     };
@@ -795,17 +816,37 @@ pub(super) fn build_hybrid_query(q: &super::HybridQuery) -> String {
             .map(|s| format!("[\"{}\"]", s.as_str().replace('"', "\\\"")))
             .collect();
         let seeds_inline = seed_data.join(", ");
-        format!(
-            "seed_list[e] <- [{seeds_inline}]\n        \
-             graph_raw[id, score] := seed_list[seed], *relationships{{src: seed, dst: id, weight: score}}\n        \
-             graph_raw[id, score] := seed_list[seed], *relationships{{src: seed, dst: mid, weight: _w}}, \
-             *relationships{{src: mid, dst: id, weight}}, score = weight * 0.5\n        \
-             graph[id, sum(score)] := graph_raw[id, score]"
-        )
+        if scoped {
+            format!(
+                "seed_list[e] <- [{seeds_inline}]\n        \
+                 graph_entity[eid, score] := seed_list[seed], *relationships{{src: seed, dst: eid, weight: score}}\n        \
+                 graph_entity[eid, score] := seed_list[seed], *relationships{{src: seed, dst: mid, weight: _w}}, \
+                 *relationships{{src: mid, dst: eid, weight}}, score = weight * 0.5\n        \
+                 graph_raw[id, score] := graph_entity[eid, score], *fact_entities{{fact_id: id, entity_id: eid}}\n        \
+                 graph[id, sum(score)] := graph_raw[id, score], visible_fact[id]"
+            )
+        } else {
+            format!(
+                "seed_list[e] <- [{seeds_inline}]\n        \
+                 graph_raw[id, score] := seed_list[seed], *relationships{{src: seed, dst: id, weight: score}}\n        \
+                 graph_raw[id, score] := seed_list[seed], *relationships{{src: seed, dst: mid, weight: _w}}, \
+                 *relationships{{src: mid, dst: id, weight}}, score = weight * 0.5\n        \
+                 graph[id, sum(score)] := graph_raw[id, score]"
+            )
+        }
     };
-    queries::HYBRID_SEARCH_BASE
+    let mut script = queries::HYBRID_SEARCH_BASE
         .replace("{BM25_RULE}", &bm25_rule)
-        .replace("{GRAPH_RULES}", &graph_rules)
+        .replace("{GRAPH_RULES}", &graph_rules);
+    if scoped {
+        script = script.replace(
+            "vec[id, score] :=\n        ~embeddings:semantic_idx{id | query: $query_vec, k: $k, ef: $ef, bind_distance: raw_dist},\n        score = 1.0 - raw_dist",
+            "vec_raw[source_id, score] :=\n        ~embeddings:semantic_idx{id, source_type, source_id | query: $query_vec, k: $k, ef: $ef, bind_distance: raw_dist},\n        source_type == 'fact',\n        score = 1.0 - raw_dist\n\n    vec[id, score] := vec_raw[id, score], visible_fact[id]",
+        );
+        format!("{}\n{script}", scoped_visibility_rules())
+    } else {
+        script
+    }
 }
 
 #[cfg(feature = "mneme-engine")]

--- a/crates/episteme/src/knowledge_store/search.rs
+++ b/crates/episteme/src/knowledge_store/search.rs
@@ -1,12 +1,19 @@
 use snafu::ResultExt;
 
 use super::marshal::{
-    build_hybrid_query, embedding_to_params, extract_str, rows_to_hybrid_results,
-    rows_to_recall_results, sanitize_fts_query,
+    build_hybrid_query, build_scoped_hybrid_query, embedding_to_params, extract_str,
+    rows_to_hybrid_results, rows_to_recall_results, sanitize_fts_query, scoped_visibility_rules,
 };
 use tracing::instrument;
 
 use super::{HybridQuery, HybridResult, KnowledgeStore, queries};
+
+#[cfg(feature = "mneme-engine")]
+fn truncate_recall_results(results: &mut Vec<crate::knowledge::RecallResult>, k: i64) {
+    let limit = usize::try_from(k.max(0)).unwrap_or(usize::MAX);
+    results.truncate(limit);
+}
+
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
     /// Insert a vector embedding for semantic search.
@@ -116,6 +123,60 @@ impl KnowledgeStore {
         Ok(results)
     }
 
+    /// kNN semantic vector search scoped to facts visible to `requester_nous_id`.
+    ///
+    /// Visibility is enforced inside the query before result hydration, cluster
+    /// expansion, or final truncation so foreign private facts cannot influence
+    /// returned scores or expansion seeds.
+    #[instrument(skip(self, query_vec))]
+    pub fn search_vectors_scoped(
+        &self,
+        query_vec: Vec<f32>,
+        k: i64,
+        ef: i64,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<Vec<crate::knowledge::RecallResult>> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::{Array1, DataValue, Vector};
+        let mut params = BTreeMap::new();
+        params.insert(
+            "query_vec".to_owned(),
+            DataValue::Vec(Vector::F32(Array1::from(query_vec))),
+        );
+        params.insert("k".to_owned(), DataValue::from(k.saturating_mul(2)));
+        params.insert("ef".to_owned(), DataValue::from(ef));
+        params.insert(
+            "requester_nous_id".to_owned(),
+            DataValue::Str(requester_nous_id.into()),
+        );
+
+        let script = format!(
+            r"
+            {visible}
+            ?[id, content, source_type, source_id, dist, scope, project_id, visibility, nous_id, sensitivity] :=
+                ~embeddings:semantic_idx {{id: embedding_id, content: _embedding_content, source_type, source_id |
+                    query: $query_vec, k: $k, ef: $ef, bind_distance: dist}},
+                source_type == 'fact',
+                visible_fact[source_id],
+                *facts{{id: source_id, content, is_forgotten, superseded_by, scope, project_id, visibility, nous_id, sensitivity}},
+                is_forgotten == false,
+                is_null(superseded_by),
+                id = source_id
+            :order dist
+            :limit $k
+            ",
+            visible = scoped_visibility_rules()
+        );
+        let mut results = rows_to_recall_results(self.run_read(&script, params)?)?;
+        self.enrich_recall_results(&mut results)?;
+        self.enrich_source_counts(&mut results);
+        self.expand_recall_by_cluster_scoped(&mut results, k, requester_nous_id)?;
+        truncate_recall_results(&mut results, k);
+        self.increment_recall_access(&results);
+        Ok(results)
+    }
+
     /// Async `search_vectors`: wraps sync call in `spawn_blocking`.
     ///
     /// # Complexity
@@ -133,6 +194,24 @@ impl KnowledgeStore {
         tokio::task::spawn_blocking(move || this.search_vectors(query_vec, k, ef))
             .await
             .context(crate::error::JoinSnafu)?
+    }
+
+    /// Async `search_vectors_scoped`: wraps sync call in `spawn_blocking`.
+    #[instrument(skip(self, query_vec))]
+    pub async fn search_vectors_scoped_async(
+        self: &std::sync::Arc<Self>,
+        query_vec: Vec<f32>,
+        k: i64,
+        ef: i64,
+        requester_nous_id: String,
+    ) -> crate::error::Result<Vec<crate::knowledge::RecallResult>> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || {
+            this.search_vectors_scoped(query_vec, k, ef, &requester_nous_id)
+        })
+        .await
+        .context(crate::error::JoinSnafu)?
     }
 
     /// BM25 full-text recall: returns `RecallResult` compatible rows without requiring embeddings.
@@ -171,6 +250,58 @@ impl KnowledgeStore {
         self.enrich_recall_results(&mut results)?;
         self.enrich_source_counts(&mut results);
         self.expand_recall_by_cluster(&mut results, k)?;
+        Ok(results)
+    }
+
+    /// BM25 full-text recall scoped to facts visible to `requester_nous_id`.
+    pub fn search_text_for_recall_scoped(
+        &self,
+        query_text: &str,
+        k: i64,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<Vec<crate::knowledge::RecallResult>> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::DataValue;
+        let sanitized_text = sanitize_fts_query(query_text);
+        if sanitized_text.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut params = BTreeMap::new();
+        params.insert(
+            "query_text".to_owned(),
+            DataValue::Str(sanitized_text.into()),
+        );
+        params.insert("k".to_owned(), DataValue::from(k));
+        params.insert(
+            "requester_nous_id".to_owned(),
+            DataValue::Str(requester_nous_id.into()),
+        );
+
+        let script = format!(
+            r"
+            {visible}
+            bm25[id, score] := ~facts:content_fts{{id | query: $query_text, k: $k, score_kind: 'bm25', bind_score: score}}
+
+            ?[id, content, source_type, source_id, dist, scope, project_id, visibility, nous_id, sensitivity] :=
+                bm25[id, bm25_score],
+                visible_fact[id],
+                *facts{{id, content, is_forgotten, superseded_by, scope, project_id, visibility, nous_id, sensitivity}},
+                is_forgotten == false,
+                is_null(superseded_by),
+                source_type = 'fact',
+                source_id = id,
+                dist = 1.0 / bm25_score
+            :order dist
+            :limit $k
+            ",
+            visible = scoped_visibility_rules()
+        );
+        let mut results = rows_to_recall_results(self.run_read(&script, params)?)?;
+        self.enrich_recall_results(&mut results)?;
+        self.enrich_source_counts(&mut results);
+        self.expand_recall_by_cluster_scoped(&mut results, k, requester_nous_id)?;
+        truncate_recall_results(&mut results, k);
         Ok(results)
     }
 
@@ -437,6 +568,160 @@ impl KnowledgeStore {
         Ok(())
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "scoped cluster expansion mirrors the unscoped query, hydration, and append flow"
+    )]
+    fn expand_recall_by_cluster_scoped(
+        &self,
+        results: &mut Vec<crate::knowledge::RecallResult>,
+        k: i64,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<()> {
+        if results.is_empty() {
+            return Ok(());
+        }
+
+        let ctx = self.load_graph_context()?;
+        if ctx.clusters.is_empty() {
+            return Ok(());
+        }
+
+        let top_n = results.len().min(5);
+        let mut context_clusters = std::collections::HashSet::new();
+        for result in results.iter().take(top_n) {
+            if result.source_type != "fact" {
+                continue;
+            }
+            let script = "?[entity_id] := *fact_entities{fact_id: $fid, entity_id}";
+            let mut params = std::collections::BTreeMap::new();
+            params.insert(
+                "fid".to_owned(),
+                crate::engine::DataValue::Str(result.source_id.as_str().into()),
+            );
+            let Ok(entity_rows) = self.run_read(script, params) else {
+                continue;
+            };
+            for row in &entity_rows.rows {
+                if let Some(cid) = row
+                    .first()
+                    .and_then(|v| v.get_str())
+                    .and_then(|entity_id| ctx.clusters.get(entity_id))
+                {
+                    context_clusters.insert(*cid);
+                }
+            }
+        }
+
+        if context_clusters.is_empty() {
+            return Ok(());
+        }
+
+        let existing_ids: std::collections::HashSet<String> =
+            results.iter().map(|r| r.source_id.clone()).collect();
+        let mut added = 0;
+        let limit = usize::try_from(k.max(1)).unwrap_or(1);
+
+        for cluster_id in context_clusters {
+            let script = format!(
+                r"
+                {visible}
+                ?[fact_id, content, nous_id, sensitivity, scope, project_id, visibility] :=
+                    *graph_scores{{entity_id, score_type: 'cluster', cluster_id: $cid}},
+                    *fact_entities{{fact_id: fid, entity_id}},
+                    visible_fact[fid],
+                    *facts{{id: fid, content, nous_id, is_forgotten, superseded_by,
+                           sensitivity, scope, project_id, visibility}},
+                    is_forgotten == false,
+                    is_null(superseded_by),
+                    fact_id = fid
+                :limit $limit
+                ",
+                visible = scoped_visibility_rules()
+            );
+            let mut params = std::collections::BTreeMap::new();
+            params.insert("cid".to_owned(), crate::engine::DataValue::from(cluster_id));
+            params.insert(
+                "limit".to_owned(),
+                crate::engine::DataValue::from(i64::try_from(limit).unwrap_or(i64::MAX)),
+            );
+            params.insert(
+                "requester_nous_id".to_owned(),
+                crate::engine::DataValue::Str(requester_nous_id.into()),
+            );
+            let Ok(rows) = self.run_read(&script, params) else {
+                continue;
+            };
+            for row in &rows.rows {
+                let Some(fact_id) = row.first().and_then(|v| v.get_str()) else {
+                    continue;
+                };
+                if existing_ids.contains(fact_id) {
+                    continue;
+                }
+                let content = row
+                    .get(1)
+                    .and_then(|v| v.get_str())
+                    .unwrap_or("")
+                    .to_owned();
+                let nous_id = row
+                    .get(2)
+                    .and_then(|v| v.get_str())
+                    .unwrap_or("")
+                    .to_owned();
+                let sensitivity = row
+                    .get(3)
+                    .and_then(|v| v.get_str())
+                    .and_then(|s| s.parse::<crate::knowledge::FactSensitivity>().ok())
+                    .unwrap_or_default();
+                let scope = row
+                    .get(4)
+                    .and_then(|v| v.get_str())
+                    .filter(|s| !s.is_empty())
+                    .and_then(|s| s.parse::<crate::knowledge::MemoryScope>().ok());
+                let project_id = row
+                    .get(5)
+                    .and_then(|v| v.get_str())
+                    .and_then(|s| eidos::workspace::ProjectId::from_sha256_hex(s).ok());
+                let visibility = row
+                    .get(6)
+                    .and_then(|v| v.get_str())
+                    .and_then(|s| s.parse::<crate::knowledge::Visibility>().ok())
+                    .unwrap_or_default();
+                results.push(crate::knowledge::RecallResult {
+                    content,
+                    distance: 1.0,
+                    source_type: "fact".to_owned(),
+                    source_id: fact_id.to_owned(),
+                    nous_id,
+                    sensitivity,
+                    graph_importance: 0.0,
+                    scope,
+                    project_id,
+                    visibility,
+                    source_count: 0,
+                });
+                added += 1;
+                if added >= limit {
+                    return Ok(());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn increment_recall_access(&self, results: &[crate::knowledge::RecallResult]) {
+        let source_ids: Vec<crate::id::FactId> = results
+            .iter()
+            .filter(|r| r.source_type == "fact")
+            .filter_map(|r| crate::id::FactId::new(&r.source_id).ok())
+            .collect();
+        if let Err(e) = self.increment_access(&source_ids) {
+            tracing::warn!(error = %e, "failed to increment access counts");
+        }
+    }
+
     /// Hybrid BM25 + HNSW vector + graph retrieval fused via `ReciprocalRankFusion`.
     ///
     /// Runs a single Datalog query combining all three signals in the engine.
@@ -495,6 +780,54 @@ impl KnowledgeStore {
         Ok(results)
     }
 
+    /// Hybrid search scoped to facts visible to `requester_nous_id`.
+    #[instrument(skip(self, q), fields(limit = q.limit, ef = q.ef))]
+    pub fn search_hybrid_scoped(
+        &self,
+        q: &HybridQuery,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<Vec<HybridResult>> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::{Array1, DataValue, Vector};
+        let mut params = BTreeMap::new();
+        let sanitized_text = sanitize_fts_query(q.text.as_str());
+        if !sanitized_text.is_empty() {
+            params.insert(
+                "query_text".to_owned(),
+                DataValue::Str(sanitized_text.into()),
+            );
+        }
+        params.insert(
+            "query_vec".to_owned(),
+            DataValue::Vec(Vector::F32(Array1::from(q.embedding.clone()))),
+        );
+        let limit_i64 = i64::try_from(q.limit).unwrap_or(i64::MAX);
+        let ef_i64 = i64::try_from(q.ef).unwrap_or(i64::MAX);
+        params.insert("k".to_owned(), DataValue::from(limit_i64.saturating_mul(2)));
+        params.insert("ef".to_owned(), DataValue::from(ef_i64));
+        params.insert(
+            "limit".to_owned(),
+            DataValue::from(limit_i64.saturating_mul(2)),
+        );
+        params.insert(
+            "requester_nous_id".to_owned(),
+            DataValue::Str(requester_nous_id.into()),
+        );
+
+        let script = build_scoped_hybrid_query(q);
+        let rows = self.run_read(&script, params)?;
+        let mut results = rows_to_hybrid_results(rows)?;
+        results.truncate(q.limit);
+
+        let fact_ids: Vec<crate::id::FactId> = results.iter().map(|r| r.id.clone()).collect();
+        if let Err(e) = self.increment_access(&fact_ids) {
+            tracing::warn!(error = %e, "failed to increment access counts");
+        }
+
+        Ok(results)
+    }
+
     /// Async `search_hybrid`: wraps sync call in `spawn_blocking`.
     #[instrument(skip(self, q), fields(limit = q.limit, ef = q.ef))]
     pub async fn search_hybrid_async(
@@ -504,6 +837,20 @@ impl KnowledgeStore {
         use snafu::ResultExt;
         let this = std::sync::Arc::clone(self);
         tokio::task::spawn_blocking(move || this.search_hybrid(&q))
+            .await
+            .context(crate::error::JoinSnafu)?
+    }
+
+    /// Async `search_hybrid_scoped`: wraps sync call in `spawn_blocking`.
+    #[instrument(skip(self, q), fields(limit = q.limit, ef = q.ef))]
+    pub async fn search_hybrid_scoped_async(
+        self: &std::sync::Arc<Self>,
+        q: HybridQuery,
+        requester_nous_id: String,
+    ) -> crate::error::Result<Vec<HybridResult>> {
+        use snafu::ResultExt;
+        let this = std::sync::Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.search_hybrid_scoped(&q, &requester_nous_id))
             .await
             .context(crate::error::JoinSnafu)?
     }
@@ -537,6 +884,41 @@ impl KnowledgeStore {
                 Ok(results) => results_per_query.push(results),
                 Err(e) => {
                     tracing::warn!(variant = %variant, error = %e, "search variant failed, skipping");
+                }
+            }
+        }
+
+        if results_per_query.is_empty() {
+            return Err(crate::error::EnhancedSearchSnafu {
+                message: format!("{} variants failed", query_variants.len()),
+            }
+            .build());
+        }
+
+        Ok(rrf_merge(&results_per_query, 60.0))
+    }
+
+    /// Multi-query hybrid search scoped to facts visible to `requester_nous_id`.
+    pub fn search_enhanced_scoped(
+        &self,
+        base_query: &HybridQuery,
+        query_variants: &[String],
+        requester_nous_id: &str,
+    ) -> crate::error::Result<Vec<HybridResult>> {
+        use crate::query_rewrite::rrf_merge;
+
+        if query_variants.is_empty() {
+            return self.search_hybrid_scoped(base_query, requester_nous_id);
+        }
+
+        let mut results_per_query = Vec::with_capacity(query_variants.len());
+        for variant in query_variants {
+            let mut q = base_query.clone();
+            q.text.clone_from(variant);
+            match self.search_hybrid_scoped(&q, requester_nous_id) {
+                Ok(results) => results_per_query.push(results),
+                Err(e) => {
+                    tracing::warn!(variant = %variant, error = %e, "scoped search variant failed, skipping");
                 }
             }
         }
@@ -624,6 +1006,74 @@ impl KnowledgeStore {
         })
     }
 
+    /// Tiered search scoped to facts visible to `requester_nous_id`.
+    pub fn search_tiered_scoped(
+        &self,
+        base_query: &HybridQuery,
+        rewriter: &crate::query_rewrite::QueryRewriter,
+        provider: &dyn crate::query_rewrite::RewriteProvider,
+        context: Option<&str>,
+        config: &crate::query_rewrite::TieredSearchConfig,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<crate::query_rewrite::TieredSearchResult<HybridResult>> {
+        let start = std::time::Instant::now();
+
+        let fast_results = self.search_hybrid_scoped(base_query, requester_nous_id)?;
+        let sufficient = fast_results.len() >= config.fast_path_min_results
+            && fast_results
+                .iter()
+                .any(|r| r.rrf_score >= config.fast_path_score_threshold);
+
+        if sufficient {
+            return Ok(crate::query_rewrite::TieredSearchResult {
+                tier: crate::query_rewrite::SearchTier::Fast,
+                results: fast_results,
+                query_variants: None,
+                total_latency_ms: start.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+            });
+        }
+
+        let rewrite_result = rewriter
+            .rewrite(&base_query.text, context, provider)
+            .map_err(|e| {
+                crate::error::QueryRewriteSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
+        let enhanced_results =
+            self.search_enhanced_scoped(base_query, &rewrite_result.variants, requester_nous_id)?;
+        let sufficient = enhanced_results.len() >= config.enhanced_min_results
+            && enhanced_results
+                .iter()
+                .any(|r| r.rrf_score >= config.enhanced_score_threshold);
+
+        if sufficient {
+            return Ok(crate::query_rewrite::TieredSearchResult {
+                tier: crate::query_rewrite::SearchTier::Enhanced,
+                results: enhanced_results,
+                query_variants: Some(rewrite_result.variants),
+                total_latency_ms: start.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+            });
+        }
+
+        let graph_results =
+            self.expand_via_graph_scoped(&enhanced_results, config, requester_nous_id);
+        let final_results = if graph_results.is_empty() {
+            enhanced_results
+        } else {
+            use crate::query_rewrite::rrf_merge;
+            rrf_merge(&[enhanced_results, graph_results], 60.0)
+        };
+
+        Ok(crate::query_rewrite::TieredSearchResult {
+            tier: crate::query_rewrite::SearchTier::GraphEnhanced,
+            results: final_results,
+            query_variants: Some(rewrite_result.variants),
+            total_latency_ms: start.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+        })
+    }
+
     /// Tiered search with hydrated recall rows for the production recall pipeline.
     ///
     /// This is the bridge from the low-level tiered retrieval orchestration
@@ -643,6 +1093,61 @@ impl KnowledgeStore {
         let mut recalled = Vec::with_capacity(tiered.results.len());
         for result in &tiered.results {
             for fact in self.read_facts_by_id(result.id.as_str())? {
+                if fact.lifecycle.is_forgotten || fact.lifecycle.superseded_by.is_some() {
+                    continue;
+                }
+                recalled.push(crate::knowledge::RecallResult {
+                    content: fact.content,
+                    distance: (1.0 - result.rrf_score).max(0.0),
+                    source_type: "fact".to_owned(),
+                    source_id: fact.id.as_str().to_owned(),
+                    nous_id: fact.nous_id,
+                    sensitivity: fact.sensitivity,
+                    graph_importance: 0.0,
+                    scope: fact.scope,
+                    project_id: fact.project_id,
+                    visibility: fact.visibility,
+                    source_count: self
+                        .get_fact_multiplicity(&fact.id)
+                        .ok()
+                        .flatten()
+                        .map_or(0, |m| m.source_count),
+                });
+                break;
+            }
+        }
+
+        Ok(crate::query_rewrite::TieredSearchResult {
+            tier: tiered.tier,
+            results: recalled,
+            query_variants: tiered.query_variants,
+            total_latency_ms: tiered.total_latency_ms,
+        })
+    }
+
+    /// Tiered search with hydrated recall rows, scoped before ranking and graph expansion.
+    pub fn search_tiered_for_recall_scoped(
+        &self,
+        base_query: &HybridQuery,
+        rewriter: &crate::query_rewrite::QueryRewriter,
+        provider: &dyn crate::query_rewrite::RewriteProvider,
+        context: Option<&str>,
+        config: &crate::query_rewrite::TieredSearchConfig,
+        requester_nous_id: &str,
+    ) -> crate::error::Result<
+        crate::query_rewrite::TieredSearchResult<crate::knowledge::RecallResult>,
+    > {
+        let tiered = self.search_tiered_scoped(
+            base_query,
+            rewriter,
+            provider,
+            context,
+            config,
+            requester_nous_id,
+        )?;
+        let mut recalled = Vec::with_capacity(tiered.results.len());
+        for result in &tiered.results {
+            for fact in self.read_visible_facts_by_id(result.id.as_str(), requester_nous_id)? {
                 if fact.lifecycle.is_forgotten || fact.lifecycle.superseded_by.is_some() {
                     continue;
                 }
@@ -732,6 +1237,84 @@ impl KnowledgeStore {
                             && !existing_ids.contains(neighbor_id)
                         {
                             expanded_ids.insert(neighbor_id.to_owned());
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut graph_results = Vec::new();
+        for (rank, id) in expanded_ids.iter().enumerate() {
+            let Ok(fact_id) = crate::id::FactId::new(id.as_str()) else {
+                continue;
+            };
+            graph_results.push(HybridResult {
+                id: fact_id,
+                rrf_score: 1.0 / (60.0 + rank as f64 + 1.0), // SAFETY: rank fits f64
+                bm25_rank: -1,
+                vec_rank: -1,
+                graph_rank: i64::try_from(rank + 1).unwrap_or(i64::MAX),
+            });
+        }
+
+        graph_results
+    }
+
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "rank indices fit in f64 mantissa"
+    )]
+    fn expand_via_graph_scoped(
+        &self,
+        existing: &[HybridResult],
+        config: &crate::query_rewrite::TieredSearchConfig,
+        requester_nous_id: &str,
+    ) -> Vec<HybridResult> {
+        let fact_ids: Vec<&str> = existing
+            .iter()
+            .take(config.graph_expansion_limit)
+            .map(|r| r.id.as_str())
+            .collect();
+
+        if fact_ids.is_empty() {
+            return vec![];
+        }
+
+        let mut expanded_ids = std::collections::HashSet::new();
+        let existing_ids: std::collections::HashSet<&str> =
+            existing.iter().map(|r| r.id.as_str()).collect();
+
+        for fact_id in &fact_ids {
+            let script = "?[entity_id] := *fact_entities{fact_id: $fid, entity_id}";
+            let mut fparams = std::collections::BTreeMap::new();
+            fparams.insert(
+                "fid".to_owned(),
+                crate::engine::DataValue::Str((*fact_id).into()),
+            );
+            let Ok(entity_rows) = self.run_read(script, fparams) else {
+                continue;
+            };
+            for entity_row in &entity_rows.rows {
+                let Some(entity_id_str) = entity_row.first().and_then(|v| v.get_str()) else {
+                    continue;
+                };
+                let Ok(entity_id) = crate::id::EntityId::new(entity_id_str) else {
+                    continue;
+                };
+                let Ok(neighborhood) = self.entity_neighborhood(&entity_id) else {
+                    continue;
+                };
+                for row in &neighborhood.rows {
+                    let Some(neighbor_entity_id) = row.first().and_then(|v| v.get_str()) else {
+                        continue;
+                    };
+                    for id in self
+                        .visible_fact_ids_for_entity(neighbor_entity_id, requester_nous_id)
+                        .unwrap_or_default()
+                    {
+                        if !existing_ids.contains(id.as_str()) {
+                            expanded_ids.insert(id);
                         }
                     }
                 }

--- a/crates/episteme/src/knowledge_store/tests/search.rs
+++ b/crates/episteme/src/knowledge_store/tests/search.rs
@@ -5,8 +5,8 @@
     reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
 )]
 
-use crate::knowledge::EmbeddedChunk;
-use crate::test_fixtures::{make_fact, make_store, test_ts};
+use crate::knowledge::{EmbeddedChunk, Visibility};
+use crate::test_fixtures::{make_entity, make_fact, make_store, test_ts};
 fn make_embedding(id: &str, content: &str, source_id: &str, nous_id: &str) -> EmbeddedChunk {
     EmbeddedChunk {
         id: crate::id::EmbeddingId::new(id).expect("valid test id"),
@@ -17,6 +17,24 @@ fn make_embedding(id: &str, content: &str, source_id: &str, nous_id: &str) -> Em
         embedding: vec![0.5, 0.5, 0.5, 0.5],
         created_at: test_ts("2026-03-01T00:00:00Z"),
     }
+}
+
+fn make_visible_fact(
+    id: &str,
+    nous_id: &str,
+    content: &str,
+    visibility: Visibility,
+) -> crate::knowledge::Fact {
+    let mut fact = make_fact(id, nous_id, content);
+    fact.visibility = visibility;
+    fact
+}
+
+fn result_ids(results: &[crate::knowledge::RecallResult]) -> Vec<&str> {
+    results
+        .iter()
+        .map(|result| result.source_id.as_str())
+        .collect()
 }
 
 /// #3380 integration: when the real embedding provider fails to initialize,
@@ -115,6 +133,205 @@ fn insert_embedding_and_search() {
     assert_eq!(results[0].content, "Rust memory safety");
     assert_eq!(results[0].source_type, "fact");
     assert_eq!(results[0].source_id, "f1");
+}
+
+#[test]
+fn scoped_visible_fact_query_hides_foreign_private_and_keeps_shared() {
+    let store = make_store();
+    store
+        .insert_fact(&make_visible_fact(
+            "alice-private",
+            "alice",
+            "alice private recall secret",
+            Visibility::Private,
+        ))
+        .expect("insert alice private");
+    store
+        .insert_fact(&make_visible_fact(
+            "alice-shared",
+            "alice",
+            "alice shared recall note",
+            Visibility::Shared,
+        ))
+        .expect("insert alice shared");
+
+    let visible = store
+        .query_visible_facts("bob", "2026-06-01T00:00:00Z", 10)
+        .expect("query visible facts");
+    let ids: Vec<&str> = visible.iter().map(|fact| fact.id.as_str()).collect();
+
+    assert!(
+        !ids.contains(&"alice-private"),
+        "foreign private fact must be hidden from direct visible fact query"
+    );
+    assert!(
+        ids.contains(&"alice-shared"),
+        "shared fact must remain visible across nouses"
+    );
+}
+
+#[test]
+fn scoped_bm25_hides_foreign_private_and_keeps_shared() {
+    let store = make_store();
+    store
+        .insert_fact(&make_visible_fact(
+            "bm25-private",
+            "alice",
+            "cross nous telescope topic private",
+            Visibility::Private,
+        ))
+        .expect("insert private");
+    store
+        .insert_fact(&make_visible_fact(
+            "bm25-shared",
+            "alice",
+            "cross nous telescope topic shared",
+            Visibility::Shared,
+        ))
+        .expect("insert shared");
+
+    let results = store
+        .search_text_for_recall_scoped("telescope topic", 10, "bob")
+        .expect("scoped bm25");
+    let ids = result_ids(&results);
+
+    assert!(!ids.contains(&"bm25-private"));
+    assert!(ids.contains(&"bm25-shared"));
+}
+
+#[test]
+fn scoped_vector_search_hides_foreign_private_and_keeps_shared() {
+    let store = make_store();
+    for (id, visibility) in [
+        ("vec-private", Visibility::Private),
+        ("vec-shared", Visibility::Shared),
+    ] {
+        store
+            .insert_fact(&make_visible_fact(
+                id,
+                "alice",
+                &format!("{id} semantic recall"),
+                visibility,
+            ))
+            .expect("insert fact");
+        let mut chunk = make_embedding(
+            &format!("emb-{id}"),
+            &format!("{id} semantic recall"),
+            id,
+            "alice",
+        );
+        chunk.embedding = vec![1.0, 0.0, 0.0, 0.0];
+        store.insert_embedding(&chunk).expect("insert embedding");
+    }
+
+    let results = store
+        .search_vectors_scoped(vec![1.0, 0.0, 0.0, 0.0], 10, 20, "bob")
+        .expect("scoped vector search");
+    let ids = result_ids(&results);
+
+    assert!(!ids.contains(&"vec-private"));
+    assert!(ids.contains(&"vec-shared"));
+}
+
+#[test]
+fn scoped_hybrid_search_hides_foreign_private_and_keeps_shared() {
+    let store = make_store();
+    for (id, visibility) in [
+        ("hybrid-private", Visibility::Private),
+        ("hybrid-shared", Visibility::Shared),
+    ] {
+        store
+            .insert_fact(&make_visible_fact(
+                id,
+                "alice",
+                &format!("hybrid anchor {id}"),
+                visibility,
+            ))
+            .expect("insert fact");
+        let mut chunk = make_embedding(
+            &format!("emb-{id}"),
+            &format!("hybrid anchor {id}"),
+            id,
+            "alice",
+        );
+        chunk.embedding = vec![1.0, 0.0, 0.0, 0.0];
+        store.insert_embedding(&chunk).expect("insert embedding");
+    }
+
+    let results = store
+        .search_hybrid_scoped(
+            &crate::knowledge_store::HybridQuery {
+                text: "hybrid anchor".to_owned(),
+                embedding: vec![1.0, 0.0, 0.0, 0.0],
+                seed_entities: Vec::new(),
+                limit: 10,
+                ef: 20,
+            },
+            "bob",
+        )
+        .expect("scoped hybrid search");
+    let ids: Vec<&str> = results.iter().map(|result| result.id.as_str()).collect();
+
+    assert!(!ids.contains(&"hybrid-private"));
+    assert!(ids.contains(&"hybrid-shared"));
+}
+
+#[test]
+fn scoped_cluster_expansion_hides_foreign_private_cluster_mates() {
+    let store = make_store();
+    let shared = make_visible_fact(
+        "cluster-shared",
+        "alice",
+        "cluster anchor visible",
+        Visibility::Shared,
+    );
+    let private = make_visible_fact(
+        "cluster-private",
+        "alice",
+        "cluster hidden private",
+        Visibility::Private,
+    );
+    store.insert_fact(&shared).expect("insert shared");
+    store.insert_fact(&private).expect("insert private");
+
+    let shared_entity = make_entity("entity-cluster-shared", "Shared Anchor", "topic");
+    let private_entity = make_entity("entity-cluster-private", "Private Anchor", "topic");
+    store
+        .insert_entity(&shared_entity)
+        .expect("insert shared entity");
+    store
+        .insert_entity(&private_entity)
+        .expect("insert private entity");
+    store
+        .insert_fact_entity(&shared.id, &shared_entity.id)
+        .expect("link shared");
+    store
+        .insert_fact_entity(&private.id, &private_entity.id)
+        .expect("link private");
+
+    store
+        .run_mut_query(
+            r#"
+            ?[entity_id, score_type, score, cluster_id, updated_at] <- [
+                ["entity-cluster-shared", "cluster", 0.0, 7, "2026-06-01T00:00:00Z"],
+                ["entity-cluster-private", "cluster", 0.0, 7, "2026-06-01T00:00:00Z"]
+            ]
+            :put graph_scores { entity_id, score_type => score, cluster_id, updated_at }
+            "#,
+            std::collections::BTreeMap::new(),
+        )
+        .expect("seed cluster scores");
+
+    let results = store
+        .search_text_for_recall_scoped("cluster anchor visible", 10, "bob")
+        .expect("scoped bm25 with cluster expansion");
+    let ids = result_ids(&results);
+
+    assert!(ids.contains(&"cluster-shared"));
+    assert!(
+        !ids.contains(&"cluster-private"),
+        "cluster expansion must not add foreign private facts"
+    );
 }
 
 #[test]

--- a/crates/nous/src/recall/mod.rs
+++ b/crates/nous/src/recall/mod.rs
@@ -332,7 +332,7 @@ impl RecallStage {
         }
 
         let k = self.config.max_results * 3;
-        let raw = text_search.search_text(query, k)?;
+        let raw = text_search.search_text(query, k, nous_id)?;
 
         if raw.is_empty() {
             debug!("no BM25 recall candidates found");
@@ -448,12 +448,12 @@ impl RecallStage {
         let query_vec = embed(query, embedding_provider)?;
         #[cfg(feature = "knowledge-store")]
         let raw = if let Some(provider) = rewrite_provider {
-            vector_search_tiered(vs, query, query_vec, k, provider)?
+            vector_search_tiered(vs, query, query_vec, k, nous_id, provider)?
         } else {
-            vector_search(vs, query_vec, k)?
+            vector_search(vs, query_vec, k, nous_id)?
         };
         #[cfg(not(feature = "knowledge-store"))]
-        let raw = vector_search(vs, query_vec, k)?;
+        let raw = vector_search(vs, query_vec, k, nous_id)?;
 
         if raw.is_empty() {
             debug!("no recall candidates found");
@@ -490,12 +490,12 @@ impl RecallStage {
         let query_vec = embed(query, embedding_provider)?;
         #[cfg(feature = "knowledge-store")]
         let raw_cycle1 = if let Some(provider) = rewrite_provider {
-            vector_search_tiered(vs, query, query_vec, k, provider)?
+            vector_search_tiered(vs, query, query_vec, k, nous_id, provider)?
         } else {
-            vector_search(vs, query_vec, k)?
+            vector_search(vs, query_vec, k, nous_id)?
         };
         #[cfg(not(feature = "knowledge-store"))]
-        let raw_cycle1 = vector_search(vs, query_vec, k)?;
+        let raw_cycle1 = vector_search(vs, query_vec, k, nous_id)?;
 
         if raw_cycle1.is_empty() {
             debug!("no recall candidates in cycle 1");
@@ -533,7 +533,7 @@ impl RecallStage {
         );
 
         let refined_vec = embed(&refined, embedding_provider)?;
-        let raw_cycle2 = vector_search(vs, refined_vec, k)?;
+        let raw_cycle2 = vector_search(vs, refined_vec, k, nous_id)?;
 
         let mut seen: HashSet<String> = HashSet::new();
         let mut merged: Vec<KnowledgeRecallResult> = Vec::new();

--- a/crates/nous/src/recall/search.rs
+++ b/crates/nous/src/recall/search.rs
@@ -11,7 +11,12 @@ use crate::error;
 /// `KnowledgeStore` implements this when the `mneme-engine` feature is available.
 pub(crate) trait TextSearch: Send + Sync {
     /// Search by text (BM25) and return the `k` best-matching results.
-    fn search_text(&self, query: &str, k: usize) -> error::Result<Vec<KnowledgeRecallResult>>;
+    fn search_text(
+        &self,
+        query: &str,
+        k: usize,
+        requester_nous_id: &str,
+    ) -> error::Result<Vec<KnowledgeRecallResult>>;
 }
 
 /// Abstracts vector knowledge search.
@@ -25,6 +30,7 @@ pub trait VectorSearch: Send + Sync {
         query_vec: Vec<f32>,
         k: usize,
         ef: usize,
+        requester_nous_id: &str,
     ) -> error::Result<Vec<KnowledgeRecallResult>>;
 
     /// Run tiered query-rewrite search when the backing store supports it.
@@ -35,6 +41,7 @@ pub trait VectorSearch: Send + Sync {
         _query_vec: Vec<f32>,
         _k: usize,
         _ef: usize,
+        _requester_nous_id: &str,
         _rewrite_provider: &dyn mneme::query_rewrite::RewriteProvider,
     ) -> Option<error::Result<Vec<KnowledgeRecallResult>>> {
         None
@@ -63,13 +70,16 @@ pub(super) fn vector_search(
     search: &dyn VectorSearch,
     query_vec: Vec<f32>,
     k: usize,
+    requester_nous_id: &str,
 ) -> error::Result<Vec<KnowledgeRecallResult>> {
-    search.search_vectors(query_vec, k, 50).map_err(|e| {
-        error::RecallSearchSnafu {
-            message: e.to_string(),
-        }
-        .build()
-    })
+    search
+        .search_vectors(query_vec, k, 50, requester_nous_id)
+        .map_err(|e| {
+            error::RecallSearchSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })
 }
 
 /// Run tiered search when available, otherwise fall back to vector search.
@@ -79,14 +89,22 @@ pub(super) fn vector_search_tiered(
     query: &str,
     query_vec: Vec<f32>,
     k: usize,
+    requester_nous_id: &str,
     rewrite_provider: &dyn mneme::query_rewrite::RewriteProvider,
 ) -> error::Result<Vec<KnowledgeRecallResult>> {
-    if let Some(result) = search.search_tiered(query, query_vec.clone(), k, 50, rewrite_provider) {
+    if let Some(result) = search.search_tiered(
+        query,
+        query_vec.clone(),
+        k,
+        50,
+        requester_nous_id,
+        rewrite_provider,
+    ) {
         // WHY: `search_tiered` already wraps engine errors in `RecallSearchSnafu`
         // (see search/search_impl.rs); return its result directly rather than
         // wrapping a second time. The prior double-wrap produced the duplicated
         // "recall search failed: recall search failed:" message. See #4156.
         return result;
     }
-    vector_search(search, query_vec, k)
+    vector_search(search, query_vec, k, requester_nous_id)
 }

--- a/crates/nous/src/recall/search/search_impl.rs
+++ b/crates/nous/src/recall/search/search_impl.rs
@@ -32,10 +32,15 @@ impl KnowledgeTextSearch {
 
 #[cfg(feature = "knowledge-store")]
 impl TextSearch for KnowledgeTextSearch {
-    fn search_text(&self, query: &str, k: usize) -> error::Result<Vec<KnowledgeRecallResult>> {
+    fn search_text(
+        &self,
+        query: &str,
+        k: usize,
+        requester_nous_id: &str,
+    ) -> error::Result<Vec<KnowledgeRecallResult>> {
         let k_i64 = i64::try_from(k).unwrap_or(i64::MAX);
         self.store
-            .search_text_for_recall(query, k_i64)
+            .search_text_for_recall_scoped(query, k_i64, requester_nous_id)
             .map_err(|e| {
                 error::RecallSearchSnafu {
                     message: e.to_string(),
@@ -67,11 +72,12 @@ impl VectorSearch for KnowledgeVectorSearch {
         query_vec: Vec<f32>,
         k: usize,
         ef: usize,
+        requester_nous_id: &str,
     ) -> error::Result<Vec<KnowledgeRecallResult>> {
         let k_i64 = i64::try_from(k).unwrap_or(i64::MAX);
         let ef_i64 = i64::try_from(ef).unwrap_or(i64::MAX);
         self.store
-            .search_vectors(query_vec, k_i64, ef_i64)
+            .search_vectors_scoped(query_vec, k_i64, ef_i64, requester_nous_id)
             .map_err(|e| {
                 error::RecallSearchSnafu {
                     message: e.to_string(),
@@ -86,6 +92,7 @@ impl VectorSearch for KnowledgeVectorSearch {
         query_vec: Vec<f32>,
         k: usize,
         ef: usize,
+        requester_nous_id: &str,
         rewrite_provider: &dyn mneme::query_rewrite::RewriteProvider,
     ) -> Option<error::Result<Vec<KnowledgeRecallResult>>> {
         let hybrid = mneme::knowledge_store::HybridQuery {
@@ -99,7 +106,14 @@ impl VectorSearch for KnowledgeVectorSearch {
         let config = mneme::query_rewrite::TieredSearchConfig::default();
         Some(
             self.store
-                .search_tiered_for_recall(&hybrid, &rewriter, rewrite_provider, None, &config)
+                .search_tiered_for_recall_scoped(
+                    &hybrid,
+                    &rewriter,
+                    rewrite_provider,
+                    None,
+                    &config,
+                    requester_nous_id,
+                )
                 .map(|r| r.results)
                 .map_err(|e| {
                     error::RecallSearchSnafu {

--- a/crates/nous/src/recall_tests/knowledge_bridge.rs
+++ b/crates/nous/src/recall_tests/knowledge_bridge.rs
@@ -3,7 +3,10 @@
 
 use std::sync::Arc;
 
-use mneme::knowledge::EmbeddedChunk;
+use mneme::knowledge::{
+    EmbeddedChunk, EpistemicTier, Fact, FactAccess, FactLifecycle, FactProvenance, FactSensitivity,
+    FactTemporal, Visibility, far_future,
+};
 use mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
 
 use super::super::*;
@@ -20,15 +23,57 @@ fn make_store() -> Arc<KnowledgeStore> {
 }
 
 fn make_chunk(id: &str, content: &str, embedding: Vec<f32>) -> EmbeddedChunk {
+    let source_id = format!("fact-{id}");
     EmbeddedChunk {
         id: mneme::id::EmbeddingId::new(id).expect("valid test id"),
         content: content.to_owned(),
         source_type: "fact".to_owned(),
-        source_id: format!("fact-{id}"),
-        nous_id: String::new(),
+        source_id,
+        nous_id: "alice".to_owned(),
         embedding,
         created_at: jiff::Timestamp::from_second(1_735_689_600).expect("valid epoch"),
     }
+}
+
+fn make_fact(id: &str, content: &str) -> Fact {
+    Fact {
+        id: mneme::id::FactId::new(id).expect("valid test fact id"),
+        nous_id: "alice".to_owned(),
+        fact_type: "test".to_owned(),
+        content: content.to_owned(),
+        scope: None,
+        project_id: None,
+        sensitivity: FactSensitivity::Public,
+        visibility: Visibility::Private,
+        temporal: FactTemporal {
+            valid_from: jiff::Timestamp::from_second(1_735_689_600).expect("valid epoch"),
+            valid_to: far_future(),
+            recorded_at: jiff::Timestamp::from_second(1_735_689_600).expect("valid epoch"),
+        },
+        provenance: FactProvenance {
+            confidence: 1.0,
+            tier: EpistemicTier::Verified,
+            source_session_id: None,
+            stability_hours: 720.0,
+        },
+        lifecycle: FactLifecycle {
+            superseded_by: None,
+            is_forgotten: false,
+            forgotten_at: None,
+            forget_reason: None,
+        },
+        access: FactAccess {
+            access_count: 0,
+            last_accessed_at: None,
+        },
+    }
+}
+
+fn insert_chunk_fact(store: &KnowledgeStore, chunk: &EmbeddedChunk) {
+    store
+        .insert_fact(&make_fact(&chunk.source_id, &chunk.content))
+        .expect("insert fact");
+    store.insert_embedding(chunk).expect("insert embedding");
 }
 
 #[test]
@@ -36,7 +81,7 @@ fn empty_store_returns_empty_vec() {
     let store = make_store();
     let search = KnowledgeVectorSearch::new(store);
     let results = search
-        .search_vectors(vec![0.0; DIM], 5, 10)
+        .search_vectors(vec![0.0; DIM], 5, 10, "alice")
         .expect("search should not error on empty store");
     assert!(results.is_empty(), "empty store should return no results");
 }
@@ -45,11 +90,11 @@ fn empty_store_returns_empty_vec() {
 fn returns_matching_results() {
     let store = make_store();
     let chunk = make_chunk("c1", "Rust is a systems language", vec![1.0, 0.0, 0.0, 0.0]);
-    store.insert_embedding(&chunk).expect("insert embedding");
+    insert_chunk_fact(&store, &chunk);
 
     let search = KnowledgeVectorSearch::new(Arc::clone(&store));
     let results = search
-        .search_vectors(vec![1.0, 0.0, 0.0, 0.0], 5, 10)
+        .search_vectors(vec![1.0, 0.0, 0.0, 0.0], 5, 10, "alice")
         .expect("search");
     assert_eq!(results.len(), 1, "should find one matching result");
     assert_eq!(
@@ -64,12 +109,12 @@ fn closer_vectors_rank_first() {
     let store = make_store();
     let close = make_chunk("c1", "close", vec![1.0, 0.0, 0.0, 0.0]);
     let far = make_chunk("c2", "far", vec![0.0, 0.0, 0.0, 1.0]);
-    store.insert_embedding(&close).expect("insert close");
-    store.insert_embedding(&far).expect("insert far");
+    insert_chunk_fact(&store, &close);
+    insert_chunk_fact(&store, &far);
 
     let search = KnowledgeVectorSearch::new(Arc::clone(&store));
     let results = search
-        .search_vectors(vec![1.0, 0.0, 0.0, 0.0], 5, 10)
+        .search_vectors(vec![1.0, 0.0, 0.0, 0.0], 5, 10, "alice")
         .expect("search");
     assert_eq!(results.len(), 2, "should find both results");
     assert!(
@@ -89,12 +134,12 @@ fn respects_k_limit() {
         let mut emb = vec![0.0; DIM];
         emb[i % DIM] = 1.0;
         let chunk = make_chunk(&format!("c{i}"), &format!("fact {i}"), emb);
-        store.insert_embedding(&chunk).expect("insert");
+        insert_chunk_fact(&store, &chunk);
     }
 
     let search = KnowledgeVectorSearch::new(Arc::clone(&store));
     let results = search
-        .search_vectors(vec![1.0, 0.0, 0.0, 0.0], 2, 10)
+        .search_vectors(vec![1.0, 0.0, 0.0, 0.0], 2, 10, "alice")
         .expect("search");
     assert!(results.len() <= 2, "should return at most k=2 results");
 }

--- a/crates/nous/src/recall_tests/mod.rs
+++ b/crates/nous/src/recall_tests/mod.rs
@@ -24,6 +24,7 @@ impl VectorSearch for MockVectorSearch {
         _query_vec: Vec<f32>,
         _k: usize,
         _ef: usize,
+        _requester_nous_id: &str,
     ) -> error::Result<Vec<KnowledgeRecallResult>> {
         Ok(self.results.clone())
     }
@@ -54,6 +55,7 @@ impl VectorSearch for CycledMockSearch {
         _query_vec: Vec<f32>,
         _k: usize,
         _ef: usize,
+        _requester_nous_id: &str,
     ) -> error::Result<Vec<KnowledgeRecallResult>> {
         let idx = self.call_index.fetch_add(1, Ordering::Relaxed);
         Ok(self.cycles.get(idx).cloned().unwrap_or_default())


### PR DESCRIPTION
Closes #4497
Closes #4498

A nous could retrieve another nous's private-scope facts through semantic recall, graph-cluster expansion, and side query paths — the most sensitive class in the campaign given the psyche local-only boundary.

- ONE `scoped_visibility_rules()` Datalog predicate (requester's own facts + `shared` + `published`) injected into the query builders — scope is enforced INSIDE the query, before ranking and expansion, so nothing leaks via scores or expansion seeds (the post-filter leak channel is structurally closed).
- `_scoped` variants unify all retrieval entry points on that one predicate: visible-fact query, BM25, vector, hybrid, enhanced, tiered, recall-tiered (dead-twin paths unified rather than fixed one at a time).
- Export scoping: agent export carries only entities/relationships reachable from the exported facts — a scoped export cannot smuggle a foreign entity or its edges.
- `nous` recall pipeline wired to the scoped variants end-to-end.
- Tests: foreign-private hidden + shared kept across direct fact query, BM25, vector search, hybrid, and cluster expansion; export reachability scoping.

Worker-gated CI-exact on verda before push. With this, the original security campaign spine (B1→B5, C1, C2) is complete.