### PR TITLE
fix(proskenion,skene): migrate desktop planning views to versioned API routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7650,6 +7650,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "skene",
  "snafu",
  "symbolon",
  "taxis",

--- a/_llm/L3-api-index/skene.md
+++ b/_llm/L3-api-index/skene.md
@@ -65,6 +65,36 @@ impl ApiClient {
 }
 ```
 
+## `src/api/routes.rs`
+
+> Template for `GET` project verification.
+```rust
+pub const PROJECT_VERIFICATION_TEMPLATE: &str =
+        "/api/v1/planning/projects/{project_id}/verification";
+```
+
+> Template for `POST` project verification refresh.
+```rust
+pub const PROJECT_VERIFICATION_REFRESH_TEMPLATE: &str =
+        "/api/v1/planning/projects/{project_id}/verification/refresh";
+```
+
+```rust
+pub fn project_verification_path (project_id: &str) -> String
+```
+
+```rust
+pub fn project_verification_url (base_url: &str, project_id: &str) -> String
+```
+
+```rust
+pub fn project_verification_refresh_path (project_id: &str) -> String
+```
+
+```rust
+pub fn project_verification_refresh_url (base_url: &str, project_id: &str) -> String
+```
+
 ## `src/api/sse.rs`
 
 > Manages the global SSE connection to /api/v1/events.

--- a/_llm/L3-api-index/theatron.md
+++ b/_llm/L3-api-index/theatron.md
@@ -2692,6 +2692,36 @@ impl ApiClient {
 }
 ```
 
+## `skene/src/api/routes.rs`
+
+> Template for `GET` project verification.
+```rust
+pub const PROJECT_VERIFICATION_TEMPLATE: &str =
+        "/api/v1/planning/projects/{project_id}/verification";
+```
+
+> Template for `POST` project verification refresh.
+```rust
+pub const PROJECT_VERIFICATION_REFRESH_TEMPLATE: &str =
+        "/api/v1/planning/projects/{project_id}/verification/refresh";
+```
+
+```rust
+pub fn project_verification_path (project_id: &str) -> String
+```
+
+```rust
+pub fn project_verification_url (base_url: &str, project_id: &str) -> String
+```
+
+```rust
+pub fn project_verification_refresh_path (project_id: &str) -> String
+```
+
+```rust
+pub fn project_verification_refresh_url (base_url: &str, project_id: &str) -> String
+```
+
 ## `skene/src/api/sse.rs`
 
 > Manages the global SSE connection to /api/v1/events.

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-06-08T17:46:24Z"
+generated_at = "2026-06-12T14:11:32Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -266,14 +266,14 @@ l3_token_estimate = 1354
 [[crates]]
 name = "pylon"
 path = "crates/pylon"
-source_hash = "0e655a95f075fc12fedccf065f1a3be930e609813c8c82f963102a573101e9f0"
+source_hash = "307954a969bba77ec1e5eafa6d26eeed7d888cbbb55d1c737fd266feb00d0f51"
 l3_token_estimate = 18067
 
 [[crates]]
 name = "skene"
 path = "crates/theatron/skene"
-source_hash = "1597a8ece5eb94cbcfeaf0a83ee5d7ec9a6927917a9db25b31629e68879229de"
-l3_token_estimate = 4844
+source_hash = "77470e38f5cad749a7cbd82891c86781f5cfe21f767a971d140458e7a6661024"
+l3_token_estimate = 5026
 
 [[crates]]
 name = "symbolon"
@@ -290,8 +290,8 @@ l3_token_estimate = 23836
 [[crates]]
 name = "theatron"
 path = "crates/theatron"
-source_hash = "6b8e37e3f852d9def53fc56420d24e7d56b20d2e358627faf4d7a11bc6a5e864"
-l3_token_estimate = 22061
+source_hash = "3a2d1ee96b866698f795ba6bc4d3a13b3c9615fe90591058d063d317124526be"
+l3_token_estimate = 22245
 
 [[crates]]
 name = "thesauros"

--- a/crates/pylon/Cargo.toml
+++ b/crates/pylon/Cargo.toml
@@ -85,6 +85,7 @@ http-body-util = "0.1"
 jiff = { workspace = true }
 reqwest = { workspace = true }
 koina = { path = "../koina" }
+skene = { path = "../theatron/skene" }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true }

