### PR TITLE
feat(koina,hermeneus): model seed catalog + claude family-prefix routing — model-identity steps 2-3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5187,6 +5187,7 @@ dependencies = [
  "snafu",
  "tempfile",
  "tokio",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "zeroize",

--- a/_llm/L3-api-index/hermeneus.md
+++ b/_llm/L3-api-index/hermeneus.md
@@ -119,6 +119,8 @@ pub struct AnthropicProvider {
     /// catalog by default; an operator-declared compatible endpoint claims
     /// exactly its configured model list instead.
     model_refs: &'static [&'static str],
+    /// Whether `model_refs` came from operator configuration.
+    has_operator_model_refs: bool,
     /// Where this instance's traffic terminates, for the recall
     /// sensitivity filter (#3404, #3413).
     deployment_target: DeploymentTarget,

--- a/_llm/L3-api-index/hermeneus.md
+++ b/_llm/L3-api-index/hermeneus.md
@@ -313,20 +313,6 @@ impl CodexProvider {
 ## `src/complexity/mod.rs`
 
 ```rust
-pub enum ModelTier {
-    /// No model call required; a deterministic fast path can handle it.
-    #[serde(rename = "no_llm", alias = "no-llm")]
-    NoLlm,
-    /// Fast, cheap, sufficient for simple queries.
-    Haiku,
-    /// Balanced capability and cost.
-    Sonnet,
-    /// Maximum capability for hard problems.
-    Opus,
-}
-```
-
-```rust
 pub struct ComplexityInput<'a> {
     /// The user's message text.
     pub message_text: &'a str,
@@ -1073,37 +1059,6 @@ pub const BACKOFF_FACTOR: u64 = 2;
 > Maximum retry backoff delay in milliseconds.
 ```rust
 pub const BACKOFF_MAX_MS: u64 = 30_000;
-```
-
-> All supported Anthropic model identifiers.
-> 
-> Includes both short names (e.g., `claude-opus-4-6`) and dated snapshots
-> (e.g., `claude-opus-4-20250514`).
-```rust
-pub static SUPPORTED_MODELS: &[&str] = &[
-    // kanon:ignore RUST/pub-visibility
-    "claude-opus-4-6",
-    "claude-opus-4-20250514",
-    "claude-sonnet-4-6",
-    "claude-sonnet-4-20250514",
-    "claude-haiku-4-5",
-    "claude-haiku-4-5-20251001",
-];
-```
-
-> Default Opus model alias.
-```rust
-pub const OPUS: &str = "claude-opus-4-6";
-```
-
-> Default Sonnet model alias.
-```rust
-pub const SONNET: &str = "claude-sonnet-4-6";
-```
-
-> Default Haiku model alias.
-```rust
-pub const HAIKU: &str = "claude-haiku-4-5-20251001";
 ```
 
 ## `src/openai/client.rs`

--- a/_llm/L3-api-index/koina.md
+++ b/_llm/L3-api-index/koina.md
@@ -825,6 +825,145 @@ impl MetricsRegistry {
 }
 ```
 
+## `src/models.rs`
+
+```rust
+pub enum ModelTier {
+    /// No model call required; a deterministic fast path can handle it.
+    #[serde(rename = "no_llm", alias = "no-llm")]
+    NoLlm,
+    /// Fast, cheap, sufficient for simple queries.
+    Haiku,
+    /// Balanced capability and cost.
+    Sonnet,
+    /// Maximum capability for hard problems.
+    Opus,
+}
+```
+
+```rust
+pub enum ModelProvider {
+    /// Anthropic Messages API models.
+    Anthropic,
+    /// Codex CLI models.
+    Codex,
+    /// Kimi CLI models.
+    Kimi,
+}
+```
+
+```rust
+pub enum TaskRole {
+    /// Implementation, testing, and debugging.
+    Coder,
+    /// Investigation, comparison, and documentation.
+    Researcher,
+    /// Code review and risk assessment.
+    Reviewer,
+    /// Codebase exploration.
+    Explorer,
+    /// Command-running task execution.
+    Runner,
+    /// Background heartbeat checks.
+    Prosoche,
+    /// Knowledge extraction.
+    Extraction,
+    /// Dispatch triage prompt generation.
+    TriagePrompt,
+}
+```
+
+```rust
+pub struct ModelPrice {
+    /// Cost per million input tokens in USD.
+    pub input_cost_per_mtok: f64,
+    /// Cost per million output tokens in USD.
+    pub output_cost_per_mtok: f64,
+}
+```
+
+```rust
+pub struct ModelMenuOption {
+    /// Model identifier written into config.
+    pub value: &'static str,
+    /// Human-readable menu label derived from the model identifier.
+    pub label: &'static str,
+}
+```
+
+```rust
+pub fn opus () -> &'static str
+```
+
+```rust
+pub fn sonnet () -> &'static str
+```
+
+```rust
+pub fn haiku () -> &'static str
+```
+
+```rust
+pub fn codex () -> &'static str
+```
+
+```rust
+pub fn kimi () -> &'static str
+```
+
+```rust
+pub fn as_of () -> &'static str
+```
+
+```rust
+pub fn tier_default (tier: ModelTier) -> &'static str
+```
+
+```rust
+pub fn task_role_tier (role: TaskRole) -> ModelTier
+```
+
+```rust
+pub fn task_role_default (role: TaskRole) -> &'static str
+```
+
+```rust
+pub fn cache_read_ratio () -> f64
+```
+
+```rust
+pub fn cache_write_ratio () -> f64
+```
+
+```rust
+pub fn provider_models (provider: ModelProvider) -> &'static [&'static str]
+```
+
+```rust
+pub fn model_for_provider (provider: ModelProvider) -> &'static str
+```
+
+```rust
+pub fn model_menu_options () -> &'static [ModelMenuOption]
+```
+
+> Pricing rows from the model catalog.
+```rust
+pub fn pricing_entries () -> impl Iterator<Item = (&'static str, ModelPrice)>
+```
+
+```rust
+pub fn context_tokens (model_id: &str) -> Option<u32>
+```
+
+```rust
+pub fn family (model_id: &str) -> Option<&'static str>
+```
+
+```rust
+pub fn model_tier (model_id: &str) -> Option<ModelTier>
+```
+
 ## `src/output_buffer.rs`
 
 ```rust

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-06-12T14:51:33Z"
+generated_at = "2026-06-12T14:52:05Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "686d5c4a8a82bf996e05f5430529e26eb9c7cd0c69a48ae8fbfaf393813b6969"
+source_hash = "6da58e679f40865d0b84b2074f7032a3d2f27ccaff0c9d361bbd99e990fdbe60"
 l3_token_estimate = 167
 
 [[crates]]
@@ -104,8 +104,8 @@ l3_token_estimate = 5367
 [[crates]]
 name = "hermeneus"
 path = "crates/hermeneus"
-source_hash = "b8dfa86215bc0c0bd6576ccda38aece20ffeb9748573f7d2cb9ac6fc9f481a80"
-l3_token_estimate = 13441
+source_hash = "8755ade2374adefd882b585335358616c3a96a0b1e60d02c28b44e1d34a3dff7"
+l3_token_estimate = 13465
 
 [[crates]]
 name = "integration-tests"

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-06-12T14:11:32Z"
+generated_at = "2026-06-12T14:51:33Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -20,7 +20,7 @@ l3_token_estimate = 5778
 [[crates]]
 name = "aletheia"
 path = "crates/aletheia"
-source_hash = "01715dab5ca8c7d193583d2216676eee8dfc0104f561ceae0bd7ad6ac1c5e500"
+source_hash = "686d5c4a8a82bf996e05f5430529e26eb9c7cd0c69a48ae8fbfaf393813b6969"
 l3_token_estimate = 167
 
 [[crates]]
@@ -86,7 +86,7 @@ l3_token_estimate = 20097
 [[crates]]
 name = "episteme"
 path = "crates/episteme"
-source_hash = "02f797fa0bd19322a12f8546fdb3058d942e1c04d102a701672d4be1a4a836ca"
+source_hash = "750afe27c829a1e4519f1791f56567913a94ad5ea7d2c4b3182f710169faa348"
 l3_token_estimate = 33980
 
 [[crates]]
@@ -104,8 +104,8 @@ l3_token_estimate = 5367
 [[crates]]
 name = "hermeneus"
 path = "crates/hermeneus"
-source_hash = "af0cb56cb209b1bfb8cf2070862b43ef9022ea4281b6d6746368a68b7c89983a"
-l3_token_estimate = 13698
+source_hash = "b8dfa86215bc0c0bd6576ccda38aece20ffeb9748573f7d2cb9ac6fc9f481a80"
+l3_token_estimate = 13441
 
 [[crates]]
 name = "integration-tests"
@@ -116,14 +116,14 @@ l3_token_estimate = 1170
 [[crates]]
 name = "koilon"
 path = "crates/theatron/koilon"
-source_hash = "7e172cb60e036a9b2c2242f72fff5806d29cba636d081048dd55e1b156d15fa4"
+source_hash = "df9b1a1f962943d56e9f2095cec56118ae6ed632a53605c8892592f5d70e1466"
 l3_token_estimate = 11570
 
 [[crates]]
 name = "koina"
 path = "crates/koina"
-source_hash = "d33f1c6f1b36a7a5a134ea71a30e82bc5d683a6b8e34822dbd6cede278781150"
-l3_token_estimate = 7804
+source_hash = "42710905aedabbd40f5d51b0d86245c60868917b1ee1a05648e80e9f0764360c"
+l3_token_estimate = 8444
 
 [[crates]]
 name = "krites"
@@ -146,7 +146,7 @@ l3_token_estimate = 51
 [[crates]]
 name = "nous"
 path = "crates/nous"
-source_hash = "c97fd8de1f1cc1b3b739f09a5aae8ce2e3146cc5aad84dc1489a652d7dcadeba"
+source_hash = "b234bac54eaf4eeda86a75fbbfe10b321f72d23ca41f7d96fff833ee707cb985"
 l3_token_estimate = 34474
 
 [[crates]]
@@ -158,7 +158,7 @@ l3_token_estimate = 12375
 [[crates]]
 name = "organon"
 path = "crates/organon"
-source_hash = "1c18a483b8009ada0ee94f5beed7d5ef0f054306f67983c972a901cf61ae85d8"
+source_hash = "9d05cc44b30a524e135aaa8559a95f6a0f4782a4cf33037293ed7a84e6a28023"
 l3_token_estimate = 12171
 
 [[crates]]
@@ -284,13 +284,13 @@ l3_token_estimate = 6585
 [[crates]]
 name = "taxis"
 path = "crates/taxis"
-source_hash = "a2a8e654c5771e21403b48c937f5f1d87903ece952d8d540b060336fdc3380f6"
+source_hash = "2bd8fc30dfeefc2cf7b0bff307fe98efdc377c0abf5628ccacc564e98d0833b3"
 l3_token_estimate = 23836
 
 [[crates]]
 name = "theatron"
 path = "crates/theatron"
-source_hash = "3a2d1ee96b866698f795ba6bc4d3a13b3c9615fe90591058d063d317124526be"
+source_hash = "01edb29c56e6b3eb20ea1781c6484611219292537fa05514e6f74a2375a14374"
 l3_token_estimate = 22245
 
 [[crates]]

--- a/crates/aletheia/src/init/mod.rs
+++ b/crates/aletheia/src/init/mod.rs
@@ -283,16 +283,11 @@ fn collect_interactive(mut answers: Answers) -> Result<Answers, InitError> {
         "api-key".clone_into(&mut answers.credential_source);
     }
 
-    let model: &str = cliclack::select("Default model")
-        .item(
-            koina::defaults::DEFAULT_MODEL,
-            "claude-sonnet-4-6 (recommended)",
-            "",
-        )
-        .item("claude-opus-4-6", "claude-opus-4-6", "")
-        .item("claude-haiku-4-5", "claude-haiku-4-5", "")
-        .interact()
-        .context(PromptSnafu)?;
+    let mut model_select = cliclack::select("Default model");
+    for option in koina::models::model_menu_options() {
+        model_select = model_select.item(option.value, option.label, "");
+    }
+    let model: &str = model_select.interact().context(PromptSnafu)?;
     model.clone_into(&mut answers.model);
 
     let agent_id: String = cliclack::input("Agent ID")

--- a/crates/aletheia/src/recall_sources/llm_context.rs
+++ b/crates/aletheia/src/recall_sources/llm_context.rs
@@ -218,51 +218,37 @@ impl RecallSource for LlmContextSource {
     }
 }
 
-/// Known Anthropic model catalog.
-///
-/// NOTE: This is intentionally static data. The issue specifies that model
-/// cards should be "updated automatically when new providers are configured,"
-/// which is handled by overlaying pricing config. Adding entirely new models
-/// requires a code UPDATE (or future config-driven model registry).
 fn anthropic_model_cards() -> Vec<ModelCard> {
-    vec![
-        ModelCard {
-            id: "claude-sonnet-4-20250514".to_owned(),
-            name: "Claude Sonnet 4".to_owned(),
-            provider: "Anthropic".to_owned(),
-            context_window: 200_000,
-            max_output_tokens: 16_000,
-            supports_tools: true,
-            supports_vision: true,
-            supports_thinking: true,
-            input_cost_per_mtok: Some(3.0),
-            output_cost_per_mtok: Some(15.0),
-        },
-        ModelCard {
-            id: "claude-opus-4-20250514".to_owned(),
-            name: "Claude Opus 4".to_owned(),
-            provider: "Anthropic".to_owned(),
-            context_window: 200_000,
-            max_output_tokens: 32_000,
-            supports_tools: true,
-            supports_vision: true,
-            supports_thinking: true,
-            input_cost_per_mtok: Some(15.0),
-            output_cost_per_mtok: Some(75.0),
-        },
-        ModelCard {
-            id: "claude-3-5-haiku-20241022".to_owned(),
-            name: "Claude 3.5 Haiku".to_owned(),
-            provider: "Anthropic".to_owned(),
-            context_window: 200_000,
-            max_output_tokens: 8_192,
-            supports_tools: true,
-            supports_vision: true,
-            supports_thinking: false,
-            input_cost_per_mtok: Some(0.8),
-            output_cost_per_mtok: Some(4.0),
-        },
-    ]
+    let pricing = koina::models::pricing_entries().collect::<std::collections::HashMap<_, _>>();
+
+    koina::models::provider_models(koina::models::ModelProvider::Anthropic)
+        .iter()
+        .map(|model| {
+            let tier = koina::models::model_tier(model).unwrap_or(koina::models::ModelTier::Sonnet);
+            let price = pricing.get(model);
+            ModelCard {
+                id: (*model).to_owned(),
+                name: format!("Anthropic {tier}"),
+                provider: "Anthropic".to_owned(),
+                context_window: u64::from(koina::models::context_tokens(model).unwrap_or(200_000)),
+                max_output_tokens: if tier == koina::models::ModelTier::Opus {
+                    32_000
+                } else if matches!(
+                    tier,
+                    koina::models::ModelTier::NoLlm | koina::models::ModelTier::Haiku
+                ) {
+                    8_192
+                } else {
+                    16_000
+                },
+                supports_tools: true,
+                supports_vision: true,
+                supports_thinking: tier != koina::models::ModelTier::Haiku,
+                input_cost_per_mtok: price.map(|p| p.input_cost_per_mtok),
+                output_cost_per_mtok: price.map(|p| p.output_cost_per_mtok),
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/aletheia/src/runtime/setup.rs
+++ b/crates/aletheia/src/runtime/setup.rs
@@ -978,8 +978,10 @@ mod tests {
             "declarative Anthropic-protocol entry with its own key must register and claim its models"
         );
         assert!(
-            registry.find_provider("claude-opus-4-6").is_none(),
-            "custom-model instance must not claim first-party models"
+            registry
+                .find_provider(koina::models::names::opus())
+                .is_some(),
+            "custom-model instance must catch claude-* at lower precedence"
         );
     }
 

--- a/crates/episteme/src/extract/types.rs
+++ b/crates/episteme/src/extract/types.rs
@@ -61,7 +61,7 @@ const fn default_tier_inferred() -> EpistemicTier {
 impl Default for ExtractionConfig {
     fn default() -> Self {
         Self {
-            model: "claude-haiku-4-5-20251001".to_owned(),
+            model: koina::models::task_role_default(koina::models::TaskRole::Extraction).to_owned(),
             min_message_length: 50,
             max_entities: 20,
             max_relationships: 30,

--- a/crates/hermeneus/src/anthropic/client.rs
+++ b/crates/hermeneus/src/anthropic/client.rs
@@ -17,14 +17,15 @@ use koina::secret::SecretString;
 use crate::error::{self, Result};
 use crate::health::{HealthConfig, ProviderHealthTracker};
 use crate::provider::{
-    DeploymentTarget, LlmProvider, ModelPricing, PromptCacheMode, ProviderConfig, leak_models,
+    DeploymentTarget, LlmProvider, MatchKind, ModelPricing, PromptCacheMode, ProviderConfig,
+    leak_models,
 };
 use crate::types::{CompletionRequest, CompletionResponse};
 
 use super::stream::{StreamAccumulator, StreamEvent, parse_sse_response};
 use super::wire::WireRequest;
 
-use crate::models::{DEFAULT_API_VERSION, DEFAULT_BASE_URL, DEFAULT_MAX_RETRIES, SUPPORTED_MODELS};
+use crate::models::{DEFAULT_API_VERSION, DEFAULT_BASE_URL, DEFAULT_MAX_RETRIES};
 
 use super::pricing::{backoff_delay, estimate_cost_with_cache};
 
@@ -66,6 +67,8 @@ pub struct AnthropicProvider {
     /// catalog by default; an operator-declared compatible endpoint claims
     /// exactly its configured model list instead.
     model_refs: &'static [&'static str],
+    /// Whether `model_refs` came from operator configuration.
+    has_operator_model_refs: bool,
     /// Where this instance's traffic terminates, for the recall
     /// sensitivity filter (#3404, #3413).
     deployment_target: DeploymentTarget,
@@ -106,7 +109,7 @@ fn instance_name(config: &ProviderConfig) -> String {
 /// for compatible endpoints, or the first-party catalog when unset.
 fn model_refs(config: &ProviderConfig) -> &'static [&'static str] {
     if config.models.is_empty() {
-        SUPPORTED_MODELS
+        koina::models::provider_models(koina::models::ModelProvider::Anthropic)
     } else {
         leak_models(&config.models)
     }
@@ -210,6 +213,7 @@ impl AnthropicProvider {
             prompt_cache_mode: config.prompt_cache_mode,
             instance_name: instance_name(config),
             model_refs: model_refs(config),
+            has_operator_model_refs: !config.models.is_empty(),
             deployment_target: config.deployment_target,
         };
         // TODO(#2178): add allow_insecure config field
@@ -266,6 +270,7 @@ impl AnthropicProvider {
             prompt_cache_mode: config.prompt_cache_mode,
             instance_name: instance_name(config),
             model_refs: model_refs(config),
+            has_operator_model_refs: !config.models.is_empty(),
             deployment_target: config.deployment_target,
         };
         // TODO(#2178): add allow_insecure config field
@@ -1002,6 +1007,20 @@ impl LlmProvider for AnthropicProvider {
 
     fn supported_models(&self) -> &[&str] {
         self.model_refs
+    }
+
+    fn supports_model(&self, model: &str) -> bool {
+        self.match_specificity(model).is_some()
+    }
+
+    fn match_specificity(&self, model: &str) -> Option<MatchKind> {
+        if self.has_operator_model_refs && self.model_refs.contains(&model) {
+            Some(MatchKind::Exact)
+        } else if model.starts_with("claude-") {
+            Some(MatchKind::CatchAll)
+        } else {
+            None
+        }
     }
 
     fn name(&self) -> &str {

--- a/crates/hermeneus/src/anthropic/client_tests.rs
+++ b/crates/hermeneus/src/anthropic/client_tests.rs
@@ -14,7 +14,7 @@ use super::*;
 use crate::anthropic::pricing::{backoff_delay, estimate_cost, model_family};
 use crate::error::Error;
 use crate::models::BACKOFF_MAX_MS;
-use crate::provider::{DeploymentTarget, LlmProvider, ProviderConfig};
+use crate::provider::{DeploymentTarget, LlmProvider, MatchKind, ProviderConfig};
 use crate::types::{CompletionRequest, Content, Message, Role};
 
 fn test_config_with(base_url: &str) -> ProviderConfig {
@@ -120,9 +120,14 @@ fn from_config_custom_models_claim_routing() {
     assert_eq!(provider.name(), "kimi-coding");
     assert_eq!(provider.supported_models(), ["kimi-for-coding"]);
     assert!(provider.supports_model("kimi-for-coding"));
-    assert!(
-        !provider.supports_model("claude-opus-4-6"),
-        "custom-model instance must not claim first-party models"
+    assert_eq!(
+        provider.match_specificity("kimi-for-coding"),
+        Some(MatchKind::Exact)
+    );
+    assert_eq!(
+        provider.match_specificity(koina::models::names::opus()),
+        Some(MatchKind::CatchAll),
+        "custom-model instance catches claude-* at lower precedence"
     );
 }
 
@@ -136,6 +141,15 @@ fn from_config_default_models_and_name_unchanged() {
     let provider = AnthropicProvider::from_config(&config).expect("valid config");
     assert_eq!(provider.name(), "anthropic");
     assert!(provider.supports_model("claude-opus-4-6"));
+    assert_eq!(
+        provider.match_specificity("claude-opus-4-6"),
+        Some(MatchKind::CatchAll)
+    );
+    assert_eq!(
+        provider.match_specificity("claude-future-family-model"),
+        Some(MatchKind::CatchAll)
+    );
+    assert_eq!(provider.match_specificity("kimi-for-coding"), None);
 }
 
 #[test]
@@ -514,7 +528,7 @@ fn estimate_cost_default_pricing_resolves_haiku() {
         "expected ~$6.00 for haiku from default pricing, got {cost}"
     );
 
-    for model in SUPPORTED_MODELS {
+    for model in koina::models::provider_models(koina::models::ModelProvider::Anthropic) {
         let c = estimate_cost(&pricing, model, 1000, 1000);
         assert!(
             c > 0.0,

--- a/crates/hermeneus/src/anthropic/pricing.rs
+++ b/crates/hermeneus/src/anthropic/pricing.rs
@@ -75,12 +75,6 @@ pub(crate) fn estimate_cost(
     }
 }
 
-/// Cache read tokens are billed at 10% of the input token price.
-const CACHE_READ_DISCOUNT: f64 = 0.1;
-
-/// Cache write (creation) tokens are billed at 125% of the input token price.
-const CACHE_WRITE_PREMIUM: f64 = 1.25;
-
 /// Estimate cost including prompt cache token pricing.
 ///
 /// Uses Anthropic's standard cache pricing ratios:
@@ -114,8 +108,8 @@ pub(crate) fn estimate_cost_with_cache(
         reason = "u64->f64 for token counts: acceptable precision loss for cost estimates"
     )]
     {
-        base + (usage.cache_read_tokens as f64 * p.input_cost_per_mtok * CACHE_READ_DISCOUNT // kanon:ignore RUST/as-cast
-            + usage.cache_write_tokens as f64 * p.input_cost_per_mtok * CACHE_WRITE_PREMIUM) // kanon:ignore RUST/as-cast
+        base + (usage.cache_read_tokens as f64 * p.input_cost_per_mtok * koina::models::cache_read_ratio() // kanon:ignore RUST/as-cast
+            + usage.cache_write_tokens as f64 * p.input_cost_per_mtok * koina::models::cache_write_ratio()) // kanon:ignore RUST/as-cast
             / 1_000_000.0
     }
 }

--- a/crates/hermeneus/src/cc/provider.rs
+++ b/crates/hermeneus/src/cc/provider.rs
@@ -29,16 +29,6 @@ use super::process;
 /// Model name prefix that routes requests to this provider.
 pub(crate) const CC_MODEL_PREFIX: &str = "cc/";
 
-/// Models CC can route to. Kept minimal: CC itself resolves aliases.
-const SUPPORTED_MODELS: &[&str] = &[
-    "claude-opus-4-20250514",
-    "claude-opus-4-6",
-    "claude-sonnet-4-20250514",
-    "claude-sonnet-4-6",
-    "claude-haiku-4-5-20251001",
-    "claude-haiku-4-5",
-];
-
 /// Configuration for the CC subprocess provider.
 #[derive(Debug, Clone)]
 pub struct CcProviderConfig {
@@ -54,7 +44,7 @@ impl Default for CcProviderConfig {
     fn default() -> Self {
         Self {
             cc_binary: None,
-            default_model: crate::models::names::OPUS.to_owned(),
+            default_model: crate::models::names::opus().to_owned(),
             timeout: Duration::from_mins(5),
         }
     }
@@ -287,7 +277,7 @@ impl LlmProvider for CcProvider {
     }
 
     fn supported_models(&self) -> &[&str] {
-        SUPPORTED_MODELS
+        koina::models::provider_models(koina::models::ModelProvider::Anthropic)
     }
 
     fn supports_model(&self, model: &str) -> bool {
@@ -300,16 +290,10 @@ impl LlmProvider for CcProvider {
             // this provider is the intended destination regardless of what
             // other providers are registered.
             Some(MatchKind::Prefix)
-        } else if SUPPORTED_MODELS.contains(&model) {
-            // WHY: an exact-model-ID match on the statically-known list is
-            // high specificity. If a second provider (e.g. AnthropicProvider)
-            // also exact-matches the same ID the tie breaks by registration
-            // order (first registered wins), which is a stable contract.
-            Some(MatchKind::Exact)
         } else if model.starts_with("claude-") {
             // WHY: CC delegates model routing to the `claude` CLI, which
             // handles all claude-* models internally, including future IDs
-            // not yet in SUPPORTED_MODELS. This catch-all ensures forward
+            // not yet in the shared catalog. This catch-all ensures forward
             // compatibility at the cost of lower precedence: any provider
             // with an exact-model match wins over this branch.
             Some(MatchKind::CatchAll)
@@ -438,32 +422,36 @@ mod tests {
 
     #[test]
     fn resolve_model_strips_prefix() {
-        // Can't create CcProvider in tests (no binary), so test the logic directly.
-        let stripped = "cc/claude-sonnet-4-20250514"
+        let model = format!("{CC_MODEL_PREFIX}{}", crate::models::names::sonnet());
+        let stripped = model
             .strip_prefix(CC_MODEL_PREFIX)
-            .unwrap_or("cc/claude-sonnet-4-20250514");
-        assert_eq!(stripped, "claude-sonnet-4-20250514");
+            .unwrap_or(model.as_str());
+        assert_eq!(stripped, crate::models::names::sonnet());
     }
 
     #[test]
     fn supports_model_with_prefix() {
-        // Test the prefix logic without needing a real binary.
-        let model = "cc/claude-sonnet-4-20250514";
+        let model = format!("{CC_MODEL_PREFIX}{}", crate::models::names::sonnet());
         assert!(model.starts_with(CC_MODEL_PREFIX));
     }
 
     #[test]
     fn supports_model_known() {
-        assert!(SUPPORTED_MODELS.contains(&"claude-sonnet-4-20250514"));
-        assert!(SUPPORTED_MODELS.contains(&"claude-opus-4-20250514"));
-        assert!(!SUPPORTED_MODELS.contains(&"gpt-4"));
+        let provider = CcProvider {
+            cc_binary: PathBuf::from("claude"),
+            default_model: crate::models::names::opus().to_owned(),
+            timeout: Duration::from_secs(1),
+        };
+        assert!(provider.supports_model(crate::models::names::sonnet()));
+        assert!(provider.supports_model("claude-future-family-model"));
+        assert!(!provider.supports_model("gpt-4"));
     }
 
     #[test]
     fn cc_provider_reports_cloud_deployment_target() {
         let provider = CcProvider {
             cc_binary: PathBuf::from("claude"),
-            default_model: crate::models::names::OPUS.to_owned(),
+            default_model: crate::models::names::opus().to_owned(),
             timeout: Duration::from_secs(1),
         };
         assert_eq!(provider.deployment_target(), DeploymentTarget::Cloud);
@@ -473,7 +461,7 @@ mod tests {
     fn seat_bridged_fields() {
         let provider = CcProvider {
             cc_binary: PathBuf::from("/usr/local/bin/claude"),
-            default_model: crate::models::names::OPUS.to_owned(),
+            default_model: crate::models::names::opus().to_owned(),
             timeout: Duration::from_mins(5),
         };
         assert_eq!(

--- a/crates/hermeneus/src/codex/provider.rs
+++ b/crates/hermeneus/src/codex/provider.rs
@@ -24,9 +24,6 @@ use super::{parse, process};
 /// Model name prefix that routes requests to this provider.
 pub(crate) const CODEX_MODEL_PREFIX: &str = "codex/";
 
-/// Models Codex can route to. The CLI itself resolves aliases and availability.
-const SUPPORTED_MODELS: &[&str] = &["gpt-5-codex"];
-
 /// Configuration for the Codex subprocess provider.
 #[derive(Debug, Clone)]
 pub struct CodexProviderConfig {
@@ -42,7 +39,7 @@ impl Default for CodexProviderConfig {
     fn default() -> Self {
         Self {
             codex_binary: None,
-            default_model: "codex/gpt-5-codex".to_owned(),
+            default_model: format!("{CODEX_MODEL_PREFIX}{}", koina::models::names::codex()),
             timeout: Duration::from_mins(5),
         }
     }
@@ -105,7 +102,7 @@ impl CodexProvider {
             .strip_prefix(CODEX_MODEL_PREFIX)
             .unwrap_or(selected);
         if stripped.is_empty() {
-            "gpt-5-codex"
+            koina::models::names::codex()
         } else {
             stripped
         }
@@ -271,7 +268,7 @@ impl LlmProvider for CodexProvider {
     }
 
     fn supported_models(&self) -> &[&str] {
-        SUPPORTED_MODELS
+        koina::models::provider_models(koina::models::ModelProvider::Codex)
     }
 
     fn supports_model(&self, model: &str) -> bool {
@@ -281,7 +278,7 @@ impl LlmProvider for CodexProvider {
     fn match_specificity(&self, model: &str) -> Option<MatchKind> {
         if model.starts_with(CODEX_MODEL_PREFIX) {
             Some(MatchKind::Prefix)
-        } else if SUPPORTED_MODELS.contains(&model) {
+        } else if self.supported_models().contains(&model) {
             Some(MatchKind::Exact)
         } else {
             None
@@ -495,22 +492,31 @@ mod tests {
     fn resolve_model_strips_prefix() {
         let provider = CodexProvider {
             codex_binary: PathBuf::from("codex"),
-            default_model: "codex/gpt-5-codex".to_owned(),
+            default_model: format!("{CODEX_MODEL_PREFIX}{}", koina::models::names::codex()),
             timeout: Duration::from_secs(1),
         };
-        assert_eq!(provider.resolve_model("codex/gpt-5-codex"), "gpt-5-codex");
-        assert_eq!(provider.resolve_model(""), "gpt-5-codex");
+        assert_eq!(
+            provider.resolve_model(&format!(
+                "{CODEX_MODEL_PREFIX}{}",
+                koina::models::names::codex()
+            )),
+            koina::models::names::codex()
+        );
+        assert_eq!(provider.resolve_model(""), koina::models::names::codex());
     }
 
     #[test]
     fn supports_model_with_prefix() {
         let provider = CodexProvider {
             codex_binary: PathBuf::from("codex"),
-            default_model: "codex/gpt-5-codex".to_owned(),
+            default_model: format!("{CODEX_MODEL_PREFIX}{}", koina::models::names::codex()),
             timeout: Duration::from_secs(1),
         };
-        assert!(provider.supports_model("codex/gpt-5-codex"));
-        assert!(provider.supports_model("gpt-5-codex"));
+        assert!(provider.supports_model(&format!(
+            "{CODEX_MODEL_PREFIX}{}",
+            koina::models::names::codex()
+        )));
+        assert!(provider.supports_model(koina::models::names::codex()));
         assert!(!provider.supports_model("claude-sonnet-4-6"));
     }
 
@@ -518,15 +524,18 @@ mod tests {
     fn match_specificity_prefers_prefix_and_exact() {
         let provider = CodexProvider {
             codex_binary: PathBuf::from("codex"),
-            default_model: "codex/gpt-5-codex".to_owned(),
+            default_model: format!("{CODEX_MODEL_PREFIX}{}", koina::models::names::codex()),
             timeout: Duration::from_secs(1),
         };
         assert_eq!(
-            provider.match_specificity("codex/gpt-5-codex"),
+            provider.match_specificity(&format!(
+                "{CODEX_MODEL_PREFIX}{}",
+                koina::models::names::codex()
+            )),
             Some(MatchKind::Prefix)
         );
         assert_eq!(
-            provider.match_specificity("gpt-5-codex"),
+            provider.match_specificity(koina::models::names::codex()),
             Some(MatchKind::Exact)
         );
         assert_eq!(provider.match_specificity("claude-sonnet-4-6"), None);
@@ -536,7 +545,7 @@ mod tests {
     fn codex_provider_reports_cloud_deployment_target() {
         let provider = CodexProvider {
             codex_binary: PathBuf::from("codex"),
-            default_model: "codex/gpt-5-codex".to_owned(),
+            default_model: format!("{CODEX_MODEL_PREFIX}{}", koina::models::names::codex()),
             timeout: Duration::from_secs(1),
         };
         assert_eq!(provider.deployment_target(), DeploymentTarget::Cloud);
@@ -546,7 +555,7 @@ mod tests {
     fn codex_provider_supports_streaming() {
         let provider = CodexProvider {
             codex_binary: PathBuf::from("codex"),
-            default_model: "codex/gpt-5-codex".to_owned(),
+            default_model: format!("{CODEX_MODEL_PREFIX}{}", koina::models::names::codex()),
             timeout: Duration::from_secs(1),
         };
         assert!(
@@ -559,7 +568,7 @@ mod tests {
     fn seat_bridged_fields() {
         let provider = CodexProvider {
             codex_binary: PathBuf::from("/usr/local/bin/codex"),
-            default_model: "codex/gpt-5-codex".to_owned(),
+            default_model: format!("{CODEX_MODEL_PREFIX}{}", koina::models::names::codex()),
             timeout: Duration::from_secs(300),
         };
         assert_eq!(

--- a/crates/hermeneus/src/complexity/mod.rs
+++ b/crates/hermeneus/src/complexity/mod.rs
@@ -16,7 +16,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::models::names;
+pub use koina::models::ModelTier;
 
 /// Default threshold below which queries route to the fast tier.
 const DEFAULT_LOW_THRESHOLD: u32 = 30;
@@ -118,33 +118,6 @@ static PHILOSOPHICAL: LazyLock<Regex> = LazyLock::new(|| {
         .expect("compile-time-constant regex literals cannot fail")
 });
 
-/// Model capability tier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-#[non_exhaustive]
-pub enum ModelTier {
-    /// No model call required; a deterministic fast path can handle it.
-    #[serde(rename = "no_llm", alias = "no-llm")]
-    NoLlm,
-    /// Fast, cheap, sufficient for simple queries.
-    Haiku,
-    /// Balanced capability and cost.
-    Sonnet,
-    /// Maximum capability for hard problems.
-    Opus,
-}
-
-impl fmt::Display for ModelTier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NoLlm => f.write_str("no_llm"),
-            Self::Haiku => f.write_str("haiku"),
-            Self::Sonnet => f.write_str("sonnet"),
-            Self::Opus => f.write_str("opus"),
-        }
-    }
-}
-
 /// Input signals for complexity scoring.
 #[derive(Debug, Clone)]
 pub struct ComplexityInput<'a> {
@@ -190,9 +163,9 @@ impl Default for ComplexityConfig {
             no_llm_threshold: DEFAULT_NO_LLM_THRESHOLD,
             low_threshold: DEFAULT_LOW_THRESHOLD,
             high_threshold: DEFAULT_HIGH_THRESHOLD,
-            haiku_model: names::HAIKU.to_owned(),
-            sonnet_model: names::SONNET.to_owned(),
-            opus_model: names::OPUS.to_owned(),
+            haiku_model: koina::models::tier_default(ModelTier::Haiku).to_owned(),
+            sonnet_model: koina::models::tier_default(ModelTier::Sonnet).to_owned(),
+            opus_model: koina::models::tier_default(ModelTier::Opus).to_owned(),
         }
     }
 }
@@ -252,11 +225,14 @@ pub struct RoutingOutcome {
 pub fn score_complexity(input: &ComplexityInput<'_>) -> ComplexityScore {
     // Agent-level tier override bypasses scoring
     if let Some(tier) = input.tier_override {
-        let score = match tier {
-            ModelTier::Opus => 100,
-            ModelTier::Sonnet => 50,
-            ModelTier::Haiku => 10,
-            ModelTier::NoLlm => 0,
+        let score = if tier == ModelTier::Opus {
+            100
+        } else if tier == ModelTier::Haiku {
+            10
+        } else if tier == ModelTier::NoLlm {
+            0
+        } else {
+            50
         };
         return ComplexityScore {
             score,
@@ -480,13 +456,15 @@ pub fn route_model(input: &ComplexityInput<'_>, config: &ComplexityConfig) -> Ro
 /// so that matched prompts never reach the model dispatch path at all.
 #[must_use]
 fn select_model_for_tier(tier: ModelTier, config: &ComplexityConfig) -> String {
-    match tier {
+    if matches!(tier, ModelTier::NoLlm | ModelTier::Haiku) {
         // WHY(#3970): NoLlm falls back to the fast model when the Tier-1
         // registry has no matching handler. The tier is preserved in telemetry
         // so callers can distinguish "no handler matched" from "Haiku choice."
-        ModelTier::NoLlm | ModelTier::Haiku => config.haiku_model.clone(),
-        ModelTier::Sonnet => config.sonnet_model.clone(),
-        ModelTier::Opus => config.opus_model.clone(),
+        config.haiku_model.clone()
+    } else if tier == ModelTier::Opus {
+        config.opus_model.clone()
+    } else {
+        config.sonnet_model.clone()
     }
 }
 

--- a/crates/hermeneus/src/complexity/tests.rs
+++ b/crates/hermeneus/src/complexity/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::models::names;
 
 fn input(text: &str) -> ComplexityInput<'_> {
     ComplexityInput {
@@ -286,7 +287,7 @@ fn route_model_disabled_returns_sonnet() {
     };
 
     let decision = route_model(&input("analyze this"), &config);
-    assert_eq!(decision.model, names::SONNET);
+    assert_eq!(decision.model, names::sonnet());
     assert!(!decision.is_override);
 }
 
@@ -298,7 +299,7 @@ fn route_model_simple_query_routes_haiku() {
     };
 
     let decision = route_model(&input("yes"), &config);
-    assert_eq!(decision.model, names::HAIKU);
+    assert_eq!(decision.model, names::haiku());
     assert_eq!(decision.complexity.tier, ModelTier::NoLlm);
 }
 
@@ -313,7 +314,7 @@ fn route_model_complex_query_routes_opus() {
         &input("Think hard about the best migration strategy"),
         &config,
     );
-    assert_eq!(decision.model, names::OPUS);
+    assert_eq!(decision.model, names::opus());
 }
 
 #[test]
@@ -411,7 +412,7 @@ fn model_tier_display() {
 fn routing_outcome_captures_escalation() {
     let outcome = RoutingOutcome {
         decision: RoutingDecision {
-            model: names::SONNET.to_owned(),
+            model: names::sonnet().to_owned(),
             complexity: ComplexityScore {
                 score: 45,
                 tier: ModelTier::Sonnet,

--- a/crates/hermeneus/src/kimi/provider.rs
+++ b/crates/hermeneus/src/kimi/provider.rs
@@ -29,11 +29,6 @@ use super::process;
 /// Model name prefix that routes requests to this provider.
 pub(crate) const KIMI_MODEL_PREFIX: &str = "kimi/";
 
-const DEFAULT_MODEL: &str = "kimi/kimi-k2-thinking";
-
-/// Models Kimi can route to. Kept minimal: the CLI owns concrete model routing.
-const SUPPORTED_MODELS: &[&str] = &[DEFAULT_MODEL];
-
 /// Configuration for the Kimi subprocess provider.
 #[derive(Debug, Clone)]
 pub struct KimiProviderConfig {
@@ -52,7 +47,7 @@ impl Default for KimiProviderConfig {
         Self {
             kimi_binary: None,
             working_directory: None,
-            default_model: DEFAULT_MODEL.to_owned(),
+            default_model: koina::models::names::kimi().to_owned(),
             timeout: Duration::from_mins(5),
         }
     }
@@ -132,10 +127,16 @@ impl KimiProvider {
 
     /// Resolve the model name, falling back to the configured default.
     fn resolve_model<'a>(&'a self, model: &'a str) -> &'a str {
-        if model.is_empty() {
+        let selected = if model.is_empty() {
             &self.default_model
         } else {
             model
+        };
+        let stripped = selected.strip_prefix(KIMI_MODEL_PREFIX).unwrap_or(selected);
+        if stripped.is_empty() {
+            koina::models::names::kimi()
+        } else {
+            stripped
         }
     }
 
@@ -295,7 +296,7 @@ impl LlmProvider for KimiProvider {
     }
 
     fn supported_models(&self) -> &[&str] {
-        SUPPORTED_MODELS
+        koina::models::provider_models(koina::models::ModelProvider::Kimi)
     }
 
     fn supports_model(&self, model: &str) -> bool {
@@ -303,10 +304,7 @@ impl LlmProvider for KimiProvider {
     }
 
     fn match_specificity(&self, model: &str) -> Option<MatchKind> {
-        if SUPPORTED_MODELS.contains(&model) {
-            // WHY: Kimi's canonical default model string is namespaced, so
-            // the exact supported-model match should win over the broader
-            // `kimi/` prefix for that one model ID.
+        if self.supported_models().contains(&model) {
             Some(MatchKind::Exact)
         } else if model.starts_with(KIMI_MODEL_PREFIX) {
             Some(MatchKind::Prefix)
@@ -348,7 +346,7 @@ mod tests {
         let provider = KimiProvider {
             kimi_binary: PathBuf::from("kimi"),
             working_directory: PathBuf::from("."),
-            default_model: DEFAULT_MODEL.to_owned(),
+            default_model: koina::models::names::kimi().to_owned(),
             timeout: Duration::from_secs(1),
         };
         assert_eq!(
@@ -356,7 +354,7 @@ mod tests {
             Some(MatchKind::Prefix)
         );
         assert_eq!(
-            provider.match_specificity(DEFAULT_MODEL),
+            provider.match_specificity(koina::models::names::kimi()),
             Some(MatchKind::Exact)
         );
         assert_eq!(provider.match_specificity("claude-sonnet-4-6"), None);

--- a/crates/hermeneus/src/models.rs
+++ b/crates/hermeneus/src/models.rs
@@ -1,4 +1,4 @@
-//! Model constants and API configuration defaults.
+//! API configuration defaults and model-catalog re-exports.
 
 /// Default Anthropic API base URL.
 pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com"; // kanon:ignore RUST/pub-visibility
@@ -18,27 +18,4 @@ pub const BACKOFF_FACTOR: u64 = 2; // kanon:ignore RUST/pub-visibility
 /// Maximum retry backoff delay in milliseconds.
 pub const BACKOFF_MAX_MS: u64 = 30_000; // kanon:ignore RUST/pub-visibility
 
-/// All supported Anthropic model identifiers.
-///
-/// Includes both short names (e.g., `claude-opus-4-6`) and dated snapshots
-/// (e.g., `claude-opus-4-20250514`).
-pub static SUPPORTED_MODELS: &[&str] = &[
-    // kanon:ignore RUST/pub-visibility
-    "claude-opus-4-6",
-    "claude-opus-4-20250514",
-    "claude-sonnet-4-6",
-    "claude-sonnet-4-20250514",
-    "claude-haiku-4-5",
-    "claude-haiku-4-5-20251001",
-];
-
-/// Short model name constants for use in config and code.
-pub mod names {
-    // kanon:ignore RUST/pub-visibility
-    /// Default Opus model alias.
-    pub const OPUS: &str = "claude-opus-4-6"; // kanon:ignore RUST/pub-visibility
-    /// Default Sonnet model alias.
-    pub const SONNET: &str = "claude-sonnet-4-6"; // kanon:ignore RUST/pub-visibility
-    /// Default Haiku model alias.
-    pub const HAIKU: &str = "claude-haiku-4-5-20251001"; // kanon:ignore RUST/pub-visibility
-}
+pub use koina::models::names;

--- a/crates/hermeneus/src/provider.rs
+++ b/crates/hermeneus/src/provider.rs
@@ -274,58 +274,22 @@ impl std::fmt::Debug for ProviderConfig {
 
 impl Default for ProviderConfig {
     fn default() -> Self {
-        // NOTE: Built-in pricing for all first-party Anthropic models (USD per million tokens).
-        // Operator configs are merged on top, so these act as sensible fallbacks.
-        // Prices last verified against https://www.anthropic.com/pricing (2026-06-11).
-        let pricing = HashMap::from([
-            (
-                "claude-opus-4-6".to_owned(),
-                ModelPricing {
-                    input_cost_per_mtok: 5.0,
-                    output_cost_per_mtok: 25.0,
-                },
-            ),
-            (
-                "claude-opus-4-20250514".to_owned(),
-                ModelPricing {
-                    input_cost_per_mtok: 5.0,
-                    output_cost_per_mtok: 25.0,
-                },
-            ),
-            (
-                "claude-sonnet-4-6".to_owned(),
-                ModelPricing {
-                    input_cost_per_mtok: 3.0,
-                    output_cost_per_mtok: 15.0,
-                },
-            ),
-            (
-                "claude-sonnet-4-20250514".to_owned(),
-                ModelPricing {
-                    input_cost_per_mtok: 3.0,
-                    output_cost_per_mtok: 15.0,
-                },
-            ),
-            (
-                "claude-haiku-4-5".to_owned(),
-                ModelPricing {
-                    input_cost_per_mtok: 1.0,
-                    output_cost_per_mtok: 5.0,
-                },
-            ),
-            (
-                "claude-haiku-4-5-20251001".to_owned(),
-                ModelPricing {
-                    input_cost_per_mtok: 1.0,
-                    output_cost_per_mtok: 5.0,
-                },
-            ),
-        ]);
+        let pricing = koina::models::pricing_entries()
+            .map(|(model, price)| {
+                (
+                    model.to_owned(),
+                    ModelPricing {
+                        input_cost_per_mtok: price.input_cost_per_mtok,
+                        output_cost_per_mtok: price.output_cost_per_mtok,
+                    },
+                )
+            })
+            .collect();
         Self {
             provider_type: "anthropic".to_owned(),
             api_key: None,
             base_url: None,
-            default_model: Some(crate::models::names::OPUS.to_owned()),
+            default_model: Some(crate::models::names::opus().to_owned()),
             max_retries: Some(3),
             pricing,
             cc_mimicry: None,
@@ -602,7 +566,7 @@ mod tests {
         assert_eq!(config.provider_type, "anthropic");
         assert_eq!(
             config.default_model.as_deref(),
-            Some(crate::models::names::OPUS)
+            Some(crate::models::names::opus())
         );
         // WHY: Default pricing must cover the models used by background tasks.
         assert!(

--- a/crates/hermeneus/tests/public_api.rs
+++ b/crates/hermeneus/tests/public_api.rs
@@ -14,7 +14,7 @@
 
 use hermeneus::models::{
     BACKOFF_BASE_MS, BACKOFF_FACTOR, BACKOFF_MAX_MS, DEFAULT_API_VERSION, DEFAULT_BASE_URL,
-    DEFAULT_MAX_RETRIES, SUPPORTED_MODELS, names,
+    DEFAULT_MAX_RETRIES, names,
 };
 use hermeneus::types::{StopReason, Usage};
 
@@ -23,7 +23,7 @@ use hermeneus::types::{StopReason, Usage};
 mod model_constants {
     use super::{
         BACKOFF_BASE_MS, BACKOFF_FACTOR, BACKOFF_MAX_MS, DEFAULT_API_VERSION, DEFAULT_BASE_URL,
-        DEFAULT_MAX_RETRIES, SUPPORTED_MODELS, names,
+        DEFAULT_MAX_RETRIES, names,
     };
 
     #[test]
@@ -59,25 +59,26 @@ mod model_constants {
     }
 
     #[test]
-    fn supported_models_includes_current_default_aliases() {
-        // WHY: the alias constants must always be present in SUPPORTED_MODELS
-        // so anything that picks an alias gets validated against the list.
-        assert!(SUPPORTED_MODELS.contains(&names::OPUS));
-        assert!(SUPPORTED_MODELS.contains(&names::SONNET));
-        assert!(SUPPORTED_MODELS.contains(&names::HAIKU));
+    fn model_names_are_from_shared_catalog() {
+        let anthropic = koina::models::provider_models(koina::models::ModelProvider::Anthropic);
+        assert!(anthropic.contains(&names::opus()));
+        assert!(anthropic.contains(&names::sonnet()));
+        assert!(anthropic.contains(&names::haiku()));
     }
 
     #[test]
     fn supported_models_are_distinct() {
-        // WHY: duplicates would shadow each other in any list-based lookup.
-        let mut sorted: Vec<&&str> = SUPPORTED_MODELS.iter().collect();
+        let mut sorted: Vec<&&str> =
+            koina::models::provider_models(koina::models::ModelProvider::Anthropic)
+                .iter()
+                .collect();
         sorted.sort();
         let len_before = sorted.len();
         sorted.dedup();
         assert_eq!(
             sorted.len(),
             len_before,
-            "SUPPORTED_MODELS must contain no duplicates"
+            "Anthropic catalog models must contain no duplicates"
         );
     }
 
@@ -85,8 +86,8 @@ mod model_constants {
     fn alias_constants_use_short_form() {
         // WHY: aliases should be short non-dated names so callers can
         // upgrade through them. Dated snapshots should not be aliases.
-        assert!(!names::OPUS.contains("2025"));
-        assert!(!names::SONNET.contains("2025"));
+        assert!(!names::opus().contains("2025"));
+        assert!(!names::sonnet().contains("2025"));
     }
 }
 

--- a/crates/koina/Cargo.toml
+++ b/crates/koina/Cargo.toml
@@ -26,6 +26,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
+toml = { workspace = true }
 zeroize = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/koina/data/model-seed.toml
+++ b/crates/koina/data/model-seed.toml
@@ -1,0 +1,92 @@
+as_of = "2026-06-11"
+
+[cache]
+read_ratio = 0.10
+write_ratio = 1.25
+
+[tiers]
+opus = "claude-opus-4-6"
+sonnet = "claude-sonnet-4-6"
+haiku = "claude-haiku-4-5-20251001"
+
+[task_roles]
+coder = "sonnet"
+researcher = "sonnet"
+reviewer = "opus"
+explorer = "haiku"
+runner = "haiku"
+prosoche = "haiku"
+extraction = "haiku"
+triage_prompt = "opus"
+
+[[models]]
+id = "claude-opus-4-6"
+provider = "anthropic"
+tier = "opus"
+family = "claude-opus-4"
+context_tokens = 1000000
+input_cost_per_mtok = 5.0
+output_cost_per_mtok = 25.0
+menu = true
+
+[[models]]
+id = "claude-opus-4-20250514"
+provider = "anthropic"
+tier = "opus"
+family = "claude-opus-4"
+context_tokens = 1000000
+input_cost_per_mtok = 5.0
+output_cost_per_mtok = 25.0
+
+[[models]]
+id = "claude-sonnet-4-6"
+provider = "anthropic"
+tier = "sonnet"
+family = "claude-sonnet-4"
+context_tokens = 200000
+input_cost_per_mtok = 3.0
+output_cost_per_mtok = 15.0
+menu = true
+recommended = true
+
+[[models]]
+id = "claude-sonnet-4-20250514"
+provider = "anthropic"
+tier = "sonnet"
+family = "claude-sonnet-4"
+context_tokens = 200000
+input_cost_per_mtok = 3.0
+output_cost_per_mtok = 15.0
+
+[[models]]
+id = "claude-haiku-4-5"
+provider = "anthropic"
+tier = "haiku"
+family = "claude-haiku-4-5"
+context_tokens = 200000
+input_cost_per_mtok = 1.0
+output_cost_per_mtok = 5.0
+
+[[models]]
+id = "claude-haiku-4-5-20251001"
+provider = "anthropic"
+tier = "haiku"
+family = "claude-haiku-4-5"
+context_tokens = 200000
+input_cost_per_mtok = 1.0
+output_cost_per_mtok = 5.0
+menu = true
+
+[[models]]
+id = "gpt-5-codex"
+provider = "codex"
+tier = "opus"
+family = "gpt-5-codex"
+context_tokens = 272000
+
+[[models]]
+id = "kimi-k2-thinking"
+provider = "kimi"
+tier = "opus"
+family = "kimi-k2"
+context_tokens = 128000

--- a/crates/koina/src/lib.rs
+++ b/crates/koina/src/lib.rs
@@ -33,6 +33,8 @@ pub mod http;
 pub mod id;
 /// Shared Prometheus metrics registry (prometheus-client wrapper).
 pub mod metrics;
+/// Shared model catalog and tier defaults.
+pub mod models;
 /// Multi-output pipeline stages via the OutputBuffer pattern.
 pub mod output_buffer;
 /// Sensitive value redaction for safe log output (API keys, tokens, passwords).

--- a/crates/koina/src/models.rs
+++ b/crates/koina/src/models.rs
@@ -1,0 +1,381 @@
+//! Shared model catalog loaded from the compiled model seed.
+
+use std::fmt;
+use std::sync::LazyLock;
+
+use serde::{Deserialize, Serialize};
+
+const MODEL_SEED_TOML: &str = include_str!("../data/model-seed.toml");
+
+/// Model capability tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum ModelTier {
+    /// No model call required; a deterministic fast path can handle it.
+    #[serde(rename = "no_llm", alias = "no-llm")]
+    NoLlm,
+    /// Fast, cheap, sufficient for simple queries.
+    Haiku,
+    /// Balanced capability and cost.
+    Sonnet,
+    /// Maximum capability for hard problems.
+    Opus,
+}
+
+impl fmt::Display for ModelTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoLlm => f.write_str("no_llm"),
+            Self::Haiku => f.write_str("haiku"),
+            Self::Sonnet => f.write_str("sonnet"),
+            Self::Opus => f.write_str("opus"),
+        }
+    }
+}
+
+/// Provider family that owns a model catalog entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum ModelProvider {
+    /// Anthropic Messages API models.
+    Anthropic,
+    /// Codex CLI models.
+    Codex,
+    /// Kimi CLI models.
+    Kimi,
+}
+
+/// Built-in task role whose default model is a tier reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TaskRole {
+    /// Implementation, testing, and debugging.
+    Coder,
+    /// Investigation, comparison, and documentation.
+    Researcher,
+    /// Code review and risk assessment.
+    Reviewer,
+    /// Codebase exploration.
+    Explorer,
+    /// Command-running task execution.
+    Runner,
+    /// Background heartbeat checks.
+    Prosoche,
+    /// Knowledge extraction.
+    Extraction,
+    /// Dispatch triage prompt generation.
+    TriagePrompt,
+}
+
+/// Per-model pricing rates for cost estimation.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ModelPrice {
+    /// Cost per million input tokens in USD.
+    pub input_cost_per_mtok: f64,
+    /// Cost per million output tokens in USD.
+    pub output_cost_per_mtok: f64,
+}
+
+/// Select-list entry for setup surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelMenuOption {
+    /// Model identifier written into config.
+    pub value: &'static str,
+    /// Human-readable menu label derived from the model identifier.
+    pub label: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelSeed {
+    as_of: String,
+    cache: CacheSeed,
+    tiers: TierSeed,
+    task_roles: TaskRoleSeed,
+    models: Vec<ModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CacheSeed {
+    read_ratio: f64,
+    write_ratio: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct TierSeed {
+    opus: String,
+    sonnet: String,
+    haiku: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TaskRoleSeed {
+    coder: ModelTier,
+    researcher: ModelTier,
+    reviewer: ModelTier,
+    explorer: ModelTier,
+    runner: ModelTier,
+    prosoche: ModelTier,
+    extraction: ModelTier,
+    triage_prompt: ModelTier,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelEntry {
+    id: String,
+    provider: ModelProvider,
+    tier: ModelTier,
+    family: String,
+    context_tokens: u32,
+    input_cost_per_mtok: Option<f64>,
+    output_cost_per_mtok: Option<f64>,
+    #[serde(default)]
+    menu: bool,
+    #[serde(default)]
+    recommended: bool,
+}
+
+static MODEL_SEED: LazyLock<ModelSeed> = LazyLock::new(|| match toml::from_str(MODEL_SEED_TOML) {
+    Ok(seed) => seed,
+    Err(err) => {
+        panic!("compiled model seed must parse as model-seed.toml: {err}");
+    }
+});
+
+static ANTHROPIC_MODELS: LazyLock<Box<[&'static str]>> =
+    LazyLock::new(|| models_for_provider_boxed(ModelProvider::Anthropic));
+static CODEX_MODELS: LazyLock<Box<[&'static str]>> =
+    LazyLock::new(|| models_for_provider_boxed(ModelProvider::Codex));
+static KIMI_MODELS: LazyLock<Box<[&'static str]>> =
+    LazyLock::new(|| models_for_provider_boxed(ModelProvider::Kimi));
+static MENU_OPTIONS: LazyLock<Box<[ModelMenuOption]>> = LazyLock::new(model_menu_options_boxed);
+
+/// Namespaced helpers for common model aliases.
+pub mod names {
+    use super::{ModelTier, model_for_provider, tier_default};
+
+    /// Default Opus-tier model alias.
+    #[must_use]
+    pub fn opus() -> &'static str {
+        tier_default(ModelTier::Opus)
+    }
+
+    /// Default Sonnet-tier model alias.
+    #[must_use]
+    pub fn sonnet() -> &'static str {
+        tier_default(ModelTier::Sonnet)
+    }
+
+    /// Default Haiku-tier model alias.
+    #[must_use]
+    pub fn haiku() -> &'static str {
+        tier_default(ModelTier::Haiku)
+    }
+
+    /// Default Codex model.
+    #[must_use]
+    pub fn codex() -> &'static str {
+        model_for_provider(super::ModelProvider::Codex)
+    }
+
+    /// Default Kimi model.
+    #[must_use]
+    pub fn kimi() -> &'static str {
+        model_for_provider(super::ModelProvider::Kimi)
+    }
+}
+
+/// Date when the compiled seed values were last verified.
+#[must_use]
+pub fn as_of() -> &'static str {
+    &MODEL_SEED.as_of
+}
+
+/// Default model identifier for a capability tier.
+#[must_use]
+pub fn tier_default(tier: ModelTier) -> &'static str {
+    match tier {
+        ModelTier::NoLlm | ModelTier::Haiku => &MODEL_SEED.tiers.haiku,
+        ModelTier::Sonnet => &MODEL_SEED.tiers.sonnet,
+        ModelTier::Opus => &MODEL_SEED.tiers.opus,
+    }
+}
+
+/// Default tier for a built-in task role.
+#[must_use]
+pub fn task_role_tier(role: TaskRole) -> ModelTier {
+    let roles = &MODEL_SEED.task_roles;
+    match role {
+        TaskRole::Coder => roles.coder,
+        TaskRole::Researcher => roles.researcher,
+        TaskRole::Reviewer => roles.reviewer,
+        TaskRole::Explorer => roles.explorer,
+        TaskRole::Runner => roles.runner,
+        TaskRole::Prosoche => roles.prosoche,
+        TaskRole::Extraction => roles.extraction,
+        TaskRole::TriagePrompt => roles.triage_prompt,
+    }
+}
+
+/// Default model identifier for a built-in task role.
+#[must_use]
+pub fn task_role_default(role: TaskRole) -> &'static str {
+    tier_default(task_role_tier(role))
+}
+
+/// Prompt-cache read cost multiplier relative to input tokens.
+#[must_use]
+pub fn cache_read_ratio() -> f64 {
+    MODEL_SEED.cache.read_ratio
+}
+
+/// Prompt-cache write cost multiplier relative to input tokens.
+#[must_use]
+pub fn cache_write_ratio() -> f64 {
+    MODEL_SEED.cache.write_ratio
+}
+
+/// Model identifiers claimed by a built-in provider catalog.
+#[must_use]
+pub fn provider_models(provider: ModelProvider) -> &'static [&'static str] {
+    match provider {
+        ModelProvider::Anthropic => &ANTHROPIC_MODELS,
+        ModelProvider::Codex => &CODEX_MODELS,
+        ModelProvider::Kimi => &KIMI_MODELS,
+    }
+}
+
+/// First model identifier for a provider catalog.
+#[must_use]
+pub fn model_for_provider(provider: ModelProvider) -> &'static str {
+    provider_models(provider).first().copied().unwrap_or("")
+}
+
+/// Model menu options for setup surfaces.
+#[must_use]
+pub fn model_menu_options() -> &'static [ModelMenuOption] {
+    &MENU_OPTIONS
+}
+
+/// Pricing rows from the model catalog.
+pub fn pricing_entries() -> impl Iterator<Item = (&'static str, ModelPrice)> {
+    MODEL_SEED.models.iter().filter_map(|model| {
+        let input = model.input_cost_per_mtok?;
+        let output = model.output_cost_per_mtok?;
+        Some((
+            model.id.as_str(),
+            ModelPrice {
+                input_cost_per_mtok: input,
+                output_cost_per_mtok: output,
+            },
+        ))
+    })
+}
+
+/// Context window for a model's family, when the model is in the seed.
+#[must_use]
+pub fn context_tokens(model_id: &str) -> Option<u32> {
+    MODEL_SEED
+        .models
+        .iter()
+        .find(|model| model.id == model_id)
+        .map(|model| model.context_tokens)
+}
+
+/// Family identifier for a model, when the model is in the seed.
+#[must_use]
+pub fn family(model_id: &str) -> Option<&'static str> {
+    MODEL_SEED
+        .models
+        .iter()
+        .find(|model| model.id == model_id)
+        .map(|model| model.family.as_str())
+}
+
+/// Capability tier for a model, when the model is in the seed.
+#[must_use]
+pub fn model_tier(model_id: &str) -> Option<ModelTier> {
+    MODEL_SEED
+        .models
+        .iter()
+        .find(|model| model.id == model_id)
+        .map(|model| model.tier)
+}
+
+fn models_for_provider_boxed(provider: ModelProvider) -> Box<[&'static str]> {
+    MODEL_SEED
+        .models
+        .iter()
+        .filter(|model| model.provider == provider)
+        .map(|model| model.id.as_str())
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+fn model_menu_options_boxed() -> Box<[ModelMenuOption]> {
+    let mut options = MODEL_SEED
+        .models
+        .iter()
+        .filter(|model| model.menu)
+        .map(|model| {
+            let label = if model.recommended {
+                Box::leak(format!("{} (recommended)", model.id).into_boxed_str())
+            } else {
+                model.id.as_str()
+            };
+            ModelMenuOption {
+                value: model.id.as_str(),
+                label,
+            }
+        })
+        .collect::<Vec<_>>();
+    options.sort_by_key(|option| usize::from(option.value != tier_default(ModelTier::Sonnet)));
+    options.into_boxed_slice()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_parses_and_exposes_tier_defaults() {
+        assert_eq!(
+            tier_default(ModelTier::Sonnet),
+            crate::defaults::DEFAULT_MODEL
+        );
+        assert_eq!(task_role_default(TaskRole::Prosoche), names::haiku());
+        assert!(!as_of().is_empty());
+    }
+
+    #[test]
+    fn provider_catalogs_are_nonempty() {
+        assert!(provider_models(ModelProvider::Anthropic).len() >= 3);
+        assert_eq!(provider_models(ModelProvider::Codex), [names::codex()]);
+        assert_eq!(provider_models(ModelProvider::Kimi), [names::kimi()]);
+    }
+
+    #[test]
+    fn pricing_and_cache_ratios_come_from_seed() {
+        let pricing = pricing_entries().collect::<Vec<_>>();
+        assert!(pricing.iter().any(|(id, _)| *id == names::haiku()));
+        assert!((cache_read_ratio() - 0.10).abs() < f64::EPSILON);
+        assert!((cache_write_ratio() - 1.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn menu_labels_derive_from_values() {
+        let options = model_menu_options();
+        assert!(
+            options
+                .iter()
+                .any(|option| option.value == crate::defaults::DEFAULT_MODEL)
+        );
+        for option in options {
+            assert!(
+                option.label.starts_with(option.value),
+                "label must derive from value: {option:?}"
+            );
+        }
+    }
+}

--- a/crates/koina/tests/model_default_consistency.rs
+++ b/crates/koina/tests/model_default_consistency.rs
@@ -28,8 +28,8 @@ fn workspace_root() -> PathBuf {
         .expect("workspace root resolves from CARGO_MANIFEST_DIR/../..")
 }
 
-/// Recursively collect every `.rs` file under `dir` into `out`.
-fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+/// Recursively collect source files under `dir` into `out`.
+fn collect_source_files(dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
@@ -41,11 +41,31 @@ fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
             if matches!(name, "target" | ".git" | "node_modules") {
                 continue;
             }
-            collect_rs_files(&path, out);
-        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+            collect_source_files(&path, out);
+        } else if matches!(
+            path.extension().and_then(|s| s.to_str()),
+            Some("rs" | "toml")
+        ) {
             out.push(path);
         }
     }
+}
+
+fn path_is_test_source(path: &Path) -> bool {
+    path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .is_some_and(|name| name.contains("tests") || name == "benches")
+    }) || path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name.contains("_tests")
+                || name.contains("tests")
+                || name.starts_with("test_")
+                || name == "test_fixtures.rs"
+        })
 }
 
 /// True iff `line` declares a `pub const DEFAULT_MODEL[_*]: &str = ...`.
@@ -80,6 +100,27 @@ fn declares_pub_default_model_str(line: &str) -> bool {
     after.trim_start().starts_with("&str")
 }
 
+fn allowed_claude_literal_path(root: &Path, path: &Path) -> bool {
+    let rel = path.strip_prefix(root).unwrap_or(path);
+    rel.starts_with("crates/koina")
+        || rel == Path::new("instance.example/versions/v0.19.0.toml")
+        || rel.starts_with("crates/hermeneus/src/anthropic/wire")
+}
+
+fn contains_claude_model_literal(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("//") || trimmed.starts_with("///") || trimmed.starts_with("//!") {
+        return false;
+    }
+    if line.contains("claude-code") || line.contains("claude-cli") {
+        return false;
+    }
+    if line.contains("starts_with(\"claude-\")") {
+        return false;
+    }
+    line.contains('"') && line.contains("claude-")
+}
+
 #[test]
 fn default_model_value_pinned_to_sonnet_4_6() {
     // WHY: the issue identified Sonnet 4.6 as the single shared default —
@@ -101,7 +142,7 @@ fn only_one_default_model_constant_in_workspace() {
     );
 
     let mut files = Vec::new();
-    collect_rs_files(&crates_dir, &mut files);
+    collect_source_files(&crates_dir, &mut files);
 
     let mut declarations: Vec<(PathBuf, usize, String)> = Vec::new();
     for path in &files {
@@ -153,6 +194,61 @@ fn only_one_default_model_constant_in_workspace() {
             .iter()
             .map(|(_, line, src)| format!("L{line}: {src}"))
             .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn claude_model_literals_stay_in_model_seed_or_wire_fixtures() {
+    let root = workspace_root();
+    let scan_roots = [
+        root.join("crates/koina"),
+        root.join("crates/hermeneus"),
+        root.join("crates/taxis"),
+        root.join("crates/nous"),
+        root.join("crates/episteme"),
+        root.join("crates/organon"),
+        root.join("crates/aletheia"),
+        root.join("crates/theatron/koilon"),
+        root.join("instance.example/versions"),
+    ];
+
+    let mut files = Vec::new();
+    for dir in scan_roots {
+        collect_source_files(&dir, &mut files);
+    }
+
+    let mut violations: Vec<(PathBuf, usize, String)> = Vec::new();
+    for path in files {
+        if path_is_test_source(&path) || allowed_claude_literal_path(&root, &path) {
+            continue;
+        }
+        let Ok(text) = fs::read_to_string(&path) else {
+            continue;
+        };
+        for (idx, line) in text.lines().enumerate() {
+            if line.trim_start().starts_with("#[cfg(test)]") {
+                break;
+            }
+            if contains_claude_model_literal(line) {
+                violations.push((path.clone(), idx + 1, line.trim().to_owned()));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "found hardcoded claude-* model literals outside the koina model seed/default home, \
+         v0.19.0 fixture, or wire fixtures:\n{}",
+        violations
+            .iter()
+            .map(|(p, line, src)| format!(
+                "  {}:{} — {}",
+                p.strip_prefix(&root).unwrap_or(p).display(),
+                line,
+                src
+            ))
+            .collect::<Vec<_>>()
+            .join("\n")
     );
 }
 

--- a/crates/nous/src/config.rs
+++ b/crates/nous/src/config.rs
@@ -86,7 +86,7 @@ impl Default for NousGenerationConfig {
     fn default() -> Self {
         use koina::defaults as d;
         Self {
-            model: "claude-opus-4-20250514".to_owned(),
+            model: koina::models::tier_default(koina::models::ModelTier::Opus).to_owned(),
             fallback_models: Vec::new(),
             retries_before_fallback: 2,
             context_window: d::CONTEXT_TOKENS,
@@ -365,7 +365,7 @@ fn default_chars_per_token() -> u32 {
 
 /// Default prosoche model: Haiku-tier for cheap heartbeat checks.
 fn default_prosoche_model() -> String {
-    "claude-haiku-4-5-20251001".to_owned()
+    koina::models::task_role_default(koina::models::TaskRole::Prosoche).to_owned()
 }
 
 fn default_max_tool_result_bytes() -> u32 {
@@ -627,7 +627,7 @@ mod tests {
             id: Arc::from("analyst"),
             name: Some("Analyst".to_owned()),
             generation: NousGenerationConfig {
-                model: "claude-haiku-4-5-20251001".to_owned(),
+                model: koina::models::tier_default(koina::models::ModelTier::Haiku).to_owned(),
                 fallback_models: Vec::new(),
                 retries_before_fallback: 2,
                 context_window: 100_000,
@@ -636,7 +636,8 @@ mod tests {
                 thinking_enabled: true,
                 thinking_budget: 5_000,
                 chars_per_token: 4,
-                prosoche_model: "claude-haiku-4-5-20251001".to_owned(),
+                prosoche_model: koina::models::task_role_default(koina::models::TaskRole::Prosoche)
+                    .to_owned(),
                 complexity: ComplexityConfig::default(),
                 extraction_model: None,
                 distillation_model: None,
@@ -677,7 +678,7 @@ mod tests {
         let config = NousConfig::default();
         assert_eq!(
             config.generation.prosoche_model,
-            "claude-haiku-4-5-20251001"
+            koina::models::task_role_default(koina::models::TaskRole::Prosoche)
         );
     }
 }

--- a/crates/nous/src/roles/mod.rs
+++ b/crates/nous/src/roles/mod.rs
@@ -134,10 +134,6 @@ pub struct RoleTemplate {
     pub model: &'static str,
 }
 
-const OPUS_MODEL: &str = "claude-opus-4-20250514";
-const SONNET_MODEL: &str = koina::defaults::DEFAULT_MODEL;
-const HAIKU_MODEL: &str = "claude-haiku-4-5-20251001";
-
 fn coder_template() -> RoleTemplate {
     RoleTemplate {
         role: Role::Coder,
@@ -160,7 +156,7 @@ fn coder_template() -> RoleTemplate {
             organon::types::ToolGroupId::Command,
             organon::types::ToolGroupId::Verify,
         ]),
-        model: SONNET_MODEL,
+        model: koina::models::task_role_default(koina::models::TaskRole::Coder),
     }
 }
 
@@ -183,7 +179,7 @@ fn researcher_template() -> RoleTemplate {
             organon::types::ToolGroupId::Mcp,
             organon::types::ToolGroupId::Plan,
         ]),
-        model: SONNET_MODEL,
+        model: koina::models::task_role_default(koina::models::TaskRole::Researcher),
     }
 }
 
@@ -204,7 +200,7 @@ fn reviewer_template() -> RoleTemplate {
             organon::types::ToolGroupId::Verify,
             organon::types::ToolGroupId::Mcp,
         ]),
-        model: OPUS_MODEL,
+        model: koina::models::task_role_default(koina::models::TaskRole::Reviewer),
     }
 }
 
@@ -223,7 +219,7 @@ fn explorer_template() -> RoleTemplate {
             organon::types::ToolGroupId::Read,
             organon::types::ToolGroupId::Plan,
         ]),
-        model: HAIKU_MODEL,
+        model: koina::models::task_role_default(koina::models::TaskRole::Explorer),
     }
 }
 
@@ -244,7 +240,7 @@ fn runner_template() -> RoleTemplate {
             organon::types::ToolGroupId::Command,
             organon::types::ToolGroupId::Verify,
         ]),
-        model: HAIKU_MODEL,
+        model: koina::models::task_role_default(koina::models::TaskRole::Runner),
     }
 }
 
@@ -563,11 +559,26 @@ mod tests {
 
     #[test]
     fn model_preferences() {
-        assert_eq!(Role::Coder.template().model, SONNET_MODEL);
-        assert_eq!(Role::Researcher.template().model, SONNET_MODEL);
-        assert_eq!(Role::Reviewer.template().model, OPUS_MODEL);
-        assert_eq!(Role::Explorer.template().model, HAIKU_MODEL);
-        assert_eq!(Role::Runner.template().model, HAIKU_MODEL);
+        assert_eq!(
+            Role::Coder.template().model,
+            koina::models::task_role_default(koina::models::TaskRole::Coder)
+        );
+        assert_eq!(
+            Role::Researcher.template().model,
+            koina::models::task_role_default(koina::models::TaskRole::Researcher)
+        );
+        assert_eq!(
+            Role::Reviewer.template().model,
+            koina::models::task_role_default(koina::models::TaskRole::Reviewer)
+        );
+        assert_eq!(
+            Role::Explorer.template().model,
+            koina::models::task_role_default(koina::models::TaskRole::Explorer)
+        );
+        assert_eq!(
+            Role::Runner.template().model,
+            koina::models::task_role_default(koina::models::TaskRole::Runner)
+        );
     }
 
     #[test]

--- a/crates/nous/src/spawn_svc.rs
+++ b/crates/nous/src/spawn_svc.rs
@@ -196,7 +196,8 @@ impl SpawnService for SpawnServiceImpl {
                 thinking_enabled: false,
                 thinking_budget: 0,
                 chars_per_token: 4,
-                prosoche_model: "claude-haiku-4-5-20251001".to_owned(),
+                prosoche_model: koina::models::task_role_default(koina::models::TaskRole::Prosoche)
+                    .to_owned(),
                 complexity: hermeneus::complexity::ComplexityConfig::default(),
                 extraction_model: None,
                 distillation_model: None,
@@ -380,11 +381,14 @@ mod tests {
     // `koina::defaults::DEFAULT_MODEL`. The mock provider's supported-models
     // list must include the workspace default so `spawn_and_run` can route
     // Coder tasks.
-    const SUPPORTED_MOCK_MODELS: &[&str] = &[
-        koina::defaults::DEFAULT_MODEL,
-        "claude-sonnet-4-20250514",
-        "claude-haiku-4-5-20251001",
-    ];
+    static SUPPORTED_MOCK_MODELS: std::sync::LazyLock<Box<[&'static str]>> =
+        std::sync::LazyLock::new(|| {
+            Box::new([
+                koina::defaults::DEFAULT_MODEL,
+                koina::models::tier_default(koina::models::ModelTier::Opus),
+                koina::models::tier_default(koina::models::ModelTier::Haiku),
+            ])
+        });
 
     fn make_providers() -> Arc<ProviderRegistry> {
         let response = CompletionResponse {
@@ -405,7 +409,7 @@ mod tests {
         };
         let mut providers = ProviderRegistry::new();
         providers.register(Box::new(
-            MockProvider::with_responses(vec![response]).models(SUPPORTED_MOCK_MODELS),
+            MockProvider::with_responses(vec![response]).models(&SUPPORTED_MOCK_MODELS),
         ));
         Arc::new(providers)
     }
@@ -533,16 +537,23 @@ mod tests {
         // WHY (#4235): Coder/Researcher templates inherit from `SONNET_MODEL
         // = koina::defaults::DEFAULT_MODEL`. Assert against the constant so
         // template/model drift is caught at the call site, not in production.
-        // Reviewer/Explorer/Runner pin specific dated IDs locally
-        // (Opus 4.0 / Haiku 4.5); those remain literal here.
         assert_eq!(Role::Coder.template().model, koina::defaults::DEFAULT_MODEL);
-        assert_eq!(Role::Reviewer.template().model, "claude-opus-4-20250514");
+        assert_eq!(
+            Role::Reviewer.template().model,
+            koina::models::task_role_default(koina::models::TaskRole::Reviewer)
+        );
         assert_eq!(
             Role::Researcher.template().model,
             koina::defaults::DEFAULT_MODEL
         );
-        assert_eq!(Role::Explorer.template().model, "claude-haiku-4-5-20251001");
-        assert_eq!(Role::Runner.template().model, "claude-haiku-4-5-20251001");
+        assert_eq!(
+            Role::Explorer.template().model,
+            koina::models::task_role_default(koina::models::TaskRole::Explorer)
+        );
+        assert_eq!(
+            Role::Runner.template().model,
+            koina::models::task_role_default(koina::models::TaskRole::Runner)
+        );
         assert!(resolve_role("unknown").is_none());
     }
 
@@ -604,7 +615,7 @@ mod tests {
         }
 
         fn supported_models(&self) -> &[&str] {
-            SUPPORTED_MOCK_MODELS
+            &SUPPORTED_MOCK_MODELS
         }
 
         #[expect(clippy::unnecessary_literal_bound, reason = "trait requires &str")]

--- a/crates/organon/src/builtins/triage/prompt_gen.rs
+++ b/crates/organon/src/builtins/triage/prompt_gen.rs
@@ -27,7 +27,8 @@ pub(crate) fn generate_prompt(issue: &GitHubIssue, repo: &str) -> String {
 
     let mut prompt = String::new();
 
-    prompt.push_str("---\nmodel: claude-opus-4-6\n---\n\n");
+    let model = koina::models::task_role_default(koina::models::TaskRole::TriagePrompt);
+    let _ = writeln!(prompt, "---\nmodel: {model}\n---\n");
 
     let _ = writeln!(prompt, "# {number}: {}\n", issue.title);
 

--- a/crates/taxis/src/config/agents.rs
+++ b/crates/taxis/src/config/agents.rs
@@ -272,7 +272,8 @@ impl Default for AgentModelDefaults {
             thinking_enabled: false,
             thinking_budget: 10_000,
             chars_per_token: d::CHARS_PER_TOKEN,
-            prosoche_model: "claude-haiku-4-5-20251001".to_owned(),
+            prosoche_model: koina::models::task_role_default(koina::models::TaskRole::Prosoche)
+                .to_owned(),
             max_tool_result_bytes: d::MAX_TOOL_RESULT_BYTES,
         }
     }

--- a/crates/theatron/koilon/src/wizard/state.rs
+++ b/crates/theatron/koilon/src/wizard/state.rs
@@ -1,6 +1,7 @@
 //! Wizard state: step definitions, field types, and collected answers.
 
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use koina::secret::SecretString;
 use koina::system::{Environment, RealSystem};
@@ -284,20 +285,20 @@ pub(crate) static AUTH_OPTIONS: &[SelectOption] = &[
     },
 ];
 
