### PR TITLE
fix(nous): unify approval-aware tool dispatch — fallback path can no longer bypass gating

### DIFF
--- a/_llm/L3-api-index/nous.md
+++ b/_llm/L3-api-index/nous.md
@@ -1905,6 +1905,20 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 ## `src/execute/mod.rs`
 
+> Execute stage: calls the LLM and iterates on tool use.
+> 
+> This is the core agent loop. It:
+> 1. Builds a `CompletionRequest` from pipeline context
+> 2. Calls the LLM
+> 3. Processes `tool_use` blocks by dispatching to the `ToolRegistry`
+> 4. Feeds tool results back and re-calls the LLM
+> 5. Repeats until `EndTurn`, `MaxTokens`, or iteration limit
+> 
+> # Cancel safety
+> 
+> Not cancel-safe. If cancelled mid-loop, tool calls may have been
+> dispatched but their results not processed, leaving the session
+> in an inconsistent state. Do not use in `select!` branches.
 ```rust
 pub async fn execute (
     ctx: &PipelineContext,

--- a/_llm/manifest.toml
+++ b/_llm/manifest.toml
@@ -5,7 +5,7 @@
 # preserves them verbatim across regeneration. See _llm/README.md.
 
 version = 1
-generated_at = "2026-06-12T14:52:05Z"
+generated_at = "2026-06-08T17:46:24Z"
 
 [levels.L3]
 path = "L3-api-index"
@@ -146,8 +146,8 @@ l3_token_estimate = 51
 [[crates]]
 name = "nous"
 path = "crates/nous"
-source_hash = "b234bac54eaf4eeda86a75fbbfe10b321f72d23ca41f7d96fff833ee707cb985"
-l3_token_estimate = 34474
+source_hash = "bafd54182bb7ae6b9d995d3011001e561cbeac157b1441131101b1f01c5b77ea"
+l3_token_estimate = 34616
 
 [[crates]]
 name = "oikonomos"

--- a/crates/nous/src/actor/tests/mod.rs
+++ b/crates/nous/src/actor/tests/mod.rs
@@ -198,8 +198,38 @@ async fn run_tool_with_limits(
         None,
     );
 
-    let result = handle.send_turn("main", "run tool").await.expect("turn");
+    // WHY: the unified dispatcher fail-closes mandatory-approval tools on
+    // gateless turns, so limit tests stream with an auto-approving gate —
+    // the limits themselves are what's under test.
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
+    let (decision_tx, decision_rx) = tokio::sync::mpsc::channel(8);
+    let gate = crate::approval::ApprovalGate::new(decision_rx, std::time::Duration::from_secs(10));
+    let approver = tokio::spawn(async move {
+        while let Some(event) = event_rx.recv().await {
+            if let crate::stream::TurnStreamEvent::ToolApprovalRequired { tool_id, .. } = event {
+                let _ = decision_tx
+                    .send(crate::approval::ApprovalDecision {
+                        tool_id,
+                        choice: crate::approval::ApprovalChoice::Approved,
+                    })
+                    .await;
+            }
+        }
+    });
+    let result = handle
+        .send_turn_streaming_with_approval(
+            "main",
+            None,
+            "run tool",
+            event_tx,
+            Some(gate),
+            std::time::Duration::from_secs(30),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("turn");
     handle.shutdown().await.expect("shutdown");
+    approver.abort();
     join.await.expect("actor join");
     drop(dir);
     result
@@ -334,8 +364,38 @@ async fn reload_config_updates_tool_limits_for_existing_actor() {
         .await
         .expect("reload");
 
-    let result = handle.send_turn("main", "run tool").await.expect("turn");
+    // WHY: the unified dispatcher fail-closes mandatory-approval tools on
+    // gateless turns, so limit tests stream with an auto-approving gate —
+    // the limits themselves are what's under test.
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
+    let (decision_tx, decision_rx) = tokio::sync::mpsc::channel(8);
+    let gate = crate::approval::ApprovalGate::new(decision_rx, std::time::Duration::from_secs(10));
+    let approver = tokio::spawn(async move {
+        while let Some(event) = event_rx.recv().await {
+            if let crate::stream::TurnStreamEvent::ToolApprovalRequired { tool_id, .. } = event {
+                let _ = decision_tx
+                    .send(crate::approval::ApprovalDecision {
+                        tool_id,
+                        choice: crate::approval::ApprovalChoice::Approved,
+                    })
+                    .await;
+            }
+        }
+    });
+    let result = handle
+        .send_turn_streaming_with_approval(
+            "main",
+            None,
+            "run tool",
+            event_tx,
+            Some(gate),
+            std::time::Duration::from_secs(30),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("turn");
     handle.shutdown().await.expect("shutdown");
+    approver.abort();
     join.await.expect("actor join");
     drop(dir);
 

--- a/crates/nous/src/approval.rs
+++ b/crates/nous/src/approval.rs
@@ -1,6 +1,6 @@
 //! User approval gate for reversibility-class tool calls (#3958, ADR-005).
 //!
-//! The gate blocks `dispatch_tools_streaming` between `ToolApprovalRequired`
+//! The gate blocks shared tool dispatch between `ToolApprovalRequired`
 //! emission and `ToolStart` until the operator answers, or the timeout
 //! elapses (default-deny). The decision arrives over a `mpsc::Receiver`
 //! whose sender lives in the caller (e.g. pylon's per-session registry,

--- a/crates/nous/src/execute/dispatch.rs
+++ b/crates/nous/src/execute/dispatch.rs
@@ -64,13 +64,16 @@ fn record_stream_send_error<T>(
 }
 
 fn emit_approval_required(
-    stream_tx: &mpsc::Sender<TurnStreamEvent>,
+    stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
     tool_ctx: &ToolContext,
     tool_id: &str,
     tool_name: &str,
     tool_input: &serde_json::Value,
     approval: ApprovalRequirement,
 ) {
+    let Some(stream_tx) = stream_tx else {
+        return;
+    };
     if let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolApprovalRequired {
         turn_id: tool_ctx.turn_number.to_string(),
         tool_id: tool_id.to_owned(),
@@ -84,12 +87,15 @@ fn emit_approval_required(
 }
 
 fn emit_approval_resolved(
-    stream_tx: &mpsc::Sender<TurnStreamEvent>,
+    stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
     tool_ctx: &ToolContext,
     tool_id: &str,
     tool_name: &str,
     decision: &str,
 ) {
+    let Some(stream_tx) = stream_tx else {
+        return;
+    };
     if let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolApprovalResolved {
         tool_id: tool_id.to_owned(),
         decision: decision.to_owned(),
@@ -104,7 +110,7 @@ fn emit_approval_resolved(
 fn record_denied_call(
     all_tool_calls: &mut Vec<ToolCall>,
     tool_results: &mut Vec<ContentBlock>,
-    stream_tx: &mpsc::Sender<TurnStreamEvent>,
+    stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
     tool_ctx: &ToolContext,
     tool_id: &str,
     tool_name: &str,
@@ -125,14 +131,56 @@ fn record_denied_call(
         content: ToolResultContent::Text(denial.clone()),
         is_error: Some(true),
     });
-    if let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolResult {
-        tool_id: tool_id.to_owned(),
-        tool_name: tool_name.to_owned(),
-        result: denial,
-        is_error: true,
-        duration_ms: 0,
-    }) {
+    if let Some(stream_tx) = stream_tx
+        && let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolResult {
+            tool_id: tool_id.to_owned(),
+            tool_name: tool_name.to_owned(),
+            result: denial,
+            is_error: true,
+            duration_ms: 0,
+        })
+    {
         record_stream_send_error(tool_ctx, tool_name, "denied_tool_result", &e);
+    }
+}
+
+fn emit_tool_start(
+    stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
+    tool_ctx: &ToolContext,
+    tool_id: &str,
+    tool_name: &str,
+    tool_input: &serde_json::Value,
+) {
+    if let Some(stream_tx) = stream_tx
+        && let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolStart {
+            tool_id: tool_id.to_owned(),
+            tool_name: tool_name.to_owned(),
+            input: tool_input.clone(),
+        })
+    {
+        record_stream_send_error(tool_ctx, tool_name, "tool_start", &e);
+    }
+}
+
+fn emit_tool_result(
+    stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
+    tool_ctx: &ToolContext,
+    tool_id: &str,
+    tool_name: &str,
+    result: String,
+    is_error: bool,
+    duration_ms: u64,
+) {
+    if let Some(stream_tx) = stream_tx
+        && let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolResult {
+            tool_id: tool_id.to_owned(),
+            tool_name: tool_name.to_owned(),
+            result,
+            is_error,
+            duration_ms,
+        })
+    {
+        record_stream_send_error(tool_ctx, tool_name, "tool_result", &e);
     }
 }
 
@@ -368,6 +416,7 @@ struct SingleToolOutcome {
 async fn dispatch_single_tool(
     tool_id: &str,
     tool_name: &str,
+    tool_name_id: ToolName,
     tool_input: &serde_json::Value,
     tools: &ToolRegistry,
     tool_ctx: &ToolContext,
@@ -375,14 +424,6 @@ async fn dispatch_single_tool(
     receipt_signer: Option<&organon::receipts::ReceiptSigner>,
     receipt_ledger: Option<&std::sync::Mutex<organon::receipts::ReceiptLedger>>,
 ) -> error::Result<SingleToolOutcome> {
-    let tool_name_id = ToolName::new(tool_name).map_err(|_err| {
-        error::PipelineStageSnafu {
-            stage: "execute",
-            message: format!("invalid tool name: {tool_name}"),
-        }
-        .build()
-    })?;
-
     // WHY(#3569): substitute secrets at the LAST moment before tool
     // execution. The original `tool_input` (with placeholders) is preserved
     // for persistence in the `ToolCall`; only the executor sees resolved
@@ -531,6 +572,10 @@ async fn dispatch_single_tool(
     clippy::too_many_arguments,
     reason = "dispatch needs tool uses, registry, context, detector, calls, iterations, limits, and receipt infra"
 )]
+#[expect(
+    clippy::too_many_lines,
+    reason = "single approval-aware dispatch loop owns the full per-tool lifecycle"
+)]
 pub(super) async fn dispatch_tools(
     tool_uses: &[(String, String, serde_json::Value)],
     tools: &ToolRegistry,
@@ -538,70 +583,7 @@ pub(super) async fn dispatch_tools(
     loop_detector: &mut LoopDetector,
     all_tool_calls: &mut Vec<ToolCall>,
     iterations: u32,
-    max_tool_result_bytes: u32,
-    receipt_signer: Option<&organon::receipts::ReceiptSigner>,
-    receipt_ledger: Option<&std::sync::Mutex<organon::receipts::ReceiptLedger>>,
-) -> error::Result<DispatchResult> {
-    let mut tool_results: Vec<ContentBlock> = Vec::new();
-
-    for (tool_id, tool_name, tool_input) in tool_uses {
-        let outcome = dispatch_single_tool(
-            tool_id,
-            tool_name,
-            tool_input,
-            tools,
-            tool_ctx,
-            max_tool_result_bytes,
-            receipt_signer,
-            receipt_ledger,
-        )
-        .await?;
-
-        all_tool_calls.push(outcome.call);
-        tool_results.push(outcome.result_block);
-
-        let input_hash = simple_hash(tool_input);
-        match loop_detector.record(tool_name, &input_hash, outcome.is_error) {
-            LoopVerdict::Ok => {}
-            LoopVerdict::Warn { message, .. } => {
-                return Ok(DispatchResult {
-                    blocks: tool_results,
-                    loop_warning: Some(message),
-                });
-            }
-            LoopVerdict::Halt { pattern, .. } => {
-                return Err(error::LoopDetectedSnafu {
-                    iterations,
-                    pattern,
-                }
-                .build());
-            }
-        }
-    }
-
-    Ok(DispatchResult {
-        blocks: tool_results,
-        loop_warning: None,
-    })
-}
-
-/// Dispatch tool calls with streaming events emitted to the channel.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "streaming dispatch inherently needs context, detector, channel, and limit"
-)]
-#[expect(
-    clippy::too_many_lines,
-    reason = "streaming dispatch: sequential tool execution with error handling and event logging; splitting would scatter the per-tool lifecycle"
-)]
-pub(super) async fn dispatch_tools_streaming(
-    tool_uses: &[(String, String, serde_json::Value)],
-    tools: &ToolRegistry,
-    tool_ctx: &ToolContext,
-    loop_detector: &mut LoopDetector,
-    all_tool_calls: &mut Vec<ToolCall>,
-    iterations: u32,
-    stream_tx: &mpsc::Sender<TurnStreamEvent>,
+    stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
     approval_gate: Option<&ApprovalGate>,
     max_tool_result_bytes: u32,
     receipt_signer: Option<&organon::receipts::ReceiptSigner>,
@@ -618,38 +600,12 @@ pub(super) async fn dispatch_tools_streaming(
             .build()
         })?;
 
-        // WHY(#3569): substitute secrets at the LAST moment before tool
-        // execution. The original `tool_input` (with placeholders) is preserved
-        // for persistence in `all_tool_calls`; only the executor sees resolved
-        // values.
-        let mut substituted_args = tool_input.clone();
-        if let Some(services) = &tool_ctx.services
-            && let Err(e) = substitute_in_json(&mut substituted_args, &services.secret_vault)
-        {
-            all_tool_calls.push(ToolCall {
-                id: tool_id.clone(),
-                name: tool_name.clone(),
-                input: tool_input.clone(),
-                result: Some(format!("Tool error: {e}")),
-                is_error: true,
-                duration_ms: 0,
-                receipt: None,
-            });
-            tool_results.push(ContentBlock::ToolResult {
-                tool_use_id: tool_id.clone(),
-                content: ToolResultContent::text(format!("Tool error: {e}")),
-                is_error: Some(true),
-            });
-            crate::metrics::record_tool_failure(tool_ctx.nous_id.as_ref(), tool_name);
-            continue;
-        }
-
         let approval = tools
             .approval_requirement(&tool_name_id)
             .unwrap_or(ApprovalRequirement::Mandatory);
 
-        // WHY(#3958, ADR-005): gate execution on operator approval. None/Advisory
-        // auto-resolve; Required/Mandatory block on the approval gate.
+        // WHY(#3958, ADR-005): one decision boundary protects streaming,
+        // fallback, and batch dispatch. Unknown future requirements block.
         match approval {
             ApprovalRequirement::None => {
                 emit_approval_resolved(stream_tx, tool_ctx, tool_id, tool_name, "auto_approved");
@@ -657,19 +613,10 @@ pub(super) async fn dispatch_tools_streaming(
             ApprovalRequirement::Advisory => {
                 emit_approval_resolved(stream_tx, tool_ctx, tool_id, tool_name, "advisory_auto");
             }
-            // WHY: ApprovalRequirement is #[non_exhaustive]; the Mandatory arm here
-            // also catches any future variant defined upstream, treating unknown
-            // requirements as "block" rather than silently auto-approving — the
-            // safer default given the design intent of this enum.
             ApprovalRequirement::Required | ApprovalRequirement::Mandatory | _ => {
                 emit_approval_required(
                     stream_tx, tool_ctx, tool_id, tool_name, tool_input, approval,
                 );
-                // ADR-005 step 4: await operator decision.
-                // No gate wired:
-                //   - Mandatory → deny (silent execution is the bug we are fixing).
-                //   - Required  → approve (lenient for batch/test contexts where the
-                //     call is partially-reversible by reversibility metadata).
                 let choice = match approval_gate {
                     Some(gate) => gate.await_decision(tool_id).await,
                     None => match approval {
@@ -677,7 +624,7 @@ pub(super) async fn dispatch_tools_streaming(
                             warn!(
                                 tool = tool_name.as_str(),
                                 tool_id = tool_id.as_str(),
-                                "mandatory tool call with no approval gate wired — default-deny"
+                                "mandatory tool call with no approval gate wired - default-deny"
                             );
                             ApprovalChoice::Denied
                         }
@@ -706,169 +653,39 @@ pub(super) async fn dispatch_tools_streaming(
             }
         }
 
-        // WHY: distinguish buffer-full (performance problem, warn) from receiver-
-        // disconnected (expected client close, debug). Silent drops violate the
-        // streaming observability contract. (#3285)
-        if let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolStart {
-            tool_id: tool_id.clone(),
-            tool_name: tool_name.clone(),
-            input: tool_input.clone(),
-        }) {
-            match e {
-                tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                    warn!(
-                        tool = tool_name.as_str(),
-                        "streaming event dropped: channel buffer full — client cannot keep up"
-                    );
-                    crate::metrics::record_stream_event_dropped(
-                        tool_ctx.nous_id.as_ref(),
-                        "buffer_full",
-                    );
-                }
-                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
-                    debug!(
-                        tool = tool_name.as_str(),
-                        "streaming event dropped: receiver disconnected"
-                    );
-                    crate::metrics::record_stream_event_dropped(
-                        tool_ctx.nous_id.as_ref(),
-                        "disconnected",
-                    );
-                }
-            }
-        }
+        emit_tool_start(stream_tx, tool_ctx, tool_id, tool_name, tool_input);
 
-        let start = std::time::Instant::now();
-        let result = tools
-            .execute(
-                &ToolInput {
-                    name: tool_name_id,
-                    tool_use_id: tool_id.clone(),
-                    arguments: substituted_args,
-                },
+        let outcome = dispatch_single_tool(
+            tool_id,
+            tool_name,
+            tool_name_id,
+            tool_input,
+            tools,
+            tool_ctx,
+            max_tool_result_bytes,
+            receipt_signer,
+            receipt_ledger,
+        )
+        .await?;
+
+        all_tool_calls.push(outcome.call);
+        if let Some(call) = all_tool_calls.last()
+            && let Some(result) = call.result.clone()
+        {
+            emit_tool_result(
+                stream_tx,
                 tool_ctx,
-            )
-            .await;
-
-        #[expect(
-            clippy::cast_possible_truncation,
-            clippy::as_conversions,
-            reason = "u128→u64: tool execution duration won't exceed u64::MAX milliseconds"
-        )]
-        let duration_ms = start.elapsed().as_millis() as u64; // kanon:ignore RUST/as-cast
-
-        let (content, is_error) = match result {
-            Ok(mut r) => {
-                if let Some(ref mut d) = r.diagnostics {
-                    d.duration_ms = duration_ms;
-                    let diag_text = d.to_llm_text();
-                    r.content = inject_diagnostics(r.content, &diag_text);
-                }
-                (r.content, r.is_error)
-            }
-            Err(e) => (ToolResultContent::text(format!("Tool error: {e}")), true),
-        };
-
-        let content = truncate_tool_result(content, max_tool_result_bytes);
-
-        let (content, receipt) = if let Some(signer) = receipt_signer {
-            let ts = jiff::Timestamp::now();
-            let result_text = content.text_summary();
-            let receipt_str = signer.sign(tool_name, &tool_input.to_string(), &result_text, ts);
-            if let Some(ledger) = receipt_ledger {
-                let mut guard = ledger.lock().unwrap_or_else(|poisoned| {
-                    tracing::warn!("receipt_ledger lock poisoned, recovering with last value");
-                    poisoned.into_inner()
-                });
-                guard.record(
-                    receipt_str.clone(),
-                    tool_name.to_owned(),
-                    tool_input.to_string(),
-                    result_text.clone(),
-                    ts,
-                );
-            }
-            let tagged = match content {
-                ToolResultContent::Text(text) => {
-                    ToolResultContent::Text(format!("{text}\n\n[receipt:{receipt_str}]"))
-                }
-                ToolResultContent::Blocks(mut blocks) => {
-                    blocks.push(ToolResultBlock::Text {
-                        text: format!("\n\n[receipt:{receipt_str}]"),
-                    });
-                    ToolResultContent::Blocks(blocks)
-                }
-                // WHY: ToolResultContent is #[non_exhaustive]; forward-compatibility arm.
-                other => other,
-            };
-            (tagged, Some(receipt_str))
-        } else {
-            (content, None)
-        };
-
-        let result_summary = content.text_summary();
-
-        if is_error {
-            warn!(
-                tool = tool_name.as_str(),
-                tool_id = tool_id.as_str(),
-                duration_ms,
-                "tool execution failed"
+                &call.id,
+                &call.name,
+                result,
+                call.is_error,
+                call.duration_ms,
             );
-            crate::metrics::record_tool_failure(tool_ctx.nous_id.as_ref(), tool_name);
-        } else {
-            debug!(tool = tool_name.as_str(), duration_ms, "tool executed");
         }
-
-        if let Err(e) = stream_tx.try_send(TurnStreamEvent::ToolResult {
-            tool_id: tool_id.clone(),
-            tool_name: tool_name.clone(),
-            result: result_summary.clone(),
-            is_error,
-            duration_ms,
-        }) {
-            match e {
-                tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                    warn!(
-                        tool = tool_name.as_str(),
-                        "streaming result dropped: channel buffer full — client cannot keep up"
-                    );
-                    crate::metrics::record_stream_event_dropped(
-                        tool_ctx.nous_id.as_ref(),
-                        "buffer_full",
-                    );
-                }
-                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
-                    debug!(
-                        tool = tool_name.as_str(),
-                        "streaming result dropped: receiver disconnected"
-                    );
-                    crate::metrics::record_stream_event_dropped(
-                        tool_ctx.nous_id.as_ref(),
-                        "disconnected",
-                    );
-                }
-            }
-        }
-
-        all_tool_calls.push(ToolCall {
-            id: tool_id.clone(),
-            name: tool_name.clone(),
-            input: tool_input.clone(),
-            result: Some(result_summary),
-            is_error,
-            duration_ms,
-            receipt,
-        });
-
-        tool_results.push(ContentBlock::ToolResult {
-            tool_use_id: tool_id.clone(),
-            content,
-            is_error: Some(is_error),
-        });
+        tool_results.push(outcome.result_block);
 
         let input_hash = simple_hash(tool_input);
-        match loop_detector.record(tool_name, &input_hash, is_error) {
+        match loop_detector.record(tool_name, &input_hash, outcome.is_error) {
             LoopVerdict::Ok => {}
             LoopVerdict::Warn { message, .. } => {
                 return Ok(DispatchResult {

--- a/crates/nous/src/execute/mod.rs
+++ b/crates/nous/src/execute/mod.rs
@@ -25,9 +25,7 @@ use koina::id::ToolName;
 use organon::registry::ToolRegistry;
 use organon::types::ToolContext;
 
-use self::dispatch::{
-    DispatchResult, build_messages, classify_signals, dispatch_tools, dispatch_tools_streaming,
-};
+use self::dispatch::{DispatchResult, build_messages, classify_signals, dispatch_tools};
 use self::resolve::{
     process_response_blocks, resolve_active_server_tools, resolve_provider_checked,
     resolve_turn_model,
@@ -55,11 +53,6 @@ use crate::stream::TurnStreamEvent;
 /// Not cancel-safe. If cancelled mid-loop, tool calls may have been
 /// dispatched but their results not processed, leaving the session
 /// in an inconsistent state. Do not use in `select!` branches.
-#[expect(
-    clippy::too_many_lines,
-    reason = "execution loop is inherently sequential, splitting would obscure control flow"
-)]
-#[instrument(skip_all, fields(nous_id = %session.nous_id, session_id = %session.id))]
 pub async fn execute(
     ctx: &PipelineContext,
     session: &SessionState,
@@ -67,6 +60,32 @@ pub async fn execute(
     providers: &ProviderRegistry,
     tools: &ToolRegistry,
     tool_ctx: &ToolContext,
+    hooks: Option<&HookRegistry>,
+) -> error::Result<TurnResult> {
+    execute_with_dispatch(
+        ctx, session, config, providers, tools, tool_ctx, None, None, hooks,
+    )
+    .await
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "execution loop is inherently sequential, splitting would obscure control flow"
+)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "shared execute core accepts optional streaming and approval adapters"
+)]
+#[instrument(skip_all, fields(nous_id = %session.nous_id, session_id = %session.id))]
+async fn execute_with_dispatch(
+    ctx: &PipelineContext,
+    session: &SessionState,
+    config: &NousConfig,
+    providers: &ProviderRegistry,
+    tools: &ToolRegistry,
+    tool_ctx: &ToolContext,
+    stream_tx: Option<&mpsc::Sender<TurnStreamEvent>>,
+    approval_gate: Option<&ApprovalGate>,
     hooks: Option<&HookRegistry>,
 ) -> error::Result<TurnResult> {
     // WHY: resolve the turn model once — complexity routing pins a tier for
@@ -347,6 +366,8 @@ pub async fn execute(
             &mut loop_detector,
             &mut all_tool_calls,
             iterations,
+            stream_tx,
+            approval_gate,
             config.limits.max_tool_result_bytes,
             Some(&session.receipt_signer),
             Some(&*session.receipt_ledger),
@@ -473,8 +494,18 @@ pub async fn execute_streaming(
     let turn_model = resolve_turn_model(ctx, config, providers, tool_count);
 
     let Some(streaming_provider) = providers.find_streaming_provider(&turn_model) else {
-        // NOTE: fall back to non-streaming execute if no streaming provider is registered
-        return execute(ctx, session, config, providers, tools, tool_ctx, hooks).await;
+        return execute_with_dispatch(
+            ctx,
+            session,
+            config,
+            providers,
+            tools,
+            tool_ctx,
+            Some(stream_tx),
+            approval_gate,
+            hooks,
+        )
+        .await;
     };
 
     let provider = resolve_provider_checked(providers, &turn_model)?;
@@ -701,14 +732,14 @@ pub async fn execute_streaming(
         let DispatchResult {
             mut blocks,
             loop_warning,
-        } = dispatch_tools_streaming(
+        } = dispatch_tools(
             &effective_tool_uses,
             tools,
             tool_ctx,
             &mut loop_detector,
             &mut all_tool_calls,
             iterations,
-            stream_tx,
+            Some(stream_tx),
             approval_gate,
             config.limits.max_tool_result_bytes,
             Some(&session.receipt_signer),

--- a/crates/nous/src/execute/tests/approval.rs
+++ b/crates/nous/src/execute/tests/approval.rs
@@ -1,9 +1,4 @@
-//! Approval-guard integration tests for `dispatch_tools_streaming` (#3958, ADR-005).
-//!
-//! These exercise the gate at the dispatch layer directly because the streaming
-//! `execute_streaming` entry point requires a streaming-capable provider, which
-//! the workspace's `MockProvider` doesn't supply. The gate logic itself lives in
-//! `dispatch_tools_streaming` and is the unit under test.
+//! Approval-guard integration tests for shared tool dispatch (#3958, ADR-005).
 #![expect(
     clippy::indexing_slicing,
     reason = "test: indices valid after asserting `len`"
@@ -18,7 +13,7 @@ use tokio::sync::mpsc;
 
 use super::*;
 use crate::approval::{ApprovalChoice, ApprovalDecision, ApprovalGate};
-use crate::execute::dispatch::dispatch_tools_streaming;
+use crate::execute::dispatch::dispatch_tools;
 use crate::pipeline::LoopDetector;
 use crate::stream::TurnStreamEvent;
 
@@ -96,14 +91,14 @@ async fn reversibility_class_call_blocks_until_approved() {
     let mut loop_detector = LoopDetector::new(3);
     let mut all_calls = Vec::new();
 
-    let result = dispatch_tools_streaming(
+    let result = dispatch_tools(
         &tool_uses,
         &tools,
         &test_tool_ctx(),
         &mut loop_detector,
         &mut all_calls,
         1,
-        &event_tx,
+        Some(&event_tx),
         Some(&gate),
         0,
         None,
@@ -157,14 +152,14 @@ async fn reversibility_class_call_denied_skips_execution() {
     let mut loop_detector = LoopDetector::new(3);
     let mut all_calls = Vec::new();
 
-    let result = dispatch_tools_streaming(
+    let result = dispatch_tools(
         &tool_uses,
         &tools,
         &test_tool_ctx(),
         &mut loop_detector,
         &mut all_calls,
         1,
-        &event_tx,
+        Some(&event_tx),
         Some(&gate),
         0,
         None,
@@ -218,14 +213,14 @@ async fn mandatory_without_gate_defaults_to_denial() {
     let mut loop_detector = LoopDetector::new(3);
     let mut all_calls = Vec::new();
 
-    let result = dispatch_tools_streaming(
+    let result = dispatch_tools(
         &tool_uses,
         &tools,
         &test_tool_ctx(),
         &mut loop_detector,
         &mut all_calls,
         1,
-        &event_tx,
+        Some(&event_tx),
         None,
         0,
         None,
@@ -248,6 +243,60 @@ async fn mandatory_without_gate_defaults_to_denial() {
 }
 
 #[tokio::test]
+async fn batch_dispatch_mandatory_without_gate_matches_streaming_denial_record() {
+    let tools = make_registry_rev("exec", Reversibility::Irreversible);
+    let tool_uses = vec![(
+        "tool-1".to_owned(),
+        "exec".to_owned(),
+        serde_json::json!({}),
+    )];
+    let mut batch_detector = LoopDetector::new(3);
+    let mut batch_calls = Vec::new();
+    let mut streaming_detector = LoopDetector::new(3);
+    let mut streaming_calls = Vec::new();
+    let (event_tx, _event_rx) = mpsc::channel::<TurnStreamEvent>(64);
+
+    let batch_result = dispatch_tools(
+        &tool_uses,
+        &tools,
+        &test_tool_ctx(),
+        &mut batch_detector,
+        &mut batch_calls,
+        1,
+        None,
+        None,
+        0,
+        None,
+        None,
+    )
+    .await
+    .expect("batch dispatch ok");
+
+    let streaming_result = dispatch_tools(
+        &tool_uses,
+        &tools,
+        &test_tool_ctx(),
+        &mut streaming_detector,
+        &mut streaming_calls,
+        1,
+        Some(&event_tx),
+        None,
+        0,
+        None,
+        None,
+    )
+    .await
+    .expect("streaming dispatch ok");
+
+    assert_eq!(batch_result.blocks.len(), streaming_result.blocks.len());
+    assert_eq!(batch_calls.len(), streaming_calls.len());
+    assert_eq!(batch_calls[0].name, streaming_calls[0].name);
+    assert_eq!(batch_calls[0].input, streaming_calls[0].input);
+    assert_eq!(batch_calls[0].is_error, streaming_calls[0].is_error);
+    assert_eq!(batch_calls[0].result, streaming_calls[0].result);
+}
+
+#[tokio::test]
 async fn safe_call_proceeds_without_gate() {
     // FullyReversible → ApprovalRequirement::None → auto-approve, execute.
     let tools = make_registry_rev("read", Reversibility::FullyReversible);
@@ -261,14 +310,14 @@ async fn safe_call_proceeds_without_gate() {
     let mut loop_detector = LoopDetector::new(3);
     let mut all_calls = Vec::new();
 
-    let result = dispatch_tools_streaming(
+    let result = dispatch_tools(
         &tool_uses,
         &tools,
         &test_tool_ctx(),
         &mut loop_detector,
         &mut all_calls,
         1,
-        &event_tx,
+        Some(&event_tx),
         None,
         0,
         None,
@@ -306,14 +355,14 @@ async fn advisory_call_executes_without_approval_required_event() {
     let mut loop_detector = LoopDetector::new(3);
     let mut all_calls = Vec::new();
 
-    let _ = dispatch_tools_streaming(
+    let _ = dispatch_tools(
         &tool_uses,
         &tools,
         &test_tool_ctx(),
         &mut loop_detector,
         &mut all_calls,
         1,
-        &event_tx,
+        Some(&event_tx),
         None,
         0,
         None,
@@ -347,14 +396,14 @@ async fn gate_timeout_denies_mandatory_call() {
     let mut loop_detector = LoopDetector::new(3);
     let mut all_calls = Vec::new();
 
-    let result = dispatch_tools_streaming(
+    let result = dispatch_tools(
         &tool_uses,
         &tools,
         &test_tool_ctx(),
         &mut loop_detector,
         &mut all_calls,
         1,
-        &event_tx,
+        Some(&event_tx),
         Some(&gate),
         0,
         None,

--- a/crates/nous/src/execute/tests/mod.rs
+++ b/crates/nous/src/execute/tests/mod.rs
@@ -145,7 +145,7 @@ fn make_tool_def(name: &str) -> ToolDef {
             required: vec![],
         },
         category: ToolCategory::Workspace,
-        reversibility: organon::types::Reversibility::Irreversible,
+        reversibility: organon::types::Reversibility::FullyReversible,
         auto_activate: false,
         groups: vec![organon::types::ToolGroupId::Read],
         tags: vec![],

--- a/crates/nous/src/execute/tests/streaming.rs
+++ b/crates/nous/src/execute/tests/streaming.rs
@@ -1,5 +1,8 @@
 //! Streaming execute tests.
+use std::time::Duration;
+
 use super::*;
+use crate::approval::{ApprovalChoice, ApprovalDecision, ApprovalGate};
 
 #[tokio::test]
 async fn streaming_falls_back_to_non_streaming_for_mock() {
@@ -80,7 +83,6 @@ async fn streaming_tool_events_emitted() {
         "streaming execute should record one tool call"
     );
 
-    // NOTE: Even with mock (non-streaming) provider, tool events should be emitted
     drop(tx);
     let mut tool_start_count = 0;
     let mut tool_result_count = 0;
@@ -88,19 +90,92 @@ async fn streaming_tool_events_emitted() {
         match event {
             TurnStreamEvent::ToolStart { .. } => tool_start_count += 1,
             TurnStreamEvent::ToolResult { .. } => tool_result_count += 1,
-            // NOTE: counting only ToolStart/ToolResult events
             _ => {}
         }
     }
-    // WHY: Falls back to non-streaming execute(), no tool events via channel
-    // (tool events only come from dispatch_tools_streaming, which requires
-    //  a streaming provider to be found)
     assert_eq!(
-        tool_start_count, 0,
-        "mock provider falls back to non-streaming so no ToolStart events should be emitted"
+        tool_start_count, 1,
+        "fallback dispatch should emit the same ToolStart event as streaming dispatch"
     );
     assert_eq!(
-        tool_result_count, 0,
-        "mock provider falls back to non-streaming so no ToolResult events should be emitted"
+        tool_result_count, 1,
+        "fallback dispatch should emit the same ToolResult event as streaming dispatch"
     );
+}
+
+#[tokio::test]
+async fn streaming_fallback_uses_approval_gate_for_mandatory_tool() {
+    let mut providers = ProviderRegistry::new();
+    providers.register(Box::new(
+        MockProvider::with_responses(vec![
+            make_tool_response("exec", "toolu_1", serde_json::json!({"input": "test"})),
+            make_text_response("Denied handled"),
+        ])
+        .models(&["test-model"]),
+    ));
+
+    let mut tools = ToolRegistry::new();
+    let mut def = make_tool_def("exec");
+    def.reversibility = organon::types::Reversibility::Irreversible;
+    tools
+        .register(def, Box::new(EchoExecutor))
+        .expect("register");
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnStreamEvent>(64);
+    let (decision_tx, decision_rx) = tokio::sync::mpsc::channel::<ApprovalDecision>(4);
+    let gate = ApprovalGate::new(decision_rx, Duration::from_secs(5));
+    decision_tx
+        .send(ApprovalDecision {
+            tool_id: "toolu_1".to_owned(),
+            choice: ApprovalChoice::Denied,
+        })
+        .await
+        .expect("send denial");
+
+    let result = execute_streaming(
+        &test_pipeline_ctx(),
+        &test_session(),
+        &test_config(),
+        &providers,
+        &tools,
+        &test_tool_ctx(),
+        &tx,
+        Some(&gate),
+        None,
+    )
+    .await
+    .expect("execute_streaming fallback");
+
+    assert_eq!(result.content, "Denied handled");
+    assert_eq!(result.tool_calls.len(), 1);
+    let tool_call = result.tool_calls.first().expect("one denied tool call");
+    assert!(tool_call.is_error);
+    assert!(
+        tool_call
+            .result
+            .as_deref()
+            .unwrap_or_default()
+            .contains("denied by user")
+    );
+
+    drop(tx);
+    let mut approval_required = 0;
+    let mut approval_resolved = 0;
+    let mut tool_start = 0;
+    let mut tool_result = 0;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            TurnStreamEvent::ToolApprovalRequired { .. } => approval_required += 1,
+            TurnStreamEvent::ToolApprovalResolved { decision, .. } => {
+                approval_resolved += 1;
+                assert_eq!(decision, "denied");
+            }
+            TurnStreamEvent::ToolStart { .. } => tool_start += 1,
+            TurnStreamEvent::ToolResult { .. } => tool_result += 1,
+            TurnStreamEvent::LlmDelta(_) => {}
+        }
+    }
+    assert_eq!(approval_required, 1);
+    assert_eq!(approval_resolved, 1);
+    assert_eq!(tool_start, 0, "denied fallback call must not execute");
+    assert_eq!(tool_result, 1);
 }

--- a/crates/nous/src/handle.rs
+++ b/crates/nous/src/handle.rs
@@ -176,7 +176,7 @@ impl NousHandle {
     /// This method passes `approval_gate: None` — intentional for batch/headless
     /// callers (e.g. `diaporeia`'s memory-MCP tool turns) where no interactive
     /// operator is present to approve reversibility-class tools. The gate's
-    /// `None` contract (see `dispatch_tools_streaming`) is: Mandatory →
+    /// `None` contract (see shared execute dispatch) is: Mandatory →
     /// default-deny, Required → approve. Callers that DO have an interactive
     /// operator session must use [`send_turn_streaming_with_approval`](Self::send_turn_streaming_with_approval)
     /// so the approval event is surfaced to the operator and the gate is wired.


### PR DESCRIPTION
Closes #4714

The streaming→non-streaming fallback executed approval-required tools ungated: the approval gate lived only in the streaming dispatcher while the fallback path in `execute/mod.rs` ran tools directly. Both paths now call ONE approval-aware dispatcher (net −14 lines — divergent copies collapsed, per #4755's direction rather than a copied gate), with identical audit records on both paths. Tests: mandatory-approval tool blocks identically on streaming and fallback; denial records match (`batch_dispatch_mandatory_without_gate_matches_streaming_denial_record`, `streaming_fallback_uses_approval_gate_for_mandatory_tool`).

First increment of the #4755 turn-execution-core unification. Worker-gated CI-exact on verda before push.