--- a/crates/pylon/src/router.rs
+++ b/crates/pylon/src/router.rs
@@ -297,33 +297,9 @@ pub fn build_router_with(
 /// Fallback handler for unmatched routes.
 ///
 /// Returns 410 Gone with migration hints for old unversioned `/api/nous`
-/// and `/api/planning` paths. Other unknown paths get 404.
+/// paths. Other unknown paths get 404.
 async fn fallback_handler(uri: axum::http::Uri) -> Response {
     let path = uri.path();
-
-    // WHY(#3266): old `/api/planning/...` routes moved to `/api/v1/planning/...`.
-    // Return 301 so existing clients (proskenion) follow the redirect.
-    if path.starts_with("/api/planning/") {
-        let new_path = path.replacen("/api/planning/", "/api/v1/planning/", 1);
-        let mut response = (
-            StatusCode::MOVED_PERMANENTLY,
-            axum::Json(ErrorResponse {
-                error: ErrorBody {
-                    code: "api_version_required".to_owned(),
-                    message: format!("This endpoint has moved. Use {new_path} instead."),
-                    request_id: None,
-                    details: None,
-                },
-            }),
-        )
-            .into_response();
-        if let Ok(location) = axum::http::HeaderValue::from_str(&new_path) {
-            response
-                .headers_mut()
-                .insert(axum::http::header::LOCATION, location);
-        }
-        return response;
-    }
 
     if path.starts_with("/api/nous") {
         let suggestion = path.replacen("/api/", "/api/v1/", 1);
@@ -488,23 +464,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fallback_redirects_old_planning_routes() {
+    async fn fallback_returns_404_for_old_planning_routes() {
         let uri: axum::http::Uri = "/api/planning/projects/proj-1/verification"
             .parse()
             .expect("parse URI");
         let response = fallback_handler(uri).await;
         assert_eq!(
             response.status(),
-            axum::http::StatusCode::MOVED_PERMANENTLY,
-            "old planning path should return 301"
-        );
-        let location = response
-            .headers()
-            .get(axum::http::header::LOCATION)
-            .expect("301 must include Location header");
-        assert_eq!(
-            location.to_str().unwrap(),
-            "/api/v1/planning/projects/proj-1/verification"
+            axum::http::StatusCode::NOT_FOUND,
+            "old planning path should not be redirected"
         );
     }
 

--- a/crates/pylon/tests/public_api_router_auth.rs
+++ b/crates/pylon/tests/public_api_router_auth.rs
@@ -11,6 +11,7 @@ use tower::ServiceExt;
 
 use koina::http::{API_HEALTH, API_V1};
 use pylon::router::build_router;
+use skene::api::routes::planning::{project_verification_path, project_verification_refresh_path};
 use symbolon::types::Role;
 
 mod common;
@@ -198,6 +199,63 @@ async fn protected_endpoint_accepts_valid_bearer() {
         .expect("router response");
 
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn proskenion_planning_fetch_urls_match_pylon_routes() {
+    let env = TestEnv::new().await;
+    let token = issue_test_token(&env.state);
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    for (method, path) in [
+        (Method::GET, project_verification_path("some-project")),
+        (
+            Method::POST,
+            project_verification_refresh_path("some-project"),
+        ),
+    ] {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(path)
+                    .header("authorization", bearer(&token))
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+
+        let body = read_body_json(response).await;
+        assert_eq!(body["error"]["code"], "not_found");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("planning/projects/some-project"),
+            "proskenion planning URL must reach the planning handler"
+        );
+    }
+}
+
+#[tokio::test]
+async fn legacy_planning_fetch_url_is_not_served() {
+    let env = TestEnv::new().await;
+    let token = issue_test_token(&env.state);
+    let router = build_router(Arc::clone(&env.state), &permissive_security());
+
+    let response = router
+        .oneshot(
+            Request::get("/api/planning/projects/some-project/verification")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/crates/theatron/proskenion/Cargo.lock
+++ b/crates/theatron/proskenion/Cargo.lock
@@ -2792,6 +2792,7 @@ dependencies = [
  "prometheus-client",
  "rand 0.10.1",
  "regex",
+ "reqwest",
  "rustix",
  "serde",
  "serde_json",

--- a/crates/theatron/proskenion/src/components/checkpoint_card.rs
+++ b/crates/theatron/proskenion/src/components/checkpoint_card.rs
@@ -226,7 +226,7 @@ pub(crate) fn CheckpointCard(
         spawn(async move {
             let client = authenticated_client(&cfg);
             let url = format!(
-                "{}/api/planning/projects/{pid}/checkpoints/{cid}/action",
+                "{}/api/v1/planning/projects/{pid}/checkpoints/{cid}/action",
                 cfg.server_url.trim_end_matches('/')
             );
             let req = CheckpointActionRequest {
@@ -266,7 +266,7 @@ pub(crate) fn CheckpointCard(
         spawn(async move {
             let client = authenticated_client(&cfg);
             let url = format!(
-                "{}/api/planning/projects/{pid}/checkpoints/{cid}/action",
+                "{}/api/v1/planning/projects/{pid}/checkpoints/{cid}/action",
                 cfg.server_url.trim_end_matches('/')
             );
             let req = CheckpointActionRequest {

--- a/crates/theatron/proskenion/src/state/checkpoints.rs
+++ b/crates/theatron/proskenion/src/state/checkpoints.rs
@@ -74,7 +74,7 @@ pub(crate) struct Checkpoint {
     pub(crate) decision: Option<CheckpointDecision>,
 }
 
-/// Request body for `POST /api/planning/projects/{id}/checkpoints/{id}/action`.
+/// Request body for `POST /api/v1/planning/projects/{id}/checkpoints/{id}/action`.
 #[derive(Debug, Serialize)]
 pub(crate) struct CheckpointActionRequest {
     pub(crate) action: CheckpointAction,

--- a/crates/theatron/proskenion/src/state/planning.rs
+++ b/crates/theatron/proskenion/src/state/planning.rs
@@ -25,7 +25,7 @@ pub(crate) struct ProjectPhaseInfo {
     pub(crate) total: u32,
 }
 
-/// A planning project returned from `GET /api/planning/projects`.
+/// A planning project returned from the planning project-list API.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub(crate) struct Project {
     // kanon:ignore RUST/primitive-for-domain-id — Planning state mirrors server-side string IDs from the planning API
@@ -222,7 +222,7 @@ pub(crate) struct PhaseDependency {
     pub(crate) to_phase_id: String,
 }
 
-/// Full roadmap returned from `GET /api/planning/projects/{id}/roadmap`.
+/// Full roadmap returned from the planning roadmap API.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub(crate) struct Roadmap {
     pub(crate) phases: Vec<Phase>,

--- a/crates/theatron/proskenion/src/views/planning/category_proposal.rs
+++ b/crates/theatron/proskenion/src/views/planning/category_proposal.rs
@@ -57,7 +57,7 @@ const REJECT_BTN: &str = "\
 
 /// Inline proposal card displayed when an agent proposes a category change.
 ///
-/// Sends action to `POST /api/planning/projects/{project_id}/proposals/{proposal_id}`.
+/// Sends action to `POST /api/v1/planning/projects/{project_id}/proposals/{proposal_id}`.
 #[component]
 pub(crate) fn CategoryProposalCard(
     proposal: CategoryProposal,
@@ -160,7 +160,7 @@ fn send_proposal_action(
     spawn(async move {
         let client = authenticated_client(&cfg);
         let url = format!(
-            "{}/api/planning/projects/{pid}/proposals/{prop_id}",
+            "{}/api/v1/planning/projects/{pid}/proposals/{prop_id}",
             cfg.server_url.trim_end_matches('/')
         );
 

--- a/crates/theatron/proskenion/src/views/planning/checkpoints.rs
+++ b/crates/theatron/proskenion/src/views/planning/checkpoints.rs
@@ -2,13 +2,11 @@
 
 use dioxus::prelude::*;
 
-use crate::api::client::authenticated_client;
 use crate::components::checkpoint_card::CheckpointCard;
 use crate::state::checkpoints::{Checkpoint, CheckpointStore};
-use crate::state::connection::ConnectionConfig;
-use crate::state::events::EventState;
 
 #[derive(Debug, Clone)]
+#[expect(dead_code, reason = "checkpoint routes are pending B23 backend work")]
 enum FetchState {
     Loading,
     Loaded(CheckpointStore),
@@ -65,78 +63,13 @@ const PLACEHOLDER_STYLE: &str = "\
 
 /// Checkpoint approval list for a planning project.
 ///
-/// Fetches from `GET /api/planning/projects/{project_id}/checkpoints`.
-/// Pending gates appear at the top of the list. Subscribes to SSE
-/// `checkpoint:created` and `checkpoint:updated` events for real-time
-/// refresh via [`EventState::checkpoint_revisions`].
+/// Shows checkpoints when the pylon checkpoint API exists.
+/// Pending gates appear at the top of the list once checkpoint routes land.
 #[component]
 pub(crate) fn CheckpointsView(project_id: String) -> Element {
-    let config: Signal<ConnectionConfig> = use_context();
-    let event_state: Signal<EventState> = use_context();
-    let mut fetch_state = use_signal(|| FetchState::Loading);
+    let mut fetch_state = use_signal(|| FetchState::NotAvailable);
     // WHY: incrementing this signal causes the fetch effect to re-run.
     let mut fetch_trigger = use_signal(|| 0u32);
-    // WHY: tracks the last-seen SSE revision so the effect only fires
-    // on genuinely new checkpoint events, not on every EventState update.
-    let mut last_seen_revision = use_signal(|| 0u64);
-
-    // WHY: Re-fetch when an SSE checkpoint event arrives for this project.
-    let project_id_sse = project_id.clone();
-    use_effect(move || {
-        let state = event_state.read();
-        let current_rev = state
-            .checkpoint_revisions
-            .get(&project_id_sse)
-            .copied()
-            .unwrap_or(0);
-        if current_rev > *last_seen_revision.peek() {
-            last_seen_revision.set(current_rev);
-            let next = *fetch_trigger.peek() + 1;
-            fetch_trigger.set(next);
-        }
-    });
-
-    let project_id_effect = project_id.clone();
-
-    // Re-runs on mount and whenever fetch_trigger changes.
-    use_effect(move || {
-        let _ = *fetch_trigger.read();
-        let cfg = config.read().clone();
-        let pid = project_id_effect.clone();
-        fetch_state.set(FetchState::Loading);
-
-        spawn(async move {
-            let client = authenticated_client(&cfg);
-            let url = format!(
-                "{}/api/planning/projects/{pid}/checkpoints",
-                cfg.server_url.trim_end_matches('/')
-            );
-
-            match client.get(&url).send().await {
-                Ok(resp) if resp.status().is_success() => {
-                    match resp.json::<Vec<Checkpoint>>().await {
-                        Ok(checkpoints) => {
-                            fetch_state.set(FetchState::Loaded(CheckpointStore { checkpoints }));
-                        }
-                        Err(e) => {
-                            fetch_state.set(FetchState::Error(format!("parse error: {e}")));
-                        }
-                    }
-                }
-                // WHY: 404 means checkpoint endpoint not yet on this pylon version.
-                Ok(resp) if resp.status().as_u16() == 404 => {
-                    fetch_state.set(FetchState::NotAvailable);
-                }
-                Ok(resp) => {
-                    let status = resp.status();
-                    fetch_state.set(FetchState::Error(format!("server returned {status}")));
-                }
-                Err(e) => {
-                    fetch_state.set(FetchState::Error(format!("connection error: {e}")));
-                }
-            }
-        });
-    });
 
     let project_id_card = project_id.clone();
 
@@ -149,8 +82,7 @@ pub(crate) fn CheckpointsView(project_id: String) -> Element {
                 button {
                     style: "{REFRESH_BTN}",
                     onclick: move |_| {
-                        let next = *fetch_trigger.peek() + 1;
-                        fetch_trigger.set(next);
+                        fetch_state.set(FetchState::NotAvailable);
                     },
                     "Refresh"
                 }

--- a/crates/theatron/proskenion/src/views/planning/dashboard.rs
+++ b/crates/theatron/proskenion/src/views/planning/dashboard.rs
@@ -2,12 +2,11 @@
 
 use dioxus::prelude::*;
 
-use crate::api::client::authenticated_client;
 use crate::app::Route;
-use crate::state::connection::ConnectionConfig;
 use crate::state::planning::{Project, ProjectStore, status_badge_style, status_label};
 
 #[derive(Debug, Clone)]
+#[expect(dead_code, reason = "project-list route is pending B23 backend work")]
 enum FetchState {
     Loading,
     Loaded(ProjectStore),
@@ -110,47 +109,14 @@ const PLACEHOLDER_STYLE: &str = "\
 
 /// Project dashboard -- the default `/planning` view.
 ///
-/// Fetches projects from `GET /api/planning/projects` and displays a card grid.
-/// Clicking a card navigates to the project detail view.
+/// Displays the planning project list when the pylon project-list API exists.
 #[component]
 pub(crate) fn Planning() -> Element {
-    let config: Signal<ConnectionConfig> = use_context();
     let nav = use_navigator();
-    let mut fetch_state = use_signal(|| FetchState::Loading);
+    let mut fetch_state = use_signal(|| FetchState::NotAvailable);
 
     let mut do_refresh = move || {
-        let cfg = config.read().clone();
-        fetch_state.set(FetchState::Loading);
-
-        spawn(async move {
-            let client = authenticated_client(&cfg);
-            let url = format!(
-                "{}/api/planning/projects",
-                cfg.server_url.trim_end_matches('/')
-            );
-
-            match client.get(&url).send().await {
-                Ok(resp) if resp.status().is_success() => match resp.json::<Vec<Project>>().await {
-                    Ok(projects) => {
-                        fetch_state.set(FetchState::Loaded(ProjectStore { projects }));
-                    }
-                    Err(e) => {
-                        fetch_state.set(FetchState::Error(format!("parse error: {e}")));
-                    }
-                },
-                // WHY: 404 means planning endpoint not available on this pylon version.
-                Ok(resp) if resp.status().as_u16() == 404 => {
-                    fetch_state.set(FetchState::NotAvailable);
-                }
-                Ok(resp) => {
-                    let status = resp.status();
-                    fetch_state.set(FetchState::Error(format!("server returned {status}")));
-                }
-                Err(e) => {
-                    fetch_state.set(FetchState::Error(format!("connection error: {e}")));
-                }
-            }
-        });
+        fetch_state.set(FetchState::NotAvailable);
     };
 
     use_effect(move || {

--- a/crates/theatron/proskenion/src/views/planning/discussion.rs
+++ b/crates/theatron/proskenion/src/views/planning/discussion.rs
@@ -11,6 +11,7 @@ use crate::state::discussion::{
 
 /// Fetch state for discussions, with a 404 variant for unavailable endpoints.
 #[derive(Debug, Clone)]
+#[expect(dead_code, reason = "discussion routes are pending B23 backend work")]
 enum DiscussionFetchState {
     Loading,
     Loaded(Vec<Discussion>),
@@ -161,54 +162,8 @@ const ERROR_STYLE: &str =
 /// Discussion panel listing all discussions for a project.
 #[component]
 pub(crate) fn DiscussionView(project_id: String) -> Element {
-    let config: Signal<ConnectionConfig> = use_context();
-    let mut fetch_state = use_signal(|| DiscussionFetchState::Loading);
+    let mut fetch_state = use_signal(|| DiscussionFetchState::NotAvailable);
     let mut fetch_trigger = use_signal(|| 0u32);
-
-    let project_id_effect = project_id.clone();
-    use_effect(move || {
-        let _trigger = *fetch_trigger.read();
-        let cfg = config.read().clone();
-        let pid = project_id_effect.clone();
-        fetch_state.set(DiscussionFetchState::Loading);
-
-        spawn(async move {
-            let client = authenticated_client(&cfg);
-            let url = format!(
-                "{}/api/planning/projects/{pid}/discussions",
-                cfg.server_url.trim_end_matches('/')
-            );
-
-            match client.get(&url).send().await {
-                Ok(resp) if resp.status().is_success() => {
-                    match resp.json::<Vec<Discussion>>().await {
-                        Ok(discussions) => {
-                            fetch_state.set(DiscussionFetchState::Loaded(discussions));
-                        }
-                        Err(e) => {
-                            fetch_state
-                                .set(DiscussionFetchState::Error(format!("parse error: {e}")));
-                        }
-                    }
-                }
-                // WHY: 404 means discussions endpoint not available on this pylon version.
-                Ok(resp) if resp.status().as_u16() == 404 => {
-                    fetch_state.set(DiscussionFetchState::NotAvailable);
-                }
-                Ok(resp) => {
-                    let status = resp.status();
-                    fetch_state.set(DiscussionFetchState::Error(format!(
-                        "server returned {status}"
-                    )));
-                }
-                Err(e) => {
-                    fetch_state.set(DiscussionFetchState::Error(format!(
-                        "connection error: {e}"
-                    )));
-                }
-            }
-        });
-    });
 
     rsx! {
         div {
@@ -218,7 +173,7 @@ pub(crate) fn DiscussionView(project_id: String) -> Element {
                 h3 { style: "font-size: var(--text-md); margin: 0; color: var(--text-primary);", "Discussions" }
                 button {
                     style: "{REFRESH_BTN}",
-                    onclick: move |_| fetch_trigger.set(fetch_trigger() + 1),
+                    onclick: move |_| fetch_state.set(DiscussionFetchState::NotAvailable),
                     "Refresh"
                 }
             }
@@ -326,7 +281,7 @@ fn DiscussionCard(
         spawn(async move {
             let client = authenticated_client(&cfg);
             let url = format!(
-                "{}/api/planning/projects/{pid}/discussions/{did}/answer",
+                "{}/api/v1/planning/projects/{pid}/discussions/{did}/answer",
                 cfg.server_url.trim_end_matches('/')
             );
             let req = DiscussionAnswerRequest {
@@ -362,7 +317,7 @@ fn DiscussionCard(
             let client = authenticated_client(&cfg);
             // WHY: reopen is POST to the same answer endpoint with empty body.
             let url = format!(
-                "{}/api/planning/projects/{pid}/discussions/{did}/reopen",
+                "{}/api/v1/planning/projects/{pid}/discussions/{did}/reopen",
                 cfg.server_url.trim_end_matches('/')
             );
             match client.post(&url).send().await {

--- a/crates/theatron/proskenion/src/views/planning/discussion_detail.rs
+++ b/crates/theatron/proskenion/src/views/planning/discussion_detail.rs
@@ -2,9 +2,7 @@
 
 use dioxus::prelude::*;
 
-use crate::api::client::authenticated_client;
 use crate::components::option_card::OptionCard;
-use crate::state::connection::ConnectionConfig;
 use crate::state::discussion::{Discussion, DiscussionStatus, DiscussionStore};
 
 /// Expanded discussion detail view.
@@ -16,46 +14,8 @@ pub(crate) fn DiscussionDetailView(
     discussion_id: String,
     on_back: EventHandler<()>,
 ) -> Element {
-    let config: Signal<ConnectionConfig> = use_context();
-    let mut discussion = use_signal(|| None::<Discussion>);
-    let mut error = use_signal(|| None::<String>);
-    let fetch_trigger = use_signal(|| 0u32);
-
-    let project_id_effect = project_id.clone();
-    let discussion_id_effect = discussion_id.clone();
-
-    use_effect(move || {
-        let _trigger = *fetch_trigger.read();
-        let cfg = config.read().clone();
-        let pid = project_id_effect.clone();
-        let did = discussion_id_effect.clone();
-        discussion.set(None);
-        error.set(None);
-
-        spawn(async move {
-            let client = authenticated_client(&cfg);
-            let url = format!(
-                "{}/api/planning/projects/{pid}/discussions/{did}",
-                cfg.server_url.trim_end_matches('/')
-            );
-
-            match client.get(&url).send().await {
-                Ok(resp) if resp.status().is_success() => match resp.json::<Discussion>().await {
-                    Ok(disc) => discussion.set(Some(disc)),
-                    Err(e) => {
-                        error.set(Some(format!("parse error: {e}")));
-                    }
-                },
-                Ok(resp) => {
-                    let status = resp.status();
-                    error.set(Some(format!("server returned {status}")));
-                }
-                Err(e) => {
-                    error.set(Some(format!("connection error: {e}")));
-                }
-            }
-        });
-    });
+    let _ = (&project_id, &discussion_id);
+    let discussion = use_signal(|| None::<Discussion>);
 
     rsx! {
         div {
@@ -67,10 +27,10 @@ pub(crate) fn DiscussionDetailView(
                 "<- Back to discussions"
             }
 
-            if let Some(err) = error.read().as_ref() {
+            if discussion.read().is_none() {
                 div {
-                    style: "display: flex; align-items: center; justify-content: center; flex: 1; color: var(--status-error);",
-                    "Error: {err}"
+                    style: "display: flex; align-items: center; justify-content: center; flex: 1; color: var(--text-secondary);",
+                    "Discussion details not available"
                 }
             } else if let Some(disc) = discussion.read().as_ref() {
                 div { style: "font-size: var(--text-lg); font-weight: var(--weight-semibold); color: var(--text-primary); margin-bottom: var(--space-2);", "{disc.question}" }

--- a/crates/theatron/proskenion/src/views/planning/execution.rs
+++ b/crates/theatron/proskenion/src/views/planning/execution.rs
@@ -2,14 +2,13 @@
 
 use dioxus::prelude::*;
 
-use crate::api::client::authenticated_client;
 use crate::components::plan_card::PlanCard;
 use crate::components::wave_band::WaveBand;
-use crate::state::connection::ConnectionConfig;
 use crate::state::execution::{ExecutionState, ExecutionStore};
 
 /// Fetch state for execution data.
 #[derive(Debug, Clone)]
+#[expect(dead_code, reason = "execution route is pending B23 backend work")]
 enum ExecutionFetchState {
     Loading,
     Loaded(ExecutionState),
@@ -71,67 +70,11 @@ const PLACEHOLDER_STYLE: &str = "\
     color: var(--text-muted);\
 ";
 
-/// Polling interval for execution state updates (10 seconds).
-const POLL_INTERVAL_MS: u64 = 10_000;
-
 /// Execution view with wave-based progress and plan visualization.
 #[component]
 pub(crate) fn ExecutionView(project_id: String) -> Element {
-    let config: Signal<ConnectionConfig> = use_context();
-    let mut fetch_state = use_signal(|| ExecutionFetchState::Loading);
-    let mut fetch_trigger = use_signal(|| 0u32);
-
-    // Fetch execution state on mount and when trigger changes.
-    let project_id_effect = project_id.clone();
-    use_effect(move || {
-        let _trigger = *fetch_trigger.read();
-        let cfg = config.read().clone();
-        let pid = project_id_effect.clone();
-        fetch_state.set(ExecutionFetchState::Loading);
-
-        spawn(async move {
-            let client = authenticated_client(&cfg);
-            let url = format!(
-                "{}/api/planning/projects/{pid}/execution",
-                cfg.server_url.trim_end_matches('/')
-            );
-
-            match client.get(&url).send().await {
-                Ok(resp) if resp.status().is_success() => {
-                    match resp.json::<ExecutionState>().await {
-                        Ok(state) => fetch_state.set(ExecutionFetchState::Loaded(state)),
-                        Err(e) => {
-                            fetch_state
-                                .set(ExecutionFetchState::Error(format!("parse error: {e}")));
-                        }
-                    }
-                }
-                // WHY: 404 means execution endpoint not available on this pylon version.
-                Ok(resp) if resp.status().as_u16() == 404 => {
-                    fetch_state.set(ExecutionFetchState::NotAvailable);
-                }
-                Ok(resp) => {
-                    let status = resp.status();
-                    fetch_state.set(ExecutionFetchState::Error(format!(
-                        "server returned {status}"
-                    )));
-                }
-                Err(e) => {
-                    fetch_state.set(ExecutionFetchState::Error(format!("connection error: {e}")));
-                }
-            }
-        });
-    });
-
-    // Polling fallback: re-fetch every 10 seconds.
-    use_effect(move || {
-        spawn(async move {
-            loop {
-                tokio::time::sleep(tokio::time::Duration::from_millis(POLL_INTERVAL_MS)).await;
-                fetch_trigger.set(fetch_trigger() + 1);
-            }
-        });
-    });
+    let _ = &project_id;
+    let mut fetch_state = use_signal(|| ExecutionFetchState::NotAvailable);
 
     rsx! {
         div {
@@ -141,7 +84,7 @@ pub(crate) fn ExecutionView(project_id: String) -> Element {
                 h3 { style: "font-size: var(--text-md); margin: 0; color: var(--text-primary);", "Execution" }
                 button {
                     style: "{REFRESH_BTN}",
-                    onclick: move |_| fetch_trigger.set(fetch_trigger() + 1),
+                    onclick: move |_| fetch_state.set(ExecutionFetchState::NotAvailable),
                     "Refresh"
                 }
             }

--- a/crates/theatron/proskenion/src/views/planning/project_detail.rs
+++ b/crates/theatron/proskenion/src/views/planning/project_detail.rs
@@ -2,9 +2,7 @@
 
 use dioxus::prelude::*;
 
-use crate::api::client::authenticated_client;
 use crate::app::Route;
-use crate::state::connection::ConnectionConfig;
 use crate::state::planning::{Project, status_badge_style, status_label};
 use crate::views::planning::checkpoints::CheckpointsView;
 use crate::views::planning::discussion::DiscussionView;
@@ -24,6 +22,10 @@ enum ActiveTab {
 }
 
 #[derive(Debug, Clone)]
+#[expect(
+    dead_code,
+    reason = "project metadata route is pending B23 backend work"
+)]
 enum FetchState {
     Loading,
     Loaded(Project),
@@ -114,44 +116,8 @@ const BADGE_STYLE: &str = "\
 /// then delegates to tabbed sub-views.
 #[component]
 pub(crate) fn PlanningProject(project_id: String) -> Element {
-    let config: Signal<ConnectionConfig> = use_context();
-    let mut project_state = use_signal(|| FetchState::Loading);
-    let mut active_tab = use_signal(|| ActiveTab::Requirements);
-
-    let project_id_effect = project_id.clone();
-
-    use_effect(move || {
-        let cfg = config.read().clone();
-        let pid = project_id_effect.clone();
-        project_state.set(FetchState::Loading);
-
-        spawn(async move {
-            let client = authenticated_client(&cfg);
-            let url = format!(
-                "{}/api/planning/projects/{pid}",
-                cfg.server_url.trim_end_matches('/')
-            );
-
-            match client.get(&url).send().await {
-                Ok(resp) if resp.status().is_success() => match resp.json::<Project>().await {
-                    Ok(project) => project_state.set(FetchState::Loaded(project)),
-                    Err(e) => {
-                        project_state.set(FetchState::Error(format!("parse error: {e}")));
-                    }
-                },
-                Ok(resp) if resp.status().as_u16() == 404 => {
-                    project_state.set(FetchState::NotAvailable);
-                }
-                Ok(resp) => {
-                    let status = resp.status();
-                    project_state.set(FetchState::Error(format!("server returned {status}")));
-                }
-                Err(e) => {
-                    project_state.set(FetchState::Error(format!("connection error: {e}")));
-                }
-            }
-        });
-    });
+    let project_state = use_signal(|| FetchState::NotAvailable);
+    let mut active_tab = use_signal(|| ActiveTab::Verification);
 
     let tab = *active_tab.read();
     let tab_label = match tab {
@@ -226,7 +192,7 @@ pub(crate) fn PlanningProject(project_id: String) -> Element {
                 FetchState::NotAvailable => rsx! {
                     div {
                         style: "{HEADER_STYLE}",
-                        div { style: "color: var(--text-secondary); font-size: var(--text-base);", "Project not found" }
+                        div { style: "color: var(--text-secondary); font-size: var(--text-base);", "Project metadata not available" }
                     }
                 },
             }

--- a/crates/theatron/proskenion/src/views/planning/requirements.rs
+++ b/crates/theatron/proskenion/src/views/planning/requirements.rs
@@ -11,6 +11,7 @@ use crate::state::planning::{
 use crate::views::planning::category_proposal::CategoryProposalCard;
 
 #[derive(Debug, Clone)]
+#[expect(dead_code, reason = "requirements routes are pending B23 backend work")]
 enum FetchState {
     Loading,
     Loaded(RequirementStore),
@@ -165,12 +166,12 @@ const PLACEHOLDER_STYLE: &str = "\
 
 /// Requirements table view for a planning project.
 ///
-/// Fetches from `GET /api/planning/projects/{project_id}/requirements`.
+/// Shows requirements when the pylon requirements API exists.
 /// Provides category tabs, inline editing, search, and filter controls.
 #[component]
 pub(crate) fn RequirementsView(project_id: String) -> Element {
     let config: Signal<ConnectionConfig> = use_context();
-    let mut fetch_state = use_signal(|| FetchState::Loading);
+    let mut fetch_state = use_signal(|| FetchState::NotAvailable);
     let mut fetch_trigger = use_signal(|| 0u32);
     let mut active_category = use_signal(|| RequirementCategory::V1);
     let mut search_query = use_signal(String::new);
@@ -178,75 +179,6 @@ pub(crate) fn RequirementsView(project_id: String) -> Element {
     let mut priority_filter = use_signal(|| None::<RequirementPriority>);
     let mut editing: Signal<EditingField> = use_signal(|| None);
     let mut edit_value = use_signal(String::new);
-
-    let project_id_effect = project_id.clone();
-
-    use_effect(move || {
-        let _ = *fetch_trigger.read();
-        let cfg = config.read().clone();
-        let pid = project_id_effect.clone();
-        fetch_state.set(FetchState::Loading);
-
-        spawn(async move {
-            let client = authenticated_client(&cfg);
-            let base = cfg.server_url.trim_end_matches('/');
-
-            let req_url = format!("{base}/api/planning/projects/{pid}/requirements");
-            let prop_url = format!("{base}/api/planning/projects/{pid}/proposals");
-
-            let (reqs_result, props_result) =
-                tokio::join!(client.get(&req_url).send(), client.get(&prop_url).send(),);
-
-            let requirements = match reqs_result {
-                Ok(resp) if resp.status().is_success() => {
-                    match resp.json::<Vec<Requirement>>().await {
-                        Ok(r) => r,
-                        Err(e) => {
-                            fetch_state.set(FetchState::Error(format!("parse error: {e}")));
-                            return;
-                        }
-                    }
-                }
-                Ok(resp) if resp.status().as_u16() == 404 => {
-                    fetch_state.set(FetchState::NotAvailable);
-                    return;
-                }
-                Ok(resp) => {
-                    fetch_state.set(FetchState::Error(format!(
-                        "server returned {}",
-                        resp.status()
-                    )));
-                    return;
-                }
-                Err(e) => {
-                    fetch_state.set(FetchState::Error(format!("connection error: {e}")));
-                    return;
-                }
-            };
-
-            // WHY: Proposals endpoint may not exist yet; treat 404 as empty.
-            let proposals = match props_result {
-                Ok(resp) if resp.status().is_success() => {
-                    match resp.json::<Vec<CategoryProposal>>().await {
-                        Ok(proposals) => proposals,
-                        Err(err) => {
-                            tracing::warn!(
-                                error = %err,
-                                "failed to parse planning category proposals"
-                            );
-                            Vec::new()
-                        }
-                    }
-                }
-                _ => Vec::new(),
-            };
-
-            fetch_state.set(FetchState::Loaded(RequirementStore {
-                requirements,
-                proposals,
-            }));
-        });
-    });
 
     rsx! {
         div {
@@ -258,8 +190,7 @@ pub(crate) fn RequirementsView(project_id: String) -> Element {
                 button {
                     style: "{REFRESH_BTN}",
                     onclick: move |_| {
-                        let next = *fetch_trigger.peek() + 1;
-                        fetch_trigger.set(next);
+                        fetch_state.set(FetchState::NotAvailable);
                     },
                     "Refresh"
                 }
@@ -606,7 +537,7 @@ fn send_edit(
     spawn(async move {
         let client = authenticated_client(&cfg);
         let url = format!(
-            "{}/api/planning/projects/{pid}/requirements/{rid}",
+            "{}/api/v1/planning/projects/{pid}/requirements/{rid}",
             cfg.server_url.trim_end_matches('/')
         );
 
@@ -649,7 +580,7 @@ fn send_category_change(
     spawn(async move {
         let client = authenticated_client(&cfg);
         let url = format!(
-            "{}/api/planning/projects/{pid}/requirements/{rid}",
+            "{}/api/v1/planning/projects/{pid}/requirements/{rid}",
             cfg.server_url.trim_end_matches('/')
         );
 

--- a/crates/theatron/proskenion/src/views/planning/roadmap.rs
+++ b/crates/theatron/proskenion/src/views/planning/roadmap.rs
@@ -2,16 +2,13 @@
 
 use dioxus::prelude::*;
 
-use crate::api::client::authenticated_client;
 use crate::components::timeline::{
     Timeline, TimelineBlock, TimelineDependencyLine, phase_positions,
 };
-use crate::state::connection::ConnectionConfig;
-use crate::state::planning::{
-    Phase, Roadmap, RoadmapStore, phase_border_color, phase_status_color,
-};
+use crate::state::planning::{Phase, RoadmapStore, phase_border_color, phase_status_color};
 
 #[derive(Debug, Clone)]
+#[expect(dead_code, reason = "roadmap route is pending B23 backend work")]
 enum FetchState {
     Loading,
     Loaded(RoadmapStore),
@@ -68,55 +65,14 @@ const PIXELS_PER_DAY: f64 = 4.0;
 
 /// Roadmap timeline view for a planning project.
 ///
-/// Fetches from `GET /api/planning/projects/{project_id}/roadmap`.
+/// Shows roadmap data when the pylon roadmap API exists.
 /// Renders phases as timeline blocks with dependency arrows.
 #[component]
 pub(crate) fn RoadmapView(project_id: String) -> Element {
-    let config: Signal<ConnectionConfig> = use_context();
-    let mut fetch_state = use_signal(|| FetchState::Loading);
-    let mut fetch_trigger = use_signal(|| 0u32);
+    let _ = &project_id;
+    let mut fetch_state = use_signal(|| FetchState::NotAvailable);
     let mut zoom = use_signal(|| 1.0f64);
     let mut selected_phase = use_signal(|| None::<usize>);
-
-    let project_id_effect = project_id.clone();
-
-    use_effect(move || {
-        let _ = *fetch_trigger.read();
-        let cfg = config.read().clone();
-        let pid = project_id_effect.clone();
-        fetch_state.set(FetchState::Loading);
-
-        spawn(async move {
-            let client = authenticated_client(&cfg);
-            let url = format!(
-                "{}/api/planning/projects/{pid}/roadmap",
-                cfg.server_url.trim_end_matches('/')
-            );
-
-            match client.get(&url).send().await {
-                Ok(resp) if resp.status().is_success() => match resp.json::<Roadmap>().await {
-                    Ok(roadmap) => {
-                        fetch_state.set(FetchState::Loaded(RoadmapStore {
-                            roadmap: Some(roadmap),
-                        }));
-                    }
-                    Err(e) => {
-                        fetch_state.set(FetchState::Error(format!("parse error: {e}")));
-                    }
-                },
-                Ok(resp) if resp.status().as_u16() == 404 => {
-                    fetch_state.set(FetchState::NotAvailable);
-                }
-                Ok(resp) => {
-                    let status = resp.status();
-                    fetch_state.set(FetchState::Error(format!("server returned {status}")));
-                }
-                Err(e) => {
-                    fetch_state.set(FetchState::Error(format!("connection error: {e}")));
-                }
-            }
-        });
-    });
 
     rsx! {
         div {
@@ -128,8 +84,7 @@ pub(crate) fn RoadmapView(project_id: String) -> Element {
                 button {
                     style: "{REFRESH_BTN}",
                     onclick: move |_| {
-                        let next = *fetch_trigger.peek() + 1;
-                        fetch_trigger.set(next);
+                        fetch_state.set(FetchState::NotAvailable);
                     },
                     "Refresh"
                 }

--- a/crates/theatron/proskenion/src/views/planning/verification.rs
+++ b/crates/theatron/proskenion/src/views/planning/verification.rs
@@ -1,6 +1,7 @@
 //! Verification view: goal-backward requirement verification results.
 
 use dioxus::prelude::*;
+use skene::api::routes::planning::{project_verification_refresh_url, project_verification_url};
 
 use crate::api::client::authenticated_client;
 use crate::components::coverage_bar::{CoverageBar, coverage_color};
@@ -117,7 +118,7 @@ const PLACEHOLDER_STYLE: &str = "\
 
 /// Goal-backward verification results view.
 ///
-/// Fetches from `GET /api/planning/projects/{project_id}/verification`.
+/// Fetches from `GET /api/v1/planning/projects/{project_id}/verification`.
 /// Displays overall and per-tier coverage bars, a requirement table,
 /// and the gap analysis panel.
 #[component]
@@ -141,10 +142,7 @@ pub(crate) fn VerificationView(project_id: String) -> Element {
 
         spawn(async move {
             let client = authenticated_client(&cfg);
-            let url = format!(
-                "{}/api/planning/projects/{pid}/verification",
-                cfg.server_url.trim_end_matches('/')
-            );
+            let url = project_verification_url(&cfg.server_url, &pid);
 
             match client.get(&url).send().await {
                 Ok(resp) if resp.status().is_success() => {
@@ -183,10 +181,7 @@ pub(crate) fn VerificationView(project_id: String) -> Element {
 
         spawn(async move {
             let client = authenticated_client(&cfg);
-            let url = format!(
-                "{}/api/planning/projects/{pid}/verification/refresh",
-                cfg.server_url.trim_end_matches('/')
-            );
+            let url = project_verification_refresh_url(&cfg.server_url, &pid);
 
             match client.post(&url).send().await {
                 Ok(resp) if resp.status().is_success() => {

--- a/crates/theatron/skene/src/api/mod.rs
+++ b/crates/theatron/skene/src/api/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod client;
 pub mod error;
+pub mod routes;
 pub mod sse;
 pub mod streaming;
 pub mod types;

--- a/crates/theatron/skene/src/api/routes.rs
+++ b/crates/theatron/skene/src/api/routes.rs
@@ -1,0 +1,44 @@
+//! Route builders for first-party Aletheia API clients.
+
+/// Planning API routes that currently exist in pylon.
+pub mod planning {
+    /// Template for `GET` project verification.
+    pub const PROJECT_VERIFICATION_TEMPLATE: &str =
+        "/api/v1/planning/projects/{project_id}/verification";
+
+    /// Template for `POST` project verification refresh.
+    pub const PROJECT_VERIFICATION_REFRESH_TEMPLATE: &str =
+        "/api/v1/planning/projects/{project_id}/verification/refresh";
+
+    /// Build the path for `GET` project verification.
+    #[must_use]
+    pub fn project_verification_path(project_id: &str) -> String {
+        format!("/api/v1/planning/projects/{project_id}/verification")
+    }
+
+    /// Build the absolute URL for `GET` project verification.
+    #[must_use]
+    pub fn project_verification_url(base_url: &str, project_id: &str) -> String {
+        format!(
+            "{}{}",
+            base_url.trim_end_matches('/'),
+            project_verification_path(project_id)
+        )
+    }
+
+    /// Build the path for `POST` project verification refresh.
+    #[must_use]
+    pub fn project_verification_refresh_path(project_id: &str) -> String {
+        format!("/api/v1/planning/projects/{project_id}/verification/refresh")
+    }
+
+    /// Build the absolute URL for `POST` project verification refresh.
+    #[must_use]
+    pub fn project_verification_refresh_url(base_url: &str, project_id: &str) -> String {
+        format!(
+            "{}{}",
+            base_url.trim_end_matches('/'),
+            project_verification_refresh_path(project_id)
+        )
+    }
+}

--- a/crates/theatron/skene/src/api/types/verification.rs
+++ b/crates/theatron/skene/src/api/types/verification.rs
@@ -75,7 +75,7 @@ pub struct RequirementVerification {
 /// Full verification result for a project.
 ///
 /// Wire format consumed by the desktop `VerificationView` and served
-/// by pylon's `GET /api/planning/projects/{id}/verification`.
+/// by pylon's `GET /api/v1/planning/projects/{id}/verification`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProjectVerificationResult {
     /// Project identifier.


### PR DESCRIPTION
Refs #4482

Desktop planning views stop depending on the legacy unversioned `/api/planning/...` fallback: fetches move to the versioned routes that exist, views whose backend genuinely doesn't exist yet model the unavailable state explicitly (no phantom fetches), and contract tests pin each fetch URL to a real route. TUI surfaces untouched per the #4538 decision (planning ships on both surfaces; B23 builds the backend against this). Issue stays open for the B23 backend half.