### PR TITLE
fix(nous): thread configured tool_limits into actor execution contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6177,6 +6177,7 @@ dependencies = [
  "prometheus-client",
  "proptest",
  "regex",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/_llm/L3-api-index/nous.md
+++ b/_llm/L3-api-index/nous.md
@@ -77,6 +77,8 @@ pub struct DaemonSpawnParams {
     pub knowledge_store: Option<Arc<KnowledgeStore>>,
     /// Optional tool services (shared with parent).
     pub tool_services: Option<Arc<organon::types::ToolServices>>,
+    /// Tool execution limits inherited from deployment config.
+    pub tool_config: Arc<taxis::config::ToolLimitsConfig>,
     /// Additional bootstrap sections for the child agent.
     pub extra_bootstrap: Vec<BootstrapSection>,
     /// Optional empirical router (shared with parent).
@@ -2037,6 +2039,7 @@ impl NousHandle {
         &self,
         config: NousConfig,
         pipeline_config: PipelineConfig,
+        tool_config: taxis::config::ToolLimitsConfig,
         timeout: Duration,
     ) -> error::Result<()>;
     pub async fn status (&self) -> error::Result<NousStatus>;
@@ -2094,6 +2097,8 @@ pub struct NousManager {
     cancel: CancellationToken,
     /// Deployment-level behavioral configuration (health intervals, restart limits).
     nous_behavior: taxis::config::NousBehaviorConfig,
+    /// Deployment-level tool execution limits shared by newly spawned actors.
+    tool_config: RwLock<Arc<taxis::config::ToolLimitsConfig>>,
     /// Prompt audit log shared across all actors (#3411).
     audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
     /// Empirical router shared across all actors.
@@ -2121,6 +2126,7 @@ impl NousManager {
         router: Option<Arc<crate::cross::CrossNousRouter>>,
         tool_services: Option<Arc<ToolServices>>,
         nous_behavior: taxis::config::NousBehaviorConfig,
+        tool_config: taxis::config::ToolLimitsConfig,
     ) -> Self;
     pub fn with_audit_log (mut self, audit_log: Arc<crate::audit::PromptAuditLog>) -> Self;
     pub fn with_empirical_router (mut self, router: Arc<dyn Router>) -> Self;
@@ -2140,6 +2146,7 @@ impl NousManager {
     pub async fn reload_actor_configs (
         &self,
         configs: Vec<(String, NousConfig, PipelineConfig)>,
+        tool_config: taxis::config::ToolLimitsConfig,
     ) -> crate::error::Result<()>;
     pub async fn check_health (&self) -> BTreeMap<String, ActorHealth>;
     pub async fn health_cycle (&mut self);
@@ -3391,6 +3398,7 @@ pub struct SpawnServiceImpl {
     router: Option<Arc<crate::cross::CrossNousRouter>>,
     audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
     empirical_router: Option<Arc<dyn aletheia_routing::Router>>,
+    tool_config: Arc<taxis::config::ToolLimitsConfig>,
     tool_services: OnceLock<Arc<ToolServices>>,
 }
 ```
@@ -3414,6 +3422,8 @@ pub struct InheritedSpawnServices {
     pub audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
     /// Empirical routing backend shared with parent actors.
     pub empirical_router: Option<Arc<dyn aletheia_routing::Router>>,
+    /// Tool execution limits inherited from deployment config.
+    pub tool_config: Arc<taxis::config::ToolLimitsConfig>,
 }
 ```
 

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "34e2feca7d2ef18773ab0ffe3b039b925e63d393ca8784c0c0e40b8e7cb30b2e"
+source_hash = "01715dab5ca8c7d193583d2216676eee8dfc0104f561ceae0bd7ad6ac1c5e500"
 l3_token_estimate = 167
 
 [[crates]]
@@ -62,7 +62,7 @@ l3_token_estimate = 7702
 [[crates]]
 name = "diaporeia"
 path = "crates/diaporeia"
-source_hash = "2916b347dad6b4c11db8d18e1d9338a7e02f3cf1d254535487e3e5f4a56b98bc"
+source_hash = "b237d33ac2de51af65c61a4c57a479f0febbd7f173197e96c3f1898241673d9d"
 l3_token_estimate = 2544
 
 [[crates]]
@@ -110,7 +110,7 @@ l3_token_estimate = 13698
 [[crates]]
 name = "integration-tests"
 path = "crates/integration-tests"
-source_hash = "0ab54fc1087d4b8758c852ec53721e1a2aaa995c12ba40c739c0bd5d13599f1c"
+source_hash = "38d05a0e2ea1e6328b2d2c51abe8c1894ff37b38dd666fd76b6dc1c3ddb3c252"
 l3_token_estimate = 1170
 
 [[crates]]
@@ -146,8 +146,8 @@ l3_token_estimate = 51
 [[crates]]
 name = "nous"
 path = "crates/nous"
-source_hash = "3983621821c6008c9f3f50d9e426c08a212782849797dcd2fcf3b106cb9db1dc"
-l3_token_estimate = 34322
+source_hash = "c97fd8de1f1cc1b3b739f09a5aae8ce2e3146cc5aad84dc1489a652d7dcadeba"
+l3_token_estimate = 34474
 
 [[crates]]
 name = "oikonomos"
@@ -158,7 +158,7 @@ l3_token_estimate = 12375
 [[crates]]
 name = "organon"
 path = "crates/organon"
-source_hash = "7db6b08917d770bb288b424f2b46554aa292c0236e78e79e663ca260efce5300"
+source_hash = "1c18a483b8009ada0ee94f5beed7d5ef0f054306f67983c972a901cf61ae85d8"
 l3_token_estimate = 12171
 
 [[crates]]
@@ -266,7 +266,7 @@ l3_token_estimate = 1354
 [[crates]]
 name = "pylon"
 path = "crates/pylon"
-source_hash = "b0c2812e62aa1fa40a3db5762c8e12dc07b50f851308ee8bdaa25c9a87fdf112"
+source_hash = "0e655a95f075fc12fedccf065f1a3be930e609813c8c82f963102a573101e9f0"
 l3_token_estimate = 18067
 
 [[crates]]
@@ -284,7 +284,7 @@ l3_token_estimate = 6585
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "cd786949b2f637059a1af84f30ead7f743495137e48b2744d4b920d3ffb07017"
+source_hash = "a2a8e654c5771e21403b48c937f5f1d87903ece952d8d540b060336fdc3380f6"
 l3_token_estimate = 23836
 
 [[crates]]

--- a/crates/aletheia/src/dispatch.rs
+++ b/crates/aletheia/src/dispatch.rs
@@ -397,6 +397,7 @@ mod tests {
             None,
             tool_services,
             taxis::config::NousBehaviorConfig::default(),
+            taxis::config::ToolLimitsConfig::default(),
         )
     }
 
@@ -416,6 +417,7 @@ mod tests {
             None,
             tool_services,
             taxis::config::NousBehaviorConfig::default(),
+            taxis::config::ToolLimitsConfig::default(),
         )
     }
 
@@ -436,6 +438,7 @@ mod tests {
             None,
             None,
             taxis::config::NousBehaviorConfig::default(),
+            taxis::config::ToolLimitsConfig::default(),
         )
     }
 

--- a/crates/aletheia/src/runtime/mod.rs
+++ b/crates/aletheia/src/runtime/mod.rs
@@ -518,6 +518,7 @@ impl RuntimeBuilder {
                     router: Some(Arc::clone(&cross_router)),
                     audit_log: Some(Arc::clone(&audit_log)),
                     empirical_router: Some(Arc::clone(&empirical_router)),
+                    tool_config: Arc::new(self.config.tool_limits.clone()),
                 }),
             ))
         } else {
@@ -564,6 +565,7 @@ impl RuntimeBuilder {
             Some(Arc::clone(&cross_router)),
             Some(tool_services),
             self.config.nous_behavior.clone(),
+            self.config.tool_limits.clone(),
         )
         .with_audit_log(Arc::clone(&audit_log))
         .with_empirical_router(Arc::clone(&empirical_router));
@@ -786,7 +788,10 @@ impl RuntimeBuilder {
                             (agent.id.clone(), nous_config, pipeline_config)
                         })
                         .collect();
