### PR TITLE
fix(taxis,pylon): schema-aware env coercion + fail-fast config startup

### DIFF
--- a/_llm/L3-api-index/pylon.md
+++ b/_llm/L3-api-index/pylon.md
@@ -2169,6 +2169,14 @@ pub struct ServerConfig {
 
 ```rust
 pub enum ServerError {
+    /// Configuration could not be loaded at startup.
+    #[snafu(display("failed to load config from {}: {source}", path.display()))]
+    Config {
+        path: PathBuf,
+        #[snafu(source(from(taxis::error::Error, Box::new)))]
+        source: Box<taxis::error::Error>,
+    },
+
     /// Failed to open or initialize the session store.
     #[snafu(display("failed to open session store: {source}"))]
     SessionStore { source: mneme::error::Error },
@@ -2211,6 +2219,7 @@ pub enum ServerError {
 > # Errors
 > 
 > Returns [`ServerError::Validation`] if the instance directory layout is invalid.
+> Returns [`ServerError::Config`] if the config cascade cannot be loaded.
 > Returns [`ServerError::SessionStore`] if the session database cannot be opened.
 > Returns [`ServerError::Bind`] if the server cannot bind to the configured address.
 > Returns [`ServerError::Serve`] if the HTTP server encounters a fatal I/O error.

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -266,8 +266,8 @@ l3_token_estimate = 1354
 [[crates]]
 name = "pylon"
 path = "crates/pylon"
-source_hash = "7daca293eb5f57e6ec3d1a908d8e7dc14081a494f61b65b1b45d365c8eecd22b"
-l3_token_estimate = 17977
+source_hash = "b0c2812e62aa1fa40a3db5762c8e12dc07b50f851308ee8bdaa25c9a87fdf112"
+l3_token_estimate = 18067
 
 [[crates]]
 name = "skene"
@@ -284,7 +284,7 @@ l3_token_estimate = 6585
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "9167277e9e9ec11cd8cfc0861123c93ca47a1862ba87c2bb96b8654bca0bdd41"
+source_hash = "cd786949b2f637059a1af84f30ead7f743495137e48b2744d4b920d3ffb07017"
 l3_token_estimate = 23836
 
 [[crates]]

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -46,6 +46,14 @@ pub struct ServerConfig {
 )]
 #[non_exhaustive]
 pub enum ServerError {
+    /// Configuration could not be loaded at startup.
+    #[snafu(display("failed to load config from {}: {source}", path.display()))]
+    Config {
+        path: PathBuf,
+        #[snafu(source(from(taxis::error::Error, Box::new)))]
+        source: Box<taxis::error::Error>,
+    },
+
     /// Failed to open or initialize the session store.
     #[snafu(display("failed to open session store: {source}"))]
     SessionStore { source: mneme::error::Error },
@@ -87,6 +95,7 @@ pub enum ServerError {
 /// # Errors
 ///
 /// Returns [`ServerError::Validation`] if the instance directory layout is invalid.
+/// Returns [`ServerError::Config`] if the config cascade cannot be loaded.
 /// Returns [`ServerError::SessionStore`] if the session database cannot be opened.
 /// Returns [`ServerError::Bind`] if the server cannot bind to the configured address.
 /// Returns [`ServerError::Serve`] if the HTTP server encounters a fatal I/O error.
@@ -105,6 +114,10 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
     let oikos = Oikos::from_root(&config.instance_path);
     oikos.validate().context(ValidationSnafu)?;
     let oikos = Arc::new(oikos);
+
+    let config_path = oikos.config().join("aletheia.toml");
+    let aletheia_config =
+        taxis::loader::load_config(&oikos).context(ConfigSnafu { path: config_path })?;
 
     let session_store = SessionStore::open(&oikos.sessions_db()).context(SessionStoreSnafu)?;
     let session_store = Arc::new(Mutex::new(session_store));
@@ -131,11 +144,6 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         .spawn(nous_config, PipelineConfig::default())
         .await
         .context(NousSpawnSnafu)?;
-
-    let aletheia_config = taxis::loader::load_config(&oikos).unwrap_or_else(|e| {
-        tracing::warn!("failed to load config, using defaults: {e}");
-        AletheiaConfig::default()
-    });
 
     // WHY: Emit a loud warning when authentication is disabled so operators
     // see the consequence in every log aggregator, not just buried in the
@@ -581,5 +589,38 @@ mod tests {
     fn server_error_tls_not_compiled_display() {
         let err: ServerError = TlsNotCompiledSnafu.build();
         assert!(err.to_string().contains("TLS"));
+    }
+
+    #[tokio::test]
+    async fn run_fails_on_malformed_config() {
+        let instance = tempfile::tempdir().unwrap_or_else(|e| panic!("create tempdir: {e}"));
+        for dir in ["config", "data", "nous"] {
+            let path = instance.path().join(dir);
+            std::fs::create_dir_all(&path)
+                .unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+        }
+        let config_path = instance.path().join("config").join("aletheia.toml");
+        koina::fs::write_restricted(&config_path, b"[gateway\nport = 9999\n")
+            .unwrap_or_else(|e| panic!("write {}: {e}", config_path.display()));
+
+        let config = ServerConfig {
+            bind_addr: "127.0.0.1:0".to_owned(),
+            instance_path: instance.path().to_path_buf(),
+            security: make_security(),
+        };
+
+        let err = match run(config).await {
+            Ok(()) => panic!("malformed config should stop startup"),
+            Err(err) => err,
+        };
+
+        let ServerError::Config { path, source } = err else {
+            panic!("expected config error, got {err}");
+        };
+        assert_eq!(path, config_path);
+        assert!(
+            source.to_string().contains("failed to parse TOML config"),
+            "source should preserve parse failure: {source}"
+        );
     }
 }

--- a/crates/taxis/src/loader.rs
+++ b/crates/taxis/src/loader.rs
@@ -108,10 +108,10 @@ pub fn load_config_with(oikos: &Oikos, fs: &impl FileSystem) -> Result<AletheiaC
     }
 
     // Tier 3: environment variables, ALETHEIA_ prefix, `__` splitting nested keys.
-    apply_env_overlay(&mut root, "ALETHEIA_", "__");
+    let applied_env_vars = apply_env_overlay(&mut root, "ALETHEIA_", "__");
 
     serde_json::from_value::<AletheiaConfig>(root).context(ConfigLoadSnafu {
-        reason: "deserialize merged config",
+        reason: deserialize_reason(&applied_env_vars),
     })
 }
 
@@ -136,11 +136,15 @@ fn deep_merge(dst: &mut JsonValue, src: JsonValue) {
 /// by `separator` to build the nested path. Keys are lowercased to match
 /// serde `rename_all = "camelCase"` output (which lowercases single words).
 ///
-/// Values are parsed as: bool (`true`/`false`), integer, float (if containing
-/// `.`), otherwise string. This preserves the pre-#3447 figment autotyping
+/// Known leaves are coerced to the existing JSON leaf type in the
+/// defaults-plus-TOML tree. Unknown paths keep the pre-#3447 figment autotyping
 /// contract so operators can keep writing `ALETHEIA_GATEWAY__PORT=9000` without quoting.
-fn apply_env_overlay(root: &mut JsonValue, prefix: &str, separator: &str) {
-    for (key, value) in std::env::vars() {
+fn apply_env_overlay(root: &mut JsonValue, prefix: &str, separator: &str) -> Vec<String> {
+    let mut applied = Vec::new();
+    let mut vars: Vec<_> = std::env::vars().collect();
+    vars.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    for (key, value) in vars {
         let Some(rest) = key.strip_prefix(prefix) else {
             continue;
         };
@@ -148,7 +152,55 @@ fn apply_env_overlay(root: &mut JsonValue, prefix: &str, separator: &str) {
         if path.iter().any(String::is_empty) {
             continue;
         }
-        set_path(root, &path, parse_env_value(&value));
+        let parsed = get_path(root, &path).map_or_else(
+            || parse_env_value(&value),
+            |existing| coerce_env_value(&value, existing),
+        );
+        set_path(root, &path, parsed);
+        applied.push(key);
+    }
+    applied
+}
+
+fn deserialize_reason(applied_env_vars: &[String]) -> String {
+    if applied_env_vars.is_empty() {
+        "deserialize merged config".to_owned()
+    } else {
+        format!(
+            "deserialize merged config after applying {}",
+            applied_env_vars.join(", ")
+        )
+    }
+}
+
+fn get_path<'a>(root: &'a JsonValue, path: &[String]) -> Option<&'a JsonValue> {
+    let mut cursor = root;
+    for segment in path {
+        let map = cursor.as_object()?;
+        let key = matching_key(map, segment)?;
+        cursor = map.get(key)?;
+    }
+    Some(cursor)
+}
+
+fn matching_key<'a>(map: &'a serde_json::Map<String, JsonValue>, segment: &str) -> Option<&'a str> {
+    if let Some((key, _)) = map.get_key_value(segment) {
+        return Some(key.as_str());
+    }
+    map.keys()
+        .find(|key| key.eq_ignore_ascii_case(segment))
+        .map(String::as_str)
+}
+
+fn coerce_env_value(raw: &str, existing: &JsonValue) -> JsonValue {
+    match existing {
+        JsonValue::Bool(_) => match raw.trim() {
+            "true" => JsonValue::Bool(true),
+            "false" => JsonValue::Bool(false),
+            _ => JsonValue::String(raw.to_owned()),
+        },
+        JsonValue::Number(_) | JsonValue::Array(_) | JsonValue::Object(_) => parse_env_value(raw),
+        JsonValue::String(_) | JsonValue::Null => JsonValue::String(raw.to_owned()),
     }
 }
 
@@ -194,7 +246,8 @@ fn set_path(root: &mut JsonValue, path: &[String], value: JsonValue) {
                 *cursor = JsonValue::Object(serde_json::Map::new());
             }
             if let Some(map) = cursor.as_object_mut() {
-                map.insert(segment.clone(), value);
+                let key = matching_key(map, segment).map_or_else(|| segment.clone(), str::to_owned);
+                map.insert(key, value);
             }
             return;
         }
@@ -204,8 +257,9 @@ fn set_path(root: &mut JsonValue, path: &[String], value: JsonValue) {
         let Some(map) = cursor.as_object_mut() else {
             return;
         };
+        let key = matching_key(map, segment).map_or_else(|| segment.clone(), str::to_owned);
         cursor = map
-            .entry(segment.clone())
+            .entry(key)
             .or_insert_with(|| JsonValue::Object(serde_json::Map::new()));
     }
 }
@@ -500,6 +554,21 @@ mod tests {
         assert_eq!(
             config.gateway.port, 7777,
             "env var should override toml port"
+        );
+    }
+
+    #[test]
+    fn env_overlay_preserves_unknown_path_autotyping() {
+        let mut jail = EnvJail::new();
+        jail.set_env("_TAXIS_TEST_UNKNOWN__PORT", "5555");
+        let mut root = serde_json::json!({});
+
+        let applied = apply_env_overlay(&mut root, "_TAXIS_TEST_", "__");
+
+        assert_eq!(applied, vec!["_TAXIS_TEST_UNKNOWN__PORT"]);
+        assert_eq!(
+            root.get("unknown").and_then(|value| value.get("port")),
+            Some(&serde_json::json!(5555))
         );
     }
 

--- a/crates/taxis/tests/public_api_loader.rs
+++ b/crates/taxis/tests/public_api_loader.rs
@@ -92,6 +92,35 @@ fn load_config_env_var_overrides_toml_value() {
 }
 
 #[test]
+fn load_config_env_var_preserves_numeric_looking_string_leaf() {
+    let mut jail = EnvJail::new();
+    let root = seed_instance(&jail).to_path_buf();
+    jail.set_env("ALETHEIA_AGENTS__DEFAULTS__MODEL__PRIMARY", "+15551234567");
+
+    let oikos = Oikos::from_root(&root);
+    let config = load_config(&oikos).unwrap();
+    assert_eq!(
+        config.agents.defaults.model_defaults.model.primary,
+        "+15551234567"
+    );
+}
+
+#[test]
+fn load_config_env_var_type_error_names_applied_var() {
+    let mut jail = EnvJail::new();
+    let root = seed_instance(&jail).to_path_buf();
+    jail.set_env("ALETHEIA_GATEWAY__TLS__ENABLED", "definitely-not-bool");
+
+    let oikos = Oikos::from_root(&root);
+    let err = load_config(&oikos).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ALETHEIA_GATEWAY__TLS__ENABLED"),
+        "error should name the env var applied before deserialization failed: {msg}"
+    );
+}
+
+#[test]
 fn load_config_parses_camel_case_keys() {
     let jail = EnvJail::new();
     let root = seed_instance(&jail);

--- a/crates/taxis/tests/public_api_loader.rs
+++ b/crates/taxis/tests/public_api_loader.rs
@@ -95,13 +95,13 @@ fn load_config_env_var_overrides_toml_value() {
 fn load_config_env_var_preserves_numeric_looking_string_leaf() {
     let mut jail = EnvJail::new();
     let root = seed_instance(&jail).to_path_buf();
-    jail.set_env("ALETHEIA_AGENTS__DEFAULTS__MODEL__PRIMARY", "+15551234567");
+    jail.set_env("ALETHEIA_AGENTS__DEFAULTS__MODEL__PRIMARY", "+05550100123");
 
     let oikos = Oikos::from_root(&root);
     let config = load_config(&oikos).unwrap();
     assert_eq!(
         config.agents.defaults.model_defaults.model.primary,
-        "+15551234567"
+        "+05550100123"
     );
 }
 


### PR DESCRIPTION
Closes #4489
Closes #4479

The compounding pair: `apply_env_overlay` autotyped every `ALETHEIA_*` value (a `+1555…` phone string coerced to a number and corrupted a string leaf, with a deserialize error that never named the culprit), and `pylon::server::run` swallowed exactly that class of failure with `unwrap_or_else` defaults — starting a server on silent defaults instead of failing.

- **taxis**: env values are coerced to the EXISTING leaf's type in the merged defaults+TOML tree; autotype only for unknown paths. The final deserialize error enumerates the applied `ALETHEIA_*` vars by name. Tests: `+1555…` stays a string, unquoted port still works, error names the offending var.
- **pylon**: `unwrap_or_else` defaults replaced with typed `ServerError::Config` carrying the config path + parse source — startup fails fast and loud. Failure path tested.

Worker-gated CI-exact on verda before push.