### PR TITLE
docs: D11 truth sweep — 12 doc-reality alignments

### DIFF
--- a/_llm/L2-crate-summaries/dokimion.md
+++ b/_llm/L2-crate-summaries/dokimion.md
@@ -1,23 +1,31 @@
 # dokimion
 
-**Purpose:** Behavioral eval framework - scenario-based API testing against a live instance.
+**Purpose:** Behavioral eval framework - scenario-based API testing against a live Aletheia instance.
 
 ## Key types
 
 | Type | Purpose |
 |------|---------|
-| `BenchmarkRunnerConfig` | Current public type or boundary; see L3/source for exact fields |
-| `BenchmarkDatasetConfig` | Current public type or boundary; see L3/source for exact fields |
-| `RunnerConfig` | Current public type or boundary; see L3/source for exact fields |
-| `ScenarioOutcome` | Current public type or boundary; see L3/source for exact fields |
+| `RunConfig` | Configuration for a scenario run (base URL, token, filter, timeout, JSON output) |
+| `RunReport` | Aggregated pass/fail/skip counts and per-scenario results |
+| `ScenarioRunner` | Runs behavioral scenarios against a live Aletheia instance |
+| `Scenario` | Trait implemented by each behavioral scenario |
+| `ScenarioMeta` | Metadata (id, description, category, auth/nous requirements) |
+| `ScenarioOutcome` | Pass / fail / skip result for a single scenario |
+| `ScenarioResult` | Pair of `ScenarioMeta` and `ScenarioOutcome` |
+| `EvalProvider` | Trait for scenario sources; `BuiltinProvider` and `CompositeProvider` implement it |
+| `EvalClient` | HTTP client for talking to the target instance during evaluation |
 
 ## Public API surface
 
-- `dokimion::benchmarks/baselines` - public items from `src/benchmarks/baselines.rs`
-- `dokimion::benchmarks/judge` - public items from `src/benchmarks/judge.rs`
-- `dokimion::benchmarks/locomo` - public items from `src/benchmarks/locomo.rs`
-- `dokimion::benchmarks/longmemeval` - public items from `src/benchmarks/longmemeval.rs`
-- `dokimion::benchmarks/metrics` - public items from `src/benchmarks/metrics.rs`
+- `dokimion::runner` - `RunConfig`, `RunReport`, `ScenarioRunner`
+- `dokimion::scenario` - `Scenario`, `ScenarioMeta`, `ScenarioOutcome`, `ScenarioResult`
+- `dokimion::provider` - `EvalProvider`, `BuiltinProvider`, `CompositeProvider`
+- `dokimion::client` - `EvalClient` (re-exported from `benchmarks`)
+- `dokimion::report` - `print_report`, `print_report_json`, `emit_eval_report`
+- `dokimion::persistence` - JSONL training-data output helpers
+- `dokimion::benchmarks` - LongMemEval / LoCoMo dataset loaders and baselines
+- `dokimion::error` - eval-specific `Error` and `Result`
 
 ## When to look here
 
@@ -26,4 +34,4 @@
 
 ## Recent changes
 
-RecallBenchmarkScenario was decoupled and scenario config now carries question_timeout, ISO-8601 helpers, and TriggerConfig.
+Scenario runner moved from benchmark-centric `RunnerConfig` / `BenchmarkRunnerConfig` to a generic `ScenarioRunner` / `RunConfig` model. Scenario filtering now supports `category_filter` in addition to substring filtering.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,29 +184,21 @@ Current provider families:
 | Provider family | Config type | Wire/runtime shape | Deployment target |
 |-----------------|-------------|--------------------|-------------------|
 | Anthropic cloud | `anthropic` | Anthropic Messages API | `cloud` |
-| Claude Code | `claude-code` | `claude` CLI subprocess adapter | operator-local process, with provider egress controlled by Claude Code |
-| OpenAI-compatible local/third-party | `openai-compatible` | `/v1/chat/completions` HTTP wire format | explicit per provider: usually `embedded` or `localhosted` |
-| OpenAI cloud | `openai` | currently `/v1/chat/completions`; target state is OpenAI Responses API | `cloud` |
+| Claude Code | `claude-code` | `claude` CLI subprocess adapter (feature-gated `cc-provider`) | operator-local process, with provider egress controlled by Claude Code |
+| OpenAI-compatible local/third-party | `openai-compatible` | `/v1/chat/completions` HTTP wire format | explicit per provider: usually `embedded` or `local-hosted` |
+| OpenAI cloud | `openai` | `/v1/responses` by default; `apiFamily = "chat-completions"` selects the legacy endpoint | `cloud` |
+| Codex OAuth | `codex-oauth` | `codex` CLI subprocess adapter (feature-gated `codex-provider`) | operator-local process |
 
-Codex routing decision, recorded 2026-05-22: Codex/OpenAI cloud model access
-should move to a first-class OpenAI Responses API provider path. The existing
-OpenAI-compatible Chat Completions provider remains valid for local servers
-such as llama.cpp, ollama, and vllm, but it is not the preferred long-term
-Codex path because Codex Chat Completions support is deprecated upstream. A
-dedicated Codex CLI adapter is deferred until Aletheia has a concrete need for
-Codex-specific session, tool, or local-environment semantics that Responses
-does not cover.
+`crates/hermeneus/src/openai/client.rs` implements both `/v1/responses` and
+`/v1/chat/completions`, selected per provider via `apiFamily`. The
+`openai-compatible` kind is reserved for local/proxy servers (llama.cpp,
+ollama, vllm) and always uses chat completions.
 