-                    if let Err(e) = reload_manager.reload_actor_configs(actor_configs).await {
+                    if let Err(e) = reload_manager
+                        .reload_actor_configs(actor_configs, config.tool_limits.clone())
+                        .await
+                    {
                         warn!(error = %e, "failed to apply hot-reloaded actor config");
                     }
                 }

--- a/crates/diaporeia/tests/common/mod.rs
+++ b/crates/diaporeia/tests/common/mod.rs
@@ -92,6 +92,7 @@ impl StateBuilder {
             None,
             None,
             taxis::config::NousBehaviorConfig::default(),
+            taxis::config::ToolLimitsConfig::default(),
         ));
 
         let jwt_manager = Arc::new(JwtManager::new(JwtConfig {

--- a/crates/diaporeia/tests/public_api_transport.rs
+++ b/crates/diaporeia/tests/public_api_transport.rs
@@ -134,6 +134,7 @@ async fn router_rejects_expired_bearer_token() {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     ));
 
     // WHY: zero access_ttl plus zero clock-skew leeway guarantees that

--- a/crates/integration-tests/src/harness.rs
+++ b/crates/integration-tests/src/harness.rs
@@ -240,6 +240,7 @@ impl TestHarness {
             None,
             None,
             taxis::config::NousBehaviorConfig::default(),
+            taxis::config::ToolLimitsConfig::default(),
         );
 
         let nous_config = NousConfig {

--- a/crates/integration-tests/tests/domain_packs.rs
+++ b/crates/integration-tests/tests/domain_packs.rs
@@ -170,6 +170,7 @@ priority = "important"
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let config = NousConfig {
@@ -326,6 +327,7 @@ domains = ["healthcare"]
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let analyst_config = NousConfig {
@@ -365,6 +367,7 @@ domains = ["healthcare"]
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let hermes_config = NousConfig {

--- a/crates/integration-tests/tests/r722_substrate_canary.rs
+++ b/crates/integration-tests/tests/r722_substrate_canary.rs
@@ -352,6 +352,7 @@ async fn identity_continuity_pins_top_three_facts_and_late_injects_anchor() {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let mut config = NousConfig {
@@ -508,6 +509,7 @@ async fn reflection_stage_runs_without_error_even_when_store_unavailable() {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let mut config = NousConfig {
@@ -834,6 +836,7 @@ async fn tool_group_gating_denies_calls_outside_allowed_groups() {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     // Coder role: only Read group allowed.
@@ -931,6 +934,7 @@ async fn spawn_class_isolation_truncates_co_occurring_tool_uses() {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let config = NousConfig {
@@ -998,6 +1002,7 @@ async fn consecutive_mistake_brake_fires_at_configured_limit() {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let config = NousConfig {
@@ -1416,6 +1421,7 @@ async fn skill_always_vs_lazy_partitioning_in_system_prompt() {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let config = NousConfig {

--- a/crates/integration-tests/tests/r722_substrate_integration.rs
+++ b/crates/integration-tests/tests/r722_substrate_integration.rs
@@ -179,6 +179,7 @@ async fn identity_continuity_pins_top_facts_and_late_injects_anchor() {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let mut config = NousConfig {

--- a/crates/nous/Cargo.toml
+++ b/crates/nous/Cargo.toml
@@ -64,9 +64,11 @@ tracing = { workspace = true }
 [dev-dependencies]
 hermeneus = { path = "../hermeneus", features = ["test-support"] }
 mneme = { path = "../mneme", features = ["test-support"] }
+organon = { path = "../organon", features = ["test-support"] }
 criterion = { workspace = true }
 indexmap = { workspace = true }
 proptest = { workspace = true }
+reqwest = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/nous/src/actor/mod.rs
+++ b/crates/nous/src/actor/mod.rs
@@ -192,6 +192,7 @@ impl NousActor {
         active_turn: Arc<AtomicBool>,
         turn_started_at_ms: Arc<AtomicU64>,
         nous_behavior: taxis::config::NousBehaviorConfig,
+        tool_config: Arc<taxis::config::ToolLimitsConfig>,
         audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
         router: Option<Arc<dyn Router>>,
     ) -> Self {
@@ -229,9 +230,7 @@ impl NousActor {
                 tool_services,
                 embedding_provider,
                 candidate_tracker: Arc::new(mneme::skills::CandidateTracker::new()),
-                tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
-                // WHY: default TTL (60s) until wired to operator config; TTL-zero
-                // would disable the cache, so default ensures the happy path benefits.
+                tool_config,
                 bootstrap_cache: Arc::new(BootstrapFileCache::with_ttl_secs(
                     nous_behavior.bootstrap_cache_ttl_secs,
                 )),
@@ -408,11 +407,13 @@ impl NousActor {
                         NousMessage::ReloadConfig {
                             mut config,
                             mut pipeline_config,
+                            tool_config,
                             reply,
                         } => {
                             config.apply_recall_profile(&mut pipeline_config);
                             self.config = *config;
                             self.pipeline_config = *pipeline_config;
+                            self.services.tool_config = Arc::new(*tool_config);
                             // kanon:ignore RUST/no-silent-result-swallow — oneshot receiver may have dropped; no recovery possible
                             let _ = reply.send(());
                         }

--- a/crates/nous/src/actor/spawn.rs
+++ b/crates/nous/src/actor/spawn.rs
@@ -55,6 +55,7 @@ pub(crate) fn spawn(
     cross_tx: Option<mpsc::Sender<CrossNousEnvelope>>,
     cancel: CancellationToken,
     nous_behavior: taxis::config::NousBehaviorConfig,
+    tool_config: Arc<taxis::config::ToolLimitsConfig>,
     audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
     router: Option<Arc<dyn Router>>,
 ) -> (
@@ -91,6 +92,7 @@ pub(crate) fn spawn(
         Arc::clone(&active_turn),
         Arc::clone(&turn_started_at_ms),
         nous_behavior,
+        tool_config,
         audit_log,
         router,
     );
@@ -130,6 +132,8 @@ pub struct DaemonSpawnParams {
     pub knowledge_store: Option<Arc<KnowledgeStore>>,
     /// Optional tool services (shared with parent).
     pub tool_services: Option<Arc<organon::types::ToolServices>>,
+    /// Tool execution limits inherited from deployment config.
+    pub tool_config: Arc<taxis::config::ToolLimitsConfig>,
     /// Additional bootstrap sections for the child agent.
     pub extra_bootstrap: Vec<BootstrapSection>,
     /// Optional empirical router (shared with parent).
@@ -173,6 +177,7 @@ pub fn spawn_for_daemon(
         None, // cross_tx
         cancel,
         taxis::config::NousBehaviorConfig::default(),
+        params.tool_config,
         None, // WHY: daemon child agents share the parent's audit log via binary crate wiring
         params.empirical_router,
     )

--- a/crates/nous/src/actor/tests/mod.rs
+++ b/crates/nous/src/actor/tests/mod.rs
@@ -4,7 +4,7 @@ use tokio_util::sync::CancellationToken;
 
 use hermeneus::provider::LlmProvider;
 use hermeneus::test_utils::MockProvider;
-use hermeneus::types::{CompletionRequest, CompletionResponse};
+use hermeneus::types::{CompletionRequest, CompletionResponse, ContentBlock, StopReason, Usage};
 
 use super::*;
 
@@ -31,6 +31,26 @@ fn test_config() -> NousConfig {
     }
 }
 
+fn test_config_with_tools(workspace: std::path::PathBuf) -> NousConfig {
+    NousConfig {
+        workspace: workspace.clone(),
+        allowed_roots: vec![workspace],
+        tool_groups: organon::types::ToolGroupPolicy::AllowAll {
+            reason: "tool limit regression test".to_owned(),
+        },
+        hooks: crate::config::HookConfig {
+            cost_control_enabled: false,
+            scope_enforcement_enabled: false,
+            correction_hooks_enabled: false,
+            audit_logging_enabled: false,
+            self_audit_enabled: false,
+            working_checkpoint_enabled: false,
+            ..crate::config::HookConfig::default()
+        },
+        ..test_config()
+    }
+}
+
 fn test_oikos() -> (tempfile::TempDir, Arc<Oikos>) {
     let dir = tempfile::TempDir::new().expect("tmpdir");
     let root = dir.path();
@@ -52,6 +72,279 @@ fn test_providers() -> Arc<ProviderRegistry> {
         MockProvider::new("Hello from actor!").models(&["test-model"]),
     ));
     Arc::new(providers)
+}
+
+fn mock_tool_response(
+    tool_name: &str,
+    tool_id: &str,
+    input: serde_json::Value,
+) -> CompletionResponse {
+    CompletionResponse {
+        id: format!("resp-{tool_id}"),
+        model: "test-model".to_owned(),
+        stop_reason: StopReason::ToolUse,
+        content: vec![ContentBlock::ToolUse {
+            id: tool_id.to_owned(),
+            name: tool_name.to_owned(),
+            input,
+        }],
+        usage: Usage {
+            input_tokens: 10,
+            output_tokens: 5,
+            ..Usage::default()
+        },
+        cost_usd: None,
+        duration_ms: None,
+    }
+}
+
+fn mock_text_response(text: &str) -> CompletionResponse {
+    CompletionResponse {
+        id: "resp-final".to_owned(),
+        model: "test-model".to_owned(),
+        stop_reason: StopReason::EndTurn,
+        content: vec![ContentBlock::Text {
+            text: text.to_owned(),
+            citations: None,
+        }],
+        usage: Usage {
+            input_tokens: 10,
+            output_tokens: 5,
+            ..Usage::default()
+        },
+        cost_usd: None,
+        duration_ms: None,
+    }
+}
+
+fn tool_response_provider(tool_name: &str, input: serde_json::Value) -> Arc<ProviderRegistry> {
+    let mut providers = ProviderRegistry::new();
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            mock_tool_response(tool_name, "tool-1", input),
+            mock_text_response("done"),
+        ])
+        .models(&["test-model"]),
+    ));
+    Arc::new(providers)
+}
+
+fn builtins_registry() -> Arc<ToolRegistry> {
+    let mut tools = ToolRegistry::new();
+    organon::builtins::register_all(&mut tools).expect("register builtins");
+    Arc::new(tools)
+}
+
+struct RecordingMessenger;
+
+impl organon::types::MessageService for RecordingMessenger {
+    fn send_message(
+        &self,
+        _to: &str,
+        _text: &str,
+        _from_nous: &str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = std::result::Result<(), String>> + Send + '_>,
+    > {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+fn tool_services_with_messenger() -> Arc<organon::types::ToolServices> {
+    organon::testing::install_crypto_provider();
+    Arc::new(organon::types::ToolServices {
+        cross_nous: None,
+        messenger: Some(Arc::new(RecordingMessenger)),
+        note_store: None,
+        blackboard_store: None,
+        spawn: None,
+        planning: None,
+        knowledge: None,
+        working_checkpoint_store: None,
+        http_client: reqwest::Client::new(),
+        secret_vault: hermeneus::secret::SecretVault::new(),
+        lazy_tool_catalog: Vec::new(),
+        server_tool_config: organon::types::ServerToolConfig::default(),
+    })
+}
+
+async fn run_tool_with_limits(
+    tool_name: &str,
+    input: serde_json::Value,
+    tool_limits: taxis::config::ToolLimitsConfig,
+    tool_services: Option<Arc<organon::types::ToolServices>>,
+) -> crate::pipeline::TurnResult {
+    let (dir, oikos) = test_oikos();
+    let config = test_config_with_tools(oikos.nous_dir("test-agent"));
+    let (handle, join, _active_turn, _turn_started_at_ms) = spawn(
+        config,
+        PipelineConfig::default(),
+        tool_response_provider(tool_name, input),
+        builtins_registry(),
+        oikos,
+        None,
+        None,
+        None,
+        #[cfg(feature = "knowledge-store")]
+        None,
+        tool_services,
+        Vec::new(),
+        None,
+        None,
+        CancellationToken::new(),
+        taxis::config::NousBehaviorConfig::default(),
+        Arc::new(tool_limits),
+        None,
+        None,
+    );
+
+    let result = handle.send_turn("main", "run tool").await.expect("turn");
+    handle.shutdown().await.expect("shutdown");
+    join.await.expect("actor join");
+    drop(dir);
+    result
+}
+
+#[tokio::test]
+async fn configured_max_write_bytes_limits_workspace_write_tool() {
+    let tool_limits = taxis::config::ToolLimitsConfig {
+        max_write_bytes: 5,
+        ..taxis::config::ToolLimitsConfig::default()
+    };
+    let result = run_tool_with_limits(
+        "write",
+        serde_json::json!({
+            "path": "limited.txt",
+            "content": "abcdef"
+        }),
+        tool_limits,
+        None,
+    )
+    .await;
+
+    let call = result.tool_calls.first().expect("tool call");
+    let output = call.result.as_deref().expect("tool output");
+    assert!(
+        call.is_error,
+        "write should be rejected by configured limit"
+    );
+    assert!(
+        output.contains("max 5 bytes"),
+        "write output should mention configured limit: {output}"
+    );
+}
+
+#[tokio::test]
+async fn configured_subprocess_timeout_limits_workspace_exec_tool() {
+    let tool_limits = taxis::config::ToolLimitsConfig {
+        subprocess_timeout_secs: 1,
+        ..taxis::config::ToolLimitsConfig::default()
+    };
+    let result = run_tool_with_limits(
+        "exec",
+        serde_json::json!({
+            "command": "sleep 2",
+            "timeout": 60_000
+        }),
+        tool_limits,
+        None,
+    )
+    .await;
+
+    let call = result.tool_calls.first().expect("tool call");
+    let output = call.result.as_deref().expect("tool output");
+    assert!(call.is_error, "exec should time out at configured cap");
+    assert!(
+        output.contains("timed out after 1000ms"),
+        "exec output should mention configured timeout: {output}"
+    );
+}
+
+#[tokio::test]
+async fn configured_message_max_len_limits_message_tool() {
+    let tool_limits = taxis::config::ToolLimitsConfig {
+        message_max_len: 5,
+        ..taxis::config::ToolLimitsConfig::default()
+    };
+    let result = run_tool_with_limits(
+        "message",
+        serde_json::json!({
+            "to": "u:alice",
+            "text": "abcdef"
+        }),
+        tool_limits,
+        Some(tool_services_with_messenger()),
+    )
+    .await;
+
+    let call = result.tool_calls.first().expect("tool call");
+    let output = call.result.as_deref().expect("tool output");
+    assert!(
+        call.is_error,
+        "message should be rejected by configured limit"
+    );
+    assert!(
+        output.contains("5 character limit"),
+        "message output should mention configured limit: {output}"
+    );
+}
+
+#[tokio::test]
+async fn reload_config_updates_tool_limits_for_existing_actor() {
+    let (dir, oikos) = test_oikos();
+    let config = test_config_with_tools(oikos.nous_dir("test-agent"));
+    let (handle, join, _active_turn, _turn_started_at_ms) = spawn(
+        config.clone(),
+        PipelineConfig::default(),
+        tool_response_provider(
+            "write",
+            serde_json::json!({
+                "path": "reloaded.txt",
+                "content": "abcdef"
+            }),
+        ),
+        builtins_registry(),
+        oikos,
+        None,
+        None,
+        None,
+        #[cfg(feature = "knowledge-store")]
+        None,
+        None,
+        Vec::new(),
+        None,
+        None,
+        CancellationToken::new(),
+        taxis::config::NousBehaviorConfig::default(),
+        Arc::new(taxis::config::ToolLimitsConfig::default()),
+        None,
+        None,
+    );
+    let tool_limits = taxis::config::ToolLimitsConfig {
+        max_write_bytes: 5,
+        ..taxis::config::ToolLimitsConfig::default()
+    };
+    handle
+        .reload_config(
+            config,
+            PipelineConfig::default(),
+            tool_limits,
+            crate::handle::DEFAULT_SEND_TIMEOUT,
+        )
+        .await
+        .expect("reload");
+
+    let result = handle.send_turn("main", "run tool").await.expect("turn");
+    handle.shutdown().await.expect("shutdown");
+    join.await.expect("actor join");
+    drop(dir);
+
+    let call = result.tool_calls.first().expect("tool call");
+    let output = call.result.as_deref().expect("tool output");
+    assert!(
+        output.contains("max 5 bytes"),
+        "reloaded write output should mention configured limit: {output}"
+    );
 }
 
 fn spawn_test_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile::TempDir) {
@@ -78,6 +371,7 @@ fn spawn_test_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile::Tem
         None,
         CancellationToken::new(),
         taxis::config::NousBehaviorConfig::default(),
+        Arc::new(taxis::config::ToolLimitsConfig::default()),
         None, // audit_log
         None, // empirical router
     );
@@ -141,6 +435,7 @@ fn spawn_panicking_actor() -> (NousHandle, tokio::task::JoinHandle<()>, tempfile
         None,
         CancellationToken::new(),
         taxis::config::NousBehaviorConfig::default(),
+        Arc::new(taxis::config::ToolLimitsConfig::default()),
         None, // audit_log
         None, // empirical router
     );
@@ -173,6 +468,7 @@ fn spawn_test_actor_with_store(
         None,
         CancellationToken::new(),
         taxis::config::NousBehaviorConfig::default(),
+        Arc::new(taxis::config::ToolLimitsConfig::default()),
         None, // audit_log
         None, // empirical router
     );
@@ -219,6 +515,7 @@ fn make_test_actor(
         active_turn,
         turn_started_at_ms,
         taxis::config::NousBehaviorConfig::default(),
+        Arc::new(taxis::config::ToolLimitsConfig::default()),
         None, // audit_log
         None, // empirical router
     );
@@ -300,6 +597,7 @@ fn spawn_test_actor_with_cross() -> (
         Some(cross_tx.clone()),
         CancellationToken::new(),
         taxis::config::NousBehaviorConfig::default(),
+        Arc::new(taxis::config::ToolLimitsConfig::default()),
         None, // audit_log
         None, // empirical router
     );
@@ -332,6 +630,7 @@ fn spawn_test_actor_with_router(
         None,
         CancellationToken::new(),
         taxis::config::NousBehaviorConfig::default(),
+        Arc::new(taxis::config::ToolLimitsConfig::default()),
         None, // audit_log
         router,
     );
@@ -369,6 +668,7 @@ fn spawn_panicking_actor_with_cross() -> (
         Some(cross_tx.clone()),
         CancellationToken::new(),
         taxis::config::NousBehaviorConfig::default(),
+        Arc::new(taxis::config::ToolLimitsConfig::default()),
         None, // audit_log
         None, // empirical router
     );

--- a/crates/nous/src/handle.rs
+++ b/crates/nous/src/handle.rs
@@ -330,6 +330,7 @@ impl NousHandle {
         &self,
         config: NousConfig,
         pipeline_config: PipelineConfig,
+        tool_config: taxis::config::ToolLimitsConfig,
         timeout: Duration,
     ) -> error::Result<()> {
         let (tx, rx) = oneshot::channel();
@@ -337,6 +338,7 @@ impl NousHandle {
             NousMessage::ReloadConfig {
                 config: Box::new(config),
                 pipeline_config: Box::new(pipeline_config),
+                tool_config: Box::new(tool_config),
                 reply: tx,
             },
             timeout,

--- a/crates/nous/src/manager.rs
+++ b/crates/nous/src/manager.rs
@@ -4,8 +4,8 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 // WHY: lock held only during synchronous .take() on Option<JoinHandle>: no await while locked
-use std::sync::Mutex; // kanon:ignore RUST/std-mutex-in-async
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Mutex, RwLock}; // kanon:ignore RUST/std-mutex-in-async
 use std::time::Duration;
 
 use tokio::sync::Mutex as TokioMutex;
@@ -91,6 +91,8 @@ pub struct NousManager {
     cancel: CancellationToken,
     /// Deployment-level behavioral configuration (health intervals, restart limits).
     nous_behavior: taxis::config::NousBehaviorConfig,
+    /// Deployment-level tool execution limits shared by newly spawned actors.
+    tool_config: RwLock<Arc<taxis::config::ToolLimitsConfig>>,
     /// Prompt audit log shared across all actors (#3411).
     audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
     /// Empirical router shared across all actors.
@@ -122,6 +124,7 @@ impl NousManager {
         router: Option<Arc<crate::cross::CrossNousRouter>>,
         tool_services: Option<Arc<ToolServices>>,
         nous_behavior: taxis::config::NousBehaviorConfig,
+        tool_config: taxis::config::ToolLimitsConfig,
     ) -> Self {
         let (ready_tx, ready_rx) = watch::channel(false);
         Self {
@@ -142,9 +145,20 @@ impl NousManager {
             ready_rx,
             cancel: CancellationToken::new(),
             nous_behavior,
+            tool_config: RwLock::new(Arc::new(tool_config)),
             audit_log: None,
             empirical_router: None,
         }
+    }
+
+    fn current_tool_config(&self) -> Arc<taxis::config::ToolLimitsConfig> {
+        self.tool_config
+            .read()
+            .unwrap_or_else(|e| {
+                warn!("tool_config lock poisoned, recovering");
+                e.into_inner()
+            })
+            .clone()
     }
 
     /// Attach a prompt audit log to the manager (#3411).
@@ -317,6 +331,7 @@ impl NousManager {
             cross_tx,
             child_cancel,
             self.nous_behavior.clone(),
+            self.current_tool_config(),
             self.audit_log.clone(),
             self.empirical_router.clone(),
         );
@@ -376,12 +391,25 @@ impl NousManager {
     pub async fn reload_actor_configs(
         &self,
         configs: Vec<(String, NousConfig, PipelineConfig)>,
+        tool_config: taxis::config::ToolLimitsConfig,
     ) -> crate::error::Result<()> {
+        {
+            let mut guard = self.tool_config.write().unwrap_or_else(|e| {
+                warn!("tool_config lock poisoned, recovering");
+                e.into_inner()
+            });
+            *guard = Arc::new(tool_config.clone());
+        }
         for (id, config, pipeline_config) in configs {
             if let Some(entry) = self.actors.get(&id) {
                 entry
                     .handle
-                    .reload_config(config, pipeline_config, DEFAULT_SEND_TIMEOUT)
+                    .reload_config(
+                        config,
+                        pipeline_config,
+                        tool_config.clone(),
+                        DEFAULT_SEND_TIMEOUT,
+                    )
                     .await?;
             }
         }

--- a/crates/nous/src/manager_tests.rs
+++ b/crates/nous/src/manager_tests.rs
@@ -47,6 +47,7 @@ fn make_manager(oikos: Arc<Oikos>) -> NousManager {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     )
 }
 

--- a/crates/nous/src/message.rs
+++ b/crates/nous/src/message.rs
@@ -58,6 +58,7 @@ pub(crate) enum NousMessage {
     ReloadConfig {
         config: Box<NousConfig>,
         pipeline_config: Box<PipelineConfig>,
+        tool_config: Box<taxis::config::ToolLimitsConfig>,
         reply: oneshot::Sender<()>,
     },
     /// Graceful shutdown.

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -57,6 +57,7 @@ pub struct SpawnServiceImpl {
     router: Option<Arc<crate::cross::CrossNousRouter>>,
     audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
     empirical_router: Option<Arc<dyn aletheia_routing::Router>>,
+    tool_config: Arc<taxis::config::ToolLimitsConfig>,
     tool_services: OnceLock<Arc<ToolServices>>,
 }
 
@@ -78,6 +79,8 @@ pub struct InheritedSpawnServices {
     pub audit_log: Option<Arc<crate::audit::PromptAuditLog>>,
     /// Empirical routing backend shared with parent actors.
     pub empirical_router: Option<Arc<dyn aletheia_routing::Router>>,
+    /// Tool execution limits inherited from deployment config.
+    pub tool_config: Arc<taxis::config::ToolLimitsConfig>,
 }
 
 impl SpawnServiceImpl {
@@ -100,6 +103,7 @@ impl SpawnServiceImpl {
             router: None,
             audit_log: None,
             empirical_router: None,
+            tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
             tool_services: OnceLock::new(),
         }
     }
@@ -117,6 +121,7 @@ impl SpawnServiceImpl {
         self.router = services.router;
         self.audit_log = services.audit_log;
         self.empirical_router = services.empirical_router;
+        self.tool_config = services.tool_config;
         self
     }
 
@@ -244,6 +249,7 @@ impl SpawnService for SpawnServiceImpl {
         let router = self.router.clone();
         let audit_log = self.audit_log.clone();
         let empirical_router = self.empirical_router.clone();
+        let tool_config = Arc::clone(&self.tool_config);
 
         let span = tracing::info_span!(
             "spawn_sub_agent",
@@ -296,6 +302,7 @@ impl SpawnService for SpawnServiceImpl {
                     cross_tx,
                     ephemeral_cancel,
                     taxis::config::NousBehaviorConfig::default(),
+                    tool_config,
                     audit_log,
                     empirical_router,
                 );
@@ -452,6 +459,7 @@ mod tests {
             router: None,
             audit_log: None,
             empirical_router: Some(router),
+            tool_config: Arc::new(taxis::config::ToolLimitsConfig::default()),
         });
 
         let result = svc

--- a/crates/organon/src/builtins/workspace.rs
+++ b/crates/organon/src/builtins/workspace.rs
@@ -612,7 +612,12 @@ impl ToolExecutor for ExecExecutor {
     ) -> Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>> {
         Box::pin(async {
             let command = extract_str(&input.arguments, "command", &input.name)?;
-            let timeout_ms = extract_opt_u64(&input.arguments, "timeout").unwrap_or(120_000);
+            let configured_timeout_ms =
+                ctx.tool_config.subprocess_timeout_secs.saturating_mul(1000);
+            let timeout_ms = extract_opt_u64(&input.arguments, "timeout")
+                .map_or(configured_timeout_ms, |timeout| {
+                    timeout.min(configured_timeout_ms)
+                });
 
             let max_cmd = ctx.tool_config.max_command_length;
             if command.len() > max_cmd {
@@ -931,9 +936,10 @@ fn exec_def() -> ToolDef {
                     "timeout".to_owned(),
                     PropertyDef {
                         property_type: PropertyType::Number,
-                        description: "Timeout in milliseconds (default 30000)".to_owned(),
+                        description: "Timeout in milliseconds, capped by deployment config"
+                            .to_owned(),
                         enum_values: None,
-                        default: Some(serde_json::json!(30000)),
+                        default: None,
                     },
                 ),
             ]),

--- a/crates/pylon/src/handlers/sessions/streaming_tests.rs
+++ b/crates/pylon/src/handlers/sessions/streaming_tests.rs
@@ -45,6 +45,7 @@ async fn reconnect_test_state() -> (SessionsState, tempfile::TempDir) {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
     let config = taxis::config::AletheiaConfig::default();
 

--- a/crates/pylon/src/server.rs
+++ b/crates/pylon/src/server.rs
@@ -138,6 +138,7 @@ pub async fn run(config: ServerConfig) -> Result<(), ServerError> {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
     let nous_config = NousConfig::default();
     nous_manager

--- a/crates/pylon/src/tests/helpers.rs
+++ b/crates/pylon/src/tests/helpers.rs
@@ -206,6 +206,7 @@ bind = "localhost"
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let nous_config = NousConfig {

--- a/crates/pylon/src/tests/signal.rs
+++ b/crates/pylon/src/tests/signal.rs
@@ -98,6 +98,7 @@ fn minimal_app_state() -> Arc<AppState> {
         None,
         None,
         taxis::config::NousBehaviorConfig::default(),
+        taxis::config::ToolLimitsConfig::default(),
     );
 
     let default_config = AletheiaConfig::default();

--- a/crates/pylon/tests/common/mod.rs
+++ b/crates/pylon/tests/common/mod.rs
@@ -139,6 +139,7 @@ impl TestEnvBuilder {
             None,
             None,
             taxis::config::NousBehaviorConfig::default(),
+            taxis::config::ToolLimitsConfig::default(),
         );
 
         if self.with_actor {


### PR DESCRIPTION
Closes #4712

`NousActor` constructed `ActorServices` with `ToolLimitsConfig::default()`, silently ignoring operator-configured tool size/time/message caps — a safety-control config surface that lied. `AletheiaConfig.tool_limits` now threads through runtime setup and `NousManager`/actor spawn into every `ToolContext`; daemon-spawned and child agents inherit the configured limits; reload semantics documented per the existing restart-required pattern; temporary-default comments removed. Tests prove non-default `max_write_bytes`, subprocess timeout, and message limits affect actual tool execution (workspace + communication paths).

Worker-gated CI-exact on verda before push.