-pub(crate) static MODEL_OPTIONS: &[SelectOption] = &[
-    SelectOption {
-        value: koina::defaults::DEFAULT_MODEL,
-        label: "claude-sonnet-4-6 (recommended)",
-    },
-    SelectOption {
-        value: "claude-opus-4-6",
-        label: "claude-opus-4-6",
-    },
-    SelectOption {
-        value: "claude-haiku-4-5",
-        label: "claude-haiku-4-5",
-    },
-];
+static MODEL_OPTIONS: LazyLock<Box<[SelectOption]>> = LazyLock::new(|| {
+    koina::models::model_menu_options()
+        .iter()
+        .map(|option| SelectOption {
+            value: option.value,
+            label: option.label,
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+});
+
+fn model_options() -> &'static [SelectOption] {
+    &MODEL_OPTIONS
+}
 
 // ─── Step factories ──────────────────────────────────────────────────────────
 
@@ -383,7 +384,7 @@ fn make_agent_step() -> StepState {
                 "pronoea",
                 "alphanumeric + hyphens, used in paths",
             ),
-            WizardField::select("Model", MODEL_OPTIONS, koina::defaults::DEFAULT_MODEL, ""),
+            WizardField::select("Model", model_options(), koina::defaults::DEFAULT_MODEL, ""),
         ],
         cursor: 0,
         editing: None,


### PR DESCRIPTION
Model-identity migration steps 2–3 (design: operator-reviewed model-identity-design; step 1 was #4508).

- **Step 2**: `koina::models` tier table + `crates/koina/data/model-seed.toml` (pricing + as_of, cache ratios, per-family context windows — 92-line dated data file, the ONE compiled home); all eight bypass sites rewired (taxis prosoche, nous config + spawn, episteme extract, hermeneus names, organon triage/complexity, init + koilon wizard menus derive labels from values); `model_default_consistency` test now scans non-test code for `claude-*` literals with an explicit allowlist.
- **Step 3**: `SUPPORTED_MODELS` and the cc/provider duplicate deleted; `AnthropicProvider::match_specificity` → Exact iff in operator-config models, else CatchAll for `claude-*`; codex literals collapsed to one const; kimi catalog entry normalized; tests pivoted to precedence-behavior asserts. Future model IDs route with zero code edits.

Deliberately hardcoded (per design): routing namespace prefixes, the `claude-` CatchAll prefix, the koina seed itself, existing wire fixtures.

Worker-gated CI-exact on verda before push.