### PR TITLE
fix(episteme): detect embedding metadata drift — v15 meta relation, fail-closed open, reembed loop closed

### DIFF
--- a/_llm/L3-api-index/episteme.md
+++ b/_llm/L3-api-index/episteme.md
@@ -964,6 +964,26 @@ impl OpenAiEmbeddingProvider {
 
 ## `src/embedding.rs`
 
+> Default model name reported by the mock provider.
+```rust
+pub const DEFAULT_MOCK_MODEL: &str = "mock-embedding";
+```
+
+> Default model repo used by the candle provider.
+```rust
+pub const DEFAULT_CANDLE_MODEL: &str = "BAAI/bge-small-en-v1.5";
+```
+
+> Default model name used by OpenAI-compatible embedding endpoints.
+```rust
+pub const DEFAULT_OPENAI_COMPAT_MODEL: &str = "default";
+```
+
+> Default model name used by Voyage embeddings.
+```rust
+pub const DEFAULT_VOYAGE_MODEL: &str = "voyage-3-lite";
+```
+
 ```rust
 pub enum EmbeddingError {
     /// The embedding model failed to initialize.
@@ -1044,6 +1064,12 @@ pub struct EmbeddingConfig {
     pub api_key: Option<koina::secret::SecretString>,
     /// Base URL for OpenAI-compatible endpoints (e.g. `http://127.0.0.1:5005/v1`).
     pub base_url: Option<String>,
+}
+```
+
+```rust
+impl EmbeddingConfig {
+    pub fn effective_model_name (&self) -> String;
 }
 ```
 
@@ -2367,6 +2393,14 @@ impl KnowledgeStore {
 
 ## `src/knowledge_store/mod.rs`
 
+> Datalog DDL for the embedding metadata relation.
+```rust
+pub const EMBEDDING_META_DDL: &str = r":create embedding_meta {
+    model: String =>
+    dim: Int
+}";
+```
+
 > Datalog DDL for initializing the knowledge schema.
 ```rust
 pub const KNOWLEDGE_DDL: &[&str] = &[
@@ -2476,6 +2510,7 @@ pub const KNOWLEDGE_DDL: &[&str] = &[
         confidence: Float,
         contributed_at: String
     }",
+    EMBEDDING_META_DDL,
 ];
 ```
 
@@ -2493,6 +2528,15 @@ pub fn hnsw_ddl (dim: usize) -> String
 
 ```rust
 pub fn fts_ddl () -> &'static str
+```
+
+```rust
+pub struct EmbeddingMeta {
+    /// Embedding model identifier persisted with the vector schema.
+    pub model: String,
+    /// Embedding vector dimension persisted with the vector schema.
+    pub dim: usize,
+}
 ```
 
 ```rust