-Planned Responses-backed config shape after the provider lands:
-
-```toml
-[[providers]]
-name = "openai-codex"
-providerType = "openai"
-apiKeyEnv = "OPENAI_API_KEY"
-deploymentTarget = "cloud"
-models = ["gpt-5.3-codex"]
-```
+Declarative `[[providers]]` entries are the supported configuration surface;
+see `docs/CONFIGURATION.md#providers` for the full field reference. Subprocess
+adapters (`claude-code`, `codex-oauth`) are primarily registered through their
+credential-chain feature paths; declarative entries for those kinds are
+accepted but currently do not alter startup behavior.
 
 Local OpenAI-compatible servers continue to use the Chat Completions-compatible
 shape:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -36,6 +36,7 @@ Runtime configuration uses the three-layer TOML cascade above. Agent bootstrap f
 - [bindings](#bindings)
 - [embedding](#embedding)
 - [credential](#credential)
+- [providers](#providers)
 - [provider capability matrix](#provider-capability-matrix)
 - [data](#data)
 - [nous_behavior](#nous_behavior)
@@ -343,16 +344,55 @@ claude_code_credentials = "~/.claude/.credentials.json"
 
 ---
 
-## provider capability matrix
+## providers
 
-Aletheia can route completions through either the native Anthropic provider or seat-bridged CLI providers. The seat-bridged providers run the CLI's own agentic loop, so `request.tools` are not translated into Aletheia tool execution.
+`[[providers]]` entries declare available LLM providers declaratively. The runtime registers them in list order; model routing picks the first provider that advertises the requested model. Provider kinds are defined in `crates/taxis/src/config/behavior/provider.rs` and registered in `crates/aletheia/src/runtime/setup.rs`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Operator-facing label, must be unique across the list. |
+| `providerType` | string | yes | `anthropic`, `openai`, `openai-compatible`, `claude-code`, or `codex-oauth`. |
+| `apiFamily` | string | no | For `openai`: `responses` (default) or `chat-completions`. For `openai-compatible`: `chat-completions` (default). Ignored for other kinds. |
+| `baseUrl` | string | no | HTTP base URL. Required for `openai-compatible`; optional for `anthropic` (defaults to `https://api.anthropic.com`); ignored for subprocess adapters. |
+| `apiKeyEnv` | string | no | Environment variable holding the API key. Read at startup via `std::env::var`. Optional for loopback providers without auth. |
+| `deploymentTarget` | string | no | `cloud` (default), `local-hosted`, or `embedded`. Drives the fact-sensitivity filter and air-gapped mode. |
+| `models` | string[] | no | Model identifiers this provider advertises. The first provider in list order claiming a model wins. |
+
+```toml
+[[providers]]
+name = "anthropic-cloud"
+providerType = "anthropic"
+apiKeyEnv = "ANTHROPIC_API_KEY"
+deploymentTarget = "cloud"
+models = ["claude-sonnet-4-6"]
+
+[[providers]]
+name = "openai-cloud"
+providerType = "openai"
+apiKeyEnv = "OPENAI_API_KEY"
+apiFamily = "responses"
+deploymentTarget = "cloud"
+models = ["gpt-5.3-codex"]
+
+[[providers]]
+name = "local-llama"
+providerType = "openai-compatible"
+baseUrl = "http://127.0.0.1:8088/v1"
+deploymentTarget = "embedded"
+models = ["llama3.1-70b"]
+```
+
+### Provider capability matrix
 
 | Provider path | Credential source | Simple chat + recall | Aletheia organon tool-loop | Notes |
 |---|---|---|---|---|
-| Native Anthropic provider | `ANTHROPIC_API_KEY` | yes | yes | Serializes `request.tools` and parses `ToolUse` blocks. |
-| Claude Code subprocess (`cc`) | Local Claude Code OAuth seat; no API key | yes | no | Runs `claude -p`; tools stay inside the CLI's own loop. |
-| Codex subprocess (`codex`) | Local Codex seat; no API key | yes | no | Runs `codex exec`; tools stay inside the CLI's own loop. |
-| Kimi subprocess (`kimi`) | Local Kimi seat; no API key | yes | no | Runs `kimi`; tools stay inside the CLI's own loop. |
+| Native Anthropic provider | `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` | yes | yes | Messages API. Declarative `anthropic` entries require `apiKeyEnv` to avoid double-registering the first-party provider. |
+| OpenAI cloud (`openai`) | `OPENAI_API_KEY` | yes | yes | First-party `/v1/responses` by default; set `apiFamily = "chat-completions"` for the legacy endpoint. |
+| OpenAI-compatible local/third-party (`openai-compatible`) | Optional (`apiKeyEnv`) | yes | yes | `/v1/chat/completions` wire format for llama.cpp, ollama, vllm, and compatible proxies. |
+| Claude Code subprocess (`claude-code`) | Local Claude Code OAuth seat | yes | no | Feature-gated (`cc-provider`); registered via the credential chain, declarative entries are accepted but skipped by the registry to avoid duplicates. |
+| Codex subprocess (`codex-oauth`) | Local Codex seat | yes | no | Feature-gated (`codex-provider`); registered via the credential chain, declarative entries are accepted but do not change startup behavior. |
+
+The `aletheia add-nous` scaffolding command currently validates only `anthropic` and `openai` provider strings and checks for `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`. Other provider kinds must be configured manually in `aletheia.toml`.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -487,7 +487,23 @@ still belong under `agents.defaults.tool_timeouts`.
 
 ## maintenance
 
-Background maintenance tasks. All run automatically when the server is running, and can be triggered via `aletheia maintenance run <task>`.
+Background maintenance tasks. Some run automatically when the server is running; others are opt-in or not yet implemented. Tasks can also be triggered manually via `aletheia maintenance run <task>`.
+
+### Always-on maintenance (enabled by default)
+
+| Task | Config section | Default | Schedule |
+|------|----------------|---------|----------|
+| Trace rotation | `maintenance.trace_rotation` | `enabled = true` | Cron |
+| Drift detection | `maintenance.drift_detection` | `enabled = true` | Cron |
+| DB size monitoring | `maintenance.db_monitoring` | `enabled = true` | Cron |
+
+### Opt-in maintenance (disabled by default)
+
+| Task | Config section | Default | Schedule |
+|------|----------------|---------|----------|
+| Retention enforcement | `maintenance.retention` | `enabled = false` | Cron |
+| Knowledge maintenance | `maintenance.knowledge_maintenance_enabled` | `false` | see below |
+| Serendipity discovery | `maintenance.knowledge_maintenance_serendipity` | `enabled = false` | Cron |
 
 ### maintenance.trace_rotation
 
@@ -523,11 +539,40 @@ Background maintenance tasks. All run automatically when the server is running, 
 
 ### maintenance.knowledge_maintenance_enabled
 
+`knowledge_maintenance_enabled` is a top-level boolean switch (not a table) that
+gates all scheduled knowledge-maintenance tasks. It defaults to `false`.
+
+When set to `true` **and** a knowledge executor is available, the daemon
+registers the following implemented tasks (`crates/daemon/src/runner/registration.rs`):
+
+| Task ID | Cadence | Purpose |
+|---------|---------|---------|
+| `decay-refresh` | every 4 hours | Refresh temporal decay scores |
+| `entity-dedup` | every 6 hours | Merge duplicate knowledge graph entities |
+| `graph-recompute` | every 8 hours | Recompute PageRank / centrality scores |
+| `skill-decay` | daily at 06:00 | Retire stale skills |
+| `derived-facts-materialize` | every 6 hours | Materialize derived Datalog rules |
+
+The following tasks are **not implemented or scheduled** today; calling them
+via `aletheia maintenance run` returns an explicit "not scheduled" error
+(`crates/aletheia/src/knowledge_maintenance.rs`):
+
+- `embedding-refresh` — requires an `EmbeddingProvider` bridge.
+- `knowledge-gc` / edge pruning — no concrete store contract.
+- `index-maintenance` — no concrete store contract.
+- `graph-health-check` — no concrete diagnostic contract.
+
+### maintenance.knowledge_maintenance_serendipity
+
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `knowledge_maintenance_enabled` | bool | `false` | Whether background knowledge graph maintenance tasks run (entity deduplication, edge pruning, embedding refresh) |
+| `enabled` | bool | `false` | Whether serendipity discovery maintenance runs |
+| `cadence` | string | `"0 0 7 * * *"` | Cron expression for the task (daily at 07:00 UTC) |
 
 ```toml
+[maintenance]
+knowledge_maintenance_enabled = true
+
 [maintenance.trace_rotation]
 enabled = true
 max_age_days = 7
@@ -542,6 +587,10 @@ alert_threshold_mb = 1000
 
 [maintenance.retention]
 enabled = true
+
+[maintenance.knowledge_maintenance_serendipity]
+enabled = true
+cadence = "0 0 7 * * *"
 ```
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -281,7 +281,10 @@ The following fields are **not implemented** in the current runtime: `dm_policy`
 
 ## bindings
 
-Array of routing rules mapping channel sources to agents. Evaluated in order; first match wins.
+Array of routing rules mapping channel sources to agents. The Agora router
+uses a fixed specificity order; it does **not** use declaration order or first
+match. The order of `[[bindings]]` entries in the config file does not affect
+routing.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -293,16 +296,28 @@ Array of routing rules mapping channel sources to agents. Evaluated in order; fi
 ```toml
 [[bindings]]
 channel = "signal"
-source = "+15559876543"
-nous_id = "research"
+source = "*"
+nous_id = "main"
 
 [[bindings]]
 channel = "signal"
-source = "*"
-nous_id = "main"
+source = "+15559876543"
+nous_id = "research"
 ```
 
-More specific bindings should appear first.
+### Routing precedence
+
+The router resolves each inbound message in the following order (`crates/agora/src/router.rs`):
+
+1. **Group binding** — exact match on `channel` + `group_id`.
+2. **Source binding** — exact match on `channel` + sender/source.
+3. **Channel default** — `channel` + `source = "*"`.
+4. **Global default** — the agent configured with `default: true`.
+5. **No match** — message is dropped.
+
+A wildcard `source = "*"` entry before an exact source entry does **not** win;
+the exact source binding always takes precedence. Use the most specific binding
+you need and rely on the fixed order above.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -262,11 +262,6 @@ clock_skew_leeway_secs = 30
 | `http_port` | u16 | `8080` | signal-cli JSON-RPC port |
 | `cli_path` | string | -- | Path to signal-cli binary (auto-detected if unset) |
 | `auto_start` | bool | `true` | Auto-start receive loop |
-| `dm_policy` | string | `"contacts"` | DM access: `"contacts"` (known contacts only), `"open"` (anyone), `"allowlist"` |
-| `group_policy` | string | `"allowlist"` | Group access: `"open"`, `"allowlist"` |
-| `require_mention` | bool | `true` | Require @mention in groups |
-| `send_read_receipts` | bool | `true` | Send read receipts |
-| `text_chunk_limit` | u32 | `2000` | Max chars per outgoing message chunk |
 
 ```toml
 [channels.signal]
@@ -276,10 +271,10 @@ enabled = true
 account = "+15551234567"
 http_host = "localhost"
 http_port = 8080
-dm_policy = "contacts"
-group_policy = "allowlist"
-require_mention = true
+auto_start = true
 ```
+
+The following fields are **not implemented** in the current runtime: `dm_policy`, `group_policy`, `require_mention`, `send_read_receipts`, and `text_chunk_limit`. They are accepted by the typed config but are not read by `build_signal_provider`; inbound Signal routing and message handling are controlled by the channel bindings (see [bindings](#bindings)) and by signal-cli's own settings until these policy fields are wired.
 
 ---
 

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -95,25 +95,27 @@ Active windows restrict execution to time ranges (e.g., `active_window: Some((8,
 
 ### Built-in tasks
 
-| Task | Schedule | Purpose |
-|------|----------|---------|
-| Prosoche | Cron | Periodic attention check |
-| TraceRotation | Cron | Compress and rotate old trace files |
-| DriftDetection | Cron | Compare instance against template config |
-| DbSizeMonitor | Cron | Alert on database growth |
-| RetentionExecution | Cron | Execute data retention policy |
-| DecayRefresh | Cron | Refresh temporal decay scores |
-| EntityDedup | Cron | Merge duplicate knowledge graph entities |
-| GraphRecompute | Cron | Recompute PageRank, centrality |
-| EmbeddingRefresh | Cron | Re-embed stale entities |
-| KnowledgeGc | Cron | Orphan removal, expired edge pruning |
-| OpsFactExtraction | Cron/startup | Persist operational fact-extraction results for later recall/audit |
-| IndexMaintenance | Cron | Rebuild/optimize graph indexes |
-| GraphHealthCheck | Cron | Diagnostic health check |
-| SkillDecay | Cron | Retire stale skills |
-| SelfAudit | Cron | Self-assessment against quality metrics |
-| EvolutionSearch | Cron | Mutate and benchmark agent configs |
-| SelfReflection | Cron | Agent evaluates recent performance |
+| Task | Schedule | Status | Purpose |
+|------|----------|--------|---------|
+| Prosoche | Cron | Implemented | Periodic attention check |
+| TraceRotation | Cron | Implemented | Compress and rotate old trace files |
+| DriftDetection | Cron | Implemented | Compare instance against template config |
+| DbSizeMonitor | Cron | Implemented | Alert on database growth |
+| RetentionExecution | Cron | Opt-in (`maintenance.retention.enabled`) | Execute data retention policy |
+| DecayRefresh | Interval (4h) | Implemented, gated by `knowledge_maintenance_enabled` | Refresh temporal decay scores |
+| EntityDedup | Interval (6h) | Implemented, gated by `knowledge_maintenance_enabled` | Merge duplicate knowledge graph entities |
+| GraphRecompute | Interval (8h) | Implemented, gated by `knowledge_maintenance_enabled` | Recompute PageRank, centrality |
+| SkillDecay | Cron (06:00) | Implemented, gated by `knowledge_maintenance_enabled` | Retire stale skills |
+| DerivedFactsMaterialize | Interval (6h) | Implemented, gated by `knowledge_maintenance_enabled` | Materialize derived Datalog rules |
+| SerendipityDiscovery | Cron | Opt-in (`maintenance.knowledge_maintenance_serendipity.enabled`) | Discover unexpected knowledge connections |
+| OpsFactExtraction | Cron/startup | Implemented (requires knowledge executor) | Persist operational fact-extraction results for later recall/audit |
+| EmbeddingRefresh | Cron | **Not implemented** | Re-embed stale entities — blocked on EmbeddingProvider bridge |
+| KnowledgeGc | Cron | **Not implemented** | Orphan removal, expired edge pruning — no store contract |
+| IndexMaintenance | Cron | **Not implemented** | Rebuild/optimize graph indexes — no store contract |
+| GraphHealthCheck | Cron | **Not implemented** | Diagnostic health check — no diagnostic contract |
+| SelfAudit | Cron | **Not implemented** | Self-assessment against quality metrics |
+| EvolutionSearch | Cron | Opt-in (`maintenance.cron_tasks.evolution`) | Mutate and benchmark agent configs |
+| SelfReflection | Cron | Opt-in (`maintenance.cron_tasks.reflection`) | Agent evaluates recent performance |
 
 ### Failure handling
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -404,26 +404,40 @@ Exposes `nous_turn_duration_seconds`, `anthropic_requests_total`, `http_requests
 
 ## Systemd service (Linux)
 
-A ready-to-use service template lives in `instance.example/services/aletheia.service`.
-It uses `%h` (systemd's `$HOME` specifier) so paths resolve automatically.
+A service template lives in `instance.example/services/aletheia.service`.
+It uses `%h` (systemd's `$HOME` specifier) so paths resolve automatically, but
+it is **not** copy-paste ready: the shipped template contains inline directive
+comments and references undefined environment variables (`${ALETHEIA_DATA_DIR}`,
+`${ALETHEIA_INSTANCE_DIR}`) that `systemd-analyze verify` will reject. Treat it
+as a starting point and customize it before enabling.
 
 ```bash
 # 1. Copy the template
 mkdir -p ~/.config/systemd/user
 cp instance.example/services/aletheia.service ~/.config/systemd/user/aletheia.service
 
-# 2. Adjust paths if needed (binary not at ~/.local/bin/, instance not at ~/aletheia/instance/)
-#    Edit ~/.config/systemd/user/aletheia.service and update ExecStart and ALETHEIA_ROOT.
+# 2. Review and edit the unit file
+#    - Move any inline comments to their own lines (systemd does not support
+#      inline comments on directive lines).
+#    - Replace ${ALETHEIA_DATA_DIR} and ${ALETHEIA_INSTANCE_DIR} with concrete
+#      paths, e.g. %h/aletheia/instance/data and %h/aletheia/instance, or
+#      define them in the EnvironmentFile loaded by the unit.
+#    - Adjust ExecStart if the binary is not at ~/.local/bin/aletheia or the
+#      instance is not at ~/aletheia/instance.
 
-# 3. Enable and start
+# 3. Verify the unit parses
+systemd-analyze verify ~/.config/systemd/user/aletheia.service
+
+# 4. Enable and start
 systemctl --user daemon-reload
 systemctl --user enable --now aletheia
 
-# 4. Persist across logout (run once per user)
+# 5. Persist across logout (run once per user)
 loginctl enable-linger
 ```
 
-The template sets `ALETHEIA_ROOT=%h/aletheia/instance` and loads an optional
+The template sets `ExecStart=%h/.local/bin/aletheia -r %h/aletheia/instance`
+(`-r` points the binary at the instance root) and loads an optional
 `EnvironmentFile` from `%h/aletheia/instance/config/env` (silently ignored if absent).
 If your API key is stored in `instance/config/credentials/anthropic.json` (written by
 `aletheia init`), no extra environment setup is needed.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -462,10 +462,16 @@ aletheia health
 aletheia backup                     # create backup
 aletheia backup --list              # list available backups
 aletheia backup --prune --keep 5    # remove old backups
-aletheia backup --export-json       # export sessions as JSON
+aletheia backup verify <path>       # verify a backup snapshot
 ```
 
 Backups are stored in `instance/data/backups/`. Always back up before upgrading.
+
+The `--export-json` flag was removed during the SQLite-to-fjall migration
+(#3446, #4657). Session archives that are already JSON live under
+`instance/data/archive/sessions/`. The cron helper `scripts/backup-cron.sh`
+still references the removed flag and should not be installed until it is
+updated.
 
 ---
 

--- a/docs/GRACEFUL-DEGRADATION.md
+++ b/docs/GRACEFUL-DEGRADATION.md
@@ -31,6 +31,10 @@ Background tasks (extraction, distillation, skill analysis) are spawned into a `
 
 The manager's `health_cycle` pings actors and restarts dead ones with exponential backoff (`manager.rs:388-434`). Restart drains the old `JoinHandle` with a timeout (`manager.rs:494`). Panics during drain are caught as `JoinError` and logged; they do not propagate.
 
+### Manager health poller
+
+**Resolved:** `start_health_poller` (`manager.rs:631`) now returns a supervisor `JoinHandle`. It spawns an inner `health_cycle` poller and, if that task panics, logs the failure, increments a metric, waits a short backoff, and respawns the poller. Health checks therefore cannot stop permanently for all actors managed by this manager.
+
 ## Pylon Handlers
 
 ### Per-request failure isolation
@@ -45,7 +49,7 @@ The streaming handler spawns three concurrent tasks (`streaming.rs:281`, `525`, 
 
 ### Signal handler startup
 
-**Gap:** The SIGHUP reload task and shutdown signal future use `.expect()` on signal handler installation (`server.rs:365`, `413`, `419`). In a restricted container or when file descriptors are exhausted, this **panics the process** during startup.
+**Resolved:** `spawn_sighup_handler` (`server.rs:427`) and `shutdown_signal_with` (`server.rs:507`) now treat signal-installation failures as warnings and continue serving without that signal path. SIGHUP handler installation returning `None` simply disables config reload on signal; Ctrl+C or SIGTERM installation failures cause the corresponding future to pend forever rather than panic. The `.expect()` calls cited in the 2026-04 audit have been removed.
 
 ## Daemon Workers
 
@@ -96,8 +100,8 @@ See [Daemon Workers](#daemon-workers). Maintenance tasks inherit the same isolat
 The following components can turn a local failure into a process-wide crash:
 
 1. **Krites Datalog engine** - `panic!` on internal invariant violations during query planning and JSON serialization.
-2. **Pylon signal handler setup** - `.expect()` on signal installation; startup crash in restricted environments.
-3. **Nous manager health poller** - fire-and-forget task; if `health_cycle()` panics, health checks stop forever for all actors.
+2. ~~Pylon signal handler setup~~ - **resolved** (`server.rs:427`, `507`).
+3. ~~Nous manager health poller~~ - **resolved** (`manager.rs:631`).
 
 ## Summary Table
 
@@ -105,7 +109,7 @@ The following components can turn a local failure into a process-wide crash:
 |---|---|---|---|---|
 | Nous actor - normal turn | Pipeline panic caught as `JoinError` | Request | Actor continues, enter degraded mode if repeated | ✅ None |
 | Nous actor - cross-nous message | Pipeline panic caught as `JoinError` via `execute_turn_with_panic_boundary` | Request | Actor continues, enter degraded mode if repeated | ✅ None (resolved: `actor/mod.rs:470`) |
-| Nous manager health poller | `health_cycle()` panic kills spawned task silently | All actors managed | Supervisor restarts poller on failure | `manager.rs:547` fire-and-forget, no monitoring |
+| Nous manager health poller | Supervisor respawns panicked inner poller | All actors managed | Supervisor restarts poller on failure | ✅ None (resolved: `manager.rs:631`) |
 | Daemon task runner | `JoinError` caught per-task in `check_in_flight` | Task | Task disabled after 3 failures | ✅ None |
 | Daemon maintenance tasks | `spawn_blocking` panics caught as `JoinError` | Task | Same isolation as async tasks | ✅ None |
 | Session store | `tokio::sync::Mutex` - no poisoning | Request | Errors returned to caller | ✅ None |
@@ -137,9 +141,12 @@ The following components can turn a local failure into a process-wide crash:
 - `crates/nous/src/manager.rs:547` - `start_health_poller` spawns health task with no restart supervision.
 
 ### Pylon
-- `crates/pylon/src/server.rs:365` - `.expect("failed to install SIGHUP handler")`.
-- `crates/pylon/src/server.rs:413` - `.expect("failed to install ctrl+c handler")`.
-- `crates/pylon/src/server.rs:419` - `.expect("failed to install SIGTERM handler")`.
+- ~~`crates/pylon/src/server.rs:365` - `.expect("failed to install SIGHUP handler")`.~~ Resolved: handler now returns `None` on failure.
+- ~~`crates/pylon/src/server.rs:413` - `.expect("failed to install ctrl+c handler")`.~~ Resolved: Ctrl+C failure logs a warning and the future pends.
+- ~~`crates/pylon/src/server.rs:419` - `.expect("failed to install SIGTERM handler")`.~~ Resolved: SIGTERM failure logs a warning and the future pends.
+
+### Nous
+- `crates/nous/src/manager.rs:631` - `start_health_poller` supervises the inner poller and respawns it on panic (resolved).
 
 ### Daemon
 - `crates/daemon/src/runner/inflight.rs:92` - `JoinError` from panics caught and logged.

--- a/docs/OBSERVABILITY-AUDIT.md
+++ b/docs/OBSERVABILITY-AUDIT.md
@@ -15,7 +15,7 @@
 | **pylon** | sessions (create, get, list, delete, update, restore, send, streaming), config (get/set/reload), knowledge bulk_import | `nous.rs` handlers (list, get_status, tools, recover) have **no span** - gap |
 | **nous** | actor run loop, pipeline stages, finalize, recall, execute (both paths), instinct (tool dispatch), cross-router | Good coverage across the hot path |
 | **hermeneus** | anthropic client complete + complete_streaming, cc process (two fns), stream accumulator, error classifier, fallback | Core LLM call paths all instrumented |
-| **organon** | triage tool only | `ToolRegistry::execute` dispatch loop has **no span** - all 67 tools (default) execute without a per-invocation parent span |
+| **organon** | triage tool, `ToolRegistry::execute` | `ToolRegistry::execute` now creates a `tool_execute` span (`crates/organon/src/registry/mod.rs:174`). Individual tool executors still vary in instrumentation. |
 | daemon | execution, watchdog, cron jobs, prosoche, self_prompt, lifecycle hooks | Good coverage |
 | episteme | consolidation engine, embedding, knowledge store ops | Good coverage |
 | agora | semeion client | Covered |
@@ -27,7 +27,7 @@
 
 **GAP-SPAN-1 (pylon/nous.rs):** `list`, `get_status`, `tools`, `recover` handlers have no `#[instrument]`. These are user-facing nous management endpoints - missing spans means no distributed trace context for nous listing/recovery operations.
 
-**GAP-SPAN-2 (organon/ToolRegistry):** The central `execute` dispatch path has no span. All 67 built-in tools (default) therefore execute without a common parent span. Traces jump from the nous pipeline span directly to individual tool calls (where they exist). Tool-level `#[instrument]` exists only in `triage/mod.rs`.
+**GAP-SPAN-2 (organon/ToolRegistry):** Resolved. `ToolRegistry::execute` now creates a `tool_execute` span with `tool.name`, `tool.reversibility`, `tool.approval`, `tool.duration_ms`, and `tool.status` fields (`crates/organon/src/registry/mod.rs:174`). Individual tool executors still vary in instrumentation; the remaining gap is per-tool coverage, not the dispatch span.
 
 ---
 
@@ -136,7 +136,7 @@ All critical LLM paths instrumented. The `AnthropicProvider::complete` and `comp
 
 ### organon
 
-Only `triage/mod.rs` has `#[instrument]`. The `ToolRegistry::execute` dispatch method has no span. Individual tool executors (filesystem, git, memory, etc.) have no `#[instrument]`. Tool metrics (`record_invocation`) are called, but without a parent span the trace is disconnected from the nous pipeline.
+`ToolRegistry::execute` now creates a `tool_execute` span (`registry/mod.rs:174`), so the dispatch path is instrumented. Individual tool executors (filesystem, git, memory, etc.) still vary in whether they add their own `#[instrument]`; the remaining gap is per-tool coverage, not the central dispatch span.
 
 ---
 
@@ -145,7 +145,7 @@ Only `triage/mod.rs` has `#[instrument]`. The `ToolRegistry::execute` dispatch m
 | ID | Severity | Gap | Recommended fix |
 |----|----------|-----|----------------|
 | GAP-SPAN-1 | Medium | `pylon/nous.rs` handlers missing `#[instrument]` | Add `#[instrument(skip(state, _claims))]` to `list`, `get_status`, `tools`, `recover` |
-| GAP-SPAN-2 | Medium | `organon/ToolRegistry::execute` missing span | Add `#[instrument(skip_all, fields(tool = %name))]` on the dispatch call site |
+| GAP-SPAN-2 | Medium | ~~organon/ToolRegistry::execute missing span~~ | Resolved: `tool_execute` span is created in `registry/mod.rs:174` |
 | GAP-METRIC-1 | High | No queue-depth metric for NousActor inboxes | Add `aletheia_nous_inbox_depth` gauge updated in actor run loop |
 | GAP-METRIC-2 | Low | `nous::metrics::init()` not wired to server boot | Call `nous::metrics::init()` alongside `pylon::metrics::init()` at server startup |
 | GAP-LOG-1 | Medium | `pylon/nous.rs` `recover` handler lacks structured error log | Add `error!(nous_id = %id, error = %e, "nous recovery failed")` on error path |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -52,12 +52,20 @@ aletheia --version
 Download the tarball from the [releases page](https://github.com/forkwright/aletheia/releases) instead of building from source:
 
 ```bash
-VERSION=v0.27.0
+VERSION=v0.30.0
 curl -L "https://github.com/forkwright/aletheia/releases/download/${VERSION}/aletheia-linux-x86_64-${VERSION}.tar.gz" \
   -o aletheia.tar.gz
 tar xzf aletheia.tar.gz
 cd "aletheia-${VERSION}"
 sudo cp aletheia /usr/local/bin/
+```
+
+To use the latest release without hard-coding the version:
+
+```bash
+VERSION=$(curl -s https://api.github.com/repos/forkwright/aletheia/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+curl -L "https://github.com/forkwright/aletheia/releases/download/${VERSION}/aletheia-linux-x86_64-${VERSION}.tar.gz" \
+  -o aletheia.tar.gz
 ```
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -235,7 +235,7 @@ nous_id = "pronoea"
 
 4. Restart the server. Send a message to your Signal number.
 
-See [CONFIGURATION.md](CONFIGURATION.md#channelssignal) for DM/group policies, allowlists, and multi-account setup.
+See [CONFIGURATION.md](CONFIGURATION.md#channelssignal) for the supported Signal account fields and multi-account setup. DM/group gating, mention requirements, read receipts, and message chunking are not enforced by the Aletheia runtime today; configure those behaviors in signal-cli directly.
 
 ---
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -276,12 +276,15 @@ If refresh fails (e.g. revoked grant), re-authenticate:
 ## Static API key rotation
 
 1. Generate a new key in the Anthropic console.
-2. Update `instance/config/aletheia.toml`:
+2. Set the environment variable `ANTHROPIC_API_KEY`, or add a declarative provider entry in `instance/config/aletheia.toml`:
    ```toml
-   [provider]
-   api_key = "sk-ant-..."
+   [[providers]]
+   name = "anthropic-cloud"
+   providerType = "anthropic"
+   apiKeyEnv = "ANTHROPIC_API_KEY"
+   deploymentTarget = "cloud"
+   models = ["claude-sonnet-4-6"]
    ```
-   Or set the environment variable `ANTHROPIC_API_KEY`.
 3. Restart the service: `systemctl --user restart aletheia`
 4. Confirm: `aletheia health`
 
@@ -384,7 +387,7 @@ aletheia backup --prune --keep 5 --yes    # skip confirmation
 
 ## Export sessions as JSON (before deletion)
 
-No built-in JSON export exists since the SQLite-to-fjall migration (#3446). Archived sessions are already JSON in `instance/data/archive/sessions/`.
+No built-in JSON export exists since the SQLite-to-fjall migration (#3446). Archived sessions are already JSON in `instance/data/archive/sessions/`. The `aletheia backup --export-json` command referenced in older docs and in `scripts/backup-cron.sh` is removed; do not use it.
 
 ## Verify backup integrity
 
@@ -743,7 +746,7 @@ The session history remains in the archive. Start a fresh session for new work.
 
 ### Configuration
 
-The distillation model defaults to the workspace-wide `koina::defaults::DEFAULT_MODEL` (currently `claude-sonnet-4-6`; the single source of truth, see #4235). To use a cheaper model for summaries, set `distillation_model` under `[agents.defaults]` in `instance/config/aletheia.toml`. This field is hot-reloadable (no restart needed).
+The distillation model defaults to the workspace-wide `koina::defaults::DEFAULT_MODEL` (currently `claude-sonnet-4-6`; the single source of truth, see #4235). There is no `distillation_model` config field under `[agents.defaults]` in the current typed config; per-agent model selection uses the `model.primary` / `model.fallbacks` fields documented in `docs/CONFIGURATION.md#agents`.
 
 ---
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -56,24 +56,69 @@ Check `git log --oneline` or [GitHub releases](https://github.com/forkwright/ale
 ## Store migration
 
 Sessions now use a fjall-backed store. The pre-fjall SQLite session backend is
-historical; use the one-shot migration tool if you still have a legacy
-`sessions.db` file.
+historical. If you have a legacy SQLite `sessions.db` from aletheia 0.15.x, use
+the `aletheia-sessions-migrate` one-shot tool to move session history into a
+fresh fjall keyspace.
 
 The embedded Datalog engine (knowledge store) manages its own schema versioning internally.
 
 **Always back up before upgrading.** While migrations are tested, restoring from backup is the safest recovery path if something goes wrong.
 
-### Upgrading from <0.16 to >=0.16 (fjall session store)
+### Migrating a legacy SQLite `sessions.db` to fjall
 
-Version 0.16.0 changed the default session store backend from historical SQLite
-to fjall. Both backends use the same path (`data/sessions.db`), but the
-historical SQLite backend creates a file while fjall creates a directory.
-Upgrading without preparation causes a startup crash.
+The migrator `crates/aletheia-sessions-migrate` (binary `aletheia-sessions-migrate`)
+reads a v32 SQLite sessions database read-only and writes its contents to a new
+fjall directory that matches the layout used by current aletheia. It supports:
 
-`data/knowledge.fjall` may also be incompatible if it was created by an
-older fjall version (the error message will mention `InvalidTag(CompressionType)`).
+- `--dry-run` — inspect the source DB and report the migration plan without writing.
+- `--verify` — after migrating, sample rows and compare SHA-256 checksums of message bodies.
+- `--verify-only` — verify a previously written destination directory.
+- `--print-mapping` — print the SQLite → fjall field mapping.
 
-**Before deploying the new binary:**
+**Requirements and limits:**
+
+- Source DB must have `PRAGMA user_version = 32` (the last SQLite session schema).
+- Required tables must exist: `sessions`, `messages`, `usage`, `distillations`, `agent_notes`, `blackboard`.
+- Columns with no direct fjall equivalent (`thinking_enabled`, `thinking_budget`, `working_state`, `distillation_priming`) are preserved under a `migration_legacy` partition rather than dropped.
+- Messages whose parent session row is missing are recovered as synthesised `orphan-recovery` sessions.
+- The migrator does not migrate the knowledge store; `knowledge.fjall` must be created fresh or handled separately.
+
+**Migration workflow:**
+
+```bash
+# 1. Stop the service
+systemctl --user stop aletheia
+
+# 2. Back up the current instance directory
+cp -r instance instance-backup-$(date +%Y%m%d)
+
+# 3. Run a dry run to confirm the source is readable
+aletheia-sessions-migrate \
+  --source instance/data/pre-0.16-archive/sessions.db \
+  --dest instance/data/sessions.db.migrated \
+  --dry-run
+
+# 4. Migrate and verify
+aletheia-sessions-migrate \
+  --source instance/data/pre-0.16-archive/sessions.db \
+  --dest instance/data/sessions.db.migrated \
+  --verify
+
+# 5. Swap the migrated keyspace into place
+mv instance/data/sessions.db instance/data/sessions.db.pre-migration
+mv instance/data/sessions.db.migrated instance/data/sessions.db
+
+# 6. Start the service and check health
+systemctl --user start aletheia
+aletheia health
+```
+
+If verification fails, the migrator exits non-zero and leaves the destination
+untouched. Restore from the backup taken in step 2 and inspect the mismatch report.
+
+### Upgrading from <0.16 to >=0.16 (fjall session store) without migration
+
+If you do not need historical session data, you can start fresh instead:
 
 ```bash
 # Stop the service
@@ -85,9 +130,7 @@ mv instance/data/sessions.db* instance/data/pre-0.16-archive/
 mv instance/data/knowledge.fjall instance/data/pre-0.16-archive/
 ```
 
-The new binary will create fresh fjall stores on startup. Existing session
-history from historical SQLite is not automatically migrated; it is preserved in the
-archive directory for manual export if needed.
+The new binary will create fresh fjall stores on startup.
 
 ---
 

--- a/docs/WORKSPACE_FILES.md
+++ b/docs/WORKSPACE_FILES.md
@@ -1,6 +1,6 @@
 # Workspace files reference
 
-Each nous has a workspace directory (`instance/nous/<name>/`) with up to 10 markdown files. These files define its identity, hold its memory, and supply runtime context. The bootstrap system (`crates/nous/src/bootstrap/`) reads these files, applies token budgeting, and assembles them into the system prompt for each API call. For shared tools available to all agents, see [shared/TOOLS-INFRASTRUCTURE.md](../shared/TOOLS-INFRASTRUCTURE.md).
+Each nous has a workspace directory (`instance/nous/<name>/`) with up to 11 markdown files. These files define its identity, hold its memory, and supply runtime context. The bootstrap system (`crates/nous/src/bootstrap/`) reads these files, applies token budgeting, and assembles them into the system prompt for each API call. For shared tools available to all agents, see [shared/TOOLS-INFRASTRUCTURE.md](../shared/TOOLS-INFRASTRUCTURE.md).
 
 ---
 
@@ -8,15 +8,24 @@ Each nous has a workspace directory (`instance/nous/<name>/`) with up to 10 mark
 
 | File | Priority | Required | Source | Purpose |
 |------|----------|----------|--------|---------|
-| SOUL.md | 1 | Yes | Hand-written | Core identity, principles, communication style, boundaries |
-| USER.md | 2 | No | Hand-written | Operator profile, preferences, goals, constraints |
-| AGENTS.md | 3 | No | Hand-written | Other nous in the system, collaboration protocols, routing |
-| GOALS.md | 4 | No | Hand-written | Active, completed, and deferred goals |
-| TOOLS.md | 5 | No | Auto-generated | Tool inventory and profiles. Regenerated when tool set changes |
-| MEMORY.md | 6 | No | Nous-maintained | Long-term curated knowledge: facts, preferences, patterns, lessons |
-| IDENTITY.md | 7 | No | Hand-written | Minimal metadata: name, emoji. Parsed as frontmatter |
-| PROSOCHE.md | 8 | No | Auto-generated | Adaptive attention directives from the prosoche daemon |
-| CONTEXT.md | 9 | No | Runtime-written | Transient session-scoped state, cleared at session boundaries |
+| `SOUL.md` | 1 | Yes | Hand-written | Core identity, principles, communication style, boundaries |
+| `VOICE.md` | 2 | No | Hand-written | Operator writing-style exemplars, near the top of the system prompt |
+| `USER.md` | 3 | No | Hand-written | Operator profile, preferences, goals, constraints |
+| `AGENTS.md` | 4 | No | Hand-written | Other nous in the system, collaboration protocols, routing |
+| `GOALS.md` | 5 | No | Hand-written | Active, completed, and deferred goals |
+| `TOOLS.md` | 6 | No | Auto-generated | Tool inventory and profiles. Regenerated when tool set changes |
+| `CHECKLIST.md` | 7 | No | Hand-written | Work procedures and checklists, loaded for coding tasks |
+| `MEMORY.md` | 8 | No | Nous-maintained | Long-term curated knowledge: facts, preferences, patterns, lessons |
+| `IDENTITY.md` | 9 | No | Hand-written | Minimal metadata: name, emoji. Parsed as frontmatter |
+| `PROSOCHE.md` | 10 | No | Auto-generated | Adaptive attention directives from the prosoche daemon |
+| `CONTEXT.md` | 11 | No | Runtime-written | Transient session-scoped state, cleared at session boundaries |
+
+### Files scaffolded but not loaded
+
+`WORKFLOWS.md` is created by `aletheia init` and `aletheia add-nous`, but the
+bootstrap runtime (`crates/nous/src/bootstrap/mod.rs`) has no `WORKFLOWS` file
+spec. It is safe to keep as operator reference, but it is not injected into the
+system prompt today.
 
 ---
 
@@ -24,8 +33,13 @@ Each nous has a workspace directory (`instance/nous/<name>/`) with up to 10 mark
 
 Files are loaded in strict priority order (1 = highest). The priority number determines two things:
 
-1. **System prompt ordering.** Lower priority number = earlier in the system prompt. SOUL.md is always first.
-2. **Drop order under budget pressure.** When total tokens exceed the budget, the loader drops files from the bottom (highest priority number) first. CONTEXT.md and PROSOCHE.md are dropped before MEMORY.md, which is dropped before TOOLS.md, and so on. SOUL.md is the last file that would ever be dropped.
+1. **System prompt ordering.** Lower priority number = earlier in the system prompt. `SOUL.md` is always first.
+2. **Drop order under budget pressure.** When total tokens exceed the budget, the loader drops files from the bottom (highest priority number) first. `CONTEXT.md` and `PROSOCHE.md` are dropped before `MEMORY.md`, which is dropped before `TOOLS.md`, and so on. `SOUL.md` is the last file that would ever be dropped.
+
+Files are also split into two load tiers:
+
+- **Always-loaded (identity tier):** `SOUL.md`, `VOICE.md`, `USER.md`, `IDENTITY.md`, `PROSOCHE.md`.
+- **Conditionally-loaded (operational tier):** `AGENTS.md`, `GOALS.md`, `TOOLS.md`, `CHECKLIST.md`, `MEMORY.md`, `CONTEXT.md`. The task hint selects which operational files are included (coding loads `TOOLS.md`, `CHECKLIST.md`, `MEMORY.md`; research loads `GOALS.md`, `CONTEXT.md`, `MEMORY.md`; planning loads `GOALS.md`, `AGENTS.md`, `CONTEXT.md`).
 
 If a file does not exist in the workspace directory, it is silently skipped. Empty files are also skipped.
 
@@ -35,24 +49,24 @@ If a file does not exist in the workspace directory, it is silently skipped. Emp
 
 Only one file is truly required for a nous to function:
 
-- **SOUL.md** - Without it, the nous has no identity or behavioral guidance. The actor fails to spawn if this file is missing from the cascade.
+- **`SOUL.md`** - Without it, the nous has no identity or behavioral guidance. The actor fails to spawn if this file is missing from the cascade.
 
-All other files are optional. A minimal nous needs only SOUL.md. In practice, most nous also have IDENTITY.md (for display name and routing), AGENTS.md (for multi-agent coordination), and MEMORY.md (for session continuity).
+All other files are optional. A minimal nous needs only `SOUL.md`. In practice, most nous also have `IDENTITY.md` (for display name and routing), `AGENTS.md` (for multi-agent coordination), and `MEMORY.md` (for session continuity).
 
 ---
 
 ## Hand-written vs auto-generated
 
 **Hand-written by the operator:**
-- SOUL.md, USER.md, AGENTS.md, IDENTITY.md, GOALS.md
+- `SOUL.md`, `VOICE.md`, `USER.md`, `AGENTS.md`, `GOALS.md`, `CHECKLIST.md`, `IDENTITY.md`
 
 **Maintained by the nous itself:**
-- MEMORY.md - The nous reads and updates this file across sessions to build persistent knowledge. The template instructs the nous: "Your workspace files are your memory. Update them proactively."
+- `MEMORY.md` - The nous reads and updates this file across sessions to build persistent knowledge. The template instructs the nous: "Your workspace files are your memory. Update them proactively."
 
 **Auto-generated by the runtime:**
-- TOOLS.md - Auto-generated by the runtime when the tool set changes. Do not edit manually.
-- PROSOCHE.md - Written by the prosoche daemon based on calendar signals, pending tasks, and cross-nous messages.
-- CONTEXT.md - Written by the runtime with transient session state. Cleared or overwritten at session boundaries.
+- `TOOLS.md` - Auto-generated by the runtime when the tool set changes. Do not edit manually.
+- `PROSOCHE.md` - Written by the prosoche daemon based on calendar signals, pending tasks, and cross-nous messages.
+- `CONTEXT.md` - Written by the runtime with transient session state. Cleared or overwritten at session boundaries.
 
 ---
 
@@ -83,7 +97,7 @@ Because all workspace files are concatenated into one block, any change to any f
 
 ## Additional injection points
 
-Beyond the 9 workspace files, the bootstrap accepts extra sections via `assemble_with_extra()`. Domain packs (loaded by `thesauros`) provide additional context and tool overlays as `BootstrapSection` values that participate in the same priority sorting and token budget as workspace files.
+Beyond the 11 workspace files, the bootstrap accepts extra sections via `assemble_with_extra()`. Domain packs (loaded by `thesauros`) provide additional context and tool overlays as `BootstrapSection` values that participate in the same priority sorting and token budget as workspace files.
 
 ---
 
@@ -93,7 +107,7 @@ Agent workspaces (`instance/nous/{id}/`) hold **identity files and session memor
 
 ### What stays in `nous/{id}/`
 
-- Bootstrap files: SOUL.md, USER.md, AGENTS.md, GOALS.md, TOOLS.md, MEMORY.md, IDENTITY.md, PROSOCHE.md, CONTEXT.md
+- Bootstrap files: `SOUL.md`, `VOICE.md`, `USER.md`, `AGENTS.md`, `GOALS.md`, `TOOLS.md`, `CHECKLIST.md`, `MEMORY.md`, `IDENTITY.md`, `PROSOCHE.md`, `CONTEXT.md`
 - Session logs: `memory/YYYY-MM-DD.md`
 
 ### What goes in `theke/`
@@ -113,5 +127,13 @@ Files organized by **subject**, not by agent. This prevents:
 - Duplication across agents
 - Files that can't be found because you don't know which agent created them
 - Maintenance overhead from managing N separate file trees
+
+### Scaffold drift note
+
+`aletheia add-nous` currently creates `nous/{id}/workspace/drafts/` and
+`nous/{id}/workspace/scripts/` even though the file-location rule above says
+working files belong in `theke/`. Those directories are created by the scaffold
+but are not part of the runtime bootstrap. If you use them, treat them as a
+private workspace; if you want shared/discoverable work, place it in `theke/`.
 
 The `_example/AGENTS.md` template includes this rule, so every newly scaffolded agent learns it during onboarding. See `instance.example/README.md` for the full directory structure.

--- a/docs/paper/draft.md
+++ b/docs/paper/draft.md
@@ -143,11 +143,11 @@ comm[labels, entity_id] <~ CommunityDetectionLouvain(edges_w[])
 
 ### 3.3 Kernel-level sandbox (organon)
 
-Aletheia executes tools in child processes with three layers of kernel enforcement, applied via `pre_exec` between `fork` and `exec`:
+Aletheia executes external-process tools in child processes with three layers of kernel enforcement, applied via `pre_exec` between `fork` and `exec` on Linux:
 
-1. **Landlock LSM** (Linux 5.13+) restricts filesystem access. The policy grants read, write, and execute permissions to specific paths. Landlock ABI v5 is probed at startup. If the kernel lacks Landlock, the system falls back to permissive mode or blocks execution based on operator configuration.
+1. **Landlock LSM** (Linux 5.13+) restricts filesystem access. The policy grants read, write, and execute permissions to specific paths. Landlock ABI v5 is probed at startup. If the kernel lacks Landlock, behavior depends on the configured enforcement level.
 
-2. **seccomp BPF** blocks dangerous syscalls. A BPF filter denies `ptrace`, `mount`, `umount2`, `reboot`, `kexec_load`, `init_module`, `delete_module`, `finit_module`, `pivot_root`, and `chroot`. In permissive mode, violations are logged; in enforcing mode, they return `EPERM`.
+2. **seccomp BPF** blocks dangerous syscalls. A BPF filter denies `ptrace`, `mount`, `umount2`, `reboot`, `kexec_load`, `init_module`, `delete_module`, `finit_module`, `pivot_root`, and `chroot`. In enforcing mode violations return `EPERM`; in permissive mode they are logged and allowed.
 
 3. **Network namespaces** isolate egress. `unshare(CLONE_NEWUSER | CLONE_NEWNET)` creates a namespace with only loopback, blocking all outbound connections without root. If unprivileged namespaces are disabled, a seccomp fallback blocks `socket(AF_INET)` and `socket(AF_INET6)`.
 
@@ -162,7 +162,7 @@ extra_read_paths = ["/data/shared"]
 extra_write_paths = ["/tmp/workspace"]
 ```
 
-Tool execution in the agent loop (`nous → organon`) applies the sandbox to every external process automatically. Built-in tools that do not spawn processes (e.g., HTTP client, file read) run inside the main process with their own restrictions.
+The compiled default is `enabled = true` with `enforcement = "permissive"` and `egress = "allow"`, so new installations log sandbox violations instead of blocking them and do not restrict outbound network. Operators who want hard isolation must set `enforcement = "enforcing"` and `egress = "deny"` (or `egress = "allowlist"`). Setting `enabled = false` disables the sandbox entirely. Tool execution in the agent loop applies the sandbox only when it is enabled and only to external-process tools; built-in tools that do not spawn processes run inside the main process with their own restrictions. On macOS and Windows the sandbox machinery compiles but is a no-op.
 
 Comparison to alternatives: OpenAI Codex [5] uses a similar sandbox but inside a containerized environment with heavier orchestration. NVIDIA OpenShell [6] applies seccomp and namespaces but focuses on shell command isolation. Aletheia's sandbox is lighter (no containers, no root) and integrated directly into the agent turn loop.
 

--- a/instance.example/README.md
+++ b/instance.example/README.md
@@ -19,7 +19,10 @@ instance/
 │   └── credentials/            # API keys, OAuth tokens, Signal creds
 │
 ├── data/                       # Runtime data stores
-│   └── *.db                    # SQLite databases (sessions, messages, planning)
+│   ├── sessions.db/            # fjall-backed session store (directory, not a file)
+│   ├── knowledge.fjall/        # fjall-backed knowledge store
+│   ├── backups/                # Daemon-managed backup snapshots
+│   └── archive/                # Archived sessions exported as JSON
 │
 ├── logs/                       # Runtime log output
 │
@@ -93,7 +96,7 @@ Tools, templates, hooks, and config all resolve through this cascade.
 | Shared tools & scripts | `shared/tools/`, `shared/bin/` | Runtime infrastructure |
 | Coordination state | `shared/coordination/` | Runtime traces, status |
 | API keys, OAuth tokens | `config/credentials/` | Deployment secrets |
-| Runtime databases | `data/` | SQLite session/message stores |
+| Runtime databases | `data/` | fjall-backed session and knowledge stores |
 
 ## Key Principles
 

--- a/instance.example/nous/_default/README.md
+++ b/instance.example/nous/_default/README.md
@@ -38,9 +38,11 @@ The `nous/{id}/` directory separates durable startup state from shared work in `
 | `GOALS.md` | Active, deferred, and completed objectives | Planning and prioritization |
 | `MEMORY.md` | Curated long-lived notes | Continuity across sessions |
 | `PROSOCHE.md` | Attention checks and recurring review prompts | Heartbeat and self-checks |
-| `WORKFLOWS.md` | Repeatable procedures | Task execution |
+| `CHECKLIST.md` | Work procedures and checklists | Coding tasks |
+| `VOICE.md` | Operator writing-style exemplars | Anchoring output style |
+| `WORKFLOWS.md` | Repeatable procedures | **Not loaded by the runtime today**; safe to keep as operator reference |
 
-Keep project drafts, research, references, and deliverables in `theke/` so every agent can find and reuse them. Keep `nous/{id}/` focused on identity, operator knowledge, agent guidance, memory, and goals.
+Keep project drafts, research, references, and deliverables in `theke/` so every agent can find and reuse them. Keep `nous/{id}/` focused on identity, operator knowledge, agent guidance, memory, and goals. Although `aletheia add-nous` creates a `workspace/` subdirectory with `drafts/` and `scripts/`, those directories are not part of the runtime bootstrap; prefer `theke/` for shared work.
 
 ## Renaming
 

--- a/instance.example/nous/_template/README.md
+++ b/instance.example/nous/_template/README.md
@@ -6,18 +6,21 @@ This directory is the reference template for new Aletheia agents. Copy it with `
 
 ```text
 {agent-id}/
-├── SOUL.md          # Identity, voice, principles
+├── SOUL.md          # Identity, voice, principles (required)
 ├── IDENTITY.md      # Runtime-required: name and emoji
+├── USER.md          # Operator profile and preferences
+├── AGENTS.md        # Operational rules, delegation, output quality
 ├── GOALS.md         # Active and completed goals
 ├── MEMORY.md        # Curated operational memory
-├── AGENTS.md        # Operational rules, delegation, output quality
 ├── CONTEXT.md       # Session-scoped state (runtime-written)
 ├── PROSOCHE.md      # Attention and heartbeat directives
 ├── TOOLS.md         # Tool inventory (auto-generated)
-├── USER.md          # Operator profile (learned from conversation)
-├── VOICE.md         # Operator writing style (learned from conversation)
-└── USER.md          # Operator profile and preferences
+├── CHECKLIST.md     # Work procedures and checklists
+└── VOICE.md         # Operator writing-style exemplars
 ```
+
+`WORKFLOWS.md` is also scaffolded but is **not loaded by the runtime bootstrap**
+today; keep it as operator reference if useful.
 
 ## What goes where
 
@@ -25,11 +28,15 @@ This directory holds **identity and session memory only**. All working files go 
 
 | Content | Location |
 |---------|----------|
-| Identity files (SOUL, GOALS, etc.) | `nous/{id}/` |
+| Identity files (SOUL, GOALS, MEMORY, etc.) | `nous/{id}/` |
 | Session logs | `nous/{id}/memory/YYYY-MM-DD.md` |
 | Project work, drafts, specs | `theke/projects/{name}/` |
 | Research | `theke/research/` |
 | Agent scratch space | `theke/nous/{id}/` |
+
+Although `aletheia add-nous` creates `workspace/drafts/` and `workspace/scripts/`
+under `nous/{id}/`, those directories are not part of the runtime bootstrap. Use
+`theke/` for shared, discoverable work.
 
 See `instance.example/README.md` for the full file organization guide.
 


### PR DESCRIPTION
Closes #4578
Closes #4579
Closes #4580
Closes #4593
Closes #4597
Closes #4606
Closes #4649
Closes #4651
Closes #4656
Closes #4657
Closes #4665
Refs #4757

Docs-only truth sweep (one commit per issue, every claim verified against source): SQLite→fjall migration workflow, dokimion L2 summary, runtime boundary claims, phantom Signal account-policy fields, provider docs vs the declarative registry, Quickstart version sync, systemd template qualification, Signal binding precedence, workspace-file scaffold drift, stale storage/rotation/backup references, maintenance-task implemented/opt-in/unimplemented labeling, and the doc half of #4757 (audit-comment staleness; the schema-default code half stays open).