@@ -2545,6 +2589,10 @@ pub struct SerendipityDiscoveryReport {
 pub struct KnowledgeConfig {
     /// Embedding dimension for the HNSW index.
     pub dim: usize,
+    /// Embedding model identifier expected by the persisted vector schema.
+    pub embedding_model: String,
+    /// Permit stores migrated with an unknown legacy embedding model.
+    pub allow_assumed_embedding_meta: bool,
     /// Admission policy for fact insertion. Default: [`DefaultAdmissionPolicy`](crate::admission::DefaultAdmissionPolicy).
     pub admission_policy: Box<dyn crate::admission::AdmissionPolicy>,
 }
@@ -2585,6 +2633,8 @@ pub struct HybridResult {
 pub struct KnowledgeStore {
     db: std::sync::Arc<crate::engine::Db>,
     dim: usize,
+    embedding_model: String,
+    allow_assumed_embedding_meta: bool,
     /// Serializes read-modify-write access counter increments to prevent races.
     access_lock: std::sync::Mutex<()>,
     /// Serializes admission-check + insert so concurrent writers for the same

--- a/_llm/L3-api-index/graphe.md
+++ b/_llm/L3-api-index/graphe.md
@@ -114,6 +114,20 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Persisted embedding metadata does not match the configured provider.
+    #[cfg(feature = "mneme-engine")]
+    #[snafu(display(
+        "embedding metadata drift detected: stored model '{stored_model}' dim {stored_dim}, configured model '{configured_model}' dim {configured_dim}; run `aletheia memory reembed` to rebuild embeddings before using recall"
+    ))]
+    EmbeddingDrift {
+        stored_model: String,
+        stored_dim: usize,
+        configured_model: String,
+        configured_dim: usize,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// Spawned blocking task failed.
     #[cfg(feature = "mneme-engine")]
     #[snafu(display("spawned task failed: {source}"))]

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "2617902368ad1c040fb60a4fbf550e8658e3743615b73dcad20da29ea9e6f9d7"
+source_hash = "34e2feca7d2ef18773ab0ffe3b039b925e63d393ca8784c0c0e40b8e7cb30b2e"
 l3_token_estimate = 167
 
 [[crates]]
@@ -86,8 +86,8 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "4913f6e978dc610c7ab85759d35a3db392f8eb56f2f75cda216400ca707b86a4"
-l3_token_estimate = 33655
+source_hash = "02f797fa0bd19322a12f8546fdb3058d942e1c04d102a701672d4be1a4a836ca"
+l3_token_estimate = 33980
 
 [[crates]]
 name = "gnosis"
@@ -98,8 +98,8 @@ l3_token_estimate = 1107
 [[crates]]
 name = "graphe"
 path = "crates/graphe"
-source_hash = "9626496f5263430277a8248469ecbd13c3b3218ccc3979f364c6d90e9791dcbb"
-l3_token_estimate = 5222
+source_hash = "c87dd1918beae56db96528a8381dd8c2154bd78da734718751f01769e12ea7d6"
+l3_token_estimate = 5367
 
 [[crates]]
 name = "hermeneus"
@@ -110,7 +110,7 @@ l3_token_estimate = 13698
 [[crates]]
 name = "integration-tests"
 path = "crates/integration-tests"
-source_hash = "83f34cf41a2b7b27d6980b6e59a4286ba91274b9d3dbf5b26fa09735b8f77d68"
+source_hash = "0ab54fc1087d4b8758c852ec53721e1a2aaa995c12ba40c739c0bd5d13599f1c"
 l3_token_estimate = 1170
 
 [[crates]]

--- a/crates/aletheia/src/bin/seed_psyche_facts.rs
+++ b/crates/aletheia/src/bin/seed_psyche_facts.rs
@@ -108,7 +108,7 @@ fn run(args: Args) -> anyhow::Result<()> {
         Fact, FactAccess, FactLifecycle, FactProvenance, FactSensitivity, FactTemporal,
         MemoryScope, Visibility, far_future,
     };
-    use mneme::knowledge_store::{KnowledgeConfig, KnowledgeStore};
+    use mneme::knowledge_store::KnowledgeStore;
 
     let facts_toml = std::fs::read_to_string(&args.facts_file)
         .map_err(|e| anyhow::anyhow!("failed to read facts file: {e}"))?;
@@ -128,7 +128,8 @@ fn run(args: Args) -> anyhow::Result<()> {
     std::fs::create_dir_all(&cohort_path)
         .map_err(|e| anyhow::anyhow!("failed to create cohort directory: {e}"))?;
 
-    let store = KnowledgeStore::open_fjall(&cohort_path, KnowledgeConfig::default())
+    let knowledge_config = knowledge_config_for_oikos(&oikos);
+    let store = KnowledgeStore::open_fjall(&cohort_path, knowledge_config)
         .map_err(|e| anyhow::anyhow!("failed to open knowledge store: {e}"))?;
 
     let now = jiff::Timestamp::now();
@@ -209,6 +210,29 @@ fn run(args: Args) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(feature = "recall")]
+fn knowledge_config_for_oikos(
+    oikos: &taxis::oikos::Oikos,
+) -> mneme::knowledge_store::KnowledgeConfig {
+    taxis::loader::load_config(oikos).ok().map_or_else(
+        mneme::knowledge_store::KnowledgeConfig::default,
+        |config| {
+            let embedding = mneme::embedding::EmbeddingConfig {
+                provider: config.embedding.provider.clone(),
+                model: config.embedding.model.clone(),
+                dimension: Some(config.embedding.dimension),
+                api_key: None,
+                base_url: None,
+            };
+            mneme::knowledge_store::KnowledgeConfig {
+                dim: config.embedding.dimension,
+                embedding_model: embedding.effective_model_name(),
+                ..Default::default()
+            }
+        },
+    )
 }
 
 #[cfg(feature = "recall")]

--- a/crates/aletheia/src/commands/agent_io.rs
+++ b/crates/aletheia/src/commands/agent_io.rs
@@ -264,6 +264,27 @@ fn knowledge_path_for_nous(oikos: &Oikos, nous_id: &str) -> PathBuf {
     oikos.knowledge_cohort_db(cohort.as_ref())
 }
 
+#[cfg(feature = "recall")]
+fn knowledge_config_for_oikos(oikos: &Oikos) -> mneme::knowledge_store::KnowledgeConfig {
+    taxis::loader::load_config(oikos).ok().map_or_else(
+        mneme::knowledge_store::KnowledgeConfig::default,
+        |config| {
+            let embedding = mneme::embedding::EmbeddingConfig {
+                provider: config.embedding.provider.clone(),
+                model: config.embedding.model.clone(),
+                dimension: Some(config.embedding.dimension),
+                api_key: None,
+                base_url: None,
+            };
+            mneme::knowledge_store::KnowledgeConfig {
+                dim: config.embedding.dimension,
+                embedding_model: embedding.effective_model_name(),
+                ..Default::default()
+            }
+        },
+    )
+}
+
 /// Enumerate the agent's typed knowledge from the live store.
 ///
 /// Returns `None` when the `recall` feature is disabled or when the
@@ -282,7 +303,7 @@ fn export_knowledge(
         return Ok(None);
     }
 
-    let config = mneme::knowledge_store::KnowledgeConfig::default();
+    let config = knowledge_config_for_oikos(oikos);
     let Ok(store) = KnowledgeStore::open_fjall(&knowledge_path, config) else {
         return Ok(None);
     };
@@ -351,6 +372,14 @@ fn import_knowledge(
         .as_ref()
         .map_or_else(KnowledgeConfig::default, |config| KnowledgeConfig {
             dim: config.embedding.dimension,
+            embedding_model: EmbeddingConfig {
+                provider: config.embedding.provider.clone(),
+                model: config.embedding.model.clone(),
+                dimension: Some(config.embedding.dimension),
+                api_key: None,
+                base_url: None,
+            }
+            .effective_model_name(),
             ..Default::default()
         });
 
@@ -1088,7 +1117,7 @@ pub(crate) fn seed_skills(instance_root: Option<&PathBuf>, args: &SeedSkillsArgs
 
         let oikos = super::resolve_oikos(instance_root)?;
         let knowledge_path = knowledge_path_for_nous(&oikos, nous_id);
-        let config = mneme::knowledge_store::KnowledgeConfig::default();
+        let config = knowledge_config_for_oikos(&oikos);
         let store =
             KnowledgeStore::open_fjall(&knowledge_path, config).with_whatever_context(|_| {
                 format!(
@@ -1223,7 +1252,7 @@ pub(crate) async fn export_skills(
         };
         let knowledge_path = knowledge_path_for_nous(&oikos, &args.nous_id);
 
-        let config = mneme::knowledge_store::KnowledgeConfig::default();
+        let config = knowledge_config_for_oikos(&oikos);
         let store =
             KnowledgeStore::open_fjall(&knowledge_path, config).with_whatever_context(|_| {
                 format!(
@@ -1313,7 +1342,7 @@ pub(crate) async fn review_skills(
         };
         let knowledge_path = knowledge_path_for_nous(&oikos, &args.nous_id);
 
-        let config = mneme::knowledge_store::KnowledgeConfig::default();
+        let config = knowledge_config_for_oikos(&oikos);
         let store =
             KnowledgeStore::open_fjall(&knowledge_path, config).with_whatever_context(|_| {
                 format!(
@@ -2854,6 +2883,7 @@ workspace = "nous/{agent_id}"
             &knowledge_path,
             mneme::knowledge_store::KnowledgeConfig {
                 dim: 4,
+                embedding_model: "mock-embedding".to_owned(),
                 ..Default::default()
             },
         )

--- a/crates/aletheia/src/commands/ingest.rs
+++ b/crates/aletheia/src/commands/ingest.rs
@@ -50,7 +50,23 @@ pub(crate) async fn run(args: &IngestArgs, instance_root: Option<&PathBuf>) -> R
             );
         }
 
-        let config = mneme::knowledge_store::KnowledgeConfig::default();
+        let config = taxis::loader::load_config(&oikos).ok().map_or_else(
+            mneme::knowledge_store::KnowledgeConfig::default,
+            |config| {
+                let embedding = mneme::embedding::EmbeddingConfig {
+                    provider: config.embedding.provider.clone(),
+                    model: config.embedding.model.clone(),
+                    dimension: Some(config.embedding.dimension),
+                    api_key: None,
+                    base_url: None,
+                };
+                mneme::knowledge_store::KnowledgeConfig {
+                    dim: config.embedding.dimension,
+                    embedding_model: embedding.effective_model_name(),
+                    ..Default::default()
+                }
+            },
+        );
         let store = mneme::knowledge_store::KnowledgeStore::open_fjall(&knowledge_path, config)
             .whatever_context("failed to open knowledge store")?;
 

--- a/crates/aletheia/src/commands/memory/mod.rs
+++ b/crates/aletheia/src/commands/memory/mod.rs
@@ -146,37 +146,22 @@ pub(crate) async fn run(action: Action, url: &str, instance_root: Option<&PathBu
             );
         }
 
-        // WHY (#4165 D): load the resolved aletheia config so the dedup
-        // CLI honours the operator's `knowledge_dedup_*` knobs the same
-        // way the scheduled maintenance task does. A missing/invalid
-        // config falls back to the historical defaults — the same shape
-        // every prior CLI invocation used — so this is strictly additive.
-        let loaded_config = if matches!(action, Action::Dedup { .. } | Action::Reembed) {
-            Some(taxis::loader::load_config(&oikos))
-        } else {
-            None
-        };
+        let loaded_config = taxis::loader::load_config(&oikos);
         let dedup_tuning = loaded_config
             .as_ref()
-            .and_then(|result| result.as_ref().ok())
+            .ok()
             .map_or(mneme::dedup::DedupTuning::DEFAULT, |cfg| {
                 crate::knowledge_maintenance::tuning_from_behavior(&cfg.agents.defaults.behavior)
             });
-        let recovery_dim = loaded_config
-            .as_ref()
-            .and_then(|result| result.as_ref().ok())
-            .map_or_else(
-                || mneme::knowledge_store::KnowledgeConfig::default().dim,
-                |cfg| cfg.embedding.dimension,
-            );
+        let recovery_config = knowledge_config_from_loaded(&loaded_config, false);
 
         match action {
             // WHY: reembed/gc iterate every cohort store themselves, so they
             // must not pre-open the shared store like the other actions.
-            Action::Reembed => run_reembed(&oikos, recovery_dim, loaded_config.as_ref()),
-            Action::Gc => run_gc(&oikos, recovery_dim),
+            Action::Reembed => run_reembed(&oikos, &loaded_config),
+            Action::Gc => run_gc(&oikos, &recovery_config),
             store_action => {
-                let store = open_recovery_store(&knowledge_path, recovery_dim)?;
+                let store = open_recovery_store(&knowledge_path, &recovery_config)?;
                 run_store_action(&store, store_action, &dedup_tuning)
             }
         }
@@ -558,12 +543,22 @@ fn run_store_action(
 }
 
 #[cfg(feature = "recall")]
+#[derive(Debug, Clone)]
+struct RecoveryKnowledgeConfig {
+    dim: usize,
+    embedding_model: String,
+    allow_assumed_embedding_meta: bool,
+}
+
+#[cfg(feature = "recall")]
 fn open_recovery_store(
     path: &Path,
-    dim: usize,
+    config: &RecoveryKnowledgeConfig,
 ) -> Result<std::sync::Arc<mneme::knowledge_store::KnowledgeStore>> {
     let config = mneme::knowledge_store::KnowledgeConfig {
-        dim,
+        dim: config.dim,
+        embedding_model: config.embedding_model.clone(),
+        allow_assumed_embedding_meta: config.allow_assumed_embedding_meta,
         ..Default::default()
     };
     // NOTE: lock contention surfaces from the typed
@@ -575,6 +570,33 @@ fn open_recovery_store(
             path.display()
         ))
     })
+}
+
+#[cfg(feature = "recall")]
+fn knowledge_config_from_loaded(
+    loaded: &std::result::Result<taxis::config::AletheiaConfig, taxis::error::Error>,
+    allow_assumed_embedding_meta: bool,
+) -> RecoveryKnowledgeConfig {
+    let Some(config) = loaded.as_ref().ok() else {
+        let default = mneme::knowledge_store::KnowledgeConfig::default();
+        return RecoveryKnowledgeConfig {
+            dim: default.dim,
+            embedding_model: default.embedding_model,
+            allow_assumed_embedding_meta,
+        };
+    };
+    let embedding_config = mneme::embedding::EmbeddingConfig {
+        provider: config.embedding.provider.clone(),
+        model: config.embedding.model.clone(),
+        dimension: Some(config.embedding.dimension),
+        api_key: None,
+        base_url: None,
+    };
+    RecoveryKnowledgeConfig {
+        dim: config.embedding.dimension,
+        embedding_model: embedding_config.effective_model_name(),
+        allow_assumed_embedding_meta,
+    }
 }
 
 #[cfg(feature = "recall")]
@@ -601,18 +623,12 @@ fn recovery_store_paths(oikos: &taxis::oikos::Oikos) -> Result<Vec<PathBuf>> {
 #[cfg(feature = "recall")]
 fn run_reembed(
     oikos: &taxis::oikos::Oikos,
-    dim: usize,
-    loaded_config: Option<&std::result::Result<taxis::config::AletheiaConfig, taxis::error::Error>>,
+    loaded_config: &std::result::Result<taxis::config::AletheiaConfig, taxis::error::Error>,
 ) -> Result<()> {
     let config = match loaded_config {
-        Some(Ok(cfg)) => cfg,
-        Some(Err(err)) => {
+        Ok(cfg) => cfg,
+        Err(err) => {
             whatever!("failed to load instance config for memory reembed: {err}");
-        }
-        None => {
-            whatever!(
-                "failed to load instance config for memory reembed; the configured embedding provider is required"
-            );
         }
     };
     let embedding_config = mneme::embedding::EmbeddingConfig {
@@ -636,8 +652,9 @@ fn run_reembed(
 
     let store_count = stores.len();
     let mut total = 0usize;
+    let recovery_config = knowledge_config_from_loaded(loaded_config, true);
     for store_path in stores {
-        let store = open_recovery_store(&store_path, dim)?;
+        let store = open_recovery_store(&store_path, &recovery_config)?;
         let written = store
             .reembed_all(provider.as_ref())
             .with_whatever_context(|err| {
@@ -655,7 +672,7 @@ fn run_reembed(
 }
 
 #[cfg(feature = "recall")]
-fn run_gc(oikos: &taxis::oikos::Oikos, dim: usize) -> Result<()> {
+fn run_gc(oikos: &taxis::oikos::Oikos, config: &RecoveryKnowledgeConfig) -> Result<()> {
     let stores = recovery_store_paths(oikos)?;
     if stores.is_empty() {
         whatever!(
@@ -667,7 +684,7 @@ fn run_gc(oikos: &taxis::oikos::Oikos, dim: usize) -> Result<()> {
 
     let mut total = 0usize;
     for store_path in &stores {
-        let store = open_recovery_store(store_path, dim)?;
+        let store = open_recovery_store(store_path, config)?;
         let removed = store
             .remove_orphaned_entities()
             .with_whatever_context(|err| {

--- a/crates/aletheia/src/commands/repl.rs
+++ b/crates/aletheia/src/commands/repl.rs
@@ -75,7 +75,23 @@ fn run_repl(instance_root: Option<&PathBuf>) -> Result<()> {
         );
     }
 
-    let config = mneme::knowledge_store::KnowledgeConfig::default();
+    let config = taxis::loader::load_config(&oikos).ok().map_or_else(
+        mneme::knowledge_store::KnowledgeConfig::default,
+        |config| {
+            let embedding = mneme::embedding::EmbeddingConfig {
+                provider: config.embedding.provider.clone(),
+                model: config.embedding.model.clone(),
+                dimension: Some(config.embedding.dimension),
+                api_key: None,
+                base_url: None,
+            };
+            mneme::knowledge_store::KnowledgeConfig {
+                dim: config.embedding.dimension,
+                embedding_model: embedding.effective_model_name(),
+                ..Default::default()
+            }
+        },
+    );
     let store = mneme::knowledge_store::KnowledgeStore::open_fjall(&knowledge_path, config)
         .whatever_context("failed to open knowledge store")?;
 

--- a/crates/aletheia/src/migrate_memory.rs
+++ b/crates/aletheia/src/migrate_memory.rs
@@ -98,7 +98,11 @@ pub(crate) async fn run(
         }
     };
 
-    let knowledge_config = KnowledgeConfig::default();
+    let knowledge_config = KnowledgeConfig {
+        dim: config.embedding.dimension,
+        embedding_model: embedding_config.effective_model_name(),
+        ..Default::default()
+    };
     let knowledgedb = if dry_run {
         KnowledgeStore::open_mem_with_config(knowledge_config)
             .whatever_context("failed to open in-memory knowledge store")?

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -406,7 +406,12 @@ impl RuntimeBuilder {
                 let resolved = resolve_nous(&self.config, &agent_def.id);
                 cohorts.insert(resolved.episteme_cohort.to_string());
             }
-            open_knowledge_stores(&self.oikos, cohorts, self.config.knowledge.admission_policy)?
+            open_knowledge_stores(
+                &self.oikos,
+                cohorts,
+                &self.config.embedding,
+                self.config.knowledge.admission_policy,
+            )?
         } else {
             std::collections::HashMap::new()
         };

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -587,6 +587,7 @@ impl LazyEmbeddingProvider {
 pub(super) fn open_knowledge_stores(
     oikos: &Oikos,
     cohorts: impl IntoIterator<Item = String>,
+    embedding: &EmbeddingSettings,
     admission_policy: taxis::config::AdmissionPolicyKind,
 ) -> Result<std::collections::HashMap<String, Arc<mneme::knowledge_store::KnowledgeStore>>> {
     let mut stores = std::collections::HashMap::new();
@@ -596,7 +597,7 @@ pub(super) fn open_knowledge_stores(
             std::fs::create_dir_all(parent)
                 .whatever_context("failed to CREATE knowledge store directory")?;
         }
-        let knowledge_config = build_knowledge_config(admission_policy);
+        let knowledge_config = build_knowledge_config(embedding, admission_policy, false);
         let store =
             match mneme::knowledge_store::KnowledgeStore::open_fjall(&kb_path, knowledge_config) {
                 Ok(s) => s,
@@ -614,7 +615,7 @@ pub(super) fn open_knowledge_stores(
                 }
             };
         mneme::trace_ingest::ensure_ops_schema(&store);
-        info!(cohort = %cohort, path = %kb_path.display(), dim = 384, "knowledge store opened (fjall)");
+        info!(cohort = %cohort, path = %kb_path.display(), dim = embedding.dimension, "knowledge store opened (fjall)");
         stores.insert(cohort, store);
     }
     Ok(stores)
@@ -626,7 +627,9 @@ pub(super) fn open_knowledge_stores(
 /// episteme runtime trait object so neither crate depends on the other directly.
 #[cfg(feature = "recall")]
 pub(super) fn build_knowledge_config(
+    embedding: &EmbeddingSettings,
     kind: taxis::config::AdmissionPolicyKind,
+    allow_assumed_embedding_meta: bool,
 ) -> mneme::knowledge_store::KnowledgeConfig {
     let policy: Box<dyn mneme::admission::AdmissionPolicy> = match kind {
         taxis::config::AdmissionPolicyKind::Structured => {
@@ -637,9 +640,18 @@ pub(super) fn build_knowledge_config(
         // NOTE: Default and any future variants fall through to admit-all.
         _ => Box::new(mneme::admission::DefaultAdmissionPolicy),
     };
+    let embedding_config = EmbeddingConfig {
+        provider: embedding.provider.clone(),
+        model: embedding.model.clone(),
+        dimension: Some(embedding.dimension),
+        api_key: None,
+        base_url: None,
+    };
     mneme::knowledge_store::KnowledgeConfig {
+        dim: embedding.dimension,
+        embedding_model: embedding_config.effective_model_name(),
+        allow_assumed_embedding_meta,
         admission_policy: policy,
-        ..mneme::knowledge_store::KnowledgeConfig::default()
     }
 }
 

--- a/crates/episteme/src/embedding.rs
+++ b/crates/episteme/src/embedding.rs
@@ -11,6 +11,15 @@
 use snafu::Snafu;
 use tracing::instrument;
 
+/// Default model name reported by the mock provider.
+pub const DEFAULT_MOCK_MODEL: &str = "mock-embedding";
+/// Default model repo used by the candle provider.
+pub const DEFAULT_CANDLE_MODEL: &str = "BAAI/bge-small-en-v1.5";
+/// Default model name used by OpenAI-compatible embedding endpoints.
+pub const DEFAULT_OPENAI_COMPAT_MODEL: &str = "default";
+/// Default model name used by Voyage embeddings.
+pub const DEFAULT_VOYAGE_MODEL: &str = "voyage-3-lite";
+
 /// Errors from embedding operations.
 #[derive(Debug, Snafu)]
 #[expect(
@@ -136,8 +145,6 @@ mod candle_provider {
     }
 
     impl CandelProvider {
-        /// Default `HuggingFace` model repo for `BGE-small-en-v1.5`.
-        const DEFAULT_REPO: &str = "BAAI/bge-small-en-v1.5";
         /// Create a provider with the given model repo, or the default (`BAAI/bge-small-en-v1.5`).
         ///
         /// Model files are downloaded to the `HuggingFace` cache on first use.
@@ -147,7 +154,7 @@ mod candle_provider {
         /// Returns `EmbeddingError::InitFailed` if model download or initialization fails.
         #[instrument]
         pub(crate) fn new(model_repo: Option<&str>) -> EmbeddingResult<Self> {
-            let repo_id = model_repo.unwrap_or(Self::DEFAULT_REPO);
+            let repo_id = model_repo.unwrap_or(super::DEFAULT_CANDLE_MODEL);
             let device = Device::Cpu;
 
             let api = hf_hub::api::sync::Api::new().map_err(|e| {
@@ -447,6 +454,23 @@ impl Default for EmbeddingConfig {
     }
 }
 
+impl EmbeddingConfig {
+    /// Return the model identifier the provider will report for this config.
+    #[must_use]
+    pub fn effective_model_name(&self) -> String {
+        if let Some(model) = self.model.as_ref().filter(|model| !model.is_empty()) {
+            return model.clone();
+        }
+        match self.provider.as_str() {
+            "mock" => DEFAULT_MOCK_MODEL.to_owned(),
+            "candle" => DEFAULT_CANDLE_MODEL.to_owned(),
+            "openai-compat" => DEFAULT_OPENAI_COMPAT_MODEL.to_owned(),
+            "voyage" => DEFAULT_VOYAGE_MODEL.to_owned(),
+            provider => provider.to_owned(),
+        }
+    }
+}
+
 /// A no-op embedding provider used in degraded mode when the real provider fails to load.
 ///
 /// Every `embed` call returns an error so callers that require embeddings (recall, search)
@@ -512,7 +536,10 @@ pub fn create_provider(config: &EmbeddingConfig) -> EmbeddingResult<Box<dyn Embe
                 .as_deref()
                 .unwrap_or("http://127.0.0.1:5005/v1")
                 .to_owned();
-            let model = config.model.clone().unwrap_or_else(|| "default".to_owned());
+            let model = config
+                .model
+                .clone()
+                .unwrap_or_else(|| DEFAULT_OPENAI_COMPAT_MODEL.to_owned());
             let dim = config.dimension.unwrap_or(384);
             let cfg = OpenAiCompatConfig {
                 base_url,
@@ -527,7 +554,7 @@ pub fn create_provider(config: &EmbeddingConfig) -> EmbeddingResult<Box<dyn Embe
             let model = config
                 .model
                 .clone()
-                .unwrap_or_else(|| "voyage-3-lite".to_owned());
+                .unwrap_or_else(|| DEFAULT_VOYAGE_MODEL.to_owned());
             let dim = config.dimension.unwrap_or(1024);
             let api_key = config.api_key.clone().or_else(|| {
                 std::env::var("VOYAGE_API_KEY")

--- a/crates/episteme/src/embedding/embedding_impl.rs
+++ b/crates/episteme/src/embedding/embedding_impl.rs
@@ -6,7 +6,8 @@ use tracing::instrument;
 #[cfg(any(test, feature = "test-support"))]
 use crate::embedding::MockEmbeddingProvider;
 use crate::embedding::{
-    DegradedEmbeddingProvider, EmbedFailedSnafu, EmbeddingProvider, EmbeddingResult,
+    DEFAULT_MOCK_MODEL, DegradedEmbeddingProvider, EmbedFailedSnafu, EmbeddingProvider,
+    EmbeddingResult,
 };
 
 // ── MockEmbeddingProvider implementation ─────────────────────────────────────
@@ -52,12 +53,8 @@ impl EmbeddingProvider for MockEmbeddingProvider {
         self.dim
     }
 
-    #[expect(
-        clippy::unnecessary_literal_bound,
-        reason = "trait method returns `&str` to support runtime-loaded model names; mock returns a literal"
-    )]
     fn model_name(&self) -> &str {
-        "mock-embedding"
+        DEFAULT_MOCK_MODEL
     }
 }
 

--- a/crates/episteme/src/knowledge_store/facts.rs
+++ b/crates/episteme/src/knowledge_store/facts.rs
@@ -15,8 +15,36 @@ impl KnowledgeStore {
         &self,
         provider: &dyn crate::embedding::EmbeddingProvider,
     ) -> crate::error::Result<usize> {
+        if crate::embedding::is_degraded_provider(provider) {
+            return Err(crate::error::EngineQuerySnafu {
+                message: "cannot re-embed facts with degraded embedding provider".to_owned(),
+            }
+            .build());
+        }
+        if provider.dimension() != self.dim {
+            return Err(crate::error::EmbeddingDimensionMismatchSnafu {
+                expected: self.dim,
+                actual: provider.dimension(),
+            }
+            .build());
+        }
         let facts = self.list_all_facts(i64::MAX)?;
         let written = self.backfill_fact_embeddings(&facts, provider);
+        let expected = u64::try_from(facts.len()).map_err(|err| {
+            crate::error::ConversionSnafu {
+                message: format!("fact count overflowed u64: {err}"),
+            }
+            .build()
+        })?;
+        if written != expected {
+            return Err(crate::error::EngineQuerySnafu {
+                message: format!(
+                    "re-embed incomplete: wrote {written} of {expected} fact embeddings"
+                ),
+            }
+            .build());
+        }
+        self.replace_embedding_meta(provider.model_name(), provider.dimension())?;
         usize::try_from(written).map_err(|err| {
             crate::error::ConversionSnafu {
                 message: format!("reembedded fact count overflowed usize: {err}"),

--- a/crates/episteme/src/knowledge_store/migration.rs
+++ b/crates/episteme/src/knowledge_store/migration.rs
@@ -2,7 +2,7 @@
     clippy::indexing_slicing,
     reason = "knowledge engine: ported codebase with numeric casts and direct indexing throughout"
 )]
-use super::{KNOWLEDGE_DDL, KnowledgeStore, entities_ddl, fts_ddl};
+use super::{EMBEDDING_META_DDL, KNOWLEDGE_DDL, KnowledgeStore, entities_ddl, fts_ddl};
 
 pub(super) struct MigrationStep {
     pub(super) target_version: i64,
@@ -61,6 +61,10 @@ pub(super) const MIGRATIONS: &[MigrationStep] = &[
     MigrationStep {
         target_version: 14,
         run: KnowledgeStore::migrate_v13_to_v14,
+    },
+    MigrationStep {
+        target_version: 15,
+        run: KnowledgeStore::migrate_v14_to_v15,
     },
 ];
 
@@ -1043,6 +1047,43 @@ impl KnowledgeStore {
         self.stamp_schema_version(14, "v13->v14")?;
 
         tracing::info!("knowledge schema migration v13 -> v14 complete");
+        Ok(())
+    }
+
+    /// Migrate v14 → v15: persist embedding schema metadata.
+    ///
+    /// Existing stores did not record the embedding model that produced their
+    /// vectors. The migration writes the explicit `assumed` marker instead of
+    /// guessing a provider name, forcing normal startup to ask the operator for
+    /// a re-embed before recall uses unknown vectors.
+    pub(super) fn migrate_v14_to_v15(&self) -> crate::error::Result<()> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::ScriptMutability;
+        tracing::info!("migrating knowledge schema v14 -> v15");
+
+        if !self
+            .relation_names()?
+            .iter()
+            .any(|name| name == "embedding_meta")
+        {
+            self.db
+                .run(
+                    EMBEDDING_META_DDL,
+                    BTreeMap::new(),
+                    ScriptMutability::Mutable,
+                )
+                .map_err(|e| {
+                    crate::error::EngineQuerySnafu {
+                        message: format!("v14->v15 create embedding_meta: {e}"),
+                    }
+                    .build()
+                })?;
+        }
+        self.replace_embedding_meta(Self::ASSUMED_EMBEDDING_MODEL, self.dim)?;
+        self.stamp_schema_version(15, "v14->v15")?;
+
+        tracing::info!("knowledge schema migration v14 -> v15 complete");
         Ok(())
     }
 }

--- a/crates/episteme/src/knowledge_store/mod.rs
+++ b/crates/episteme/src/knowledge_store/mod.rs
@@ -28,6 +28,8 @@
 //! embeddings { id: String => content: String, source_type: String, source_id: String,
 //!              nous_id: String, embedding: <F32; DIM>, created_at: String }
 //!
+//! embedding_meta { model: String => dim: Int }
+//!
 //! type_hierarchy { child_type: String, parent_type: String => created_at: String }
 //!
 //! derived_facts { entity_id: String, rule_id: String, derived_content: String =>
@@ -70,6 +72,12 @@ mod skills;
 mod tests;
 
 use tracing::instrument;
+
+/// Datalog DDL for the embedding metadata relation.
+pub const EMBEDDING_META_DDL: &str = r":create embedding_meta {
+    model: String =>
+    dim: Int
+}";
 
 /// Datalog DDL for initializing the knowledge schema.
 pub const KNOWLEDGE_DDL: &[&str] = &[
@@ -179,6 +187,7 @@ pub const KNOWLEDGE_DDL: &[&str] = &[
         confidence: Float,
         contributed_at: String
     }",
+    EMBEDDING_META_DDL,
 ];
 
 /// Datalog DDL for the entities relation. Dimension is parameterized so the
@@ -241,6 +250,16 @@ pub fn fts_ddl() -> &'static str {
         tokenizer: Simple,
         filters: [Lowercase, Stemmer('English'), Stopwords('en')]
     }"
+}
+
+#[cfg(feature = "mneme-engine")]
+/// Persisted embedding metadata for the knowledge store vector schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingMeta {
+    /// Embedding model identifier persisted with the vector schema.
+    pub model: String,
+    /// Embedding vector dimension persisted with the vector schema.
+    pub dim: usize,
 }
 
 /// Re-export query builder types and pre-built query scripts.
@@ -455,6 +474,10 @@ pub struct SerendipityDiscoveryReport {
 pub struct KnowledgeConfig {
     /// Embedding dimension for the HNSW index.
     pub dim: usize,
+    /// Embedding model identifier expected by the persisted vector schema.
+    pub embedding_model: String,
+    /// Permit stores migrated with an unknown legacy embedding model.
+    pub allow_assumed_embedding_meta: bool,
     /// Admission policy for fact insertion. Default: [`DefaultAdmissionPolicy`](crate::admission::DefaultAdmissionPolicy).
     pub admission_policy: Box<dyn crate::admission::AdmissionPolicy>,
 }
@@ -464,6 +487,11 @@ impl std::fmt::Debug for KnowledgeConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KnowledgeConfig")
             .field("dim", &self.dim)
+            .field("embedding_model", &self.embedding_model)
+            .field(
+                "allow_assumed_embedding_meta",
+                &self.allow_assumed_embedding_meta,
+            )
             .field("admission_policy", &"<dyn AdmissionPolicy>")
             .finish()
     }
@@ -474,6 +502,8 @@ impl Default for KnowledgeConfig {
     fn default() -> Self {
         Self {
             dim: 384,
+            embedding_model: crate::embedding::DEFAULT_CANDLE_MODEL.to_owned(),
+            allow_assumed_embedding_meta: false,
             admission_policy: Box::new(crate::admission::DefaultAdmissionPolicy),
         }
     }
@@ -534,6 +564,8 @@ impl crate::query_rewrite::HasRrfScore for HybridResult {
 pub struct KnowledgeStore {
     db: std::sync::Arc<crate::engine::Db>,
     dim: usize,
+    embedding_model: String,
+    allow_assumed_embedding_meta: bool,
     /// Serializes read-modify-write access counter increments to prevent races.
     access_lock: std::sync::Mutex<()>,
     /// Serializes admission-check + insert so concurrent writers for the same
@@ -552,8 +584,9 @@ pub struct KnowledgeStore {
 
 #[cfg(feature = "mneme-engine")]
 impl KnowledgeStore {
-    pub(crate) const SCHEMA_VERSION: i64 = 14;
+    pub(crate) const SCHEMA_VERSION: i64 = 15;
     const MIN_SCHEMA_VERSION: i64 = 1;
+    pub(crate) const ASSUMED_EMBEDDING_MODEL: &'static str = "assumed";
 
     /// Open an in-memory knowledge store with default configuration.
     ///
@@ -583,6 +616,8 @@ impl KnowledgeStore {
         let store = Self {
             db: std::sync::Arc::new(db),
             dim: config.dim,
+            embedding_model: config.embedding_model,
+            allow_assumed_embedding_meta: config.allow_assumed_embedding_meta,
             access_lock: std::sync::Mutex::new(()),
             insert_lock: std::sync::Mutex::new(()),
             admission_policy: config.admission_policy,
@@ -617,6 +652,8 @@ impl KnowledgeStore {
         let store = Self {
             db: std::sync::Arc::new(db),
             dim: config.dim,
+            embedding_model: config.embedding_model,
+            allow_assumed_embedding_meta: config.allow_assumed_embedding_meta,
             access_lock: std::sync::Mutex::new(()),
             insert_lock: std::sync::Mutex::new(()),
             admission_policy: config.admission_policy,
@@ -752,6 +789,7 @@ impl KnowledgeStore {
             self.verify_schema_integrity(current_version)?;
             self.apply_pending_migrations(current_version)?;
             self.verify_schema_integrity(Self::SCHEMA_VERSION)?;
+            self.verify_embedding_meta()?;
             return Ok(());
         }
 
@@ -876,6 +914,7 @@ impl KnowledgeStore {
             })?;
 
         self.stamp_fresh_schema_versions()?;
+        self.write_configured_embedding_meta()?;
 
         Ok(())
     }
@@ -1070,6 +1109,105 @@ impl KnowledgeStore {
                 .build()
             })?;
         Ok(())
+    }
+
+    fn write_configured_embedding_meta(&self) -> crate::error::Result<()> {
+        self.replace_embedding_meta(&self.embedding_model, self.dim)
+    }
+
+    fn replace_embedding_meta(&self, model: &str, dim: usize) -> crate::error::Result<()> {
+        use std::collections::BTreeMap;
+
+        use crate::engine::{DataValue, ScriptMutability};
+        let dim = i64::try_from(dim).map_err(|err| {
+            crate::error::ConversionSnafu {
+                message: format!("embedding dimension overflowed i64: {err}"),
+            }
+            .build()
+        })?;
+        let mut params = BTreeMap::new();
+        params.insert("model".to_owned(), DataValue::Str(model.into()));
+        params.insert("dim".to_owned(), DataValue::from(dim));
+        self.db
+            .run(
+                r"?[model] := *embedding_meta{model}
+                  :rm embedding_meta {model}",
+                BTreeMap::new(),
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("embedding metadata clear failed: {e}"),
+                }
+                .build()
+            })?;
+        self.db
+            .run(
+                r"?[model, dim] <- [[$model, $dim]]
+                  :put embedding_meta {model => dim}",
+                params,
+                ScriptMutability::Mutable,
+            )
+            .map_err(|e| {
+                crate::error::EngineQuerySnafu {
+                    message: format!("embedding metadata write failed: {e}"),
+                }
+                .build()
+            })?;
+        Ok(())
+    }
+
+    pub(crate) fn embedding_meta(&self) -> crate::error::Result<EmbeddingMeta> {
+        let rows = self.run_read(
+            r"?[model, dim] := *embedding_meta{model, dim}",
+            std::collections::BTreeMap::new(),
+        )?;
+        let row = rows.rows.into_iter().next().ok_or_else(|| {
+            crate::error::EngineQuerySnafu {
+                message: "embedding metadata row missing".to_owned(),
+            }
+            .build()
+        })?;
+        let model = marshal::extract_str(row.first().ok_or_else(|| {
+            crate::error::EngineQuerySnafu {
+                message: "embedding metadata model cell missing".to_owned(),
+            }
+            .build()
+        })?)?
+        .clone();
+        let dim_value = marshal::extract_int(row.get(1).ok_or_else(|| {
+            crate::error::EngineQuerySnafu {
+                message: "embedding metadata dimension cell missing".to_owned(),
+            }
+            .build()
+        })?)?;
+        let dim = usize::try_from(dim_value).map_err(|err| {
+            crate::error::ConversionSnafu {
+                message: format!("embedding metadata dimension was not usize: {err}"),
+            }
+            .build()
+        })?;
+        Ok(EmbeddingMeta { model, dim })
+    }
+
+    fn verify_embedding_meta(&self) -> crate::error::Result<()> {
+        let meta = self.embedding_meta()?;
+        if meta.model == Self::ASSUMED_EMBEDDING_MODEL
+            && self.allow_assumed_embedding_meta
+            && meta.dim == self.dim
+        {
+            return Ok(());
+        }
+        if meta.model == self.embedding_model && meta.dim == self.dim {
+            return Ok(());
+        }
+        Err(crate::error::EmbeddingDriftSnafu {
+            stored_model: meta.model,
+            stored_dim: meta.dim,
+            configured_model: self.embedding_model.clone(),
+            configured_dim: self.dim,
+        }
+        .build())
     }
 
     fn schema_integrity_error(message: impl Into<String>) -> crate::error::Error {

--- a/crates/episteme/src/knowledge_store/tests/admission.rs
+++ b/crates/episteme/src/knowledge_store/tests/admission.rs
@@ -23,6 +23,7 @@ fn make_structured_store(threshold: f64) -> Arc<KnowledgeStore> {
     KnowledgeStore::open_mem_with_config(KnowledgeConfig {
         dim: DIM,
         admission_policy: Box::new(StructuredAdmissionPolicy::new(config)),
+        ..Default::default()
     })
     .expect("open structured-policy store")
 }
@@ -31,6 +32,7 @@ fn make_default_store() -> Arc<KnowledgeStore> {
     KnowledgeStore::open_mem_with_config(KnowledgeConfig {
         dim: DIM,
         admission_policy: Box::new(DefaultAdmissionPolicy),
+        ..Default::default()
     })
     .expect("open default-policy store")
 }
@@ -163,6 +165,7 @@ fn concurrent_insert_same_fact_store_contains_one_row() {
         KnowledgeStore::open_mem_with_config(KnowledgeConfig {
             dim: DIM,
             admission_policy: Box::new(DefaultAdmissionPolicy),
+            ..Default::default()
         })
         .expect("open store"),
     );

--- a/crates/episteme/src/knowledge_store/tests/ddl.rs
+++ b/crates/episteme/src/knowledge_store/tests/ddl.rs
@@ -12,8 +12,8 @@ use super::super::*;
 #[test]
 fn ddl_templates_are_valid_strings() {
     assert!(
-        KNOWLEDGE_DDL.len() == 12,
-        "expected 12 DDL entries (including type_hierarchy, derived_facts, defaults, published_facts, provenance)"
+        KNOWLEDGE_DDL.len() == 13,
+        "expected 13 DDL entries (including type_hierarchy, derived_facts, defaults, published_facts, provenance, embedding_meta)"
     );
     let emb = embeddings_ddl(1024);
     assert!(emb.contains("1024"));

--- a/crates/episteme/src/knowledge_store/tests/migration.rs
+++ b/crates/episteme/src/knowledge_store/tests/migration.rs
@@ -124,7 +124,7 @@ fn missing_intermediate_stamp_is_detected_as_hole() {
 
 #[test]
 fn crash_mid_sequence_resume_applies_only_missing_tail() {
-    let store = make_store();
+    let store = make_store_allowing_assumed_meta();
     store
         .run_mut_query(
             r#"?[key] <- [["migration:13"]] :rm schema_version {key}"#,
@@ -199,9 +199,37 @@ fn make_store() -> std::sync::Arc<KnowledgeStore> {
     .expect("open in-memory knowledge store")
 }
 
+fn make_store_allowing_assumed_meta() -> std::sync::Arc<KnowledgeStore> {
+    KnowledgeStore::open_mem_with_config(KnowledgeConfig {
+        dim: 4,
+        allow_assumed_embedding_meta: true,
+        ..Default::default()
+    })
+    .expect("open in-memory knowledge store")
+}
+
+fn mock_config(model: &str) -> KnowledgeConfig {
+    KnowledgeConfig {
+        dim: 4,
+        embedding_model: model.to_owned(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn fresh_create_writes_embedding_meta() {
+    let store = KnowledgeStore::open_mem_with_config(mock_config("mock-embedding"))
+        .expect("open in-memory knowledge store");
+
+    let meta = store.embedding_meta().expect("read embedding metadata");
+
+    assert_eq!(meta.model, "mock-embedding");
+    assert_eq!(meta.dim, 4);
+}
+
 #[test]
 fn v14_migration_backfills_existing_fact_sensitivity_to_public() {
-    let store = make_store();
+    let store = make_store_allowing_assumed_meta();
     store
         .run_mut_query(
             "::fts drop facts:content_fts",
@@ -235,6 +263,87 @@ fn v14_migration_backfills_existing_fact_sensitivity_to_public() {
         store.schema_version().expect("schema version"),
         KnowledgeStore::SCHEMA_VERSION
     );
+}
+
+#[test]
+fn v15_migration_backfills_embedding_meta_as_assumed() {
+    let store = make_store_allowing_assumed_meta();
+    store
+        .run_mut_query("::remove embedding_meta", std::collections::BTreeMap::new())
+        .expect("remove embedding metadata relation");
+    store
+        .run_mut_query(
+            r#"?[key] <- [["migration:15"]] :rm schema_version {key}"#,
+            std::collections::BTreeMap::new(),
+        )
+        .expect("remove v15 stamp");
+    store
+        .stamp_schema_version(14, "test")
+        .expect("stamp v14 schema");
+
+    store.init_schema().expect("apply v15 migration");
+
+    let meta = store.embedding_meta().expect("read embedding metadata");
+    assert_eq!(meta.model, KnowledgeStore::ASSUMED_EMBEDDING_MODEL);
+    assert_eq!(meta.dim, 4);
+}
+
+#[test]
+fn reembed_all_updates_embedding_meta() {
+    let store = KnowledgeStore::open_mem_with_config(mock_config("old-model"))
+        .expect("open in-memory knowledge store");
+    let fact = make_fact(
+        "reembed-fact",
+        "alice",
+        "reembed updates embedding metadata",
+    );
+    store.insert_fact(&fact).expect("insert fact");
+    let provider = crate::embedding::MockEmbeddingProvider::new(4);
+
+    let written = store.reembed_all(&provider).expect("reembed facts");
+
+    assert_eq!(written, 1);
+    let meta = store.embedding_meta().expect("read embedding metadata");
+    assert_eq!(meta.model, "mock-embedding");
+    assert_eq!(meta.dim, 4);
+}
+
+#[cfg(feature = "storage-fjall")]
+#[test]
+fn open_fjall_detects_embedding_drift() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("knowledge");
+    {
+        let _store = KnowledgeStore::open_fjall(&path, mock_config("mock-embedding"))
+            .expect("open original store");
+    }
+
+    let Err(err) = KnowledgeStore::open_fjall(&path, mock_config("other-model")) else {
+        panic!("embedding model drift should fail closed");
+    };
+
+    assert!(
+        matches!(err, crate::error::Error::EmbeddingDrift { .. }),
+        "expected embedding drift error, got: {err}"
+    );
+    assert!(
+        err.to_string().contains("aletheia memory reembed"),
+        "error should direct operator to reembed, got: {err}"
+    );
+}
+
+#[cfg(feature = "storage-fjall")]
+#[test]
+fn open_fjall_passes_matching_embedding_meta() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("knowledge");
+    {
+        let _store = KnowledgeStore::open_fjall(&path, mock_config("mock-embedding"))
+            .expect("open original store");
+    }
+
+    KnowledgeStore::open_fjall(&path, mock_config("mock-embedding"))
+        .expect("matching embedding metadata should open");
 }
 
 const V13_FACTS_DDL: &str = r":create facts {

--- a/crates/graphe/src/error.rs
+++ b/crates/graphe/src/error.rs
@@ -117,6 +117,20 @@ pub enum Error {
         location: snafu::Location,
     },
 
+    /// Persisted embedding metadata does not match the configured provider.
+    #[cfg(feature = "mneme-engine")]
+    #[snafu(display(
+        "embedding metadata drift detected: stored model '{stored_model}' dim {stored_dim}, configured model '{configured_model}' dim {configured_dim}; run `aletheia memory reembed` to rebuild embeddings before using recall"
+    ))]
+    EmbeddingDrift {
+        stored_model: String,
+        stored_dim: usize,
+        configured_model: String,
+        configured_dim: usize,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// Spawned blocking task failed.
     #[cfg(feature = "mneme-engine")]
     #[snafu(display("spawned task failed: {source}"))]

--- a/crates/integration-tests/tests/knowledge_engine.rs
+++ b/crates/integration-tests/tests/knowledge_engine.rs
@@ -207,7 +207,7 @@ fn schema_version_queryable() {
     .expect("open_mem");
     let version = store.schema_version().expect("version");
     // NOTE: pins `KnowledgeStore::SCHEMA_VERSION`; bump when a migration lands.
-    assert_eq!(version, 14);
+    assert_eq!(version, 15);
 }
 
 // Verify ordering of multiple facts by confidence (descending).


### PR DESCRIPTION
Closes #4496

The knowledge store recorded nothing about which embedding model/dimension produced its vectors — swapping the embedding model in config silently degraded recall into garbage similarity scores (the class behind the #4471 reembed recovery).

- `embedding_meta` relation (model, dim) written on fresh create; **v15 migration** (next sequential via the #4705 registry) backfills existing stores with an explicit `assumed` marker.
- `KnowledgeConfig.embedding_model` plumbed taxis → mneme → aletheia open sites.
- On `already_initialized` open, persisted meta vs config mismatch → typed `EmbeddingDrift` error directing `aletheia memory reembed` — fail closed, no silent degraded recall. `allow_assumed_embedding_meta` covers the migrated-store grace path.
- `reembed_all` updates the meta on completion — the #4471 recovery loop is closed.
- Tests: fresh-create writes meta, v15 backfills `assumed`, drift detected on mismatch, reembed updates meta, matched open passes.

Worker-gated CI-exact on verda before push.